### PR TITLE
fix: correct total_size and binary_end_offset in TBF header of the app

### DIFF
--- a/xtask/src/apps_build.rs
+++ b/xtask/src/apps_build.rs
@@ -97,10 +97,11 @@ fn app_build_tbf(
 
     // read the flat binary
     let b = std::fs::read(&app_bin)?;
+    let total_size = b.len() + tbf_header_size;
 
-    tbf.set_total_size(b.len() as u32);
+    tbf.set_total_size(total_size as u32);
     tbf.set_init_fn_offset(0x20);
-    tbf.set_binary_end_offset(b.len() as u32);
+    tbf.set_binary_end_offset(total_size as u32);
     let tbf = tbf.generate()?;
 
     // concatenate the TBF header and the binary


### PR DESCRIPTION
The total size calculation in the TBF header was incorrect due to a missing TBF header. This caused failures when loading multiple processes in the kernel, as the kernel relies on the total size in the TBF header to locate the next available app on flash. Without correct setting, kernel looked at the wrong offset on flash when loading the second apps and caused "TBF header not found" error.