### PR TITLE
Remove atty from dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,17 +99,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -907,7 +896,6 @@ dependencies = [
 name = "emulator"
 version = "0.1.0"
 dependencies = [
- "atty",
  "caliptra-emu-cpu",
  "caliptra-emu-periph",
  "clap 4.5.21",
@@ -1161,15 +1149,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "hex"
@@ -2420,22 +2399,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
 name = "winapi-util"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2443,12 +2406,6 @@ checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
  "windows-sys 0.59.0",
 ]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ authors = ["Caliptra contributors"]
 
 [workspace.dependencies]
 arrayref = "0.3.6"
-atty = "0.2.14"
 bitfield = "0.14.0"
 bit-vec = "0.6.3"
 clap = { version = "4.5.11", features = [

--- a/emulator/app/Cargo.toml
+++ b/emulator/app/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atty.workspace = true
 caliptra-emu-cpu.workspace = true
 caliptra-emu-periph.workspace = true
 clap.workspace = true

--- a/emulator/app/src/main.rs
+++ b/emulator/app/src/main.rs
@@ -31,7 +31,7 @@ use gdb::gdb_target::GdbTarget;
 use std::cell::RefCell;
 use std::fs::File;
 use std::io;
-use std::io::{Read, Write};
+use std::io::{IsTerminal, Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::exit;
 use std::rc::Rc;
@@ -234,7 +234,7 @@ fn run(cli: Emulator, capture_uart_output: bool) -> io::Result<Vec<u8>> {
     // exit cleanly on Ctrl-C so that we save any state.
     let running = Arc::new(AtomicBool::new(true));
     let running_clone = running.clone();
-    if atty::is(atty::Stream::Stdout) {
+    if std::io::stdout().is_terminal() {
         ctrlc::set_handler(move || {
             running_clone.store(false, std::sync::atomic::Ordering::Relaxed);
             Term::stdout().clear_line().unwrap();
@@ -306,7 +306,7 @@ fn run(cli: Emulator, capture_uart_output: bool) -> io::Result<Vec<u8>> {
         None
     };
 
-    let stdin_uart = if cli.stdin_uart && atty::is(atty::Stream::Stdin) {
+    let stdin_uart = if cli.stdin_uart && std::io::stdin().is_terminal() {
         Some(Arc::new(Mutex::new(None)))
     } else {
         None


### PR DESCRIPTION
This is built into the standard library now.

This resolves https://github.com/chipsalliance/caliptra-mcu-sw/security/dependabot/1