### PR TITLE
Porting SPI host and SPI flash emulation into mcu emulator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,6 +120,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "capsules-core"
 version = "0.1.0"
 source = "git+https://github.com/tock/tock.git?rev=b128ae817b86706c8c4e39d27fae5c54b98659f1#b128ae817b86706c8c4e39d27fae5c54b98659f1"
@@ -451,9 +457,11 @@ dependencies = [
  "emulator-derive",
  "emulator-types",
  "lazy_static",
+ "num_enum",
  "serde",
  "serde_json",
  "tock-registers 0.9.0 (git+https://github.com/tock/tock.git)",
+ "zerocopy",
 ]
 
 [[package]]
@@ -951,6 +959,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
+dependencies = [
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -997,6 +1026,15 @@ name = "portable-atomic"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
+dependencies = [
+ "toml_edit",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -1524,4 +1562,25 @@ dependencies = [
  "semver",
  "tempfile",
  "walkdir",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854e949ac82d619ee9a14c66a1b674ac730422372ccb759ce0c39cabcf2bf8e6"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "125139de3f6b9d625c39e2efdd73d41bdac468ccd556556440e322be0e1bbd91"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,8 @@ serde = { version = "1.0.209", features = ["alloc", "derive", "serde_derive"] }
 serde_json = { version = "1.0.127", features = ["alloc"] }
 num-traits = "0.2"
 num-derive = "0.4.2"
+num_enum = "0.7.2"
+zerocopy = "0.6.6"
 
 # Always optimize the emulator during tests, as it is a major bottleneck for
 # test speed.

--- a/emulator/periph/Cargo.toml
+++ b/emulator/periph/Cargo.toml
@@ -18,3 +18,5 @@ lazy_static.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tock-registers.workspace = true
+zerocopy.workspace = true
+num_enum.workspace = true

--- a/emulator/periph/src/lib.rs
+++ b/emulator/periph/src/lib.rs
@@ -17,9 +17,12 @@ mod emu_ctrl;
 mod otp;
 mod otp_digest;
 mod root_bus;
+mod spi_flash;
+mod spi_host;
 mod uart;
 
 pub use emu_ctrl::EmuCtrl;
 pub use otp::Otp;
 pub use root_bus::{CaliptraRootBus, CaliptraRootBusArgs};
+pub use spi_flash::IoMode;
 pub use uart::Uart;

--- a/emulator/periph/src/root_bus.rs
+++ b/emulator/periph/src/root_bus.rs
@@ -12,7 +12,7 @@ Abstract:
 
 --*/
 
-use crate::{EmuCtrl, Otp, Uart};
+use crate::{spi_host::SpiHost, EmuCtrl, Otp, Uart};
 use emulator_bus::{Clock, Ram, Rom};
 use emulator_cpu::{Pic, PicMmioRegisters};
 use emulator_derive::Bus;
@@ -41,6 +41,9 @@ pub struct CaliptraRootBusArgs {
 pub struct CaliptraRootBus {
     #[peripheral(offset = 0x0000_0000, len = 0xc000)]
     pub rom: Rom,
+
+    #[peripheral(offset = 0x2000_0000, len = 0x40)]
+    pub spi: SpiHost,
 
     #[peripheral(offset = 0x2000_1000, len = 0x100)]
     pub uart: Uart,
@@ -81,6 +84,7 @@ impl CaliptraRootBus {
             rom,
             iccm,
             dccm: Ram::new(vec![0; Self::RAM_SIZE]),
+            spi: SpiHost::new(&clock.clone()),
             uart: Uart::new(args.uart_output, args.uart_rx, uart_irq, &clock.clone()),
             ctrl: EmuCtrl::new(),
             otp: Otp::new(&clock.clone(), args.otp_file)?,

--- a/emulator/periph/src/spi_flash.rs
+++ b/emulator/periph/src/spi_flash.rs
@@ -1,0 +1,1254 @@
+/*++
+
+Licensed under the Apache-2.0 license.
+
+File Name:
+
+    spi_flash.rs
+
+Abstract:
+
+    File contains SPI flash emulation
+
+--*/
+
+use bitfield::Bit;
+use num_enum::{IntoPrimitive, TryFromPrimitive};
+use std::{cell::RefCell, rc::Rc};
+
+#[derive(PartialEq, Default, Debug, Clone, Copy)]
+pub enum IoMode {
+    #[default]
+    Single,
+    Dual,
+    Quad,
+}
+
+#[derive(PartialEq, Debug)]
+pub struct SpiByte {
+    pub mode: IoMode,
+    pub byte: u8,
+}
+
+#[derive(Debug)]
+pub enum SpiFlashInput {
+    CsLow,
+    CsHigh,
+    DummyCycles(u32),
+    BytesSend(Vec<SpiByte>),
+}
+
+#[derive(Debug)]
+pub struct SpiFlashOutReq {
+    pub mode: IoMode,
+    pub n_bytes: u32,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum SpiFlashErr {
+    ImpossibleCodeflow,
+    Unimplemented,
+    CsChangeUnsupported,
+    //    FlashIdle,
+    CmdUnsupported,
+    InvalidOpcode,
+    InvalidAddress,
+    InvalidAddressMode,
+    InvalidLength,
+    SpiFlashBusy, // note: HW dependent mechanism
+    WriteDisabled,
+    CrossPageProgram,
+    PageProgramNotFF,
+    EraseAdressUnaligned,
+    TooManyDummyCycles,
+    ResetBeforeEnable,
+    WriteStatusDisabled,
+    ModeClockNotFF,
+    BytesReqNothingToSend,
+    BytesReqZeroBytes,
+    BytesReqWrongMode,
+    //    BytesReqTooMuch,
+    CommandNotSuccessful,
+    InvalidTimePassWhileNotIdle,
+}
+
+struct FlashPartInfo {
+    part_name: &'static str,
+    id: &'static [u8],
+    chip_size: u32,
+    max_page_program_size: u32,
+    #[allow(dead_code)] // Unused by implemented flash chip
+    max_aai_size: u32,
+    se_20_size: u32,
+    be_52_size: u32,
+    be_d8_size: u32, // Same as 0xdc with 4ba
+    ce_60_size: u32,
+    ce_c7_size: u32,
+    sfdp: &'static [u8],
+    // sfdp_read fn pointer TODO
+}
+
+#[derive(Default)]
+struct FlashState {
+    data: Vec<u8>,
+    page_buffer: Vec<u8>,
+    outbuffer: Vec<SpiByte>,
+    idle: bool,
+    busy: Option<u64>, // Time that the flash needs to be idle after erase/write
+    write_enable: bool,
+    four_bytes_address: bool,
+    reset_enable: bool,
+    quad_enable: bool,
+    status_write_enable: bool,
+    cmd: JedecSpiFlashCmd,
+    bytes_to_receive: u32,
+    page_program_get_data: bool,
+    mode_clocks_needed: u32,
+    dummy_cycles_needed: u32,
+    address: u32,
+}
+
+#[derive(Debug, Default, IntoPrimitive, TryFromPrimitive, PartialEq)]
+#[repr(u8)]
+enum JedecSpiFlashCmd {
+    #[default]
+    Noop = 0x00,
+    Wrsr1 = 0x01,
+    PageProgram = 0x02,
+    Read = 0x03,
+    WriteDisable = 0x04,
+    Rdsr1 = 0x05,
+    WriteEnable = 0x06,
+    FastRead = 0x0b,
+    FastRead4ba = 0x0c,
+    Wrsr3 = 0x11,
+    PageProgram4ba = 0x12,
+    Read4ba = 0x13,
+    Rdsr3 = 0x15,
+    SectorErase = 0x20,
+    SectorErase4ba = 0x21,
+    Wrsr2 = 0x31,
+    QuadPageProgram = 0x32,
+    QuadPageProgram4ba = 0x34,
+    Rdsr2 = 0x35,
+    IndividualBlockLock = 0x36,
+    IndividualBlockUnlock = 0x39,
+    FastReadDualOutput = 0x3b,
+    FastReadDualOutput4ba = 0x3c,
+    ReadBlockLock = 0x3d,
+    ProgramSecurityRegs = 0x42,
+    EraseSecurityRegs = 0x44,
+    ReadSecurityRegs = 0x48,
+    ReadUniqueId = 0x4b,
+    Ewsr = 0x50,
+    BlockErase52 = 0x52,
+    Sfdp = 0x5a,
+    ChipErase60 = 0x60,
+    ResetEnable = 0x66,
+    FastReadQuadOutput = 0x6b,
+    FastReadQuadOutput4ba = 0x6c,
+    EraseProgramSuspend = 0x75,
+    SetBurstWrap = 0x77,
+    EraseProgramResume = 0x7a,
+    GlobalBlockLock = 0x7e,
+    Rems = 0x90,
+    RemsDualIO = 0x92,
+    RemsQuadIO = 0x94,
+    GlobalBlockUnlock = 0x98,
+    Reset = 0x99,
+    Rdid = 0x9f,
+    RelaesePowerDownDeviceId = 0xab,
+    Enter4ba = 0xb7,
+    PowerDown = 0xb9,
+    FastReadDualIO = 0xbb,
+    FastReadDualIO4ba = 0xbc,
+    FastReadQuadIO = 0xbe,
+    SetReadParam = 0xc0,
+    ChipErasec7 = 0xc7,
+    BlockErased8 = 0xd8,
+    BlockErasedc4ba = 0xdc,
+    Exit4ba = 0xe9,
+    FastReadQuadIO4ba = 0xec,
+}
+
+pub struct SpiFlashImpl {
+    info: &'static FlashPartInfo,
+    state: FlashState,
+}
+
+impl<'a> SpiFlashImpl {
+    const SUPPORTED_FLASH: &'a [FlashPartInfo] = &[FlashPartInfo {
+        part_name: "w25q01jv",
+        id: &[0xef, 0x40, 0x21],
+        chip_size: 256 * 1024 * 1024,
+        max_page_program_size: 256,
+        max_aai_size: 0,
+        se_20_size: 4 * 1024,
+        be_52_size: 32 * 1024,
+        be_d8_size: 64 * 1024,
+        ce_60_size: 256 * 1024 * 1024,
+        ce_c7_size: 256 * 1024 * 1024,
+        sfdp: &[
+            0x53, 0x46, 0x44, 0x50, 0x06, 0x01, 0x01, 0xff, 0x00, 0x06, 0x01, 0x10, 0x80, 0x00,
+            0x00, 0xff, 0x84, 0x00, 0x01, 0x02, 0xd0, 0x00, 0x00, 0xff, 0x03, 0x00, 0x01, 0x02,
+            0xf0, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xe5, 0x20, 0xfb, 0xff, 0xff, 0xff, 0xff, 0x3f, 0x44, 0xeb, 0x08, 0x6b,
+            0x08, 0x3b, 0x42, 0xbb, 0xfe, 0xff, 0xff, 0xff, 0xff, 0xff, 0x00, 0x00, 0xff, 0xff,
+            0x40, 0xeb, 0x0c, 0x20, 0x0f, 0x52, 0x10, 0xd8, 0x00, 0x00, 0x36, 0x02, 0xa6, 0x00,
+            0x82, 0xea, 0x14, 0xe2, 0xe9, 0x63, 0x76, 0x33, 0x7a, 0x75, 0x7a, 0x75, 0xf7, 0xa2,
+            0xd5, 0x5c, 0x19, 0xf7, 0x4d, 0xff, 0xe9, 0x70, 0xf9, 0xa5, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x0a,
+            0xf0, 0xff, 0x21, 0xff, 0xdc, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff,
+        ],
+    }];
+
+    const SECTOR_ERASE_TIME: u64 = 50;
+    const BLOCK_32K_ERASE_TIME: u64 = 120;
+    const BLOCK_64K_ERASE_TIME: u64 = 150;
+    const CHIP_ERASE_TIME: u64 = 200000;
+
+    pub fn new(name: &str) -> Option<Self> {
+        let info = Self::SUPPORTED_FLASH.iter().find(|f| f.part_name == name)?;
+
+        Some(Self {
+            info,
+            state: FlashState {
+                data: vec![0xff; info.chip_size.try_into().unwrap()],
+                idle: true,
+                busy: None,
+                write_enable: false,
+                ..Default::default()
+            },
+        })
+    }
+
+    // Process the first byte which is always the command
+    fn process_cmd(&mut self, byte: &SpiByte) -> Result<(), SpiFlashErr> {
+        if byte.mode != IoMode::Single {
+            return Err(SpiFlashErr::CmdUnsupported);
+        }
+
+        let cmd: JedecSpiFlashCmd = byte
+            .byte
+            .try_into()
+            .map_err(|_| SpiFlashErr::InvalidOpcode)?;
+
+        let address_length = if self.state.four_bytes_address { 4 } else { 3 };
+
+        // If any command follow Reset enable that is not reset, then reset is disabled
+        if self.state.reset_enable && cmd != JedecSpiFlashCmd::Reset {
+            self.state.reset_enable = false;
+        }
+
+        // Status writes can only follow states write enable
+        let is_status_write = matches!(
+            cmd,
+            JedecSpiFlashCmd::Wrsr1 | JedecSpiFlashCmd::Wrsr2 | JedecSpiFlashCmd::Wrsr3
+        );
+        if self.state.status_write_enable && !is_status_write {
+            self.state.status_write_enable = false;
+        }
+
+        if self.state.busy.is_some()
+            && !matches!(
+                cmd,
+                JedecSpiFlashCmd::Rdsr1
+                    | JedecSpiFlashCmd::Rdsr2
+                    | JedecSpiFlashCmd::Rdsr3
+                    | JedecSpiFlashCmd::EraseProgramSuspend
+                    | JedecSpiFlashCmd::EraseProgramResume
+            )
+        {
+            return Err(SpiFlashErr::SpiFlashBusy);
+        }
+
+        match cmd {
+            JedecSpiFlashCmd::Rdid
+            | JedecSpiFlashCmd::ChipErase60
+            | JedecSpiFlashCmd::ChipErasec7
+            | JedecSpiFlashCmd::Enter4ba
+            | JedecSpiFlashCmd::Exit4ba
+            | JedecSpiFlashCmd::Rdsr1
+            | JedecSpiFlashCmd::Rdsr2
+            | JedecSpiFlashCmd::Rdsr3
+            | JedecSpiFlashCmd::WriteEnable
+            // TODO this does not exist on each chip. Some need Write Enable instead
+            | JedecSpiFlashCmd::Ewsr
+            | JedecSpiFlashCmd::WriteDisable
+            | JedecSpiFlashCmd::ResetEnable => {
+                self.state.bytes_to_receive = 0;
+            }
+            JedecSpiFlashCmd::Read => {
+                self.state.bytes_to_receive = address_length;
+            }
+            JedecSpiFlashCmd::Read4ba => {
+                self.state.bytes_to_receive = 4;
+            }
+            JedecSpiFlashCmd::FastRead
+            | JedecSpiFlashCmd::FastReadDualOutput
+            | JedecSpiFlashCmd::FastReadQuadOutput => {
+                self.state.bytes_to_receive = address_length;
+                self.state.dummy_cycles_needed = 8;
+            }
+            JedecSpiFlashCmd::FastRead4ba
+            | JedecSpiFlashCmd::FastReadDualOutput4ba
+            | JedecSpiFlashCmd::FastReadQuadOutput4ba => {
+                self.state.bytes_to_receive = 4;
+                self.state.dummy_cycles_needed = 8;
+            }
+            JedecSpiFlashCmd::FastReadDualIO => {
+                self.state.bytes_to_receive = address_length;
+                self.state.dummy_cycles_needed = 4;
+            }
+            JedecSpiFlashCmd::FastReadDualIO4ba => {
+                self.state.bytes_to_receive = 4;
+                self.state.dummy_cycles_needed = 4;
+            }
+            // TODO Quad IO mode clocks and dummy cycles have both SPI flash dependent
+            // defaults as ways to reconfigure them. When adding new flash this could be moved
+            // to struct FlashPartInfo for chip default or implement the configuration mechanism.
+            JedecSpiFlashCmd::FastReadQuadIO => {
+                self.state.bytes_to_receive = address_length;
+                self.state.mode_clocks_needed = 2;
+                self.state.dummy_cycles_needed = 6; // TODO configurable
+            }
+            JedecSpiFlashCmd::FastReadQuadIO4ba => {
+                self.state.bytes_to_receive = 4;
+                self.state.mode_clocks_needed = 2;
+                self.state.dummy_cycles_needed = 6; // TODO configurable
+            }
+            JedecSpiFlashCmd::PageProgram => {
+                if self.state.write_enable {
+                    self.state.bytes_to_receive = address_length;
+                    self.state.page_program_get_data = false;
+                } else {
+                    return Err(SpiFlashErr::WriteDisabled);
+                }
+            }
+            JedecSpiFlashCmd::PageProgram4ba => {
+                if self.state.write_enable {
+                    self.state.bytes_to_receive = 4;
+                    self.state.page_program_get_data = false;
+                } else {
+                    return Err(SpiFlashErr::WriteDisabled);
+                }
+            }
+            JedecSpiFlashCmd::Wrsr1 | JedecSpiFlashCmd::Wrsr2 | JedecSpiFlashCmd::Wrsr3 => {
+                if self.state.status_write_enable {
+                    // TODO some flash chips write multiple status regs with wrsr1
+                    self.state.bytes_to_receive = 1;
+                } else {
+                    return Err(SpiFlashErr::WriteStatusDisabled)
+                }
+            }
+            JedecSpiFlashCmd::SectorErase
+            | JedecSpiFlashCmd::BlockErase52
+            | JedecSpiFlashCmd::BlockErased8 => {
+                if self.state.write_enable {
+                    self.state.bytes_to_receive = address_length;
+                } else {
+                    return Err(SpiFlashErr::WriteDisabled);
+                }
+            }
+            JedecSpiFlashCmd::SectorErase4ba | JedecSpiFlashCmd::BlockErasedc4ba => {
+                if self.state.write_enable {
+                    self.state.bytes_to_receive = 4;
+                } else {
+                    return Err(SpiFlashErr::WriteDisabled);
+                }
+            }
+            JedecSpiFlashCmd::Sfdp => {
+                self.state.bytes_to_receive = 3;
+                self.state.dummy_cycles_needed = 8;
+            }
+            JedecSpiFlashCmd::Reset => {
+                if !self.state.reset_enable {
+                    return Err(SpiFlashErr::ResetBeforeEnable);
+                }
+                self.state.bytes_to_receive = 0;
+            }
+            _ => return Err(SpiFlashErr::Unimplemented),
+        };
+        self.state.cmd = cmd;
+        Ok(())
+    }
+
+    // Process a byte into address
+    // Input:
+    //   byte: the SpiByte to process
+    //   mode: expected mode off address bytes: Single, Dual, Quad
+    //   max_addr: Sanity check for address
+    fn process_address(
+        &mut self,
+        byte: &SpiByte,
+        mode: IoMode,
+        max_addr: u32,
+    ) -> Result<(), SpiFlashErr> {
+        if self.state.bytes_to_receive > 4 {
+            return Err(SpiFlashErr::InvalidAddress);
+        }
+
+        if byte.mode != mode {
+            return Err(SpiFlashErr::InvalidAddressMode);
+        }
+        self.state.address |= (byte.byte as u32) << (8 * (self.state.bytes_to_receive - 1));
+        if self.state.address >= max_addr {
+            return Err(SpiFlashErr::InvalidAddress);
+        }
+        self.state.bytes_to_receive -= 1;
+        Ok(())
+    }
+
+    // Process page programming input. First 3 or 4 bytes are the address.
+    // The next bytes are the bytes to program. Up to the flash page size
+    // can be send in one go, with the limitation that bytes cannot cross pages.
+    fn process_page_program_input(&mut self, byte: &SpiByte) -> Result<(), SpiFlashErr> {
+        if byte.mode != IoMode::Single {
+            return Err(SpiFlashErr::InvalidAddress);
+        }
+        if !self.state.page_program_get_data {
+            self.process_address(byte, IoMode::Single, self.info.chip_size - 1)?;
+
+            if self.state.bytes_to_receive == 0 {
+                self.state.page_program_get_data = true;
+                self.state.bytes_to_receive = 1; // Receive an arbitrary number of bytes (never decreased)
+            }
+        } else {
+            let bytes_gathered = self.state.page_buffer.len() as u32;
+            let mask = !(self.info.max_page_program_size - 1);
+            let page_begin = self.state.address & mask;
+            let new_addr = self.state.address + bytes_gathered;
+
+            let clean_up = |state: &mut FlashState| {
+                state.page_buffer.clear();
+                state.bytes_to_receive = 0;
+                state.page_program_get_data = false;
+            };
+            if page_begin != (new_addr & mask) {
+                clean_up(&mut self.state);
+                return Err(SpiFlashErr::CrossPageProgram);
+            }
+            if self.state.data[new_addr as usize] != 0xff {
+                clean_up(&mut self.state);
+                return Err(SpiFlashErr::PageProgramNotFF);
+            }
+            self.state.page_buffer.push(byte.byte);
+        }
+        Ok(())
+    }
+
+    // After CS is pulled high page program can begin
+    // TODO: The flash is now in a busy state for some time
+    // Timing handling will be added later with SPI Host code.
+    fn perform_page_program(&mut self) {
+        let address = self.state.address as usize;
+
+        for (index, byte) in self.state.page_buffer.iter().enumerate() {
+            self.state.data[address + index] = *byte;
+        }
+        // Page program are TYP from W25Q01JV
+        self.state.busy = Some(1);
+        self.state.page_buffer.clear();
+    }
+
+    // After CS is pulled high erase can begin
+    // TODO: The flash is now in a busy state for some time
+    // Timing handling will be added later with SPI Host code.
+    fn perform_erase(&mut self) -> Result<(), SpiFlashErr> {
+        // Should be 0 for full flash erase CMDs
+        let address = self.state.address;
+
+        // Erase times are the TYP from W25Q01JV
+        let (size, erase_time) = match self.state.cmd {
+            JedecSpiFlashCmd::BlockErase52 => {
+                (Some(self.info.be_52_size), Self::BLOCK_32K_ERASE_TIME)
+            }
+            JedecSpiFlashCmd::BlockErased8 | JedecSpiFlashCmd::BlockErasedc4ba => {
+                (Some(self.info.be_d8_size), Self::BLOCK_64K_ERASE_TIME)
+            }
+            JedecSpiFlashCmd::SectorErase | JedecSpiFlashCmd::SectorErase4ba => {
+                (Some(self.info.se_20_size), Self::SECTOR_ERASE_TIME)
+            }
+            JedecSpiFlashCmd::ChipErase60 => (Some(self.info.ce_60_size), Self::CHIP_ERASE_TIME),
+            JedecSpiFlashCmd::ChipErasec7 => (Some(self.info.ce_c7_size), Self::CHIP_ERASE_TIME),
+            _ => (None, 0),
+        };
+        let size = size.unwrap();
+
+        if size == 0 {
+            return Err(SpiFlashErr::CmdUnsupported);
+        }
+
+        let last = address + size - 1;
+
+        if address & !(size - 1) != 0 {
+            return Err(SpiFlashErr::EraseAdressUnaligned);
+        }
+        for idx in address..last {
+            self.state.data[idx as usize] = 0xff;
+        }
+
+        self.state.busy = Some(erase_time);
+
+        Ok(())
+    }
+
+    fn perform_status_write(&mut self) -> Result<(), SpiFlashErr> {
+        let input = self.state.address as u8;
+        match self.state.cmd {
+            // TODO flash specific
+            JedecSpiFlashCmd::Wrsr1 => todo!(),
+            JedecSpiFlashCmd::Wrsr2 => {
+                // TODO implement other bits
+                self.state.quad_enable = input.bit(1);
+            }
+            JedecSpiFlashCmd::Wrsr3 => todo!(),
+            _ => {
+                return Err(SpiFlashErr::ImpossibleCodeflow);
+            }
+        }
+        // Status program are TYP from W25Q01JV
+        self.state.busy = Some(10);
+
+        Ok(())
+    }
+
+    fn process_input_bytes(&mut self, bytes: &Vec<SpiByte>) -> Result<(), SpiFlashErr> {
+        // Process input
+        for byte in bytes {
+            if self.state.bytes_to_receive == 0 {
+                // If more bytes than needed are received those could be dummy cycles
+                // or mode clocks
+                let clocks = match byte.mode {
+                    IoMode::Single => 8,
+                    IoMode::Dual => 4,
+                    IoMode::Quad => 2,
+                };
+
+                if self.state.mode_clocks_needed != 0 {
+                    if self.state.mode_clocks_needed < clocks {
+                        return Err(SpiFlashErr::InvalidLength);
+                    } else if byte.byte != 0xff {
+                        return Err(SpiFlashErr::ModeClockNotFF);
+                    } else {
+                        self.state.mode_clocks_needed -= clocks;
+                        continue;
+                    }
+                }
+
+                if self.state.dummy_cycles_needed != 0 {
+                    if self.state.dummy_cycles_needed < clocks {
+                        return Err(SpiFlashErr::InvalidLength);
+                    } else {
+                        // Sending a random byte also counts as dummy cycle
+                        self.state.dummy_cycles_needed -= clocks;
+                        continue;
+                    }
+                }
+            }
+
+            match self.state.cmd {
+                JedecSpiFlashCmd::Noop => self.process_cmd(byte)?,
+                JedecSpiFlashCmd::Read
+                | JedecSpiFlashCmd::Read4ba
+                | JedecSpiFlashCmd::FastRead
+                | JedecSpiFlashCmd::FastRead4ba
+                | JedecSpiFlashCmd::FastReadDualOutput
+                | JedecSpiFlashCmd::FastReadDualOutput4ba
+                | JedecSpiFlashCmd::FastReadQuadOutput
+                | JedecSpiFlashCmd::FastReadQuadOutput4ba => {
+                    self.process_address(byte, IoMode::Single, self.info.chip_size - 1)?
+                }
+                JedecSpiFlashCmd::FastReadDualIO | JedecSpiFlashCmd::FastReadDualIO4ba => {
+                    self.process_address(byte, IoMode::Dual, self.info.chip_size - 1)?
+                }
+                JedecSpiFlashCmd::FastReadQuadIO | JedecSpiFlashCmd::FastReadQuadIO4ba => {
+                    self.process_address(byte, IoMode::Quad, self.info.chip_size - 1)?;
+                }
+                JedecSpiFlashCmd::PageProgram | JedecSpiFlashCmd::PageProgram4ba => {
+                    self.process_page_program_input(byte)?
+                }
+                JedecSpiFlashCmd::SectorErase
+                | JedecSpiFlashCmd::SectorErase4ba
+                | JedecSpiFlashCmd::BlockErase52
+                | JedecSpiFlashCmd::BlockErased8
+                | JedecSpiFlashCmd::BlockErasedc4ba => {
+                    self.process_address(byte, IoMode::Single, self.info.chip_size)?
+                }
+                JedecSpiFlashCmd::Sfdp => {
+                    self.process_address(byte, IoMode::Single, (self.info.sfdp.len() as u32) - 1)?
+                }
+                // TODO this works differently on some flash chips
+                JedecSpiFlashCmd::Wrsr1 | JedecSpiFlashCmd::Wrsr2 | JedecSpiFlashCmd::Wrsr3 => {
+                    if byte.mode != IoMode::Single {
+                        return Err(SpiFlashErr::InvalidAddressMode);
+                    }
+                    self.state.address = byte.byte.into();
+                    self.state.bytes_to_receive -= 1;
+                }
+                _ => return Err(SpiFlashErr::Unimplemented),
+            }
+        }
+        Ok(())
+    }
+
+    fn process_dummy(&mut self, cycles: u32) -> Result<(), SpiFlashErr> {
+        if self.state.dummy_cycles_needed >= cycles {
+            self.state.dummy_cycles_needed -= cycles;
+            Ok(())
+        } else {
+            Err(SpiFlashErr::TooManyDummyCycles)
+        }
+    }
+
+    // After all the CMDs inputs (CMD, ADDR, MODE, DUMMY, ...) have been gathered
+    // output bytes
+    fn process_output(&mut self) -> Result<Option<Vec<SpiByte>>, SpiFlashErr> {
+        match self.state.cmd {
+            JedecSpiFlashCmd::Rdid => Ok(Some(
+                self.info
+                    .id
+                    .iter()
+                    .map(|b| SpiByte {
+                        byte: *b,
+                        mode: IoMode::Single,
+                    })
+                    .collect(),
+            )),
+            JedecSpiFlashCmd::Read
+            | JedecSpiFlashCmd::Read4ba
+            | JedecSpiFlashCmd::FastRead
+            | JedecSpiFlashCmd::FastRead4ba => Ok(Some(vec![SpiByte {
+                mode: IoMode::Single,
+                byte: self.state.data[self.state.address as usize],
+            }])),
+            JedecSpiFlashCmd::FastReadDualOutput
+            | JedecSpiFlashCmd::FastReadDualOutput4ba
+            | JedecSpiFlashCmd::FastReadDualIO
+            | JedecSpiFlashCmd::FastReadDualIO4ba => Ok(Some(vec![SpiByte {
+                mode: IoMode::Dual,
+                byte: self.state.data[self.state.address as usize],
+            }])),
+            JedecSpiFlashCmd::FastReadQuadOutput
+            | JedecSpiFlashCmd::FastReadQuadOutput4ba
+            | JedecSpiFlashCmd::FastReadQuadIO
+            | JedecSpiFlashCmd::FastReadQuadIO4ba => Ok(Some(vec![SpiByte {
+                mode: IoMode::Quad,
+                byte: self.state.data[self.state.address as usize],
+            }])),
+            JedecSpiFlashCmd::Sfdp => {
+                let addr = self.state.address as usize;
+
+                let sfdp_part_slice = &self.info.sfdp[addr..];
+                Ok(Some(
+                    sfdp_part_slice
+                        .iter()
+                        .cloned()
+                        .map(|b| SpiByte {
+                            mode: IoMode::Single,
+                            byte: b,
+                        })
+                        .collect(),
+                ))
+            }
+            JedecSpiFlashCmd::Rdsr1 => {
+                let mut status = 0;
+                // TODO: use tock registers
+                if self.state.busy.is_some() {
+                    status |= 1; // BUSY
+                }
+                if self.state.write_enable {
+                    status |= 1 << 1; // Write Enable Latch set
+                }
+                Ok(Some(vec![SpiByte {
+                    mode: IoMode::Single,
+                    byte: status,
+                }]))
+            }
+            JedecSpiFlashCmd::Rdsr2 => {
+                let mut status = 0;
+                // TODO: use tock registers
+                if self.state.quad_enable {
+                    status |= 1 << 1;
+                }
+                Ok(Some(vec![SpiByte {
+                    mode: IoMode::Single,
+                    byte: status,
+                }]))
+            }
+            JedecSpiFlashCmd::Rdsr3 => {
+                let mut status = 0;
+                // TODO: use tock registers
+                if self.state.four_bytes_address {
+                    status |= 1 << 0;
+                }
+                Ok(Some(vec![SpiByte {
+                    mode: IoMode::Single,
+                    byte: status,
+                }]))
+            }
+            _ => Ok(None),
+        }
+    }
+
+    /// Process input
+    ///
+    /// # arguments
+    ///
+    /// * `input` - SpiFlashInput
+    ///
+    /// #
+    ///
+    /// * Err: SpiFlashErr
+    /// * Ok(()):
+    pub fn input(&mut self, input: &SpiFlashInput) -> Result<(), SpiFlashErr> {
+        match input {
+            SpiFlashInput::CsLow => {
+                if !self.state.idle {
+                    // TODO clean up flash state?
+                    return Err(SpiFlashErr::CsChangeUnsupported);
+                }
+                self.state.idle = false;
+                self.state.bytes_to_receive = 1;
+                return Ok(());
+            }
+            SpiFlashInput::CsHigh => {
+                if self.state.idle {
+                    return Err(SpiFlashErr::CsChangeUnsupported);
+                }
+
+                let state_cleanup = |f: &mut SpiFlashImpl| {
+                    f.state.idle = true;
+                    f.state.address = 0;
+                    f.state.dummy_cycles_needed = 0;
+                    f.state.mode_clocks_needed = 0;
+                    f.state.page_buffer.clear();
+                    f.state.cmd = JedecSpiFlashCmd::Noop;
+                    f.state.outbuffer.clear();
+                };
+
+                match self.state.cmd {
+                    JedecSpiFlashCmd::PageProgram | JedecSpiFlashCmd::PageProgram4ba => {
+                        self.perform_page_program();
+                        // TODO need to wait
+                        state_cleanup(self);
+                        self.state.write_enable = false;
+
+                        return Ok(());
+                    }
+                    JedecSpiFlashCmd::SectorErase
+                    | JedecSpiFlashCmd::SectorErase4ba
+                    | JedecSpiFlashCmd::BlockErase52
+                    | JedecSpiFlashCmd::BlockErased8
+                    | JedecSpiFlashCmd::BlockErasedc4ba
+                    | JedecSpiFlashCmd::ChipErase60
+                    | JedecSpiFlashCmd::ChipErasec7 => {
+                        let ret = self.perform_erase();
+                        state_cleanup(self);
+                        self.state.write_enable = false;
+                        match ret {
+                            Ok(()) => return Ok(()),
+                            Err(err) => return Err(err),
+                        }
+                    }
+                    JedecSpiFlashCmd::Reset => {
+                        if self.state.reset_enable {
+                            self.state.reset_enable = false;
+                            self.state.write_enable = false;
+                            state_cleanup(self)
+                        }
+                    }
+                    JedecSpiFlashCmd::WriteEnable => {
+                        self.state.write_enable = true;
+                        state_cleanup(self);
+                        //                 self.state.status_write_enable = true; TODO on chips where it works like this
+                    }
+                    JedecSpiFlashCmd::WriteDisable => {
+                        self.state.write_enable = false;
+                        state_cleanup(self);
+                    }
+                    JedecSpiFlashCmd::Ewsr => {
+                        self.state.status_write_enable = true;
+                        state_cleanup(self);
+                    }
+                    JedecSpiFlashCmd::Enter4ba => {
+                        self.state.four_bytes_address = true;
+                        state_cleanup(self);
+                    }
+                    JedecSpiFlashCmd::Exit4ba => {
+                        self.state.four_bytes_address = false;
+                        state_cleanup(self);
+                    }
+                    JedecSpiFlashCmd::ResetEnable => {
+                        self.state.reset_enable = true;
+                        state_cleanup(self);
+                    }
+                    JedecSpiFlashCmd::Wrsr1 | JedecSpiFlashCmd::Wrsr2 | JedecSpiFlashCmd::Wrsr3 => {
+                        let ret = self.perform_status_write();
+                        self.state.status_write_enable = false;
+                        state_cleanup(self);
+                        match ret {
+                            Ok(()) => return Ok(()),
+                            Err(err) => return Err(err),
+                        }
+                    }
+                    _ => (),
+                }
+
+                if self.state.bytes_to_receive == 0
+                    && self.state.dummy_cycles_needed == 0
+                    && self.state.mode_clocks_needed == 0
+                {
+                    state_cleanup(self);
+                    return Ok(());
+                }
+                return Err(SpiFlashErr::CommandNotSuccessful);
+            }
+            SpiFlashInput::BytesSend(bytes) => {
+                self.process_input_bytes(bytes)?;
+            }
+            SpiFlashInput::DummyCycles(cycles) => self.process_dummy(*cycles)?,
+        };
+        if self.state.dummy_cycles_needed == 0
+            && self.state.bytes_to_receive == 0
+            && self.state.mode_clocks_needed == 0
+        {
+            let output = self.process_output()?;
+            if let Some(bytes) = output {
+                self.state.outbuffer = bytes;
+            }
+        }
+        Ok(())
+    }
+
+    /// Process time passing
+    ///
+    /// # arguments
+    ///
+    /// * `time` - u64
+    ///
+    /// * Err: SpiFlashErr
+    /// * Ok(()):
+    pub fn time_pass(&mut self, time: u64) -> Result<(), SpiFlashErr> {
+        if !self.state.idle {
+            return Err(SpiFlashErr::InvalidTimePassWhileNotIdle);
+        }
+        match self.state.busy {
+            None => return Ok(()),
+            Some(time_to_wait) => {
+                if time >= time_to_wait {
+                    self.state.busy = None;
+                } else {
+                    self.state.busy = Some(time_to_wait - time);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub fn req_output(&mut self, req: SpiFlashOutReq) -> Result<Vec<u8>, SpiFlashErr> {
+        if req.n_bytes == 0 {
+            return Err(SpiFlashErr::BytesReqZeroBytes);
+        }
+        if self.state.outbuffer.is_empty() {
+            return Err(SpiFlashErr::BytesReqNothingToSend);
+        }
+        // TODO figure out what to do when requesting too much later? It's not a problem
+        // if self.state.outbuffer.len() < req.n_bytes {
+        //     return Err(SpiFlashErr::BytesReqTooMuch);
+        // }
+        // Assume the output is always of the same type
+        if self.state.outbuffer.first().unwrap().mode != req.mode {
+            return Err(SpiFlashErr::BytesReqWrongMode);
+        }
+        let remain = self
+            .state
+            .outbuffer
+            .split_off(req.n_bytes.try_into().unwrap());
+        let to_send = self.state.outbuffer.iter().map(|x| x.byte).collect();
+        self.state.outbuffer = remain;
+        Ok(to_send)
+    }
+}
+
+impl Default for SpiFlashImpl {
+    fn default() -> Self {
+        SpiFlashImpl::new("w25q01jv").unwrap()
+    }
+}
+
+pub struct SpiFlash {
+    flash: Rc<RefCell<SpiFlashImpl>>,
+}
+impl SpiFlash {
+    pub fn new(name: &str) -> Option<Self> {
+        let flash = SpiFlashImpl::new(name)?;
+        Some(Self {
+            flash: Rc::new(RefCell::new(flash)),
+        })
+    }
+
+    /// Process input
+    ///
+    /// # arguments
+    ///
+    /// * `input` - SpiFlashInput
+    ///
+    /// #
+    ///
+    /// * Err: SpiFlashErr
+    /// * Ok(()):
+    pub fn input(&mut self, input: &SpiFlashInput) -> Result<(), SpiFlashErr> {
+        let mut flash = self.flash.try_borrow_mut().unwrap();
+        flash.input(input)
+    }
+
+    /// Request output
+    ///
+    /// # arguments
+    ///
+    /// * `input` - SpiFlashOutReq
+    ///
+    /// #
+    /// * Err: SpiFlashErr
+    /// * Ok: vec<u8>
+    pub fn req_output(&mut self, req: SpiFlashOutReq) -> Result<Vec<u8>, SpiFlashErr> {
+        let mut flash = self.flash.try_borrow_mut().unwrap();
+        flash.req_output(req)
+    }
+
+    /// Process time passing
+    ///
+    /// # arguments
+    ///
+    /// * `time` - u64
+    ///
+    /// * Err: SpiFlashErr
+    /// * Ok(()):
+    pub fn time_pass(&mut self, time: u64) -> Result<(), SpiFlashErr> {
+        let mut flash = self.flash.try_borrow_mut().unwrap();
+        flash.time_pass(time)
+    }
+}
+impl Default for SpiFlash {
+    fn default() -> Self {
+        Self::new("w25q01jv").unwrap()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn test_jedec_read_id() {
+        let mut flash: SpiFlashImpl = Default::default();
+        flash.input(&SpiFlashInput::CsLow).unwrap();
+
+        let input = SpiFlashInput::BytesSend(vec![encode_cmd(JedecSpiFlashCmd::Rdid)]);
+        flash.input(&input).unwrap();
+        assert_eq!(
+            flash
+                .req_output(SpiFlashOutReq {
+                    mode: IoMode::Single,
+                    n_bytes: 3
+                })
+                .unwrap(),
+            vec![0xef, 0x40, 0x21]
+        );
+
+        flash.input(&SpiFlashInput::CsHigh).unwrap();
+    }
+
+    fn encode_cmd(cmd: JedecSpiFlashCmd) -> SpiByte {
+        SpiByte {
+            mode: IoMode::Single,
+            byte: cmd.into(),
+        }
+    }
+
+    fn encode_addr(addr: u32, four_ba: bool, mode: &IoMode) -> Vec<SpiByte> {
+        let mut encoded_addr = Vec::new();
+        let addr_size = if four_ba { 4 } else { 3 };
+
+        for idx in 0..addr_size {
+            let byte = (addr >> (8 * (addr_size - idx - 1)) & 0xff) as u8;
+            encoded_addr.push(SpiByte { byte, mode: *mode });
+        }
+
+        encoded_addr
+    }
+
+    fn jedec_read(flash: &mut SpiFlashImpl, cmd: JedecSpiFlashCmd, addr: u32) -> u8 {
+        flash.input(&SpiFlashInput::CsLow).unwrap();
+        let input = SpiFlashInput::BytesSend(vec![encode_cmd(JedecSpiFlashCmd::Rdsr3)]);
+        flash.input(&input).unwrap();
+
+        let four_ba_en = flash
+            .req_output(SpiFlashOutReq {
+                mode: IoMode::Single,
+                n_bytes: 1,
+            })
+            .unwrap()
+            .first()
+            .unwrap()
+            .bit(0);
+        flash.input(&SpiFlashInput::CsHigh).unwrap();
+
+        let (four_ba, input_mode, output_mode, dummy_cycles, mode_cycles) = match cmd {
+            JedecSpiFlashCmd::Read => (four_ba_en, IoMode::Single, IoMode::Single, 0, 0),
+            JedecSpiFlashCmd::Read4ba => (true, IoMode::Single, IoMode::Single, 0, 0),
+            JedecSpiFlashCmd::FastRead => (four_ba_en, IoMode::Single, IoMode::Single, 8, 0),
+            JedecSpiFlashCmd::FastRead4ba => (true, IoMode::Single, IoMode::Single, 8, 0),
+            JedecSpiFlashCmd::FastReadDualOutput => {
+                (four_ba_en, IoMode::Single, IoMode::Dual, 8, 0)
+            }
+            JedecSpiFlashCmd::FastReadDualOutput4ba => (true, IoMode::Single, IoMode::Dual, 8, 0),
+            JedecSpiFlashCmd::FastReadDualIO => (four_ba_en, IoMode::Dual, IoMode::Dual, 4, 0),
+            JedecSpiFlashCmd::FastReadDualIO4ba => (true, IoMode::Dual, IoMode::Dual, 4, 0),
+
+            JedecSpiFlashCmd::FastReadQuadOutput => {
+                (four_ba_en, IoMode::Single, IoMode::Quad, 8, 0)
+            }
+            JedecSpiFlashCmd::FastReadQuadOutput4ba => (true, IoMode::Single, IoMode::Quad, 8, 0),
+            JedecSpiFlashCmd::FastReadQuadIO => (four_ba_en, IoMode::Quad, IoMode::Quad, 4, 2),
+            JedecSpiFlashCmd::FastReadQuadIO4ba => (true, IoMode::Quad, IoMode::Quad, 4, 2),
+            _ => panic!("Invalid CMD"),
+        };
+
+        flash.input(&SpiFlashInput::CsLow).unwrap();
+
+        let mut seq = Vec::new();
+        seq.push(encode_cmd(cmd));
+        seq.append(&mut encode_addr(addr, four_ba, &input_mode));
+        let cycles = match input_mode {
+            IoMode::Single => 8,
+            IoMode::Dual => 4,
+            IoMode::Quad => 2,
+        };
+        for _ in 0..mode_cycles / cycles {
+            seq.push(SpiByte {
+                mode: input_mode,
+                byte: 0xff,
+            });
+        }
+        for _ in 0..dummy_cycles / cycles {
+            seq.push(SpiByte {
+                mode: input_mode,
+                byte: 0xff,
+            });
+        }
+
+        let input = SpiFlashInput::BytesSend(seq);
+        flash.input(&input).unwrap();
+
+        let output = flash
+            .req_output(SpiFlashOutReq {
+                mode: output_mode,
+                n_bytes: 1,
+            })
+            .unwrap();
+
+        let byte = output.first().unwrap();
+
+        flash.input(&SpiFlashInput::CsHigh).unwrap();
+
+        *byte
+    }
+
+    fn jedec_program_byte_4ba(flash: &mut SpiFlashImpl, addr: u32, byte: u8) {
+        // Write enable latch
+        flash.input(&SpiFlashInput::CsLow).unwrap();
+        let input = SpiFlashInput::BytesSend(vec![encode_cmd(JedecSpiFlashCmd::WriteEnable)]);
+        flash.input(&input).unwrap();
+        flash.input(&SpiFlashInput::CsHigh).unwrap();
+
+        flash.input(&SpiFlashInput::CsLow).unwrap();
+
+        // Read at address 0
+        let mut seq = vec![SpiByte {
+            mode: IoMode::Single,
+            byte: JedecSpiFlashCmd::PageProgram.into(),
+        }];
+
+        seq.append(&mut encode_addr(addr, true, &IoMode::Single));
+        seq.push(SpiByte {
+            mode: IoMode::Single,
+            byte,
+        });
+        let input = SpiFlashInput::BytesSend(seq);
+        flash.input(&input).unwrap();
+
+        flash.input(&SpiFlashInput::CsHigh).unwrap();
+    }
+
+    #[test]
+    fn test_jedec_read_program_erase() {
+        let mut flash: SpiFlashImpl = Default::default();
+
+        // Enter 4ba
+        flash.input(&SpiFlashInput::CsLow).unwrap();
+        let input = SpiFlashInput::BytesSend(vec![encode_cmd(JedecSpiFlashCmd::Enter4ba)]);
+        flash.input(&input).unwrap();
+        flash.input(&SpiFlashInput::CsHigh).unwrap();
+
+        assert_eq!(jedec_read(&mut flash, JedecSpiFlashCmd::Read, 0), 0xff);
+
+        jedec_program_byte_4ba(&mut flash, 0, 0xab);
+        flash.time_pass(1000).unwrap();
+        jedec_program_byte_4ba(&mut flash, 1, 0xab);
+        flash.time_pass(1000).unwrap();
+        assert_eq!(jedec_read(&mut flash, JedecSpiFlashCmd::Read, 1), 0xab);
+        assert_eq!(jedec_read(&mut flash, JedecSpiFlashCmd::Read4ba, 1), 0xab);
+        assert_eq!(jedec_read(&mut flash, JedecSpiFlashCmd::FastRead, 1), 0xab);
+        assert_eq!(
+            jedec_read(&mut flash, JedecSpiFlashCmd::FastRead4ba, 1),
+            0xab
+        );
+        assert_eq!(
+            jedec_read(&mut flash, JedecSpiFlashCmd::FastReadDualOutput, 1),
+            0xab
+        );
+        assert_eq!(
+            jedec_read(&mut flash, JedecSpiFlashCmd::FastReadDualOutput4ba, 1),
+            0xab
+        );
+        assert_eq!(
+            jedec_read(&mut flash, JedecSpiFlashCmd::FastReadDualIO, 1),
+            0xab
+        );
+        assert_eq!(
+            jedec_read(&mut flash, JedecSpiFlashCmd::FastReadDualIO4ba, 1),
+            0xab
+        );
+
+        // Enable status write
+        flash.input(&SpiFlashInput::CsLow).unwrap();
+        let input = SpiFlashInput::BytesSend(vec![encode_cmd(JedecSpiFlashCmd::Ewsr)]);
+        flash.input(&input).unwrap();
+        flash.input(&SpiFlashInput::CsHigh).unwrap();
+
+        // Write status reg
+        flash.input(&SpiFlashInput::CsLow).unwrap();
+        let input = SpiFlashInput::BytesSend(vec![
+            encode_cmd(JedecSpiFlashCmd::Wrsr2),
+            SpiByte {
+                mode: IoMode::Single,
+                byte: 0x02,
+            },
+        ]);
+        flash.input(&input).unwrap();
+        flash.input(&SpiFlashInput::CsHigh).unwrap();
+        flash.time_pass(100).unwrap();
+
+        // Write enable latch
+        flash.input(&SpiFlashInput::CsLow).unwrap();
+        let input = SpiFlashInput::BytesSend(vec![encode_cmd(JedecSpiFlashCmd::WriteEnable)]);
+        flash.input(&input).unwrap();
+        flash.input(&SpiFlashInput::CsHigh).unwrap();
+
+        // Erase whole chip
+        flash.input(&SpiFlashInput::CsLow).unwrap();
+        let input = SpiFlashInput::BytesSend(vec![encode_cmd(JedecSpiFlashCmd::ChipErase60)]);
+        flash.input(&input).unwrap();
+        flash.input(&SpiFlashInput::CsHigh).unwrap();
+        flash.time_pass(1000000).unwrap();
+        assert_eq!(jedec_read(&mut flash, JedecSpiFlashCmd::Read, 1), 0xff);
+    }
+
+    #[test]
+    fn test_jedec_sfdp() {
+        let mut flash: SpiFlashImpl = Default::default();
+
+        flash.input(&SpiFlashInput::CsLow).unwrap();
+        let mut seq = vec![encode_cmd(JedecSpiFlashCmd::Sfdp)];
+        seq.append(&mut encode_addr(0, false, &IoMode::Single));
+
+        let input = SpiFlashInput::BytesSend(seq);
+        flash.input(&input).unwrap();
+        flash.input(&SpiFlashInput::DummyCycles(8)).unwrap();
+        let output = flash
+            .req_output(SpiFlashOutReq {
+                mode: IoMode::Single,
+                n_bytes: 256,
+            })
+            .unwrap();
+        assert_eq!(output.as_slice(), SpiFlashImpl::SUPPORTED_FLASH[0].sfdp);
+
+        flash.input(&SpiFlashInput::CsHigh).unwrap();
+    }
+
+    #[test]
+    fn test_jecec_reset() {
+        let mut flash: SpiFlashImpl = Default::default();
+        flash.input(&SpiFlashInput::CsLow).unwrap();
+        let input = SpiFlashInput::BytesSend(vec![encode_cmd(JedecSpiFlashCmd::ResetEnable)]);
+        flash.input(&input).unwrap();
+
+        flash.input(&SpiFlashInput::CsHigh).unwrap();
+
+        flash.input(&SpiFlashInput::CsLow).unwrap();
+        let input = SpiFlashInput::BytesSend(vec![encode_cmd(JedecSpiFlashCmd::Reset)]);
+        flash.input(&input).unwrap();
+
+        flash.input(&SpiFlashInput::CsHigh).unwrap();
+    }
+
+    #[test]
+    fn test_write_to_0x10_without_write_enable() {
+        let mut flash: SpiFlashImpl = Default::default();
+
+        // Try to write without enabling write first
+        flash.input(&SpiFlashInput::CsLow).unwrap();
+        let mut seq = vec![encode_cmd(JedecSpiFlashCmd::PageProgram)];
+
+        // Set address 0x10
+        seq.append(&mut encode_addr(0x10, false, &IoMode::Single));
+
+        // Write 0xAB to address 0x10
+        seq.push(SpiByte {
+            mode: IoMode::Single,
+            byte: 0xAB,
+        });
+        let input = SpiFlashInput::BytesSend(seq);
+        assert!(matches!(
+            flash.input(&input),
+            Err(SpiFlashErr::WriteDisabled)
+        ));
+
+        assert_eq!(
+            flash.input(&SpiFlashInput::CsHigh),
+            Err(SpiFlashErr::CommandNotSuccessful)
+        );
+    }
+
+    #[test]
+    fn test_erase_0x10_without_write_enable() {
+        let mut flash: SpiFlashImpl = Default::default();
+
+        // Try to erase without enabling write first
+        flash.input(&SpiFlashInput::CsLow).unwrap();
+
+        // Set address 0x10 and attempt sector erase command
+        let mut seq = vec![encode_cmd(JedecSpiFlashCmd::SectorErase)];
+        seq.append(&mut encode_addr(0x10, false, &IoMode::Single));
+
+        let input = SpiFlashInput::BytesSend(seq);
+        assert_eq!(flash.input(&input), Err(SpiFlashErr::WriteDisabled));
+
+        assert_eq!(
+            flash.input(&SpiFlashInput::CsHigh),
+            Err(SpiFlashErr::CommandNotSuccessful)
+        );
+    }
+}

--- a/emulator/periph/src/spi_host.rs
+++ b/emulator/periph/src/spi_host.rs
@@ -1,0 +1,881 @@
+/*++
+
+Licensed under the Apache-2.0 license.
+
+File Name:
+
+    spi_host.rs
+
+Abstract:
+
+    File contains SPI host emulation
+
+--*/
+
+use std::collections::VecDeque;
+use std::convert::TryInto;
+
+use emulator_bus::ReadWriteRegisterArray;
+use emulator_bus::{
+    ActionHandle, BusError, Clock, ReadOnlyRegister, ReadWriteRegister, Timer, WriteOnlyRegister,
+};
+use emulator_derive::Bus;
+use emulator_types::{RvData, RvSize};
+use tock_registers::fields::FieldValue;
+use tock_registers::interfaces::{ReadWriteable, Readable, Writeable};
+use tock_registers::register_bitfields;
+
+use crate::spi_flash::{self, IoMode, SpiByte, SpiFlashOutReq};
+use crate::spi_host::Command::LEN;
+use crate::spi_host::Status::RXEMPTY;
+
+use self::Command::{CSAAT, DIRECTION, SPEED};
+use self::Status::{ACTIVE, CMDQD, RXQD, RXWM, TXFULL, TXQD, TXWM};
+use crate::spi_flash::SpiFlash;
+
+use self::Control::{OUTPUT_EN, RX_WATERMARK, SPIEN, TX_WATERMARK};
+
+register_bitfields! [
+    u32,
+
+    /// Interrupt Status
+    InterruptState [
+        ERROR OFFSET(0) NUMBITS(1) [],
+        SPI_EVENT OFFSET(1) NUMBITS(1) [],
+    ],
+
+    /// Interrupt Enable
+    InterruptEnable [
+        ERROR OFFSET(0) NUMBITS(1) [],
+        SPI_EVENT OFFSET(1) NUMBITS(1) [],
+    ],
+
+    /// Interrupt Test
+    InterruptTest [
+        ERROR OFFSET(0) NUMBITS(1) [],
+        SPI_EVENT OFFSET(1) NUMBITS(1) [],
+    ],
+
+    /// Alert Test
+    AlertTest [
+        FATAL_FAULT OFFSET(0) NUMBITS(1) [],
+    ],
+
+    /// Control
+    Control [
+        RX_WATERMARK OFFSET(0) NUMBITS(8) [],
+        TX_WATERMARK OFFSET(8) NUMBITS(8) [],
+        OUTPUT_EN OFFSET(29) NUMBITS(1) [],
+        SW_RST OFFSET(30) NUMBITS(1) [],
+        SPIEN OFFSET(31) NUMBITS(1) [],
+    ],
+
+    /// Status
+    Status [
+        TXQD OFFSET(0) NUMBITS(8) [],
+        RXQD OFFSET(8) NUMBITS(8) [],
+        CMDQD OFFSET(16) NUMBITS(4) [],
+        RXWM OFFSET(20) NUMBITS(1) [],
+        BYTEORDER OFFSET(22) NUMBITS(1) [],
+        RXSTALL OFFSET(23) NUMBITS(1) [],
+        RXEMPTY OFFSET(24) NUMBITS(1) [],
+        RXFULL OFFSET(25) NUMBITS(1) [],
+        TXWM OFFSET(26) NUMBITS(1) [],
+        TXSTALL OFFSET(27) NUMBITS(1) [],
+        TXEMPTY OFFSET(28) NUMBITS(1) [],
+        TXFULL OFFSET(29) NUMBITS(1) [],
+        ACTIVE OFFSET(30) NUMBITS(1) [],
+        READY OFFSET(31) NUMBITS(1) [],
+    ],
+
+    /// Configopts
+    Configopts [
+        CLKDIV OFFSET(0) NUMBITS(16) [],
+        CSNIDLE OFFSET(16) NUMBITS(4) [],
+        CSNTRAIL OFFSET(20) NUMBITS(4) [],
+        CSNLEAD OFFSET(24) NUMBITS(4) [],
+        FULLCYC OFFSET(29) NUMBITS(1) [],
+        CPHA OFFSET(30) NUMBITS(1) [],
+        CPOL OFFSET(31) NUMBITS(1) [],
+    ],
+
+    /// Command
+    Command [
+        LEN OFFSET(0) NUMBITS(9) [],
+        CSAAT OFFSET(9) NUMBITS(1) [],
+        SPEED OFFSET(10) NUMBITS(2) [
+            SINGLE_IO = 0x0,
+            DUAL_IO = 0x1,
+            QUAD_IO = 0x3,
+        ],
+        DIRECTION OFFSET(12) NUMBITS(2) [
+            DUMMY = 0x0,
+            RX = 0x1,
+            TX = 0x2,
+            RX_TX = 0x3,
+        ],
+    ],
+
+    /// Error Enable
+    ErrorEnable [
+        CMDBUSY OFFSET(0) NUMBITS(1) [],
+        OVERFLOW OFFSET(1) NUMBITS(1) [],
+    ],
+
+    /// Error Status
+    ErrorStatus [
+        CMDBUSY OFFSET(0) NUMBITS(1) [],
+        OVERFLOW OFFSET(1) NUMBITS(1) [],
+        UNDERFLOW OFFSET(2) NUMBITS(1) [],
+        CMDINVAL OFFSET(3) NUMBITS(1) [],
+        CSIDINVAL OFFSET(4) NUMBITS(1) [],
+        ACCESSINVAL OFFSET(5) NUMBITS(1) [],
+    ],
+
+    /// Event Enable
+    EventEnable [
+        RXFULL OFFSET(0) NUMBITS(1) [],
+        TXEMPTY OFFSET(1) NUMBITS(1) [],
+        RXWM OFFSET(2) NUMBITS(1) [],
+        TXWN OFFSET(3) NUMBITS(1) [],
+        READY OFFSET(4) NUMBITS(1) [],
+        IDLE OFFSET(5) NUMBITS(1) [],
+    ],
+
+];
+
+/// SPI host peripheral
+#[derive(Bus)]
+#[poll_fn(bus_poll)]
+#[warm_reset_fn(warm_reset)]
+#[update_reset_fn(update_reset)]
+pub struct SpiHost {
+    /// Interrupt State
+    #[register(offset = 0x00)]
+    interrupt_state: ReadWriteRegister<u32, InterruptState::Register>,
+
+    /// Interrupt Enable
+    #[register(offset = 0x04)]
+    interrupt_enable: ReadWriteRegister<u32, InterruptEnable::Register>,
+
+    /// Interrupt Test
+    #[register(offset = 0x08)]
+    interrupt_test: WriteOnlyRegister<u32, InterruptTest::Register>,
+
+    /// Alert Test
+    #[register(offset = 0x0c)]
+    alert_test: WriteOnlyRegister<u32, AlertTest::Register>,
+
+    /// Control
+    #[register(offset = 0x10, write_fn = on_write_control)]
+    control: ReadWriteRegister<u32, Control::Register>,
+
+    /// Status
+    #[register(offset = 0x14, read_fn = on_read_status)]
+    status: ReadOnlyRegister<u32, Status::Register>,
+
+    /// Configopts
+    #[register_array(offset = 0x18)]
+    configopts: ReadWriteRegisterArray<u32, 2, Configopts::Register>,
+
+    /// CSID
+    #[register(offset = 0x20)]
+    csid: ReadWriteRegister<u32>,
+
+    /// Command
+    #[register(offset = 0x24, write_fn = on_write_command)]
+    command: WriteOnlyRegister<u32, Command::Register>,
+
+    /// RxData
+    #[register(offset = 0x28, read_fn = on_read_rx_data)]
+    rxdata: ReadOnlyRegister<u32>,
+
+    /// TxData
+    #[register(offset = 0x2c, write_fn = on_write_tx_data)]
+    txdata: WriteOnlyRegister<u32>,
+
+    /// Error Enable
+    #[register(offset = 0x30)]
+    error_enable: ReadWriteRegister<u32, ErrorEnable::Register>,
+
+    #[register(offset = 0x34)]
+    error_status: ReadWriteRegister<u32, ErrorStatus::Register>,
+
+    #[register(offset = 0x38)]
+    event_enable: ReadWriteRegister<u32, EventEnable::Register>,
+
+    /// CS state
+    cs_low: bool,
+
+    /// TXFIFO
+    tx_fifo: VecDeque<u8>,
+
+    /// RXFIFO
+    rx_fifo: VecDeque<u8>,
+
+    /// Segments
+    segments: VecDeque<u32>,
+
+    /// Timer
+    timer: Timer,
+
+    ready: Option<ActionHandle>,
+
+    command_complete: Option<ActionHandle>,
+
+    time_pass: Option<ActionHandle>,
+
+    /// Spi Flash 0
+    flash0: SpiFlash,
+}
+
+impl SpiHost {
+    const POLL_TIME: u64 = 1000;
+    const TX_RX_FIFO_SIZE_BYTES: usize = 1024;
+    const CMD_Q_SIZE: usize = 16;
+
+    pub fn new(clock: &Clock) -> Self {
+        Self {
+            interrupt_state: ReadWriteRegister::new(0),
+            interrupt_enable: ReadWriteRegister::new(0),
+            interrupt_test: WriteOnlyRegister::new(0),
+            alert_test: WriteOnlyRegister::new(0),
+            control: ReadWriteRegister::new(0x7f),
+            status: ReadOnlyRegister::new(0x400000),
+            configopts: ReadWriteRegisterArray::new(0),
+            csid: ReadWriteRegister::new(0),
+            command: WriteOnlyRegister::new(0),
+            rxdata: ReadOnlyRegister::new(0),
+            txdata: WriteOnlyRegister::new(0),
+            error_enable: ReadWriteRegister::new(0x1f),
+            error_status: ReadWriteRegister::new(0),
+            event_enable: ReadWriteRegister::new(0),
+            cs_low: false,
+            tx_fifo: VecDeque::with_capacity(Self::TX_RX_FIFO_SIZE_BYTES),
+            rx_fifo: VecDeque::with_capacity(Self::TX_RX_FIFO_SIZE_BYTES),
+            segments: VecDeque::with_capacity(Self::CMD_Q_SIZE),
+            timer: clock.timer(),
+            ready: None,
+            command_complete: None,
+            time_pass: None,
+            flash0: Default::default(),
+        }
+    }
+
+    fn spi_enabled(&self) -> bool {
+        self.control.reg.is_set(SPIEN)
+    }
+
+    fn output_enable(&self) -> bool {
+        self.control.reg.is_set(OUTPUT_EN)
+    }
+
+    fn reset(&mut self) {
+        self.control.reg.modify(
+            SPIEN::CLEAR
+                + OUTPUT_EN::CLEAR
+                + Control::TX_WATERMARK.val(0)
+                + Control::RX_WATERMARK.val(0x7f),
+        );
+        self.tx_fifo.clear();
+        self.rx_fifo.clear();
+        // TODO CMD que not cleared according to docs??
+        self.segments.clear();
+        self.status.reg.set(0x8040_0000);
+        self.configopts.iter_mut().for_each(|c| c.set(0));
+        self.csid.reg.set(0);
+        self.error_enable.reg.set(0x1f);
+        self.event_enable.reg.set(0);
+        self.ready = None;
+        self.command_complete = None;
+        self.time_pass = None;
+    }
+
+    /// On Write callback for `control` register
+    ///
+    /// # Arguments
+    ///
+    /// * `size` - Size of the write
+    /// * `val` - Data to write
+    ///
+    /// # Error
+    ///
+    /// * `BusError` - Exception with cause `BusError::StoreAccessFault` or `BusError::StoreAddrMisaligned`
+    pub fn on_write_control(&mut self, size: RvSize, val: RvData) -> Result<(), BusError> {
+        // Writes have to be Word aligned
+        if size != RvSize::Word {
+            Err(BusError::StoreAccessFault)?
+        }
+
+        // Set the control register
+        self.control.reg.set(val);
+
+        if self.control.reg.is_set(Control::SW_RST) {
+            self.reset();
+            // Clear the control register
+            self.control.reg.modify(Control::SW_RST::CLEAR)
+        }
+
+        if self.spi_enabled() {
+            self.time_pass = Some(self.timer.schedule_poll_in(Self::POLL_TIME));
+        } else {
+            self.time_pass = None;
+        }
+        Ok(())
+    }
+
+    /// On Read callback for `status` register
+    ///
+    /// # Arguments
+    ///
+    /// * `size` - Size of the write
+    ///
+    /// # Error
+    ///
+    pub fn on_read_status(&mut self, size: RvSize) -> Result<u32, BusError> {
+        // Writes have to be Word aligned
+        if size != RvSize::Word {
+            Err(BusError::StoreAccessFault)?
+        }
+        let tx_fifo_len = self.tx_fifo.len() as u32;
+        let txqd = tx_fifo_len / 4 + if tx_fifo_len % 4 == 0 { 0 } else { 1 };
+        let txwm = self.control.reg.read(TX_WATERMARK);
+
+        let rx_fifo_len = self.rx_fifo.len() as u32;
+        let rxqd = rx_fifo_len / 4 + if rx_fifo_len % 4 == 0 { 0 } else { 1 };
+        let rxwm = self.control.reg.read(RX_WATERMARK);
+
+        let cmdqd = self.segments.len() as u32;
+        self.status.reg.modify(
+            TXQD.val(txqd)
+                + RXQD.val(rxqd)
+                + CMDQD.val(cmdqd)
+                + RXWM.val((rxqd > rxwm).into())
+                + RXEMPTY.val((rx_fifo_len == 0).into())
+                + Status::RXFULL.val((rx_fifo_len == Self::TX_RX_FIFO_SIZE_BYTES as u32).into())
+                + TXWM.val((txqd > txwm).into())
+                + Status::TXEMPTY.val((tx_fifo_len == 0).into())
+                + TXFULL.val((tx_fifo_len == Self::TX_RX_FIFO_SIZE_BYTES as u32).into())
+                + ACTIVE.val((cmdqd > 0).into()),
+        );
+
+        Ok(self.status.reg.get())
+    }
+
+    fn scedule_next_command(&mut self, command: WriteOnlyRegister<u32, Command::Register>) {
+        if self.command_complete.is_some() {
+            return;
+        }
+
+        const READY_DELAY: u64 = 4;
+        // TODO scedule interrupt if enabled
+        self.ready = Some(self.timer.schedule_poll_in(READY_DELAY));
+        // TODO make configurable based on actual speed?
+        const CPU_CLOCK_PER_SPI_CLOCK: u64 = 8;
+        let spi_clocks_per_len: u64 = if command.reg.read(DIRECTION)
+            == <FieldValue<u32, Command::Register> as Into<u32>>::into(DIRECTION::DUMMY)
+        {
+            1
+        } else {
+            match command.reg.read_as_enum(SPEED).unwrap() {
+                SPEED::Value::SINGLE_IO => 8,
+                SPEED::Value::DUAL_IO => 4,
+                SPEED::Value::QUAD_IO => 2,
+            }
+        };
+        let len: u64 = (command.reg.read(LEN) + 1).into();
+        self.command_complete = Some(
+            self.timer
+                .schedule_poll_in(CPU_CLOCK_PER_SPI_CLOCK * len * spi_clocks_per_len),
+        );
+    }
+
+    /// On Write callback for `command` register
+    ///
+    /// # Arguments
+    ///
+    /// * `size` - Size of the write
+    /// * `val` - Data to write
+    ///
+    /// # Error
+    ///
+    /// * `BusError` - Exception with cause `BusError::StoreAccessFault` or `BusError::StoreAddrMisaligned`
+    pub fn on_write_command(&mut self, size: RvSize, val: RvData) -> Result<(), BusError> {
+        // Writes have to be Word aligned
+        if size != RvSize::Word {
+            Err(BusError::StoreAccessFault)?
+        }
+
+        if !self.spi_enabled() {
+            return Ok(());
+        }
+
+        let command: WriteOnlyRegister<u32, Command::Register> = WriteOnlyRegister::new(val);
+        let speed: SPEED::Value = command.reg.read_as_enum(SPEED).unwrap();
+        let direction: DIRECTION::Value = command.reg.read_as_enum(DIRECTION).unwrap();
+        if speed == SPEED::Value::QUAD_IO && direction == DIRECTION::Value::RX_TX {
+            todo!();
+        }
+
+        // Save command register
+        self.segments.push_back(val);
+
+        self.status.reg.modify(Status::READY::CLEAR);
+
+        self.scedule_next_command(command);
+        // TODO TX + RX WATERMARK
+
+        Ok(())
+    }
+
+    /// On Write callback for `tx_data` register
+    ///
+    /// # Arguments
+    ///
+    /// * `size` - Size of the write
+    /// * `val` - Data to write
+    ///
+    /// # Error
+    ///
+    /// * `BusError`
+    pub fn on_write_tx_data(&mut self, size: RvSize, val: RvData) -> Result<(), BusError> {
+        if !self.spi_enabled() {
+            return Ok(());
+        }
+
+        let is_little_endian = self.status.reg.is_set(Status::BYTEORDER);
+
+        if self.tx_fifo.len() + usize::from(size) > SpiHost::TX_RX_FIFO_SIZE_BYTES {
+            self.error_status.reg.modify(ErrorStatus::OVERFLOW::SET);
+            println!("Overflow TX Fifo");
+            return Ok(());
+        }
+
+        let range = if is_little_endian {
+            0..size.into()
+        } else {
+            size.into()..0
+        };
+
+        for i in range {
+            let byte = (val >> (i * 8)) & 0xff;
+            self.tx_fifo.push_back(byte.try_into().unwrap());
+        }
+        Ok(())
+    }
+
+    /// On Read callback for `rx_data` register
+    ///
+    /// # Arguments
+    ///
+    /// * `size` - Size of the write
+    ///
+    /// # Error
+    ///
+    /// * `BusError`
+    pub fn on_read_rx_data(&mut self, size: RvSize) -> Result<u32, BusError> {
+        if !self.spi_enabled() {
+            return Ok(0);
+        }
+
+        let is_little_endian = self.status.reg.is_set(Status::BYTEORDER);
+
+        if self.rx_fifo.len() < usize::from(size) {
+            self.error_status.reg.modify(ErrorStatus::UNDERFLOW::SET);
+            println!("Underflow RX Fifo");
+            return Ok(0);
+        }
+
+        let range = if is_little_endian {
+            0..size.into()
+        } else {
+            size.into()..0
+        };
+
+        Ok(range
+            .into_iter()
+            .map(|x| (x, self.rx_fifo.pop_front().unwrap())) // We checked for this earlier
+            .fold(0u32, |acc, (x, byte)| acc | (u32::from(byte) << (8 * x))))
+    }
+
+    fn segment_handle(&mut self) {
+        if !self.cs_low {
+            self.cs_low = true;
+            self.flash0.input(&spi_flash::SpiFlashInput::CsLow).unwrap();
+        }
+        let segment = self.segments.pop_front().unwrap();
+        let command: WriteOnlyRegister<u32, Command::Register> = WriteOnlyRegister::new(segment);
+        let mode = match command.reg.read_as_enum(SPEED).unwrap() {
+            SPEED::Value::SINGLE_IO => IoMode::Single,
+            SPEED::Value::DUAL_IO => IoMode::Dual,
+            SPEED::Value::QUAD_IO => IoMode::Quad,
+        };
+        if !self.output_enable() {
+            println!("Output not enabled");
+            return;
+        }
+        if self.csid.reg.get() != 0 {
+            println!("CS not set to 0 and only flash0 hooked up");
+            return;
+        }
+        // bytes to be send is LEN + 1
+        let size = usize::try_from(command.reg.read(LEN)).unwrap() + 1;
+        match command.reg.read_as_enum(DIRECTION).unwrap() {
+            DIRECTION::Value::DUMMY => self.flash0.input(&spi_flash::SpiFlashInput::DummyCycles(
+                command.reg.read(LEN),
+            )),
+            DIRECTION::Value::RX_TX => panic!("No SPI flash implements full duplex operations"),
+            DIRECTION::Value::RX => {
+                let fifo_remaining_size = SpiHost::TX_RX_FIFO_SIZE_BYTES - self.rx_fifo.len();
+                if size > fifo_remaining_size {
+                    todo!(); // FIFO overflow
+                }
+                let len = size.min(fifo_remaining_size);
+
+                let output_req = SpiFlashOutReq {
+                    mode,
+                    n_bytes: len.try_into().unwrap(),
+                };
+                match self.flash0.req_output(output_req) {
+                    Ok(out) => {
+                        self.rx_fifo.append(&mut out.into());
+                        Ok(())
+                    }
+                    Err(err) => Err(err),
+                }
+            }
+            DIRECTION::Value::TX => {
+                if size > self.tx_fifo.len() {
+                    // TODO set TXSTALL
+                    todo!();
+                }
+                let range = 0..size;
+                let input: Vec<SpiByte> = range
+                    .into_iter()
+                    .map(|_| SpiByte {
+                        byte: self.tx_fifo.pop_front().unwrap(),
+                        mode,
+                    })
+                    .collect();
+                self.flash0
+                    .input(&spi_flash::SpiFlashInput::BytesSend(input))
+            }
+        }
+        .unwrap_or_else(|e| {
+            println!(
+                "Spi flash reports error: {:?} on CMD {:x?}",
+                e,
+                command.reg.get()
+            )
+        });
+        if !command.reg.is_set(CSAAT) {
+            self.cs_low = false;
+            self.flash0
+                .input(&spi_flash::SpiFlashInput::CsHigh)
+                .unwrap_or_else(|e| {
+                    println!(
+                        "Spi flash reports error: {:?} on CMD {:x?}",
+                        e,
+                        command.reg.get()
+                    )
+                });
+        }
+    }
+
+    fn bus_poll(&mut self) {
+        if self.timer.fired(&mut self.ready) {
+            self.status.reg.modify(Status::READY::SET);
+        }
+        if self.timer.fired(&mut self.command_complete) {
+            self.segment_handle();
+            if let Some(segment) = self.segments.front() {
+                let command: WriteOnlyRegister<u32, Command::Register> =
+                    WriteOnlyRegister::new(*segment);
+                self.scedule_next_command(command);
+            }
+        }
+        if self.timer.fired(&mut self.time_pass) {
+            // Let the SPI flash know if some time has passed
+            if !self.cs_low {
+                self.flash0
+                    .time_pass(Self::POLL_TIME)
+                    .unwrap_or_else(|e| println!("Spi flash reports error: {:?}", e));
+            }
+            self.time_pass = Some(self.timer.schedule_poll_in(Self::POLL_TIME));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bitfield::Bit;
+    use emulator_bus::Bus;
+    use std::fmt::write;
+
+    const CONTROL_REG_OFFSET: RvData = 0x10;
+    const STATUS_REG_OFFSET: RvData = 0x14;
+    const COMMAND_REG_OFFSET: RvData = 0x24;
+    const RX_FIFO_OFFSET: RvData = 0x28;
+    const TX_FIFO_OFFSET: RvData = 0x2c;
+    const ERROR_STATUS_REG_OFFSET: RvData = 0x34;
+
+    const DUMMY_CYCLES_CMD: u32 = 0 << 12;
+    const RX_CMD: u32 = 1 << 12;
+    const TX_CMD: u32 = 2 << 12;
+    const SINGLE_CMD: u32 = 0 << 10;
+    const DUAL_CMD: u32 = 1 << 10;
+    const QUAD_CMD: u32 = 2 << 10;
+    const CSAAT_BIT: u32 = 1 << 9;
+
+    struct SpiXfer<'a> {
+        cmd: u8,
+        addr_mode: spi_flash::IoMode,
+        addr: &'a [u8],
+        mode_clocks: u8,
+        dummy_clocks: u8,
+        receive_mode: spi_flash::IoMode,
+        receive_len: usize,
+    }
+
+    fn spi_xfer(clock: &Clock, spi_host: &mut SpiHost, xfer: &SpiXfer) -> Result<Vec<u8>, String> {
+        let wait_for_ready = |clock: &Clock, spi_host: &mut SpiHost| {
+            while !spi_host
+                .read(RvSize::Word, STATUS_REG_OFFSET)
+                .unwrap()
+                .bit(31)
+            {
+                clock.increment_and_process_timer_actions(1, spi_host);
+            }
+        };
+
+        let wait_for_done = |clock: &Clock, spi_host: &mut SpiHost| {
+            while spi_host
+                .read(RvSize::Word, STATUS_REG_OFFSET)
+                .unwrap()
+                .bit(30)
+            {
+                clock.increment_and_process_timer_actions(1, spi_host);
+            }
+        };
+
+        let encode_speed = |mode| match mode {
+            spi_flash::IoMode::Single => SINGLE_CMD,
+            spi_flash::IoMode::Dual => DUAL_CMD,
+            spi_flash::IoMode::Quad => QUAD_CMD,
+        };
+
+        // CMD
+        spi_host
+            .write(RvSize::Byte, TX_FIFO_OFFSET, xfer.cmd.into())
+            .unwrap();
+        let cs_high = xfer.addr.is_empty()
+            && xfer.mode_clocks == 0
+            && xfer.dummy_clocks == 0
+            && xfer.receive_len == 0;
+        spi_host
+            .write(
+                RvSize::Word,
+                COMMAND_REG_OFFSET,
+                TX_CMD | SINGLE_CMD | if cs_high { 0 } else { CSAAT_BIT },
+            )
+            .unwrap();
+        wait_for_ready(clock, spi_host);
+
+        // ADDR
+        if !xfer.addr.is_empty() {
+            xfer.addr.iter().for_each(|b| {
+                spi_host
+                    .write(RvSize::Byte, TX_FIFO_OFFSET, (*b).into())
+                    .unwrap()
+            });
+            let cs_high = xfer.mode_clocks == 0 && xfer.dummy_clocks == 0 && xfer.receive_len == 0;
+            let spi_len: u32 = (xfer.addr.len() - 1).try_into().unwrap();
+            spi_host
+                .write(
+                    RvSize::Word,
+                    COMMAND_REG_OFFSET,
+                    TX_CMD
+                        | encode_speed(xfer.addr_mode)
+                        | if cs_high { 0 } else { CSAAT_BIT }
+                        | spi_len,
+                )
+                .unwrap();
+            wait_for_ready(clock, spi_host);
+        }
+
+        // Mode Clocks
+        if xfer.mode_clocks != 0 {
+            let divisor = match xfer.addr_mode {
+                spi_flash::IoMode::Single => 8,
+                spi_flash::IoMode::Dual => 4,
+                spi_flash::IoMode::Quad => 2,
+            };
+            (0..(xfer.mode_clocks / divisor))
+                .for_each(|_| spi_host.write(RvSize::Byte, TX_FIFO_OFFSET, 0xff).unwrap());
+
+            let cs_high = xfer.dummy_clocks == 0 && xfer.receive_len == 0;
+            let spi_len: u32 = (xfer.mode_clocks / divisor - 1).try_into().unwrap();
+            spi_host
+                .write(
+                    RvSize::Word,
+                    COMMAND_REG_OFFSET,
+                    TX_CMD
+                        | encode_speed(xfer.addr_mode)
+                        | if cs_high { 0 } else { CSAAT_BIT }
+                        | spi_len,
+                )
+                .unwrap();
+            wait_for_ready(clock, spi_host);
+        }
+
+        // DummyCycles
+        if xfer.dummy_clocks != 0 {
+            let cs_high = xfer.receive_len == 0;
+            let spi_len: u32 = (xfer.dummy_clocks - 1).try_into().unwrap();
+            spi_host
+                .write(
+                    RvSize::Word,
+                    COMMAND_REG_OFFSET,
+                    DUMMY_CYCLES_CMD | SINGLE_CMD | if cs_high { 0 } else { CSAAT_BIT } | spi_len,
+                )
+                .unwrap();
+            wait_for_ready(clock, spi_host);
+        }
+
+        // RX bytes
+        let ret = if xfer.receive_len == 0 {
+            Ok(Vec::new())
+        } else {
+            let spi_len: u32 = (xfer.receive_len - 1).try_into().unwrap();
+            spi_host
+                .write(
+                    RvSize::Word,
+                    COMMAND_REG_OFFSET,
+                    RX_CMD | encode_speed(xfer.receive_mode) | spi_len,
+                )
+                .unwrap();
+            wait_for_ready(clock, spi_host);
+            wait_for_done(clock, spi_host);
+
+            let resp: Vec<u8> = (0..xfer.receive_len)
+                .map(|_| {
+                    spi_host
+                        .read(RvSize::Byte, RX_FIFO_OFFSET)
+                        .unwrap()
+                        .try_into()
+                        .unwrap()
+                })
+                .collect();
+            Ok(resp)
+        };
+        let error = spi_host
+            .read(RvSize::Word, ERROR_STATUS_REG_OFFSET)
+            .unwrap();
+        if error != 0 {
+            let mut string = String::new();
+            write(&mut string, format_args!("Spi Host has an error {}", error)).unwrap();
+            Err(string)
+        } else {
+            ret
+        }
+    }
+
+    #[test]
+    fn test_spi_rdid() {
+        let clock = Clock::new();
+        let mut spi_host = SpiHost::new(&clock);
+        // Enable SPI, reset + output enable
+        spi_host
+            .write(RvSize::Word, CONTROL_REG_OFFSET, 0xa000_007f)
+            .unwrap();
+
+        let xfer = SpiXfer {
+            cmd: 0x9f,
+            addr: &[],
+            addr_mode: IoMode::Single,
+            mode_clocks: 0,
+            dummy_clocks: 0,
+            receive_len: 3,
+            receive_mode: IoMode::Single,
+        };
+
+        let receive = spi_xfer(&clock, &mut spi_host, &xfer).unwrap();
+        assert_eq!(receive.as_slice(), &[0xef, 0x40, 0x21]);
+
+        // Do it twice
+        let receive = spi_xfer(&clock, &mut spi_host, &xfer).unwrap();
+        assert_eq!(receive.as_slice(), &[0xef, 0x40, 0x21]);
+    }
+
+    #[test]
+    fn test_spi_read_program_erase() {
+        let clock = Clock::new();
+        let mut spi_host = SpiHost::new(&clock);
+        // Enable SPI, reset + output enable
+        spi_host
+            .write(RvSize::Word, CONTROL_REG_OFFSET, 0xa000_007f)
+            .unwrap();
+
+        // Read 4ba at addr 5
+        let read_xfer = SpiXfer {
+            cmd: 0x13,
+            addr: &[0x00, 0x00, 0x00, 0x05],
+            addr_mode: IoMode::Single,
+            mode_clocks: 0,
+            dummy_clocks: 0,
+            receive_len: 1,
+            receive_mode: IoMode::Single,
+        };
+        let receive = spi_xfer(&clock, &mut spi_host, &read_xfer).unwrap();
+        assert_eq!(receive.as_slice(), &[0xff]);
+
+        let enable_write_xfer = SpiXfer {
+            cmd: 0x06,
+            addr: &[],
+            addr_mode: IoMode::Single,
+            mode_clocks: 0,
+            dummy_clocks: 0,
+            receive_len: 0,
+            receive_mode: IoMode::Single,
+        };
+        spi_xfer(&clock, &mut spi_host, &enable_write_xfer).unwrap();
+
+        // Page program 4ba: addr 5 set to 0xab
+        let page_program_xfer = SpiXfer {
+            cmd: 0x12,
+            addr: &[0x00, 0x00, 0x00, 0x05, 0xab],
+            addr_mode: IoMode::Single,
+            mode_clocks: 0,
+            dummy_clocks: 0,
+            receive_len: 0,
+            receive_mode: IoMode::Single,
+        };
+        spi_xfer(&clock, &mut spi_host, &page_program_xfer).unwrap();
+        // Wait some time
+        for _ in 0..10 {
+            clock.increment_and_process_timer_actions(1000, &mut spi_host);
+        }
+        let receive = spi_xfer(&clock, &mut spi_host, &read_xfer).unwrap();
+        assert_eq!(receive.as_slice(), &[0xab]);
+
+        // Erase chip
+        let chip_erase_xfer = SpiXfer {
+            cmd: 0x60,
+            addr: &[],
+            addr_mode: IoMode::Single,
+            mode_clocks: 0,
+            dummy_clocks: 0,
+            receive_len: 0,
+            receive_mode: IoMode::Single,
+        };
+        spi_xfer(&clock, &mut spi_host, &enable_write_xfer).unwrap();
+        spi_xfer(&clock, &mut spi_host, &chip_erase_xfer).unwrap();
+        // Wait some time
+        for _ in 0..1000 {
+            clock.increment_and_process_timer_actions(1000, &mut spi_host);
+        }
+        let receive = spi_xfer(&clock, &mut spi_host, &read_xfer).unwrap();
+        assert_eq!(receive.as_slice(), &[0xff]);
+    }
+}


### PR DESCRIPTION
This PR is to port SPI host and flash emulation code from another repo into MCU emulator.

Reference: 
https://github.com/Azure/caliptra-sw-mirror/blob/main/sw-emulator/lib/periph/src/spi_host.rs
https://github.com/Azure/caliptra-sw-mirror/blob/main/sw-emulator/lib/periph/src/spi_flash.rs 