### PR TITLE
emulator: If external interrupt is set, keep triggering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,6 +73,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -382,6 +393,7 @@ dependencies = [
 name = "emulator"
 version = "0.1.0"
 dependencies = [
+ "atty",
  "clap",
  "console",
  "ctrlc",
@@ -537,6 +549,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "hex"
@@ -1334,6 +1355,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1341,6 +1378,12 @@ checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ authors = ["Caliptra contributors"]
 
 [workspace.dependencies]
 arrayref = "0.3.6"
+atty = "0.2.14"
 bitfield = "0.14.0"
 bit-vec = "0.6.3"
 clap = { version = "4.5.11", features = [

--- a/emulator/app/Cargo.toml
+++ b/emulator/app/Cargo.toml
@@ -8,16 +8,17 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+atty.workspace = true
+clap.workspace = true
+console.workspace = true
+ctrlc.workspace = true
+elf.workspace = true
 emulator-bus.workspace = true
 emulator-cpu.workspace = true
 emulator-periph.workspace = true
-emulator-types.workspace = true
 emulator-registers-generated.workspace = true
-clap.workspace = true
-elf.workspace = true
+emulator-types.workspace = true
 gdbstub_arch.workspace = true
 gdbstub.workspace = true
 hex.workspace = true
 tock-registers.workspace = true
-ctrlc.workspace = true
-console.workspace = true

--- a/emulator/periph/src/emu_ctrl.rs
+++ b/emulator/periph/src/emu_ctrl.rs
@@ -73,9 +73,9 @@ impl Bus for EmuCtrl {
     ///
     /// * `RvException` - Exception with cause `RvExceptionCause::StoreAccessFault`
     ///                   or `RvExceptionCause::StoreAddrMisaligned`
-    fn write(&mut self, size: RvSize, addr: RvAddr, val: RvData) -> Result<(), BusError> {
-        match (size, addr) {
-            (RvSize::Word, EmuCtrl::ADDR_EXIT) => {
+    fn write(&mut self, _size: RvSize, addr: RvAddr, val: RvData) -> Result<(), BusError> {
+        match addr {
+            EmuCtrl::ADDR_EXIT => {
                 exit(val as i32);
             }
             _ => Err(BusError::StoreAccessFault)?,


### PR DESCRIPTION
We previously had a workaround to prevent re-triggering an interrupt while handling an interrupt, but this is unnecessary as the `mstatus` CSR disables interrupts in the handler until `mret` is called at the end.

This was causing UART interrupts to not be reasserted even through there was still data in the buffer to handle.

In addition, we add a loop around handling the UART input buffer (to avoid needing to wait for another interrupt). We also handle backspaces correctly now.

We also fix the emulator control address to be in the right place (the RISC-V code was using a similar address from a Verilator simulated CPU).