### PR TITLE
Compile with unaligned-scalar-mem feature

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,4 +4,8 @@
 xtask = "run --package xtask --"
 
 [target.riscv32imc-unknown-none-elf]
-rustflags = ["-C", "panic=abort"]
+rustflags = [
+    "-C panic=abort",
+    "-C target-feature=+relax,+unaligned-scalar-mem",
+    "-C force-frame-pointers=no"
+]

--- a/xtask/src/apps_build.rs
+++ b/xtask/src/apps_build.rs
@@ -1,6 +1,6 @@
 // Licensed under the Apache-2.0 license
 
-use crate::runtime_build::{objcopy, target_binary, OBJCOPY_FLAGS};
+use crate::runtime_build::{objcopy, target_binary, OBJCOPY_FLAGS, RUSTFLAGS_COMMON};
 use crate::tbf::TbfHeader;
 use crate::{DynError, PROJECT_ROOT, TARGET};
 use std::process::Command;
@@ -114,12 +114,14 @@ INCLUDE runtime/apps/app_layout.ld",
         ),
     )?;
 
+    let ld_flag = format!("-C link-arg=-T{}", layout_ld.display());
+    let mut rustc_flags = Vec::from(RUSTFLAGS_COMMON);
+    rustc_flags.push(ld_flag.as_str());
+    let rustc_flags = rustc_flags.join(" ");
+
     let status = Command::new("cargo")
         .current_dir(&*PROJECT_ROOT)
-        .env(
-            "RUSTFLAGS",
-            format!("-C link-arg=-T{}", layout_ld.display()),
-        )
+        .env("RUSTFLAGS", rustc_flags)
         .env("LIBTOCK_LINKER_FLASH", format!("0x{:x}", offset))
         .env("LIBTOCK_LINKER_FLASH_LENGTH", "128K")
         .env("LIBTOCK_LINKER_RAM", "0x50000000")

--- a/xtask/src/rom.rs
+++ b/xtask/src/rom.rs
@@ -1,12 +1,17 @@
 // Licensed under the Apache-2.0 license
 
+use crate::runtime_build::RUSTFLAGS_COMMON;
 use crate::{runtime_build::objcopy, DynError, PROJECT_ROOT, TARGET};
 use std::process::Command;
 
 pub fn rom_build() -> Result<(), DynError> {
+    let mut rustc_flags = Vec::from(RUSTFLAGS_COMMON);
+    rustc_flags.push("-C link-arg=-Trom/layout.ld");
+    let rustc_flags = rustc_flags.join(" ");
+
     let status = Command::new("cargo")
         .current_dir(&*PROJECT_ROOT)
-        .env("RUSTFLAGS", "-C link-arg=-Trom/layout.ld")
+        .env("RUSTFLAGS", rustc_flags)
         .args(["b", "-p", "rom", "--release", "--target", TARGET])
         .status()?;
     if !status.success() {


### PR DESCRIPTION
This optimizes memory reads and writes so that they don't have to be aligned, as this is not required for our CPU.

This saves abot 3 KB of instruction space in the runtime binary.

The VeeR CPU also supports bit manipulation instructions, but we don't have complete support for those in the emulator, so I left that as a TODO. That saves a few hundred bytes more (for now).