### PR TITLE
registers: Correct relative offset and RW for autogenerated bus

### DIFF
--- a/registers/generated-emulator/src/I3CCSR.rs
+++ b/registers/generated-emulator/src/I3CCSR.rs
@@ -1259,6 +1259,12 @@ impl emulator_bus::Bus for I3ccsrBus {
             (emulator_types::RvSize::Word, 0x801..=0x803) => {
                 Err(emulator_bus::BusError::LoadAddrMisaligned)
             }
+            (emulator_types::RvSize::Word, 0) => Ok(emulator_types::RvData::from(
+                self.periph.read_i3c_base_hci_version(),
+            )),
+            (emulator_types::RvSize::Word, 1..=3) => {
+                Err(emulator_bus::BusError::LoadAddrMisaligned)
+            }
             (emulator_types::RvSize::Word, 4) => Ok(emulator_types::RvData::from(
                 self.periph.read_i3c_base_hc_control().reg.get(),
             )),
@@ -1385,14 +1391,14 @@ impl emulator_bus::Bus for I3ccsrBus {
             (emulator_types::RvSize::Word, 0x69..=0x6b) => {
                 Err(emulator_bus::BusError::LoadAddrMisaligned)
             }
-            (emulator_types::RvSize::Word, 0x80) => Ok(emulator_types::RvData::from(
-                self.periph.read_piocontrol_command_port(),
+            (emulator_types::RvSize::Word, 0x84) => Ok(emulator_types::RvData::from(
+                self.periph.read_piocontrol_response_port(),
             )),
-            (emulator_types::RvSize::Word, 0x81..=0x83) => {
+            (emulator_types::RvSize::Word, 0x85..=0x87) => {
                 Err(emulator_bus::BusError::LoadAddrMisaligned)
             }
             (emulator_types::RvSize::Word, 0x88) => Ok(emulator_types::RvData::from(
-                self.periph.read_piocontrol_tx_data_port(),
+                self.periph.read_piocontrol_rx_data_port(),
             )),
             (emulator_types::RvSize::Word, 0x89..=0x8b) => {
                 Err(emulator_bus::BusError::LoadAddrMisaligned)
@@ -1812,22 +1818,16 @@ impl emulator_bus::Bus for I3ccsrBus {
             (emulator_types::RvSize::Word, 0x1d9..=0x1db) => {
                 Err(emulator_bus::BusError::LoadAddrMisaligned)
             }
-            (emulator_types::RvSize::Word, 0x1e4) => Ok(emulator_types::RvData::from(
-                self.periph.read_i3c_ec_tti_tx_desc_queue_port(),
+            (emulator_types::RvSize::Word, 0x1dc) => Ok(emulator_types::RvData::from(
+                self.periph.read_i3c_ec_tti_rx_desc_queue_port(),
             )),
-            (emulator_types::RvSize::Word, 0x1e5..=0x1e7) => {
+            (emulator_types::RvSize::Word, 0x1dd..=0x1df) => {
                 Err(emulator_bus::BusError::LoadAddrMisaligned)
             }
-            (emulator_types::RvSize::Word, 0x1e8) => Ok(emulator_types::RvData::from(
-                self.periph.read_i3c_ec_tti_tx_data_port(),
+            (emulator_types::RvSize::Word, 0x1e0) => Ok(emulator_types::RvData::from(
+                self.periph.read_i3c_ec_tti_rx_data_port(),
             )),
-            (emulator_types::RvSize::Word, 0x1e9..=0x1eb) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1ec) => Ok(emulator_types::RvData::from(
-                self.periph.read_i3c_ec_tti_tti_ibi_port(),
-            )),
-            (emulator_types::RvSize::Word, 0x1ed..=0x1ef) => {
+            (emulator_types::RvSize::Word, 0x1e1..=0x1e3) => {
                 Err(emulator_bus::BusError::LoadAddrMisaligned)
             }
             (emulator_types::RvSize::Word, 0x1f0) => Ok(emulator_types::RvData::from(
@@ -2037,13 +2037,6 @@ impl emulator_bus::Bus for I3ccsrBus {
             (emulator_types::RvSize::Word, 0x801..=0x803) => {
                 Err(emulator_bus::BusError::StoreAddrMisaligned)
             }
-            (emulator_types::RvSize::Word, 0) => {
-                self.periph.write_i3c_base_hci_version(val);
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 1..=3) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
             (emulator_types::RvSize::Word, 4) => {
                 self.periph
                     .write_i3c_base_hc_control(emulator_bus::ReadWriteRegister::new(val));
@@ -2207,15 +2200,15 @@ impl emulator_bus::Bus for I3ccsrBus {
             (emulator_types::RvSize::Word, 0x69..=0x6b) => {
                 Err(emulator_bus::BusError::StoreAddrMisaligned)
             }
-            (emulator_types::RvSize::Word, 0x84) => {
-                self.periph.write_piocontrol_response_port(val);
+            (emulator_types::RvSize::Word, 0x80) => {
+                self.periph.write_piocontrol_command_port(val);
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x85..=0x87) => {
+            (emulator_types::RvSize::Word, 0x81..=0x83) => {
                 Err(emulator_bus::BusError::StoreAddrMisaligned)
             }
             (emulator_types::RvSize::Word, 0x88) => {
-                self.periph.write_piocontrol_rx_data_port(val);
+                self.periph.write_piocontrol_tx_data_port(val);
                 Ok(())
             }
             (emulator_types::RvSize::Word, 0x89..=0x8b) => {
@@ -2705,18 +2698,25 @@ impl emulator_bus::Bus for I3ccsrBus {
             (emulator_types::RvSize::Word, 0x1d9..=0x1db) => {
                 Err(emulator_bus::BusError::StoreAddrMisaligned)
             }
-            (emulator_types::RvSize::Word, 0x1dc) => {
-                self.periph.write_i3c_ec_tti_rx_desc_queue_port(val);
+            (emulator_types::RvSize::Word, 0x1e4) => {
+                self.periph.write_i3c_ec_tti_tx_desc_queue_port(val);
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x1dd..=0x1df) => {
+            (emulator_types::RvSize::Word, 0x1e5..=0x1e7) => {
                 Err(emulator_bus::BusError::StoreAddrMisaligned)
             }
-            (emulator_types::RvSize::Word, 0x1e0) => {
-                self.periph.write_i3c_ec_tti_rx_data_port(val);
+            (emulator_types::RvSize::Word, 0x1e8) => {
+                self.periph.write_i3c_ec_tti_tx_data_port(val);
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x1e1..=0x1e3) => {
+            (emulator_types::RvSize::Word, 0x1e9..=0x1eb) => {
+                Err(emulator_bus::BusError::StoreAddrMisaligned)
+            }
+            (emulator_types::RvSize::Word, 0x1ec) => {
+                self.periph.write_i3c_ec_tti_tti_ibi_port(val);
+                Ok(())
+            }
+            (emulator_types::RvSize::Word, 0x1ed..=0x1ef) => {
                 Err(emulator_bus::BusError::StoreAddrMisaligned)
             }
             (emulator_types::RvSize::Word, 0x1f0) => {

--- a/registers/generated-emulator/src/mbox.rs
+++ b/registers/generated-emulator/src/mbox.rs
@@ -97,6 +97,12 @@ impl emulator_bus::Bus for MboxBus {
             (emulator_types::RvSize::Word, 1..=3) => {
                 Err(emulator_bus::BusError::LoadAddrMisaligned)
             }
+            (emulator_types::RvSize::Word, 4) => {
+                Ok(emulator_types::RvData::from(self.periph.read_id()))
+            }
+            (emulator_types::RvSize::Word, 5..=7) => {
+                Err(emulator_bus::BusError::LoadAddrMisaligned)
+            }
             (emulator_types::RvSize::Word, 8) => {
                 Ok(emulator_types::RvData::from(self.periph.read_cmd()))
             }
@@ -155,13 +161,6 @@ impl emulator_bus::Bus for MboxBus {
                 Ok(())
             }
             (emulator_types::RvSize::Word, 1..=3) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 4) => {
-                self.periph.write_id(val);
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 5..=7) => {
                 Err(emulator_bus::BusError::StoreAddrMisaligned)
             }
             (emulator_types::RvSize::Word, 8) => {

--- a/registers/generated-emulator/src/root_bus.rs
+++ b/registers/generated-emulator/src/root_bus.rs
@@ -40,35 +40,35 @@ impl emulator_bus::Bus for AutoRootBus {
         let result = match addr {
             0x2000_4000..=0x2000_5988 => {
                 if let Some(periph) = self.i3c_csr_periph.as_mut() {
-                    periph.read(size, addr)
+                    periph.read(size, addr - 0x2000_4000)
                 } else {
                     Err(emulator_bus::BusError::LoadAccessFault)
                 }
             }
             0x3002_0000..=0x3002_00b4 => {
                 if let Some(periph) = self.mbox_periph.as_mut() {
-                    periph.read(size, addr)
+                    periph.read(size, addr - 0x3002_0000)
                 } else {
                     Err(emulator_bus::BusError::LoadAccessFault)
                 }
             }
             0x3002_1000..=0x3002_289c => {
                 if let Some(periph) = self.sha512_acc_periph.as_mut() {
-                    periph.read(size, addr)
+                    periph.read(size, addr - 0x3002_1000)
                 } else {
                     Err(emulator_bus::BusError::LoadAccessFault)
                 }
             }
             0x3003_0000..=0x3003_91c0 => {
                 if let Some(periph) = self.soc_periph.as_mut() {
-                    periph.read(size, addr)
+                    periph.read(size, addr - 0x3003_0000)
                 } else {
                     Err(emulator_bus::BusError::LoadAccessFault)
                 }
             }
             0x6000_0000..=0x6000_f018 => {
                 if let Some(periph) = self.el2_pic_periph.as_mut() {
-                    periph.read(size, addr)
+                    periph.read(size, addr - 0x6000_0000)
                 } else {
                     Err(emulator_bus::BusError::LoadAccessFault)
                 }
@@ -93,35 +93,35 @@ impl emulator_bus::Bus for AutoRootBus {
         let result = match addr {
             0x2000_4000..=0x2000_5988 => {
                 if let Some(periph) = self.i3c_csr_periph.as_mut() {
-                    periph.write(size, addr, val)
+                    periph.write(size, addr - 0x2000_4000, val)
                 } else {
                     Err(emulator_bus::BusError::StoreAccessFault)
                 }
             }
             0x3002_0000..=0x3002_00b4 => {
                 if let Some(periph) = self.mbox_periph.as_mut() {
-                    periph.write(size, addr, val)
+                    periph.write(size, addr - 0x3002_0000, val)
                 } else {
                     Err(emulator_bus::BusError::StoreAccessFault)
                 }
             }
             0x3002_1000..=0x3002_289c => {
                 if let Some(periph) = self.sha512_acc_periph.as_mut() {
-                    periph.write(size, addr, val)
+                    periph.write(size, addr - 0x3002_1000, val)
                 } else {
                     Err(emulator_bus::BusError::StoreAccessFault)
                 }
             }
             0x3003_0000..=0x3003_91c0 => {
                 if let Some(periph) = self.soc_periph.as_mut() {
-                    periph.write(size, addr, val)
+                    periph.write(size, addr - 0x3003_0000, val)
                 } else {
                     Err(emulator_bus::BusError::StoreAccessFault)
                 }
             }
             0x6000_0000..=0x6000_f018 => {
                 if let Some(periph) = self.el2_pic_periph.as_mut() {
-                    periph.write(size, addr, val)
+                    periph.write(size, addr - 0x6000_0000, val)
                 } else {
                     Err(emulator_bus::BusError::StoreAccessFault)
                 }

--- a/registers/generated-emulator/src/sha512_acc.rs
+++ b/registers/generated-emulator/src/sha512_acc.rs
@@ -363,6 +363,12 @@ impl emulator_bus::Bus for Sha512AccBus {
             (emulator_types::RvSize::Word, 1..=3) => {
                 Err(emulator_bus::BusError::LoadAddrMisaligned)
             }
+            (emulator_types::RvSize::Word, 4) => {
+                Ok(emulator_types::RvData::from(self.periph.read_id()))
+            }
+            (emulator_types::RvSize::Word, 5..=7) => {
+                Err(emulator_bus::BusError::LoadAddrMisaligned)
+            }
             (emulator_types::RvSize::Word, 8) => Ok(emulator_types::RvData::from(
                 self.periph.read_mode().reg.get(),
             )),
@@ -397,6 +403,12 @@ impl emulator_bus::Bus for Sha512AccBus {
                 self.periph.read_status().reg.get(),
             )),
             (emulator_types::RvSize::Word, 0x1d..=0x1f) => {
+                Err(emulator_bus::BusError::LoadAddrMisaligned)
+            }
+            (emulator_types::RvSize::Word, 0x20) => {
+                Ok(emulator_types::RvData::from(self.periph.read_digest()))
+            }
+            (emulator_types::RvSize::Word, 0x21..=0x23) => {
                 Err(emulator_bus::BusError::LoadAddrMisaligned)
             }
             (emulator_types::RvSize::Word, 0x60) => Ok(emulator_types::RvData::from(
@@ -564,13 +576,6 @@ impl emulator_bus::Bus for Sha512AccBus {
             (emulator_types::RvSize::Word, 1..=3) => {
                 Err(emulator_bus::BusError::StoreAddrMisaligned)
             }
-            (emulator_types::RvSize::Word, 4) => {
-                self.periph.write_id(val);
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 5..=7) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
             (emulator_types::RvSize::Word, 8) => {
                 self.periph
                     .write_mode(emulator_bus::ReadWriteRegister::new(val));
@@ -614,13 +619,6 @@ impl emulator_bus::Bus for Sha512AccBus {
                 Ok(())
             }
             (emulator_types::RvSize::Word, 0x1d..=0x1f) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x20) => {
-                self.periph.write_digest(val);
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0x21..=0x23) => {
                 Err(emulator_bus::BusError::StoreAddrMisaligned)
             }
             (emulator_types::RvSize::Word, 0x60) => {

--- a/registers/generated-emulator/src/soc.rs
+++ b/registers/generated-emulator/src/soc.rs
@@ -1237,6 +1237,12 @@ impl emulator_bus::Bus for SocBus {
             (emulator_types::RvSize::Word, 0xc1..=0xc3) => {
                 Err(emulator_bus::BusError::LoadAddrMisaligned)
             }
+            (emulator_types::RvSize::Word, 0xc4) => Ok(emulator_types::RvData::from(
+                self.periph.read_cptra_generic_input_wires(),
+            )),
+            (emulator_types::RvSize::Word, 0xc5..=0xc7) => {
+                Err(emulator_bus::BusError::LoadAddrMisaligned)
+            }
             (emulator_types::RvSize::Word, 0xcc) => Ok(emulator_types::RvData::from(
                 self.periph.read_cptra_generic_output_wires(),
             )),
@@ -1339,18 +1345,6 @@ impl emulator_bus::Bus for SocBus {
             (emulator_types::RvSize::Word, 0x121..=0x123) => {
                 Err(emulator_bus::BusError::LoadAddrMisaligned)
             }
-            (emulator_types::RvSize::Word, 0x200) => Ok(emulator_types::RvData::from(
-                self.periph.read_fuse_uds_seed(),
-            )),
-            (emulator_types::RvSize::Word, 0x201..=0x203) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x230) => Ok(emulator_types::RvData::from(
-                self.periph.read_fuse_field_entropy(),
-            )),
-            (emulator_types::RvSize::Word, 0x231..=0x233) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
             (emulator_types::RvSize::Word, 0x250) => Ok(emulator_types::RvData::from(
                 self.periph.read_fuse_key_manifest_pk_hash(),
             )),
@@ -1421,12 +1415,6 @@ impl emulator_bus::Bus for SocBus {
                 self.periph.read_fuse_soc_stepping_id().reg.get(),
             )),
             (emulator_types::RvSize::Word, 0x349..=0x34b) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x600) => Ok(emulator_types::RvData::from(
-                self.periph.read_internal_obf_key(),
-            )),
-            (emulator_types::RvSize::Word, 0x601..=0x603) => {
                 Err(emulator_bus::BusError::LoadAddrMisaligned)
             }
             (emulator_types::RvSize::Word, 0x620) => Ok(emulator_types::RvData::from(
@@ -1976,13 +1964,6 @@ impl emulator_bus::Bus for SocBus {
             (emulator_types::RvSize::Word, 0xc1..=0xc3) => {
                 Err(emulator_bus::BusError::StoreAddrMisaligned)
             }
-            (emulator_types::RvSize::Word, 0xc4) => {
-                self.periph.write_cptra_generic_input_wires(val);
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0xc5..=0xc7) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
             (emulator_types::RvSize::Word, 0xcc) => {
                 self.periph.write_cptra_generic_output_wires(val);
                 Ok(())
@@ -2112,6 +2093,20 @@ impl emulator_bus::Bus for SocBus {
             (emulator_types::RvSize::Word, 0x121..=0x123) => {
                 Err(emulator_bus::BusError::StoreAddrMisaligned)
             }
+            (emulator_types::RvSize::Word, 0x200) => {
+                self.periph.write_fuse_uds_seed(val);
+                Ok(())
+            }
+            (emulator_types::RvSize::Word, 0x201..=0x203) => {
+                Err(emulator_bus::BusError::StoreAddrMisaligned)
+            }
+            (emulator_types::RvSize::Word, 0x230) => {
+                self.periph.write_fuse_field_entropy(val);
+                Ok(())
+            }
+            (emulator_types::RvSize::Word, 0x231..=0x233) => {
+                Err(emulator_bus::BusError::StoreAddrMisaligned)
+            }
             (emulator_types::RvSize::Word, 0x250) => {
                 self.periph.write_fuse_key_manifest_pk_hash(val);
                 Ok(())
@@ -2200,6 +2195,13 @@ impl emulator_bus::Bus for SocBus {
                 Ok(())
             }
             (emulator_types::RvSize::Word, 0x349..=0x34b) => {
+                Err(emulator_bus::BusError::StoreAddrMisaligned)
+            }
+            (emulator_types::RvSize::Word, 0x600) => {
+                self.periph.write_internal_obf_key(val);
+                Ok(())
+            }
+            (emulator_types::RvSize::Word, 0x601..=0x603) => {
                 Err(emulator_bus::BusError::StoreAddrMisaligned)
             }
             (emulator_types::RvSize::Word, 0x620) => {


### PR DESCRIPTION
The offset was not being adjusted correctly to be relative to the peripheral's base address.

We also had read/write reversed.