### PR TITLE
Support running under gdb-multiarch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,3 +93,7 @@ opt-level = 3
 opt-level = 3
 [profile.test.package.tock-registers]
 opt-level = 3
+
+# Keep debug symbols in the release ELF so that we can debug more easily.
+[profile.release]
+debug = true


### PR DESCRIPTION
We add debug symbols to compiled ELF files (does not affect final runtime binary).

And we allow gdb to read and write arbitrary memory, since the first thing it seems to do when it starts is to try to read 0xffffffff, which is not valid. This makes gdb support a bit more robust.

To use:

Compile the binaries.
```shell
cargo xtask runtime-build
```

In one shell, start the emulator manually:
```shell
cargo run -p emulator -- --rom target/riscv32imc-unknown-none-elf/release/rom -f target/riscv32imc-unknown-none-elf/release/runtime -g 3333
```

In another shell, connect with `gdb-multiarch`, and start debugging. You'll need to manually set the PC to `0x40000080` to start.

```shell
gdb-multiarch target/riscv32imc-unknown-none-elf/release/runtime

(gdb) target remote localhost:3333
(gdb) break runtime::main
(gdb) set $pc = 0x40000080
(gdb) s 1
(gdb) s 1
```