### PR TITLE
emulator: Save interrupts to be processed later in action loop

### DIFF
--- a/emulator/bus/src/clock.rs
+++ b/emulator/bus/src/clock.rs
@@ -262,7 +262,7 @@ pub enum TimerAction {
 
 impl TimerAction {
     /// Sort priority based on VeeR EL2 Programmer's Reference Manual Table 14.1.
-    pub fn priority(&self) -> usize {
+    pub fn priority(&self) -> isize {
         match self {
             TimerAction::Poll => 0,
             TimerAction::Halt => 1,

--- a/emulator/cpu/src/cpu.rs
+++ b/emulator/cpu/src/cpu.rs
@@ -166,6 +166,11 @@ pub struct Cpu<TBus: Bus> {
     pub(crate) watch_ptr_cfg: WatchPtrCfg,
 
     pub code_coverage: CodeCoverage,
+
+    #[cfg(test)]
+    internal_timer_local_int_counter: usize,
+    #[cfg(test)]
+    external_int_counter: usize,
 }
 
 /// Cpu instruction step action
@@ -206,6 +211,10 @@ impl<TBus: Bus> Cpu<TBus> {
             // TODO: Pass in code_coverage from the outside (as caliptra-emu-cpu
             // isn't supposed to know anything about the caliptra memory map)
             code_coverage: CodeCoverage::new(ROM_SIZE, ICCM_SIZE),
+            #[cfg(test)]
+            internal_timer_local_int_counter: 0,
+            #[cfg(test)]
+            external_int_counter: 0,
         }
     }
 
@@ -664,6 +673,10 @@ impl<TBus: Bus> Cpu<TBus> {
     }
 
     fn handle_internal_timer_local_interrupt(&mut self, timer_id: u8) -> StepAction {
+        #[cfg(test)]
+        {
+            self.internal_timer_local_int_counter += 1;
+        }
         let mcause = 0x8000_001D - (timer_id as u32);
         match self.handle_trap(
             self.read_pc(),
@@ -748,6 +761,10 @@ impl<TBus: Bus> Cpu<TBus> {
 
     //// Handle external interrupts
     fn handle_external_int(&mut self, irq: u8) -> StepAction {
+        #[cfg(test)]
+        {
+            self.external_int_counter += 1;
+        }
         const REDIRECT_ENTRY_SIZE: u32 = 4;
         const MAX_IRQ: u32 = 32;
 
@@ -1735,5 +1752,64 @@ mod tests {
 
         // Check for expected values
         assert_eq!(count_executed(&coverage), 8);
+    }
+
+    #[test]
+    fn test_multiple_events_not_lost() {
+        const RV32_NO_OP: u32 = 0x00000013;
+
+        let clock = Rc::new(Clock::new());
+        let timer = Timer::new(&clock);
+        let mut bus = DynamicBus::new();
+
+        let rom = Rom::new(
+            std::iter::repeat(RV32_NO_OP)
+                .take(256)
+                .flat_map(u32::to_le_bytes)
+                .collect(),
+        );
+        bus.attach_dev("ROM", 0..=0x3ff, Box::new(rom)).unwrap();
+
+        let mut action0 = Some(timer.schedule_poll_in(31));
+        timer.schedule_action_in(31, TimerAction::InternalTimerLocalInterrupt { timer_id: 0 });
+        timer.schedule_action_in(
+            31,
+            TimerAction::ExtInt {
+                irq: 1,
+                can_wake: true,
+            },
+        );
+
+        let pic = Rc::new(Pic::new());
+        let mut cpu = Cpu::new(bus, clock.clone(), pic);
+        cpu.global_int_en = true;
+        cpu.ext_int_en = true;
+
+        for i in 0..30 {
+            assert_eq!(cpu.clock.now(), i);
+            assert_eq!(cpu.step(None), StepAction::Continue);
+        }
+        assert!(!timer.fired(&mut action0));
+
+        assert_eq!(cpu.internal_timer_local_int_counter, 0);
+        assert_eq!(cpu.external_int_counter, 0);
+
+        assert_eq!(cpu.step(None), StepAction::Continue);
+
+        assert!(timer.fired(&mut action0));
+        // the external interrupt should be handled first
+        assert_eq!(cpu.internal_timer_local_int_counter, 0);
+        assert_eq!(cpu.external_int_counter, 1);
+
+        // this will trigger a disabling of the global interrupt enable, which takes priority
+        assert_eq!(cpu.step(None), StepAction::Continue);
+
+        // re-allow global interrupts
+        cpu.global_int_en = true;
+        assert_eq!(cpu.step(None), StepAction::Continue);
+
+        // now the timer interrupt should be processed
+        assert_eq!(cpu.internal_timer_local_int_counter, 1);
+        assert_eq!(cpu.external_int_counter, 1);
     }
 }

--- a/emulator/cpu/src/cpu.rs
+++ b/emulator/cpu/src/cpu.rs
@@ -20,7 +20,6 @@ use crate::Pic;
 use bit_vec::BitVec;
 use emulator_bus::{Bus, BusError, Clock, TimerAction};
 use emulator_types::{RvAddr, RvData, RvException, RvExceptionCause, RvSize, RAM_OFFSET, RAM_SIZE};
-use std::collections::VecDeque;
 use std::rc::Rc;
 
 pub type InstrTracer<'a> = dyn FnMut(u32, RvInstr) + 'a;
@@ -585,13 +584,11 @@ impl<TBus: Bus> Cpu<TBus> {
             .increment_and_process_timer_actions(1, &mut self.bus)
             .into_iter()
             .collect();
-        fired_action_types.sort_by_key(|a| a.priority());
-        let mut fired_action_types: VecDeque<TimerAction> =
-            fired_action_types.into_iter().collect();
+        fired_action_types.sort_by_key(|a| -a.priority());
         let mut step_action = None;
         let mut saved = vec![];
         while !fired_action_types.is_empty() {
-            let action_type = fired_action_types.pop_front().unwrap();
+            let action_type = fired_action_types.pop().unwrap();
             let mut save = false;
             match action_type {
                 TimerAction::WarmReset => {

--- a/emulator/cpu/src/cpu.rs
+++ b/emulator/cpu/src/cpu.rs
@@ -596,8 +596,7 @@ impl<TBus: Bus> Cpu<TBus> {
         fired_action_types.sort_by_key(|a| -a.priority());
         let mut step_action = None;
         let mut saved = vec![];
-        while !fired_action_types.is_empty() {
-            let action_type = fired_action_types.pop().unwrap();
+        while let Some(action_type) = fired_action_types.pop() {
             let mut save = false;
             match action_type {
                 TimerAction::WarmReset => {


### PR DESCRIPTION
Otherwise, if the CPU is busy with another interrupt, then additional interrupts are dropped and never sent to the interrupt handler. This is different from how the real CPU works, where the interrupt would keep being asserted until the the interrupt handler re-enables interrupts (when it jumps out of machine mode).

This was causing problems with our test code sometimes as the timer interrupts were getting lost randomly.