### PR TITLE
Speed up compiles and clean up RUSTFLAGS

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -8,7 +8,33 @@ rustflags = [
     "-C",
     "panic=abort",
     "-C",
-    "target-feature=+relax,+unaligned-scalar-mem,+b",
+    "target-feature=+relax,+unaligned-scalar-mem,+zba,+zbb,+zbc,+zbs",
     "-C",
     "force-frame-pointers=no",
+    # See https://github.com/tock/tock/pull/2853
+    "-C",
+    "relocation-model=static",
+    # Opt-in to Rust v0 symbol mangling scheme.
+    #   See https://github.com/rust-lang/rust/issues/60705 and
+    #   https://github.com/tock/tock/issues/3529.
+    "-C",
+    "symbol-mangling-version=v0",
+    "-C",
+    # Tell rustc to use the LLVM linker. This avoids needing GCC as a
+    # dependency to build the kernel.
+    "linker=rust-lld",
+    "-C",
+    # Use the LLVM lld executable with the `-flavor gnu` flag.
+    "linker-flavor=ld.lld",
+    "-C",
+    # lld by default uses a default page size to align program
+    # sections. Tock expects that program sections are set back-to-back. `-nmagic`
+    # instructs the linker to not page-align sections.
+    "link-arg=-nmagic",
+    # Identical Code Folding (ICF) set to all. This tells the linker to be
+    # more aggressive about removing duplicate code. The default is `safe`, and
+    # the downside to `all` is that different functions in the code can end up with
+    # the same address in the binary. However, it can save a fair bit of code  size.
+    "-C",
+    "link-arg=-icf=all",
 ]

--- a/runtime/src/board.rs
+++ b/runtime/src/board.rs
@@ -4,8 +4,6 @@ use crate::chip::VeeRDefaultPeripherals;
 use crate::chip::TIMERS;
 use crate::timers::InternalTimers;
 use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
-use capsules_runtime::mctp::mux::MuxMCTPDriver;
-use capsules_runtime::mctp::transport_binding::MCTPI3CBinding;
 use core::ptr::{addr_of, addr_of_mut};
 use kernel::capabilities;
 use kernel::component::Component;

--- a/xtask/src/apps_build.rs
+++ b/xtask/src/apps_build.rs
@@ -1,6 +1,6 @@
 // Licensed under the Apache-2.0 license
 
-use crate::runtime_build::{objcopy, target_binary, OBJCOPY_FLAGS, RUSTFLAGS_COMMON};
+use crate::runtime_build::{objcopy, target_binary, OBJCOPY_FLAGS};
 use crate::tbf::TbfHeader;
 use crate::{DynError, PROJECT_ROOT, TARGET};
 use std::process::Command;
@@ -115,18 +115,23 @@ INCLUDE runtime/apps/app_layout.ld",
     )?;
 
     let ld_flag = format!("-C link-arg=-T{}", layout_ld.display());
-    let mut rustc_flags = Vec::from(RUSTFLAGS_COMMON);
-    rustc_flags.push(ld_flag.as_str());
-    let rustc_flags = rustc_flags.join(" ");
 
     let status = Command::new("cargo")
         .current_dir(&*PROJECT_ROOT)
-        .env("RUSTFLAGS", rustc_flags)
         .env("LIBTOCK_LINKER_FLASH", format!("0x{:x}", offset))
         .env("LIBTOCK_LINKER_FLASH_LENGTH", "128K")
         .env("LIBTOCK_LINKER_RAM", "0x50000000")
         .env("LIBTOCK_LINKER_RAM_LENGTH", "128K")
-        .args(["b", "-p", app_name, "--release", "--target", TARGET])
+        .args([
+            "rustc",
+            "-p",
+            app_name,
+            "--release",
+            "--target",
+            TARGET,
+            "--",
+        ])
+        .args(ld_flag.split(' '))
         .status()?;
     if !status.success() {
         Err("build ROM ELF failed")?;

--- a/xtask/src/rom.rs
+++ b/xtask/src/rom.rs
@@ -1,18 +1,23 @@
 // Licensed under the Apache-2.0 license
 
-use crate::runtime_build::RUSTFLAGS_COMMON;
-use crate::{runtime_build::objcopy, DynError, PROJECT_ROOT, TARGET};
+use crate::runtime_build::objcopy;
+use crate::{DynError, PROJECT_ROOT, TARGET};
 use std::process::Command;
 
 pub fn rom_build() -> Result<(), DynError> {
-    let mut rustc_flags = Vec::from(RUSTFLAGS_COMMON);
-    rustc_flags.push("-C link-arg=-Trom/layout.ld");
-    let rustc_flags = rustc_flags.join(" ");
-
     let status = Command::new("cargo")
         .current_dir(&*PROJECT_ROOT)
-        .env("RUSTFLAGS", rustc_flags)
-        .args(["b", "-p", "rom", "--release", "--target", TARGET])
+        .args([
+            "rustc",
+            "-p",
+            "rom",
+            "--release",
+            "--target",
+            TARGET,
+            "--",
+            "-C",
+            "link-arg=-Trom/layout.ld",
+        ])
         .status()?;
     if !status.success() {
         Err("build ROM binary failed")?;


### PR DESCRIPTION
Before:

```
cargo t  14.69s user 7.03s system 161% cpu 13.420 total
```

After:

```
cargo t  12.20s user 5.38s system 182% cpu 9.612 total
```

We consolidate RUSTFLAGS so that they are entirely in `.cargo/config.toml` -- this speeds up compiles since we aren't modifying `RUSTFLAGS` as part of `cargo xtask *-build` (which triggers recompiles). This also means we only need to worry about the flags in `.cargo/config.toml`.

Putting all of the `RUSTFLAGS` in `.cargo/config.toml` is mostly equivalent to passing them as an environment variable: there was a 100 byte difference in the application build, but it's not clear why.

We also add a filesystem cache of the result of finding the `sysroot`. For some reason, repeated calculation of it can be expensive (adds multiple seconds to the build).

Fixes #39