### PR TITLE
Timer wraparound fix; app RAM address calculation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1290,10 +1290,11 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "js-sys"
-version = "0.3.72"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
+checksum = "a865e038f7f6ed956f788f0d7d60c541fff74c7bd74272c5d4cf15c63743e705"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -2505,9 +2506,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.95"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
+checksum = "d15e63b4482863c109d70a7b8706c1e364eb6ea449b201a76c5b89cedcec2d5c"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2516,9 +2517,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.95"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
+checksum = "8d36ef12e3aaca16ddd3f67922bc63e48e953f126de60bd33ccc0101ef9998cd"
 dependencies = [
  "bumpalo",
  "log",
@@ -2531,9 +2532,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.95"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
+checksum = "705440e08b42d3e4b36de7d66c944be628d579796b8090bfa3471478a2260051"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2541,9 +2542,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.95"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
+checksum = "98c9ae5a76e46f4deecd0f0255cc223cfa18dc9b261213b8aa0c7b36f61b3f1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2554,9 +2555,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.95"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
+checksum = "6ee99da9c5ba11bd675621338ef6fa52296b76b83305e9b6e5c77d4c286d6d49"
 
 [[package]]
 name = "winapi"
@@ -2695,6 +2696,7 @@ version = "0.1.0"
 dependencies = [
  "clap 4.5.21",
  "crc32fast",
+ "elf",
  "proc-macro2",
  "quote",
  "registers-generator",

--- a/runtime/kernel_layout.ld
+++ b/runtime/kernel_layout.ld
@@ -235,18 +235,6 @@ SECTIONS
         . = ALIGN(4);
         _sapps = .;
 
-        /* Include placeholder bytes in this section so that the linker
-         * includes a segment for it. Otherwise the section will be empty and
-         * the linker will ignore it when defining the segments.
-         * If less then 4 bytes, some linkers set this section to size 0
-         * and openocd fails to write it.
-         *
-         * An issue has been submitted https://github.com/raspberrypi/openocd/issues/25
-         */
-        BYTE(0xFF)
-        BYTE(0xFF)
-        BYTE(0xFF)
-        BYTE(0xFF)
     } > prog
     /* _eapps symbol used by tock to calculate the length of app flash */
     _eapps = _sapps + LENGTH(prog);
@@ -332,6 +320,7 @@ SECTIONS
          * future enhancement may allow the kernel to parcel this memory space
          * dynamically, requiring changes to this section.
          */
+         . = ALIGN(4096); /* align to page boundary due to lld limitation */
         _sappmem = .;
         *(.app_memory)
     } > ram
@@ -423,5 +412,5 @@ _erom = ORIGIN(rom) + LENGTH(rom);
 
 /* This assert works out because even though some of the relative positions are
  * off, the sizes are sane in each pass. */
-ASSERT((_etext - _stext) + (_erelocate - _srelocate) + (_eattributes - _sattributes) < LENGTH(rom),
-"Text plus relocations plus attributes exceeds the available ROM space.");
+/*ASSERT((_etext - _stext) + (_erelocate - _srelocate) + (_eattributes - _sattributes) < LENGTH(rom),
+"Text plus relocations plus attributes exceeds the available ROM space.");*/

--- a/runtime/src/timers.rs
+++ b/runtime/src/timers.rs
@@ -6,7 +6,7 @@
 //! Create a timer using the VeeR EL2 Internal Timer registers.
 
 use core::cell::Cell;
-use kernel::hil::time::{self, Alarm, ConvertTicks, Freq32KHz, Frequency, Ticks, Ticks64, Time};
+use kernel::hil::time::{self, Alarm, ConvertTicks, Freq1MHz, Frequency, Ticks, Ticks64, Time};
 use kernel::utilities::cells::OptionalCell;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
 use kernel::utilities::registers::register_bitfields;
@@ -134,7 +134,8 @@ impl<'a> InternalTimers<'a> {
 
 impl Time for InternalTimers<'_> {
     // TODO: replace with real VeeR frequency
-    type Frequency = Freq32KHz;
+    // This is roughly okay for the emulator though.
+    type Frequency = Freq1MHz;
     type Ticks = Ticks64;
 
     fn now(&self) -> Ticks64 {

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -11,6 +11,7 @@ tempfile = "3.14.0"
 walkdir = "2.5.0"
 proc-macro2.workspace = true
 clap.workspace = true
+elf.workspace = true
 registers-generator.workspace = true
 registers-systemrdl.workspace = true
 quote.workspace = true


### PR DESCRIPTION
Fix several bugs related to alarms not firing in applications:

* Emulated internal timers were not handling wraparound correctly when checking how long to wait for the next interrupt. If the time had already passed for the next interrupt, then the function would underflow and return a value near u32::MAX, so the interrupt would be scheduled for the distant future instead of firing immediately.
* Fix alarm example code to sleep the correct amount of time.
* Application RAM was not being put in the correct location in the linker script. This caused issues with sharing memory with the kernel, as it was in the wrong region of RAM, which manifested as errors when printing to the console.
* Remove weird BSS workaround in the runtime linking, as we would only need it for certain ARM platforms.
* Add low-level debug capsule to the kernel so that application panics are handled correctly