### PR TITLE
runtime: Enable PMP

### DIFF
--- a/emulator/cpu/src/cpu.rs
+++ b/emulator/cpu/src/cpu.rs
@@ -35,11 +35,11 @@ pub struct CoverageBitmaps<'a> {
     pub iccm: &'a bit_vec::BitVec,
 }
 
-const ICCM_SIZE: usize = 128 * 1024;
-const ICCM_ORG: usize = 0x40000000;
+const ICCM_SIZE: usize = RAM_SIZE as usize;
+const ICCM_ORG: usize = RAM_OFFSET as usize;
 const ICCM_UPPER: usize = ICCM_ORG + ICCM_SIZE - 1;
 
-const ROM_SIZE: usize = 48 * 1024;
+const ROM_SIZE: usize = emulator_types::ROM_SIZE as usize;
 const ROM_ORG: usize = 0x00000000;
 const ROM_UPPER: usize = ROM_ORG + ROM_SIZE - 1;
 

--- a/emulator/cpu/src/csr_file.rs
+++ b/emulator/cpu/src/csr_file.rs
@@ -131,7 +131,7 @@ impl Csr {
     pub const PMPADDR_END: RvAddr = 0x3EF;
 
     /// Number of PMP address/cfg registers
-    pub const PMPCOUNT: usize = 16;
+    pub const PMPCOUNT: usize = 64;
 
     /// Create a new Configurations and Status register
     ///

--- a/emulator/cpu/src/csr_file.rs
+++ b/emulator/cpu/src/csr_file.rs
@@ -122,13 +122,13 @@ impl Csr {
     pub const PMPCFG_START: RvAddr = 0x3A0;
 
     /// PMP configuration register range end, inclusive
-    pub const PMPCFG_END: RvAddr = 0x3A3;
+    pub const PMPCFG_END: RvAddr = 0x3AF;
 
     /// PMP address register range start, inclusive
     pub const PMPADDR_START: RvAddr = 0x3B0;
 
     /// PMP address register range end, inclusive
-    pub const PMPADDR_END: RvAddr = 0x3C0;
+    pub const PMPADDR_END: RvAddr = 0x3EF;
 
     /// Number of PMP address/cfg registers
     pub const PMPCOUNT: usize = 16;
@@ -766,8 +766,9 @@ impl CsrFile {
             return Ok(false);
         }
 
+        let addr = addr as u64;
         let pmpaddr = self.any_read(RvPrivMode::M, Csr::PMPADDR_START + index as RvAddr)?;
-        let pmpaddr_shift = pmpaddr << 2;
+        let pmpaddr_shift = (pmpaddr as u64) << 2;
         let addr_top;
         let addr_bottom;
 
@@ -777,7 +778,9 @@ impl CsrFile {
                 // otherwise it's the previous one
                 addr_top = pmpaddr_shift;
                 addr_bottom = if index > 0 {
-                    self.any_read(RvPrivMode::M, Csr::PMPADDR_START + (index - 1) as RvAddr)? << 2
+                    (self.any_read(RvPrivMode::M, Csr::PMPADDR_START + (index - 1) as RvAddr)?
+                        as u64)
+                        << 2
                 } else {
                     0
                 };
@@ -788,13 +791,12 @@ impl CsrFile {
                 addr_bottom = pmpaddr_shift;
             }
             RvPmpAddrMode::Napot => {
-                // Range from 8..32
-                addr_top = pmpaddr_shift + (1 << (pmpaddr.trailing_ones() + 3));
-                addr_bottom = pmpaddr_shift;
+                let (bot, top) = decode_napot_pmpaddr(pmpaddr);
+                addr_bottom = bot;
+                addr_top = top;
             }
             _ => unreachable!(),
         }
-
         Ok(addr >= addr_bottom && addr < addr_top)
     }
 
@@ -977,11 +979,43 @@ impl CsrFile {
     }
 }
 
