### PR TITLE
Add interrupts support for I3C target

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1214,6 +1214,7 @@ dependencies = [
  "capsules-core",
  "kernel",
  "registers-generated",
+ "romtime",
  "tock-registers",
 ]
 
@@ -2039,6 +2040,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "romtime"
+version = "0.1.0"
+
+[[package]]
 name = "runtime"
 version = "0.1.0"
 dependencies = [
@@ -2052,6 +2057,7 @@ dependencies = [
  "registers-generated",
  "riscv",
  "riscv-csr",
+ "romtime",
  "rv32i",
  "tock-registers",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "registers/generator",
     "registers/systemrdl",
     "rom",
+    "romtime",
     "runtime",
     "runtime/capsules",
     "runtime/apps/pldm",
@@ -71,6 +72,7 @@ num-derive = "0.4.2"
 num_enum = "0.7.2"
 num-traits = "0.2"
 proc-macro2 = "1.0.66"
+romtime = { path = "romtime" }
 quote = "1.0"
 registers-generated = { path = "registers/generated-firmware" }
 registers-generator = { path = "registers/generator" }

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Commands such as `cargo b` and `cargo t` will also work, but won't execute the e
 * `emulator/`: Emulator to run the ROM and RT firmware
 * `rom/`: ROM code
 * `runtime/`: runtime firmware
+* `romtime/`: Shared code between ROM and runtime
 * `tests/`: firmware and end-to-end tests
 * `xtask/`: all of the tooling for building, checking, and running everything.
 

--- a/emulator/periph/src/i3c.rs
+++ b/emulator/periph/src/i3c.rs
@@ -163,7 +163,7 @@ impl I3c {
             }
             // we only need the first byte, which is the MDB.
             // TODO: handle more than the MDB?
-            self.i3c_target.send_ibi(self.tti_ibi_buffer[5]);
+            self.i3c_target.send_ibi(self.tti_ibi_buffer[4]);
             self.tti_ibi_buffer.drain(0..len + 4);
         }
     }

--- a/emulator/periph/src/i3c_protocol.rs
+++ b/emulator/periph/src/i3c_protocol.rs
@@ -288,6 +288,10 @@ impl I3cTarget {
         self.target.lock().unwrap().rx_buffer.pop_front()
     }
 
+    pub fn peek_command(&mut self) -> Option<I3cTcriCommandXfer> {
+        self.target.lock().unwrap().rx_buffer.front().cloned()
+    }
+
     pub fn set_response(&mut self, resp: I3cTcriResponseXfer) {
         self.target.lock().unwrap().tx_buffer.push_back(resp)
     }
@@ -332,11 +336,11 @@ bitfield! {
     u8, short_read_err, set_short_read_err: 24, 24;
     u8, dbp, set_dbp: 25, 25;
     u8, mode, set_mode: 28, 26;
-    u8, rnw, set_rnw: 29, 29;
+    pub u8, rnw, set_rnw: 29, 29;
     u8, wroc, set_wroc: 30, 30;
     u8, toc, set_toc: 31, 31;
     u8, def_byte, set_def_byte: 39, 32;
-    u16, data_length, set_data_length: 63, 48;
+    pub u16, data_length, set_data_length: 63, 48;
 }
 
 bitfield! {

--- a/romtime/Cargo.toml
+++ b/romtime/Cargo.toml
@@ -1,0 +1,11 @@
+# Licensed under the Apache-2.0 license
+
+[package]
+name = "romtime"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+
+[dependencies]
+
+[target.'cfg(target_arch = "riscv32")'.dependencies]

--- a/romtime/src/lib.rs
+++ b/romtime/src/lib.rs
@@ -1,0 +1,37 @@
+// Licensed under the Apache-2.0 license
+#![cfg_attr(target_arch = "riscv32", no_std)]
+
+// Helpers to handle writing to the emulator UART output.
+
+pub struct EmulatorWriter {}
+pub static mut WRITER: EmulatorWriter = EmulatorWriter {};
+
+impl core::fmt::Write for EmulatorWriter {
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        print_to_console(s);
+        Ok(())
+    }
+}
+
+#[macro_export]
+macro_rules! print {
+    ($($arg:tt)*) => {
+        let _ = write!(unsafe { &mut $crate::WRITER }, $($arg)*);
+    };
+}
+
+#[macro_export]
+macro_rules! println {
+    ($($arg:tt)*) => {
+        let _ = writeln!(unsafe { &mut $crate::WRITER }, $($arg)*);
+    };
+}
+
+pub(crate) fn print_to_console(buf: &str) {
+    for b in buf.bytes() {
+        // Print to this address for emulator output
+        unsafe {
+            core::ptr::write_volatile(0x2000_1041 as *mut u8, b);
+        }
+    }
+}

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -7,10 +7,9 @@ authors.workspace = true
 edition.workspace = true
 
 [dependencies]
