### PR TITLE
runtime: Fix UART transmission to use deferred calls

### DIFF
--- a/runtime/src/chip.rs
+++ b/runtime/src/chip.rs
@@ -50,7 +50,9 @@ impl<'a> VeeRDefaultPeripherals<'a> {
         }
     }
 
-    pub fn init(&self) {}
+    pub fn init(&'static self) {
+        kernel::deferred_call::DeferredCallClient::register(&self.uart);
+    }
 }
 
 impl<'a> InterruptService for VeeRDefaultPeripherals<'a> {


### PR DESCRIPTION
This way the debug logs don't get jammed up forever.