+// Returns the base address (inclusive) and end address (exclusive) of a NAPOT PMP address
+fn decode_napot_pmpaddr(addr: u32) -> (u64, u64) {
+    let bits = addr.trailing_ones();
+    let addr = addr as u64;
+    let base = (addr & !((1 << bits) - 1)) << 2;
+    (base, base + (1 << (bits + 3)))
+}
+
 #[cfg(test)]
 mod tests {
 
     use super::*;
     use std::rc::Rc;
+
+    #[test]
+    fn test_decode_napot_pmpaddr() {
+        assert_eq!((0x0000_0000, 0x0000_0008), decode_napot_pmpaddr(0x00000000));
+        assert_eq!((0x0000_0000, 0x0000_0010), decode_napot_pmpaddr(0x00000001));
+        assert_eq!((0x0040_0000, 0x0040_8000), decode_napot_pmpaddr(0x00100fff));
+        assert_eq!((0x1000_0000, 0x2000_0000), decode_napot_pmpaddr(0x05ffffff));
+        assert_eq!(
+            (0x0000_0000, 0x1_0000_0000),
+            decode_napot_pmpaddr(0x1fffffff)
+        );
+        assert_eq!(
+            (0x0000_0000, 0x2_0000_0000),
+            decode_napot_pmpaddr(0x3fffffff)
+        );
+        assert_eq!(
+            (0x0000_0000, 0x4_0000_0000),
+            decode_napot_pmpaddr(0x7fffffff)
+        );
+        assert_eq!(
+            (0x0000_0000, 0x8_0000_0000),
+            decode_napot_pmpaddr(0xffffffff)
+        );
+    }
 
     #[test]
     fn test_u_mode_read_m_mode_csr() {

--- a/emulator/periph/src/root_bus.rs
+++ b/emulator/periph/src/root_bus.rs
@@ -42,16 +42,16 @@ pub struct CaliptraRootBus {
     #[peripheral(offset = 0x0000_0000, len = 0xc000)]
     pub rom: Rom,
 
+    #[peripheral(offset = 0x1000_1000, len = 0x100)]
+    pub uart: Uart,
+
+    #[peripheral(offset = 0x1000_2000, len = 0x4)]
+    pub ctrl: EmuCtrl,
+
     #[peripheral(offset = 0x2000_0000, len = 0x40)]
     pub spi: SpiHost,
 
-    #[peripheral(offset = 0x2000_1000, len = 0x100)]
-    pub uart: Uart,
-
-    #[peripheral(offset = 0x2000_f000, len = 0x4)]
-    pub ctrl: EmuCtrl,
-
-    #[peripheral(offset = 0x3000_4000, len = 0x1000)]
+    #[peripheral(offset = 0x2000_1000, len = 0x1000)]
     pub otp: Otp,
 
     #[peripheral(offset = 0x4000_0000, len = 0x60000)]

--- a/rom/src/io.rs
+++ b/rom/src/io.rs
@@ -17,7 +17,7 @@ pub fn panic_fmt(_pi: &PanicInfo) -> ! {
 
     // Cause the emulator to exit
     unsafe {
-        write_volatile(0x200f0000 as *mut u32, 0);
+        write_volatile(0x1000_2000 as *mut u32, 0);
     }
     unreachable!()
 }
@@ -33,10 +33,10 @@ fn write_byte(b: u8) {
     // # Safety
     // Accesses memory-mapped registers.
     unsafe {
-        write_volatile(0x2000_1041 as *mut u8, b);
+        write_volatile(0x1000_1041 as *mut u8, b);
     }
 }
 
 fn _read_byte() -> u8 {
-    unsafe { read_volatile(0x2000_1041 as *mut u8) }
+    unsafe { read_volatile(0x1000_1041 as *mut u8) }
 }

--- a/romtime/src/lib.rs
+++ b/romtime/src/lib.rs
@@ -31,7 +31,7 @@ pub(crate) fn print_to_console(buf: &str) {
     for b in buf.bytes() {
         // Print to this address for emulator output
         unsafe {
-            core::ptr::write_volatile(0x2000_1041 as *mut u8, b);
+            core::ptr::write_volatile(0x1000_1041 as *mut u8, b);
         }
     }
 }

--- a/runtime/kernel_layout.ld
+++ b/runtime/kernel_layout.ld
@@ -359,7 +359,13 @@ SECTIONS
 _eattributes = LOADADDR(.attributes) + SIZEOF(.attributes);*/
 _sattributes = 0;
 _eattributes = 0;
+_srom = ORIGIN(rom);
 _erom = ORIGIN(rom) + LENGTH(rom);
+_sprog = ORIGIN(prog);
+_eprog = ORIGIN(prog) + LENGTH(prog);
+_ssram = ORIGIN(ram);
+_esram = ORIGIN(ram) + LENGTH(ram);
+
 
 /* This.. this is a dirty, not-fully-understood, hack. In some way, linking is
  * a multi-pass process. i.e., if you were to ASSERT(0, "how many links")

--- a/runtime/src/board.rs
+++ b/runtime/src/board.rs
@@ -3,6 +3,11 @@
 use crate::chip::VeeRDefaultPeripherals;
 use crate::chip::TIMERS;
 use crate::components as runtime_components;
+use crate::pmp::CodeRegion;
+use crate::pmp::DataRegion;
+use crate::pmp::KernelTextRegion;
+use crate::pmp::MMIORegion;
+use crate::pmp::VeeRProtectionMMLEPMP;
 use crate::timers::InternalTimers;
 
 use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
@@ -16,6 +21,7 @@ use kernel::scheduler::cooperative::CooperativeSched;
 use kernel::utilities::registers::interfaces::ReadWriteable;
 use kernel::{create_capability, debug, static_init};
 use rv32i::csr;
+use rv32i::pmp::{NAPOTRegionSpec, TORRegionSpec};
 
 // These symbols are defined in the linker script.
 extern "C" {
@@ -27,6 +33,18 @@ extern "C" {
     static mut _sappmem: u8;
     /// End of the RAM region for app memory.
     static _eappmem: u8;
+    /// The start of the kernel text (Included only for kernel PMP)
+    static _stext: u8;
+    /// The end of the kernel text (Included only for kernel PMP)
+    static _etext: u8;
+    /// The start of the kernel / app / storage flash (Included only for kernel PMP)
+    static _srom: u8;
+    /// The end of the kernel / app / storage flash (Included only for kernel PMP)
+    static _eprog: u8;
+    /// The start of the kernel / app RAM (Included only for kernel PMP)
+    static _ssram: u8;
+    /// The end of the kernel / app RAM (Included only for kernel PMP)
+    static _esram: u8;
 
     pub(crate) static _pic_vector_table: u8;
 }
@@ -154,6 +172,36 @@ pub unsafe fn main() {
     // only machine mode
     rv32i::configure_trap_handler();
 
+    // Set up memory protection immediately after setting the trap handler, to
+    // ensure that much of the board initialization routine runs with ePMP
+    // protection.
+
+    // fixed regions to allow user mode direct access to emulator control and UART
+    let user_mmio = [MMIORegion(
+        NAPOTRegionSpec::new(0x1000_0000 as *const u8, 0x1000_0000).unwrap(),
+    )];
+    // additional MMIO for machine only peripherals
+    let machine_mmio = [
+        MMIORegion(NAPOTRegionSpec::new(0x2000_0000 as *const u8, 0x2000_0000).unwrap()),
+        MMIORegion(NAPOTRegionSpec::new(0x6000_0000 as *const u8, 0x1_0000).unwrap()),
+    ];
+
+    let epmp = VeeRProtectionMMLEPMP::new(
+        CodeRegion(
+            TORRegionSpec::new(core::ptr::addr_of!(_srom), core::ptr::addr_of!(_eprog)).unwrap(),
+        ),
+        DataRegion(
+            TORRegionSpec::new(core::ptr::addr_of!(_ssram), core::ptr::addr_of!(_esram)).unwrap(),
+        ),
+        // use the MMIO for the PIC
+        &user_mmio[..],
+        &machine_mmio[..],
+        KernelTextRegion(
+            TORRegionSpec::new(core::ptr::addr_of!(_stext), core::ptr::addr_of!(_etext)).unwrap(),
+        ),
+    )
+    .unwrap();
+
     // initialize capabilities
     let process_mgmt_cap = create_capability!(capabilities::ProcessManagementCapability);
     let memory_allocation_cap = create_capability!(capabilities::MemoryAllocationCapability);
@@ -198,7 +246,7 @@ pub unsafe fn main() {
         VeeRDefaultPeripherals::new(&*mux_alarm)
     );
 
-    let chip = static_init!(VeeRChip, crate::chip::VeeR::new(peripherals));
+    let chip = static_init!(VeeRChip, crate::chip::VeeR::new(peripherals, epmp));
     chip.init();
     CHIP = Some(chip);
 

--- a/runtime/src/chip.rs
+++ b/runtime/src/chip.rs
@@ -9,6 +9,7 @@
 
 use crate::flash_ctrl;
 use crate::io::SemihostUart;
+use crate::pmp::{VeeRPMP, VeeRProtectionMMLEPMP};
 use crate::timers::{InternalTimers, TimerInterrupts};
 use capsules_core::virtualizers::virtual_alarm::MuxAlarm;
 use core::fmt::Write;
@@ -18,7 +19,6 @@ use kernel::platform::chip::{Chip, InterruptService};
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable};
 use kernel::utilities::StaticRef;
 use rv32i::csr::{mcause, mie::mie, CSR};
-use rv32i::pmp::{simple::SimplePMP, PMPUserMPU};
 use rv32i::syscall::SysCall;
 
 use crate::pic::Pic;
@@ -40,7 +40,7 @@ pub struct VeeR<'a, I: InterruptService + 'a> {
     pic: &'a Pic,
     timers: &'static InternalTimers<'static>,
     pub peripherals: &'a I,
-    pmp: PMPUserMPU<4, SimplePMP<8>>,
+    pmp: VeeRPMP,
 }
 
 pub struct VeeRDefaultPeripherals<'a> {
@@ -89,14 +89,14 @@ impl<'a> InterruptService for VeeRDefaultPeripherals<'a> {
 
 impl<'a, I: InterruptService + 'a> VeeR<'a, I> {
     /// # Safety
-    /// Accesses memory-mapped registers.
-    pub unsafe fn new(pic_interrupt_service: &'a I) -> Self {
+    /// Accesses memory<-mapped registers.
+    pub unsafe fn new(pic_interrupt_service: &'a I, epmp: VeeRProtectionMMLEPMP) -> Self {
         Self {
             userspace_kernel_boundary: SysCall::new(),
             pic: &*addr_of!(PIC),
             timers: &*addr_of!(TIMERS),
             peripherals: pic_interrupt_service,
-            pmp: PMPUserMPU::new(SimplePMP::new().unwrap()),
+            pmp: rv32i::pmp::PMPUserMPU::new(epmp),
         }
     }
 
@@ -130,7 +130,7 @@ impl<'a, I: InterruptService + 'a> VeeR<'a, I> {
 }
 
 impl<'a, I: InterruptService + 'a> kernel::platform::chip::Chip for VeeR<'a, I> {
-    type MPU = PMPUserMPU<4, SimplePMP<8>>;
+    type MPU = VeeRPMP;
     type UserspaceKernelBoundary = SysCall;
 
     fn mpu(&self) -> &Self::MPU {

--- a/runtime/src/io.rs
+++ b/runtime/src/io.rs
@@ -51,7 +51,7 @@ pub fn exit_emulator(exit_code: u32) -> ! {
     // Safety: This is a safe memory address to write to for exiting the emulator.
     unsafe {
         // By writing to this address we can exit the emulator.
-        write_volatile(0x2000_f000 as *mut u32, exit_code);
+        write_volatile(0x1000_2000 as *mut u32, exit_code);
     }
     unreachable!()
 }
@@ -70,7 +70,7 @@ impl IoWrite for Writer {
         for b in buf {
             // Print to this address for emulator output
             unsafe {
-                write_volatile(0x2000_1041 as *mut u8, *b);
+                write_volatile(0x1000_1041 as *mut u8, *b);
             }
         }
         buf.len()
@@ -78,7 +78,7 @@ impl IoWrite for Writer {
 }
 
 fn read_byte() -> u8 {
-    unsafe { read_volatile(0x2000_1041 as *mut u8) }
+    unsafe { read_volatile(0x1000_1041 as *mut u8) }
 }
 
 pub struct SemihostUart<'a> {

--- a/runtime/src/main.rs
+++ b/runtime/src/main.rs
@@ -23,6 +23,8 @@ pub mod io;
 #[cfg(target_arch = "riscv32")]
 mod pic;
 #[cfg(target_arch = "riscv32")]
+mod pmp;
+#[cfg(target_arch = "riscv32")]
 #[allow(unused_imports)]
 mod tests;
 #[cfg(target_arch = "riscv32")]

--- a/runtime/src/pmp.rs
+++ b/runtime/src/pmp.rs
@@ -1,0 +1,601 @@
+// Licensed under the Apache-2.0 license.
+
+// Copyright Tock Contributors 2022.
+
+// Based on https://github.com/tock/tock/blob/b128ae817b86706c8c4e39d27fae5c54b98659f1/arch/rv32i/src/pmp.rs
+// KernelProtectionMMLEPMP
+
+use core::cell::Cell;
+use core::fmt;
+use kernel::platform::mpu;
+use kernel::utilities::registers::interfaces::{Readable, Writeable};
+use kernel::utilities::registers::{FieldValue, LocalRegisterCopy};
+use rv32i::csr;
+use rv32i::pmp::PMPUserMPU;
+use rv32i::pmp::{pmpcfg_octet, NAPOTRegionSpec, TORRegionSpec, TORUserPMP, TORUserPMPCFG};
+
+const MPU_REGIONS: usize = 16;
+pub const AVAILABLE_ENTRIES: usize = 64;
+
+pub type VeeRPMP = PMPUserMPU<MPU_REGIONS, VeeRProtectionMMLEPMP>;
+
+fn reset_entry(i: usize) {
+    // Read the entry's CSR:
+    let pmpcfg_csr = csr::CSR.pmpconfig_get(i / 4);
+
+    // Extract the entry's pmpcfg octet:
+    let pmpcfg: LocalRegisterCopy<u8, pmpcfg_octet::Register> =
+        LocalRegisterCopy::new(pmpcfg_csr.overflowing_shr(((i % 4) * 8) as u32).0 as u8);
+
+    // As outlined above, we never touch a locked region. Thus, bail
+    // out if it's locked:
+    if pmpcfg.is_set(pmpcfg_octet::l) {
+        panic!("PMP region was locked");
+    }
+
+    // Now that it's not locked, we can be sure that regardless of
+    // any ePMP bits, this region is either ignored or entirely
+    // denied for machine-mode access. Hence, we can change it in
+    // arbitrary ways without breaking our own memory access. Try to
+    // flip the R/W/X bits:
+    csr::CSR.pmpconfig_set(i / 4, pmpcfg_csr ^ (7 << ((i % 4) * 8)));
+
+    // Check if the CSR changed:
+    if pmpcfg_csr == csr::CSR.pmpconfig_get(i / 4) {
+        // Didn't change! This means that this region is not backed
+        // by HW. Return an error as `AVAILABLE_ENTRIES` is
+        // incorrect:
+        panic!("AVAILABLE_ENTRIES is incorrect: PMP region changes did not persist");
+    }
+
+    // Finally, turn the region off:
+    csr::CSR.pmpconfig_set(i / 4, pmpcfg_csr & !(0x18 << ((i % 4) * 8)));
+}
+
+// Helper to modify an arbitrary PMP entry.
+fn write_pmpaddr_pmpcfg(i: usize, pmpcfg: u8, pmpaddr: usize) {
+    // Important to set the address first. Locking the pmpcfg
+    // register will also lock the adress register!
+    csr::CSR.pmpaddr_set(i, pmpaddr);
+    csr::CSR.pmpconfig_modify(
+        i / 4,
+        FieldValue::<usize, csr::pmpconfig::pmpcfg::Register>::new(
+            0x000000FF_usize,
+            (i % 4) * 8,
+            u32::from_be_bytes([0, 0, 0, pmpcfg]) as usize,
+        ),
+    );
+}
+
+// ---------- Kernel memory-protection PMP memory region wrapper types -----
+//
+// These types exist primarily to avoid argument confusion in the
+// [`VeeRProtectionMMLEPMP`] constructor, which accepts the addresses of
+// these memory regions as arguments. They further encode whether a region
+// must adhere to the `NAPOT` or `TOR` addressing mode constraints:
+
+/// The code (kernel + apps) RAM region address range.
+///
+/// Configured in the PMP as a `NAPOT` region.
+#[derive(Copy, Clone, Debug)]
+pub struct CodeRegion(pub TORRegionSpec);
+
+/// The Data RAM region address range.
+///
+/// Configured in the PMP as a `NAPOT` region.
+#[derive(Copy, Clone, Debug)]
+pub struct DataRegion(pub TORRegionSpec);
+
+/// The MMIO region address range.
+///
+/// Configured in the PMP as a `NAPOT` region.
+#[derive(Copy, Clone, Debug)]
+pub struct MMIORegion(pub NAPOTRegionSpec);
+
+/// The PMP region specification for the kernel `.text` section.
+///
+/// This is to be made accessible to machine-mode as read-execute.
+/// Configured in the PMP as a `TOR` region.
+#[derive(Copy, Clone, Debug)]
+pub struct KernelTextRegion(pub TORRegionSpec);
+
+/// A RISC-V ePMP implementation which supports machine-mode (kernel) memory
+/// protection by using the machine-mode lockdown mode (MML), with a fixed
+/// number of "kernel regions" (such as `.text`, flash, RAM and MMIO).
+///
+/// This implementation will configure the ePMP in the following way:
+///
+/// - `mseccfg` CSR:
+///   ```text
+///   |-------------+-----------------------------------------------+-------|
+///   | MSECCFG BIT | LABEL                                         | STATE |
+///   |-------------+-----------------------------------------------+-------|
+///   |           0 | Machine-Mode Lockdown (MML)                   |     1 |
+///   |           1 | Machine-Mode Whitelist Policy (MMWP)          |     1 |
+///   |           2 | Rule-Lock Bypass (RLB)                        |     0 |
+///   |-------------+-----------------------------------------------+-------|
+///   ```
+///
+/// - `pmpaddrX` / `pmpcfgX` CSRs:
+///   ```text
+///   +-------------------+------------------------------------+-------+---+-------+
+///   | ENTRY             | REGION / ADDR                      | MODE  | L | PERMS |
+///   +-------------------+------------------------------------+-------+---+-------+
+///   |                 0 | ---------------------------------- | OFF   | X | ----- |
+///   |                 1 | Kernel .text section               | TOR   | X | R/X   |
+///   |                   |                                    |       |   |       |
+///   |                 2 | /                                \ | OFF   |   |       |
+///   |                 3 | \ Userspace TOR region #0        / | TOR   |   | ????? |
+///   |                   |                                    |       |   |       |
+///   |                 4 | /                                \ | OFF   |   |       |
+///   |                 5 | \ Userspace TOR region #1        / | TOR   |   | ????? |
+///   |                   |                                    |       |   |       |
+///   |     n - M - U - 6 | /                                \ |       |   |       |
+///   |     n - M - U - 5 | \ Userspace TOR region #x        / |       |   |       |
+///   |                   |                                    |       |   |       |
+///   | n - M - U - 4 ... | User MMIO                          | NAPOT |   | R/W   |
+///   |                   |                                    |       |   |       |
+///   |     n - M - 4 ... | Machine MMIO                       | NAPOT | X | R/W   |
+///   |                   |                                    |       |   |       |
+///   |             n - 4 | /                                \ | OFF   | X | ----- |
+///   |             n - 3 | \ Code (spanning kernel & apps)  / | TOR   | X | R     |
+///   |                   |                                    |       |   |       |
+///   |             n - 2 | /                                \ | OFF   | X | ----- |
+///   |             n - 1 | \ Data (spanning kernel & apps)  / | TOR   | X | R/W   |
+///   +-------------------+------------------------------------+-------+---+-------|
+///   ```
+///
+/// Crucially, this implementation relies on an unconfigured hardware PMP
+/// implementing the ePMP (`mseccfg` CSR) extension, providing the Machine
+/// Lockdown Mode (MML) security bit. This bit is required to ensure that
+/// any machine-mode (kernel) protection regions (lock bit set) are only
+/// accessible to kernel mode.
+pub struct VeeRProtectionMMLEPMP {
+    user_pmp_enabled: Cell<bool>,
+    shadow_user_pmpcfgs: [Cell<TORUserPMPCFG>; MPU_REGIONS],
+}
+
+impl VeeRProtectionMMLEPMP {
+    // Start user-mode TOR regions after the first kernel .text region:
+    fn tor_regions_offset(&self) -> usize {
+        1
+    }
+
+    pub unsafe fn new(
+        code: CodeRegion,
+        data: DataRegion,
+        user_mmio: &[MMIORegion],
+        machine_mmio: &[MMIORegion],
+        kernel_text: KernelTextRegion,
+    ) -> Result<Self, ()> {
+        // Ensure that the MPU_REGIONS (starting at entry, and occupying two
+        // entries per region) don't overflow the available entires, excluding
+        // the 6 entries used for implementing the kernel memory protection:
+        let u = user_mmio.len();
+        let m = machine_mmio.len();
+        assert!(MPU_REGIONS <= ((AVAILABLE_ENTRIES - 6 - m - u) / 2));
+
+        for i in 0..AVAILABLE_ENTRIES {
+            reset_entry(i);
+        }
+
+        // -----------------------------------------------------------------
+        // Hardware PMP is verified to be in a compatible mode & state, and
+        // has at least `AVAILABLE_ENTRIES` entries. We have not yet checked
+        // whether the PMP is actually an _e_PMP. However, we don't want to
+        // produce a gadget to set RLB, and so the only safe way to test
+        // this is to set up the PMP regions and then try to enable the
+        // mseccfg bits.
+        // -----------------------------------------------------------------
+
+        // Set the kernel `.text`, flash, RAM and MMIO regions, in no
+        // particular order, with the exception of `.text` and flash:
+        // `.text` must precede flash, as otherwise we'd be revoking execute
+        // permissions temporarily. Given that we can currently execute
+        // code, this should not have any impact on our accessible memory,
+        // assuming that the provided regions are not otherwise aliased.
+
+        // `.text` at beginning
+        write_pmpaddr_pmpcfg(
+            0,
+            (pmpcfg_octet::a::OFF
+                + pmpcfg_octet::r::CLEAR
+                + pmpcfg_octet::w::CLEAR
+                + pmpcfg_octet::x::CLEAR
+                + pmpcfg_octet::l::SET)
+                .into(),
+            (kernel_text.0.start() as usize) >> 2,
+        );
+        write_pmpaddr_pmpcfg(
+            1,
+            (pmpcfg_octet::a::TOR
+                + pmpcfg_octet::r::SET
+                + pmpcfg_octet::w::CLEAR
+                + pmpcfg_octet::x::SET
+                + pmpcfg_octet::l::SET)
+                .into(),
+            (kernel_text.0.end() as usize) >> 2,
+        );
+
+        // user MMIO at n - m - u - 4
+        for (i, mmio) in user_mmio.iter().enumerate() {
+            write_pmpaddr_pmpcfg(
+                AVAILABLE_ENTRIES - m - u - 4 + i,
+                (pmpcfg_octet::a::NAPOT
+                    + pmpcfg_octet::r::CLEAR
+                    + pmpcfg_octet::w::SET
+                    + pmpcfg_octet::x::SET
+                    + pmpcfg_octet::l::CLEAR) // shared region, R/W for both U and M
+                    .into(),
+                mmio.0.napot_addr(),
+            );
+        }
+
+        // machine MMIO at n - m - 4
+        for (i, mmio) in machine_mmio.iter().enumerate() {
+            write_pmpaddr_pmpcfg(
+                AVAILABLE_ENTRIES - m - 4 + i,
+                (pmpcfg_octet::a::NAPOT
+                    + pmpcfg_octet::r::SET
+                    + pmpcfg_octet::w::SET
+                    + pmpcfg_octet::x::CLEAR
+                    + pmpcfg_octet::l::SET)
+                    .into(),
+                mmio.0.napot_addr(),
+            );
+        }
+
+        // code at n - 4 .. n - 3:
+        write_pmpaddr_pmpcfg(
+            AVAILABLE_ENTRIES - 4,
+            (pmpcfg_octet::a::OFF
+                + pmpcfg_octet::r::CLEAR
+                + pmpcfg_octet::w::CLEAR
+                + pmpcfg_octet::x::CLEAR
+                + pmpcfg_octet::l::SET)
+                .into(),
+            (code.0.start() as usize) >> 2,
+        );
+        write_pmpaddr_pmpcfg(
+            AVAILABLE_ENTRIES - 3,
+            (pmpcfg_octet::a::TOR
+                + pmpcfg_octet::r::SET
+                + pmpcfg_octet::w::CLEAR
+                + pmpcfg_octet::x::CLEAR
+                + pmpcfg_octet::l::SET)
+                .into(),
+            (code.0.end() as usize) >> 2,
+        );
+
+        // data at n - 2 .. n - 1:
+        write_pmpaddr_pmpcfg(
+            AVAILABLE_ENTRIES - 2,
+            (pmpcfg_octet::a::OFF
+                + pmpcfg_octet::r::CLEAR
+                + pmpcfg_octet::w::CLEAR
+                + pmpcfg_octet::x::CLEAR
+                + pmpcfg_octet::l::SET)
+                .into(),
+            (data.0.start() as usize) >> 2,
+        );
+        write_pmpaddr_pmpcfg(
+            AVAILABLE_ENTRIES - 1,
+            (pmpcfg_octet::a::TOR
+                + pmpcfg_octet::r::SET
+                + pmpcfg_octet::w::SET
+                + pmpcfg_octet::x::CLEAR
+                + pmpcfg_octet::l::SET)
+                .into(),
+            (data.0.end() as usize) >> 2,
+        );
+
+        // Finally, attempt to enable the MSECCFG security bits, and verify
+        // that they have been set correctly. If they have not been set to
+        // the written value, this means that this hardware either does not
+        // support ePMP, or it was in some invalid state otherwise. We don't
+        // need to read back the above regions, as we previous verified that
+        // none of their entries were locked -- so writing to them must work
+        // even without RLB set.
+        //
+        // Set RLB(2) = 0, MMWP(1) = 1, MML(0) = 1
+        csr::CSR.mseccfg.set(0x00000003);
+
+        // Read back the MSECCFG CSR to ensure that the machine's security
+        // configuration was set properly. If this fails, we have set up the
+        // PMP in a way that would give userspace access to kernel
+        // space. The caller of this method must appropriately handle this
+        // error condition by ensuring that the platform will never execute
+        // userspace code!
+        if csr::CSR.mseccfg.get() != 0x00000003 {
+            return Err(());
+        }
+
+        // Setup complete
+        const DEFAULT_USER_PMPCFG_OCTET: Cell<TORUserPMPCFG> = Cell::new(TORUserPMPCFG::OFF);
+        Ok(VeeRProtectionMMLEPMP {
+            user_pmp_enabled: Cell::new(false),
+            shadow_user_pmpcfgs: [DEFAULT_USER_PMPCFG_OCTET; MPU_REGIONS],
+        })
+    }
+}
+
+impl TORUserPMP<MPU_REGIONS> for VeeRProtectionMMLEPMP {
+    // this has to be checked in new()
+    const CONST_ASSERT_CHECK: () = ();
+
+    fn available_regions(&self) -> usize {
+        // Always assume to have `MPU_REGIONS` usable TOR regions. We don't
+        // support locking additional regions at runtime.
+        MPU_REGIONS
+    }
+
+    // This implementation is specific for 32-bit systems. We use
+    // `u32::from_be_bytes` and then cast to usize, as it manages to compile
+    // on 64-bit systems as well. However, this implementation will not work
+    // on RV64I systems, due to the changed pmpcfgX CSR layout.
+    fn configure_pmp(
+        &self,
+        regions: &[(TORUserPMPCFG, *const u8, *const u8); MPU_REGIONS],
+    ) -> Result<(), ()> {
+        // Configure all of the regions' addresses and store their pmpcfg octets
+        // in our shadow storage. If the user PMP is already enabled, we further
+        // apply this configuration (set the pmpcfgX CSRs) by running
+        // `enable_user_pmp`:
+        for (i, (region, shadow_user_pmpcfg)) in regions
+            .iter()
+            .zip(self.shadow_user_pmpcfgs.iter())
+            .enumerate()
+        {
+            // The ePMP in MML mode does not support read-write-execute
+            // regions. If such a region is to be configured, abort. As this
+            // loop here only modifies the shadow state, we can simply abort and
+            // return an error. We don't make any promises about the ePMP state
+            // if the configuration files, but it is still being activated with
+            // `enable_user_pmp`:
+            if region.0.get()
+                == <TORUserPMPCFG as From<mpu::Permissions>>::from(
+                    mpu::Permissions::ReadWriteExecute,
+                )
+                .get()
+            {
+                return Err(());
+            }
+
+            // Set the CSR addresses for this region (if its not OFF, in which
+            // case the hardware-configured addresses are irrelevant):
+            if region.0 != TORUserPMPCFG::OFF {
+                csr::CSR.pmpaddr_set(
+                    (i + self.tor_regions_offset()) * 2 + 0,
+                    (region.1 as usize).overflowing_shr(2).0,
+                );
+                csr::CSR.pmpaddr_set(
+                    (i + self.tor_regions_offset()) * 2 + 1,
+                    (region.2 as usize).overflowing_shr(2).0,
+                );
+            }
+
+            // Store the region's pmpcfg octet:
+            shadow_user_pmpcfg.set(region.0);
+        }
+
+        // If the PMP is currently active, apply the changes to the CSRs:
+        if self.user_pmp_enabled.get() {
+            self.enable_user_pmp()?;
+        }
+
+        Ok(())
+    }
+
+    fn enable_user_pmp(&self) -> Result<(), ()> {
+        // We store the "enabled" PMPCFG octets of user regions in the
+        // `shadow_user_pmpcfg` field, such that we can re-enable the PMP
+        // without a call to `configure_pmp` (where the `TORUserPMPCFG`s are
+        // provided by the caller).
+
+        // Could use `iter_array_chunks` once that's stable.
+        let mut shadow_user_pmpcfgs_iter = self.shadow_user_pmpcfgs.iter();
+        let mut i = self.tor_regions_offset();
+
+        while let Some(first_region_pmpcfg) = shadow_user_pmpcfgs_iter.next() {
+            // If we're at a "region" offset divisible by two (where "region" =
+            // 2 PMP "entries"), then we can configure an entire `pmpcfgX` CSR
+            // in one operation. As CSR writes are expensive, this is an
+            // operation worth making:
+            let second_region_opt = if i % 2 == 0 {
+                shadow_user_pmpcfgs_iter.next()
+            } else {
+                None
+            };
+
+            if let Some(second_region_pmpcfg) = second_region_opt {
+                // We're at an even index and have two regions to configure, so
+                // do that with a single CSR write:
+                csr::CSR.pmpconfig_set(
+                    i / 2,
+                    u32::from_be_bytes([
+                        second_region_pmpcfg.get().get(),
+                        TORUserPMPCFG::OFF.get(),
+                        first_region_pmpcfg.get().get(),
+                        TORUserPMPCFG::OFF.get(),
+                    ]) as usize,
+                );
+
+                i += 2;
+            } else if i % 2 == 0 {
+                // This is a single region at an even index. Thus, modify the
+                // first two pmpcfgX octets for this region.
+                csr::CSR.pmpconfig_modify(
+                    i / 2,
+                    FieldValue::<usize, csr::pmpconfig::pmpcfg::Register>::new(
+                        0x0000FFFF,
+                        0, // lower two octets
+                        u32::from_be_bytes([
+                            0,
+                            0,
+                            first_region_pmpcfg.get().get(),
+                            TORUserPMPCFG::OFF.get(),
+                        ]) as usize,
+                    ),
+                );
+
+                i += 1;
+            } else {
+                // This is a single region at an odd index. Thus, modify the
+                // latter two pmpcfgX octets for this region.
+                csr::CSR.pmpconfig_modify(
+                    i / 2,
+                    FieldValue::<usize, csr::pmpconfig::pmpcfg::Register>::new(
+                        0x0000FFFF,
+                        16, // higher two octets
+                        u32::from_be_bytes([
+                            0,
+                            0,
+                            first_region_pmpcfg.get().get(),
+                            TORUserPMPCFG::OFF.get(),
+                        ]) as usize,
+                    ),
+                );
+
+                i += 1;
+            }
+        }
+
+        self.user_pmp_enabled.set(true);
+
+        Ok(())
+    }
+
+    fn disable_user_pmp(&self) {
+        // Simply set all of the user-region pmpcfg octets to OFF:
+
+        let mut user_region_pmpcfg_octet_pairs =
+            (self.tor_regions_offset())..(self.tor_regions_offset() + MPU_REGIONS);
+        while let Some(first_region_idx) = user_region_pmpcfg_octet_pairs.next() {
+            let second_region_opt = if first_region_idx % 2 == 0 {
+                user_region_pmpcfg_octet_pairs.next()
+            } else {
+                None
+            };
+
+            if let Some(_second_region_idx) = second_region_opt {
+                // We're at an even index and have two regions to configure, so
+                // do that with a single CSR write:
+                csr::CSR.pmpconfig_set(
+                    first_region_idx / 2,
+                    u32::from_be_bytes([
+                        TORUserPMPCFG::OFF.get(),
+                        TORUserPMPCFG::OFF.get(),
+                        TORUserPMPCFG::OFF.get(),
+                        TORUserPMPCFG::OFF.get(),
+                    ]) as usize,
+                );
+            } else if first_region_idx % 2 == 0 {
+                // This is a single region at an even index. Thus, modify the
+                // first two pmpcfgX octets for this region.
+                csr::CSR.pmpconfig_modify(
+                    first_region_idx / 2,
+                    FieldValue::<usize, csr::pmpconfig::pmpcfg::Register>::new(
+                        0x0000FFFF,
+                        0, // lower two octets
+                        u32::from_be_bytes([
+                            0,
+                            0,
+                            TORUserPMPCFG::OFF.get(),
+                            TORUserPMPCFG::OFF.get(),
+                        ]) as usize,
+                    ),
+                );
+            } else {
+                // This is a single region at an odd index. Thus, modify the
+                // latter two pmpcfgX octets for this region.
+                csr::CSR.pmpconfig_modify(
+                    first_region_idx / 2,
+                    FieldValue::<usize, csr::pmpconfig::pmpcfg::Register>::new(
+                        0x0000FFFF,
+                        16, // higher two octets
+                        u32::from_be_bytes([
+                            0,
+                            0,
+                            TORUserPMPCFG::OFF.get(),
+                            TORUserPMPCFG::OFF.get(),
+                        ]) as usize,
+                    ),
+                );
+            }
+        }
+
+        self.user_pmp_enabled.set(false);
+    }
+}
+
+impl fmt::Display for VeeRProtectionMMLEPMP {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            " ePMP configuration:\r\n  mseccfg: {:#08X}, user-mode PMP active: {:?}, entries:\r\n",
+            csr::CSR.mseccfg.get(),
+            self.user_pmp_enabled.get()
+        )?;
+        unsafe { rv32i::pmp::format_pmp_entries::<AVAILABLE_ENTRIES>(f) }?;
+
+        write!(f, "  Shadow PMP entries for user-mode:\r\n")?;
+        for (i, shadowed_pmpcfg) in self.shadow_user_pmpcfgs.iter().enumerate() {
+            let (start_pmpaddr_label, startaddr_pmpaddr, endaddr, mode) =
+                if shadowed_pmpcfg.get() == TORUserPMPCFG::OFF {
+                    (
+                        "pmpaddr",
+                        csr::CSR.pmpaddr_get((i + self.tor_regions_offset()) * 2),
+                        0,
+                        "OFF",
+                    )
+                } else {
+                    (
+                        "  start",
+                        csr::CSR
+                            .pmpaddr_get((i + self.tor_regions_offset()) * 2)
+                            .overflowing_shl(2)
+                            .0,
+                        csr::CSR
+                            .pmpaddr_get((i + self.tor_regions_offset()) * 2 + 1)
+                            .overflowing_shl(2)
+                            .0
+                            | 0b11,
+                        "TOR",
+                    )
+                };
+
+            write!(
+                f,
+                "  [{:02}]: {}={:#010X}, end={:#010X}, cfg={:#04X} ({}  ) ({}{}{}{})\r\n",
+                (i + self.tor_regions_offset()) * 2 + 1,
+                start_pmpaddr_label,
+                startaddr_pmpaddr,
+                endaddr,
+                shadowed_pmpcfg.get().get(),
+                mode,
+                if shadowed_pmpcfg.get().get_reg().is_set(pmpcfg_octet::l) {
+                    "l"
+                } else {
+                    "-"
+                },
+                if shadowed_pmpcfg.get().get_reg().is_set(pmpcfg_octet::r) {
+                    "r"
+                } else {
+                    "-"
+                },
+                if shadowed_pmpcfg.get().get_reg().is_set(pmpcfg_octet::w) {
+                    "w"
+                } else {
+                    "-"
+                },
+                if shadowed_pmpcfg.get().get_reg().is_set(pmpcfg_octet::x) {
+                    "x"
+                } else {
+                    "-"
+                },
+            )?;
+        }
+
+        Ok(())
+    }
+}

--- a/tests/hello/src/hello.rs
+++ b/tests/hello/src/hello.rs
@@ -27,7 +27,7 @@ const OUT_STR: &[u8; 14] = b"Hello Caliptra";
 #[cfg(target_arch = "riscv32")]
 #[no_mangle]
 pub extern "C" fn main() {
-    const UART0: *mut u8 = 0x2000_1041 as *mut u8;
+    const UART0: *mut u8 = 0x1000_1041 as *mut u8;
     unsafe {
         for byte in OUT_STR {
             core::ptr::write_volatile(UART0, *byte);

--- a/tests/hello/src/start.S
+++ b/tests/hello/src/start.S
@@ -35,7 +35,7 @@ copy_bss:
     addi t0, t0, 4
     j copy_bss
 end_copy_bss:
-    
+
     # Copy data
     la t0, ROM_DATA_START
     la t1, DATA_START
@@ -48,13 +48,13 @@ copy_data:
     addi t1, t1, 4
     j copy_data
 end_copy_data:
-    
+
     # call main entry point
     call main
-    
+
     # exit the emulator
     la t0, EMU_CTRL_EXIT
     sw zero, 0(t0)
 
 .section .data
-.equ  EMU_CTRL_EXIT, 0x2000F000
+.equ  EMU_CTRL_EXIT, 0x10002000


### PR DESCRIPTION
I wasn't able to use an existing PMP layout due to our potential for multiple MMIO blocks as well as our unified RAM block: the existing PMP layouts that Tock has built in expect things to be aligned to neater boundaries with power of two sizes.

So, I modified the standard kernel EPMP layout to support what we need.

The "E" is used to indicate we support the SMEPMP extension, which provides some additional mode bits that allow more fine-grained control of shared areas between machine and user mode and allowing us to set a default deny all policy.

I moved around our memory map a little to make the PMP setup a little easier and reduce the number of regions we need, but left it flexible enough that we can still accommodate whatever memory map changes we need to make in the future. I moved the emulator-only UART and control peripherals to be in the `0x1000_0000` range, which will be accessible from user mode, while the `0x2000_0000` peripherals will only be accessible by the kernel.

This also fixes a bug in the CPU emulator's PMP calculation when using natural power of 2 regions (NAPOT). I've also ported that fix over to Caliptra core.