-
-[target.'cfg(target_arch = "riscv32")'.dependencies]
 capsules-core = { git = "https://github.com/tock/tock.git", rev = "b128ae817b86706c8c4e39d27fae5c54b98659f1" }
 capsules-extra = { git = "https://github.com/tock/tock.git", rev = "b128ae817b86706c8c4e39d27fae5c54b98659f1" }
+capsules-runtime.workspace = true
 capsules-system = { git = "https://github.com/tock/tock.git", rev = "b128ae817b86706c8c4e39d27fae5c54b98659f1" }
 components = { git = "https://github.com/tock/tock.git", rev = "b128ae817b86706c8c4e39d27fae5c54b98659f1" }
 i3c-driver.workspace = true
@@ -18,9 +17,9 @@ kernel = { git = "https://github.com/tock/tock.git", rev = "b128ae817b86706c8c4e
 registers-generated.workspace = true
 riscv = { git = "https://github.com/tock/tock.git", rev = "b128ae817b86706c8c4e39d27fae5c54b98659f1" }
 riscv-csr = { git = "https://github.com/tock/tock.git", rev = "b128ae817b86706c8c4e39d27fae5c54b98659f1" }
+romtime.workspace = true
 rv32i = { git = "https://github.com/tock/tock.git", rev = "b128ae817b86706c8c4e39d27fae5c54b98659f1" }
 tock-registers.workspace = true
-capsules-runtime.workspace = true
 
 [features]
 default = []

--- a/runtime/i3c/Cargo.toml
+++ b/runtime/i3c/Cargo.toml
@@ -12,4 +12,5 @@ kernel = { git = "https://github.com/tock/tock.git", rev = "b128ae817b86706c8c4e
 [target.'cfg(target_arch = "riscv32")'.dependencies]
 capsules-core = { git = "https://github.com/tock/tock.git", rev = "b128ae817b86706c8c4e39d27fae5c54b98659f1" }
 registers-generated.workspace = true
+romtime.workspace = true
 tock-registers.workspace = true

--- a/runtime/i3c/src/core.rs
+++ b/runtime/i3c/src/core.rs
@@ -325,11 +325,10 @@ impl<'a, A: Alarm<'a>> I3CCore<'a, A> {
         let rx_buffer = self.rx_buffer.take().unwrap();
         let mut buf_idx = self.rx_buffer_idx.get();
         let buf_size = self.rx_buffer_size.get();
-        // TODO: verify which order we get the descriptor in, big or little word first
         let desc0 = self.registers.rx_desc_queue_port.get();
         let desc1 = self.registers.rx_desc_queue_port.get();
         let desc = LocalRegisterCopy::<u64, I3CCommandDescriptor::Register>::new(
-            ((desc0 as u64) << 32) | (desc1 as u64),
+            ((desc1 as u64) << 32) | (desc0 as u64),
         );
         let len = desc.read(I3CCommandDescriptor::DataLength) as usize;
         // read everything

--- a/runtime/i3c/src/core.rs
+++ b/runtime/i3c/src/core.rs
@@ -73,6 +73,17 @@ register_bitfields! {
     ]
 }
 
+register_bitfields! {
+    u64,
+    I3CCommandDescriptor [
+        RNW OFFSET(29) NUMBITS(1) [
+            Write = 0,
+            Read = 1,
+        ],
+        DataLength OFFSET(48) NUMBITS(16) [],
+    ],
+}
+
 pub struct I3CCore<'a, A: Alarm<'a>> {
     registers: StaticRef<I3c>,
     tx_client: OptionalCell<&'a dyn TxClient>,
@@ -314,56 +325,43 @@ impl<'a, A: Alarm<'a>> I3CCore<'a, A> {
         let rx_buffer = self.rx_buffer.take().unwrap();
         let mut buf_idx = self.rx_buffer_idx.get();
         let buf_size = self.rx_buffer_size.get();
-        let desc = LocalRegisterCopy::<u32, I3CResponseDescriptor::Register>::new(
-            self.registers.rx_desc_queue_port.get(),
+        // TODO: verify which order we get the descriptor in, big or little word first
+        let desc0 = self.registers.rx_desc_queue_port.get();
+        let desc1 = self.registers.rx_desc_queue_port.get();
+        let desc = LocalRegisterCopy::<u64, I3CCommandDescriptor::Register>::new(
+            ((desc0 as u64) << 32) | (desc1 as u64),
         );
-        match desc.read_as_enum::<I3CResponseDescriptor::ErrStatus::Value>(
-            I3CResponseDescriptor::ErrStatus,
-        ) {
-            Some(I3CResponseDescriptor::ErrStatus::Value::Success) => {
-                let len = desc.read(I3CResponseDescriptor::DataLength) as usize;
-                // read everything
-                let mut full = false;
-                for i in (0..len.next_multiple_of(4)).step_by(4) {
-                    let data = self.registers.rx_data_port0.get().to_le_bytes();
-                    for j in 0..4 {
-                        if buf_idx >= buf_size {
-                            full = true;
-                            break;
-                        }
-                        if let Some(x) = rx_buffer.get_mut(buf_idx) {
-                            *x = data[j];
-                        } else {
-                            // check if we ran out of space or if this is just the padding
-                            if i + j < len {
-                                full = true;
-                            }
-                        }
-                        buf_idx += 1;
+        let len = desc.read(I3CCommandDescriptor::DataLength) as usize;
+        // read everything
+        let mut full = false;
+        for i in (0..len.next_multiple_of(4)).step_by(4) {
+            let data = self.registers.rx_data_port0.get().to_le_bytes();
+            for j in 0..4 {
+                if buf_idx >= buf_size {
+                    full = true;
+                    break;
+                }
+                if let Some(x) = rx_buffer.get_mut(buf_idx) {
+                    *x = data[j];
+                } else {
+                    // check if we ran out of space or if this is just the padding
+                    if i + j < len {
+                        full = true;
                     }
                 }
-                if full {
-                    // TODO: we need a way to say that the buffer was not big enough
-                }
-                self.rx_client.map(|client| {
-                    client.receive_write(rx_buffer, len.min(buf_size));
-                });
-                // reset
-                self.rx_buffer_idx.set(0);
-                self.rx_buffer_size.set(0);
-            }
-            _err => {
-                debug!("Error receiving I3C write from controller");
-                // TODO: do we still need to read this?
-                let len = desc.read(I3CResponseDescriptor::DataLength) as usize;
-                for _ in (0..len.next_multiple_of(4)).step_by(4) {
-                    let _ = self.registers.rx_data_port0.get();
-                }
-                // TODO: should we let the client know somehow?
-                // put the buffer back
-                self.rx_buffer.replace(rx_buffer);
+                buf_idx += 1;
             }
         }
+
+        if full {
+            // TODO: we need a way to say that the buffer was not big enough
+        }
+        self.rx_client.map(|client| {
+            client.receive_write(rx_buffer, len.min(buf_size));
+        });
+        // reset
+        self.rx_buffer_idx.set(0);
+        self.rx_buffer_size.set(0);
     }
 
     // called when TTI wants us to send data for a private Read

--- a/runtime/src/chip.rs
+++ b/runtime/src/chip.rs
@@ -252,30 +252,6 @@ unsafe fn handle_interrupt(intr: mcause::Interrupt, mcause: u32) {
 
 // these are useful when debugging interrupts
 
-#[allow(dead_code)]
-fn print_to_console(buf: &[u8]) {
-    for b in buf {
-        // Print to this address for emulator output
-        unsafe {
-            core::ptr::write_volatile(0x2000_1041 as *mut u8, *b);
-        }
-    }
-}
-
-#[allow(dead_code)]
-fn print_hex(x: u32) {
-    let mut buf = [0u8; 8];
-    for i in 0..8 {
-        let nibble = (x >> (4 * (7 - i))) & 0xF;
-        buf[i] = if nibble < 10 {
-            b'0' + nibble as u8
-        } else {
-            b'A' + (nibble - 10) as u8
-        };
-    }
-    print_to_console(&buf);
-}
-
 /// Trap handler for board/chip specific code.
 ///
 /// This gets called when an interrupt occurs while the chip is

--- a/runtime/src/main.rs
+++ b/runtime/src/main.rs
@@ -21,6 +21,7 @@ pub mod io;
 #[cfg(target_arch = "riscv32")]
 mod pic;
 #[cfg(target_arch = "riscv32")]
+#[allow(unused_imports)]
 mod tests;
 #[cfg(target_arch = "riscv32")]
 mod timers;

--- a/runtime/src/timers.rs
+++ b/runtime/src/timers.rs
@@ -111,8 +111,10 @@ impl<'a> InternalTimers<'a> {
         self.saved.set(match (self.saved.get(), i) {
             (TimerInterrupts::None, 0) => TimerInterrupts::Timer0,
             (TimerInterrupts::None, 1) => TimerInterrupts::Timer1,
+            (TimerInterrupts::Timer0, 0) => TimerInterrupts::Timer0,
             (TimerInterrupts::Timer0, 1) => TimerInterrupts::Timer0AndTimer1,
             (TimerInterrupts::Timer1, 0) => TimerInterrupts::Timer0AndTimer1,
+            (TimerInterrupts::Timer1, 1) => TimerInterrupts::Timer1,
             (TimerInterrupts::Timer0AndTimer1, _) => TimerInterrupts::Timer0AndTimer1,
             _ => unreachable!(),
         });


### PR DESCRIPTION
This maps the internal queues in the I3C emulator peripheral to the interrupt controller, and modifies the tests so that they no longer manually poll.

I also added a new package, `romtime`, for drivers and utilities that are useful for both ROM and Runtime. For now, this contains an implementation of `print!` and `println!` that output to the emulator UART immediately, which is useful for both ROM and when running in Tock kernel when `debug!` may not be available (such as during tests or interrupts).