### PR TITLE
Compliance test fix for latest sail-riscv

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -48,7 +48,7 @@ jobs:
         git clone https://github.com/riscv/sail-riscv.git && \
         pushd sail-riscv && \
         ./build_simulators.sh && \
-        sudo cp -r build/c_emulator/riscv_sim_RV32 /usr/bin && \
+        sudo cp -r build/c_emulator/riscv_sim_rv32d /usr/bin/riscv_sim_RV32 && \
         popd
     - name: Install Rust tools
       run: rustup update

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -47,8 +47,8 @@ jobs:
       run: |
         git clone https://github.com/riscv/sail-riscv.git && \
         pushd sail-riscv && \
-        make c_emulator/riscv_sim_RV32 ARCH=32 -j$(nproc) && \
-        sudo cp -r c_emulator/riscv_sim_RV32 /usr/bin && \
+        ./build_simulators.sh && \
+        sudo cp -r build/c_emulator/riscv_sim_RV32 /usr/bin && \
         popd
     - name: Install Rust tools
       run: rustup update


### PR DESCRIPTION
They switched to CMake from make, so we need to use a slightly different
way of building the official simulator.