### PR TITLE
Fix the hello.elf build script to reference correct files

### DIFF
--- a/tests/hello/build.rs
+++ b/tests/hello/build.rs
@@ -13,7 +13,6 @@ Abstract:
 --*/
 
 fn main() {
-    println!("cargo:rerun-if-changed=layout.ld");
-    println!("cargo:rerun-if-changed=kernel_layout.ld");
+    println!("cargo:rerun-if-changed=link.ld");
     println!("cargo:rerun-if-changed=src/start.S");
 }


### PR DESCRIPTION
This was slowing down builds slightly since it would force that binary to be recompiled every time.

With it referencing the correct files, the build can be cached.