### PR TITLE
I3C peripheral updates and integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -944,6 +944,7 @@ dependencies = [
  "gdbstub_arch",
  "hex",
  "tock-registers",
+ "zerocopy 0.8.10",
 ]
 
 [[package]]
@@ -2323,6 +2324,28 @@ dependencies = [
 [[package]]
 name = "test-hello"
 version = "0.1.0"
+
+[[package]]
+name = "tests-integration"
+version = "0.1.0"
+dependencies = [
+ "caliptra-emu-cpu",
+ "caliptra-emu-periph",
+ "clap 4.5.21",
+ "ctrlc",
+ "elf",
+ "emulator-bus",
+ "emulator-caliptra",
+ "emulator-cpu",
+ "emulator-periph",
+ "emulator-registers-generated",
+ "emulator-types",
+ "gdbstub",
+ "gdbstub_arch",
+ "hex",
+ "tock-registers",
+ "zerocopy 0.8.10",
+]
 
 [[package]]
 name = "textwrap"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
     "runtime/apps/pldm",
     "runtime/i3c",
     "tests/hello",
+    "tests/integration",
     "xtask",
 ]
 resolver = "2"

--- a/emulator/app/src/i3c_socket.rs
+++ b/emulator/app/src/i3c_socket.rs
@@ -1,0 +1,179 @@
+/*++
+
+Licensed under the Apache-2.0 license.
+
+File Name:
+
+    i3c_socket.rs
+
+Abstract:
+
+    I3C over TCP socket implementation.
+
+    The protocol is byte-based and is relatively simple.
+
+    The server is running and will forward all responses from targets in the emulator to the client.
+    Data written to the server is interpreted as a command.
+
+     and sends commands, and the client is one (or more)
+    more targets who can only respond or send IBIs.
+
+    The server will read (and the client will write) packets of the form:
+    to_addr: u8
+    command_descriptor: [u8; 8]
+    data: [u8; N] // length is in the descriptor
+
+    The server will write (and the client will read) packets of the form:
+    ibi: u8,
+    from_addr: u8
+    response_descriptor: [u8; 4]
+    data: [u8; N] // length is in the descriptor
+
+    If the ibi field is non-zero, then it should be interpreted as the MDB for the IBI.
+
+--*/
+
+use emulator_periph::{
+    I3cBusCommand, I3cBusResponse, I3cTcriCommand, I3cTcriCommandXfer, ResponseDescriptor,
+};
+use std::io::{ErrorKind, Read, Write};
+use std::net::{SocketAddr, TcpListener, TcpStream};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{Receiver, Sender};
+use std::sync::{mpsc, Arc};
+use zerocopy::{transmute, FromBytes, IntoBytes};
+
+pub(crate) fn start_i3c_socket(
+    running: Arc<AtomicBool>,
+    port: u16,
+) -> (Receiver<I3cBusCommand>, Sender<I3cBusResponse>) {
+    let listener = TcpListener::bind(format!("127.0.0.1:{}", port))
+        .expect("Failed to bind TCP socket for port");
+
+    let (bus_command_tx, bus_command_rx) = mpsc::channel::<I3cBusCommand>();
+    let (bus_response_tx, bus_response_rx) = mpsc::channel::<I3cBusResponse>();
+    let running_clone = running.clone();
+    std::thread::spawn(move || {
+        handle_i3c_socket_loop(running_clone, listener, bus_response_rx, bus_command_tx)
+    });
+
+    (bus_command_rx, bus_response_tx)
+}
+
+fn handle_i3c_socket_loop(
+    running: Arc<AtomicBool>,
+    listener: TcpListener,
+    mut bus_response_rx: Receiver<I3cBusResponse>,
+    mut bus_command_tx: Sender<I3cBusCommand>,
+) {
+    listener
+        .set_nonblocking(true)
+        .expect("Could not set non-blocking");
+    while running.load(Ordering::Relaxed) {
+        match listener.accept() {
+            Ok((stream, addr)) => {
+                handle_i3c_socket_connection(
+                    running.clone(),
+                    stream,
+                    addr,
+                    &mut bus_response_rx,
+                    &mut bus_command_tx,
+                );
+            }
+            Err(ref e) if e.kind() == ErrorKind::WouldBlock => {
+                std::thread::sleep(std::time::Duration::from_millis(10));
+            }
+            Err(e) => panic!("Error accepting connection: {}", e),
+        }
+    }
+}
+
+#[derive(FromBytes, IntoBytes)]
+#[repr(C, packed)]
+struct IncomingHeader {
+    to_addr: u8,
+    command: [u32; 2],
+}
+
+#[derive(FromBytes, IntoBytes)]
+#[repr(C, packed)]
+struct OutgoingHeader {
+    ibi: u8,
+    from_addr: u8,
+    response_descriptor: ResponseDescriptor,
+}
+
+fn handle_i3c_socket_connection(
+    running: Arc<AtomicBool>,
+    mut stream: TcpStream,
+    _addr: SocketAddr,
+    bus_response_rx: &mut Receiver<I3cBusResponse>,
+    bus_command_tx: &mut Sender<I3cBusCommand>,
+) {
+    let stream = &mut stream;
+    stream.set_nonblocking(true).unwrap();
+
+    while running.load(Ordering::Relaxed) {
+        // try reading
+        let mut incoming_header_bytes = [0u8; 9];
+        match stream.read_exact(&mut incoming_header_bytes) {
+            Ok(()) => {
+                let incoming_header: IncomingHeader = transmute!(incoming_header_bytes);
+                let cmd: I3cTcriCommand = incoming_header.command.try_into().unwrap();
+                let mut data = vec![0u8; cmd.data_len()];
+                stream.set_nonblocking(false).unwrap();
+                stream
+                    .read_exact(&mut data)
+                    .expect("Failed to read message from socket");
+                stream.set_nonblocking(true).unwrap();
+                let bus_command = I3cBusCommand {
+                    addr: incoming_header.to_addr.into(),
+                    cmd: I3cTcriCommandXfer { cmd, data },
+                };
+                bus_command_tx.send(bus_command).unwrap();
+            }
+            Err(ref e) if e.kind() == ErrorKind::WouldBlock => {}
+            Err(e) => panic!("Error reading message from socket: {}", e),
+        }
+        match bus_response_rx.try_recv() {
+            Ok(response) => {
+                let data_len = response.resp.data.len();
+                if data_len > 255 {
+                    panic!("Cannot write more than 255 bytes to socket");
+                }
+                let outgoing_header = OutgoingHeader {
+                    ibi: response.ibi.unwrap_or_default(),
+                    from_addr: response.addr.into(),
+                    response_descriptor: response.resp.resp,
+                };
+                let header_bytes: [u8; 6] = transmute!(outgoing_header);
+                stream.write_all(&header_bytes).unwrap();
+                stream.write_all(&response.resp.data).unwrap();
+            }
+            Err(e) => panic!("Error writing to socket: {}", e),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::i3c_socket::*;
+    use zerocopy::transmute;
+
+    #[test]
+    fn test_into_bytes() {
+        let idata = IncomingHeader {
+            to_addr: 10,
+            command: [0x01020304, 0x05060708],
+        };
+        let serialized: [u8; 9] = transmute!(idata);
+        assert_eq!("0a0403020108070605", hex::encode(serialized));
+        let odata = OutgoingHeader {
+            ibi: 0,
+            from_addr: 10,
+            response_descriptor: ResponseDescriptor(0x01020304),
+        };
+        let serialized: [u8; 6] = transmute!(odata);
+        assert_eq!("000a04030201", hex::encode(serialized));
+    }
+}

--- a/emulator/bus/src/register.rs
+++ b/emulator/bus/src/register.rs
@@ -197,6 +197,12 @@ pub struct ReadWriteRegister<T: UIntLike, R: RegisterLongName = ()> {
     pub reg: InMemoryRegister<T, R>,
 }
 
+impl<T: UIntLike, R: RegisterLongName> Clone for ReadWriteRegister<T, R> {
+    fn clone(&self) -> Self {
+        ReadWriteRegister::new(self.reg.get())
+    }
+}
+
 impl<T: UIntLike, R: RegisterLongName> ReadWriteRegister<T, R> {
     /// Create an instance of Read Write Register
     pub fn new(val: T) -> Self {

--- a/emulator/periph/Cargo.toml
+++ b/emulator/periph/Cargo.toml
@@ -25,3 +25,7 @@ zerocopy.workspace = true
 
 [dev-dependencies]
 libc = "0.2"
+
+[features]
+default = []
+test-i3c-constant-writes = []

--- a/emulator/periph/src/i3c.rs
+++ b/emulator/periph/src/i3c.rs
@@ -152,6 +152,21 @@ impl I3cPeripheral for I3c {
         self.interrupt_status.clone()
     }
 
+    fn write_i3c_ec_tti_interrupt_status(
+        &mut self,
+        _size: emulator_types::RvSize,
+        val: emulator_bus::ReadWriteRegister<
+            u32,
+            registers_generated::i3c::bits::InterruptStatus::Register,
+        >,
+    ) {
+        let current = self.interrupt_status.reg.get();
+        let new = val.reg.get();
+        // clear the interrupts that are set
+        self.interrupt_status.reg.set(current & !new);
+        self.check_interrupts();
+    }
+
     fn write_i3c_ec_tti_interrupt_enable(
         &mut self,
         _size: emulator_types::RvSize,

--- a/emulator/periph/src/i3c.rs
+++ b/emulator/periph/src/i3c.rs
@@ -12,10 +12,10 @@ use emulator_bus::{Clock, ReadWriteRegister, Timer};
 use emulator_cpu::Irq;
 use emulator_registers_generated::i3c::I3cPeripheral;
 use emulator_types::{RvData, RvSize};
-use registers_generated::i3c::bits::InterruptEnable;
-use registers_generated::i3c::bits::InterruptStatus;
-use registers_generated::i3c::bits::StbyCrDeviceAddr;
-use registers_generated::i3c::bits::{ExtcapHeader, StbyCrCapabilities, TtiQueueSize};
+use registers_generated::i3c::bits::{
+    ExtcapHeader, InterruptEnable, InterruptStatus, StbyCrCapabilities, StbyCrDeviceAddr,
+    TtiQueueSize,
+};
 use std::collections::VecDeque;
 use tock_registers::interfaces::{ReadWriteable, Readable, Writeable};
 use zerocopy::FromBytes;
@@ -33,7 +33,7 @@ pub struct I3c {
     tti_rx_current: Vec<u8>,
     /// TX Command in u32
     tti_tx_desc_queue_raw: VecDeque<u32>,
-    /// TX DATA in u32
+    /// TX DATA in u8
     tti_tx_data_raw: VecDeque<Vec<u8>>,
     /// Error interrupt
     _error_irq: Irq,

--- a/emulator/periph/src/i3c.rs
+++ b/emulator/periph/src/i3c.rs
@@ -7,12 +7,17 @@ Abstract:
 --*/
 
 use crate::i3c_protocol::{I3cController, I3cTarget, I3cTcriResponseXfer, ResponseDescriptor};
-use emulator_bus::{Clock, Timer};
+use crate::DynamicI3cAddress;
+use emulator_bus::{Clock, ReadWriteRegister, Timer};
 use emulator_cpu::Irq;
 use emulator_registers_generated::i3c::I3cPeripheral;
 use emulator_types::{RvData, RvSize};
+use registers_generated::i3c::bits::InterruptEnable;
+use registers_generated::i3c::bits::InterruptStatus;
+use registers_generated::i3c::bits::StbyCrDeviceAddr;
 use registers_generated::i3c::bits::{ExtcapHeader, StbyCrCapabilities, TtiQueueSize};
 use std::collections::VecDeque;
+use tock_registers::interfaces::{ReadWriteable, Readable, Writeable};
 use zerocopy::FromBytes;
 
 pub struct I3c {
@@ -23,15 +28,20 @@ pub struct I3c {
     /// RX Command in u32
     tti_rx_desc_queue_raw: VecDeque<u32>,
     /// RX DATA in u8
-    tti_rx_data_raw: VecDeque<u8>,
+    tti_rx_data_raw: VecDeque<Vec<u8>>,
+    /// RX DATA currently being read from driver
+    tti_rx_current: Vec<u8>,
     /// TX Command in u32
     tti_tx_desc_queue_raw: VecDeque<u32>,
     /// TX DATA in u32
-    tti_tx_data_raw: VecDeque<u8>,
+    tti_tx_data_raw: VecDeque<Vec<u8>>,
     /// Error interrupt
     _error_irq: Irq,
     /// Notification interrupt
     _notif_irq: Irq,
+
+    interrupt_status: ReadWriteRegister<u32, InterruptStatus::Register>,
+    interrupt_enable: ReadWriteRegister<u32, InterruptEnable::Register>,
 }
 
 impl I3c {
@@ -55,24 +65,28 @@ impl I3c {
             timer,
             tti_rx_desc_queue_raw: VecDeque::new(),
             tti_rx_data_raw: VecDeque::new(),
+            tti_rx_current: vec![],
             tti_tx_desc_queue_raw: VecDeque::new(),
             tti_tx_data_raw: VecDeque::new(),
             _error_irq: error_irq,
             _notif_irq: notif_irq,
+            interrupt_status: ReadWriteRegister::new(0),
+            interrupt_enable: ReadWriteRegister::new(0),
         }
     }
 
     fn write_tx_data_into_target(&mut self) {
         if !self.tti_tx_desc_queue_raw.is_empty() {
             let resp_desc = ResponseDescriptor::read_from_bytes(
-                &self.tti_tx_desc_queue_raw[0].to_ne_bytes()[..],
+                &self.tti_tx_desc_queue_raw[0].to_le_bytes()[..],
             )
             .unwrap();
             let data_size = resp_desc.data_length().into();
-            if self.tti_tx_data_raw.len() >= data_size {
+            if self.tti_tx_data_raw[0].len() >= data_size {
+                self.tti_tx_data_raw.pop_front();
                 let resp = I3cTcriResponseXfer {
                     resp: resp_desc,
-                    data: self.tti_tx_data_raw.drain(..data_size).collect(),
+                    data: self.tti_tx_data_raw.pop_front().unwrap(),
                 };
                 self.i3c_target.set_response(resp);
             }
@@ -87,47 +101,115 @@ impl I3c {
                 .push_back((cmd & 0xffff_ffff) as u32);
             self.tti_rx_desc_queue_raw
                 .push_back(((cmd >> 32) & 0xffff_ffff) as u32);
-            self.tti_rx_data_raw.extend(data);
+            self.tti_rx_data_raw.push_back(data);
         }
+    }
+
+    fn check_interrupts(&mut self) {
+        // TODO: implement the rest of the interrupts
+        self.interrupt_status
+            .reg
+            .modify(if self.tti_rx_desc_queue_raw.is_empty() {
+                InterruptStatus::RxDescStat::CLEAR
+            } else {
+                InterruptStatus::RxDescStat::SET
+            });
+
+        // disabled for now as these aren't quite working yet
+        // self.notif_irq
+        //     .set_level(self.interrupt_status.reg.any_matching_bits_set(
+        //         InterruptStatus::RxDescStat::SET
+        //             + InterruptStatus::TxDescStat::SET
+        //             + InterruptStatus::RxDescTimeout::SET
+        //             + InterruptStatus::TxDescTimeout::SET,
+        //     ));
     }
 }
 
 impl I3cPeripheral for I3c {
+    // TODO: route IBI to controller to let them know we're ready for a read
     fn read_i3c_base_hci_version(&mut self, _size: RvSize) -> RvData {
         RvData::from(Self::HCI_VERSION)
     }
 
-    fn read_i3c_ec_stdby_ctrl_mode_stby_cr_capabilities(
+    fn read_i3c_ec_tti_interrupt_enable(
         &mut self,
         _size: emulator_types::RvSize,
-    ) -> emulator_bus::ReadWriteRegister<u32, StbyCrCapabilities::Register> {
-        emulator_bus::ReadWriteRegister::new(StbyCrCapabilities::TargetXactSupport.val(1).value)
+    ) -> emulator_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::InterruptEnable::Register,
+    > {
+        self.interrupt_enable.clone()
+    }
+
+    fn read_i3c_ec_tti_interrupt_status(
+        &mut self,
+        _size: emulator_types::RvSize,
+    ) -> emulator_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::InterruptStatus::Register,
+    > {
+        self.interrupt_status.clone()
+    }
+
+    fn write_i3c_ec_tti_interrupt_enable(
+        &mut self,
+        _size: emulator_types::RvSize,
+        val: emulator_bus::ReadWriteRegister<
+            u32,
+            registers_generated::i3c::bits::InterruptEnable::Register,
+        >,
+    ) {
+        self.interrupt_enable.reg.set(val.reg.get());
+    }
+
+    fn read_i3c_ec_stdby_ctrl_mode_stby_cr_capabilities(
+        &mut self,
+        _size: RvSize,
+    ) -> ReadWriteRegister<u32, StbyCrCapabilities::Register> {
+        ReadWriteRegister::new(StbyCrCapabilities::TargetXactSupport.val(1).value)
+    }
+
+    fn read_i3c_ec_stdby_ctrl_mode_stby_cr_device_addr(
+        &mut self,
+        _size: RvSize,
+    ) -> ReadWriteRegister<u32, StbyCrDeviceAddr::Register> {
+        ReadWriteRegister::new(
+            self.i3c_target
+                .get_address()
+                .unwrap_or(DynamicI3cAddress::new(0x3d).unwrap())
+                .into(),
+        )
     }
 
     fn read_i3c_ec_tti_extcap_header(
         &mut self,
         _size: RvSize,
-    ) -> emulator_bus::ReadWriteRegister<u32, ExtcapHeader::Register> {
-        emulator_bus::ReadWriteRegister::new(ExtcapHeader::CapId.val(0xc4).value)
+    ) -> ReadWriteRegister<u32, ExtcapHeader::Register> {
+        ReadWriteRegister::new(ExtcapHeader::CapId.val(0xc4).value)
     }
 
     fn read_i3c_ec_tti_rx_desc_queue_port(&mut self, _size: RvSize) -> u32 {
+        if self.tti_rx_desc_queue_raw.len() & 1 == 0 {
+            // only replace the data every other read since the descriptor is 64 bits
+            self.tti_rx_current = self.tti_tx_data_raw.pop_front().unwrap_or_default();
+        }
         self.tti_rx_desc_queue_raw.pop_front().unwrap_or(0)
     }
 
     fn read_i3c_ec_tti_rx_data_port(&mut self, size: RvSize) -> u32 {
         match size {
-            RvSize::Byte => self.tti_rx_data_raw.pop_front().unwrap_or(0).into(),
+            RvSize::Byte => self.tti_rx_current.pop().unwrap_or(0) as u32,
             RvSize::HalfWord => {
-                let mut data = (self.tti_rx_data_raw.pop_front().unwrap_or(0) as u32) << 8;
-                data |= self.tti_rx_data_raw.pop_front().unwrap_or(0) as u32;
+                let mut data = (self.tti_rx_current.pop().unwrap_or(0) as u32) << 8;
+                data |= self.tti_rx_current.pop().unwrap_or(0) as u32;
                 data
             }
             RvSize::Word => {
-                let mut data = (self.tti_rx_data_raw.pop_front().unwrap_or(0) as u32) << 24;
-                data |= (self.tti_rx_data_raw.pop_front().unwrap_or(0) as u32) << 16;
-                data |= (self.tti_rx_data_raw.pop_front().unwrap_or(0) as u32) << 8;
-                data |= self.tti_rx_data_raw.pop_front().unwrap_or(0) as u32;
+                let mut data = (self.tti_rx_current.pop().unwrap_or(0) as u32) << 24;
+                data |= (self.tti_rx_current.pop().unwrap_or(0) as u32) << 16;
+                data |= (self.tti_rx_current.pop().unwrap_or(0) as u32) << 8;
+                data |= self.tti_rx_current.pop().unwrap_or(0) as u32;
                 data
             }
             RvSize::Invalid => {
@@ -138,22 +220,24 @@ impl I3cPeripheral for I3c {
 
     fn write_i3c_ec_tti_tx_desc_queue_port(&mut self, _size: RvSize, val: u32) {
         self.tti_tx_desc_queue_raw.push_back(val);
+        self.tti_tx_data_raw.push_back(vec![]);
         self.write_tx_data_into_target();
     }
 
     fn write_i3c_ec_tti_tx_data_port(&mut self, size: RvSize, val: u32) {
         let to_append = val.to_le_bytes();
+        let idx = self.tti_tx_data_raw.len() - 1;
         for byte in &to_append[..size.into()] {
-            self.tti_tx_data_raw.push_back(*byte)
+            self.tti_tx_data_raw[idx].push(*byte);
         }
         self.write_tx_data_into_target();
     }
 
     fn read_i3c_ec_tti_tti_queue_size(
         &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_bus::ReadWriteRegister<u32, TtiQueueSize::Register> {
-        emulator_bus::ReadWriteRegister::new(
+        _size: RvSize,
+    ) -> ReadWriteRegister<u32, TtiQueueSize::Register> {
+        ReadWriteRegister::new(
             (TtiQueueSize::RxDataBufferSize.val(5)
                 + TtiQueueSize::TxDataBufferSize.val(5)
                 + TtiQueueSize::RxDescBufferSize.val(5)
@@ -163,8 +247,18 @@ impl I3cPeripheral for I3c {
     }
 
     fn poll(&mut self) {
+        self.check_interrupts();
         self.read_rx_data_into_buffer();
+        self.write_tx_data_into_target();
         self.timer.schedule_poll_in(Self::HCI_TICKS);
+
+        if cfg!(feature = "test-i3c-constant-writes") {
+            // ensure there is always a write queued
+            if self.tti_rx_desc_queue_raw.is_empty() {
+                self.tti_rx_desc_queue_raw.push_back(100);
+                self.tti_rx_data_raw.push_back(vec![0xff; 100]);
+            }
+        }
     }
 }
 

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -21,3 +21,8 @@ riscv-csr = { git = "https://github.com/tock/tock.git", rev = "b128ae817b86706c8
 rv32i = { git = "https://github.com/tock/tock.git", rev = "b128ae817b86706c8c4e39d27fae5c54b98659f1" }
 tock-registers.workspace = true
 capsules-runtime.workspace = true
+
+[features]
+default = []
+test-i3c-simple = []
+test-i3c-constant-writes = []

--- a/runtime/i3c/src/core.rs
+++ b/runtime/i3c/src/core.rs
@@ -211,7 +211,7 @@ impl<'a, A: Alarm<'a>> I3CCore<'a, A> {
                 // clear the interrupt
                 self.registers
                     .interrupt_status
-                    .modify(InterruptStatus::TransferErrStat::CLEAR);
+                    .write(InterruptStatus::TransferErrStat::SET);
             }
             // Bus aborted transaction
             if tti_interrupts.read(InterruptStatus::TransferAbortStat) != 0 {
@@ -219,7 +219,7 @@ impl<'a, A: Alarm<'a>> I3CCore<'a, A> {
                 // clear the interrupt
                 self.registers
                     .interrupt_status
-                    .modify(InterruptStatus::TransferAbortStat::CLEAR);
+                    .write(InterruptStatus::TransferAbortStat::SET);
             }
             // TTI IBI Buffer Threshold Status, the Target Controller shall set this bit to 1 when the number of available entries in the TTI IBI Queue is >= the value defined in `TTI_IBI_THLD`
             if tti_interrupts.read(InterruptStatus::IbiThldStat) != 0 {
@@ -262,7 +262,7 @@ impl<'a, A: Alarm<'a>> I3CCore<'a, A> {
                 // clear the interrupt
                 self.registers
                     .interrupt_status
-                    .modify(InterruptStatus::TxDescTimeout::CLEAR);
+                    .write(InterruptStatus::TxDescTimeout::SET);
             }
             // Pending Read was NACK’ed because the `RX_DESC_STAT` event was not handled in time
             if tti_interrupts.read(InterruptStatus::RxDescTimeout) != 0 {
@@ -270,7 +270,7 @@ impl<'a, A: Alarm<'a>> I3CCore<'a, A> {
                 // clear the interrupt
                 self.registers
                     .interrupt_status
-                    .modify(InterruptStatus::TxDescTimeout::CLEAR);
+                    .write(InterruptStatus::TxDescTimeout::SET);
             }
             // There is a pending Read Transaction on the I3C Bus. Software should write data to the TX Descriptor Queue and the TX Data Queue
             if tti_interrupts.read(InterruptStatus::TxDescStat) != 0 {

--- a/runtime/src/board.rs
+++ b/runtime/src/board.rs
@@ -252,5 +252,18 @@ pub unsafe fn main() {
         debug!("{:?}", err);
     });
 
+    // Run any requested test
+    let exit = if cfg!(feature = "test-i3c-simple") {
+        debug!("Executing test-i3c-simple");
+        crate::tests::test_i3c_simple()
+    } else if cfg!(feature = "test-i3c-constant-writes") {
+        debug!("Executing test-i3c-constant-writes");
+        crate::tests::test_i3c_constant_writes()
+    } else {
+        None
+    };
+    if let Some(exit) = exit {
+        crate::io::exit_emulator(exit);
+    }
     board_kernel.kernel_loop(&veer, chip, None::<&kernel::ipc::IPC<0>>, &main_loop_cap);
 }

--- a/runtime/src/io.rs
+++ b/runtime/src/io.rs
@@ -35,7 +35,6 @@ pub(crate) static mut WRITER: Writer = Writer {};
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
     let writer = &mut *addr_of_mut!(WRITER);
-
     debug::panic_print(
         writer,
         pi,
@@ -44,10 +43,16 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
         &*addr_of!(CHIP),
         &*addr_of!(PROCESS_PRINTER),
     );
+    exit_emulator(1);
+}
 
-    // By writing to this address we can exit the emulator.
-    write_volatile(0x2000_f000 as *mut u32, 0);
-
+/// Exit the emulator
+pub fn exit_emulator(exit_code: u32) -> ! {
+    // Safety: This is a safe memory address to write to for exiting the emulator.
+    unsafe {
+        // By writing to this address we can exit the emulator.
+        write_volatile(0x2000_f000 as *mut u32, exit_code);
+    }
     unreachable!()
 }
 

--- a/runtime/src/main.rs
+++ b/runtime/src/main.rs
@@ -21,6 +21,8 @@ pub mod io;
 #[cfg(target_arch = "riscv32")]
 mod pic;
 #[cfg(target_arch = "riscv32")]
+mod tests;
+#[cfg(target_arch = "riscv32")]
 mod timers;
 #[cfg(target_arch = "riscv32")]
 pub use board::*;

--- a/runtime/src/tests.rs
+++ b/runtime/src/tests.rs
@@ -1,0 +1,117 @@
+// Licensed under the Apache-2.0 license.
+
+use crate::timers::InternalTimers;
+use core::cell::Cell;
+use i3c_driver::{
+    core::I3CCore,
+    hil::{I3CTarget, RxClient},
+};
+use kernel::{
+    debug, debug_flush_queue,
+    deferred_call::{DeferredCall, DeferredCallClient},
+    static_buf, static_init,
+    utilities::cells::{OptionalCell, TakeCell},
+};
+
+fn success() -> ! {
+    debug_flush_queue!();
+    crate::io::exit_emulator(0);
+}
+
+#[allow(dead_code)]
+fn fail() -> ! {
+    debug_flush_queue!();
+    crate::io::exit_emulator(1);
+}
+
+/// A simple test that just enables and disables the I3C driver.
+pub(crate) fn test_i3c_simple() -> Option<u32> {
+    // Safety: this is run after the board has initialized the chip.
+    let chip = unsafe { crate::CHIP.unwrap() };
+    chip.peripherals.i3c.enable();
+    chip.peripherals.i3c.disable();
+    Some(0)
+}
+
+/// Tests that writes are handled properly
+pub(crate) fn test_i3c_constant_writes() -> Option<u32> {
+    debug!("initializing test");
+    // Safety: this is run after the board has initialized the chip.
+    let chip = unsafe { crate::CHIP.unwrap() };
+    let i3c = &chip.peripherals.i3c;
+    // Safety: this buffer is only used by one function at a time, and only once.
+    let const_writes_buf = unsafe { static_buf!([u8; 128]) };
+    let const_writes_buf = const_writes_buf.write([0u8; 128]) as &'static mut [u8];
+    let tester = unsafe { static_init!(I3CConstantWritesTest, I3CConstantWritesTest::new()) };
+    tester.buf.replace(const_writes_buf);
+    tester.i3c.set(i3c);
+    tester.register();
+    tester.deferred_call.set();
+    i3c.set_rx_client(tester);
+    i3c.enable();
+    None
+}
+
+struct I3CConstantWritesTest<'a> {
+    deferred_call: DeferredCall,
+    count: Cell<usize>,
+    buf: TakeCell<'static, [u8]>,
+    i3c: OptionalCell<&'a I3CCore<'static, InternalTimers<'static>>>,
+    deferred_calls: Cell<usize>,
+}
+
+impl<'a> I3CConstantWritesTest<'a> {
+    pub fn new() -> I3CConstantWritesTest<'a> {
+        I3CConstantWritesTest {
+            deferred_call: DeferredCall::new(),
+            count: Cell::new(0),
+            buf: TakeCell::empty(),
+            i3c: OptionalCell::empty(),
+            deferred_calls: Cell::new(0),
+        }
+    }
+}
+
+impl<'a> DeferredCallClient for I3CConstantWritesTest<'a> {
+    fn handle_deferred_call(&self) {
+        if self.count.get() > 10 {
+            debug!("Passed");
+            success();
+        }
+        let iter = self.deferred_calls.get();
+        self.deferred_calls.set(iter + 1);
+        if iter > 10000 {
+            debug!(
+                "Too many deferred calls; failing test; only got {}",
+                self.count.get()
+            );
+            // TODO: this test is actually failing, but we succeed for now while we debug it
+            fail();
+        }
+        // HACK: manually call the handlers every iteration since interrupts are not handled correctly
+        // TODO: remove these hacks when interrupts are handled correctly
+        self.i3c.get().unwrap().handle_outgoing_read();
+        self.i3c.get().unwrap().handle_incoming_write();
+
+        // try again in the next kernel loop
+        self.deferred_call.set();
+    }
+
+    fn register(&'static self) {
+        self.deferred_call.register(self);
+    }
+}
+
+impl<'a> RxClient for I3CConstantWritesTest<'a> {
+    fn receive_write(&self, rx_buffer: &'static mut [u8], _len: usize) {
+        self.buf.replace(rx_buffer);
+        self.count.set(self.count.get() + 1);
+    }
+
+    fn write_expected(&self) {
+        self.i3c
+            .get()
+            .unwrap()
+            .set_rx_buffer(self.buf.take().unwrap());
+    }
+}

--- a/tests/integration/Cargo.toml
+++ b/tests/integration/Cargo.toml
@@ -1,7 +1,7 @@
 # Licensed under the Apache-2.0 license
 
 [package]
-name = "emulator"
+name = "tests-integration"
 version = "0.1.0"
 edition = "2021"
 
@@ -11,7 +11,6 @@ edition = "2021"
 caliptra-emu-cpu.workspace = true
 caliptra-emu-periph.workspace = true
 clap.workspace = true
-crossterm.workspace = true
 ctrlc.workspace = true
 elf.workspace = true
 emulator-bus.workspace = true
@@ -25,8 +24,3 @@ gdbstub.workspace = true
 hex.workspace = true
 tock-registers.workspace = true
 zerocopy.workspace = true
-
-[features]
-default = []
-test-i3c-simple = []
-test-i3c-constant-writes = ["emulator-periph/test-i3c-constant-writes"]

--- a/tests/integration/src/lib.rs
+++ b/tests/integration/src/lib.rs
@@ -1,0 +1,128 @@
+// Licensed under the Apache-2.0 license
+
+#[cfg(test)]
+mod test {
+    use std::io::Write;
+    use std::process::ExitStatus;
+    use std::sync::atomic::AtomicU32;
+    use std::sync::Mutex;
+    use std::{
+        path::{Path, PathBuf},
+        process::Command,
+        sync::LazyLock,
+    };
+
+    const TARGET: &str = "riscv32imc-unknown-none-elf";
+
+    static PROJECT_ROOT: LazyLock<PathBuf> = LazyLock::new(|| {
+        Path::new(&env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap()
+            .parent()
+            .unwrap()
+            .to_path_buf()
+    });
+
+    fn target_binary(name: &str) -> PathBuf {
+        PROJECT_ROOT
+            .join("target")
+            .join(TARGET)
+            .join("release")
+            .join(name)
+    }
+
+    static BUILD_LOCK: LazyLock<Mutex<AtomicU32>> = LazyLock::new(|| Mutex::new(AtomicU32::new(0)));
+
+    fn compile_rom() -> PathBuf {
+        let lock = BUILD_LOCK.lock().unwrap();
+        lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
+        let output = target_binary("rom.bin");
+        let mut cmd = Command::new("cargo");
+        let cmd = cmd
+            .args(&["xtask", "rom-build"])
+            .current_dir(&*PROJECT_ROOT);
+        let cmd_output = cmd.output().unwrap();
+        if !cmd.status().unwrap().success() {
+            std::io::stdout().write_all(&cmd_output.stdout).unwrap();
+            std::io::stderr().write_all(&cmd_output.stderr).unwrap();
+            panic!("failed to compile ROM");
+        }
+        assert!(output.exists());
+        // force the compiler to keep the lock
+        lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        output
+    }
+
+    fn compile_runtime(feature: &str) -> PathBuf {
+        let lock = BUILD_LOCK.lock().unwrap();
+        lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
+        let output = target_binary(&format!("runtime-{}.bin", feature));
+        let mut cmd = Command::new("cargo");
+        let cmd = cmd
+            .args(&[
+                "xtask",
+                "runtime-build",
+                "--features",
+                feature,
+                "--output",
+                &format!("{}", output.display()),
+            ])
+            .current_dir(&*PROJECT_ROOT);
+        let cmd_output = cmd.output().unwrap();
+        if !cmd.status().unwrap().success() {
+            std::io::stdout().write_all(&cmd_output.stdout).unwrap();
+            std::io::stderr().write_all(&cmd_output.stderr).unwrap();
+            panic!("failed to compile runtime");
+        }
+        assert!(output.exists());
+
+        // force the compiler to keep the lock
+        lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        output
+    }
+
+    fn run_runtime(feature: &str, rom_path: PathBuf, runtime_path: PathBuf) -> ExitStatus {
+        let cargo_run_args = vec![
+            "run",
+            "-p",
+            "emulator",
+            "--release",
+            "--features",
+            feature,
+            "--",
+            "--rom",
+            rom_path.to_str().unwrap(),
+            "--firmware",
+            runtime_path.to_str().unwrap(),
+        ];
+        println!("Running test firmware {}", feature.replace("_", "-"));
+        let mut cmd = Command::new("cargo");
+        let cmd = cmd.args(&cargo_run_args).current_dir(&*PROJECT_ROOT);
+        cmd.status().unwrap()
+    }
+
+    #[macro_export]
+    macro_rules! run_test {
+        ($test:ident) => {
+            #[test]
+            fn $test() {
+                println!("Compiling test firmware {}", stringify!($test));
+                let test_rom = compile_rom();
+                let feature = stringify!($test).replace("_", "-");
+                let test_runtime = compile_runtime(&feature);
+                let test = run_runtime(&feature, test_rom, test_runtime);
+                assert_eq!(0, test.code().unwrap_or_default())
+            }
+        };
+    }
+
+    // To add a test:
+    // * add the test name here
+    // * add the feature to the emulator and use it to implement any behavior needed
+    // * add the feature to the runtime and use it in board.rs at the end of the main function to call your test
+    // These use underscores but will be converted to dashes in the feature flags
+    run_test!(test_i3c_simple);
+    run_test!(test_i3c_constant_writes);
+}

--- a/xtask/src/precheckin.rs
+++ b/xtask/src/precheckin.rs
@@ -5,6 +5,6 @@ pub(crate) fn precheckin() -> Result<(), crate::DynError> {
     crate::format::format()?;
     crate::clippy::clippy()?;
     crate::header::check()?;
-    crate::runtime_build::runtime_build_with_apps()?;
+    crate::runtime_build::runtime_build_with_apps(&[], None)?;
     crate::test::test()
 }


### PR DESCRIPTION
This progresses more on the I3C peripheral, correctly queueing writes how the hardware does.

We also start on writing a socket protocol so that another thread or program can send reads and writes to the I3C bus. This hasn't been teste yet though.

I noticed two bugs that I will address in separate PRs:
* The I3C interrupts are not quite working yet. When enabled, they are routed correctly to the kernel handler, but keep getting retriggered and not handled properly. I've disabled the interrupts for now, so the read/write methods need to be called manually.
* Alarms are not firing properly. I tried to work around the interrupts not handling correctly by scheduling an alarm to call the read/write methods periodically, but the alarms never fire. I've noticed something similar to this before. I will debug this separately.

The biggest piece though is adding new integration tests for the kernel:

* A test can be added to `tests/integration/src/lib.rs`
* This will build the emulator and firmware with the feature equal to the test name, and then run them.
* The test can exit with a non-zero exit code to signal failure.

The tests need to built sequentially so that they don't conflict when writing the `layout.ld` linker script (this has to have the same name each time to avoid modifying `RUSTFLAGS` with every invocation; otherwise dependencies are recompiled every single time).