### PR TITLE
Run GitHub actions for pull requests; build docs

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -4,7 +4,7 @@ name: Build and Test
 
 on:
   push:
-    branches: ["main", "gha"]
+    branches: ["main"]
   pull_request:
   workflow_call:
   workflow_dispatch:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,7 +9,7 @@ name: Deploy docs
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: [$default-branch, gha]
+    branches: [main]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
Every pull request and the main branch should run the precheckin tests. This is mostly copied from the `caliptra-sw` repo.

In addition, we also publish docs on merges to main now. An example is published at https://verbose-adventure-9pevejn.pages.github.io/ (these will be moved to a better location when this repo is made public).