### PR TITLE
i3c: Start basic driver

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,7 +5,10 @@ xtask = "run --package xtask --"
 
 [target.riscv32imc-unknown-none-elf]
 rustflags = [
-    "-C panic=abort",
-    "-C target-feature=+relax,+unaligned-scalar-mem",
-    "-C force-frame-pointers=no"
+    "-C",
+    "panic=abort",
+    "-C",
+    "target-feature=+relax,+unaligned-scalar-mem",
+    "-C",
+    "force-frame-pointers=no",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1175,6 +1175,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "i3c-driver"
+version = "0.1.0"
+dependencies = [
+ "capsules-core",
+ "kernel",
+ "registers-generated",
+ "tock-registers",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1947,10 +1957,13 @@ dependencies = [
  "capsules-extra",
  "capsules-system",
  "components",
+ "i3c-driver",
  "kernel",
+ "registers-generated",
  "riscv",
  "riscv-csr",
  "rv32i",
+ "tock-registers",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,23 +3,24 @@
 [workspace]
 members = [
     "emulator/app",
+    "emulator/bmc/pldm-fw-pkg",
+    "emulator/bus",
     "emulator/caliptra",
     "emulator/compliance-test",
-    "emulator/bus",
     "emulator/cpu",
     "emulator/derive",
     "emulator/periph",
     "emulator/types",
-    "rom",
-    "runtime",
-    "runtime/apps/pldm",
-    "tests/hello",
-    "xtask",
     "registers/generated-emulator",
     "registers/generated-firmware",
     "registers/generator",
     "registers/systemrdl",
-    "emulator/bmc/pldm-fw-pkg",
+    "rom",
+    "runtime",
+    "runtime/apps/pldm",
+    "runtime/i3c",
+    "tests/hello",
+    "xtask",
 ]
 resolver = "2"
 
@@ -61,6 +62,7 @@ gdbstub = "0.6.3"
 gdbstub_arch = "0.2.4"
 getrandom = "0.2"
 hex = "0.4.3"
+i3c-driver = { path = "runtime/i3c" }
 lazy_static = "1.4.0"
 num-derive = "0.4.2"
 num_enum = "0.7.2"

--- a/emulator/periph/src/i3c.rs
+++ b/emulator/periph/src/i3c.rs
@@ -11,7 +11,7 @@ use emulator_bus::{Clock, Timer};
 use emulator_cpu::Irq;
 use emulator_registers_generated::i3c::I3cPeripheral;
 use emulator_types::{RvData, RvSize};
-use registers_generated::i3c::bits::{ExtcapHeader, TtiQueueSize};
+use registers_generated::i3c::bits::{ExtcapHeader, StbyCrCapabilities, TtiQueueSize};
 use std::collections::VecDeque;
 use zerocopy::FromBytes;
 
@@ -95,6 +95,13 @@ impl I3c {
 impl I3cPeripheral for I3c {
     fn read_i3c_base_hci_version(&mut self, _size: RvSize) -> RvData {
         RvData::from(Self::HCI_VERSION)
+    }
+
+    fn read_i3c_ec_stdby_ctrl_mode_stby_cr_capabilities(
+        &mut self,
+        _size: emulator_types::RvSize,
+    ) -> emulator_bus::ReadWriteRegister<u32, StbyCrCapabilities::Register> {
+        emulator_bus::ReadWriteRegister::new(StbyCrCapabilities::TargetXactSupport.val(1).value)
     }
 
     fn read_i3c_ec_tti_extcap_header(

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -13,7 +13,10 @@ capsules-core = { git = "https://github.com/tock/tock.git", rev = "b128ae817b867
 capsules-extra = { git = "https://github.com/tock/tock.git", rev = "b128ae817b86706c8c4e39d27fae5c54b98659f1" }
 capsules-system = { git = "https://github.com/tock/tock.git", rev = "b128ae817b86706c8c4e39d27fae5c54b98659f1" }
 components = { git = "https://github.com/tock/tock.git", rev = "b128ae817b86706c8c4e39d27fae5c54b98659f1" }
+i3c-driver.workspace = true
 kernel = { git = "https://github.com/tock/tock.git", rev = "b128ae817b86706c8c4e39d27fae5c54b98659f1" }
+registers-generated.workspace = true
 riscv = { git = "https://github.com/tock/tock.git", rev = "b128ae817b86706c8c4e39d27fae5c54b98659f1" }
 riscv-csr = { git = "https://github.com/tock/tock.git", rev = "b128ae817b86706c8c4e39d27fae5c54b98659f1" }
 rv32i = { git = "https://github.com/tock/tock.git", rev = "b128ae817b86706c8c4e39d27fae5c54b98659f1" }
+tock-registers.workspace = true

--- a/runtime/i3c/Cargo.toml
+++ b/runtime/i3c/Cargo.toml
@@ -1,0 +1,15 @@
+# Licensed under the Apache-2.0 license
+
+[package]
+name = "i3c-driver"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+
+[dependencies]
+kernel = { git = "https://github.com/tock/tock.git", rev = "b128ae817b86706c8c4e39d27fae5c54b98659f1" }
+
+[target.'cfg(target_arch = "riscv32")'.dependencies]
+capsules-core = { git = "https://github.com/tock/tock.git", rev = "b128ae817b86706c8c4e39d27fae5c54b98659f1" }
+registers-generated.workspace = true
+tock-registers.workspace = true

--- a/runtime/i3c/src/core.rs
+++ b/runtime/i3c/src/core.rs
@@ -1,0 +1,502 @@
+// Licensed under the Apache-2.0 license
+
+// I2C / I3C driver for the https://github.com/chipsalliance/i3c-core chip.
+
+use crate::hil::{RxClient, TxClient};
+use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
+use core::cell::Cell;
+use kernel::hil::time::Alarm;
+use kernel::hil::time::AlarmClient;
+use kernel::hil::time::Time;
+use kernel::utilities::cells::{OptionalCell, TakeCell};
+use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
+use kernel::utilities::StaticRef;
+use kernel::{debug, ErrorCode};
+use registers_generated::i3c::bits::HcControl::{BusEnable, ModeSelector};
+use registers_generated::i3c::bits::InterruptStatus;
+use registers_generated::i3c::bits::QueueThldCtrl;
+use registers_generated::i3c::bits::RingHeadersSectionOffset;
+use registers_generated::i3c::bits::StbyCrCapabilities;
+use registers_generated::i3c::bits::StbyCrControl;
+use registers_generated::i3c::bits::StbyCrDeviceChar;
+use registers_generated::i3c::bits::TtiQueueThldCtrl;
+use registers_generated::i3c::bits::{ControllerDeviceAddr, InterruptEnable};
+use registers_generated::i3c::regs::I3c;
+use registers_generated::i3c::I3C_CSR_ADDR;
+use tock_registers::register_bitfields;
+use tock_registers::LocalRegisterCopy;
+
+pub const I3C_BASE: StaticRef<I3c> = unsafe { StaticRef::new(I3C_CSR_ADDR as *const I3c) };
+pub const MDB_PENDING_READ_MCTP: u8 = 0xae;
+
+register_bitfields! {
+    u32,
+        I3CResponseDescriptor [
+            ErrStatus OFFSET(28) NUMBITS(4) [
+                Success = 0,
+                CRCError = 1,
+                ParityError = 2,
+                FrameError = 3,
+                AddrHeaderError = 4,
+                Nack = 5,
+                Overflow = 6,
+                ShortReadError = 7,
+                Aborted = 8,
+                BusError = 9,
+                NotSupported = 10,
+                Reserved0 = 11,
+                Reserved1 = 12,
+                Reserved2 = 13,
+                Reserved3 = 14,
+                Reserved4 = 15,
+            ],
+            TID OFFSET(24) NUMBITS(4) [],
+            DataLength OFFSET(0) NUMBITS(16) [],
+        ],
+    IbiDescriptor [
+        ReceivedStatus OFFSET(31) NUMBITS(1) [],
+        Error OFFSET(30) NUMBITS(1) [],
+        StatusType OFFSET(27) NUMBITS(3) [
+            Regular = 0,
+            CreditAck = 1,
+            ScheduledCmd = 2,
+            AutocmdRead = 4,
+            StbyCrBcastCcc = 7,
+        ],
+        TimestampPreset OFFSET(25) NUMBITS(1) [],
+        LastStatus OFFSET(24) NUMBITS(1) [],
+        Chunks OFFSET(16) NUMBITS(8) [],
+        ID OFFSET(8) NUMBITS(8) [],
+        DataLength OFFSET(0) NUMBITS(8) [],
+    ]
+}
+
+pub struct I3CCore<'a, A: Alarm<'a>> {
+    registers: StaticRef<I3c>,
+    tx_client: OptionalCell<&'a dyn TxClient>,
+    rx_client: OptionalCell<&'a dyn RxClient>,
+
+    // buffers data to be received from the controller when it issues a write to us
+    rx_buffer: TakeCell<'static, [u8]>,
+    rx_buffer_idx: Cell<usize>,
+    rx_buffer_size: Cell<usize>,
+
+    // buffers data to be sent to the controller when it issues a read to us
+    tx_buffer: TakeCell<'static, [u8]>,
+    tx_buffer_idx: Cell<usize>,
+    tx_buffer_size: Cell<usize>,
+
+    // alarm conditions
+    alarm: VirtualMuxAlarm<'a, A>,
+    retry_outgoing_read: Cell<bool>,
+    retry_incoming_write: Cell<bool>,
+}
+
+impl<'a, A: Alarm<'a>> I3CCore<'a, A> {
+    // bit 4 = 0: we don't support virtual targets
+    // bit 3 = 0: we will always respond to bus commands
+    // bit 2 = 0: no ibi data bytes
+    // bit 1 = 2: ibi request capable
+    // bit 0 = 0: no max data speed limitation
+    const BCR: u32 = 2;
+    // how long to wait to retry
+    const RETRY_WAIT_TICKS: u32 = 1000;
+
+    pub fn new(base: StaticRef<I3c>, alarm: &'a MuxAlarm<'a, A>) -> Self {
+        I3CCore {
+            registers: base,
+            tx_client: OptionalCell::empty(),
+            rx_client: OptionalCell::empty(),
+            rx_buffer: TakeCell::empty(),
+            rx_buffer_idx: Cell::new(0),
+            rx_buffer_size: Cell::new(0),
+            tx_buffer: TakeCell::empty(),
+            tx_buffer_idx: Cell::new(0),
+            tx_buffer_size: Cell::new(0),
+            alarm: VirtualMuxAlarm::new(alarm),
+            retry_outgoing_read: Cell::new(false),
+            retry_incoming_write: Cell::new(false),
+        }
+    }
+
+    pub fn configure(&self, device_characteristic: u8) {
+        self.registers.stby_cr_device_char.modify(
+            StbyCrDeviceChar::Dcr.val(device_characteristic as u32)
+                + StbyCrDeviceChar::BcrVar.val(Self::BCR),
+        );
+    }
+
+    pub fn init(&self) {
+        // Run the initialization steps for the primary and secondary controller from:
+        // https://chipsalliance.github.io/i3c-core/initialization.html
+
+        // Verify the value of the HCI_VERSION register at the I3CBase address. The controller is compliant with MIPI HCI v1.2 and therefore the HCI_VERSION should read 0x120
+        if self.registers.hci_version.get() != 0x120 {
+            panic!("HCI version is not 0x120");
+        }
+        if !self
+            .registers
+            .stby_cr_capabilities
+            .is_set(StbyCrCapabilities::TargetXactSupport)
+        {
+            panic!("I3C target transaction support is not enabled");
+        }
+
+        // Evaluate RING_HEADERS_SECTION_OFFSET, the SECTION_OFFSET should read 0x0 as this controller doesn’t support the DMA mode
+        let rhso = self
+            .registers
+            .ring_headers_section_offset
+            .read(RingHeadersSectionOffset::SectionOffset);
+        if rhso != 0 {
+            panic!("RING_HEADERS_SECTION_OFFSET is not 0");
+        }
+
+        // Setup the threshold for the HCI queues (in the internal/private software data structures):
+        self.registers.queue_thld_ctrl.modify(
+            QueueThldCtrl::CmdEmptyBufThld.val(0)
+                + QueueThldCtrl::RespBufThld.val(1)
+                + QueueThldCtrl::IbiStatusThld.val(1),
+        );
+
+        self.registers.stby_cr_control.modify(
+            StbyCrControl::StbyCrEnableInit::SET // enable the standby controller
+                + StbyCrControl::TargetXactEnable::SET // enable Target Transaction Interface
+                + StbyCrControl::DaaEntdaaEnable::SET // enable dynamic address assignment
+                + StbyCrControl::BastCccIbiRing.val(0) // Set the IBI to use ring buffer 0
+                + StbyCrControl::PrimeAcceptGetacccr::CLEAR // // don't auto-accept primary controller role
+                + StbyCrControl::AcrFsmOpSelect::CLEAR, // don't become the active controller and set us as not the bus owner
+        );
+
+        // set TTI queue thresholds
+        self.registers.tti_queue_thld_ctrl.modify(
+            TtiQueueThldCtrl::IbiThld.val(1)
+                + TtiQueueThldCtrl::RxDescThld.val(1)
+                + TtiQueueThldCtrl::TxDescThld.val(1),
+        );
+
+        // enable the PHY connection to the bus
+        self.registers
+            .hc_control
+            .modify(ModeSelector::SET + BusEnable::SET);
+    }
+
+    pub fn enable_interrupts(&self) {
+        self.registers.interrupt_enable.modify(
+            InterruptEnable::IbiThldStatEn::SET
+                + InterruptEnable::RxDescThldStatEn::SET
+                + InterruptEnable::TxDescThldStatEn::SET
+                + InterruptEnable::RxDataThldStatEn::SET
+                + InterruptEnable::TxDataThldStatEn::SET,
+        );
+    }
+
+    pub fn disable_interrupts(&self) {
+        self.registers.interrupt_enable.modify(
+            InterruptEnable::IbiThldStatEn::CLEAR
+                + InterruptEnable::RxDescThldStatEn::CLEAR
+                + InterruptEnable::TxDescThldStatEn::CLEAR
+                + InterruptEnable::RxDataThldStatEn::CLEAR
+                + InterruptEnable::TxDataThldStatEn::CLEAR,
+        );
+    }
+
+    pub fn handle_interrupt(&self, _error: bool) {
+        let tti_interrupts = self.registers.interrupt_status.extract();
+        if tti_interrupts.get() != 0 {
+            // Bus error occurred
+            if tti_interrupts.read(InterruptStatus::TransferErrStat) != 0 {
+                self.transfer_error();
+                // clear the interrupt
+                self.registers
+                    .interrupt_status
+                    .modify(InterruptStatus::TransferErrStat::CLEAR);
+            }
+            // Bus aborted transaction
+            if tti_interrupts.read(InterruptStatus::TransferAbortStat) != 0 {
+                self.transfer_error();
+                // clear the interrupt
+                self.registers
+                    .interrupt_status
+                    .modify(InterruptStatus::TransferAbortStat::CLEAR);
+            }
+            // TTI IBI Buffer Threshold Status, the Target Controller shall set this bit to 1 when the number of available entries in the TTI IBI Queue is >= the value defined in `TTI_IBI_THLD`
+            if tti_interrupts.read(InterruptStatus::IbiThldStat) != 0 {
+                debug!("Ignoring I3C IBI threshold interrupt");
+                self.registers
+                    .interrupt_enable
+                    .modify(InterruptEnable::IbiThldStatEn::CLEAR);
+            }
+            // TTI RX Descriptor Buffer Threshold Status, the Target Controller shall set this bit to 1 when the number of available entries in the TTI RX Descriptor Queue is >= the value defined in `TTI_RX_DESC_THLD`
+            if tti_interrupts.read(InterruptStatus::RxDescThldStat) != 0 {
+                debug!("Ignoring I3C RX descriptor buffer threshold interrupt");
+                self.registers
+                    .interrupt_enable
+                    .modify(InterruptEnable::RxDescThldStatEn::CLEAR);
+            }
+            // TTI TX Descriptor Buffer Threshold Status, the Target Controller shall set this bit to 1 when the number of available entries in the TTI TX Descriptor Queue is >= the value defined in `TTI_TX_DESC_THLD`
+            if tti_interrupts.read(InterruptStatus::TxDescThldStat) != 0 {
+                debug!("Ignoring I3C TX descriptor buffer threshold interrupt");
+                self.registers
+                    .interrupt_enable
+                    .modify(InterruptEnable::TxDescThldStatEn::CLEAR);
+            }
+            // TTI RX Data Buffer Threshold Status, the Target Controller shall set this bit to 1 when the number of entries in the TTI RX Data Queue is >= the value defined in `TTI_RX_DATA_THLD`
+            if tti_interrupts.read(InterruptStatus::RxDataThldStat) != 0 {
+                debug!("Ignoring I3C RX data buffer buffer threshold interrupt");
+                self.registers
+                    .interrupt_enable
+                    .modify(InterruptEnable::RxDataThldStatEn::CLEAR);
+            }
+            // TTI TX Data Buffer Threshold Status, the Target Controller shall set this bit to 1 when the number of available entries in the TTI TX Data Queue is >= the value defined in TTI_TX_DATA_THLD
+            if tti_interrupts.read(InterruptStatus::TxDataThldStat) != 0 {
+                debug!("Ignoring I3C TX data buffer buffer threshold interrupt");
+                self.registers
+                    .interrupt_enable
+                    .modify(InterruptEnable::TxDataThldStatEn::CLEAR);
+            }
+            // Pending Write was NACK’ed because the `TX_DESC_STAT` event was not handled in time
+            if tti_interrupts.read(InterruptStatus::TxDescTimeout) != 0 {
+                self.pending_write_nack();
+                // clear the interrupt
+                self.registers
+                    .interrupt_status
+                    .modify(InterruptStatus::TxDescTimeout::CLEAR);
+            }
+            // Pending Read was NACK’ed because the `RX_DESC_STAT` event was not handled in time
+            if tti_interrupts.read(InterruptStatus::RxDescTimeout) != 0 {
+                self.pending_read_nack();
+                // clear the interrupt
+                self.registers
+                    .interrupt_status
+                    .modify(InterruptStatus::TxDescTimeout::CLEAR);
+            }
+            // There is a pending Read Transaction on the I3C Bus. Software should write data to the TX Descriptor Queue and the TX Data Queue
+            if tti_interrupts.read(InterruptStatus::TxDescStat) != 0 {
+                // disable this interrupt
+                self.registers
+                    .interrupt_enable
+                    .modify(InterruptEnable::TxDescThldStatEn::CLEAR);
+                self.handle_outgoing_read();
+            }
+            // There is a pending Write Transaction. Software should read data from the RX Descriptor Queue and the RX Data Queue
+            if tti_interrupts.read(InterruptStatus::RxDescStat) != 0 {
+                // disable this interrupt
+                self.registers
+                    .interrupt_enable
+                    .modify(InterruptEnable::RxDescThldStatEn::CLEAR);
+                self.handle_incoming_write();
+            }
+        }
+    }
+
+    fn set_alarm(&self, ticks: u32) {
+        let now = self.alarm.now();
+        self.alarm.set_alarm(now, ticks.into());
+    }
+
+    pub fn handle_error_interrupt(&self) {
+        self.handle_interrupt(true);
+    }
+
+    pub fn handle_notification_interrupt(&self) {
+        self.handle_interrupt(false);
+    }
+
+    // called when TTI has a private Write with data for us to grab
+    fn handle_incoming_write(&self) {
+        self.retry_incoming_write.set(false);
+        if self.rx_buffer.is_none() {
+            self.rx_client.map(|client| {
+                client.write_expected();
+            });
+        }
+        if self.rx_buffer.is_none() {
+            // try again later
+            self.retry_incoming_write.set(true);
+            self.set_alarm(Self::RETRY_WAIT_TICKS);
+            return;
+        }
+
+        let rx_buffer = self.rx_buffer.take().unwrap();
+        let mut buf_idx = self.rx_buffer_idx.get();
+        let buf_size = self.rx_buffer_size.get();
+        let desc = LocalRegisterCopy::<u32, I3CResponseDescriptor::Register>::new(
+            self.registers.rx_desc_queue_port.get(),
+        );
+        match desc.read_as_enum::<I3CResponseDescriptor::ErrStatus::Value>(
+            I3CResponseDescriptor::ErrStatus,
+        ) {
+            Some(I3CResponseDescriptor::ErrStatus::Value::Success) => {
+                let len = desc.read(I3CResponseDescriptor::DataLength) as usize;
+                // read everything
+                let mut full = false;
+                for i in (0..len.next_multiple_of(4)).step_by(4) {
+                    let data = self.registers.rx_data_port0.get().to_le_bytes();
+                    for j in 0..4 {
+                        if buf_idx >= buf_size {
+                            full = true;
+                            break;
+                        }
+                        if let Some(x) = rx_buffer.get_mut(buf_idx) {
+                            *x = data[j];
+                        } else {
+                            // check if we ran out of space or if this is just the padding
+                            if i + j < len {
+                                full = true;
+                            }
+                        }
+                        buf_idx += 1;
+                    }
+                }
+                if full {
+                    // TODO: we need a way to say that the buffer was not big enough
+                }
+                self.rx_client.map(|client| {
+                    client.receive_write(rx_buffer, len.min(buf_size));
+                });
+                // reset
+                self.rx_buffer_idx.set(0);
+                self.rx_buffer_size.set(0);
+            }
+            _err => {
+                debug!("Error receiving I3C write from controller");
+                // TODO: do we still need to read this?
+                let len = desc.read(I3CResponseDescriptor::DataLength) as usize;
+                for _ in (0..len.next_multiple_of(4)).step_by(4) {
+                    let _ = self.registers.rx_data_port0.get();
+                }
+                // TODO: should we let the client know somehow?
+                // put the buffer back
+                self.rx_buffer.replace(rx_buffer);
+            }
+        }
+        // re-enable this interrupt
+        self.registers
+            .interrupt_enable
+            .modify(InterruptEnable::RxDescThldStatEn::SET);
+    }
+
+    // called when TTI wants us to send data for a private Read
+    fn handle_outgoing_read(&self) {
+        self.retry_outgoing_read.set(false);
+
+        if self.tx_buffer.is_none() {
+            // we have nothing to send, retry in a little while
+            self.retry_outgoing_read.set(true);
+            self.set_alarm(Self::RETRY_WAIT_TICKS);
+            return;
+        }
+
+        let buf = self.tx_buffer.take().unwrap();
+        let mut idx = self.tx_buffer_idx.replace(0);
+        let size = self.tx_buffer_size.replace(0);
+        if idx < size {
+            // TODO: get the correct structure of this descriptor
+            self.registers.tx_desc_queue_port.set((size - idx) as u32);
+            while idx < size {
+                let mut bytes = [0; 4];
+                for i in idx..(idx + 4).min(size) {
+                    bytes[i - idx] = buf[i];
+                    idx += 1;
+                }
+                let word = u32::from_le_bytes(bytes);
+                self.registers.tx_data_port0.set(word);
+            }
+        }
+        // we're done
+        self.tx_client.map(|client| {
+            client.send_done(buf, Ok(()));
+        });
+        // TODO: if no tx_client then we just drop the buffer?
+        // re-enable the interrupt
+        self.registers
+            .interrupt_enable
+            .modify(InterruptEnable::TxDescThldStatEn::SET);
+    }
+
+    fn transfer_error(&self) {
+        if self.tx_buffer.is_some() {
+            self.tx_client.map(|client| {
+                client.send_done(self.tx_buffer.take().unwrap(), Err(ErrorCode::FAIL))
+            });
+        }
+    }
+
+    fn pending_read_nack(&self) {
+        if self.tx_buffer.is_some() {
+            self.tx_client.map(|client| {
+                client.send_done(self.tx_buffer.take().unwrap(), Err(ErrorCode::CANCEL));
+            });
+        }
+    }
+
+    fn pending_write_nack(&self) {
+        // TODO: we have no way to send this to the client
+    }
+
+    fn send_ibi(&self, mdb: u8) {
+        // TODO: it is unclear if we need to set anything else in the descriptor
+        self.registers
+            .tti_ibi_port
+            .set(IbiDescriptor::DataLength.val(1).value);
+        self.registers.tti_ibi_port.set(mdb as u32);
+    }
+}
+
+impl<'a, A: Alarm<'a>> crate::hil::I3CTarget<'a> for I3CCore<'a, A> {
+    fn set_tx_client(&self, client: &'a dyn TxClient) {
+        self.tx_client.set(client)
+    }
+
+    fn set_rx_client(&self, client: &'a dyn RxClient) {
+        self.rx_client.set(client)
+    }
+
+    fn set_rx_buffer(&self, rx_buf: &'static mut [u8]) {
+        let len = rx_buf.len();
+        self.rx_buffer.replace(rx_buf);
+        self.rx_buffer_idx.replace(0);
+        self.rx_buffer_size.replace(len);
+    }
+
+    fn transmit_read(&self, tx_buf: &'static mut [u8], len: usize) -> Result<(), ErrorCode> {
+        if self.tx_buffer.is_some() {
+            return Err(ErrorCode::BUSY);
+        }
+        self.tx_buffer.replace(tx_buf);
+        self.tx_buffer_idx.set(0);
+        self.tx_buffer_size.set(len);
+        // TODO: check that this is for MCTP or something else
+        self.send_ibi(MDB_PENDING_READ_MCTP);
+        Ok(())
+    }
+
+    fn enable(&self) {
+        self.enable_interrupts()
+    }
+
+    fn disable(&self) {
+        self.disable_interrupts()
+    }
+
+    fn get_mtu_size(&self) -> usize {
+        250
+    }
+
+    fn get_address(&self) -> u8 {
+        self.registers
+            .controller_device_addr
+            .read(ControllerDeviceAddr::DynamicAddr) as u8
+    }
+}
+
+impl<'a, A: Alarm<'a>> AlarmClient for I3CCore<'a, A> {
+    fn alarm(&self) {
+        if self.retry_outgoing_read.get() {
+            self.handle_outgoing_read();
+        }
+        if self.retry_incoming_write.get() {
+            self.handle_notification_interrupt();
+        }
+    }
+}

--- a/runtime/i3c/src/hil.rs
+++ b/runtime/i3c/src/hil.rs
@@ -1,0 +1,45 @@
+// Licensed under the Apache-2.0 license
+
+use core::result::Result;
+use kernel::ErrorCode;
+
+pub trait TxClient {
+    /// Called when the packet has been transmitted.
+    fn send_done(&self, tx_buffer: &'static mut [u8], result: Result<(), ErrorCode>);
+}
+
+pub trait RxClient {
+    /// Called when a complete MCTP packet is received and ready to be processed.
+    fn receive_write(&self, rx_buffer: &'static mut [u8], len: usize);
+
+    /// Called when the I3C Controller has requested a private Write by addressing the target
+    /// and the driver needs buffer to receive the data.
+    /// The client should call set_rx_buffer() to set the buffer.
+    fn write_expected(&self);
+}
+
+pub trait I3CTarget<'a> {
+    /// Set the client that will be called when the packet is transmitted.
+    fn set_tx_client(&self, client: &'a dyn TxClient);
+
+    /// Set the client that will be called when the packet is received.
+    fn set_rx_client(&self, client: &'a dyn RxClient);
+
+    /// Set the buffer that will be used for receiving Write packets.
+    fn set_rx_buffer(&self, rx_buf: &'static mut [u8]);
+
+    /// Queue a packet in response to a private Read.
+    fn transmit_read(&self, tx_buf: &'static mut [u8], len: usize) -> Result<(), ErrorCode>;
+
+    /// Enable the I3C target device
+    fn enable(&self);
+
+    /// Disable the I3C target device
+    fn disable(&self);
+
+    /// Get the maximum transmission unit (MTU) size.
+    fn get_mtu_size(&self) -> usize;
+
+    /// Get the address of the I3C target device. Needed for PEC calculation.
+    fn get_address(&self) -> u8;
+}

--- a/runtime/i3c/src/hil.rs
+++ b/runtime/i3c/src/hil.rs
@@ -3,6 +3,19 @@
 use core::result::Result;
 use kernel::ErrorCode;
 
+/// Provides information about an I3C target device.
+pub struct I3CTargetInfo {
+    /// Could be assigned by the hardware or absent.
+    pub static_addr: Option<u8>,
+    /// Could be assigned by the controller or absent if
+    /// static address is used, or device has not received the address yet.
+    pub dynamic_addr: Option<u8>,
+    /// Maximum length of data that will be received in a Write command.
+    pub max_read_len: usize,
+    /// Maximum length of data that can be sent in response to a Read command.
+    pub max_write_len: usize,
+}
+
 pub trait TxClient {
     /// Called when the packet has been transmitted.
     fn send_done(&self, tx_buffer: &'static mut [u8], result: Result<(), ErrorCode>);
@@ -19,6 +32,9 @@ pub trait RxClient {
 }
 
 pub trait I3CTarget<'a> {
+    /// Get the maximum size for reads and writes.
+    const MAX_READ_WRITE_SIZE: usize;
+
     /// Set the client that will be called when the packet is transmitted.
     fn set_tx_client(&self, client: &'a dyn TxClient);
 
@@ -37,9 +53,6 @@ pub trait I3CTarget<'a> {
     /// Disable the I3C target device
     fn disable(&self);
 
-    /// Get the maximum transmission unit (MTU) size.
-    fn get_mtu_size(&self) -> usize;
-
-    /// Get the address of the I3C target device. Needed for PEC calculation.
-    fn get_address(&self) -> u8;
+    /// Returns information about this I3C Target Device.
+    fn get_device_info(&self) -> I3CTargetInfo;
 }

--- a/runtime/i3c/src/lib.rs
+++ b/runtime/i3c/src/lib.rs
@@ -1,0 +1,7 @@
+// Licensed under the Apache-2.0 license.
+
+#![cfg_attr(target_arch = "riscv32", no_std)]
+
+#[cfg(target_arch = "riscv32")]
+pub mod core;
+pub mod hil;

--- a/runtime/src/board.rs
+++ b/runtime/src/board.rs
@@ -150,7 +150,6 @@ pub unsafe fn main() {
         VeeRDefaultPeripherals,
         VeeRDefaultPeripherals::new(&*mux_alarm)
     );
-    peripherals.init();
 
     let chip = static_init!(VeeRChip, crate::chip::VeeR::new(peripherals));
     CHIP = Some(chip);
@@ -187,6 +186,8 @@ pub unsafe fn main() {
         InternalTimers
     ));
     let _ = process_console.start();
+
+    peripherals.init();
 
     // Need to enable all interrupts for Tock Kernel
     chip.enable_pic_interrupts();


### PR DESCRIPTION
This does the initialization sequence, routes interrupts, and does passes reads and writes to the clients.

I haven't had a chance to do much testing yet, but that will be easier once the peripheral is more complete.