### PR TITLE
Disable MCTP user loopback tests really, really hard when disabled

### DIFF
--- a/runtime/apps/example/src/main.rs
+++ b/runtime/apps/example/src/main.rs
@@ -77,7 +77,8 @@ pub(crate) async fn async_main<S: Syscalls>() {
         writeln!(console_writer, "async sleeper woke").unwrap();
     }
 
-    if cfg!(feature = "test-mctp-user-loopback") {
+    #[cfg(feature = "test-mctp-user-loopback")]
+    {
         writeln!(
             console_writer,
             "Running test-mctp-user-loopback test for SPDM msg type"
@@ -118,6 +119,7 @@ pub(crate) async fn async_main<S: Syscalls>() {
     writeln!(console_writer, "app finished").unwrap();
 }
 
+#[allow(dead_code)]
 async fn test_mctp_loopback<S: Syscalls>() {
     use libsyscall_caliptra::mctp::{driver_num, Mctp};
     let mctp_spdm = Mctp::<S>::new(driver_num::MCTP_SPDM);

--- a/runtime/apps/example/src/main.rs
+++ b/runtime/apps/example/src/main.rs
@@ -8,7 +8,6 @@
 use core::fmt::Write;
 #[cfg(feature = "test-flash-usermode")]
 use libsyscall_caliptra::flash::{driver_num as par_driver_num, FlashCapacity, SpiFlash};
-use libsyscall_caliptra::mctp::{driver_num, Mctp};
 use libtock::alarm::*;
 use libtock_console::Console;
 use libtock_platform::{self as platform};
@@ -120,6 +119,7 @@ pub(crate) async fn async_main<S: Syscalls>() {
 }
 
 async fn test_mctp_loopback<S: Syscalls>() {
+    use libsyscall_caliptra::mctp::{driver_num, Mctp};
     let mctp_spdm = Mctp::<S>::new(driver_num::MCTP_SPDM);
     loop {
         let mut msg_buffer: [u8; 1024] = [0; 1024];


### PR DESCRIPTION
Functionally there should be no difference because of this PR, as this function is not even called unless the feature is enabled.

But, before, you can see that when running the runtime that it is blocked keyboard input before the async sleeps will finish, while after this fix, it is not.

This functionality makes no sense. The `cfg!()` macro should be evaluated to `if false`, which should remove the code block entirely from the resulting binary.

Switching it to use this double `cfg` pattern removes 2 KB from the application binary, and removes this confusing keyboard behavior.

I suspect this is due to a compiler bug. It seems to be present even on the latest nightly compilers as well.

I'm going to keep investigating this and if applicable, report it to the Rust compiler devs.