### PR TITLE
registers: Honor read-only / write-only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ runtime/apps/layout.ld
 
 # mdbook
 book
+
+# flash file
+dummy_flash.bin

--- a/emulator/periph/src/flash_ctrl.rs
+++ b/emulator/periph/src/flash_ctrl.rs
@@ -462,18 +462,6 @@ impl FlashPeripheral for DummyFlashCtrl {
     > {
         emulator_bus::ReadWriteRegister::new(self.ctrl_regwen.reg.get())
     }
-
-    fn write_ctrl_regwen(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_bus::ReadWriteRegister<
-            u32,
-            registers_generated::flash_ctrl::bits::CtrlRegwen::Register,
-        >,
-    ) {
-        // Unreachable
-        panic!("Write to read-only ctrl_regwen register");
-    }
 }
 
 #[cfg(test)]

--- a/registers/generated-emulator/src/el2_pic.rs
+++ b/registers/generated-emulator/src/el2_pic.rs
@@ -33,15 +33,6 @@ pub trait El2PicPeripheral {
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
-    fn write_meip(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_bus::ReadWriteRegister<
-            u32,
-            registers_generated::el2_pic_ctrl::bits::Meip::Register,
-        >,
-    ) {
-    }
     fn read_meie(
         &mut self,
         _size: emulator_types::RvSize,
@@ -174,16 +165,6 @@ impl emulator_bus::Bus for El2PicBus {
                 Ok(())
             }
             (emulator_types::RvSize::Word, 1..=3) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1000) => {
-                self.periph.write_meip(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0x1001..=0x1003) => {
                 Err(emulator_bus::BusError::StoreAddrMisaligned)
             }
             (emulator_types::RvSize::Word, 0x2000) => {

--- a/registers/generated-emulator/src/flash.rs
+++ b/registers/generated-emulator/src/flash.rs
@@ -101,15 +101,6 @@ pub trait FlashPeripheral {
     > {
         emulator_bus::ReadWriteRegister::new(0)
     }
-    fn write_ctrl_regwen(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_bus::ReadWriteRegister<
-            u32,
-            registers_generated::flash_ctrl::bits::CtrlRegwen::Register,
-        >,
-    ) {
-    }
 }
 pub struct FlashBus {
     pub periph: Box<dyn FlashPeripheral>,
@@ -235,16 +226,6 @@ impl emulator_bus::Bus for FlashBus {
                 Ok(())
             }
             (emulator_types::RvSize::Word, 0x19..=0x1b) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1c) => {
-                self.periph.write_ctrl_regwen(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0x1d..=0x1f) => {
                 Err(emulator_bus::BusError::StoreAddrMisaligned)
             }
             _ => Err(emulator_bus::BusError::StoreAccessFault),

--- a/registers/generated-emulator/src/i3c.rs
+++ b/registers/generated-emulator/src/i3c.rs
@@ -22,12 +22,6 @@ pub trait I3cPeripheral {
     ) -> emulator_types::RvData {
         0
     }
-    fn write_i3c_base_hci_version(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
     fn read_i3c_base_hc_control(
         &mut self,
         _size: emulator_types::RvSize,
@@ -71,15 +65,6 @@ pub trait I3cPeripheral {
     > {
         emulator_bus::ReadWriteRegister::new(0)
     }
-    fn write_i3c_base_hc_capabilities(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_bus::ReadWriteRegister<
-            u32,
-            registers_generated::i3c::bits::HcCapabilities::Register,
-        >,
-    ) {
-    }
     fn read_i3c_base_reset_control(
         &mut self,
         _size: emulator_types::RvSize,
@@ -102,15 +87,6 @@ pub trait I3cPeripheral {
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::PresentState::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
-    }
-    fn write_i3c_base_present_state(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_bus::ReadWriteRegister<
-            u32,
-            registers_generated::i3c::bits::PresentState::Register,
-        >,
-    ) {
     }
     fn read_i3c_base_intr_status(
         &mut self,
@@ -164,13 +140,6 @@ pub trait I3cPeripheral {
         >,
     ) {
     }
-    fn read_i3c_base_intr_force(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::IntrForce::Register>
-    {
-        emulator_bus::ReadWriteRegister::new(0)
-    }
     fn write_i3c_base_intr_force(
         &mut self,
         _size: emulator_types::RvSize,
@@ -188,15 +157,6 @@ pub trait I3cPeripheral {
         registers_generated::i3c::bits::DatSectionOffset::Register,
     > {
         emulator_bus::ReadWriteRegister::new(0)
-    }
-    fn write_i3c_base_dat_section_offset(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_bus::ReadWriteRegister<
-            u32,
-            registers_generated::i3c::bits::DatSectionOffset::Register,
-        >,
-    ) {
     }
     fn read_i3c_base_dct_section_offset(
         &mut self,
@@ -225,15 +185,6 @@ pub trait I3cPeripheral {
     > {
         emulator_bus::ReadWriteRegister::new(0)
     }
-    fn write_i3c_base_ring_headers_section_offset(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_bus::ReadWriteRegister<
-            u32,
-            registers_generated::i3c::bits::RingHeadersSectionOffset::Register,
-        >,
-    ) {
-    }
     fn read_i3c_base_pio_section_offset(
         &mut self,
         _size: emulator_types::RvSize,
@@ -242,15 +193,6 @@ pub trait I3cPeripheral {
         registers_generated::i3c::bits::PioSectionOffset::Register,
     > {
         emulator_bus::ReadWriteRegister::new(0)
-    }
-    fn write_i3c_base_pio_section_offset(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_bus::ReadWriteRegister<
-            u32,
-            registers_generated::i3c::bits::PioSectionOffset::Register,
-        >,
-    ) {
     }
     fn read_i3c_base_ext_caps_section_offset(
         &mut self,
@@ -261,30 +203,12 @@ pub trait I3cPeripheral {
     > {
         emulator_bus::ReadWriteRegister::new(0)
     }
-    fn write_i3c_base_ext_caps_section_offset(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_bus::ReadWriteRegister<
-            u32,
-            registers_generated::i3c::bits::ExtCapsSectionOffset::Register,
-        >,
-    ) {
-    }
     fn read_i3c_base_int_ctrl_cmds_en(
         &mut self,
         _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::IntCtrlCmdsEn::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
-    }
-    fn write_i3c_base_int_ctrl_cmds_en(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_bus::ReadWriteRegister<
-            u32,
-            registers_generated::i3c::bits::IntCtrlCmdsEn::Register,
-        >,
-    ) {
     }
     fn read_i3c_base_ibi_notify_ctrl(
         &mut self,
@@ -359,21 +283,6 @@ pub trait I3cPeripheral {
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
-    fn write_i3c_base_dev_ctx_sg(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_bus::ReadWriteRegister<
-            u32,
-            registers_generated::i3c::bits::DevCtxSg::Register,
-        >,
-    ) {
-    }
-    fn read_piocontrol_command_port(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
-        0
-    }
     fn write_piocontrol_command_port(
         &mut self,
         _size: emulator_types::RvSize,
@@ -381,18 +290,6 @@ pub trait I3cPeripheral {
     ) {
     }
     fn read_piocontrol_response_port(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
-        0
-    }
-    fn write_piocontrol_response_port(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_piocontrol_tx_data_port(
         &mut self,
         _size: emulator_types::RvSize,
     ) -> emulator_types::RvData {
@@ -410,27 +307,12 @@ pub trait I3cPeripheral {
     ) -> emulator_types::RvData {
         0
     }
-    fn write_piocontrol_rx_data_port(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
     fn read_piocontrol_ibi_port(
         &mut self,
         _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::IbiPort::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
-    }
-    fn write_piocontrol_ibi_port(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_bus::ReadWriteRegister<
-            u32,
-            registers_generated::i3c::bits::IbiPort::Register,
-        >,
-    ) {
     }
     fn read_piocontrol_queue_thld_ctrl(
         &mut self,
@@ -473,30 +355,12 @@ pub trait I3cPeripheral {
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
-    fn write_piocontrol_queue_size(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_bus::ReadWriteRegister<
-            u32,
-            registers_generated::i3c::bits::QueueSize::Register,
-        >,
-    ) {
-    }
     fn read_piocontrol_alt_queue_size(
         &mut self,
         _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::AltQueueSize::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
-    }
-    fn write_piocontrol_alt_queue_size(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_bus::ReadWriteRegister<
-            u32,
-            registers_generated::i3c::bits::AltQueueSize::Register,
-        >,
-    ) {
     }
     fn read_piocontrol_pio_intr_status(
         &mut self,
@@ -550,13 +414,6 @@ pub trait I3cPeripheral {
         >,
     ) {
     }
-    fn read_piocontrol_pio_intr_force(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::PioIntrForce::Register>
-    {
-        emulator_bus::ReadWriteRegister::new(0)
-    }
     fn write_piocontrol_pio_intr_force(
         &mut self,
         _size: emulator_types::RvSize,
@@ -588,15 +445,6 @@ pub trait I3cPeripheral {
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::ExtcapHeader::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
-    }
-    fn write_i3c_ec_sec_fw_recovery_if_extcap_header(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_bus::ReadWriteRegister<
-            u32,
-            registers_generated::i3c::bits::ExtcapHeader::Register,
-        >,
-    ) {
     }
     fn read_i3c_ec_sec_fw_recovery_if_prot_cap_0(
         &mut self,
@@ -917,15 +765,6 @@ pub trait I3cPeripheral {
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
-    fn write_i3c_ec_stdby_ctrl_mode_extcap_header(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_bus::ReadWriteRegister<
-            u32,
-            registers_generated::i3c::bits::ExtcapHeader::Register,
-        >,
-    ) {
-    }
     fn read_i3c_ec_stdby_ctrl_mode_stby_cr_control(
         &mut self,
         _size: emulator_types::RvSize,
@@ -1169,15 +1008,6 @@ pub trait I3cPeripheral {
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
-    fn write_i3c_ec_tti_extcap_header(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_bus::ReadWriteRegister<
-            u32,
-            registers_generated::i3c::bits::ExtcapHeader::Register,
-        >,
-    ) {
-    }
     fn read_i3c_ec_tti_control(&mut self, _size: emulator_types::RvSize) -> emulator_types::RvData {
         0
     }
@@ -1274,25 +1104,7 @@ pub trait I3cPeripheral {
     ) -> emulator_types::RvData {
         0
     }
-    fn write_i3c_ec_tti_rx_desc_queue_port(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
     fn read_i3c_ec_tti_rx_data_port(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
-        0
-    }
-    fn write_i3c_ec_tti_rx_data_port(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_i3c_ec_tti_tx_desc_queue_port(
         &mut self,
         _size: emulator_types::RvSize,
     ) -> emulator_types::RvData {
@@ -1304,23 +1116,11 @@ pub trait I3cPeripheral {
         _val: emulator_types::RvData,
     ) {
     }
-    fn read_i3c_ec_tti_tx_data_port(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
-        0
-    }
     fn write_i3c_ec_tti_tx_data_port(
         &mut self,
         _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
-    }
-    fn read_i3c_ec_tti_tti_ibi_port(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
-        0
     }
     fn write_i3c_ec_tti_tti_ibi_port(
         &mut self,
@@ -1335,15 +1135,6 @@ pub trait I3cPeripheral {
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
-    fn write_i3c_ec_tti_tti_queue_size(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_bus::ReadWriteRegister<
-            u32,
-            registers_generated::i3c::bits::TtiQueueSize::Register,
-        >,
-    ) {
-    }
     fn read_i3c_ec_tti_ibi_tti_queue_size(
         &mut self,
         _size: emulator_types::RvSize,
@@ -1352,15 +1143,6 @@ pub trait I3cPeripheral {
         registers_generated::i3c::bits::IbiTtiQueueSize::Register,
     > {
         emulator_bus::ReadWriteRegister::new(0)
-    }
-    fn write_i3c_ec_tti_ibi_tti_queue_size(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_bus::ReadWriteRegister<
-            u32,
-            registers_generated::i3c::bits::IbiTtiQueueSize::Register,
-        >,
-    ) {
     }
     fn read_i3c_ec_tti_tti_queue_thld_ctrl(
         &mut self,
@@ -1404,15 +1186,6 @@ pub trait I3cPeripheral {
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::ExtcapHeader::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
-    }
-    fn write_i3c_ec_soc_mgmt_if_extcap_header(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_bus::ReadWriteRegister<
-            u32,
-            registers_generated::i3c::bits::ExtcapHeader::Register,
-        >,
-    ) {
     }
     fn read_i3c_ec_soc_mgmt_if_soc_mgmt_control(
         &mut self,
@@ -1721,15 +1494,6 @@ pub trait I3cPeripheral {
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
-    fn write_i3c_ec_ctrl_cfg_extcap_header(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_bus::ReadWriteRegister<
-            u32,
-            registers_generated::i3c::bits::ExtcapHeader::Register,
-        >,
-    ) {
-    }
     fn read_i3c_ec_ctrl_cfg_controller_config(
         &mut self,
         _size: emulator_types::RvSize,
@@ -1738,15 +1502,6 @@ pub trait I3cPeripheral {
         registers_generated::i3c::bits::ControllerConfig::Register,
     > {
         emulator_bus::ReadWriteRegister::new(0)
-    }
-    fn write_i3c_ec_ctrl_cfg_controller_config(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_bus::ReadWriteRegister<
-            u32,
-            registers_generated::i3c::bits::ControllerConfig::Register,
-        >,
-    ) {
     }
 }
 pub struct I3cBus {
@@ -1835,15 +1590,6 @@ impl emulator_bus::Bus for I3cBus {
                     .get(),
             )),
             (emulator_types::RvSize::Word, 0x29..=0x2b) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x2c) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_i3c_base_intr_force(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0x2d..=0x2f) => {
                 Err(emulator_bus::BusError::LoadAddrMisaligned)
             }
             (emulator_types::RvSize::Word, 0x30) => Ok(emulator_types::RvData::from(
@@ -2019,15 +1765,6 @@ impl emulator_bus::Bus for I3cBus {
                     .get(),
             )),
             (emulator_types::RvSize::Word, 0xa9..=0xab) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xac) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_piocontrol_pio_intr_force(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0xad..=0xaf) => {
                 Err(emulator_bus::BusError::LoadAddrMisaligned)
             }
             (emulator_types::RvSize::Word, 0xb0) => Ok(emulator_types::RvData::from(
@@ -2522,16 +2259,6 @@ impl emulator_bus::Bus for I3cBus {
             (emulator_types::RvSize::Word, 9..=0xb) => {
                 Err(emulator_bus::BusError::StoreAddrMisaligned)
             }
-            (emulator_types::RvSize::Word, 0xc) => {
-                self.periph.write_i3c_base_hc_capabilities(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0xd..=0xf) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
             (emulator_types::RvSize::Word, 0x10) => {
                 self.periph.write_i3c_base_reset_control(
                     emulator_types::RvSize::Word,
@@ -2540,16 +2267,6 @@ impl emulator_bus::Bus for I3cBus {
                 Ok(())
             }
             (emulator_types::RvSize::Word, 0x11..=0x13) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x14) => {
-                self.periph.write_i3c_base_present_state(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0x15..=0x17) => {
                 Err(emulator_bus::BusError::StoreAddrMisaligned)
             }
             (emulator_types::RvSize::Word, 0x20) => {
@@ -2592,16 +2309,6 @@ impl emulator_bus::Bus for I3cBus {
             (emulator_types::RvSize::Word, 0x2d..=0x2f) => {
                 Err(emulator_bus::BusError::StoreAddrMisaligned)
             }
-            (emulator_types::RvSize::Word, 0x30) => {
-                self.periph.write_i3c_base_dat_section_offset(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0x31..=0x33) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
             (emulator_types::RvSize::Word, 0x34) => {
                 self.periph.write_i3c_base_dct_section_offset(
                     emulator_types::RvSize::Word,
@@ -2610,46 +2317,6 @@ impl emulator_bus::Bus for I3cBus {
                 Ok(())
             }
             (emulator_types::RvSize::Word, 0x35..=0x37) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x38) => {
-                self.periph.write_i3c_base_ring_headers_section_offset(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0x39..=0x3b) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x3c) => {
-                self.periph.write_i3c_base_pio_section_offset(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0x3d..=0x3f) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x40) => {
-                self.periph.write_i3c_base_ext_caps_section_offset(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0x41..=0x43) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x4c) => {
-                self.periph.write_i3c_base_int_ctrl_cmds_en(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0x4d..=0x4f) => {
                 Err(emulator_bus::BusError::StoreAddrMisaligned)
             }
             (emulator_types::RvSize::Word, 0x58) => {
@@ -2692,16 +2359,6 @@ impl emulator_bus::Bus for I3cBus {
             (emulator_types::RvSize::Word, 0x65..=0x67) => {
                 Err(emulator_bus::BusError::StoreAddrMisaligned)
             }
-            (emulator_types::RvSize::Word, 0x68) => {
-                self.periph.write_i3c_base_dev_ctx_sg(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0x69..=0x6b) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
             (size, 0x80) => {
                 self.periph.write_piocontrol_command_port(size, val);
                 Ok(())
@@ -2712,16 +2369,6 @@ impl emulator_bus::Bus for I3cBus {
                 Ok(())
             }
             (_, 0x89..=0x8b) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x8c) => {
-                self.periph.write_piocontrol_ibi_port(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0x8d..=0x8f) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
             (emulator_types::RvSize::Word, 0x90) => {
                 self.periph.write_piocontrol_queue_thld_ctrl(
                     emulator_types::RvSize::Word,
@@ -2740,26 +2387,6 @@ impl emulator_bus::Bus for I3cBus {
                 Ok(())
             }
             (emulator_types::RvSize::Word, 0x95..=0x97) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x98) => {
-                self.periph.write_piocontrol_queue_size(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0x99..=0x9b) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x9c) => {
-                self.periph.write_piocontrol_alt_queue_size(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0x9d..=0x9f) => {
                 Err(emulator_bus::BusError::StoreAddrMisaligned)
             }
             (emulator_types::RvSize::Word, 0xa0) => {
@@ -2810,16 +2437,6 @@ impl emulator_bus::Bus for I3cBus {
                 Ok(())
             }
             (emulator_types::RvSize::Word, 0xb1..=0xb3) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x100) => {
-                self.periph.write_i3c_ec_sec_fw_recovery_if_extcap_header(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0x101..=0x103) => {
                 Err(emulator_bus::BusError::StoreAddrMisaligned)
             }
             (size, 0x104) => {
@@ -2978,16 +2595,6 @@ impl emulator_bus::Bus for I3cBus {
                 Ok(())
             }
             (_, 0x169..=0x16b) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x180) => {
-                self.periph.write_i3c_ec_stdby_ctrl_mode_extcap_header(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0x181..=0x183) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
             (emulator_types::RvSize::Word, 0x184) => {
                 self.periph.write_i3c_ec_stdby_ctrl_mode_stby_cr_control(
                     emulator_types::RvSize::Word,
@@ -3121,16 +2728,6 @@ impl emulator_bus::Bus for I3cBus {
                 Ok(())
             }
             (_, 0x1bd..=0x1bf) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x1c0) => {
-                self.periph.write_i3c_ec_tti_extcap_header(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0x1c1..=0x1c3) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
             (size, 0x1c4) => {
                 self.periph.write_i3c_ec_tti_control(size, val);
                 Ok(())
@@ -3196,26 +2793,6 @@ impl emulator_bus::Bus for I3cBus {
                 Ok(())
             }
             (_, 0x1ed..=0x1ef) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x1f0) => {
-                self.periph.write_i3c_ec_tti_tti_queue_size(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0x1f1..=0x1f3) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1f4) => {
-                self.periph.write_i3c_ec_tti_ibi_tti_queue_size(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0x1f5..=0x1f7) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
             (emulator_types::RvSize::Word, 0x1f8) => {
                 self.periph.write_i3c_ec_tti_tti_queue_thld_ctrl(
                     emulator_types::RvSize::Word,
@@ -3234,16 +2811,6 @@ impl emulator_bus::Bus for I3cBus {
                 Ok(())
             }
             (emulator_types::RvSize::Word, 0x1fd..=0x1ff) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x200) => {
-                self.periph.write_i3c_ec_soc_mgmt_if_extcap_header(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0x201..=0x203) => {
                 Err(emulator_bus::BusError::StoreAddrMisaligned)
             }
             (size, 0x204) => {
@@ -3419,26 +2986,6 @@ impl emulator_bus::Bus for I3cBus {
                 Ok(())
             }
             (_, 0x259..=0x25b) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x260) => {
-                self.periph.write_i3c_ec_ctrl_cfg_extcap_header(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0x261..=0x263) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x264) => {
-                self.periph.write_i3c_ec_ctrl_cfg_controller_config(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0x265..=0x267) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
             _ => Err(emulator_bus::BusError::StoreAccessFault),
         }
     }

--- a/registers/generated-emulator/src/mbox.rs
+++ b/registers/generated-emulator/src/mbox.rs
@@ -14,16 +14,9 @@ pub trait MboxPeripheral {
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::mbox::bits::Lock::Register> {
         emulator_bus::ReadWriteRegister::new(0)
     }
-    fn write_lock(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_bus::ReadWriteRegister<u32, registers_generated::mbox::bits::Lock::Register>,
-    ) {
-    }
     fn read_id(&mut self, _size: emulator_types::RvSize) -> emulator_types::RvData {
         0
     }
-    fn write_id(&mut self, _size: emulator_types::RvSize, _val: emulator_types::RvData) {}
     fn read_cmd(&mut self, _size: emulator_types::RvSize) -> emulator_types::RvData {
         0
     }
@@ -155,16 +148,6 @@ impl emulator_bus::Bus for MboxBus {
         val: emulator_types::RvData,
     ) -> Result<(), emulator_bus::BusError> {
         match (size, addr) {
-            (emulator_types::RvSize::Word, 0) => {
-                self.periph.write_lock(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 1..=3) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
             (size, 8) => {
                 self.periph.write_cmd(size, val);
                 Ok(())

--- a/registers/generated-emulator/src/sha512_acc.rs
+++ b/registers/generated-emulator/src/sha512_acc.rs
@@ -27,7 +27,6 @@ pub trait Sha512AccPeripheral {
     fn read_id(&mut self, _size: emulator_types::RvSize) -> emulator_types::RvData {
         0
     }
-    fn write_id(&mut self, _size: emulator_types::RvSize, _val: emulator_types::RvData) {}
     fn read_mode(
         &mut self,
         _size: emulator_types::RvSize,
@@ -82,19 +81,9 @@ pub trait Sha512AccPeripheral {
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
-    fn write_status(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_bus::ReadWriteRegister<
-            u32,
-            registers_generated::sha512_acc::bits::Status::Register,
-        >,
-    ) {
-    }
     fn read_digest(&mut self, _size: emulator_types::RvSize) -> emulator_types::RvData {
         0
     }
-    fn write_digest(&mut self, _size: emulator_types::RvSize, _val: emulator_types::RvData) {}
     fn read_control(
         &mut self,
         _size: emulator_types::RvSize,
@@ -176,15 +165,6 @@ pub trait Sha512AccPeripheral {
     > {
         emulator_bus::ReadWriteRegister::new(0)
     }
-    fn write_intr_block_rf_error_global_intr_r(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_bus::ReadWriteRegister<
-            u32,
-            registers_generated::soc_ifc::bits::GlobalIntrT::Register,
-        >,
-    ) {
-    }
     fn read_intr_block_rf_notif_global_intr_r(
         &mut self,
         _size: emulator_types::RvSize,
@@ -193,15 +173,6 @@ pub trait Sha512AccPeripheral {
         registers_generated::soc_ifc::bits::GlobalIntrT::Register,
     > {
         emulator_bus::ReadWriteRegister::new(0)
-    }
-    fn write_intr_block_rf_notif_global_intr_r(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_bus::ReadWriteRegister<
-            u32,
-            registers_generated::soc_ifc::bits::GlobalIntrT::Register,
-        >,
-    ) {
     }
     fn read_intr_block_rf_error_internal_intr_r(
         &mut self,
@@ -344,15 +315,6 @@ pub trait Sha512AccPeripheral {
     > {
         emulator_bus::ReadWriteRegister::new(0)
     }
-    fn write_intr_block_rf_error0_intr_count_incr_r(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_bus::ReadWriteRegister<
-            u32,
-            registers_generated::soc_ifc::bits::IntrCountIncrT::Register,
-        >,
-    ) {
-    }
     fn read_intr_block_rf_error1_intr_count_incr_r(
         &mut self,
         _size: emulator_types::RvSize,
@@ -361,15 +323,6 @@ pub trait Sha512AccPeripheral {
         registers_generated::soc_ifc::bits::IntrCountIncrT::Register,
     > {
         emulator_bus::ReadWriteRegister::new(0)
-    }
-    fn write_intr_block_rf_error1_intr_count_incr_r(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_bus::ReadWriteRegister<
-            u32,
-            registers_generated::soc_ifc::bits::IntrCountIncrT::Register,
-        >,
-    ) {
     }
     fn read_intr_block_rf_error2_intr_count_incr_r(
         &mut self,
@@ -380,15 +333,6 @@ pub trait Sha512AccPeripheral {
     > {
         emulator_bus::ReadWriteRegister::new(0)
     }
-    fn write_intr_block_rf_error2_intr_count_incr_r(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_bus::ReadWriteRegister<
-            u32,
-            registers_generated::soc_ifc::bits::IntrCountIncrT::Register,
-        >,
-    ) {
-    }
     fn read_intr_block_rf_error3_intr_count_incr_r(
         &mut self,
         _size: emulator_types::RvSize,
@@ -398,15 +342,6 @@ pub trait Sha512AccPeripheral {
     > {
         emulator_bus::ReadWriteRegister::new(0)
     }
-    fn write_intr_block_rf_error3_intr_count_incr_r(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_bus::ReadWriteRegister<
-            u32,
-            registers_generated::soc_ifc::bits::IntrCountIncrT::Register,
-        >,
-    ) {
-    }
     fn read_intr_block_rf_notif_cmd_done_intr_count_incr_r(
         &mut self,
         _size: emulator_types::RvSize,
@@ -415,15 +350,6 @@ pub trait Sha512AccPeripheral {
         registers_generated::soc_ifc::bits::IntrCountIncrT::Register,
     > {
         emulator_bus::ReadWriteRegister::new(0)
-    }
-    fn write_intr_block_rf_notif_cmd_done_intr_count_incr_r(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_bus::ReadWriteRegister<
-            u32,
-            registers_generated::soc_ifc::bits::IntrCountIncrT::Register,
-        >,
-    ) {
     }
 }
 pub struct Sha512AccBus {
@@ -686,16 +612,6 @@ impl emulator_bus::Bus for Sha512AccBus {
             (emulator_types::RvSize::Word, 0x19..=0x1b) => {
                 Err(emulator_bus::BusError::StoreAddrMisaligned)
             }
-            (emulator_types::RvSize::Word, 0x1c) => {
-                self.periph.write_status(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0x1d..=0x1f) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
             (emulator_types::RvSize::Word, 0x60) => {
                 self.periph.write_control(
                     emulator_types::RvSize::Word,
@@ -734,26 +650,6 @@ impl emulator_bus::Bus for Sha512AccBus {
                 Ok(())
             }
             (emulator_types::RvSize::Word, 0x809..=0x80b) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x80c) => {
-                self.periph.write_intr_block_rf_error_global_intr_r(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0x80d..=0x80f) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x810) => {
-                self.periph.write_intr_block_rf_notif_global_intr_r(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0x811..=0x813) => {
                 Err(emulator_bus::BusError::StoreAddrMisaligned)
             }
             (emulator_types::RvSize::Word, 0x814) => {
@@ -826,57 +722,6 @@ impl emulator_bus::Bus for Sha512AccBus {
                 Ok(())
             }
             (_, 0x981..=0x983) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (emulator_types::RvSize::Word, 0xa00) => {
-                self.periph.write_intr_block_rf_error0_intr_count_incr_r(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0xa01..=0xa03) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xa04) => {
-                self.periph.write_intr_block_rf_error1_intr_count_incr_r(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0xa05..=0xa07) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xa08) => {
-                self.periph.write_intr_block_rf_error2_intr_count_incr_r(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0xa09..=0xa0b) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xa0c) => {
-                self.periph.write_intr_block_rf_error3_intr_count_incr_r(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0xa0d..=0xa0f) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xa10) => {
-                self.periph
-                    .write_intr_block_rf_notif_cmd_done_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                        emulator_bus::ReadWriteRegister::new(val),
-                    );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0xa11..=0xa13) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
             _ => Err(emulator_bus::BusError::StoreAccessFault),
         }
     }

--- a/registers/generated-emulator/src/soc.rs
+++ b/registers/generated-emulator/src/soc.rs
@@ -134,15 +134,6 @@ pub trait SocPeripheral {
     > {
         emulator_bus::ReadWriteRegister::new(0)
     }
-    fn write_cptra_reset_reason(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_bus::ReadWriteRegister<
-            u32,
-            registers_generated::soc_ifc::bits::CptraResetReason::Register,
-        >,
-    ) {
-    }
     fn read_cptra_security_state(
         &mut self,
         _size: emulator_types::RvSize,
@@ -151,15 +142,6 @@ pub trait SocPeripheral {
         registers_generated::soc_ifc::bits::CptraSecurityState::Register,
     > {
         emulator_bus::ReadWriteRegister::new(0)
-    }
-    fn write_cptra_security_state(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_bus::ReadWriteRegister<
-            u32,
-            registers_generated::soc_ifc::bits::CptraSecurityState::Register,
-        >,
-    ) {
     }
     fn read_cptra_mbox_valid_axi_id(
         &mut self,
@@ -347,12 +329,6 @@ pub trait SocPeripheral {
     ) -> emulator_types::RvData {
         0
     }
-    fn write_cptra_generic_input_wires(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
     fn read_cptra_generic_output_wires(
         &mut self,
         _size: emulator_types::RvSize,
@@ -374,15 +350,6 @@ pub trait SocPeripheral {
     > {
         emulator_bus::ReadWriteRegister::new(0)
     }
-    fn write_cptra_hw_rev_id(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_bus::ReadWriteRegister<
-            u32,
-            registers_generated::soc_ifc::bits::CptraHwRevId::Register,
-        >,
-    ) {
-    }
     fn read_cptra_fw_rev_id(&mut self, _size: emulator_types::RvSize) -> emulator_types::RvData {
         0
     }
@@ -400,15 +367,6 @@ pub trait SocPeripheral {
         registers_generated::soc_ifc::bits::CptraHwConfig::Register,
     > {
         emulator_bus::ReadWriteRegister::new(0)
-    }
-    fn write_cptra_hw_config(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_bus::ReadWriteRegister<
-            u32,
-            registers_generated::soc_ifc::bits::CptraHwConfig::Register,
-        >,
-    ) {
     }
     fn read_cptra_wdt_timer1_en(
         &mut self,
@@ -604,13 +562,7 @@ pub trait SocPeripheral {
         _val: emulator_types::RvData,
     ) {
     }
-    fn read_fuse_uds_seed(&mut self, _size: emulator_types::RvSize) -> emulator_types::RvData {
-        0
-    }
     fn write_fuse_uds_seed(&mut self, _size: emulator_types::RvSize, _val: emulator_types::RvData) {
-    }
-    fn read_fuse_field_entropy(&mut self, _size: emulator_types::RvSize) -> emulator_types::RvData {
-        0
     }
     fn write_fuse_field_entropy(
         &mut self,
@@ -785,9 +737,6 @@ pub trait SocPeripheral {
             registers_generated::soc_ifc::bits::FuseSocSteppingId::Register,
         >,
     ) {
-    }
-    fn read_internal_obf_key(&mut self, _size: emulator_types::RvSize) -> emulator_types::RvData {
-        0
     }
     fn write_internal_obf_key(
         &mut self,
@@ -1032,15 +981,6 @@ pub trait SocPeripheral {
     > {
         emulator_bus::ReadWriteRegister::new(0)
     }
-    fn write_intr_block_rf_error_global_intr_r(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_bus::ReadWriteRegister<
-            u32,
-            registers_generated::soc_ifc::bits::GlobalIntrT::Register,
-        >,
-    ) {
-    }
     fn read_intr_block_rf_notif_global_intr_r(
         &mut self,
         _size: emulator_types::RvSize,
@@ -1049,15 +989,6 @@ pub trait SocPeripheral {
         registers_generated::soc_ifc::bits::GlobalIntrT::Register,
     > {
         emulator_bus::ReadWriteRegister::new(0)
-    }
-    fn write_intr_block_rf_notif_global_intr_r(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_bus::ReadWriteRegister<
-            u32,
-            registers_generated::soc_ifc::bits::GlobalIntrT::Register,
-        >,
-    ) {
     }
     fn read_intr_block_rf_error_internal_intr_r(
         &mut self,
@@ -1308,15 +1239,6 @@ pub trait SocPeripheral {
     > {
         emulator_bus::ReadWriteRegister::new(0)
     }
-    fn write_intr_block_rf_error_internal_intr_count_incr_r(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_bus::ReadWriteRegister<
-            u32,
-            registers_generated::soc_ifc::bits::IntrCountIncrT::Register,
-        >,
-    ) {
-    }
     fn read_intr_block_rf_error_inv_dev_intr_count_incr_r(
         &mut self,
         _size: emulator_types::RvSize,
@@ -1325,15 +1247,6 @@ pub trait SocPeripheral {
         registers_generated::soc_ifc::bits::IntrCountIncrT::Register,
     > {
         emulator_bus::ReadWriteRegister::new(0)
-    }
-    fn write_intr_block_rf_error_inv_dev_intr_count_incr_r(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_bus::ReadWriteRegister<
-            u32,
-            registers_generated::soc_ifc::bits::IntrCountIncrT::Register,
-        >,
-    ) {
     }
     fn read_intr_block_rf_error_cmd_fail_intr_count_incr_r(
         &mut self,
@@ -1344,15 +1257,6 @@ pub trait SocPeripheral {
     > {
         emulator_bus::ReadWriteRegister::new(0)
     }
-    fn write_intr_block_rf_error_cmd_fail_intr_count_incr_r(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_bus::ReadWriteRegister<
-            u32,
-            registers_generated::soc_ifc::bits::IntrCountIncrT::Register,
-        >,
-    ) {
-    }
     fn read_intr_block_rf_error_bad_fuse_intr_count_incr_r(
         &mut self,
         _size: emulator_types::RvSize,
@@ -1361,15 +1265,6 @@ pub trait SocPeripheral {
         registers_generated::soc_ifc::bits::IntrCountIncrT::Register,
     > {
         emulator_bus::ReadWriteRegister::new(0)
-    }
-    fn write_intr_block_rf_error_bad_fuse_intr_count_incr_r(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_bus::ReadWriteRegister<
-            u32,
-            registers_generated::soc_ifc::bits::IntrCountIncrT::Register,
-        >,
-    ) {
     }
     fn read_intr_block_rf_error_iccm_blocked_intr_count_incr_r(
         &mut self,
@@ -1380,15 +1275,6 @@ pub trait SocPeripheral {
     > {
         emulator_bus::ReadWriteRegister::new(0)
     }
-    fn write_intr_block_rf_error_iccm_blocked_intr_count_incr_r(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_bus::ReadWriteRegister<
-            u32,
-            registers_generated::soc_ifc::bits::IntrCountIncrT::Register,
-        >,
-    ) {
-    }
     fn read_intr_block_rf_error_mbox_ecc_unc_intr_count_incr_r(
         &mut self,
         _size: emulator_types::RvSize,
@@ -1397,15 +1283,6 @@ pub trait SocPeripheral {
         registers_generated::soc_ifc::bits::IntrCountIncrT::Register,
     > {
         emulator_bus::ReadWriteRegister::new(0)
-    }
-    fn write_intr_block_rf_error_mbox_ecc_unc_intr_count_incr_r(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_bus::ReadWriteRegister<
-            u32,
-            registers_generated::soc_ifc::bits::IntrCountIncrT::Register,
-        >,
-    ) {
     }
     fn read_intr_block_rf_error_wdt_timer1_timeout_intr_count_incr_r(
         &mut self,
@@ -1416,15 +1293,6 @@ pub trait SocPeripheral {
     > {
         emulator_bus::ReadWriteRegister::new(0)
     }
-    fn write_intr_block_rf_error_wdt_timer1_timeout_intr_count_incr_r(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_bus::ReadWriteRegister<
-            u32,
-            registers_generated::soc_ifc::bits::IntrCountIncrT::Register,
-        >,
-    ) {
-    }
     fn read_intr_block_rf_error_wdt_timer2_timeout_intr_count_incr_r(
         &mut self,
         _size: emulator_types::RvSize,
@@ -1433,15 +1301,6 @@ pub trait SocPeripheral {
         registers_generated::soc_ifc::bits::IntrCountIncrT::Register,
     > {
         emulator_bus::ReadWriteRegister::new(0)
-    }
-    fn write_intr_block_rf_error_wdt_timer2_timeout_intr_count_incr_r(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_bus::ReadWriteRegister<
-            u32,
-            registers_generated::soc_ifc::bits::IntrCountIncrT::Register,
-        >,
-    ) {
     }
     fn read_intr_block_rf_notif_cmd_avail_intr_count_incr_r(
         &mut self,
@@ -1452,15 +1311,6 @@ pub trait SocPeripheral {
     > {
         emulator_bus::ReadWriteRegister::new(0)
     }
-    fn write_intr_block_rf_notif_cmd_avail_intr_count_incr_r(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_bus::ReadWriteRegister<
-            u32,
-            registers_generated::soc_ifc::bits::IntrCountIncrT::Register,
-        >,
-    ) {
-    }
     fn read_intr_block_rf_notif_mbox_ecc_cor_intr_count_incr_r(
         &mut self,
         _size: emulator_types::RvSize,
@@ -1469,15 +1319,6 @@ pub trait SocPeripheral {
         registers_generated::soc_ifc::bits::IntrCountIncrT::Register,
     > {
         emulator_bus::ReadWriteRegister::new(0)
-    }
-    fn write_intr_block_rf_notif_mbox_ecc_cor_intr_count_incr_r(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_bus::ReadWriteRegister<
-            u32,
-            registers_generated::soc_ifc::bits::IntrCountIncrT::Register,
-        >,
-    ) {
     }
     fn read_intr_block_rf_notif_debug_locked_intr_count_incr_r(
         &mut self,
@@ -1488,15 +1329,6 @@ pub trait SocPeripheral {
     > {
         emulator_bus::ReadWriteRegister::new(0)
     }
-    fn write_intr_block_rf_notif_debug_locked_intr_count_incr_r(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_bus::ReadWriteRegister<
-            u32,
-            registers_generated::soc_ifc::bits::IntrCountIncrT::Register,
-        >,
-    ) {
-    }
     fn read_intr_block_rf_notif_scan_mode_intr_count_incr_r(
         &mut self,
         _size: emulator_types::RvSize,
@@ -1505,15 +1337,6 @@ pub trait SocPeripheral {
         registers_generated::soc_ifc::bits::IntrCountIncrT::Register,
     > {
         emulator_bus::ReadWriteRegister::new(0)
-    }
-    fn write_intr_block_rf_notif_scan_mode_intr_count_incr_r(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_bus::ReadWriteRegister<
-            u32,
-            registers_generated::soc_ifc::bits::IntrCountIncrT::Register,
-        >,
-    ) {
     }
     fn read_intr_block_rf_notif_soc_req_lock_intr_count_incr_r(
         &mut self,
@@ -1524,15 +1347,6 @@ pub trait SocPeripheral {
     > {
         emulator_bus::ReadWriteRegister::new(0)
     }
-    fn write_intr_block_rf_notif_soc_req_lock_intr_count_incr_r(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_bus::ReadWriteRegister<
-            u32,
-            registers_generated::soc_ifc::bits::IntrCountIncrT::Register,
-        >,
-    ) {
-    }
     fn read_intr_block_rf_notif_gen_in_toggle_intr_count_incr_r(
         &mut self,
         _size: emulator_types::RvSize,
@@ -1541,15 +1355,6 @@ pub trait SocPeripheral {
         registers_generated::soc_ifc::bits::IntrCountIncrT::Register,
     > {
         emulator_bus::ReadWriteRegister::new(0)
-    }
-    fn write_intr_block_rf_notif_gen_in_toggle_intr_count_incr_r(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_bus::ReadWriteRegister<
-            u32,
-            registers_generated::soc_ifc::bits::IntrCountIncrT::Register,
-        >,
-    ) {
     }
 }
 pub struct SocBus {
@@ -2277,26 +2082,6 @@ impl emulator_bus::Bus for SocBus {
             (emulator_types::RvSize::Word, 0x3d..=0x3f) => {
                 Err(emulator_bus::BusError::StoreAddrMisaligned)
             }
-            (emulator_types::RvSize::Word, 0x40) => {
-                self.periph.write_cptra_reset_reason(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0x41..=0x43) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x44) => {
-                self.periph.write_cptra_security_state(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0x45..=0x47) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
             (size, 0x48) => {
                 self.periph.write_cptra_mbox_valid_axi_id(size, val);
                 Ok(())
@@ -2397,31 +2182,11 @@ impl emulator_bus::Bus for SocBus {
                 Ok(())
             }
             (_, 0xcd..=0xcf) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (emulator_types::RvSize::Word, 0xd4) => {
-                self.periph.write_cptra_hw_rev_id(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0xd5..=0xd7) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
             (size, 0xd8) => {
                 self.periph.write_cptra_fw_rev_id(size, val);
                 Ok(())
             }
             (_, 0xd9..=0xdb) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (emulator_types::RvSize::Word, 0xe0) => {
-                self.periph.write_cptra_hw_config(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0xe1..=0xe3) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
             (emulator_types::RvSize::Word, 0xe4) => {
                 self.periph.write_cptra_wdt_timer1_en(
                     emulator_types::RvSize::Word,
@@ -2743,26 +2508,6 @@ impl emulator_bus::Bus for SocBus {
             (emulator_types::RvSize::Word, 0x809..=0x80b) => {
                 Err(emulator_bus::BusError::StoreAddrMisaligned)
             }
-            (emulator_types::RvSize::Word, 0x80c) => {
-                self.periph.write_intr_block_rf_error_global_intr_r(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0x80d..=0x80f) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x810) => {
-                self.periph.write_intr_block_rf_notif_global_intr_r(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0x811..=0x813) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
             (emulator_types::RvSize::Word, 0x814) => {
                 self.periph.write_intr_block_rf_error_internal_intr_r(
                     emulator_types::RvSize::Word,
@@ -2887,160 +2632,6 @@ impl emulator_bus::Bus for SocBus {
                 Ok(())
             }
             (_, 0x995..=0x997) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (emulator_types::RvSize::Word, 0xa00) => {
-                self.periph
-                    .write_intr_block_rf_error_internal_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                        emulator_bus::ReadWriteRegister::new(val),
-                    );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0xa01..=0xa03) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xa04) => {
-                self.periph
-                    .write_intr_block_rf_error_inv_dev_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                        emulator_bus::ReadWriteRegister::new(val),
-                    );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0xa05..=0xa07) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xa08) => {
-                self.periph
-                    .write_intr_block_rf_error_cmd_fail_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                        emulator_bus::ReadWriteRegister::new(val),
-                    );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0xa09..=0xa0b) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xa0c) => {
-                self.periph
-                    .write_intr_block_rf_error_bad_fuse_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                        emulator_bus::ReadWriteRegister::new(val),
-                    );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0xa0d..=0xa0f) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xa10) => {
-                self.periph
-                    .write_intr_block_rf_error_iccm_blocked_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                        emulator_bus::ReadWriteRegister::new(val),
-                    );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0xa11..=0xa13) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xa14) => {
-                self.periph
-                    .write_intr_block_rf_error_mbox_ecc_unc_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                        emulator_bus::ReadWriteRegister::new(val),
-                    );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0xa15..=0xa17) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xa18) => {
-                self.periph
-                    .write_intr_block_rf_error_wdt_timer1_timeout_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                        emulator_bus::ReadWriteRegister::new(val),
-                    );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0xa19..=0xa1b) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xa1c) => {
-                self.periph
-                    .write_intr_block_rf_error_wdt_timer2_timeout_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                        emulator_bus::ReadWriteRegister::new(val),
-                    );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0xa1d..=0xa1f) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xa20) => {
-                self.periph
-                    .write_intr_block_rf_notif_cmd_avail_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                        emulator_bus::ReadWriteRegister::new(val),
-                    );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0xa21..=0xa23) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xa24) => {
-                self.periph
-                    .write_intr_block_rf_notif_mbox_ecc_cor_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                        emulator_bus::ReadWriteRegister::new(val),
-                    );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0xa25..=0xa27) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xa28) => {
-                self.periph
-                    .write_intr_block_rf_notif_debug_locked_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                        emulator_bus::ReadWriteRegister::new(val),
-                    );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0xa29..=0xa2b) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xa2c) => {
-                self.periph
-                    .write_intr_block_rf_notif_scan_mode_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                        emulator_bus::ReadWriteRegister::new(val),
-                    );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0xa2d..=0xa2f) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xa30) => {
-                self.periph
-                    .write_intr_block_rf_notif_soc_req_lock_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                        emulator_bus::ReadWriteRegister::new(val),
-                    );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0xa31..=0xa33) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xa34) => {
-                self.periph
-                    .write_intr_block_rf_notif_gen_in_toggle_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                        emulator_bus::ReadWriteRegister::new(val),
-                    );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0xa35..=0xa37) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
             _ => Err(emulator_bus::BusError::StoreAccessFault),
         }
     }


### PR DESCRIPTION
If a field is read-only, we shouldn't generate write methods for it. Likewise if a field is write-only, we shouldn't generate read methods for it.

Fixes #37