### PR TITLE
registers: Implement emulated register arrays correctly

### DIFF
--- a/emulator/periph/src/flash_ctrl.rs
+++ b/emulator/periph/src/flash_ctrl.rs
@@ -363,7 +363,6 @@ impl MainFlashPeripheral for DummyFlashCtrl {
 
     fn read_fl_interrupt_state(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::main_flash_ctrl::bits::FlInterruptState::Register,
@@ -373,7 +372,6 @@ impl MainFlashPeripheral for DummyFlashCtrl {
 
     fn write_fl_interrupt_state(
         &mut self,
-        _size: emulator_types::RvSize,
         val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::main_flash_ctrl::bits::FlInterruptState::Register,
@@ -396,7 +394,6 @@ impl MainFlashPeripheral for DummyFlashCtrl {
 
     fn read_fl_interrupt_enable(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::main_flash_ctrl::bits::FlInterruptEnable::Register,
@@ -406,7 +403,6 @@ impl MainFlashPeripheral for DummyFlashCtrl {
 
     fn write_fl_interrupt_enable(
         &mut self,
-        _size: emulator_types::RvSize,
         val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::main_flash_ctrl::bits::FlInterruptEnable::Register,
@@ -433,34 +429,33 @@ impl MainFlashPeripheral for DummyFlashCtrl {
         self.interrupt_enable.reg.set(val.reg.get());
     }
 
-    fn write_page_size(&mut self, _size: emulator_types::RvSize, val: emulator_types::RvData) {
+    fn write_page_size(&mut self, val: emulator_types::RvData) {
         self.page_size.reg.set(val);
     }
 
     // Return the page size of the flash storage connected to the controller
-    fn read_page_size(&mut self, _size: emulator_types::RvSize) -> emulator_types::RvData {
+    fn read_page_size(&mut self) -> emulator_types::RvData {
         Self::PAGE_SIZE as u32
     }
 
-    fn read_page_num(&mut self, _size: emulator_types::RvSize) -> emulator_types::RvData {
+    fn read_page_num(&mut self) -> emulator_types::RvData {
         self.page_num.reg.get()
     }
 
-    fn write_page_num(&mut self, _size: emulator_types::RvSize, val: emulator_types::RvData) {
+    fn write_page_num(&mut self, val: emulator_types::RvData) {
         self.page_num.reg.set(val);
     }
 
-    fn read_page_addr(&mut self, _size: emulator_types::RvSize) -> emulator_types::RvData {
+    fn read_page_addr(&mut self) -> emulator_types::RvData {
         self.page_addr.reg.get()
     }
 
-    fn write_page_addr(&mut self, _size: emulator_types::RvSize, val: emulator_types::RvData) {
+    fn write_page_addr(&mut self, val: emulator_types::RvData) {
         self.page_addr.reg.set(val);
     }
 
     fn read_fl_control(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::main_flash_ctrl::bits::FlControl::Register,
@@ -470,7 +465,6 @@ impl MainFlashPeripheral for DummyFlashCtrl {
 
     fn write_fl_control(
         &mut self,
-        _size: emulator_types::RvSize,
         val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::main_flash_ctrl::bits::FlControl::Register,
@@ -493,7 +487,6 @@ impl MainFlashPeripheral for DummyFlashCtrl {
 
     fn read_op_status(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::main_flash_ctrl::bits::OpStatus::Register,
@@ -503,7 +496,6 @@ impl MainFlashPeripheral for DummyFlashCtrl {
 
     fn write_op_status(
         &mut self,
-        _size: emulator_types::RvSize,
         val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::main_flash_ctrl::bits::OpStatus::Register,
@@ -514,7 +506,6 @@ impl MainFlashPeripheral for DummyFlashCtrl {
 
     fn read_ctrl_regwen(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::main_flash_ctrl::bits::CtrlRegwen::Register,
@@ -539,7 +530,6 @@ impl RecoveryFlashPeripheral for DummyFlashCtrl {
 
     fn read_fl_interrupt_state(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::main_flash_ctrl::bits::FlInterruptState::Register,
@@ -549,7 +539,6 @@ impl RecoveryFlashPeripheral for DummyFlashCtrl {
 
     fn write_fl_interrupt_state(
         &mut self,
-        _size: emulator_types::RvSize,
         val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::main_flash_ctrl::bits::FlInterruptState::Register,
@@ -572,7 +561,6 @@ impl RecoveryFlashPeripheral for DummyFlashCtrl {
 
     fn read_fl_interrupt_enable(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::main_flash_ctrl::bits::FlInterruptEnable::Register,
@@ -582,7 +570,6 @@ impl RecoveryFlashPeripheral for DummyFlashCtrl {
 
     fn write_fl_interrupt_enable(
         &mut self,
-        _size: emulator_types::RvSize,
         val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::main_flash_ctrl::bits::FlInterruptEnable::Register,
@@ -609,34 +596,33 @@ impl RecoveryFlashPeripheral for DummyFlashCtrl {
         self.interrupt_enable.reg.set(val.reg.get());
     }
 
-    fn write_page_size(&mut self, _size: emulator_types::RvSize, val: emulator_types::RvData) {
+    fn write_page_size(&mut self, val: emulator_types::RvData) {
         self.page_size.reg.set(val);
     }
 
     // Return the page size of the flash storage connected to the controller
-    fn read_page_size(&mut self, _size: emulator_types::RvSize) -> emulator_types::RvData {
+    fn read_page_size(&mut self) -> emulator_types::RvData {
         Self::PAGE_SIZE as u32
     }
 
-    fn read_page_num(&mut self, _size: emulator_types::RvSize) -> emulator_types::RvData {
+    fn read_page_num(&mut self) -> emulator_types::RvData {
         self.page_num.reg.get()
     }
 
-    fn write_page_num(&mut self, _size: emulator_types::RvSize, val: emulator_types::RvData) {
+    fn write_page_num(&mut self, val: emulator_types::RvData) {
         self.page_num.reg.set(val);
     }
 
-    fn read_page_addr(&mut self, _size: emulator_types::RvSize) -> emulator_types::RvData {
+    fn read_page_addr(&mut self) -> emulator_types::RvData {
         self.page_addr.reg.get()
     }
 
-    fn write_page_addr(&mut self, _size: emulator_types::RvSize, val: emulator_types::RvData) {
+    fn write_page_addr(&mut self, val: emulator_types::RvData) {
         self.page_addr.reg.set(val);
     }
 
     fn read_fl_control(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::main_flash_ctrl::bits::FlControl::Register,
@@ -646,7 +632,6 @@ impl RecoveryFlashPeripheral for DummyFlashCtrl {
 
     fn write_fl_control(
         &mut self,
-        _size: emulator_types::RvSize,
         val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::main_flash_ctrl::bits::FlControl::Register,
@@ -669,7 +654,6 @@ impl RecoveryFlashPeripheral for DummyFlashCtrl {
 
     fn read_op_status(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::main_flash_ctrl::bits::OpStatus::Register,
@@ -679,7 +663,6 @@ impl RecoveryFlashPeripheral for DummyFlashCtrl {
 
     fn write_op_status(
         &mut self,
-        _size: emulator_types::RvSize,
         val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::main_flash_ctrl::bits::OpStatus::Register,
@@ -690,7 +673,6 @@ impl RecoveryFlashPeripheral for DummyFlashCtrl {
 
     fn read_ctrl_regwen(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::main_flash_ctrl::bits::CtrlRegwen::Register,

--- a/emulator/periph/src/i3c.rs
+++ b/emulator/periph/src/i3c.rs
@@ -293,9 +293,7 @@ impl I3cPeripheral for I3c {
     fn write_i3c_ec_tti_tx_data_port(&mut self, val: u32) {
         let to_append = val.to_le_bytes();
         let idx = self.tti_tx_data_raw.len() - 1;
-        for byte in to_append {
-            self.tti_tx_data_raw[idx].push(byte);
-        }
+        self.tti_tx_data_raw[idx].extend_from_slice(&to_append);
         self.write_tx_data_into_target();
     }
 

--- a/emulator/periph/src/i3c.rs
+++ b/emulator/periph/src/i3c.rs
@@ -11,7 +11,7 @@ use crate::{DynamicI3cAddress, I3cIncomingCommandClient, IbiDescriptor, ReguData
 use emulator_bus::{Clock, ReadWriteRegister, Timer};
 use emulator_cpu::Irq;
 use emulator_registers_generated::i3c::I3cPeripheral;
-use emulator_types::{RvData, RvSize};
+use emulator_types::RvData;
 use registers_generated::i3c::bits::{
     ExtcapHeader, InterruptEnable, InterruptStatus, StbyCrCapabilities, StbyCrDeviceAddr,
     TtiQueueSize,
@@ -191,13 +191,12 @@ impl I3c {
 }
 
 impl I3cPeripheral for I3c {
-    fn read_i3c_base_hci_version(&mut self, _size: RvSize) -> RvData {
+    fn read_i3c_base_hci_version(&mut self) -> RvData {
         RvData::from(Self::HCI_VERSION)
     }
 
     fn read_i3c_ec_tti_interrupt_enable(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::InterruptEnable::Register,
@@ -207,7 +206,6 @@ impl I3cPeripheral for I3c {
 
     fn read_i3c_ec_tti_interrupt_status(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::InterruptStatus::Register,
@@ -217,7 +215,7 @@ impl I3cPeripheral for I3c {
 
     fn write_i3c_ec_tti_interrupt_status(
         &mut self,
-        _size: emulator_types::RvSize,
+
         val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::InterruptStatus::Register,
@@ -232,7 +230,7 @@ impl I3cPeripheral for I3c {
 
     fn write_i3c_ec_tti_interrupt_enable(
         &mut self,
-        _size: emulator_types::RvSize,
+
         val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::InterruptEnable::Register,
@@ -241,41 +239,20 @@ impl I3cPeripheral for I3c {
         self.interrupt_enable.reg.set(val.reg.get());
     }
 
-    fn write_i3c_ec_tti_tti_ibi_port(
-        &mut self,
-        size: emulator_types::RvSize,
-        val: emulator_types::RvData,
-    ) {
-        match size {
-            RvSize::Byte => {
-                self.tti_ibi_buffer.push(val as u8);
-            }
-            RvSize::HalfWord => {
-                let val = val as u16;
-                self.tti_ibi_buffer.push(val as u8);
-                self.tti_ibi_buffer.push((val >> 8) as u8);
-            }
-            RvSize::Word => {
-                self.tti_ibi_buffer
-                    .extend_from_slice(val.to_le_bytes().as_ref());
-            }
-            RvSize::Invalid => {
-                panic!("Invalid size")
-            }
-        }
+    fn write_i3c_ec_tti_tti_ibi_port(&mut self, val: emulator_types::RvData) {
+        self.tti_ibi_buffer
+            .extend_from_slice(val.to_le_bytes().as_ref());
         self.check_ibi_buffer();
     }
 
     fn read_i3c_ec_stdby_ctrl_mode_stby_cr_capabilities(
         &mut self,
-        _size: RvSize,
     ) -> ReadWriteRegister<u32, StbyCrCapabilities::Register> {
         ReadWriteRegister::new(StbyCrCapabilities::TargetXactSupport.val(1).value)
     }
 
     fn read_i3c_ec_stdby_ctrl_mode_stby_cr_device_addr(
         &mut self,
-        _size: RvSize,
     ) -> ReadWriteRegister<u32, StbyCrDeviceAddr::Register> {
         let val = match self.i3c_target.get_address() {
             Some(addr) => {
@@ -287,14 +264,11 @@ impl I3cPeripheral for I3c {
         ReadWriteRegister::new(val.value)
     }
 
-    fn read_i3c_ec_tti_extcap_header(
-        &mut self,
-        _size: RvSize,
-    ) -> ReadWriteRegister<u32, ExtcapHeader::Register> {
+    fn read_i3c_ec_tti_extcap_header(&mut self) -> ReadWriteRegister<u32, ExtcapHeader::Register> {
         ReadWriteRegister::new(ExtcapHeader::CapId.val(0xc4).value)
     }
 
-    fn read_i3c_ec_tti_rx_desc_queue_port(&mut self, _size: RvSize) -> u32 {
+    fn read_i3c_ec_tti_rx_desc_queue_port(&mut self) -> u32 {
         if self.tti_rx_desc_queue_raw.len() & 1 == 0 {
             // only replace the data every other read since the descriptor is 64 bits
             self.tti_rx_current = self.tti_rx_data_raw.pop_front().unwrap_or_default().into();
@@ -302,46 +276,30 @@ impl I3cPeripheral for I3c {
         self.tti_rx_desc_queue_raw.pop_front().unwrap_or(0)
     }
 
-    fn read_i3c_ec_tti_rx_data_port(&mut self, size: RvSize) -> u32 {
-        match size {
-            RvSize::Byte => self.tti_rx_current.pop_front().unwrap_or(0) as u32,
-            RvSize::HalfWord => {
-                let mut data = (self.tti_rx_current.pop_front().unwrap_or(0) as u32) << 8;
-                data |= self.tti_rx_current.pop_front().unwrap_or(0) as u32;
-                data
-            }
-            RvSize::Word => {
-                let mut data = self.tti_rx_current.pop_front().unwrap_or(0) as u32;
-                data |= (self.tti_rx_current.pop_front().unwrap_or(0) as u32) << 8;
-                data |= (self.tti_rx_current.pop_front().unwrap_or(0) as u32) << 16;
-                data |= (self.tti_rx_current.pop_front().unwrap_or(0) as u32) << 24;
-                data
-            }
-            RvSize::Invalid => {
-                panic!("Invalid size")
-            }
-        }
+    fn read_i3c_ec_tti_rx_data_port(&mut self) -> u32 {
+        let mut data = self.tti_rx_current.pop_front().unwrap_or(0) as u32;
+        data |= (self.tti_rx_current.pop_front().unwrap_or(0) as u32) << 8;
+        data |= (self.tti_rx_current.pop_front().unwrap_or(0) as u32) << 16;
+        data |= (self.tti_rx_current.pop_front().unwrap_or(0) as u32) << 24;
+        data
     }
 
-    fn write_i3c_ec_tti_tx_desc_queue_port(&mut self, _size: RvSize, val: u32) {
+    fn write_i3c_ec_tti_tx_desc_queue_port(&mut self, val: u32) {
         self.tti_tx_desc_queue_raw.push_back(val);
         self.tti_tx_data_raw.push_back(vec![]);
         self.write_tx_data_into_target();
     }
 
-    fn write_i3c_ec_tti_tx_data_port(&mut self, size: RvSize, val: u32) {
+    fn write_i3c_ec_tti_tx_data_port(&mut self, val: u32) {
         let to_append = val.to_le_bytes();
         let idx = self.tti_tx_data_raw.len() - 1;
-        for byte in &to_append[..size.into()] {
-            self.tti_tx_data_raw[idx].push(*byte);
+        for byte in to_append {
+            self.tti_tx_data_raw[idx].push(byte);
         }
         self.write_tx_data_into_target();
     }
 
-    fn read_i3c_ec_tti_tti_queue_size(
-        &mut self,
-        _size: RvSize,
-    ) -> ReadWriteRegister<u32, TtiQueueSize::Register> {
+    fn read_i3c_ec_tti_tti_queue_size(&mut self) -> ReadWriteRegister<u32, TtiQueueSize::Register> {
         ReadWriteRegister::new(
             (TtiQueueSize::RxDataBufferSize.val(5)
                 + TtiQueueSize::TxDataBufferSize.val(5)
@@ -381,7 +339,7 @@ mod tests {
     use emulator_bus::Bus;
     use emulator_cpu::Pic;
     use emulator_registers_generated::root_bus::AutoRootBus;
-    use emulator_types::RvAddr;
+    use emulator_types::{RvAddr, RvSize};
 
     const TTI_RX_DESC_QUEUE_PORT: RvAddr = 0x1dc;
 
@@ -394,10 +352,7 @@ mod tests {
         let mut i3c_controller = I3cController::default();
         let mut i3c = Box::new(I3c::new(&clock, &mut i3c_controller, error_irq, notif_irq));
 
-        assert_eq!(
-            i3c.read_i3c_base_hci_version(RvSize::Word),
-            I3c::HCI_VERSION
-        );
+        assert_eq!(i3c.read_i3c_base_hci_version(), I3c::HCI_VERSION);
 
         let cmd_bytes: [u8; 8] = [0x01, 0, 0, 0, 0, 0, 0, 0];
         let cmd = I3cTcriCommandXfer {

--- a/registers/generated-emulator/src/i3c.rs
+++ b/registers/generated-emulator/src/i3c.rs
@@ -9,30 +9,25 @@ pub trait I3cPeripheral {
     fn poll(&mut self) {}
     fn warm_reset(&mut self) {}
     fn update_reset(&mut self) {}
-    fn read_dat(&mut self, _size: emulator_types::RvSize) -> emulator_types::RvData {
+    fn read_dat(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_dat(&mut self, _size: emulator_types::RvSize, _val: emulator_types::RvData) {}
-    fn read_dct(&mut self, _size: emulator_types::RvSize) -> emulator_types::RvData {
+    fn write_dat(&mut self, _val: emulator_types::RvData) {}
+    fn read_dct(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_dct(&mut self, _size: emulator_types::RvSize, _val: emulator_types::RvData) {}
-    fn read_i3c_base_hci_version(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_dct(&mut self, _val: emulator_types::RvData) {}
+    fn read_i3c_base_hci_version(&mut self) -> emulator_types::RvData {
         0
     }
     fn read_i3c_base_hc_control(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::HcControl::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_base_hc_control(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::HcControl::Register,
@@ -41,7 +36,6 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_base_controller_device_addr(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::ControllerDeviceAddr::Register,
@@ -50,7 +44,6 @@ pub trait I3cPeripheral {
     }
     fn write_i3c_base_controller_device_addr(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::ControllerDeviceAddr::Register,
@@ -59,7 +52,6 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_base_hc_capabilities(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::HcCapabilities::Register,
@@ -68,14 +60,12 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_base_reset_control(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::ResetControl::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_base_reset_control(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::ResetControl::Register,
@@ -84,21 +74,18 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_base_present_state(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::PresentState::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn read_i3c_base_intr_status(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::IntrStatus::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_base_intr_status(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::IntrStatus::Register,
@@ -107,7 +94,6 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_base_intr_status_enable(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::IntrStatusEnable::Register,
@@ -116,7 +102,6 @@ pub trait I3cPeripheral {
     }
     fn write_i3c_base_intr_status_enable(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::IntrStatusEnable::Register,
@@ -125,7 +110,6 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_base_intr_signal_enable(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::IntrSignalEnable::Register,
@@ -134,7 +118,6 @@ pub trait I3cPeripheral {
     }
     fn write_i3c_base_intr_signal_enable(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::IntrSignalEnable::Register,
@@ -143,7 +126,6 @@ pub trait I3cPeripheral {
     }
     fn write_i3c_base_intr_force(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::IntrForce::Register,
@@ -152,7 +134,6 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_base_dat_section_offset(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::DatSectionOffset::Register,
@@ -161,7 +142,6 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_base_dct_section_offset(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::DctSectionOffset::Register,
@@ -170,7 +150,6 @@ pub trait I3cPeripheral {
     }
     fn write_i3c_base_dct_section_offset(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::DctSectionOffset::Register,
@@ -179,7 +158,6 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_base_ring_headers_section_offset(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::RingHeadersSectionOffset::Register,
@@ -188,7 +166,6 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_base_pio_section_offset(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::PioSectionOffset::Register,
@@ -197,7 +174,6 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_base_ext_caps_section_offset(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::ExtCapsSectionOffset::Register,
@@ -206,21 +182,18 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_base_int_ctrl_cmds_en(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::IntCtrlCmdsEn::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn read_i3c_base_ibi_notify_ctrl(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::IbiNotifyCtrl::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_base_ibi_notify_ctrl(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::IbiNotifyCtrl::Register,
@@ -229,7 +202,6 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_base_ibi_data_abort_ctrl(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::IbiDataAbortCtrl::Register,
@@ -238,7 +210,6 @@ pub trait I3cPeripheral {
     }
     fn write_i3c_base_ibi_data_abort_ctrl(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::IbiDataAbortCtrl::Register,
@@ -247,14 +218,12 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_base_dev_ctx_base_lo(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::DevCtxBaseLo::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_base_dev_ctx_base_lo(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::DevCtxBaseLo::Register,
@@ -263,14 +232,12 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_base_dev_ctx_base_hi(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::DevCtxBaseHi::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_base_dev_ctx_base_hi(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::DevCtxBaseHi::Register,
@@ -279,51 +246,29 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_base_dev_ctx_sg(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::DevCtxSg::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
-    fn write_piocontrol_command_port(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_piocontrol_response_port(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_piocontrol_command_port(&mut self, _val: emulator_types::RvData) {}
+    fn read_piocontrol_response_port(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_piocontrol_tx_data_port(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_piocontrol_rx_data_port(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_piocontrol_tx_data_port(&mut self, _val: emulator_types::RvData) {}
+    fn read_piocontrol_rx_data_port(&mut self) -> emulator_types::RvData {
         0
     }
-    fn read_piocontrol_ibi_port(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_piocontrol_ibi_port(&mut self) -> emulator_types::RvData {
         0
     }
     fn read_piocontrol_queue_thld_ctrl(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::QueueThldCtrl::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn write_piocontrol_queue_thld_ctrl(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::QueueThldCtrl::Register,
@@ -332,7 +277,6 @@ pub trait I3cPeripheral {
     }
     fn read_piocontrol_data_buffer_thld_ctrl(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::DataBufferThldCtrl::Register,
@@ -341,7 +285,6 @@ pub trait I3cPeripheral {
     }
     fn write_piocontrol_data_buffer_thld_ctrl(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::DataBufferThldCtrl::Register,
@@ -350,28 +293,24 @@ pub trait I3cPeripheral {
     }
     fn read_piocontrol_queue_size(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::QueueSize::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn read_piocontrol_alt_queue_size(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::AltQueueSize::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn read_piocontrol_pio_intr_status(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::PioIntrStatus::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn write_piocontrol_pio_intr_status(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::PioIntrStatus::Register,
@@ -380,7 +319,6 @@ pub trait I3cPeripheral {
     }
     fn read_piocontrol_pio_intr_status_enable(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::PioIntrStatusEnable::Register,
@@ -389,7 +327,6 @@ pub trait I3cPeripheral {
     }
     fn write_piocontrol_pio_intr_status_enable(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::PioIntrStatusEnable::Register,
@@ -398,7 +335,6 @@ pub trait I3cPeripheral {
     }
     fn read_piocontrol_pio_intr_signal_enable(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::PioIntrSignalEnable::Register,
@@ -407,7 +343,6 @@ pub trait I3cPeripheral {
     }
     fn write_piocontrol_pio_intr_signal_enable(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::PioIntrSignalEnable::Register,
@@ -416,7 +351,6 @@ pub trait I3cPeripheral {
     }
     fn write_piocontrol_pio_intr_force(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::PioIntrForce::Register,
@@ -425,14 +359,12 @@ pub trait I3cPeripheral {
     }
     fn read_piocontrol_pio_control(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::PioControl::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn write_piocontrol_pio_control(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::PioControl::Register,
@@ -441,325 +373,151 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_sec_fw_recovery_if_extcap_header(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::ExtcapHeader::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
-    fn read_i3c_ec_sec_fw_recovery_if_prot_cap_0(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_i3c_ec_sec_fw_recovery_if_prot_cap_0(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_i3c_ec_sec_fw_recovery_if_prot_cap_0(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_i3c_ec_sec_fw_recovery_if_prot_cap_1(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_i3c_ec_sec_fw_recovery_if_prot_cap_0(&mut self, _val: emulator_types::RvData) {}
+    fn read_i3c_ec_sec_fw_recovery_if_prot_cap_1(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_i3c_ec_sec_fw_recovery_if_prot_cap_1(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_i3c_ec_sec_fw_recovery_if_prot_cap_2(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_i3c_ec_sec_fw_recovery_if_prot_cap_1(&mut self, _val: emulator_types::RvData) {}
+    fn read_i3c_ec_sec_fw_recovery_if_prot_cap_2(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_i3c_ec_sec_fw_recovery_if_prot_cap_2(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_i3c_ec_sec_fw_recovery_if_prot_cap_3(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_i3c_ec_sec_fw_recovery_if_prot_cap_2(&mut self, _val: emulator_types::RvData) {}
+    fn read_i3c_ec_sec_fw_recovery_if_prot_cap_3(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_i3c_ec_sec_fw_recovery_if_prot_cap_3(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_i3c_ec_sec_fw_recovery_if_device_id_0(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_i3c_ec_sec_fw_recovery_if_prot_cap_3(&mut self, _val: emulator_types::RvData) {}
+    fn read_i3c_ec_sec_fw_recovery_if_device_id_0(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_i3c_ec_sec_fw_recovery_if_device_id_0(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_i3c_ec_sec_fw_recovery_if_device_id_1(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_i3c_ec_sec_fw_recovery_if_device_id_0(&mut self, _val: emulator_types::RvData) {}
+    fn read_i3c_ec_sec_fw_recovery_if_device_id_1(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_i3c_ec_sec_fw_recovery_if_device_id_1(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_i3c_ec_sec_fw_recovery_if_device_id_2(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_i3c_ec_sec_fw_recovery_if_device_id_1(&mut self, _val: emulator_types::RvData) {}
+    fn read_i3c_ec_sec_fw_recovery_if_device_id_2(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_i3c_ec_sec_fw_recovery_if_device_id_2(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_i3c_ec_sec_fw_recovery_if_device_id_3(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_i3c_ec_sec_fw_recovery_if_device_id_2(&mut self, _val: emulator_types::RvData) {}
+    fn read_i3c_ec_sec_fw_recovery_if_device_id_3(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_i3c_ec_sec_fw_recovery_if_device_id_3(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_i3c_ec_sec_fw_recovery_if_device_id_4(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_i3c_ec_sec_fw_recovery_if_device_id_3(&mut self, _val: emulator_types::RvData) {}
+    fn read_i3c_ec_sec_fw_recovery_if_device_id_4(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_i3c_ec_sec_fw_recovery_if_device_id_4(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_i3c_ec_sec_fw_recovery_if_device_id_5(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_i3c_ec_sec_fw_recovery_if_device_id_4(&mut self, _val: emulator_types::RvData) {}
+    fn read_i3c_ec_sec_fw_recovery_if_device_id_5(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_i3c_ec_sec_fw_recovery_if_device_id_5(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_i3c_ec_sec_fw_recovery_if_device_id_6(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_i3c_ec_sec_fw_recovery_if_device_id_5(&mut self, _val: emulator_types::RvData) {}
+    fn read_i3c_ec_sec_fw_recovery_if_device_id_6(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_i3c_ec_sec_fw_recovery_if_device_id_6(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_i3c_ec_sec_fw_recovery_if_device_status_0(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_i3c_ec_sec_fw_recovery_if_device_id_6(&mut self, _val: emulator_types::RvData) {}
+    fn read_i3c_ec_sec_fw_recovery_if_device_status_0(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_i3c_ec_sec_fw_recovery_if_device_status_0(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_i3c_ec_sec_fw_recovery_if_device_status_1(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_i3c_ec_sec_fw_recovery_if_device_status_0(&mut self, _val: emulator_types::RvData) {}
+    fn read_i3c_ec_sec_fw_recovery_if_device_status_1(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_i3c_ec_sec_fw_recovery_if_device_status_1(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_i3c_ec_sec_fw_recovery_if_device_reset(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_i3c_ec_sec_fw_recovery_if_device_status_1(&mut self, _val: emulator_types::RvData) {}
+    fn read_i3c_ec_sec_fw_recovery_if_device_reset(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_i3c_ec_sec_fw_recovery_if_device_reset(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_i3c_ec_sec_fw_recovery_if_recovery_ctrl(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_i3c_ec_sec_fw_recovery_if_device_reset(&mut self, _val: emulator_types::RvData) {}
+    fn read_i3c_ec_sec_fw_recovery_if_recovery_ctrl(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_i3c_ec_sec_fw_recovery_if_recovery_ctrl(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_i3c_ec_sec_fw_recovery_if_recovery_status(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_i3c_ec_sec_fw_recovery_if_recovery_ctrl(&mut self, _val: emulator_types::RvData) {}
+    fn read_i3c_ec_sec_fw_recovery_if_recovery_status(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_i3c_ec_sec_fw_recovery_if_recovery_status(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_i3c_ec_sec_fw_recovery_if_hw_status(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_i3c_ec_sec_fw_recovery_if_recovery_status(&mut self, _val: emulator_types::RvData) {}
+    fn read_i3c_ec_sec_fw_recovery_if_hw_status(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_i3c_ec_sec_fw_recovery_if_hw_status(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_0(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_i3c_ec_sec_fw_recovery_if_hw_status(&mut self, _val: emulator_types::RvData) {}
+    fn read_i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_0(&mut self) -> emulator_types::RvData {
         0
     }
     fn write_i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_0(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
-    fn read_i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_1(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_1(&mut self) -> emulator_types::RvData {
         0
     }
     fn write_i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_1(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
     fn read_i3c_ec_sec_fw_recovery_if_indirect_fifo_status_0(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::IndirectFifoStatus0::Register,
     > {
         emulator_bus::ReadWriteRegister::new(0)
     }
-    fn read_i3c_ec_sec_fw_recovery_if_indirect_fifo_status_1(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_i3c_ec_sec_fw_recovery_if_indirect_fifo_status_1(&mut self) -> emulator_types::RvData {
         0
     }
-    fn read_i3c_ec_sec_fw_recovery_if_indirect_fifo_status_2(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_i3c_ec_sec_fw_recovery_if_indirect_fifo_status_2(&mut self) -> emulator_types::RvData {
         0
     }
-    fn read_i3c_ec_sec_fw_recovery_if_indirect_fifo_status_3(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_i3c_ec_sec_fw_recovery_if_indirect_fifo_status_3(&mut self) -> emulator_types::RvData {
         0
     }
     fn write_i3c_ec_sec_fw_recovery_if_indirect_fifo_status_3(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
-    fn read_i3c_ec_sec_fw_recovery_if_indirect_fifo_status_4(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_i3c_ec_sec_fw_recovery_if_indirect_fifo_status_4(&mut self) -> emulator_types::RvData {
         0
     }
     fn write_i3c_ec_sec_fw_recovery_if_indirect_fifo_status_4(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
-    fn read_i3c_ec_sec_fw_recovery_if_indirect_fifo_status_5(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_i3c_ec_sec_fw_recovery_if_indirect_fifo_status_5(&mut self) -> emulator_types::RvData {
         0
     }
     fn write_i3c_ec_sec_fw_recovery_if_indirect_fifo_status_5(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
-    fn read_i3c_ec_sec_fw_recovery_if_indirect_fifo_data(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_i3c_ec_sec_fw_recovery_if_indirect_fifo_data(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_i3c_ec_sec_fw_recovery_if_indirect_fifo_data(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
+    fn write_i3c_ec_sec_fw_recovery_if_indirect_fifo_data(&mut self, _val: emulator_types::RvData) {
     }
     fn read_i3c_ec_stdby_ctrl_mode_extcap_header(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::ExtcapHeader::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn read_i3c_ec_stdby_ctrl_mode_stby_cr_control(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::StbyCrControl::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_stdby_ctrl_mode_stby_cr_control(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::StbyCrControl::Register,
@@ -768,7 +526,6 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_stdby_ctrl_mode_stby_cr_device_addr(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::StbyCrDeviceAddr::Register,
@@ -777,7 +534,6 @@ pub trait I3cPeripheral {
     }
     fn write_i3c_ec_stdby_ctrl_mode_stby_cr_device_addr(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::StbyCrDeviceAddr::Register,
@@ -786,7 +542,6 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_stdby_ctrl_mode_stby_cr_capabilities(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::StbyCrCapabilities::Register,
@@ -795,35 +550,24 @@ pub trait I3cPeripheral {
     }
     fn write_i3c_ec_stdby_ctrl_mode_stby_cr_capabilities(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::StbyCrCapabilities::Register,
         >,
     ) {
     }
-    fn read_i3c_ec_stdby_ctrl_mode_rsvd_0(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_i3c_ec_stdby_ctrl_mode_rsvd_0(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_i3c_ec_stdby_ctrl_mode_rsvd_0(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
+    fn write_i3c_ec_stdby_ctrl_mode_rsvd_0(&mut self, _val: emulator_types::RvData) {}
     fn read_i3c_ec_stdby_ctrl_mode_stby_cr_status(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::StbyCrStatus::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_stdby_ctrl_mode_stby_cr_status(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::StbyCrStatus::Register,
@@ -832,7 +576,6 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_stdby_ctrl_mode_stby_cr_device_char(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::StbyCrDeviceChar::Register,
@@ -841,28 +584,19 @@ pub trait I3cPeripheral {
     }
     fn write_i3c_ec_stdby_ctrl_mode_stby_cr_device_char(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::StbyCrDeviceChar::Register,
         >,
     ) {
     }
-    fn read_i3c_ec_stdby_ctrl_mode_stby_cr_device_pid_lo(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_i3c_ec_stdby_ctrl_mode_stby_cr_device_pid_lo(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_i3c_ec_stdby_ctrl_mode_stby_cr_device_pid_lo(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
+    fn write_i3c_ec_stdby_ctrl_mode_stby_cr_device_pid_lo(&mut self, _val: emulator_types::RvData) {
     }
     fn read_i3c_ec_stdby_ctrl_mode_stby_cr_intr_status(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::StbyCrIntrStatus::Register,
@@ -871,28 +605,18 @@ pub trait I3cPeripheral {
     }
     fn write_i3c_ec_stdby_ctrl_mode_stby_cr_intr_status(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::StbyCrIntrStatus::Register,
         >,
     ) {
     }
-    fn read_i3c_ec_stdby_ctrl_mode_rsvd_1(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_i3c_ec_stdby_ctrl_mode_rsvd_1(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_i3c_ec_stdby_ctrl_mode_rsvd_1(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
+    fn write_i3c_ec_stdby_ctrl_mode_rsvd_1(&mut self, _val: emulator_types::RvData) {}
     fn read_i3c_ec_stdby_ctrl_mode_stby_cr_intr_signal_enable(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::StbyCrIntrSignalEnable::Register,
@@ -901,7 +625,6 @@ pub trait I3cPeripheral {
     }
     fn write_i3c_ec_stdby_ctrl_mode_stby_cr_intr_signal_enable(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::StbyCrIntrSignalEnable::Register,
@@ -910,7 +633,6 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_stdby_ctrl_mode_stby_cr_intr_force(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::StbyCrIntrForce::Register,
@@ -919,7 +641,6 @@ pub trait I3cPeripheral {
     }
     fn write_i3c_ec_stdby_ctrl_mode_stby_cr_intr_force(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::StbyCrIntrForce::Register,
@@ -928,7 +649,6 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_getcaps(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::StbyCrCccConfigGetcaps::Register,
@@ -937,7 +657,6 @@ pub trait I3cPeripheral {
     }
     fn write_i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_getcaps(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::StbyCrCccConfigGetcaps::Register,
@@ -946,7 +665,6 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_rstact_params(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::StbyCrCccConfigRstactParams::Register,
@@ -955,7 +673,6 @@ pub trait I3cPeripheral {
     }
     fn write_i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_rstact_params(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::StbyCrCccConfigRstactParams::Register,
@@ -964,7 +681,6 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_stdby_ctrl_mode_stby_cr_virt_device_addr(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::StbyCrVirtDeviceAddr::Register,
@@ -973,35 +689,24 @@ pub trait I3cPeripheral {
     }
     fn write_i3c_ec_stdby_ctrl_mode_stby_cr_virt_device_addr(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::StbyCrVirtDeviceAddr::Register,
         >,
     ) {
     }
-    fn read_i3c_ec_stdby_ctrl_mode_rsvd_3(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_i3c_ec_stdby_ctrl_mode_rsvd_3(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_i3c_ec_stdby_ctrl_mode_rsvd_3(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
+    fn write_i3c_ec_stdby_ctrl_mode_rsvd_3(&mut self, _val: emulator_types::RvData) {}
     fn read_i3c_ec_tti_extcap_header(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::ExtcapHeader::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn read_i3c_ec_tti_control(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::sha512_acc::bits::Control::Register,
@@ -1010,7 +715,6 @@ pub trait I3cPeripheral {
     }
     fn write_i3c_ec_tti_control(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::sha512_acc::bits::Control::Register,
@@ -1019,14 +723,12 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_tti_status(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::otp_ctrl::bits::Status::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn read_i3c_ec_tti_tti_reset_control(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::TtiResetControl::Register,
@@ -1035,7 +737,6 @@ pub trait I3cPeripheral {
     }
     fn write_i3c_ec_tti_tti_reset_control(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::TtiResetControl::Register,
@@ -1044,7 +745,6 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_tti_interrupt_status(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::InterruptStatus::Register,
@@ -1053,7 +753,6 @@ pub trait I3cPeripheral {
     }
     fn write_i3c_ec_tti_interrupt_status(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::InterruptStatus::Register,
@@ -1062,7 +761,6 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_tti_interrupt_enable(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::InterruptEnable::Register,
@@ -1071,7 +769,6 @@ pub trait I3cPeripheral {
     }
     fn write_i3c_ec_tti_interrupt_enable(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::InterruptEnable::Register,
@@ -1080,7 +777,6 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_tti_interrupt_force(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::InterruptForce::Register,
@@ -1089,53 +785,29 @@ pub trait I3cPeripheral {
     }
     fn write_i3c_ec_tti_interrupt_force(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::InterruptForce::Register,
         >,
     ) {
     }
-    fn read_i3c_ec_tti_rx_desc_queue_port(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_i3c_ec_tti_rx_desc_queue_port(&mut self) -> emulator_types::RvData {
         0
     }
-    fn read_i3c_ec_tti_rx_data_port(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_i3c_ec_tti_rx_data_port(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_i3c_ec_tti_tx_desc_queue_port(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn write_i3c_ec_tti_tx_data_port(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn write_i3c_ec_tti_tti_ibi_port(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
+    fn write_i3c_ec_tti_tx_desc_queue_port(&mut self, _val: emulator_types::RvData) {}
+    fn write_i3c_ec_tti_tx_data_port(&mut self, _val: emulator_types::RvData) {}
+    fn write_i3c_ec_tti_tti_ibi_port(&mut self, _val: emulator_types::RvData) {}
     fn read_i3c_ec_tti_tti_queue_size(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::TtiQueueSize::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn read_i3c_ec_tti_ibi_tti_queue_size(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::IbiTtiQueueSize::Register,
@@ -1144,7 +816,6 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_tti_tti_queue_thld_ctrl(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::TtiQueueThldCtrl::Register,
@@ -1153,7 +824,6 @@ pub trait I3cPeripheral {
     }
     fn write_i3c_ec_tti_tti_queue_thld_ctrl(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::TtiQueueThldCtrl::Register,
@@ -1162,7 +832,6 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_tti_tti_data_buffer_thld_ctrl(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::TtiDataBufferThldCtrl::Register,
@@ -1171,7 +840,6 @@ pub trait I3cPeripheral {
     }
     fn write_i3c_ec_tti_tti_data_buffer_thld_ctrl(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::TtiDataBufferThldCtrl::Register,
@@ -1180,93 +848,42 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_soc_mgmt_if_extcap_header(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::ExtcapHeader::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
-    fn read_i3c_ec_soc_mgmt_if_soc_mgmt_control(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_i3c_ec_soc_mgmt_if_soc_mgmt_control(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_i3c_ec_soc_mgmt_if_soc_mgmt_control(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_i3c_ec_soc_mgmt_if_soc_mgmt_status(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_i3c_ec_soc_mgmt_if_soc_mgmt_control(&mut self, _val: emulator_types::RvData) {}
+    fn read_i3c_ec_soc_mgmt_if_soc_mgmt_status(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_i3c_ec_soc_mgmt_if_soc_mgmt_status(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_0(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_i3c_ec_soc_mgmt_if_soc_mgmt_status(&mut self, _val: emulator_types::RvData) {}
+    fn read_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_0(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_0(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_1(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_0(&mut self, _val: emulator_types::RvData) {}
+    fn read_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_1(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_1(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_2(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_1(&mut self, _val: emulator_types::RvData) {}
+    fn read_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_2(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_2(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_3(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_2(&mut self, _val: emulator_types::RvData) {}
+    fn read_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_3(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_3(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
+    fn write_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_3(&mut self, _val: emulator_types::RvData) {}
     fn read_i3c_ec_soc_mgmt_if_soc_pad_conf(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::SocPadConf::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_soc_mgmt_if_soc_pad_conf(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::SocPadConf::Register,
@@ -1275,78 +892,54 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_soc_mgmt_if_soc_pad_attr(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::SocPadAttr::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_soc_mgmt_if_soc_pad_attr(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::SocPadAttr::Register,
         >,
     ) {
     }
-    fn read_i3c_ec_soc_mgmt_if_soc_mgmt_feature_2(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_i3c_ec_soc_mgmt_if_soc_mgmt_feature_2(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_i3c_ec_soc_mgmt_if_soc_mgmt_feature_2(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_i3c_ec_soc_mgmt_if_soc_mgmt_feature_3(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_i3c_ec_soc_mgmt_if_soc_mgmt_feature_2(&mut self, _val: emulator_types::RvData) {}
+    fn read_i3c_ec_soc_mgmt_if_soc_mgmt_feature_3(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_i3c_ec_soc_mgmt_if_soc_mgmt_feature_3(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
+    fn write_i3c_ec_soc_mgmt_if_soc_mgmt_feature_3(&mut self, _val: emulator_types::RvData) {}
     fn read_i3c_ec_soc_mgmt_if_t_r_reg(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::TRReg::Register> {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_soc_mgmt_if_t_r_reg(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::TRReg::Register>,
     ) {
     }
     fn read_i3c_ec_soc_mgmt_if_t_f_reg(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::TFReg::Register> {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_soc_mgmt_if_t_f_reg(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::TFReg::Register>,
     ) {
     }
     fn read_i3c_ec_soc_mgmt_if_t_su_dat_reg(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::TSuDatReg::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_soc_mgmt_if_t_su_dat_reg(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::TSuDatReg::Register,
@@ -1355,14 +948,12 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_soc_mgmt_if_t_hd_dat_reg(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::THdDatReg::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_soc_mgmt_if_t_hd_dat_reg(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::THdDatReg::Register,
@@ -1371,14 +962,12 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_soc_mgmt_if_t_high_reg(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::THighReg::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_soc_mgmt_if_t_high_reg(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::THighReg::Register,
@@ -1387,14 +976,12 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_soc_mgmt_if_t_low_reg(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::TLowReg::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_soc_mgmt_if_t_low_reg(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::TLowReg::Register,
@@ -1403,14 +990,12 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_soc_mgmt_if_t_hd_sta_reg(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::THdStaReg::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_soc_mgmt_if_t_hd_sta_reg(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::THdStaReg::Register,
@@ -1419,14 +1004,12 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_soc_mgmt_if_t_su_sta_reg(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::TSuStaReg::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_soc_mgmt_if_t_su_sta_reg(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::TSuStaReg::Register,
@@ -1435,66 +1018,38 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_soc_mgmt_if_t_su_sto_reg(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::TSuStoReg::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_soc_mgmt_if_t_su_sto_reg(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::TSuStoReg::Register,
         >,
     ) {
     }
-    fn read_i3c_ec_soc_mgmt_if_t_free_reg(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_i3c_ec_soc_mgmt_if_t_free_reg(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_i3c_ec_soc_mgmt_if_t_free_reg(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_i3c_ec_soc_mgmt_if_t_aval_reg(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_i3c_ec_soc_mgmt_if_t_free_reg(&mut self, _val: emulator_types::RvData) {}
+    fn read_i3c_ec_soc_mgmt_if_t_aval_reg(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_i3c_ec_soc_mgmt_if_t_aval_reg(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_i3c_ec_soc_mgmt_if_t_idle_reg(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_i3c_ec_soc_mgmt_if_t_aval_reg(&mut self, _val: emulator_types::RvData) {}
+    fn read_i3c_ec_soc_mgmt_if_t_idle_reg(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_i3c_ec_soc_mgmt_if_t_idle_reg(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
+    fn write_i3c_ec_soc_mgmt_if_t_idle_reg(&mut self, _val: emulator_types::RvData) {}
     fn read_i3c_ec_ctrl_cfg_extcap_header(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::ExtcapHeader::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn read_i3c_ec_ctrl_cfg_controller_config(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::ControllerConfig::Register,
@@ -1511,735 +1066,340 @@ impl emulator_bus::Bus for I3cBus {
         size: emulator_types::RvSize,
         addr: emulator_types::RvAddr,
     ) -> Result<emulator_types::RvData, emulator_bus::BusError> {
-        match (size, addr) {
-            (size, 0x400) => Ok(self.periph.read_dat(size)),
-            (_, 0x401..=0x403) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x800) => Ok(self.periph.read_dct(size)),
-            (_, 0x801..=0x803) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0) => Ok(self.periph.read_i3c_base_hci_version(size)),
-            (_, 1..=3) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (emulator_types::RvSize::Word, 4) => Ok(emulator_types::RvData::from(
+        if addr & 0x3 != 0 || size != emulator_types::RvSize::Word {
+            return Err(emulator_bus::BusError::LoadAddrMisaligned);
+        }
+        match addr {
+            0x400..0x800 => Ok(self.periph.read_dat()),
+            0x800..0x1000 => Ok(self.periph.read_dct()),
+            0..4 => Ok(self.periph.read_i3c_base_hci_version()),
+            4..8 => Ok(emulator_types::RvData::from(
+                self.periph.read_i3c_base_hc_control().reg.get(),
+            )),
+            8..0xc => Ok(emulator_types::RvData::from(
+                self.periph.read_i3c_base_controller_device_addr().reg.get(),
+            )),
+            0xc..0x10 => Ok(emulator_types::RvData::from(
+                self.periph.read_i3c_base_hc_capabilities().reg.get(),
+            )),
+            0x10..0x14 => Ok(emulator_types::RvData::from(
+                self.periph.read_i3c_base_reset_control().reg.get(),
+            )),
+            0x14..0x18 => Ok(emulator_types::RvData::from(
+                self.periph.read_i3c_base_present_state().reg.get(),
+            )),
+            0x20..0x24 => Ok(emulator_types::RvData::from(
+                self.periph.read_i3c_base_intr_status().reg.get(),
+            )),
+            0x24..0x28 => Ok(emulator_types::RvData::from(
+                self.periph.read_i3c_base_intr_status_enable().reg.get(),
+            )),
+            0x28..0x2c => Ok(emulator_types::RvData::from(
+                self.periph.read_i3c_base_intr_signal_enable().reg.get(),
+            )),
+            0x30..0x34 => Ok(emulator_types::RvData::from(
+                self.periph.read_i3c_base_dat_section_offset().reg.get(),
+            )),
+            0x34..0x38 => Ok(emulator_types::RvData::from(
+                self.periph.read_i3c_base_dct_section_offset().reg.get(),
+            )),
+            0x38..0x3c => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_i3c_base_hc_control(emulator_types::RvSize::Word)
+                    .read_i3c_base_ring_headers_section_offset()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 5..=7) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 8) => Ok(emulator_types::RvData::from(
+            0x3c..0x40 => Ok(emulator_types::RvData::from(
+                self.periph.read_i3c_base_pio_section_offset().reg.get(),
+            )),
+            0x40..0x44 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_i3c_base_controller_device_addr(emulator_types::RvSize::Word)
+                    .read_i3c_base_ext_caps_section_offset()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 9..=0xb) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xc) => Ok(emulator_types::RvData::from(
+            0x4c..0x50 => Ok(emulator_types::RvData::from(
+                self.periph.read_i3c_base_int_ctrl_cmds_en().reg.get(),
+            )),
+            0x58..0x5c => Ok(emulator_types::RvData::from(
+                self.periph.read_i3c_base_ibi_notify_ctrl().reg.get(),
+            )),
+            0x5c..0x60 => Ok(emulator_types::RvData::from(
+                self.periph.read_i3c_base_ibi_data_abort_ctrl().reg.get(),
+            )),
+            0x60..0x64 => Ok(emulator_types::RvData::from(
+                self.periph.read_i3c_base_dev_ctx_base_lo().reg.get(),
+            )),
+            0x64..0x68 => Ok(emulator_types::RvData::from(
+                self.periph.read_i3c_base_dev_ctx_base_hi().reg.get(),
+            )),
+            0x68..0x6c => Ok(emulator_types::RvData::from(
+                self.periph.read_i3c_base_dev_ctx_sg().reg.get(),
+            )),
+            0x84..0x88 => Ok(self.periph.read_piocontrol_response_port()),
+            0x88..0x8c => Ok(self.periph.read_piocontrol_rx_data_port()),
+            0x8c..0x90 => Ok(self.periph.read_piocontrol_ibi_port()),
+            0x90..0x94 => Ok(emulator_types::RvData::from(
+                self.periph.read_piocontrol_queue_thld_ctrl().reg.get(),
+            )),
+            0x94..0x98 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_i3c_base_hc_capabilities(emulator_types::RvSize::Word)
+                    .read_piocontrol_data_buffer_thld_ctrl()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0xd..=0xf) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x10) => Ok(emulator_types::RvData::from(
+            0x98..0x9c => Ok(emulator_types::RvData::from(
+                self.periph.read_piocontrol_queue_size().reg.get(),
+            )),
+            0x9c..0xa0 => Ok(emulator_types::RvData::from(
+                self.periph.read_piocontrol_alt_queue_size().reg.get(),
+            )),
+            0xa0..0xa4 => Ok(emulator_types::RvData::from(
+                self.periph.read_piocontrol_pio_intr_status().reg.get(),
+            )),
+            0xa4..0xa8 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_i3c_base_reset_control(emulator_types::RvSize::Word)
+                    .read_piocontrol_pio_intr_status_enable()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x11..=0x13) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x14) => Ok(emulator_types::RvData::from(
+            0xa8..0xac => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_i3c_base_present_state(emulator_types::RvSize::Word)
+                    .read_piocontrol_pio_intr_signal_enable()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x15..=0x17) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x20) => Ok(emulator_types::RvData::from(
+            0xb0..0xb4 => Ok(emulator_types::RvData::from(
+                self.periph.read_piocontrol_pio_control().reg.get(),
+            )),
+            0x100..0x104 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_i3c_base_intr_status(emulator_types::RvSize::Word)
+                    .read_i3c_ec_sec_fw_recovery_if_extcap_header()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x21..=0x23) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x24) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_i3c_base_intr_status_enable(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0x25..=0x27) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x28) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_i3c_base_intr_signal_enable(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0x29..=0x2b) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x30) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_i3c_base_dat_section_offset(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0x31..=0x33) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x34) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_i3c_base_dct_section_offset(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0x35..=0x37) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x38) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_i3c_base_ring_headers_section_offset(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0x39..=0x3b) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x3c) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_i3c_base_pio_section_offset(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0x3d..=0x3f) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x40) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_i3c_base_ext_caps_section_offset(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0x41..=0x43) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x4c) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_i3c_base_int_ctrl_cmds_en(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0x4d..=0x4f) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x58) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_i3c_base_ibi_notify_ctrl(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0x59..=0x5b) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x5c) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_i3c_base_ibi_data_abort_ctrl(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0x5d..=0x5f) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x60) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_i3c_base_dev_ctx_base_lo(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0x61..=0x63) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x64) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_i3c_base_dev_ctx_base_hi(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0x65..=0x67) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x68) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_i3c_base_dev_ctx_sg(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0x69..=0x6b) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (size, 0x84) => Ok(self.periph.read_piocontrol_response_port(size)),
-            (_, 0x85..=0x87) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x88) => Ok(self.periph.read_piocontrol_rx_data_port(size)),
-            (_, 0x89..=0x8b) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x8c) => Ok(self.periph.read_piocontrol_ibi_port(size)),
-            (_, 0x8d..=0x8f) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x90) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_piocontrol_queue_thld_ctrl(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0x91..=0x93) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x94) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_piocontrol_data_buffer_thld_ctrl(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0x95..=0x97) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x98) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_piocontrol_queue_size(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0x99..=0x9b) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x9c) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_piocontrol_alt_queue_size(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0x9d..=0x9f) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xa0) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_piocontrol_pio_intr_status(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0xa1..=0xa3) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xa4) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_piocontrol_pio_intr_status_enable(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0xa5..=0xa7) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xa8) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_piocontrol_pio_intr_signal_enable(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0xa9..=0xab) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xb0) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_piocontrol_pio_control(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0xb1..=0xb3) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x100) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_i3c_ec_sec_fw_recovery_if_extcap_header(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0x101..=0x103) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (size, 0x104) => Ok(self.periph.read_i3c_ec_sec_fw_recovery_if_prot_cap_0(size)),
-            (_, 0x105..=0x107) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x108) => Ok(self.periph.read_i3c_ec_sec_fw_recovery_if_prot_cap_1(size)),
-            (_, 0x109..=0x10b) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x10c) => Ok(self.periph.read_i3c_ec_sec_fw_recovery_if_prot_cap_2(size)),
-            (_, 0x10d..=0x10f) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x110) => Ok(self.periph.read_i3c_ec_sec_fw_recovery_if_prot_cap_3(size)),
-            (_, 0x111..=0x113) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x114) => Ok(self.periph.read_i3c_ec_sec_fw_recovery_if_device_id_0(size)),
-            (_, 0x115..=0x117) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x118) => Ok(self.periph.read_i3c_ec_sec_fw_recovery_if_device_id_1(size)),
-            (_, 0x119..=0x11b) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x11c) => Ok(self.periph.read_i3c_ec_sec_fw_recovery_if_device_id_2(size)),
-            (_, 0x11d..=0x11f) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x120) => Ok(self.periph.read_i3c_ec_sec_fw_recovery_if_device_id_3(size)),
-            (_, 0x121..=0x123) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x124) => Ok(self.periph.read_i3c_ec_sec_fw_recovery_if_device_id_4(size)),
-            (_, 0x125..=0x127) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x128) => Ok(self.periph.read_i3c_ec_sec_fw_recovery_if_device_id_5(size)),
-            (_, 0x129..=0x12b) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x12c) => Ok(self.periph.read_i3c_ec_sec_fw_recovery_if_device_id_6(size)),
-            (_, 0x12d..=0x12f) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x130) => Ok(self
+            0x104..0x108 => Ok(self.periph.read_i3c_ec_sec_fw_recovery_if_prot_cap_0()),
+            0x108..0x10c => Ok(self.periph.read_i3c_ec_sec_fw_recovery_if_prot_cap_1()),
+            0x10c..0x110 => Ok(self.periph.read_i3c_ec_sec_fw_recovery_if_prot_cap_2()),
+            0x110..0x114 => Ok(self.periph.read_i3c_ec_sec_fw_recovery_if_prot_cap_3()),
+            0x114..0x118 => Ok(self.periph.read_i3c_ec_sec_fw_recovery_if_device_id_0()),
+            0x118..0x11c => Ok(self.periph.read_i3c_ec_sec_fw_recovery_if_device_id_1()),
+            0x11c..0x120 => Ok(self.periph.read_i3c_ec_sec_fw_recovery_if_device_id_2()),
+            0x120..0x124 => Ok(self.periph.read_i3c_ec_sec_fw_recovery_if_device_id_3()),
+            0x124..0x128 => Ok(self.periph.read_i3c_ec_sec_fw_recovery_if_device_id_4()),
+            0x128..0x12c => Ok(self.periph.read_i3c_ec_sec_fw_recovery_if_device_id_5()),
+            0x12c..0x130 => Ok(self.periph.read_i3c_ec_sec_fw_recovery_if_device_id_6()),
+            0x130..0x134 => Ok(self.periph.read_i3c_ec_sec_fw_recovery_if_device_status_0()),
+            0x134..0x138 => Ok(self.periph.read_i3c_ec_sec_fw_recovery_if_device_status_1()),
+            0x138..0x13c => Ok(self.periph.read_i3c_ec_sec_fw_recovery_if_device_reset()),
+            0x13c..0x140 => Ok(self.periph.read_i3c_ec_sec_fw_recovery_if_recovery_ctrl()),
+            0x140..0x144 => Ok(self.periph.read_i3c_ec_sec_fw_recovery_if_recovery_status()),
+            0x144..0x148 => Ok(self.periph.read_i3c_ec_sec_fw_recovery_if_hw_status()),
+            0x148..0x14c => Ok(self
                 .periph
-                .read_i3c_ec_sec_fw_recovery_if_device_status_0(size)),
-            (_, 0x131..=0x133) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x134) => Ok(self
+                .read_i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_0()),
+            0x14c..0x150 => Ok(self
                 .periph
-                .read_i3c_ec_sec_fw_recovery_if_device_status_1(size)),
-            (_, 0x135..=0x137) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x138) => Ok(self
+                .read_i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_1()),
+            0x150..0x154 => Ok(emulator_types::RvData::from(
+                self.periph
+                    .read_i3c_ec_sec_fw_recovery_if_indirect_fifo_status_0()
+                    .reg
+                    .get(),
+            )),
+            0x154..0x158 => Ok(self
                 .periph
-                .read_i3c_ec_sec_fw_recovery_if_device_reset(size)),
-            (_, 0x139..=0x13b) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x13c) => Ok(self
+                .read_i3c_ec_sec_fw_recovery_if_indirect_fifo_status_1()),
+            0x158..0x15c => Ok(self
                 .periph
-                .read_i3c_ec_sec_fw_recovery_if_recovery_ctrl(size)),
-            (_, 0x13d..=0x13f) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x140) => Ok(self
+                .read_i3c_ec_sec_fw_recovery_if_indirect_fifo_status_2()),
+            0x15c..0x160 => Ok(self
                 .periph
-                .read_i3c_ec_sec_fw_recovery_if_recovery_status(size)),
-            (_, 0x141..=0x143) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x144) => Ok(self.periph.read_i3c_ec_sec_fw_recovery_if_hw_status(size)),
-            (_, 0x145..=0x147) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x148) => Ok(self
+                .read_i3c_ec_sec_fw_recovery_if_indirect_fifo_status_3()),
+            0x160..0x164 => Ok(self
                 .periph
-                .read_i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_0(size)),
-            (_, 0x149..=0x14b) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x14c) => Ok(self
+                .read_i3c_ec_sec_fw_recovery_if_indirect_fifo_status_4()),
+            0x164..0x168 => Ok(self
                 .periph
-                .read_i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_1(size)),
-            (_, 0x14d..=0x14f) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x150) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_i3c_ec_sec_fw_recovery_if_indirect_fifo_status_0(
-                        emulator_types::RvSize::Word,
-                    )
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0x151..=0x153) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (size, 0x154) => Ok(self
+                .read_i3c_ec_sec_fw_recovery_if_indirect_fifo_status_5()),
+            0x168..0x16c => Ok(self
                 .periph
-                .read_i3c_ec_sec_fw_recovery_if_indirect_fifo_status_1(size)),
-            (_, 0x155..=0x157) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x158) => Ok(self
+                .read_i3c_ec_sec_fw_recovery_if_indirect_fifo_data()),
+            0x180..0x184 => Ok(emulator_types::RvData::from(
+                self.periph
+                    .read_i3c_ec_stdby_ctrl_mode_extcap_header()
+                    .reg
+                    .get(),
+            )),
+            0x184..0x188 => Ok(emulator_types::RvData::from(
+                self.periph
+                    .read_i3c_ec_stdby_ctrl_mode_stby_cr_control()
+                    .reg
+                    .get(),
+            )),
+            0x188..0x18c => Ok(emulator_types::RvData::from(
+                self.periph
+                    .read_i3c_ec_stdby_ctrl_mode_stby_cr_device_addr()
+                    .reg
+                    .get(),
+            )),
+            0x18c..0x190 => Ok(emulator_types::RvData::from(
+                self.periph
+                    .read_i3c_ec_stdby_ctrl_mode_stby_cr_capabilities()
+                    .reg
+                    .get(),
+            )),
+            0x190..0x194 => Ok(self.periph.read_i3c_ec_stdby_ctrl_mode_rsvd_0()),
+            0x194..0x198 => Ok(emulator_types::RvData::from(
+                self.periph
+                    .read_i3c_ec_stdby_ctrl_mode_stby_cr_status()
+                    .reg
+                    .get(),
+            )),
+            0x198..0x19c => Ok(emulator_types::RvData::from(
+                self.periph
+                    .read_i3c_ec_stdby_ctrl_mode_stby_cr_device_char()
+                    .reg
+                    .get(),
+            )),
+            0x19c..0x1a0 => Ok(self
                 .periph
-                .read_i3c_ec_sec_fw_recovery_if_indirect_fifo_status_2(size)),
-            (_, 0x159..=0x15b) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x15c) => Ok(self
-                .periph
-                .read_i3c_ec_sec_fw_recovery_if_indirect_fifo_status_3(size)),
-            (_, 0x15d..=0x15f) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x160) => Ok(self
-                .periph
-                .read_i3c_ec_sec_fw_recovery_if_indirect_fifo_status_4(size)),
-            (_, 0x161..=0x163) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x164) => Ok(self
-                .periph
-                .read_i3c_ec_sec_fw_recovery_if_indirect_fifo_status_5(size)),
-            (_, 0x165..=0x167) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x168) => Ok(self
-                .periph
-                .read_i3c_ec_sec_fw_recovery_if_indirect_fifo_data(size)),
-            (_, 0x169..=0x16b) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x180) => Ok(emulator_types::RvData::from(
+                .read_i3c_ec_stdby_ctrl_mode_stby_cr_device_pid_lo()),
+            0x1a0..0x1a4 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_i3c_ec_stdby_ctrl_mode_extcap_header(emulator_types::RvSize::Word)
+                    .read_i3c_ec_stdby_ctrl_mode_stby_cr_intr_status()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x181..=0x183) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x184) => Ok(emulator_types::RvData::from(
+            0x1a4..0x1a8 => Ok(self.periph.read_i3c_ec_stdby_ctrl_mode_rsvd_1()),
+            0x1a8..0x1ac => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_i3c_ec_stdby_ctrl_mode_stby_cr_control(emulator_types::RvSize::Word)
+                    .read_i3c_ec_stdby_ctrl_mode_stby_cr_intr_signal_enable()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x185..=0x187) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x188) => Ok(emulator_types::RvData::from(
+            0x1ac..0x1b0 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_i3c_ec_stdby_ctrl_mode_stby_cr_device_addr(emulator_types::RvSize::Word)
+                    .read_i3c_ec_stdby_ctrl_mode_stby_cr_intr_force()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x189..=0x18b) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x18c) => Ok(emulator_types::RvData::from(
+            0x1b0..0x1b4 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_i3c_ec_stdby_ctrl_mode_stby_cr_capabilities(emulator_types::RvSize::Word)
+                    .read_i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_getcaps()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x18d..=0x18f) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (size, 0x190) => Ok(self.periph.read_i3c_ec_stdby_ctrl_mode_rsvd_0(size)),
-            (_, 0x191..=0x193) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x194) => Ok(emulator_types::RvData::from(
+            0x1b4..0x1b8 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_i3c_ec_stdby_ctrl_mode_stby_cr_status(emulator_types::RvSize::Word)
+                    .read_i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_rstact_params()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x195..=0x197) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x198) => Ok(emulator_types::RvData::from(
+            0x1b8..0x1bc => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_i3c_ec_stdby_ctrl_mode_stby_cr_device_char(emulator_types::RvSize::Word)
+                    .read_i3c_ec_stdby_ctrl_mode_stby_cr_virt_device_addr()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x199..=0x19b) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (size, 0x19c) => Ok(self
-                .periph
-                .read_i3c_ec_stdby_ctrl_mode_stby_cr_device_pid_lo(size)),
-            (_, 0x19d..=0x19f) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x1a0) => Ok(emulator_types::RvData::from(
+            0x1bc..0x1c0 => Ok(self.periph.read_i3c_ec_stdby_ctrl_mode_rsvd_3()),
+            0x1c0..0x1c4 => Ok(emulator_types::RvData::from(
+                self.periph.read_i3c_ec_tti_extcap_header().reg.get(),
+            )),
+            0x1c4..0x1c8 => Ok(emulator_types::RvData::from(
+                self.periph.read_i3c_ec_tti_control().reg.get(),
+            )),
+            0x1c8..0x1cc => Ok(emulator_types::RvData::from(
+                self.periph.read_i3c_ec_tti_status().reg.get(),
+            )),
+            0x1cc..0x1d0 => Ok(emulator_types::RvData::from(
+                self.periph.read_i3c_ec_tti_tti_reset_control().reg.get(),
+            )),
+            0x1d0..0x1d4 => Ok(emulator_types::RvData::from(
+                self.periph.read_i3c_ec_tti_interrupt_status().reg.get(),
+            )),
+            0x1d4..0x1d8 => Ok(emulator_types::RvData::from(
+                self.periph.read_i3c_ec_tti_interrupt_enable().reg.get(),
+            )),
+            0x1d8..0x1dc => Ok(emulator_types::RvData::from(
+                self.periph.read_i3c_ec_tti_interrupt_force().reg.get(),
+            )),
+            0x1dc..0x1e0 => Ok(self.periph.read_i3c_ec_tti_rx_desc_queue_port()),
+            0x1e0..0x1e4 => Ok(self.periph.read_i3c_ec_tti_rx_data_port()),
+            0x1f0..0x1f4 => Ok(emulator_types::RvData::from(
+                self.periph.read_i3c_ec_tti_tti_queue_size().reg.get(),
+            )),
+            0x1f4..0x1f8 => Ok(emulator_types::RvData::from(
+                self.periph.read_i3c_ec_tti_ibi_tti_queue_size().reg.get(),
+            )),
+            0x1f8..0x1fc => Ok(emulator_types::RvData::from(
+                self.periph.read_i3c_ec_tti_tti_queue_thld_ctrl().reg.get(),
+            )),
+            0x1fc..0x200 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_i3c_ec_stdby_ctrl_mode_stby_cr_intr_status(emulator_types::RvSize::Word)
+                    .read_i3c_ec_tti_tti_data_buffer_thld_ctrl()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x1a1..=0x1a3) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (size, 0x1a4) => Ok(self.periph.read_i3c_ec_stdby_ctrl_mode_rsvd_1(size)),
-            (_, 0x1a5..=0x1a7) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x1a8) => Ok(emulator_types::RvData::from(
+            0x200..0x204 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_i3c_ec_stdby_ctrl_mode_stby_cr_intr_signal_enable(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_i3c_ec_soc_mgmt_if_extcap_header()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x1a9..=0x1ab) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1ac) => Ok(emulator_types::RvData::from(
+            0x204..0x208 => Ok(self.periph.read_i3c_ec_soc_mgmt_if_soc_mgmt_control()),
+            0x208..0x20c => Ok(self.periph.read_i3c_ec_soc_mgmt_if_soc_mgmt_status()),
+            0x20c..0x210 => Ok(self.periph.read_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_0()),
+            0x210..0x214 => Ok(self.periph.read_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_1()),
+            0x214..0x218 => Ok(self.periph.read_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_2()),
+            0x218..0x21c => Ok(self.periph.read_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_3()),
+            0x21c..0x220 => Ok(emulator_types::RvData::from(
+                self.periph.read_i3c_ec_soc_mgmt_if_soc_pad_conf().reg.get(),
+            )),
+            0x220..0x224 => Ok(emulator_types::RvData::from(
+                self.periph.read_i3c_ec_soc_mgmt_if_soc_pad_attr().reg.get(),
+            )),
+            0x224..0x228 => Ok(self.periph.read_i3c_ec_soc_mgmt_if_soc_mgmt_feature_2()),
+            0x228..0x22c => Ok(self.periph.read_i3c_ec_soc_mgmt_if_soc_mgmt_feature_3()),
+            0x22c..0x230 => Ok(emulator_types::RvData::from(
+                self.periph.read_i3c_ec_soc_mgmt_if_t_r_reg().reg.get(),
+            )),
+            0x230..0x234 => Ok(emulator_types::RvData::from(
+                self.periph.read_i3c_ec_soc_mgmt_if_t_f_reg().reg.get(),
+            )),
+            0x234..0x238 => Ok(emulator_types::RvData::from(
+                self.periph.read_i3c_ec_soc_mgmt_if_t_su_dat_reg().reg.get(),
+            )),
+            0x238..0x23c => Ok(emulator_types::RvData::from(
+                self.periph.read_i3c_ec_soc_mgmt_if_t_hd_dat_reg().reg.get(),
+            )),
+            0x23c..0x240 => Ok(emulator_types::RvData::from(
+                self.periph.read_i3c_ec_soc_mgmt_if_t_high_reg().reg.get(),
+            )),
+            0x240..0x244 => Ok(emulator_types::RvData::from(
+                self.periph.read_i3c_ec_soc_mgmt_if_t_low_reg().reg.get(),
+            )),
+            0x244..0x248 => Ok(emulator_types::RvData::from(
+                self.periph.read_i3c_ec_soc_mgmt_if_t_hd_sta_reg().reg.get(),
+            )),
+            0x248..0x24c => Ok(emulator_types::RvData::from(
+                self.periph.read_i3c_ec_soc_mgmt_if_t_su_sta_reg().reg.get(),
+            )),
+            0x24c..0x250 => Ok(emulator_types::RvData::from(
+                self.periph.read_i3c_ec_soc_mgmt_if_t_su_sto_reg().reg.get(),
+            )),
+            0x250..0x254 => Ok(self.periph.read_i3c_ec_soc_mgmt_if_t_free_reg()),
+            0x254..0x258 => Ok(self.periph.read_i3c_ec_soc_mgmt_if_t_aval_reg()),
+            0x258..0x25c => Ok(self.periph.read_i3c_ec_soc_mgmt_if_t_idle_reg()),
+            0x260..0x264 => Ok(emulator_types::RvData::from(
+                self.periph.read_i3c_ec_ctrl_cfg_extcap_header().reg.get(),
+            )),
+            0x264..0x268 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_i3c_ec_stdby_ctrl_mode_stby_cr_intr_force(emulator_types::RvSize::Word)
+                    .read_i3c_ec_ctrl_cfg_controller_config()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x1ad..=0x1af) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1b0) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_getcaps(
-                        emulator_types::RvSize::Word,
-                    )
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0x1b1..=0x1b3) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1b4) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_rstact_params(
-                        emulator_types::RvSize::Word,
-                    )
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0x1b5..=0x1b7) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1b8) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_i3c_ec_stdby_ctrl_mode_stby_cr_virt_device_addr(
-                        emulator_types::RvSize::Word,
-                    )
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0x1b9..=0x1bb) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (size, 0x1bc) => Ok(self.periph.read_i3c_ec_stdby_ctrl_mode_rsvd_3(size)),
-            (_, 0x1bd..=0x1bf) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x1c0) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_i3c_ec_tti_extcap_header(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0x1c1..=0x1c3) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1c4) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_i3c_ec_tti_control(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0x1c5..=0x1c7) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1c8) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_i3c_ec_tti_status(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0x1c9..=0x1cb) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1cc) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_i3c_ec_tti_tti_reset_control(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0x1cd..=0x1cf) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1d0) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_i3c_ec_tti_interrupt_status(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0x1d1..=0x1d3) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1d4) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_i3c_ec_tti_interrupt_enable(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0x1d5..=0x1d7) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1d8) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_i3c_ec_tti_interrupt_force(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0x1d9..=0x1db) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (size, 0x1dc) => Ok(self.periph.read_i3c_ec_tti_rx_desc_queue_port(size)),
-            (_, 0x1dd..=0x1df) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x1e0) => Ok(self.periph.read_i3c_ec_tti_rx_data_port(size)),
-            (_, 0x1e1..=0x1e3) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x1f0) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_i3c_ec_tti_tti_queue_size(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0x1f1..=0x1f3) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1f4) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_i3c_ec_tti_ibi_tti_queue_size(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0x1f5..=0x1f7) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1f8) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_i3c_ec_tti_tti_queue_thld_ctrl(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0x1f9..=0x1fb) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1fc) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_i3c_ec_tti_tti_data_buffer_thld_ctrl(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0x1fd..=0x1ff) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x200) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_i3c_ec_soc_mgmt_if_extcap_header(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0x201..=0x203) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (size, 0x204) => Ok(self.periph.read_i3c_ec_soc_mgmt_if_soc_mgmt_control(size)),
-            (_, 0x205..=0x207) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x208) => Ok(self.periph.read_i3c_ec_soc_mgmt_if_soc_mgmt_status(size)),
-            (_, 0x209..=0x20b) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x20c) => Ok(self.periph.read_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_0(size)),
-            (_, 0x20d..=0x20f) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x210) => Ok(self.periph.read_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_1(size)),
-            (_, 0x211..=0x213) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x214) => Ok(self.periph.read_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_2(size)),
-            (_, 0x215..=0x217) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x218) => Ok(self.periph.read_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_3(size)),
-            (_, 0x219..=0x21b) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x21c) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_i3c_ec_soc_mgmt_if_soc_pad_conf(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0x21d..=0x21f) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x220) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_i3c_ec_soc_mgmt_if_soc_pad_attr(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0x221..=0x223) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (size, 0x224) => Ok(self.periph.read_i3c_ec_soc_mgmt_if_soc_mgmt_feature_2(size)),
-            (_, 0x225..=0x227) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x228) => Ok(self.periph.read_i3c_ec_soc_mgmt_if_soc_mgmt_feature_3(size)),
-            (_, 0x229..=0x22b) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x22c) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_i3c_ec_soc_mgmt_if_t_r_reg(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0x22d..=0x22f) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x230) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_i3c_ec_soc_mgmt_if_t_f_reg(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0x231..=0x233) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x234) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_i3c_ec_soc_mgmt_if_t_su_dat_reg(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0x235..=0x237) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x238) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_i3c_ec_soc_mgmt_if_t_hd_dat_reg(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0x239..=0x23b) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x23c) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_i3c_ec_soc_mgmt_if_t_high_reg(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0x23d..=0x23f) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x240) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_i3c_ec_soc_mgmt_if_t_low_reg(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0x241..=0x243) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x244) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_i3c_ec_soc_mgmt_if_t_hd_sta_reg(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0x245..=0x247) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x248) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_i3c_ec_soc_mgmt_if_t_su_sta_reg(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0x249..=0x24b) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x24c) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_i3c_ec_soc_mgmt_if_t_su_sto_reg(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0x24d..=0x24f) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (size, 0x250) => Ok(self.periph.read_i3c_ec_soc_mgmt_if_t_free_reg(size)),
-            (_, 0x251..=0x253) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x254) => Ok(self.periph.read_i3c_ec_soc_mgmt_if_t_aval_reg(size)),
-            (_, 0x255..=0x257) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x258) => Ok(self.periph.read_i3c_ec_soc_mgmt_if_t_idle_reg(size)),
-            (_, 0x259..=0x25b) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x260) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_i3c_ec_ctrl_cfg_extcap_header(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0x261..=0x263) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x264) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_i3c_ec_ctrl_cfg_controller_config(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0x265..=0x267) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
             _ => Err(emulator_bus::BusError::LoadAccessFault),
         }
     }
@@ -2249,752 +1409,474 @@ impl emulator_bus::Bus for I3cBus {
         addr: emulator_types::RvAddr,
         val: emulator_types::RvData,
     ) -> Result<(), emulator_bus::BusError> {
-        match (size, addr) {
-            (size, 0x400) => {
-                self.periph.write_dat(size, val);
+        if addr & 0x3 != 0 || size != emulator_types::RvSize::Word {
+            return Err(emulator_bus::BusError::StoreAddrMisaligned);
+        }
+        match addr {
+            0x400..0x800 => {
+                self.periph.write_dat(val);
                 Ok(())
             }
-            (_, 0x401..=0x403) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x800) => {
-                self.periph.write_dct(size, val);
+            0x800..0x1000 => {
+                self.periph.write_dct(val);
                 Ok(())
             }
-            (_, 0x801..=0x803) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (emulator_types::RvSize::Word, 4) => {
-                self.periph.write_i3c_base_hc_control(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
+            4..8 => {
+                self.periph
+                    .write_i3c_base_hc_control(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 5..=7) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 8) => {
+            8..0xc => {
                 self.periph.write_i3c_base_controller_device_addr(
-                    emulator_types::RvSize::Word,
                     emulator_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 9..=0xb) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x10) => {
-                self.periph.write_i3c_base_reset_control(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
+            0x10..0x14 => {
+                self.periph
+                    .write_i3c_base_reset_control(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x11..=0x13) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x20) => {
-                self.periph.write_i3c_base_intr_status(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
+            0x20..0x24 => {
+                self.periph
+                    .write_i3c_base_intr_status(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x21..=0x23) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x24) => {
-                self.periph.write_i3c_base_intr_status_enable(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
+            0x24..0x28 => {
+                self.periph
+                    .write_i3c_base_intr_status_enable(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x25..=0x27) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x28) => {
-                self.periph.write_i3c_base_intr_signal_enable(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
+            0x28..0x2c => {
+                self.periph
+                    .write_i3c_base_intr_signal_enable(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x29..=0x2b) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x2c) => {
-                self.periph.write_i3c_base_intr_force(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
+            0x2c..0x30 => {
+                self.periph
+                    .write_i3c_base_intr_force(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x2d..=0x2f) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x34) => {
-                self.periph.write_i3c_base_dct_section_offset(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
+            0x34..0x38 => {
+                self.periph
+                    .write_i3c_base_dct_section_offset(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x35..=0x37) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x58) => {
-                self.periph.write_i3c_base_ibi_notify_ctrl(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
+            0x58..0x5c => {
+                self.periph
+                    .write_i3c_base_ibi_notify_ctrl(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x59..=0x5b) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x5c) => {
-                self.periph.write_i3c_base_ibi_data_abort_ctrl(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
+            0x5c..0x60 => {
+                self.periph
+                    .write_i3c_base_ibi_data_abort_ctrl(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x5d..=0x5f) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x60) => {
-                self.periph.write_i3c_base_dev_ctx_base_lo(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
+            0x60..0x64 => {
+                self.periph
+                    .write_i3c_base_dev_ctx_base_lo(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x61..=0x63) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x64) => {
-                self.periph.write_i3c_base_dev_ctx_base_hi(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
+            0x64..0x68 => {
+                self.periph
+                    .write_i3c_base_dev_ctx_base_hi(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x65..=0x67) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (size, 0x80) => {
-                self.periph.write_piocontrol_command_port(size, val);
+            0x80..0x84 => {
+                self.periph.write_piocontrol_command_port(val);
                 Ok(())
             }
-            (_, 0x81..=0x83) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x88) => {
-                self.periph.write_piocontrol_tx_data_port(size, val);
+            0x88..0x8c => {
+                self.periph.write_piocontrol_tx_data_port(val);
                 Ok(())
             }
-            (_, 0x89..=0x8b) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x90) => {
-                self.periph.write_piocontrol_queue_thld_ctrl(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
+            0x90..0x94 => {
+                self.periph
+                    .write_piocontrol_queue_thld_ctrl(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x91..=0x93) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x94) => {
+            0x94..0x98 => {
                 self.periph.write_piocontrol_data_buffer_thld_ctrl(
-                    emulator_types::RvSize::Word,
                     emulator_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x95..=0x97) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xa0) => {
-                self.periph.write_piocontrol_pio_intr_status(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
+            0xa0..0xa4 => {
+                self.periph
+                    .write_piocontrol_pio_intr_status(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0xa1..=0xa3) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xa4) => {
+            0xa4..0xa8 => {
                 self.periph.write_piocontrol_pio_intr_status_enable(
-                    emulator_types::RvSize::Word,
                     emulator_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0xa5..=0xa7) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xa8) => {
+            0xa8..0xac => {
                 self.periph.write_piocontrol_pio_intr_signal_enable(
-                    emulator_types::RvSize::Word,
                     emulator_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0xa9..=0xab) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xac) => {
-                self.periph.write_piocontrol_pio_intr_force(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0xad..=0xaf) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xb0) => {
-                self.periph.write_piocontrol_pio_control(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0xb1..=0xb3) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (size, 0x104) => {
+            0xac..0xb0 => {
                 self.periph
-                    .write_i3c_ec_sec_fw_recovery_if_prot_cap_0(size, val);
+                    .write_piocontrol_pio_intr_force(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (_, 0x105..=0x107) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x108) => {
+            0xb0..0xb4 => {
                 self.periph
-                    .write_i3c_ec_sec_fw_recovery_if_prot_cap_1(size, val);
+                    .write_piocontrol_pio_control(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (_, 0x109..=0x10b) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x10c) => {
+            0x104..0x108 => {
+                self.periph.write_i3c_ec_sec_fw_recovery_if_prot_cap_0(val);
+                Ok(())
+            }
+            0x108..0x10c => {
+                self.periph.write_i3c_ec_sec_fw_recovery_if_prot_cap_1(val);
+                Ok(())
+            }
+            0x10c..0x110 => {
+                self.periph.write_i3c_ec_sec_fw_recovery_if_prot_cap_2(val);
+                Ok(())
+            }
+            0x110..0x114 => {
+                self.periph.write_i3c_ec_sec_fw_recovery_if_prot_cap_3(val);
+                Ok(())
+            }
+            0x114..0x118 => {
+                self.periph.write_i3c_ec_sec_fw_recovery_if_device_id_0(val);
+                Ok(())
+            }
+            0x118..0x11c => {
+                self.periph.write_i3c_ec_sec_fw_recovery_if_device_id_1(val);
+                Ok(())
+            }
+            0x11c..0x120 => {
+                self.periph.write_i3c_ec_sec_fw_recovery_if_device_id_2(val);
+                Ok(())
+            }
+            0x120..0x124 => {
+                self.periph.write_i3c_ec_sec_fw_recovery_if_device_id_3(val);
+                Ok(())
+            }
+            0x124..0x128 => {
+                self.periph.write_i3c_ec_sec_fw_recovery_if_device_id_4(val);
+                Ok(())
+            }
+            0x128..0x12c => {
+                self.periph.write_i3c_ec_sec_fw_recovery_if_device_id_5(val);
+                Ok(())
+            }
+            0x12c..0x130 => {
+                self.periph.write_i3c_ec_sec_fw_recovery_if_device_id_6(val);
+                Ok(())
+            }
+            0x130..0x134 => {
                 self.periph
-                    .write_i3c_ec_sec_fw_recovery_if_prot_cap_2(size, val);
+                    .write_i3c_ec_sec_fw_recovery_if_device_status_0(val);
                 Ok(())
             }
-            (_, 0x10d..=0x10f) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x110) => {
+            0x134..0x138 => {
                 self.periph
-                    .write_i3c_ec_sec_fw_recovery_if_prot_cap_3(size, val);
+                    .write_i3c_ec_sec_fw_recovery_if_device_status_1(val);
                 Ok(())
             }
-            (_, 0x111..=0x113) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x114) => {
+            0x138..0x13c => {
                 self.periph
-                    .write_i3c_ec_sec_fw_recovery_if_device_id_0(size, val);
+                    .write_i3c_ec_sec_fw_recovery_if_device_reset(val);
                 Ok(())
             }
-            (_, 0x115..=0x117) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x118) => {
+            0x13c..0x140 => {
                 self.periph
-                    .write_i3c_ec_sec_fw_recovery_if_device_id_1(size, val);
+                    .write_i3c_ec_sec_fw_recovery_if_recovery_ctrl(val);
                 Ok(())
             }
-            (_, 0x119..=0x11b) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x11c) => {
+            0x140..0x144 => {
                 self.periph
-                    .write_i3c_ec_sec_fw_recovery_if_device_id_2(size, val);
+                    .write_i3c_ec_sec_fw_recovery_if_recovery_status(val);
                 Ok(())
             }
-            (_, 0x11d..=0x11f) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x120) => {
+            0x144..0x148 => {
+                self.periph.write_i3c_ec_sec_fw_recovery_if_hw_status(val);
+                Ok(())
+            }
+            0x148..0x14c => {
                 self.periph
-                    .write_i3c_ec_sec_fw_recovery_if_device_id_3(size, val);
+                    .write_i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_0(val);
                 Ok(())
             }
-            (_, 0x121..=0x123) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x124) => {
+            0x14c..0x150 => {
                 self.periph
-                    .write_i3c_ec_sec_fw_recovery_if_device_id_4(size, val);
+                    .write_i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_1(val);
                 Ok(())
             }
-            (_, 0x125..=0x127) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x128) => {
+            0x15c..0x160 => {
                 self.periph
-                    .write_i3c_ec_sec_fw_recovery_if_device_id_5(size, val);
+                    .write_i3c_ec_sec_fw_recovery_if_indirect_fifo_status_3(val);
                 Ok(())
             }
-            (_, 0x129..=0x12b) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x12c) => {
+            0x160..0x164 => {
                 self.periph
-                    .write_i3c_ec_sec_fw_recovery_if_device_id_6(size, val);
+                    .write_i3c_ec_sec_fw_recovery_if_indirect_fifo_status_4(val);
                 Ok(())
             }
-            (_, 0x12d..=0x12f) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x130) => {
+            0x164..0x168 => {
                 self.periph
-                    .write_i3c_ec_sec_fw_recovery_if_device_status_0(size, val);
+                    .write_i3c_ec_sec_fw_recovery_if_indirect_fifo_status_5(val);
                 Ok(())
             }
-            (_, 0x131..=0x133) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x134) => {
+            0x168..0x16c => {
                 self.periph
-                    .write_i3c_ec_sec_fw_recovery_if_device_status_1(size, val);
+                    .write_i3c_ec_sec_fw_recovery_if_indirect_fifo_data(val);
                 Ok(())
             }
-            (_, 0x135..=0x137) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x138) => {
-                self.periph
-                    .write_i3c_ec_sec_fw_recovery_if_device_reset(size, val);
-                Ok(())
-            }
-            (_, 0x139..=0x13b) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x13c) => {
-                self.periph
-                    .write_i3c_ec_sec_fw_recovery_if_recovery_ctrl(size, val);
-                Ok(())
-            }
-            (_, 0x13d..=0x13f) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x140) => {
-                self.periph
-                    .write_i3c_ec_sec_fw_recovery_if_recovery_status(size, val);
-                Ok(())
-            }
-            (_, 0x141..=0x143) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x144) => {
-                self.periph
-                    .write_i3c_ec_sec_fw_recovery_if_hw_status(size, val);
-                Ok(())
-            }
-            (_, 0x145..=0x147) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x148) => {
-                self.periph
-                    .write_i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_0(size, val);
-                Ok(())
-            }
-            (_, 0x149..=0x14b) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x14c) => {
-                self.periph
-                    .write_i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_1(size, val);
-                Ok(())
-            }
-            (_, 0x14d..=0x14f) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x15c) => {
-                self.periph
-                    .write_i3c_ec_sec_fw_recovery_if_indirect_fifo_status_3(size, val);
-                Ok(())
-            }
-            (_, 0x15d..=0x15f) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x160) => {
-                self.periph
-                    .write_i3c_ec_sec_fw_recovery_if_indirect_fifo_status_4(size, val);
-                Ok(())
-            }
-            (_, 0x161..=0x163) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x164) => {
-                self.periph
-                    .write_i3c_ec_sec_fw_recovery_if_indirect_fifo_status_5(size, val);
-                Ok(())
-            }
-            (_, 0x165..=0x167) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x168) => {
-                self.periph
-                    .write_i3c_ec_sec_fw_recovery_if_indirect_fifo_data(size, val);
-                Ok(())
-            }
-            (_, 0x169..=0x16b) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x184) => {
+            0x184..0x188 => {
                 self.periph.write_i3c_ec_stdby_ctrl_mode_stby_cr_control(
-                    emulator_types::RvSize::Word,
                     emulator_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x185..=0x187) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x188) => {
+            0x188..0x18c => {
                 self.periph
                     .write_i3c_ec_stdby_ctrl_mode_stby_cr_device_addr(
-                        emulator_types::RvSize::Word,
                         emulator_bus::ReadWriteRegister::new(val),
                     );
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x189..=0x18b) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x18c) => {
+            0x18c..0x190 => {
                 self.periph
                     .write_i3c_ec_stdby_ctrl_mode_stby_cr_capabilities(
-                        emulator_types::RvSize::Word,
                         emulator_bus::ReadWriteRegister::new(val),
                     );
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x18d..=0x18f) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (size, 0x190) => {
-                self.periph.write_i3c_ec_stdby_ctrl_mode_rsvd_0(size, val);
+            0x190..0x194 => {
+                self.periph.write_i3c_ec_stdby_ctrl_mode_rsvd_0(val);
                 Ok(())
             }
-            (_, 0x191..=0x193) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x194) => {
+            0x194..0x198 => {
                 self.periph.write_i3c_ec_stdby_ctrl_mode_stby_cr_status(
-                    emulator_types::RvSize::Word,
                     emulator_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x195..=0x197) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x198) => {
+            0x198..0x19c => {
                 self.periph
                     .write_i3c_ec_stdby_ctrl_mode_stby_cr_device_char(
-                        emulator_types::RvSize::Word,
                         emulator_bus::ReadWriteRegister::new(val),
                     );
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x199..=0x19b) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (size, 0x19c) => {
+            0x19c..0x1a0 => {
                 self.periph
-                    .write_i3c_ec_stdby_ctrl_mode_stby_cr_device_pid_lo(size, val);
+                    .write_i3c_ec_stdby_ctrl_mode_stby_cr_device_pid_lo(val);
                 Ok(())
             }
-            (_, 0x19d..=0x19f) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x1a0) => {
+            0x1a0..0x1a4 => {
                 self.periph
                     .write_i3c_ec_stdby_ctrl_mode_stby_cr_intr_status(
-                        emulator_types::RvSize::Word,
                         emulator_bus::ReadWriteRegister::new(val),
                     );
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x1a1..=0x1a3) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (size, 0x1a4) => {
-                self.periph.write_i3c_ec_stdby_ctrl_mode_rsvd_1(size, val);
+            0x1a4..0x1a8 => {
+                self.periph.write_i3c_ec_stdby_ctrl_mode_rsvd_1(val);
                 Ok(())
             }
-            (_, 0x1a5..=0x1a7) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x1a8) => {
+            0x1a8..0x1ac => {
                 self.periph
                     .write_i3c_ec_stdby_ctrl_mode_stby_cr_intr_signal_enable(
-                        emulator_types::RvSize::Word,
                         emulator_bus::ReadWriteRegister::new(val),
                     );
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x1a9..=0x1ab) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1ac) => {
+            0x1ac..0x1b0 => {
                 self.periph.write_i3c_ec_stdby_ctrl_mode_stby_cr_intr_force(
-                    emulator_types::RvSize::Word,
                     emulator_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x1ad..=0x1af) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1b0) => {
+            0x1b0..0x1b4 => {
                 self.periph
                     .write_i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_getcaps(
-                        emulator_types::RvSize::Word,
                         emulator_bus::ReadWriteRegister::new(val),
                     );
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x1b1..=0x1b3) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1b4) => {
+            0x1b4..0x1b8 => {
                 self.periph
                     .write_i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_rstact_params(
-                        emulator_types::RvSize::Word,
                         emulator_bus::ReadWriteRegister::new(val),
                     );
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x1b5..=0x1b7) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1b8) => {
+            0x1b8..0x1bc => {
                 self.periph
                     .write_i3c_ec_stdby_ctrl_mode_stby_cr_virt_device_addr(
-                        emulator_types::RvSize::Word,
                         emulator_bus::ReadWriteRegister::new(val),
                     );
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x1b9..=0x1bb) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (size, 0x1bc) => {
-                self.periph.write_i3c_ec_stdby_ctrl_mode_rsvd_3(size, val);
+            0x1bc..0x1c0 => {
+                self.periph.write_i3c_ec_stdby_ctrl_mode_rsvd_3(val);
                 Ok(())
             }
-            (_, 0x1bd..=0x1bf) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x1c4) => {
-                self.periph.write_i3c_ec_tti_control(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
+            0x1c4..0x1c8 => {
+                self.periph
+                    .write_i3c_ec_tti_control(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x1c5..=0x1c7) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1cc) => {
-                self.periph.write_i3c_ec_tti_tti_reset_control(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
+            0x1cc..0x1d0 => {
+                self.periph
+                    .write_i3c_ec_tti_tti_reset_control(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x1cd..=0x1cf) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1d0) => {
-                self.periph.write_i3c_ec_tti_interrupt_status(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
+            0x1d0..0x1d4 => {
+                self.periph
+                    .write_i3c_ec_tti_interrupt_status(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x1d1..=0x1d3) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1d4) => {
-                self.periph.write_i3c_ec_tti_interrupt_enable(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
+            0x1d4..0x1d8 => {
+                self.periph
+                    .write_i3c_ec_tti_interrupt_enable(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x1d5..=0x1d7) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1d8) => {
-                self.periph.write_i3c_ec_tti_interrupt_force(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
+            0x1d8..0x1dc => {
+                self.periph
+                    .write_i3c_ec_tti_interrupt_force(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x1d9..=0x1db) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (size, 0x1e4) => {
-                self.periph.write_i3c_ec_tti_tx_desc_queue_port(size, val);
+            0x1e4..0x1e8 => {
+                self.periph.write_i3c_ec_tti_tx_desc_queue_port(val);
                 Ok(())
             }
-            (_, 0x1e5..=0x1e7) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x1e8) => {
-                self.periph.write_i3c_ec_tti_tx_data_port(size, val);
+            0x1e8..0x1ec => {
+                self.periph.write_i3c_ec_tti_tx_data_port(val);
                 Ok(())
             }
-            (_, 0x1e9..=0x1eb) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x1ec) => {
-                self.periph.write_i3c_ec_tti_tti_ibi_port(size, val);
+            0x1ec..0x1f0 => {
+                self.periph.write_i3c_ec_tti_tti_ibi_port(val);
                 Ok(())
             }
-            (_, 0x1ed..=0x1ef) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x1f8) => {
+            0x1f8..0x1fc => {
                 self.periph.write_i3c_ec_tti_tti_queue_thld_ctrl(
-                    emulator_types::RvSize::Word,
                     emulator_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x1f9..=0x1fb) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1fc) => {
+            0x1fc..0x200 => {
                 self.periph.write_i3c_ec_tti_tti_data_buffer_thld_ctrl(
-                    emulator_types::RvSize::Word,
                     emulator_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x1fd..=0x1ff) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (size, 0x204) => {
-                self.periph
-                    .write_i3c_ec_soc_mgmt_if_soc_mgmt_control(size, val);
+            0x204..0x208 => {
+                self.periph.write_i3c_ec_soc_mgmt_if_soc_mgmt_control(val);
                 Ok(())
             }
-            (_, 0x205..=0x207) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x208) => {
-                self.periph
-                    .write_i3c_ec_soc_mgmt_if_soc_mgmt_status(size, val);
+            0x208..0x20c => {
+                self.periph.write_i3c_ec_soc_mgmt_if_soc_mgmt_status(val);
                 Ok(())
             }
-            (_, 0x209..=0x20b) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x20c) => {
-                self.periph
-                    .write_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_0(size, val);
+            0x20c..0x210 => {
+                self.periph.write_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_0(val);
                 Ok(())
             }
-            (_, 0x20d..=0x20f) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x210) => {
-                self.periph
-                    .write_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_1(size, val);
+            0x210..0x214 => {
+                self.periph.write_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_1(val);
                 Ok(())
             }
-            (_, 0x211..=0x213) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x214) => {
-                self.periph
-                    .write_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_2(size, val);
+            0x214..0x218 => {
+                self.periph.write_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_2(val);
                 Ok(())
             }
-            (_, 0x215..=0x217) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x218) => {
-                self.periph
-                    .write_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_3(size, val);
+            0x218..0x21c => {
+                self.periph.write_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_3(val);
                 Ok(())
             }
-            (_, 0x219..=0x21b) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x21c) => {
+            0x21c..0x220 => {
                 self.periph.write_i3c_ec_soc_mgmt_if_soc_pad_conf(
-                    emulator_types::RvSize::Word,
                     emulator_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x21d..=0x21f) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x220) => {
+            0x220..0x224 => {
                 self.periph.write_i3c_ec_soc_mgmt_if_soc_pad_attr(
-                    emulator_types::RvSize::Word,
                     emulator_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x221..=0x223) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
+            0x224..0x228 => {
+                self.periph.write_i3c_ec_soc_mgmt_if_soc_mgmt_feature_2(val);
+                Ok(())
             }
-            (size, 0x224) => {
+            0x228..0x22c => {
+                self.periph.write_i3c_ec_soc_mgmt_if_soc_mgmt_feature_3(val);
+                Ok(())
+            }
+            0x22c..0x230 => {
                 self.periph
-                    .write_i3c_ec_soc_mgmt_if_soc_mgmt_feature_2(size, val);
+                    .write_i3c_ec_soc_mgmt_if_t_r_reg(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (_, 0x225..=0x227) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x228) => {
+            0x230..0x234 => {
                 self.periph
-                    .write_i3c_ec_soc_mgmt_if_soc_mgmt_feature_3(size, val);
+                    .write_i3c_ec_soc_mgmt_if_t_f_reg(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (_, 0x229..=0x22b) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x22c) => {
-                self.periph.write_i3c_ec_soc_mgmt_if_t_r_reg(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0x22d..=0x22f) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x230) => {
-                self.periph.write_i3c_ec_soc_mgmt_if_t_f_reg(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0x231..=0x233) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x234) => {
+            0x234..0x238 => {
                 self.periph.write_i3c_ec_soc_mgmt_if_t_su_dat_reg(
-                    emulator_types::RvSize::Word,
                     emulator_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x235..=0x237) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x238) => {
+            0x238..0x23c => {
                 self.periph.write_i3c_ec_soc_mgmt_if_t_hd_dat_reg(
-                    emulator_types::RvSize::Word,
                     emulator_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x239..=0x23b) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x23c) => {
-                self.periph.write_i3c_ec_soc_mgmt_if_t_high_reg(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
+            0x23c..0x240 => {
+                self.periph
+                    .write_i3c_ec_soc_mgmt_if_t_high_reg(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x23d..=0x23f) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x240) => {
-                self.periph.write_i3c_ec_soc_mgmt_if_t_low_reg(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
+            0x240..0x244 => {
+                self.periph
+                    .write_i3c_ec_soc_mgmt_if_t_low_reg(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x241..=0x243) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x244) => {
+            0x244..0x248 => {
                 self.periph.write_i3c_ec_soc_mgmt_if_t_hd_sta_reg(
-                    emulator_types::RvSize::Word,
                     emulator_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x245..=0x247) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x248) => {
+            0x248..0x24c => {
                 self.periph.write_i3c_ec_soc_mgmt_if_t_su_sta_reg(
-                    emulator_types::RvSize::Word,
                     emulator_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x249..=0x24b) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x24c) => {
+            0x24c..0x250 => {
                 self.periph.write_i3c_ec_soc_mgmt_if_t_su_sto_reg(
-                    emulator_types::RvSize::Word,
                     emulator_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x24d..=0x24f) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (size, 0x250) => {
-                self.periph.write_i3c_ec_soc_mgmt_if_t_free_reg(size, val);
+            0x250..0x254 => {
+                self.periph.write_i3c_ec_soc_mgmt_if_t_free_reg(val);
                 Ok(())
             }
-            (_, 0x251..=0x253) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x254) => {
-                self.periph.write_i3c_ec_soc_mgmt_if_t_aval_reg(size, val);
+            0x254..0x258 => {
+                self.periph.write_i3c_ec_soc_mgmt_if_t_aval_reg(val);
                 Ok(())
             }
-            (_, 0x255..=0x257) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x258) => {
-                self.periph.write_i3c_ec_soc_mgmt_if_t_idle_reg(size, val);
+            0x258..0x25c => {
+                self.periph.write_i3c_ec_soc_mgmt_if_t_idle_reg(val);
                 Ok(())
             }
-            (_, 0x259..=0x25b) => Err(emulator_bus::BusError::StoreAddrMisaligned),
             _ => Err(emulator_bus::BusError::StoreAccessFault),
         }
     }

--- a/registers/generated-emulator/src/main_flash.rs
+++ b/registers/generated-emulator/src/main_flash.rs
@@ -11,7 +11,6 @@ pub trait MainFlashPeripheral {
     fn update_reset(&mut self) {}
     fn read_fl_interrupt_state(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::main_flash_ctrl::bits::FlInterruptState::Register,
@@ -20,7 +19,6 @@ pub trait MainFlashPeripheral {
     }
     fn write_fl_interrupt_state(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::main_flash_ctrl::bits::FlInterruptState::Register,
@@ -29,7 +27,6 @@ pub trait MainFlashPeripheral {
     }
     fn read_fl_interrupt_enable(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::main_flash_ctrl::bits::FlInterruptEnable::Register,
@@ -38,28 +35,26 @@ pub trait MainFlashPeripheral {
     }
     fn write_fl_interrupt_enable(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::main_flash_ctrl::bits::FlInterruptEnable::Register,
         >,
     ) {
     }
-    fn read_page_size(&mut self, _size: emulator_types::RvSize) -> emulator_types::RvData {
+    fn read_page_size(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_page_size(&mut self, _size: emulator_types::RvSize, _val: emulator_types::RvData) {}
-    fn read_page_num(&mut self, _size: emulator_types::RvSize) -> emulator_types::RvData {
+    fn write_page_size(&mut self, _val: emulator_types::RvData) {}
+    fn read_page_num(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_page_num(&mut self, _size: emulator_types::RvSize, _val: emulator_types::RvData) {}
-    fn read_page_addr(&mut self, _size: emulator_types::RvSize) -> emulator_types::RvData {
+    fn write_page_num(&mut self, _val: emulator_types::RvData) {}
+    fn read_page_addr(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_page_addr(&mut self, _size: emulator_types::RvSize, _val: emulator_types::RvData) {}
+    fn write_page_addr(&mut self, _val: emulator_types::RvData) {}
     fn read_fl_control(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::main_flash_ctrl::bits::FlControl::Register,
@@ -68,7 +63,6 @@ pub trait MainFlashPeripheral {
     }
     fn write_fl_control(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::main_flash_ctrl::bits::FlControl::Register,
@@ -77,7 +71,6 @@ pub trait MainFlashPeripheral {
     }
     fn read_op_status(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::main_flash_ctrl::bits::OpStatus::Register,
@@ -86,7 +79,6 @@ pub trait MainFlashPeripheral {
     }
     fn write_op_status(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::main_flash_ctrl::bits::OpStatus::Register,
@@ -95,7 +87,6 @@ pub trait MainFlashPeripheral {
     }
     fn read_ctrl_regwen(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::main_flash_ctrl::bits::CtrlRegwen::Register,
@@ -112,58 +103,28 @@ impl emulator_bus::Bus for MainFlashBus {
         size: emulator_types::RvSize,
         addr: emulator_types::RvAddr,
     ) -> Result<emulator_types::RvData, emulator_bus::BusError> {
-        match (size, addr) {
-            (emulator_types::RvSize::Word, 0) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_fl_interrupt_state(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+        if addr & 0x3 != 0 || size != emulator_types::RvSize::Word {
+            return Err(emulator_bus::BusError::LoadAddrMisaligned);
+        }
+        match addr {
+            0..4 => Ok(emulator_types::RvData::from(
+                self.periph.read_fl_interrupt_state().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 1..=3) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 4) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_fl_interrupt_enable(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            4..8 => Ok(emulator_types::RvData::from(
+                self.periph.read_fl_interrupt_enable().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 5..=7) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (size, 8) => Ok(self.periph.read_page_size(size)),
-            (_, 9..=0xb) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0xc) => Ok(self.periph.read_page_num(size)),
-            (_, 0xd..=0xf) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x10) => Ok(self.periph.read_page_addr(size)),
-            (_, 0x11..=0x13) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x14) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_fl_control(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            8..0xc => Ok(self.periph.read_page_size()),
+            0xc..0x10 => Ok(self.periph.read_page_num()),
+            0x10..0x14 => Ok(self.periph.read_page_addr()),
+            0x14..0x18 => Ok(emulator_types::RvData::from(
+                self.periph.read_fl_control().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0x15..=0x17) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x18) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_op_status(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0x18..0x1c => Ok(emulator_types::RvData::from(
+                self.periph.read_op_status().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0x19..=0x1b) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1c) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_ctrl_regwen(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0x1c..0x20 => Ok(emulator_types::RvData::from(
+                self.periph.read_ctrl_regwen().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0x1d..=0x1f) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
             _ => Err(emulator_bus::BusError::LoadAccessFault),
         }
     }
@@ -173,61 +134,41 @@ impl emulator_bus::Bus for MainFlashBus {
         addr: emulator_types::RvAddr,
         val: emulator_types::RvData,
     ) -> Result<(), emulator_bus::BusError> {
-        match (size, addr) {
-            (emulator_types::RvSize::Word, 0) => {
-                self.periph.write_fl_interrupt_state(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
+        if addr & 0x3 != 0 || size != emulator_types::RvSize::Word {
+            return Err(emulator_bus::BusError::StoreAddrMisaligned);
+        }
+        match addr {
+            0..4 => {
+                self.periph
+                    .write_fl_interrupt_state(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 1..=3) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 4) => {
-                self.periph.write_fl_interrupt_enable(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
+            4..8 => {
+                self.periph
+                    .write_fl_interrupt_enable(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 5..=7) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (size, 8) => {
-                self.periph.write_page_size(size, val);
+            8..0xc => {
+                self.periph.write_page_size(val);
                 Ok(())
             }
-            (_, 9..=0xb) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0xc) => {
-                self.periph.write_page_num(size, val);
+            0xc..0x10 => {
+                self.periph.write_page_num(val);
                 Ok(())
             }
-            (_, 0xd..=0xf) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x10) => {
-                self.periph.write_page_addr(size, val);
+            0x10..0x14 => {
+                self.periph.write_page_addr(val);
                 Ok(())
             }
-            (_, 0x11..=0x13) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x14) => {
-                self.periph.write_fl_control(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
+            0x14..0x18 => {
+                self.periph
+                    .write_fl_control(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x15..=0x17) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x18) => {
-                self.periph.write_op_status(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
+            0x18..0x1c => {
+                self.periph
+                    .write_op_status(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
-            }
-            (emulator_types::RvSize::Word, 0x19..=0x1b) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
             }
             _ => Err(emulator_bus::BusError::StoreAccessFault),
         }

--- a/registers/generated-emulator/src/mci.rs
+++ b/registers/generated-emulator/src/mci.rs
@@ -11,43 +11,38 @@ pub trait MciPeripheral {
     fn update_reset(&mut self) {}
     fn read_capabilities(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::mci::bits::Capabilities::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn read_hw_rev_id(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::mci::bits::HwRevId::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
-    fn read_fw_rev_id(&mut self, _size: emulator_types::RvSize) -> emulator_types::RvData {
+    fn read_fw_rev_id(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_fw_rev_id(&mut self, _size: emulator_types::RvSize, _val: emulator_types::RvData) {}
+    fn write_fw_rev_id(&mut self, _val: emulator_types::RvData) {}
     fn read_hw_config(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::mci::bits::HwConfig::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
-    fn read_boot_status(&mut self, _size: emulator_types::RvSize) -> emulator_types::RvData {
+    fn read_boot_status(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_boot_status(&mut self, _size: emulator_types::RvSize, _val: emulator_types::RvData) {}
+    fn write_boot_status(&mut self, _val: emulator_types::RvData) {}
     fn read_flow_status(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::mci::bits::FlowStatus::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn write_flow_status(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::FlowStatus::Register,
@@ -56,21 +51,18 @@ pub trait MciPeripheral {
     }
     fn read_reset_reason(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::mci::bits::ResetReason::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn read_reset_status(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::mci::bits::ResetStatus::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn write_reset_status(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::ResetStatus::Register,
@@ -79,14 +71,12 @@ pub trait MciPeripheral {
     }
     fn read_hw_error_fatal(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::mci::bits::HwErrorFatal::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn write_hw_error_fatal(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::HwErrorFatal::Register,
@@ -95,14 +85,12 @@ pub trait MciPeripheral {
     }
     fn read_agg_error_fatal(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::mci::bits::AggErrorFatal::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn write_agg_error_fatal(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::AggErrorFatal::Register,
@@ -111,7 +99,6 @@ pub trait MciPeripheral {
     }
     fn read_hw_error_non_fatal(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::HwErrorNonFatal::Register,
@@ -120,7 +107,6 @@ pub trait MciPeripheral {
     }
     fn write_hw_error_non_fatal(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::HwErrorNonFatal::Register,
@@ -129,7 +115,6 @@ pub trait MciPeripheral {
     }
     fn read_agg_error_non_fatal(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::AggErrorNonFatal::Register,
@@ -138,54 +123,34 @@ pub trait MciPeripheral {
     }
     fn write_agg_error_non_fatal(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::AggErrorNonFatal::Register,
         >,
     ) {
     }
-    fn read_fw_error_fatal(&mut self, _size: emulator_types::RvSize) -> emulator_types::RvData {
+    fn read_fw_error_fatal(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_fw_error_fatal(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_fw_error_non_fatal(&mut self, _size: emulator_types::RvSize) -> emulator_types::RvData {
+    fn write_fw_error_fatal(&mut self, _val: emulator_types::RvData) {}
+    fn read_fw_error_non_fatal(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_fw_error_non_fatal(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_hw_error_enc(&mut self, _size: emulator_types::RvSize) -> emulator_types::RvData {
+    fn write_fw_error_non_fatal(&mut self, _val: emulator_types::RvData) {}
+    fn read_hw_error_enc(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_hw_error_enc(&mut self, _size: emulator_types::RvSize, _val: emulator_types::RvData) {}
-    fn read_fw_error_enc(&mut self, _size: emulator_types::RvSize) -> emulator_types::RvData {
+    fn write_hw_error_enc(&mut self, _val: emulator_types::RvData) {}
+    fn read_fw_error_enc(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_fw_error_enc(&mut self, _size: emulator_types::RvSize, _val: emulator_types::RvData) {}
-    fn read_fw_extended_error_info(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_fw_error_enc(&mut self, _val: emulator_types::RvData) {}
+    fn read_fw_extended_error_info(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_fw_extended_error_info(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
+    fn write_fw_extended_error_info(&mut self, _val: emulator_types::RvData) {}
     fn read_internal_hw_error_fatal_mask(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::InternalHwErrorFatalMask::Register,
@@ -194,7 +159,6 @@ pub trait MciPeripheral {
     }
     fn write_internal_hw_error_fatal_mask(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::InternalHwErrorFatalMask::Register,
@@ -203,7 +167,6 @@ pub trait MciPeripheral {
     }
     fn read_internal_hw_error_non_fatal_mask(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::Field07d1d1037962a7ee::Register,
@@ -212,7 +175,6 @@ pub trait MciPeripheral {
     }
     fn write_internal_hw_error_non_fatal_mask(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::Field07d1d1037962a7ee::Register,
@@ -221,7 +183,6 @@ pub trait MciPeripheral {
     }
     fn read_internal_agg_error_fatal_mask(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::InternalAggErrorFatalMask::Register,
@@ -230,7 +191,6 @@ pub trait MciPeripheral {
     }
     fn write_internal_agg_error_fatal_mask(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::InternalAggErrorFatalMask::Register,
@@ -239,7 +199,6 @@ pub trait MciPeripheral {
     }
     fn read_internal_agg_error_non_fatal_mask(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::InternalAggErrorNonFatalMask::Register,
@@ -248,47 +207,28 @@ pub trait MciPeripheral {
     }
     fn write_internal_agg_error_non_fatal_mask(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::InternalAggErrorNonFatalMask::Register,
         >,
     ) {
     }
-    fn read_internal_fw_error_fatal_mask(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_internal_fw_error_fatal_mask(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_internal_fw_error_fatal_mask(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_internal_fw_error_non_fatal_mask(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_internal_fw_error_fatal_mask(&mut self, _val: emulator_types::RvData) {}
+    fn read_internal_fw_error_non_fatal_mask(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_internal_fw_error_non_fatal_mask(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
+    fn write_internal_fw_error_non_fatal_mask(&mut self, _val: emulator_types::RvData) {}
     fn read_wdt_timer1_en(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::mci::bits::WdtTimer1En::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn write_wdt_timer1_en(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::WdtTimer1En::Register,
@@ -297,42 +237,30 @@ pub trait MciPeripheral {
     }
     fn read_wdt_timer1_ctrl(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::mci::bits::WdtTimer1Ctrl::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn write_wdt_timer1_ctrl(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::WdtTimer1Ctrl::Register,
         >,
     ) {
     }
-    fn read_wdt_timer1_timeout_period(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_wdt_timer1_timeout_period(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_wdt_timer1_timeout_period(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
+    fn write_wdt_timer1_timeout_period(&mut self, _val: emulator_types::RvData) {}
     fn read_wdt_timer2_en(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::mci::bits::WdtTimer2En::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn write_wdt_timer2_en(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::WdtTimer2En::Register,
@@ -341,107 +269,68 @@ pub trait MciPeripheral {
     }
     fn read_wdt_timer2_ctrl(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::mci::bits::WdtTimer2Ctrl::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn write_wdt_timer2_ctrl(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::WdtTimer2Ctrl::Register,
         >,
     ) {
     }
-    fn read_wdt_timer2_timeout_period(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_wdt_timer2_timeout_period(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_wdt_timer2_timeout_period(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
+    fn write_wdt_timer2_timeout_period(&mut self, _val: emulator_types::RvData) {}
     fn read_wdt_status(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::mci::bits::WdtStatus::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn write_wdt_status(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::WdtStatus::Register,
         >,
     ) {
     }
-    fn read_wdt_cfg(&mut self, _size: emulator_types::RvSize) -> emulator_types::RvData {
+    fn read_wdt_cfg(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_wdt_cfg(&mut self, _size: emulator_types::RvSize, _val: emulator_types::RvData) {}
-    fn read_mcu_timer_config(&mut self, _size: emulator_types::RvSize) -> emulator_types::RvData {
+    fn write_wdt_cfg(&mut self, _val: emulator_types::RvData) {}
+    fn read_mcu_timer_config(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_mcu_timer_config(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_mcu_rv_mtime_l(&mut self, _size: emulator_types::RvSize) -> emulator_types::RvData {
+    fn write_mcu_timer_config(&mut self, _val: emulator_types::RvData) {}
+    fn read_mcu_rv_mtime_l(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_mcu_rv_mtime_l(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_mcu_rv_mtime_h(&mut self, _size: emulator_types::RvSize) -> emulator_types::RvData {
+    fn write_mcu_rv_mtime_l(&mut self, _val: emulator_types::RvData) {}
+    fn read_mcu_rv_mtime_h(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_mcu_rv_mtime_h(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_mcu_rv_mtimecmp_l(&mut self, _size: emulator_types::RvSize) -> emulator_types::RvData {
+    fn write_mcu_rv_mtime_h(&mut self, _val: emulator_types::RvData) {}
+    fn read_mcu_rv_mtimecmp_l(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_mcu_rv_mtimecmp_l(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_mcu_rv_mtimecmp_h(&mut self, _size: emulator_types::RvSize) -> emulator_types::RvData {
+    fn write_mcu_rv_mtimecmp_l(&mut self, _val: emulator_types::RvData) {}
+    fn read_mcu_rv_mtimecmp_h(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_mcu_rv_mtimecmp_h(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
+    fn write_mcu_rv_mtimecmp_h(&mut self, _val: emulator_types::RvData) {}
     fn read_reset_request(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::mci::bits::ResetRequest::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn write_reset_request(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::ResetRequest::Register,
@@ -450,7 +339,6 @@ pub trait MciPeripheral {
     }
     fn read_caliptra_boot_go(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::CaliptraBootGo::Register,
@@ -459,7 +347,6 @@ pub trait MciPeripheral {
     }
     fn write_caliptra_boot_go(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::CaliptraBootGo::Register,
@@ -468,7 +355,6 @@ pub trait MciPeripheral {
     }
     fn read_fw_sram_exec_region_size(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::FwSramExecRegionSize::Register,
@@ -477,43 +363,26 @@ pub trait MciPeripheral {
     }
     fn write_fw_sram_exec_region_size(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::FwSramExecRegionSize::Register,
         >,
     ) {
     }
-    fn read_mcu_nmi_vector(&mut self, _size: emulator_types::RvSize) -> emulator_types::RvData {
+    fn read_mcu_nmi_vector(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_mcu_nmi_vector(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_mcu_reset_vector(&mut self, _size: emulator_types::RvSize) -> emulator_types::RvData {
+    fn write_mcu_nmi_vector(&mut self, _val: emulator_types::RvData) {}
+    fn read_mcu_reset_vector(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_mcu_reset_vector(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_mbox0_valid_axi_id(&mut self, _size: emulator_types::RvSize) -> emulator_types::RvData {
+    fn write_mcu_reset_vector(&mut self, _val: emulator_types::RvData) {}
+    fn read_mbox0_valid_axi_id(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_mbox0_valid_axi_id(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
+    fn write_mbox0_valid_axi_id(&mut self, _val: emulator_types::RvData) {}
     fn read_mbox0_valid_axi_id_lock(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::MboxxValidAxiIdLock::Register,
@@ -522,25 +391,18 @@ pub trait MciPeripheral {
     }
     fn write_mbox0_valid_axi_id_lock(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::MboxxValidAxiIdLock::Register,
         >,
     ) {
     }
-    fn read_mbox1_valid_axi_id(&mut self, _size: emulator_types::RvSize) -> emulator_types::RvData {
+    fn read_mbox1_valid_axi_id(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_mbox1_valid_axi_id(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
+    fn write_mbox1_valid_axi_id(&mut self, _val: emulator_types::RvData) {}
     fn read_mbox1_valid_axi_id_lock(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::MboxxValidAxiIdLock::Register,
@@ -549,34 +411,21 @@ pub trait MciPeripheral {
     }
     fn write_mbox1_valid_axi_id_lock(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::MboxxValidAxiIdLock::Register,
         >,
     ) {
     }
-    fn read_generic_input_wires(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_generic_input_wires(&mut self) -> emulator_types::RvData {
         0
     }
-    fn read_generic_output_wires(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_generic_output_wires(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_generic_output_wires(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
+    fn write_generic_output_wires(&mut self, _val: emulator_types::RvData) {}
     fn read_debug_in(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::Field07d1d1037962a7ee::Register,
@@ -585,7 +434,6 @@ pub trait MciPeripheral {
     }
     fn write_debug_in(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::Field07d1d1037962a7ee::Register,
@@ -594,7 +442,6 @@ pub trait MciPeripheral {
     }
     fn read_debug_out(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::Field07d1d1037962a7ee::Register,
@@ -603,7 +450,6 @@ pub trait MciPeripheral {
     }
     fn write_debug_out(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::Field07d1d1037962a7ee::Register,
@@ -612,42 +458,30 @@ pub trait MciPeripheral {
     }
     fn read_fuse_wr_done(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::mci::bits::FuseWrDone::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn write_fuse_wr_done(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::FuseWrDone::Register,
         >,
     ) {
     }
-    fn read_prod_debug_unlock_pk_hash_reg(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_prod_debug_unlock_pk_hash_reg(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_prod_debug_unlock_pk_hash_reg(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
+    fn write_prod_debug_unlock_pk_hash_reg(&mut self, _val: emulator_types::RvData) {}
     fn read_sticky_data_vault_ctrl(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::mci::bits::DataVaultCtrl::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn write_sticky_data_vault_ctrl(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::DataVaultCtrl::Register,
@@ -656,7 +490,6 @@ pub trait MciPeripheral {
     }
     fn read_sticky_data_vault_entry(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::DataVaultEntry::Register,
@@ -665,7 +498,6 @@ pub trait MciPeripheral {
     }
     fn write_sticky_data_vault_entry(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::DataVaultEntry::Register,
@@ -674,14 +506,12 @@ pub trait MciPeripheral {
     }
     fn read_data_vault_ctrl(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::mci::bits::DataVaultCtrl::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn write_data_vault_ctrl(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::DataVaultCtrl::Register,
@@ -690,7 +520,6 @@ pub trait MciPeripheral {
     }
     fn read_data_vault_entry(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::DataVaultEntry::Register,
@@ -699,7 +528,6 @@ pub trait MciPeripheral {
     }
     fn write_data_vault_entry(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::DataVaultEntry::Register,
@@ -708,7 +536,6 @@ pub trait MciPeripheral {
     }
     fn read_sticky_lockable_scratch_reg_ctrl(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::LockableScratchRegCtrl::Register,
@@ -717,28 +544,18 @@ pub trait MciPeripheral {
     }
     fn write_sticky_lockable_scratch_reg_ctrl(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::LockableScratchRegCtrl::Register,
         >,
     ) {
     }
-    fn read_sticky_lockable_scratch_reg(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_sticky_lockable_scratch_reg(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_sticky_lockable_scratch_reg(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
+    fn write_sticky_lockable_scratch_reg(&mut self, _val: emulator_types::RvData) {}
     fn read_lockable_scratch_reg_ctrl(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::LockableScratchRegCtrl::Register,
@@ -747,47 +564,28 @@ pub trait MciPeripheral {
     }
     fn write_lockable_scratch_reg_ctrl(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::LockableScratchRegCtrl::Register,
         >,
     ) {
     }
-    fn read_lockable_scratch_reg(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_lockable_scratch_reg(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_lockable_scratch_reg(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_non_sticky_generic_scratch_reg(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_lockable_scratch_reg(&mut self, _val: emulator_types::RvData) {}
+    fn read_non_sticky_generic_scratch_reg(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_non_sticky_generic_scratch_reg(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
+    fn write_non_sticky_generic_scratch_reg(&mut self, _val: emulator_types::RvData) {}
     fn read_intr_block_rf_global_intr_en_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::soc::bits::GlobalIntrEnT::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn write_intr_block_rf_global_intr_en_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::GlobalIntrEnT::Register,
@@ -796,14 +594,12 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_error0_intr_en_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::mci::bits::Error0IntrEnT::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn write_intr_block_rf_error0_intr_en_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::Error0IntrEnT::Register,
@@ -812,14 +608,12 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_error1_intr_en_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::mci::bits::Error1IntrEnT::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn write_intr_block_rf_error1_intr_en_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::Error1IntrEnT::Register,
@@ -828,14 +622,12 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_notif0_intr_en_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::mci::bits::Notif0IntrEnT::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn write_intr_block_rf_notif0_intr_en_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::Notif0IntrEnT::Register,
@@ -844,14 +636,12 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_notif1_intr_en_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::mci::bits::Notif1IntrEnT::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn write_intr_block_rf_notif1_intr_en_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::Notif1IntrEnT::Register,
@@ -860,28 +650,24 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_error_global_intr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::soc::bits::GlobalIntrT::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn read_intr_block_rf_notif_global_intr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::soc::bits::GlobalIntrT::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn read_intr_block_rf_error0_internal_intr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::mci::bits::Error0IntrT::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn write_intr_block_rf_error0_internal_intr_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::Error0IntrT::Register,
@@ -890,14 +676,12 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_error1_internal_intr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::mci::bits::Error1IntrT::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn write_intr_block_rf_error1_internal_intr_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::Error1IntrT::Register,
@@ -906,14 +690,12 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_notif0_internal_intr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::mci::bits::Notif0IntrT::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn write_intr_block_rf_notif0_internal_intr_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::Notif0IntrT::Register,
@@ -922,14 +704,12 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_notif1_internal_intr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::mci::bits::Notif1IntrT::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn write_intr_block_rf_notif1_internal_intr_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::Notif1IntrT::Register,
@@ -938,7 +718,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_error0_intr_trig_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::Error0IntrTrigT::Register,
@@ -947,7 +726,6 @@ pub trait MciPeripheral {
     }
     fn write_intr_block_rf_error0_intr_trig_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::Error0IntrTrigT::Register,
@@ -956,7 +734,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_error1_intr_trig_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::Error1IntrTrigT::Register,
@@ -965,7 +742,6 @@ pub trait MciPeripheral {
     }
     fn write_intr_block_rf_error1_intr_trig_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::Error1IntrTrigT::Register,
@@ -974,7 +750,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_notif0_intr_trig_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::Notif0IntrTrigT::Register,
@@ -983,7 +758,6 @@ pub trait MciPeripheral {
     }
     fn write_intr_block_rf_notif0_intr_trig_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::Notif0IntrTrigT::Register,
@@ -992,7 +766,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_notif1_intr_trig_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::Notif1IntrTrigT::Register,
@@ -1001,7 +774,6 @@ pub trait MciPeripheral {
     }
     fn write_intr_block_rf_notif1_intr_trig_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::Notif1IntrTrigT::Register,
@@ -1010,823 +782,664 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_error_wdt_timer1_timeout_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_error_wdt_timer1_timeout_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
     fn read_intr_block_rf_error_wdt_timer2_timeout_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_error_wdt_timer2_timeout_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
-    fn read_intr_block_rf_error_agg_error_fatal0_intr_count_r(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_intr_block_rf_error_agg_error_fatal0_intr_count_r(&mut self) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_error_agg_error_fatal0_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
-    fn read_intr_block_rf_error_agg_error_fatal1_intr_count_r(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_intr_block_rf_error_agg_error_fatal1_intr_count_r(&mut self) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_error_agg_error_fatal1_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
-    fn read_intr_block_rf_error_agg_error_fatal2_intr_count_r(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_intr_block_rf_error_agg_error_fatal2_intr_count_r(&mut self) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_error_agg_error_fatal2_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
-    fn read_intr_block_rf_error_agg_error_fatal3_intr_count_r(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_intr_block_rf_error_agg_error_fatal3_intr_count_r(&mut self) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_error_agg_error_fatal3_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
-    fn read_intr_block_rf_error_agg_error_fatal4_intr_count_r(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_intr_block_rf_error_agg_error_fatal4_intr_count_r(&mut self) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_error_agg_error_fatal4_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
-    fn read_intr_block_rf_error_agg_error_fatal5_intr_count_r(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_intr_block_rf_error_agg_error_fatal5_intr_count_r(&mut self) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_error_agg_error_fatal5_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
-    fn read_intr_block_rf_error_agg_error_fatal6_intr_count_r(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_intr_block_rf_error_agg_error_fatal6_intr_count_r(&mut self) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_error_agg_error_fatal6_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
-    fn read_intr_block_rf_error_agg_error_fatal7_intr_count_r(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_intr_block_rf_error_agg_error_fatal7_intr_count_r(&mut self) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_error_agg_error_fatal7_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
-    fn read_intr_block_rf_error_agg_error_fatal8_intr_count_r(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_intr_block_rf_error_agg_error_fatal8_intr_count_r(&mut self) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_error_agg_error_fatal8_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
-    fn read_intr_block_rf_error_agg_error_fatal9_intr_count_r(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_intr_block_rf_error_agg_error_fatal9_intr_count_r(&mut self) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_error_agg_error_fatal9_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
     fn read_intr_block_rf_error_agg_error_fatal10_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_error_agg_error_fatal10_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
     fn read_intr_block_rf_error_agg_error_fatal11_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_error_agg_error_fatal11_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
     fn read_intr_block_rf_error_agg_error_fatal12_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_error_agg_error_fatal12_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
     fn read_intr_block_rf_error_agg_error_fatal13_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_error_agg_error_fatal13_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
     fn read_intr_block_rf_error_agg_error_fatal14_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_error_agg_error_fatal14_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
     fn read_intr_block_rf_error_agg_error_fatal15_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_error_agg_error_fatal15_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
     fn read_intr_block_rf_error_agg_error_fatal16_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_error_agg_error_fatal16_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
     fn read_intr_block_rf_error_agg_error_fatal17_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_error_agg_error_fatal17_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
     fn read_intr_block_rf_error_agg_error_fatal18_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_error_agg_error_fatal18_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
     fn read_intr_block_rf_error_agg_error_fatal19_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_error_agg_error_fatal19_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
     fn read_intr_block_rf_error_agg_error_fatal20_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_error_agg_error_fatal20_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
     fn read_intr_block_rf_error_agg_error_fatal21_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_error_agg_error_fatal21_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
     fn read_intr_block_rf_error_agg_error_fatal22_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_error_agg_error_fatal22_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
     fn read_intr_block_rf_error_agg_error_fatal23_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_error_agg_error_fatal23_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
     fn read_intr_block_rf_error_agg_error_fatal24_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_error_agg_error_fatal24_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
     fn read_intr_block_rf_error_agg_error_fatal25_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_error_agg_error_fatal25_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
     fn read_intr_block_rf_error_agg_error_fatal26_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_error_agg_error_fatal26_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
     fn read_intr_block_rf_error_agg_error_fatal27_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_error_agg_error_fatal27_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
     fn read_intr_block_rf_error_agg_error_fatal28_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_error_agg_error_fatal28_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
     fn read_intr_block_rf_error_agg_error_fatal29_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_error_agg_error_fatal29_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
     fn read_intr_block_rf_error_agg_error_fatal30_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_error_agg_error_fatal30_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
     fn read_intr_block_rf_error_agg_error_fatal31_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_error_agg_error_fatal31_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
-    fn read_intr_block_rf_notif_mcu_sram_ecc_cor_intr_count_r(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_intr_block_rf_notif_mcu_sram_ecc_cor_intr_count_r(&mut self) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_notif_mcu_sram_ecc_cor_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
     fn read_intr_block_rf_notif_clpra_mcu_reset_req_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_notif_clpra_mcu_reset_req_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
     fn read_intr_block_rf_notif_agg_error_non_fatal0_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_notif_agg_error_non_fatal0_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
     fn read_intr_block_rf_notif_agg_error_non_fatal1_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_notif_agg_error_non_fatal1_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
     fn read_intr_block_rf_notif_agg_error_non_fatal2_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_notif_agg_error_non_fatal2_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
     fn read_intr_block_rf_notif_agg_error_non_fatal3_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_notif_agg_error_non_fatal3_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
     fn read_intr_block_rf_notif_agg_error_non_fatal4_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_notif_agg_error_non_fatal4_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
     fn read_intr_block_rf_notif_agg_error_non_fatal5_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_notif_agg_error_non_fatal5_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
     fn read_intr_block_rf_notif_agg_error_non_fatal6_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_notif_agg_error_non_fatal6_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
     fn read_intr_block_rf_notif_agg_error_non_fatal7_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_notif_agg_error_non_fatal7_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
     fn read_intr_block_rf_notif_agg_error_non_fatal8_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_notif_agg_error_non_fatal8_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
     fn read_intr_block_rf_notif_agg_error_non_fatal9_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_notif_agg_error_non_fatal9_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
     fn read_intr_block_rf_notif_agg_error_non_fatal10_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_notif_agg_error_non_fatal10_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
     fn read_intr_block_rf_notif_agg_error_non_fatal11_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_notif_agg_error_non_fatal11_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
     fn read_intr_block_rf_notif_agg_error_non_fatal12_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_notif_agg_error_non_fatal12_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
     fn read_intr_block_rf_notif_agg_error_non_fatal13_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_notif_agg_error_non_fatal13_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
     fn read_intr_block_rf_notif_agg_error_non_fatal14_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_notif_agg_error_non_fatal14_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
     fn read_intr_block_rf_notif_agg_error_non_fatal15_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_notif_agg_error_non_fatal15_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
     fn read_intr_block_rf_notif_agg_error_non_fatal16_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_notif_agg_error_non_fatal16_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
     fn read_intr_block_rf_notif_agg_error_non_fatal17_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_notif_agg_error_non_fatal17_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
     fn read_intr_block_rf_notif_agg_error_non_fatal18_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_notif_agg_error_non_fatal18_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
     fn read_intr_block_rf_notif_agg_error_non_fatal19_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_notif_agg_error_non_fatal19_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
     fn read_intr_block_rf_notif_agg_error_non_fatal20_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_notif_agg_error_non_fatal20_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
     fn read_intr_block_rf_notif_agg_error_non_fatal21_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_notif_agg_error_non_fatal21_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
     fn read_intr_block_rf_notif_agg_error_non_fatal22_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_notif_agg_error_non_fatal22_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
     fn read_intr_block_rf_notif_agg_error_non_fatal23_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_notif_agg_error_non_fatal23_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
     fn read_intr_block_rf_notif_agg_error_non_fatal24_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_notif_agg_error_non_fatal24_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
     fn read_intr_block_rf_notif_agg_error_non_fatal25_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_notif_agg_error_non_fatal25_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
     fn read_intr_block_rf_notif_agg_error_non_fatal26_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_notif_agg_error_non_fatal26_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
     fn read_intr_block_rf_notif_agg_error_non_fatal27_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_notif_agg_error_non_fatal27_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
     fn read_intr_block_rf_notif_agg_error_non_fatal28_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_notif_agg_error_non_fatal28_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
     fn read_intr_block_rf_notif_agg_error_non_fatal29_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_notif_agg_error_non_fatal29_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
     fn read_intr_block_rf_notif_agg_error_non_fatal30_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_notif_agg_error_non_fatal30_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
     fn read_intr_block_rf_notif_agg_error_non_fatal31_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_notif_agg_error_non_fatal31_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
     fn read_intr_block_rf_error_wdt_timer1_timeout_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -1835,7 +1448,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_error_wdt_timer2_timeout_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -1844,7 +1456,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_error_agg_error_fatal0_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -1853,7 +1464,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_error_agg_error_fatal1_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -1862,7 +1472,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_error_agg_error_fatal2_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -1871,7 +1480,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_error_agg_error_fatal3_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -1880,7 +1488,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_error_agg_error_fatal4_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -1889,7 +1496,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_error_agg_error_fatal5_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -1898,7 +1504,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_error_agg_error_fatal6_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -1907,7 +1512,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_error_agg_error_fatal7_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -1916,7 +1520,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_error_agg_error_fatal8_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -1925,7 +1528,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_error_agg_error_fatal9_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -1934,7 +1536,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_error_agg_error_fatal10_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -1943,7 +1544,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_error_agg_error_fatal11_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -1952,7 +1552,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_error_agg_error_fatal12_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -1961,7 +1560,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_error_agg_error_fatal13_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -1970,7 +1568,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_error_agg_error_fatal14_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -1979,7 +1576,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_error_agg_error_fatal15_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -1988,7 +1584,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_error_agg_error_fatal16_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -1997,7 +1592,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_error_agg_error_fatal17_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -2006,7 +1600,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_error_agg_error_fatal18_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -2015,7 +1608,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_error_agg_error_fatal19_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -2024,7 +1616,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_error_agg_error_fatal20_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -2033,7 +1624,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_error_agg_error_fatal21_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -2042,7 +1632,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_error_agg_error_fatal22_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -2051,7 +1640,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_error_agg_error_fatal23_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -2060,7 +1648,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_error_agg_error_fatal24_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -2069,7 +1656,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_error_agg_error_fatal25_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -2078,7 +1664,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_error_agg_error_fatal26_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -2087,7 +1672,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_error_agg_error_fatal27_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -2096,7 +1680,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_error_agg_error_fatal28_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -2105,7 +1688,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_error_agg_error_fatal29_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -2114,7 +1696,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_error_agg_error_fatal30_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -2123,7 +1704,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_error_agg_error_fatal31_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -2132,7 +1712,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_notif_mcu_sram_ecc_cor_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -2141,7 +1720,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_notif_clpra_mcu_reset_req_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -2150,7 +1728,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_notif_agg_error_non_fatal0_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -2159,7 +1736,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_notif_agg_error_non_fatal1_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -2168,7 +1744,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_notif_agg_error_non_fatal2_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -2177,7 +1752,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_notif_agg_error_non_fatal3_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -2186,7 +1760,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_notif_agg_error_non_fatal4_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -2195,7 +1768,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_notif_agg_error_non_fatal5_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -2204,7 +1776,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_notif_agg_error_non_fatal6_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -2213,7 +1784,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_notif_agg_error_non_fatal7_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -2222,7 +1792,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_notif_agg_error_non_fatal8_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -2231,7 +1800,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_notif_agg_error_non_fatal9_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -2240,7 +1808,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_notif_agg_error_non_fatal10_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -2249,7 +1816,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_notif_agg_error_non_fatal11_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -2258,7 +1824,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_notif_agg_error_non_fatal12_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -2267,7 +1832,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_notif_agg_error_non_fatal13_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -2276,7 +1840,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_notif_agg_error_non_fatal14_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -2285,7 +1848,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_notif_agg_error_non_fatal15_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -2294,7 +1856,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_notif_agg_error_non_fatal16_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -2303,7 +1864,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_notif_agg_error_non_fatal17_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -2312,7 +1872,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_notif_agg_error_non_fatal18_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -2321,7 +1880,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_notif_agg_error_non_fatal19_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -2330,7 +1888,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_notif_agg_error_non_fatal20_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -2339,7 +1896,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_notif_agg_error_non_fatal21_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -2348,7 +1904,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_notif_agg_error_non_fatal22_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -2357,7 +1912,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_notif_agg_error_non_fatal23_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -2366,7 +1920,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_notif_agg_error_non_fatal24_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -2375,7 +1928,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_notif_agg_error_non_fatal25_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -2384,7 +1936,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_notif_agg_error_non_fatal26_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -2393,7 +1944,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_notif_agg_error_non_fatal27_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -2402,7 +1952,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_notif_agg_error_non_fatal28_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -2411,7 +1960,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_notif_agg_error_non_fatal29_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -2420,7 +1968,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_notif_agg_error_non_fatal30_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -2429,7 +1976,6 @@ pub trait MciPeripheral {
     }
     fn read_intr_block_rf_notif_agg_error_non_fatal31_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -2446,1513 +1992,832 @@ impl emulator_bus::Bus for MciBus {
         size: emulator_types::RvSize,
         addr: emulator_types::RvAddr,
     ) -> Result<emulator_types::RvData, emulator_bus::BusError> {
-        match (size, addr) {
-            (emulator_types::RvSize::Word, 0) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_capabilities(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+        if addr & 0x3 != 0 || size != emulator_types::RvSize::Word {
+            return Err(emulator_bus::BusError::LoadAddrMisaligned);
+        }
+        match addr {
+            0..4 => Ok(emulator_types::RvData::from(
+                self.periph.read_capabilities().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 1..=3) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 4) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_hw_rev_id(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            4..8 => Ok(emulator_types::RvData::from(
+                self.periph.read_hw_rev_id().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 5..=7) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (size, 8) => Ok(self.periph.read_fw_rev_id(size)),
-            (_, 9..=0xb) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x10) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_hw_config(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            8..0x10 => Ok(self.periph.read_fw_rev_id()),
+            0x10..0x14 => Ok(emulator_types::RvData::from(
+                self.periph.read_hw_config().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0x11..=0x13) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (size, 0x20) => Ok(self.periph.read_boot_status(size)),
-            (_, 0x21..=0x23) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x24) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_flow_status(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0x20..0x24 => Ok(self.periph.read_boot_status()),
+            0x24..0x28 => Ok(emulator_types::RvData::from(
+                self.periph.read_flow_status().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0x25..=0x27) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x28) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_reset_reason(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0x28..0x2c => Ok(emulator_types::RvData::from(
+                self.periph.read_reset_reason().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0x29..=0x2b) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x2c) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_reset_status(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0x2c..0x30 => Ok(emulator_types::RvData::from(
+                self.periph.read_reset_status().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0x2d..=0x2f) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x40) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_hw_error_fatal(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0x40..0x44 => Ok(emulator_types::RvData::from(
+                self.periph.read_hw_error_fatal().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0x41..=0x43) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x44) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_agg_error_fatal(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0x44..0x48 => Ok(emulator_types::RvData::from(
+                self.periph.read_agg_error_fatal().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0x45..=0x47) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x48) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_hw_error_non_fatal(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0x48..0x4c => Ok(emulator_types::RvData::from(
+                self.periph.read_hw_error_non_fatal().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0x49..=0x4b) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x4c) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_agg_error_non_fatal(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0x4c..0x50 => Ok(emulator_types::RvData::from(
+                self.periph.read_agg_error_non_fatal().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0x4d..=0x4f) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (size, 0x50) => Ok(self.periph.read_fw_error_fatal(size)),
-            (_, 0x51..=0x53) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x54) => Ok(self.periph.read_fw_error_non_fatal(size)),
-            (_, 0x55..=0x57) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x58) => Ok(self.periph.read_hw_error_enc(size)),
-            (_, 0x59..=0x5b) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x5c) => Ok(self.periph.read_fw_error_enc(size)),
-            (_, 0x5d..=0x5f) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x60) => Ok(self.periph.read_fw_extended_error_info(size)),
-            (_, 0x61..=0x63) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x80) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_internal_hw_error_fatal_mask(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0x50..0x54 => Ok(self.periph.read_fw_error_fatal()),
+            0x54..0x58 => Ok(self.periph.read_fw_error_non_fatal()),
+            0x58..0x5c => Ok(self.periph.read_hw_error_enc()),
+            0x5c..0x60 => Ok(self.periph.read_fw_error_enc()),
+            0x60..0x80 => Ok(self.periph.read_fw_extended_error_info()),
+            0x80..0x84 => Ok(emulator_types::RvData::from(
+                self.periph.read_internal_hw_error_fatal_mask().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0x81..=0x83) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x84) => Ok(emulator_types::RvData::from(
+            0x84..0x88 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_internal_hw_error_non_fatal_mask(emulator_types::RvSize::Word)
+                    .read_internal_hw_error_non_fatal_mask()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x85..=0x87) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x88) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_internal_agg_error_fatal_mask(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0x88..0x8c => Ok(emulator_types::RvData::from(
+                self.periph.read_internal_agg_error_fatal_mask().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0x89..=0x8b) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x8c) => Ok(emulator_types::RvData::from(
+            0x8c..0x90 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_internal_agg_error_non_fatal_mask(emulator_types::RvSize::Word)
+                    .read_internal_agg_error_non_fatal_mask()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x8d..=0x8f) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (size, 0x90) => Ok(self.periph.read_internal_fw_error_fatal_mask(size)),
-            (_, 0x91..=0x93) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x94) => Ok(self.periph.read_internal_fw_error_non_fatal_mask(size)),
-            (_, 0x95..=0x97) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (emulator_types::RvSize::Word, 0xa0) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_wdt_timer1_en(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0x90..0x94 => Ok(self.periph.read_internal_fw_error_fatal_mask()),
+            0x94..0x98 => Ok(self.periph.read_internal_fw_error_non_fatal_mask()),
+            0xa0..0xa4 => Ok(emulator_types::RvData::from(
+                self.periph.read_wdt_timer1_en().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0xa1..=0xa3) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xa4) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_wdt_timer1_ctrl(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0xa4..0xa8 => Ok(emulator_types::RvData::from(
+                self.periph.read_wdt_timer1_ctrl().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0xa5..=0xa7) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (size, 0xa8) => Ok(self.periph.read_wdt_timer1_timeout_period(size)),
-            (_, 0xa9..=0xab) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (emulator_types::RvSize::Word, 0xb0) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_wdt_timer2_en(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0xa8..0xb0 => Ok(self.periph.read_wdt_timer1_timeout_period()),
+            0xb0..0xb4 => Ok(emulator_types::RvData::from(
+                self.periph.read_wdt_timer2_en().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0xb1..=0xb3) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xb4) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_wdt_timer2_ctrl(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0xb4..0xb8 => Ok(emulator_types::RvData::from(
+                self.periph.read_wdt_timer2_ctrl().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0xb5..=0xb7) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (size, 0xb8) => Ok(self.periph.read_wdt_timer2_timeout_period(size)),
-            (_, 0xb9..=0xbb) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (emulator_types::RvSize::Word, 0xc0) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_wdt_status(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0xb8..0xc0 => Ok(self.periph.read_wdt_timer2_timeout_period()),
+            0xc0..0xc4 => Ok(emulator_types::RvData::from(
+                self.periph.read_wdt_status().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0xc1..=0xc3) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (size, 0xd0) => Ok(self.periph.read_wdt_cfg(size)),
-            (_, 0xd1..=0xd3) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0xe0) => Ok(self.periph.read_mcu_timer_config(size)),
-            (_, 0xe1..=0xe3) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0xe4) => Ok(self.periph.read_mcu_rv_mtime_l(size)),
-            (_, 0xe5..=0xe7) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0xe8) => Ok(self.periph.read_mcu_rv_mtime_h(size)),
-            (_, 0xe9..=0xeb) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0xec) => Ok(self.periph.read_mcu_rv_mtimecmp_l(size)),
-            (_, 0xed..=0xef) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0xf0) => Ok(self.periph.read_mcu_rv_mtimecmp_h(size)),
-            (_, 0xf1..=0xf3) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x100) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_reset_request(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0xd0..0xd8 => Ok(self.periph.read_wdt_cfg()),
+            0xe0..0xe4 => Ok(self.periph.read_mcu_timer_config()),
+            0xe4..0xe8 => Ok(self.periph.read_mcu_rv_mtime_l()),
+            0xe8..0xec => Ok(self.periph.read_mcu_rv_mtime_h()),
+            0xec..0xf0 => Ok(self.periph.read_mcu_rv_mtimecmp_l()),
+            0xf0..0xf4 => Ok(self.periph.read_mcu_rv_mtimecmp_h()),
+            0x100..0x104 => Ok(emulator_types::RvData::from(
+                self.periph.read_reset_request().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0x101..=0x103) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x104) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_caliptra_boot_go(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0x104..0x108 => Ok(emulator_types::RvData::from(
+                self.periph.read_caliptra_boot_go().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0x105..=0x107) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x108) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_fw_sram_exec_region_size(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0x108..0x10c => Ok(emulator_types::RvData::from(
+                self.periph.read_fw_sram_exec_region_size().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0x109..=0x10b) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (size, 0x10c) => Ok(self.periph.read_mcu_nmi_vector(size)),
-            (_, 0x10d..=0x10f) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x110) => Ok(self.periph.read_mcu_reset_vector(size)),
-            (_, 0x111..=0x113) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x180) => Ok(self.periph.read_mbox0_valid_axi_id(size)),
-            (_, 0x181..=0x183) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x1a0) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_mbox0_valid_axi_id_lock(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0x10c..0x110 => Ok(self.periph.read_mcu_nmi_vector()),
+            0x110..0x114 => Ok(self.periph.read_mcu_reset_vector()),
+            0x180..0x194 => Ok(self.periph.read_mbox0_valid_axi_id()),
+            0x1a0..0x1b4 => Ok(emulator_types::RvData::from(
+                self.periph.read_mbox0_valid_axi_id_lock().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0x1a1..=0x1a3) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (size, 0x1c0) => Ok(self.periph.read_mbox1_valid_axi_id(size)),
-            (_, 0x1c1..=0x1c3) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x1e0) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_mbox1_valid_axi_id_lock(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0x1c0..0x1d4 => Ok(self.periph.read_mbox1_valid_axi_id()),
+            0x1e0..0x1f4 => Ok(emulator_types::RvData::from(
+                self.periph.read_mbox1_valid_axi_id_lock().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0x1e1..=0x1e3) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (size, 0x400) => Ok(self.periph.read_generic_input_wires(size)),
-            (_, 0x401..=0x403) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x408) => Ok(self.periph.read_generic_output_wires(size)),
-            (_, 0x409..=0x40b) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x410) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_debug_in(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0x400..0x408 => Ok(self.periph.read_generic_input_wires()),
+            0x408..0x410 => Ok(self.periph.read_generic_output_wires()),
+            0x410..0x414 => Ok(emulator_types::RvData::from(
+                self.periph.read_debug_in().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0x411..=0x413) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x414) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_debug_out(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0x414..0x418 => Ok(emulator_types::RvData::from(
+                self.periph.read_debug_out().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0x415..=0x417) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x440) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_fuse_wr_done(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0x440..0x444 => Ok(emulator_types::RvData::from(
+                self.periph.read_fuse_wr_done().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0x441..=0x443) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (size, 0x480) => Ok(self.periph.read_prod_debug_unlock_pk_hash_reg(size)),
-            (_, 0x481..=0x483) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x800) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_sticky_data_vault_ctrl(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0x480..0x600 => Ok(self.periph.read_prod_debug_unlock_pk_hash_reg()),
+            0x800..0x828 => Ok(emulator_types::RvData::from(
+                self.periph.read_sticky_data_vault_ctrl().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0x801..=0x803) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x828) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_sticky_data_vault_entry(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0x828..0xa08 => Ok(emulator_types::RvData::from(
+                self.periph.read_sticky_data_vault_entry().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0x829..=0x82b) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xa08) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_data_vault_ctrl(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0xa08..0xa30 => Ok(emulator_types::RvData::from(
+                self.periph.read_data_vault_ctrl().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0xa09..=0xa0b) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xa30) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_data_vault_entry(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0xa30..0xc10 => Ok(emulator_types::RvData::from(
+                self.periph.read_data_vault_entry().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0xa31..=0xa33) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xc10) => Ok(emulator_types::RvData::from(
+            0xc10..0xc30 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_sticky_lockable_scratch_reg_ctrl(emulator_types::RvSize::Word)
+                    .read_sticky_lockable_scratch_reg_ctrl()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0xc11..=0xc13) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (size, 0xc30) => Ok(self.periph.read_sticky_lockable_scratch_reg(size)),
-            (_, 0xc31..=0xc33) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (emulator_types::RvSize::Word, 0xc50) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_lockable_scratch_reg_ctrl(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0xc30..0xc50 => Ok(self.periph.read_sticky_lockable_scratch_reg()),
+            0xc50..0xc78 => Ok(emulator_types::RvData::from(
+                self.periph.read_lockable_scratch_reg_ctrl().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0xc51..=0xc53) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (size, 0xc78) => Ok(self.periph.read_lockable_scratch_reg(size)),
-            (_, 0xc79..=0xc7b) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0xca0) => Ok(self.periph.read_non_sticky_generic_scratch_reg(size)),
-            (_, 0xca1..=0xca3) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x1000) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_intr_block_rf_global_intr_en_r(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0xc78..0xca0 => Ok(self.periph.read_lockable_scratch_reg()),
+            0xca0..0xcc0 => Ok(self.periph.read_non_sticky_generic_scratch_reg()),
+            0x1000..0x1004 => Ok(emulator_types::RvData::from(
+                self.periph.read_intr_block_rf_global_intr_en_r().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0x1001..=0x1003) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1004) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_intr_block_rf_error0_intr_en_r(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0x1004..0x1008 => Ok(emulator_types::RvData::from(
+                self.periph.read_intr_block_rf_error0_intr_en_r().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0x1005..=0x1007) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1008) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_intr_block_rf_error1_intr_en_r(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0x1008..0x100c => Ok(emulator_types::RvData::from(
+                self.periph.read_intr_block_rf_error1_intr_en_r().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0x1009..=0x100b) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x100c) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_intr_block_rf_notif0_intr_en_r(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0x100c..0x1010 => Ok(emulator_types::RvData::from(
+                self.periph.read_intr_block_rf_notif0_intr_en_r().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0x100d..=0x100f) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1010) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_intr_block_rf_notif1_intr_en_r(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0x1010..0x1014 => Ok(emulator_types::RvData::from(
+                self.periph.read_intr_block_rf_notif1_intr_en_r().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0x1011..=0x1013) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1014) => Ok(emulator_types::RvData::from(
+            0x1014..0x1018 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_error_global_intr_r(emulator_types::RvSize::Word)
+                    .read_intr_block_rf_error_global_intr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x1015..=0x1017) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1018) => Ok(emulator_types::RvData::from(
+            0x1018..0x101c => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_notif_global_intr_r(emulator_types::RvSize::Word)
+                    .read_intr_block_rf_notif_global_intr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x1019..=0x101b) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x101c) => Ok(emulator_types::RvData::from(
+            0x101c..0x1020 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_error0_internal_intr_r(emulator_types::RvSize::Word)
+                    .read_intr_block_rf_error0_internal_intr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x101d..=0x101f) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1020) => Ok(emulator_types::RvData::from(
+            0x1020..0x1024 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_error1_internal_intr_r(emulator_types::RvSize::Word)
+                    .read_intr_block_rf_error1_internal_intr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x1021..=0x1023) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1024) => Ok(emulator_types::RvData::from(
+            0x1024..0x1028 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_notif0_internal_intr_r(emulator_types::RvSize::Word)
+                    .read_intr_block_rf_notif0_internal_intr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x1025..=0x1027) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1028) => Ok(emulator_types::RvData::from(
+            0x1028..0x102c => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_notif1_internal_intr_r(emulator_types::RvSize::Word)
+                    .read_intr_block_rf_notif1_internal_intr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x1029..=0x102b) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x102c) => Ok(emulator_types::RvData::from(
+            0x102c..0x1030 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_error0_intr_trig_r(emulator_types::RvSize::Word)
+                    .read_intr_block_rf_error0_intr_trig_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x102d..=0x102f) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1030) => Ok(emulator_types::RvData::from(
+            0x1030..0x1034 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_error1_intr_trig_r(emulator_types::RvSize::Word)
+                    .read_intr_block_rf_error1_intr_trig_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x1031..=0x1033) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1034) => Ok(emulator_types::RvData::from(
+            0x1034..0x1038 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_notif0_intr_trig_r(emulator_types::RvSize::Word)
+                    .read_intr_block_rf_notif0_intr_trig_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x1035..=0x1037) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1038) => Ok(emulator_types::RvData::from(
+            0x1038..0x103c => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_notif1_intr_trig_r(emulator_types::RvSize::Word)
+                    .read_intr_block_rf_notif1_intr_trig_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x1039..=0x103b) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (size, 0x1100) => Ok(self
+            0x1100..0x1104 => Ok(self
                 .periph
-                .read_intr_block_rf_error_wdt_timer1_timeout_intr_count_r(size)),
-            (_, 0x1101..=0x1103) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x1104) => Ok(self
+                .read_intr_block_rf_error_wdt_timer1_timeout_intr_count_r()),
+            0x1104..0x1108 => Ok(self
                 .periph
-                .read_intr_block_rf_error_wdt_timer2_timeout_intr_count_r(size)),
-            (_, 0x1105..=0x1107) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x1108) => Ok(self
+                .read_intr_block_rf_error_wdt_timer2_timeout_intr_count_r()),
+            0x1108..0x110c => Ok(self
                 .periph
-                .read_intr_block_rf_error_agg_error_fatal0_intr_count_r(size)),
-            (_, 0x1109..=0x110b) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x110c) => Ok(self
+                .read_intr_block_rf_error_agg_error_fatal0_intr_count_r()),
+            0x110c..0x1110 => Ok(self
                 .periph
-                .read_intr_block_rf_error_agg_error_fatal1_intr_count_r(size)),
-            (_, 0x110d..=0x110f) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x1110) => Ok(self
+                .read_intr_block_rf_error_agg_error_fatal1_intr_count_r()),
+            0x1110..0x1114 => Ok(self
                 .periph
-                .read_intr_block_rf_error_agg_error_fatal2_intr_count_r(size)),
-            (_, 0x1111..=0x1113) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x1114) => Ok(self
+                .read_intr_block_rf_error_agg_error_fatal2_intr_count_r()),
+            0x1114..0x1118 => Ok(self
                 .periph
-                .read_intr_block_rf_error_agg_error_fatal3_intr_count_r(size)),
-            (_, 0x1115..=0x1117) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x1118) => Ok(self
+                .read_intr_block_rf_error_agg_error_fatal3_intr_count_r()),
+            0x1118..0x111c => Ok(self
                 .periph
-                .read_intr_block_rf_error_agg_error_fatal4_intr_count_r(size)),
-            (_, 0x1119..=0x111b) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x111c) => Ok(self
+                .read_intr_block_rf_error_agg_error_fatal4_intr_count_r()),
+            0x111c..0x1120 => Ok(self
                 .periph
-                .read_intr_block_rf_error_agg_error_fatal5_intr_count_r(size)),
-            (_, 0x111d..=0x111f) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x1120) => Ok(self
+                .read_intr_block_rf_error_agg_error_fatal5_intr_count_r()),
+            0x1120..0x1124 => Ok(self
                 .periph
-                .read_intr_block_rf_error_agg_error_fatal6_intr_count_r(size)),
-            (_, 0x1121..=0x1123) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x1124) => Ok(self
+                .read_intr_block_rf_error_agg_error_fatal6_intr_count_r()),
+            0x1124..0x1128 => Ok(self
                 .periph
-                .read_intr_block_rf_error_agg_error_fatal7_intr_count_r(size)),
-            (_, 0x1125..=0x1127) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x1128) => Ok(self
+                .read_intr_block_rf_error_agg_error_fatal7_intr_count_r()),
+            0x1128..0x112c => Ok(self
                 .periph
-                .read_intr_block_rf_error_agg_error_fatal8_intr_count_r(size)),
-            (_, 0x1129..=0x112b) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x112c) => Ok(self
+                .read_intr_block_rf_error_agg_error_fatal8_intr_count_r()),
+            0x112c..0x1130 => Ok(self
                 .periph
-                .read_intr_block_rf_error_agg_error_fatal9_intr_count_r(size)),
-            (_, 0x112d..=0x112f) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x1130) => Ok(self
+                .read_intr_block_rf_error_agg_error_fatal9_intr_count_r()),
+            0x1130..0x1134 => Ok(self
                 .periph
-                .read_intr_block_rf_error_agg_error_fatal10_intr_count_r(size)),
-            (_, 0x1131..=0x1133) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x1134) => Ok(self
+                .read_intr_block_rf_error_agg_error_fatal10_intr_count_r()),
+            0x1134..0x1138 => Ok(self
                 .periph
-                .read_intr_block_rf_error_agg_error_fatal11_intr_count_r(size)),
-            (_, 0x1135..=0x1137) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x1138) => Ok(self
+                .read_intr_block_rf_error_agg_error_fatal11_intr_count_r()),
+            0x1138..0x113c => Ok(self
                 .periph
-                .read_intr_block_rf_error_agg_error_fatal12_intr_count_r(size)),
-            (_, 0x1139..=0x113b) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x113c) => Ok(self
+                .read_intr_block_rf_error_agg_error_fatal12_intr_count_r()),
+            0x113c..0x1140 => Ok(self
                 .periph
-                .read_intr_block_rf_error_agg_error_fatal13_intr_count_r(size)),
-            (_, 0x113d..=0x113f) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x1140) => Ok(self
+                .read_intr_block_rf_error_agg_error_fatal13_intr_count_r()),
+            0x1140..0x1144 => Ok(self
                 .periph
-                .read_intr_block_rf_error_agg_error_fatal14_intr_count_r(size)),
-            (_, 0x1141..=0x1143) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x1144) => Ok(self
+                .read_intr_block_rf_error_agg_error_fatal14_intr_count_r()),
+            0x1144..0x1148 => Ok(self
                 .periph
-                .read_intr_block_rf_error_agg_error_fatal15_intr_count_r(size)),
-            (_, 0x1145..=0x1147) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x1148) => Ok(self
+                .read_intr_block_rf_error_agg_error_fatal15_intr_count_r()),
+            0x1148..0x114c => Ok(self
                 .periph
-                .read_intr_block_rf_error_agg_error_fatal16_intr_count_r(size)),
-            (_, 0x1149..=0x114b) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x114c) => Ok(self
+                .read_intr_block_rf_error_agg_error_fatal16_intr_count_r()),
+            0x114c..0x1150 => Ok(self
                 .periph
-                .read_intr_block_rf_error_agg_error_fatal17_intr_count_r(size)),
-            (_, 0x114d..=0x114f) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x1150) => Ok(self
+                .read_intr_block_rf_error_agg_error_fatal17_intr_count_r()),
+            0x1150..0x1154 => Ok(self
                 .periph
-                .read_intr_block_rf_error_agg_error_fatal18_intr_count_r(size)),
-            (_, 0x1151..=0x1153) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x1154) => Ok(self
+                .read_intr_block_rf_error_agg_error_fatal18_intr_count_r()),
+            0x1154..0x1158 => Ok(self
                 .periph
-                .read_intr_block_rf_error_agg_error_fatal19_intr_count_r(size)),
-            (_, 0x1155..=0x1157) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x1158) => Ok(self
+                .read_intr_block_rf_error_agg_error_fatal19_intr_count_r()),
+            0x1158..0x115c => Ok(self
                 .periph
-                .read_intr_block_rf_error_agg_error_fatal20_intr_count_r(size)),
-            (_, 0x1159..=0x115b) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x115c) => Ok(self
+                .read_intr_block_rf_error_agg_error_fatal20_intr_count_r()),
+            0x115c..0x1160 => Ok(self
                 .periph
-                .read_intr_block_rf_error_agg_error_fatal21_intr_count_r(size)),
-            (_, 0x115d..=0x115f) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x1160) => Ok(self
+                .read_intr_block_rf_error_agg_error_fatal21_intr_count_r()),
+            0x1160..0x1164 => Ok(self
                 .periph
-                .read_intr_block_rf_error_agg_error_fatal22_intr_count_r(size)),
-            (_, 0x1161..=0x1163) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x1164) => Ok(self
+                .read_intr_block_rf_error_agg_error_fatal22_intr_count_r()),
+            0x1164..0x1168 => Ok(self
                 .periph
-                .read_intr_block_rf_error_agg_error_fatal23_intr_count_r(size)),
-            (_, 0x1165..=0x1167) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x1168) => Ok(self
+                .read_intr_block_rf_error_agg_error_fatal23_intr_count_r()),
+            0x1168..0x116c => Ok(self
                 .periph
-                .read_intr_block_rf_error_agg_error_fatal24_intr_count_r(size)),
-            (_, 0x1169..=0x116b) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x116c) => Ok(self
+                .read_intr_block_rf_error_agg_error_fatal24_intr_count_r()),
+            0x116c..0x1170 => Ok(self
                 .periph
-                .read_intr_block_rf_error_agg_error_fatal25_intr_count_r(size)),
-            (_, 0x116d..=0x116f) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x1170) => Ok(self
+                .read_intr_block_rf_error_agg_error_fatal25_intr_count_r()),
+            0x1170..0x1174 => Ok(self
                 .periph
-                .read_intr_block_rf_error_agg_error_fatal26_intr_count_r(size)),
-            (_, 0x1171..=0x1173) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x1174) => Ok(self
+                .read_intr_block_rf_error_agg_error_fatal26_intr_count_r()),
+            0x1174..0x1178 => Ok(self
                 .periph
-                .read_intr_block_rf_error_agg_error_fatal27_intr_count_r(size)),
-            (_, 0x1175..=0x1177) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x1178) => Ok(self
+                .read_intr_block_rf_error_agg_error_fatal27_intr_count_r()),
+            0x1178..0x117c => Ok(self
                 .periph
-                .read_intr_block_rf_error_agg_error_fatal28_intr_count_r(size)),
-            (_, 0x1179..=0x117b) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x117c) => Ok(self
+                .read_intr_block_rf_error_agg_error_fatal28_intr_count_r()),
+            0x117c..0x1180 => Ok(self
                 .periph
-                .read_intr_block_rf_error_agg_error_fatal29_intr_count_r(size)),
-            (_, 0x117d..=0x117f) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x1180) => Ok(self
+                .read_intr_block_rf_error_agg_error_fatal29_intr_count_r()),
+            0x1180..0x1184 => Ok(self
                 .periph
-                .read_intr_block_rf_error_agg_error_fatal30_intr_count_r(size)),
-            (_, 0x1181..=0x1183) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x1184) => Ok(self
+                .read_intr_block_rf_error_agg_error_fatal30_intr_count_r()),
+            0x1184..0x1188 => Ok(self
                 .periph
-                .read_intr_block_rf_error_agg_error_fatal31_intr_count_r(size)),
-            (_, 0x1185..=0x1187) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x1200) => Ok(self
+                .read_intr_block_rf_error_agg_error_fatal31_intr_count_r()),
+            0x1200..0x1204 => Ok(self
                 .periph
-                .read_intr_block_rf_notif_mcu_sram_ecc_cor_intr_count_r(size)),
-            (_, 0x1201..=0x1203) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x1204) => Ok(self
+                .read_intr_block_rf_notif_mcu_sram_ecc_cor_intr_count_r()),
+            0x1204..0x1208 => Ok(self
                 .periph
-                .read_intr_block_rf_notif_clpra_mcu_reset_req_intr_count_r(size)),
-            (_, 0x1205..=0x1207) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x1208) => Ok(self
+                .read_intr_block_rf_notif_clpra_mcu_reset_req_intr_count_r()),
+            0x1208..0x120c => Ok(self
                 .periph
-                .read_intr_block_rf_notif_agg_error_non_fatal0_intr_count_r(size)),
-            (_, 0x1209..=0x120b) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x120c) => Ok(self
+                .read_intr_block_rf_notif_agg_error_non_fatal0_intr_count_r()),
+            0x120c..0x1210 => Ok(self
                 .periph
-                .read_intr_block_rf_notif_agg_error_non_fatal1_intr_count_r(size)),
-            (_, 0x120d..=0x120f) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x1210) => Ok(self
+                .read_intr_block_rf_notif_agg_error_non_fatal1_intr_count_r()),
+            0x1210..0x1214 => Ok(self
                 .periph
-                .read_intr_block_rf_notif_agg_error_non_fatal2_intr_count_r(size)),
-            (_, 0x1211..=0x1213) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x1214) => Ok(self
+                .read_intr_block_rf_notif_agg_error_non_fatal2_intr_count_r()),
+            0x1214..0x1218 => Ok(self
                 .periph
-                .read_intr_block_rf_notif_agg_error_non_fatal3_intr_count_r(size)),
-            (_, 0x1215..=0x1217) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x1218) => Ok(self
+                .read_intr_block_rf_notif_agg_error_non_fatal3_intr_count_r()),
+            0x1218..0x121c => Ok(self
                 .periph
-                .read_intr_block_rf_notif_agg_error_non_fatal4_intr_count_r(size)),
-            (_, 0x1219..=0x121b) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x121c) => Ok(self
+                .read_intr_block_rf_notif_agg_error_non_fatal4_intr_count_r()),
+            0x121c..0x1220 => Ok(self
                 .periph
-                .read_intr_block_rf_notif_agg_error_non_fatal5_intr_count_r(size)),
-            (_, 0x121d..=0x121f) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x1220) => Ok(self
+                .read_intr_block_rf_notif_agg_error_non_fatal5_intr_count_r()),
+            0x1220..0x1224 => Ok(self
                 .periph
-                .read_intr_block_rf_notif_agg_error_non_fatal6_intr_count_r(size)),
-            (_, 0x1221..=0x1223) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x1224) => Ok(self
+                .read_intr_block_rf_notif_agg_error_non_fatal6_intr_count_r()),
+            0x1224..0x1228 => Ok(self
                 .periph
-                .read_intr_block_rf_notif_agg_error_non_fatal7_intr_count_r(size)),
-            (_, 0x1225..=0x1227) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x1228) => Ok(self
+                .read_intr_block_rf_notif_agg_error_non_fatal7_intr_count_r()),
+            0x1228..0x122c => Ok(self
                 .periph
-                .read_intr_block_rf_notif_agg_error_non_fatal8_intr_count_r(size)),
-            (_, 0x1229..=0x122b) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x122c) => Ok(self
+                .read_intr_block_rf_notif_agg_error_non_fatal8_intr_count_r()),
+            0x122c..0x1230 => Ok(self
                 .periph
-                .read_intr_block_rf_notif_agg_error_non_fatal9_intr_count_r(size)),
-            (_, 0x122d..=0x122f) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x1230) => Ok(self
+                .read_intr_block_rf_notif_agg_error_non_fatal9_intr_count_r()),
+            0x1230..0x1234 => Ok(self
                 .periph
-                .read_intr_block_rf_notif_agg_error_non_fatal10_intr_count_r(size)),
-            (_, 0x1231..=0x1233) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x1234) => Ok(self
+                .read_intr_block_rf_notif_agg_error_non_fatal10_intr_count_r()),
+            0x1234..0x1238 => Ok(self
                 .periph
-                .read_intr_block_rf_notif_agg_error_non_fatal11_intr_count_r(size)),
-            (_, 0x1235..=0x1237) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x1238) => Ok(self
+                .read_intr_block_rf_notif_agg_error_non_fatal11_intr_count_r()),
+            0x1238..0x123c => Ok(self
                 .periph
-                .read_intr_block_rf_notif_agg_error_non_fatal12_intr_count_r(size)),
-            (_, 0x1239..=0x123b) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x123c) => Ok(self
+                .read_intr_block_rf_notif_agg_error_non_fatal12_intr_count_r()),
+            0x123c..0x1240 => Ok(self
                 .periph
-                .read_intr_block_rf_notif_agg_error_non_fatal13_intr_count_r(size)),
-            (_, 0x123d..=0x123f) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x1240) => Ok(self
+                .read_intr_block_rf_notif_agg_error_non_fatal13_intr_count_r()),
+            0x1240..0x1244 => Ok(self
                 .periph
-                .read_intr_block_rf_notif_agg_error_non_fatal14_intr_count_r(size)),
-            (_, 0x1241..=0x1243) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x1244) => Ok(self
+                .read_intr_block_rf_notif_agg_error_non_fatal14_intr_count_r()),
+            0x1244..0x1248 => Ok(self
                 .periph
-                .read_intr_block_rf_notif_agg_error_non_fatal15_intr_count_r(size)),
-            (_, 0x1245..=0x1247) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x1248) => Ok(self
+                .read_intr_block_rf_notif_agg_error_non_fatal15_intr_count_r()),
+            0x1248..0x124c => Ok(self
                 .periph
-                .read_intr_block_rf_notif_agg_error_non_fatal16_intr_count_r(size)),
-            (_, 0x1249..=0x124b) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x124c) => Ok(self
+                .read_intr_block_rf_notif_agg_error_non_fatal16_intr_count_r()),
+            0x124c..0x1250 => Ok(self
                 .periph
-                .read_intr_block_rf_notif_agg_error_non_fatal17_intr_count_r(size)),
-            (_, 0x124d..=0x124f) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x1250) => Ok(self
+                .read_intr_block_rf_notif_agg_error_non_fatal17_intr_count_r()),
+            0x1250..0x1254 => Ok(self
                 .periph
-                .read_intr_block_rf_notif_agg_error_non_fatal18_intr_count_r(size)),
-            (_, 0x1251..=0x1253) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x1254) => Ok(self
+                .read_intr_block_rf_notif_agg_error_non_fatal18_intr_count_r()),
+            0x1254..0x1258 => Ok(self
                 .periph
-                .read_intr_block_rf_notif_agg_error_non_fatal19_intr_count_r(size)),
-            (_, 0x1255..=0x1257) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x1258) => Ok(self
+                .read_intr_block_rf_notif_agg_error_non_fatal19_intr_count_r()),
+            0x1258..0x125c => Ok(self
                 .periph
-                .read_intr_block_rf_notif_agg_error_non_fatal20_intr_count_r(size)),
-            (_, 0x1259..=0x125b) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x125c) => Ok(self
+                .read_intr_block_rf_notif_agg_error_non_fatal20_intr_count_r()),
+            0x125c..0x1260 => Ok(self
                 .periph
-                .read_intr_block_rf_notif_agg_error_non_fatal21_intr_count_r(size)),
-            (_, 0x125d..=0x125f) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x1260) => Ok(self
+                .read_intr_block_rf_notif_agg_error_non_fatal21_intr_count_r()),
+            0x1260..0x1264 => Ok(self
                 .periph
-                .read_intr_block_rf_notif_agg_error_non_fatal22_intr_count_r(size)),
-            (_, 0x1261..=0x1263) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x1264) => Ok(self
+                .read_intr_block_rf_notif_agg_error_non_fatal22_intr_count_r()),
+            0x1264..0x1268 => Ok(self
                 .periph
-                .read_intr_block_rf_notif_agg_error_non_fatal23_intr_count_r(size)),
-            (_, 0x1265..=0x1267) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x1268) => Ok(self
+                .read_intr_block_rf_notif_agg_error_non_fatal23_intr_count_r()),
+            0x1268..0x126c => Ok(self
                 .periph
-                .read_intr_block_rf_notif_agg_error_non_fatal24_intr_count_r(size)),
-            (_, 0x1269..=0x126b) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x126c) => Ok(self
+                .read_intr_block_rf_notif_agg_error_non_fatal24_intr_count_r()),
+            0x126c..0x1270 => Ok(self
                 .periph
-                .read_intr_block_rf_notif_agg_error_non_fatal25_intr_count_r(size)),
-            (_, 0x126d..=0x126f) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x1270) => Ok(self
+                .read_intr_block_rf_notif_agg_error_non_fatal25_intr_count_r()),
+            0x1270..0x1274 => Ok(self
                 .periph
-                .read_intr_block_rf_notif_agg_error_non_fatal26_intr_count_r(size)),
-            (_, 0x1271..=0x1273) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x1274) => Ok(self
+                .read_intr_block_rf_notif_agg_error_non_fatal26_intr_count_r()),
+            0x1274..0x1278 => Ok(self
                 .periph
-                .read_intr_block_rf_notif_agg_error_non_fatal27_intr_count_r(size)),
-            (_, 0x1275..=0x1277) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x1278) => Ok(self
+                .read_intr_block_rf_notif_agg_error_non_fatal27_intr_count_r()),
+            0x1278..0x127c => Ok(self
                 .periph
-                .read_intr_block_rf_notif_agg_error_non_fatal28_intr_count_r(size)),
-            (_, 0x1279..=0x127b) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x127c) => Ok(self
+                .read_intr_block_rf_notif_agg_error_non_fatal28_intr_count_r()),
+            0x127c..0x1280 => Ok(self
                 .periph
-                .read_intr_block_rf_notif_agg_error_non_fatal29_intr_count_r(size)),
-            (_, 0x127d..=0x127f) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x1280) => Ok(self
+                .read_intr_block_rf_notif_agg_error_non_fatal29_intr_count_r()),
+            0x1280..0x1284 => Ok(self
                 .periph
-                .read_intr_block_rf_notif_agg_error_non_fatal30_intr_count_r(size)),
-            (_, 0x1281..=0x1283) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x1284) => Ok(self
+                .read_intr_block_rf_notif_agg_error_non_fatal30_intr_count_r()),
+            0x1284..0x1288 => Ok(self
                 .periph
-                .read_intr_block_rf_notif_agg_error_non_fatal31_intr_count_r(size)),
-            (_, 0x1285..=0x1287) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x1300) => Ok(emulator_types::RvData::from(
+                .read_intr_block_rf_notif_agg_error_non_fatal31_intr_count_r()),
+            0x1300..0x1304 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_error_wdt_timer1_timeout_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_error_wdt_timer1_timeout_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x1301..=0x1303) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1304) => Ok(emulator_types::RvData::from(
+            0x1304..0x1308 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_error_wdt_timer2_timeout_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_error_wdt_timer2_timeout_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x1305..=0x1307) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1308) => Ok(emulator_types::RvData::from(
+            0x1308..0x130c => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_error_agg_error_fatal0_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_error_agg_error_fatal0_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x1309..=0x130b) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x130c) => Ok(emulator_types::RvData::from(
+            0x130c..0x1310 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_error_agg_error_fatal1_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_error_agg_error_fatal1_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x130d..=0x130f) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1310) => Ok(emulator_types::RvData::from(
+            0x1310..0x1314 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_error_agg_error_fatal2_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_error_agg_error_fatal2_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x1311..=0x1313) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1314) => Ok(emulator_types::RvData::from(
+            0x1314..0x1318 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_error_agg_error_fatal3_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_error_agg_error_fatal3_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x1315..=0x1317) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1318) => Ok(emulator_types::RvData::from(
+            0x1318..0x131c => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_error_agg_error_fatal4_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_error_agg_error_fatal4_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x1319..=0x131b) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x131c) => Ok(emulator_types::RvData::from(
+            0x131c..0x1320 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_error_agg_error_fatal5_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_error_agg_error_fatal5_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x131d..=0x131f) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1320) => Ok(emulator_types::RvData::from(
+            0x1320..0x1324 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_error_agg_error_fatal6_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_error_agg_error_fatal6_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x1321..=0x1323) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1324) => Ok(emulator_types::RvData::from(
+            0x1324..0x1328 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_error_agg_error_fatal7_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_error_agg_error_fatal7_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x1325..=0x1327) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1328) => Ok(emulator_types::RvData::from(
+            0x1328..0x132c => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_error_agg_error_fatal8_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_error_agg_error_fatal8_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x1329..=0x132b) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x132c) => Ok(emulator_types::RvData::from(
+            0x132c..0x1330 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_error_agg_error_fatal9_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_error_agg_error_fatal9_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x132d..=0x132f) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1330) => Ok(emulator_types::RvData::from(
+            0x1330..0x1334 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_error_agg_error_fatal10_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_error_agg_error_fatal10_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x1331..=0x1333) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1334) => Ok(emulator_types::RvData::from(
+            0x1334..0x1338 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_error_agg_error_fatal11_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_error_agg_error_fatal11_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x1335..=0x1337) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1338) => Ok(emulator_types::RvData::from(
+            0x1338..0x133c => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_error_agg_error_fatal12_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_error_agg_error_fatal12_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x1339..=0x133b) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x133c) => Ok(emulator_types::RvData::from(
+            0x133c..0x1340 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_error_agg_error_fatal13_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_error_agg_error_fatal13_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x133d..=0x133f) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1340) => Ok(emulator_types::RvData::from(
+            0x1340..0x1344 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_error_agg_error_fatal14_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_error_agg_error_fatal14_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x1341..=0x1343) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1344) => Ok(emulator_types::RvData::from(
+            0x1344..0x1348 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_error_agg_error_fatal15_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_error_agg_error_fatal15_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x1345..=0x1347) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1348) => Ok(emulator_types::RvData::from(
+            0x1348..0x134c => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_error_agg_error_fatal16_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_error_agg_error_fatal16_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x1349..=0x134b) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x134c) => Ok(emulator_types::RvData::from(
+            0x134c..0x1350 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_error_agg_error_fatal17_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_error_agg_error_fatal17_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x134d..=0x134f) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1350) => Ok(emulator_types::RvData::from(
+            0x1350..0x1354 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_error_agg_error_fatal18_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_error_agg_error_fatal18_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x1351..=0x1353) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1354) => Ok(emulator_types::RvData::from(
+            0x1354..0x1358 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_error_agg_error_fatal19_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_error_agg_error_fatal19_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x1355..=0x1357) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1358) => Ok(emulator_types::RvData::from(
+            0x1358..0x135c => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_error_agg_error_fatal20_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_error_agg_error_fatal20_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x1359..=0x135b) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x135c) => Ok(emulator_types::RvData::from(
+            0x135c..0x1360 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_error_agg_error_fatal21_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_error_agg_error_fatal21_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x135d..=0x135f) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1360) => Ok(emulator_types::RvData::from(
+            0x1360..0x1364 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_error_agg_error_fatal22_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_error_agg_error_fatal22_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x1361..=0x1363) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1364) => Ok(emulator_types::RvData::from(
+            0x1364..0x1368 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_error_agg_error_fatal23_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_error_agg_error_fatal23_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x1365..=0x1367) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1368) => Ok(emulator_types::RvData::from(
+            0x1368..0x136c => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_error_agg_error_fatal24_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_error_agg_error_fatal24_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x1369..=0x136b) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x136c) => Ok(emulator_types::RvData::from(
+            0x136c..0x1370 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_error_agg_error_fatal25_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_error_agg_error_fatal25_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x136d..=0x136f) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1370) => Ok(emulator_types::RvData::from(
+            0x1370..0x1374 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_error_agg_error_fatal26_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_error_agg_error_fatal26_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x1371..=0x1373) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1374) => Ok(emulator_types::RvData::from(
+            0x1374..0x1378 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_error_agg_error_fatal27_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_error_agg_error_fatal27_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x1375..=0x1377) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1378) => Ok(emulator_types::RvData::from(
+            0x1378..0x137c => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_error_agg_error_fatal28_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_error_agg_error_fatal28_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x1379..=0x137b) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x137c) => Ok(emulator_types::RvData::from(
+            0x137c..0x1380 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_error_agg_error_fatal29_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_error_agg_error_fatal29_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x137d..=0x137f) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1380) => Ok(emulator_types::RvData::from(
+            0x1380..0x1384 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_error_agg_error_fatal30_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_error_agg_error_fatal30_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x1381..=0x1383) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1384) => Ok(emulator_types::RvData::from(
+            0x1384..0x1388 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_error_agg_error_fatal31_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_error_agg_error_fatal31_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x1385..=0x1387) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1388) => Ok(emulator_types::RvData::from(
+            0x1388..0x138c => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_notif_mcu_sram_ecc_cor_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_notif_mcu_sram_ecc_cor_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x1389..=0x138b) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x138c) => Ok(emulator_types::RvData::from(
+            0x138c..0x1390 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_notif_clpra_mcu_reset_req_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_notif_clpra_mcu_reset_req_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x138d..=0x138f) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1390) => Ok(emulator_types::RvData::from(
+            0x1390..0x1394 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_notif_agg_error_non_fatal0_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_notif_agg_error_non_fatal0_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x1391..=0x1393) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1394) => Ok(emulator_types::RvData::from(
+            0x1394..0x1398 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_notif_agg_error_non_fatal1_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_notif_agg_error_non_fatal1_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x1395..=0x1397) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1398) => Ok(emulator_types::RvData::from(
+            0x1398..0x139c => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_notif_agg_error_non_fatal2_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_notif_agg_error_non_fatal2_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x1399..=0x139b) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x139c) => Ok(emulator_types::RvData::from(
+            0x139c..0x13a0 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_notif_agg_error_non_fatal3_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_notif_agg_error_non_fatal3_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x139d..=0x139f) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x13a0) => Ok(emulator_types::RvData::from(
+            0x13a0..0x13a4 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_notif_agg_error_non_fatal4_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_notif_agg_error_non_fatal4_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x13a1..=0x13a3) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x13a4) => Ok(emulator_types::RvData::from(
+            0x13a4..0x13a8 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_notif_agg_error_non_fatal5_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_notif_agg_error_non_fatal5_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x13a5..=0x13a7) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x13a8) => Ok(emulator_types::RvData::from(
+            0x13a8..0x13ac => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_notif_agg_error_non_fatal6_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_notif_agg_error_non_fatal6_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x13a9..=0x13ab) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x13ac) => Ok(emulator_types::RvData::from(
+            0x13ac..0x13b0 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_notif_agg_error_non_fatal7_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_notif_agg_error_non_fatal7_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x13ad..=0x13af) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x13b0) => Ok(emulator_types::RvData::from(
+            0x13b0..0x13b4 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_notif_agg_error_non_fatal8_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_notif_agg_error_non_fatal8_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x13b1..=0x13b3) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x13b4) => Ok(emulator_types::RvData::from(
+            0x13b4..0x13b8 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_notif_agg_error_non_fatal9_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_notif_agg_error_non_fatal9_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x13b5..=0x13b7) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x13b8) => Ok(emulator_types::RvData::from(
+            0x13b8..0x13bc => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_notif_agg_error_non_fatal10_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_notif_agg_error_non_fatal10_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x13b9..=0x13bb) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x13bc) => Ok(emulator_types::RvData::from(
+            0x13bc..0x13c0 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_notif_agg_error_non_fatal11_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_notif_agg_error_non_fatal11_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x13bd..=0x13bf) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x13c0) => Ok(emulator_types::RvData::from(
+            0x13c0..0x13c4 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_notif_agg_error_non_fatal12_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_notif_agg_error_non_fatal12_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x13c1..=0x13c3) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x13c4) => Ok(emulator_types::RvData::from(
+            0x13c4..0x13c8 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_notif_agg_error_non_fatal13_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_notif_agg_error_non_fatal13_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x13c5..=0x13c7) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x13c8) => Ok(emulator_types::RvData::from(
+            0x13c8..0x13cc => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_notif_agg_error_non_fatal14_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_notif_agg_error_non_fatal14_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x13c9..=0x13cb) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x13cc) => Ok(emulator_types::RvData::from(
+            0x13cc..0x13d0 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_notif_agg_error_non_fatal15_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_notif_agg_error_non_fatal15_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x13cd..=0x13cf) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x13d0) => Ok(emulator_types::RvData::from(
+            0x13d0..0x13d4 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_notif_agg_error_non_fatal16_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_notif_agg_error_non_fatal16_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x13d1..=0x13d3) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x13d4) => Ok(emulator_types::RvData::from(
+            0x13d4..0x13d8 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_notif_agg_error_non_fatal17_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_notif_agg_error_non_fatal17_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x13d5..=0x13d7) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x13d8) => Ok(emulator_types::RvData::from(
+            0x13d8..0x13dc => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_notif_agg_error_non_fatal18_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_notif_agg_error_non_fatal18_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x13d9..=0x13db) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x13dc) => Ok(emulator_types::RvData::from(
+            0x13dc..0x13e0 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_notif_agg_error_non_fatal19_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_notif_agg_error_non_fatal19_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x13dd..=0x13df) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x13e0) => Ok(emulator_types::RvData::from(
+            0x13e0..0x13e4 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_notif_agg_error_non_fatal20_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_notif_agg_error_non_fatal20_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x13e1..=0x13e3) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x13e4) => Ok(emulator_types::RvData::from(
+            0x13e4..0x13e8 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_notif_agg_error_non_fatal21_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_notif_agg_error_non_fatal21_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x13e5..=0x13e7) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x13e8) => Ok(emulator_types::RvData::from(
+            0x13e8..0x13ec => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_notif_agg_error_non_fatal22_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_notif_agg_error_non_fatal22_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x13e9..=0x13eb) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x13ec) => Ok(emulator_types::RvData::from(
+            0x13ec..0x13f0 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_notif_agg_error_non_fatal23_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_notif_agg_error_non_fatal23_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x13ed..=0x13ef) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x13f0) => Ok(emulator_types::RvData::from(
+            0x13f0..0x13f4 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_notif_agg_error_non_fatal24_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_notif_agg_error_non_fatal24_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x13f1..=0x13f3) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x13f4) => Ok(emulator_types::RvData::from(
+            0x13f4..0x13f8 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_notif_agg_error_non_fatal25_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_notif_agg_error_non_fatal25_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x13f5..=0x13f7) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x13f8) => Ok(emulator_types::RvData::from(
+            0x13f8..0x13fc => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_notif_agg_error_non_fatal26_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_notif_agg_error_non_fatal26_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x13f9..=0x13fb) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x13fc) => Ok(emulator_types::RvData::from(
+            0x13fc..0x1400 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_notif_agg_error_non_fatal27_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_notif_agg_error_non_fatal27_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x13fd..=0x13ff) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1400) => Ok(emulator_types::RvData::from(
+            0x1400..0x1404 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_notif_agg_error_non_fatal28_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_notif_agg_error_non_fatal28_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x1401..=0x1403) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1404) => Ok(emulator_types::RvData::from(
+            0x1404..0x1408 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_notif_agg_error_non_fatal29_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_notif_agg_error_non_fatal29_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x1405..=0x1407) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1408) => Ok(emulator_types::RvData::from(
+            0x1408..0x140c => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_notif_agg_error_non_fatal30_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_notif_agg_error_non_fatal30_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x1409..=0x140b) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x140c) => Ok(emulator_types::RvData::from(
+            0x140c..0x1410 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_notif_agg_error_non_fatal31_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_notif_agg_error_non_fatal31_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x140d..=0x140f) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
             _ => Err(emulator_bus::BusError::LoadAccessFault),
         }
     }
@@ -3962,966 +2827,680 @@ impl emulator_bus::Bus for MciBus {
         addr: emulator_types::RvAddr,
         val: emulator_types::RvData,
     ) -> Result<(), emulator_bus::BusError> {
-        match (size, addr) {
-            (size, 8) => {
-                self.periph.write_fw_rev_id(size, val);
+        if addr & 0x3 != 0 || size != emulator_types::RvSize::Word {
+            return Err(emulator_bus::BusError::StoreAddrMisaligned);
+        }
+        match addr {
+            8..0x10 => {
+                self.periph.write_fw_rev_id(val);
                 Ok(())
             }
-            (_, 9..=0xb) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x20) => {
-                self.periph.write_boot_status(size, val);
+            0x20..0x24 => {
+                self.periph.write_boot_status(val);
                 Ok(())
             }
-            (_, 0x21..=0x23) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x24) => {
-                self.periph.write_flow_status(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
+            0x24..0x28 => {
+                self.periph
+                    .write_flow_status(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x25..=0x27) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x2c) => {
-                self.periph.write_reset_status(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
+            0x2c..0x30 => {
+                self.periph
+                    .write_reset_status(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x2d..=0x2f) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x40) => {
-                self.periph.write_hw_error_fatal(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
+            0x40..0x44 => {
+                self.periph
+                    .write_hw_error_fatal(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x41..=0x43) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x44) => {
-                self.periph.write_agg_error_fatal(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
+            0x44..0x48 => {
+                self.periph
+                    .write_agg_error_fatal(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x45..=0x47) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x48) => {
-                self.periph.write_hw_error_non_fatal(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
+            0x48..0x4c => {
+                self.periph
+                    .write_hw_error_non_fatal(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x49..=0x4b) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x4c) => {
-                self.periph.write_agg_error_non_fatal(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
+            0x4c..0x50 => {
+                self.periph
+                    .write_agg_error_non_fatal(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x4d..=0x4f) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (size, 0x50) => {
-                self.periph.write_fw_error_fatal(size, val);
+            0x50..0x54 => {
+                self.periph.write_fw_error_fatal(val);
                 Ok(())
             }
-            (_, 0x51..=0x53) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x54) => {
-                self.periph.write_fw_error_non_fatal(size, val);
+            0x54..0x58 => {
+                self.periph.write_fw_error_non_fatal(val);
                 Ok(())
             }
-            (_, 0x55..=0x57) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x58) => {
-                self.periph.write_hw_error_enc(size, val);
+            0x58..0x5c => {
+                self.periph.write_hw_error_enc(val);
                 Ok(())
             }
-            (_, 0x59..=0x5b) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x5c) => {
-                self.periph.write_fw_error_enc(size, val);
+            0x5c..0x60 => {
+                self.periph.write_fw_error_enc(val);
                 Ok(())
             }
-            (_, 0x5d..=0x5f) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x60) => {
-                self.periph.write_fw_extended_error_info(size, val);
+            0x60..0x80 => {
+                self.periph.write_fw_extended_error_info(val);
                 Ok(())
             }
-            (_, 0x61..=0x63) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x80) => {
-                self.periph.write_internal_hw_error_fatal_mask(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
+            0x80..0x84 => {
+                self.periph
+                    .write_internal_hw_error_fatal_mask(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x81..=0x83) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x84) => {
+            0x84..0x88 => {
                 self.periph.write_internal_hw_error_non_fatal_mask(
-                    emulator_types::RvSize::Word,
                     emulator_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x85..=0x87) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x88) => {
-                self.periph.write_internal_agg_error_fatal_mask(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
+            0x88..0x8c => {
+                self.periph
+                    .write_internal_agg_error_fatal_mask(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x89..=0x8b) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x8c) => {
+            0x8c..0x90 => {
                 self.periph.write_internal_agg_error_non_fatal_mask(
-                    emulator_types::RvSize::Word,
                     emulator_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x8d..=0x8f) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (size, 0x90) => {
-                self.periph.write_internal_fw_error_fatal_mask(size, val);
+            0x90..0x94 => {
+                self.periph.write_internal_fw_error_fatal_mask(val);
                 Ok(())
             }
-            (_, 0x91..=0x93) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x94) => {
+            0x94..0x98 => {
+                self.periph.write_internal_fw_error_non_fatal_mask(val);
+                Ok(())
+            }
+            0xa0..0xa4 => {
                 self.periph
-                    .write_internal_fw_error_non_fatal_mask(size, val);
+                    .write_wdt_timer1_en(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (_, 0x95..=0x97) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (emulator_types::RvSize::Word, 0xa0) => {
-                self.periph.write_wdt_timer1_en(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
+            0xa4..0xa8 => {
+                self.periph
+                    .write_wdt_timer1_ctrl(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0xa1..=0xa3) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xa4) => {
-                self.periph.write_wdt_timer1_ctrl(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
+            0xa8..0xb0 => {
+                self.periph.write_wdt_timer1_timeout_period(val);
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0xa5..=0xa7) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (size, 0xa8) => {
-                self.periph.write_wdt_timer1_timeout_period(size, val);
+            0xb0..0xb4 => {
+                self.periph
+                    .write_wdt_timer2_en(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (_, 0xa9..=0xab) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (emulator_types::RvSize::Word, 0xb0) => {
-                self.periph.write_wdt_timer2_en(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
+            0xb4..0xb8 => {
+                self.periph
+                    .write_wdt_timer2_ctrl(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0xb1..=0xb3) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xb4) => {
-                self.periph.write_wdt_timer2_ctrl(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
+            0xb8..0xc0 => {
+                self.periph.write_wdt_timer2_timeout_period(val);
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0xb5..=0xb7) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (size, 0xb8) => {
-                self.periph.write_wdt_timer2_timeout_period(size, val);
+            0xc0..0xc4 => {
+                self.periph
+                    .write_wdt_status(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (_, 0xb9..=0xbb) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (emulator_types::RvSize::Word, 0xc0) => {
-                self.periph.write_wdt_status(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
+            0xd0..0xd8 => {
+                self.periph.write_wdt_cfg(val);
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0xc1..=0xc3) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (size, 0xd0) => {
-                self.periph.write_wdt_cfg(size, val);
+            0xe0..0xe4 => {
+                self.periph.write_mcu_timer_config(val);
                 Ok(())
             }
-            (_, 0xd1..=0xd3) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0xe0) => {
-                self.periph.write_mcu_timer_config(size, val);
+            0xe4..0xe8 => {
+                self.periph.write_mcu_rv_mtime_l(val);
                 Ok(())
             }
-            (_, 0xe1..=0xe3) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0xe4) => {
-                self.periph.write_mcu_rv_mtime_l(size, val);
+            0xe8..0xec => {
+                self.periph.write_mcu_rv_mtime_h(val);
                 Ok(())
             }
-            (_, 0xe5..=0xe7) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0xe8) => {
-                self.periph.write_mcu_rv_mtime_h(size, val);
+            0xec..0xf0 => {
+                self.periph.write_mcu_rv_mtimecmp_l(val);
                 Ok(())
             }
-            (_, 0xe9..=0xeb) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0xec) => {
-                self.periph.write_mcu_rv_mtimecmp_l(size, val);
+            0xf0..0xf4 => {
+                self.periph.write_mcu_rv_mtimecmp_h(val);
                 Ok(())
             }
-            (_, 0xed..=0xef) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0xf0) => {
-                self.periph.write_mcu_rv_mtimecmp_h(size, val);
+            0x100..0x104 => {
+                self.periph
+                    .write_reset_request(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (_, 0xf1..=0xf3) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x100) => {
-                self.periph.write_reset_request(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
+            0x104..0x108 => {
+                self.periph
+                    .write_caliptra_boot_go(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x101..=0x103) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x104) => {
-                self.periph.write_caliptra_boot_go(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
+            0x108..0x10c => {
+                self.periph
+                    .write_fw_sram_exec_region_size(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x105..=0x107) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x108) => {
-                self.periph.write_fw_sram_exec_region_size(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
+            0x10c..0x110 => {
+                self.periph.write_mcu_nmi_vector(val);
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x109..=0x10b) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (size, 0x10c) => {
-                self.periph.write_mcu_nmi_vector(size, val);
+            0x110..0x114 => {
+                self.periph.write_mcu_reset_vector(val);
                 Ok(())
             }
-            (_, 0x10d..=0x10f) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x110) => {
-                self.periph.write_mcu_reset_vector(size, val);
+            0x180..0x194 => {
+                self.periph.write_mbox0_valid_axi_id(val);
                 Ok(())
             }
-            (_, 0x111..=0x113) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x180) => {
-                self.periph.write_mbox0_valid_axi_id(size, val);
+            0x1a0..0x1b4 => {
+                self.periph
+                    .write_mbox0_valid_axi_id_lock(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (_, 0x181..=0x183) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x1a0) => {
-                self.periph.write_mbox0_valid_axi_id_lock(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
+            0x1c0..0x1d4 => {
+                self.periph.write_mbox1_valid_axi_id(val);
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x1a1..=0x1a3) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (size, 0x1c0) => {
-                self.periph.write_mbox1_valid_axi_id(size, val);
+            0x1e0..0x1f4 => {
+                self.periph
+                    .write_mbox1_valid_axi_id_lock(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (_, 0x1c1..=0x1c3) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x1e0) => {
-                self.periph.write_mbox1_valid_axi_id_lock(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
+            0x408..0x410 => {
+                self.periph.write_generic_output_wires(val);
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x1e1..=0x1e3) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (size, 0x408) => {
-                self.periph.write_generic_output_wires(size, val);
+            0x410..0x414 => {
+                self.periph
+                    .write_debug_in(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (_, 0x409..=0x40b) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x410) => {
-                self.periph.write_debug_in(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
+            0x414..0x418 => {
+                self.periph
+                    .write_debug_out(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x411..=0x413) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x414) => {
-                self.periph.write_debug_out(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
+            0x440..0x444 => {
+                self.periph
+                    .write_fuse_wr_done(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x415..=0x417) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x440) => {
-                self.periph.write_fuse_wr_done(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
+            0x480..0x600 => {
+                self.periph.write_prod_debug_unlock_pk_hash_reg(val);
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x441..=0x443) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (size, 0x480) => {
-                self.periph.write_prod_debug_unlock_pk_hash_reg(size, val);
+            0x800..0x828 => {
+                self.periph
+                    .write_sticky_data_vault_ctrl(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (_, 0x481..=0x483) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x800) => {
-                self.periph.write_sticky_data_vault_ctrl(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
+            0x828..0xa08 => {
+                self.periph
+                    .write_sticky_data_vault_entry(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x801..=0x803) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x828) => {
-                self.periph.write_sticky_data_vault_entry(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
+            0xa08..0xa30 => {
+                self.periph
+                    .write_data_vault_ctrl(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x829..=0x82b) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xa08) => {
-                self.periph.write_data_vault_ctrl(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
+            0xa30..0xc10 => {
+                self.periph
+                    .write_data_vault_entry(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0xa09..=0xa0b) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xa30) => {
-                self.periph.write_data_vault_entry(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0xa31..=0xa33) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xc10) => {
+            0xc10..0xc30 => {
                 self.periph.write_sticky_lockable_scratch_reg_ctrl(
-                    emulator_types::RvSize::Word,
                     emulator_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0xc11..=0xc13) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (size, 0xc30) => {
-                self.periph.write_sticky_lockable_scratch_reg(size, val);
+            0xc30..0xc50 => {
+                self.periph.write_sticky_lockable_scratch_reg(val);
                 Ok(())
             }
-            (_, 0xc31..=0xc33) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (emulator_types::RvSize::Word, 0xc50) => {
-                self.periph.write_lockable_scratch_reg_ctrl(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
+            0xc50..0xc78 => {
+                self.periph
+                    .write_lockable_scratch_reg_ctrl(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0xc51..=0xc53) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (size, 0xc78) => {
-                self.periph.write_lockable_scratch_reg(size, val);
+            0xc78..0xca0 => {
+                self.periph.write_lockable_scratch_reg(val);
                 Ok(())
             }
-            (_, 0xc79..=0xc7b) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0xca0) => {
-                self.periph.write_non_sticky_generic_scratch_reg(size, val);
+            0xca0..0xcc0 => {
+                self.periph.write_non_sticky_generic_scratch_reg(val);
                 Ok(())
             }
-            (_, 0xca1..=0xca3) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x1000) => {
+            0x1000..0x1004 => {
                 self.periph.write_intr_block_rf_global_intr_en_r(
-                    emulator_types::RvSize::Word,
                     emulator_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x1001..=0x1003) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1004) => {
+            0x1004..0x1008 => {
                 self.periph.write_intr_block_rf_error0_intr_en_r(
-                    emulator_types::RvSize::Word,
                     emulator_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x1005..=0x1007) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1008) => {
+            0x1008..0x100c => {
                 self.periph.write_intr_block_rf_error1_intr_en_r(
-                    emulator_types::RvSize::Word,
                     emulator_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x1009..=0x100b) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x100c) => {
+            0x100c..0x1010 => {
                 self.periph.write_intr_block_rf_notif0_intr_en_r(
-                    emulator_types::RvSize::Word,
                     emulator_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x100d..=0x100f) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1010) => {
+            0x1010..0x1014 => {
                 self.periph.write_intr_block_rf_notif1_intr_en_r(
-                    emulator_types::RvSize::Word,
                     emulator_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x1011..=0x1013) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x101c) => {
+            0x101c..0x1020 => {
                 self.periph.write_intr_block_rf_error0_internal_intr_r(
-                    emulator_types::RvSize::Word,
                     emulator_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x101d..=0x101f) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1020) => {
+            0x1020..0x1024 => {
                 self.periph.write_intr_block_rf_error1_internal_intr_r(
-                    emulator_types::RvSize::Word,
                     emulator_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x1021..=0x1023) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1024) => {
+            0x1024..0x1028 => {
                 self.periph.write_intr_block_rf_notif0_internal_intr_r(
-                    emulator_types::RvSize::Word,
                     emulator_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x1025..=0x1027) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1028) => {
+            0x1028..0x102c => {
                 self.periph.write_intr_block_rf_notif1_internal_intr_r(
-                    emulator_types::RvSize::Word,
                     emulator_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x1029..=0x102b) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x102c) => {
+            0x102c..0x1030 => {
                 self.periph.write_intr_block_rf_error0_intr_trig_r(
-                    emulator_types::RvSize::Word,
                     emulator_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x102d..=0x102f) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1030) => {
+            0x1030..0x1034 => {
                 self.periph.write_intr_block_rf_error1_intr_trig_r(
-                    emulator_types::RvSize::Word,
                     emulator_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x1031..=0x1033) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1034) => {
+            0x1034..0x1038 => {
                 self.periph.write_intr_block_rf_notif0_intr_trig_r(
-                    emulator_types::RvSize::Word,
                     emulator_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x1035..=0x1037) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1038) => {
+            0x1038..0x103c => {
                 self.periph.write_intr_block_rf_notif1_intr_trig_r(
-                    emulator_types::RvSize::Word,
                     emulator_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x1039..=0x103b) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (size, 0x1100) => {
+            0x1100..0x1104 => {
                 self.periph
-                    .write_intr_block_rf_error_wdt_timer1_timeout_intr_count_r(size, val);
+                    .write_intr_block_rf_error_wdt_timer1_timeout_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x1101..=0x1103) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x1104) => {
+            0x1104..0x1108 => {
                 self.periph
-                    .write_intr_block_rf_error_wdt_timer2_timeout_intr_count_r(size, val);
+                    .write_intr_block_rf_error_wdt_timer2_timeout_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x1105..=0x1107) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x1108) => {
+            0x1108..0x110c => {
                 self.periph
-                    .write_intr_block_rf_error_agg_error_fatal0_intr_count_r(size, val);
+                    .write_intr_block_rf_error_agg_error_fatal0_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x1109..=0x110b) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x110c) => {
+            0x110c..0x1110 => {
                 self.periph
-                    .write_intr_block_rf_error_agg_error_fatal1_intr_count_r(size, val);
+                    .write_intr_block_rf_error_agg_error_fatal1_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x110d..=0x110f) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x1110) => {
+            0x1110..0x1114 => {
                 self.periph
-                    .write_intr_block_rf_error_agg_error_fatal2_intr_count_r(size, val);
+                    .write_intr_block_rf_error_agg_error_fatal2_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x1111..=0x1113) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x1114) => {
+            0x1114..0x1118 => {
                 self.periph
-                    .write_intr_block_rf_error_agg_error_fatal3_intr_count_r(size, val);
+                    .write_intr_block_rf_error_agg_error_fatal3_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x1115..=0x1117) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x1118) => {
+            0x1118..0x111c => {
                 self.periph
-                    .write_intr_block_rf_error_agg_error_fatal4_intr_count_r(size, val);
+                    .write_intr_block_rf_error_agg_error_fatal4_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x1119..=0x111b) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x111c) => {
+            0x111c..0x1120 => {
                 self.periph
-                    .write_intr_block_rf_error_agg_error_fatal5_intr_count_r(size, val);
+                    .write_intr_block_rf_error_agg_error_fatal5_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x111d..=0x111f) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x1120) => {
+            0x1120..0x1124 => {
                 self.periph
-                    .write_intr_block_rf_error_agg_error_fatal6_intr_count_r(size, val);
+                    .write_intr_block_rf_error_agg_error_fatal6_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x1121..=0x1123) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x1124) => {
+            0x1124..0x1128 => {
                 self.periph
-                    .write_intr_block_rf_error_agg_error_fatal7_intr_count_r(size, val);
+                    .write_intr_block_rf_error_agg_error_fatal7_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x1125..=0x1127) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x1128) => {
+            0x1128..0x112c => {
                 self.periph
-                    .write_intr_block_rf_error_agg_error_fatal8_intr_count_r(size, val);
+                    .write_intr_block_rf_error_agg_error_fatal8_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x1129..=0x112b) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x112c) => {
+            0x112c..0x1130 => {
                 self.periph
-                    .write_intr_block_rf_error_agg_error_fatal9_intr_count_r(size, val);
+                    .write_intr_block_rf_error_agg_error_fatal9_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x112d..=0x112f) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x1130) => {
+            0x1130..0x1134 => {
                 self.periph
-                    .write_intr_block_rf_error_agg_error_fatal10_intr_count_r(size, val);
+                    .write_intr_block_rf_error_agg_error_fatal10_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x1131..=0x1133) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x1134) => {
+            0x1134..0x1138 => {
                 self.periph
-                    .write_intr_block_rf_error_agg_error_fatal11_intr_count_r(size, val);
+                    .write_intr_block_rf_error_agg_error_fatal11_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x1135..=0x1137) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x1138) => {
+            0x1138..0x113c => {
                 self.periph
-                    .write_intr_block_rf_error_agg_error_fatal12_intr_count_r(size, val);
+                    .write_intr_block_rf_error_agg_error_fatal12_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x1139..=0x113b) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x113c) => {
+            0x113c..0x1140 => {
                 self.periph
-                    .write_intr_block_rf_error_agg_error_fatal13_intr_count_r(size, val);
+                    .write_intr_block_rf_error_agg_error_fatal13_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x113d..=0x113f) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x1140) => {
+            0x1140..0x1144 => {
                 self.periph
-                    .write_intr_block_rf_error_agg_error_fatal14_intr_count_r(size, val);
+                    .write_intr_block_rf_error_agg_error_fatal14_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x1141..=0x1143) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x1144) => {
+            0x1144..0x1148 => {
                 self.periph
-                    .write_intr_block_rf_error_agg_error_fatal15_intr_count_r(size, val);
+                    .write_intr_block_rf_error_agg_error_fatal15_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x1145..=0x1147) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x1148) => {
+            0x1148..0x114c => {
                 self.periph
-                    .write_intr_block_rf_error_agg_error_fatal16_intr_count_r(size, val);
+                    .write_intr_block_rf_error_agg_error_fatal16_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x1149..=0x114b) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x114c) => {
+            0x114c..0x1150 => {
                 self.periph
-                    .write_intr_block_rf_error_agg_error_fatal17_intr_count_r(size, val);
+                    .write_intr_block_rf_error_agg_error_fatal17_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x114d..=0x114f) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x1150) => {
+            0x1150..0x1154 => {
                 self.periph
-                    .write_intr_block_rf_error_agg_error_fatal18_intr_count_r(size, val);
+                    .write_intr_block_rf_error_agg_error_fatal18_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x1151..=0x1153) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x1154) => {
+            0x1154..0x1158 => {
                 self.periph
-                    .write_intr_block_rf_error_agg_error_fatal19_intr_count_r(size, val);
+                    .write_intr_block_rf_error_agg_error_fatal19_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x1155..=0x1157) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x1158) => {
+            0x1158..0x115c => {
                 self.periph
-                    .write_intr_block_rf_error_agg_error_fatal20_intr_count_r(size, val);
+                    .write_intr_block_rf_error_agg_error_fatal20_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x1159..=0x115b) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x115c) => {
+            0x115c..0x1160 => {
                 self.periph
-                    .write_intr_block_rf_error_agg_error_fatal21_intr_count_r(size, val);
+                    .write_intr_block_rf_error_agg_error_fatal21_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x115d..=0x115f) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x1160) => {
+            0x1160..0x1164 => {
                 self.periph
-                    .write_intr_block_rf_error_agg_error_fatal22_intr_count_r(size, val);
+                    .write_intr_block_rf_error_agg_error_fatal22_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x1161..=0x1163) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x1164) => {
+            0x1164..0x1168 => {
                 self.periph
-                    .write_intr_block_rf_error_agg_error_fatal23_intr_count_r(size, val);
+                    .write_intr_block_rf_error_agg_error_fatal23_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x1165..=0x1167) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x1168) => {
+            0x1168..0x116c => {
                 self.periph
-                    .write_intr_block_rf_error_agg_error_fatal24_intr_count_r(size, val);
+                    .write_intr_block_rf_error_agg_error_fatal24_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x1169..=0x116b) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x116c) => {
+            0x116c..0x1170 => {
                 self.periph
-                    .write_intr_block_rf_error_agg_error_fatal25_intr_count_r(size, val);
+                    .write_intr_block_rf_error_agg_error_fatal25_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x116d..=0x116f) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x1170) => {
+            0x1170..0x1174 => {
                 self.periph
-                    .write_intr_block_rf_error_agg_error_fatal26_intr_count_r(size, val);
+                    .write_intr_block_rf_error_agg_error_fatal26_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x1171..=0x1173) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x1174) => {
+            0x1174..0x1178 => {
                 self.periph
-                    .write_intr_block_rf_error_agg_error_fatal27_intr_count_r(size, val);
+                    .write_intr_block_rf_error_agg_error_fatal27_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x1175..=0x1177) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x1178) => {
+            0x1178..0x117c => {
                 self.periph
-                    .write_intr_block_rf_error_agg_error_fatal28_intr_count_r(size, val);
+                    .write_intr_block_rf_error_agg_error_fatal28_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x1179..=0x117b) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x117c) => {
+            0x117c..0x1180 => {
                 self.periph
-                    .write_intr_block_rf_error_agg_error_fatal29_intr_count_r(size, val);
+                    .write_intr_block_rf_error_agg_error_fatal29_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x117d..=0x117f) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x1180) => {
+            0x1180..0x1184 => {
                 self.periph
-                    .write_intr_block_rf_error_agg_error_fatal30_intr_count_r(size, val);
+                    .write_intr_block_rf_error_agg_error_fatal30_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x1181..=0x1183) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x1184) => {
+            0x1184..0x1188 => {
                 self.periph
-                    .write_intr_block_rf_error_agg_error_fatal31_intr_count_r(size, val);
+                    .write_intr_block_rf_error_agg_error_fatal31_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x1185..=0x1187) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x1200) => {
+            0x1200..0x1204 => {
                 self.periph
-                    .write_intr_block_rf_notif_mcu_sram_ecc_cor_intr_count_r(size, val);
+                    .write_intr_block_rf_notif_mcu_sram_ecc_cor_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x1201..=0x1203) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x1204) => {
+            0x1204..0x1208 => {
                 self.periph
-                    .write_intr_block_rf_notif_clpra_mcu_reset_req_intr_count_r(size, val);
+                    .write_intr_block_rf_notif_clpra_mcu_reset_req_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x1205..=0x1207) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x1208) => {
+            0x1208..0x120c => {
                 self.periph
-                    .write_intr_block_rf_notif_agg_error_non_fatal0_intr_count_r(size, val);
+                    .write_intr_block_rf_notif_agg_error_non_fatal0_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x1209..=0x120b) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x120c) => {
+            0x120c..0x1210 => {
                 self.periph
-                    .write_intr_block_rf_notif_agg_error_non_fatal1_intr_count_r(size, val);
+                    .write_intr_block_rf_notif_agg_error_non_fatal1_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x120d..=0x120f) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x1210) => {
+            0x1210..0x1214 => {
                 self.periph
-                    .write_intr_block_rf_notif_agg_error_non_fatal2_intr_count_r(size, val);
+                    .write_intr_block_rf_notif_agg_error_non_fatal2_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x1211..=0x1213) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x1214) => {
+            0x1214..0x1218 => {
                 self.periph
-                    .write_intr_block_rf_notif_agg_error_non_fatal3_intr_count_r(size, val);
+                    .write_intr_block_rf_notif_agg_error_non_fatal3_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x1215..=0x1217) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x1218) => {
+            0x1218..0x121c => {
                 self.periph
-                    .write_intr_block_rf_notif_agg_error_non_fatal4_intr_count_r(size, val);
+                    .write_intr_block_rf_notif_agg_error_non_fatal4_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x1219..=0x121b) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x121c) => {
+            0x121c..0x1220 => {
                 self.periph
-                    .write_intr_block_rf_notif_agg_error_non_fatal5_intr_count_r(size, val);
+                    .write_intr_block_rf_notif_agg_error_non_fatal5_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x121d..=0x121f) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x1220) => {
+            0x1220..0x1224 => {
                 self.periph
-                    .write_intr_block_rf_notif_agg_error_non_fatal6_intr_count_r(size, val);
+                    .write_intr_block_rf_notif_agg_error_non_fatal6_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x1221..=0x1223) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x1224) => {
+            0x1224..0x1228 => {
                 self.periph
-                    .write_intr_block_rf_notif_agg_error_non_fatal7_intr_count_r(size, val);
+                    .write_intr_block_rf_notif_agg_error_non_fatal7_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x1225..=0x1227) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x1228) => {
+            0x1228..0x122c => {
                 self.periph
-                    .write_intr_block_rf_notif_agg_error_non_fatal8_intr_count_r(size, val);
+                    .write_intr_block_rf_notif_agg_error_non_fatal8_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x1229..=0x122b) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x122c) => {
+            0x122c..0x1230 => {
                 self.periph
-                    .write_intr_block_rf_notif_agg_error_non_fatal9_intr_count_r(size, val);
+                    .write_intr_block_rf_notif_agg_error_non_fatal9_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x122d..=0x122f) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x1230) => {
+            0x1230..0x1234 => {
                 self.periph
-                    .write_intr_block_rf_notif_agg_error_non_fatal10_intr_count_r(size, val);
+                    .write_intr_block_rf_notif_agg_error_non_fatal10_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x1231..=0x1233) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x1234) => {
+            0x1234..0x1238 => {
                 self.periph
-                    .write_intr_block_rf_notif_agg_error_non_fatal11_intr_count_r(size, val);
+                    .write_intr_block_rf_notif_agg_error_non_fatal11_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x1235..=0x1237) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x1238) => {
+            0x1238..0x123c => {
                 self.periph
-                    .write_intr_block_rf_notif_agg_error_non_fatal12_intr_count_r(size, val);
+                    .write_intr_block_rf_notif_agg_error_non_fatal12_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x1239..=0x123b) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x123c) => {
+            0x123c..0x1240 => {
                 self.periph
-                    .write_intr_block_rf_notif_agg_error_non_fatal13_intr_count_r(size, val);
+                    .write_intr_block_rf_notif_agg_error_non_fatal13_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x123d..=0x123f) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x1240) => {
+            0x1240..0x1244 => {
                 self.periph
-                    .write_intr_block_rf_notif_agg_error_non_fatal14_intr_count_r(size, val);
+                    .write_intr_block_rf_notif_agg_error_non_fatal14_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x1241..=0x1243) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x1244) => {
+            0x1244..0x1248 => {
                 self.periph
-                    .write_intr_block_rf_notif_agg_error_non_fatal15_intr_count_r(size, val);
+                    .write_intr_block_rf_notif_agg_error_non_fatal15_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x1245..=0x1247) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x1248) => {
+            0x1248..0x124c => {
                 self.periph
-                    .write_intr_block_rf_notif_agg_error_non_fatal16_intr_count_r(size, val);
+                    .write_intr_block_rf_notif_agg_error_non_fatal16_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x1249..=0x124b) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x124c) => {
+            0x124c..0x1250 => {
                 self.periph
-                    .write_intr_block_rf_notif_agg_error_non_fatal17_intr_count_r(size, val);
+                    .write_intr_block_rf_notif_agg_error_non_fatal17_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x124d..=0x124f) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x1250) => {
+            0x1250..0x1254 => {
                 self.periph
-                    .write_intr_block_rf_notif_agg_error_non_fatal18_intr_count_r(size, val);
+                    .write_intr_block_rf_notif_agg_error_non_fatal18_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x1251..=0x1253) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x1254) => {
+            0x1254..0x1258 => {
                 self.periph
-                    .write_intr_block_rf_notif_agg_error_non_fatal19_intr_count_r(size, val);
+                    .write_intr_block_rf_notif_agg_error_non_fatal19_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x1255..=0x1257) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x1258) => {
+            0x1258..0x125c => {
                 self.periph
-                    .write_intr_block_rf_notif_agg_error_non_fatal20_intr_count_r(size, val);
+                    .write_intr_block_rf_notif_agg_error_non_fatal20_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x1259..=0x125b) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x125c) => {
+            0x125c..0x1260 => {
                 self.periph
-                    .write_intr_block_rf_notif_agg_error_non_fatal21_intr_count_r(size, val);
+                    .write_intr_block_rf_notif_agg_error_non_fatal21_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x125d..=0x125f) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x1260) => {
+            0x1260..0x1264 => {
                 self.periph
-                    .write_intr_block_rf_notif_agg_error_non_fatal22_intr_count_r(size, val);
+                    .write_intr_block_rf_notif_agg_error_non_fatal22_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x1261..=0x1263) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x1264) => {
+            0x1264..0x1268 => {
                 self.periph
-                    .write_intr_block_rf_notif_agg_error_non_fatal23_intr_count_r(size, val);
+                    .write_intr_block_rf_notif_agg_error_non_fatal23_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x1265..=0x1267) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x1268) => {
+            0x1268..0x126c => {
                 self.periph
-                    .write_intr_block_rf_notif_agg_error_non_fatal24_intr_count_r(size, val);
+                    .write_intr_block_rf_notif_agg_error_non_fatal24_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x1269..=0x126b) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x126c) => {
+            0x126c..0x1270 => {
                 self.periph
-                    .write_intr_block_rf_notif_agg_error_non_fatal25_intr_count_r(size, val);
+                    .write_intr_block_rf_notif_agg_error_non_fatal25_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x126d..=0x126f) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x1270) => {
+            0x1270..0x1274 => {
                 self.periph
-                    .write_intr_block_rf_notif_agg_error_non_fatal26_intr_count_r(size, val);
+                    .write_intr_block_rf_notif_agg_error_non_fatal26_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x1271..=0x1273) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x1274) => {
+            0x1274..0x1278 => {
                 self.periph
-                    .write_intr_block_rf_notif_agg_error_non_fatal27_intr_count_r(size, val);
+                    .write_intr_block_rf_notif_agg_error_non_fatal27_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x1275..=0x1277) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x1278) => {
+            0x1278..0x127c => {
                 self.periph
-                    .write_intr_block_rf_notif_agg_error_non_fatal28_intr_count_r(size, val);
+                    .write_intr_block_rf_notif_agg_error_non_fatal28_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x1279..=0x127b) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x127c) => {
+            0x127c..0x1280 => {
                 self.periph
-                    .write_intr_block_rf_notif_agg_error_non_fatal29_intr_count_r(size, val);
+                    .write_intr_block_rf_notif_agg_error_non_fatal29_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x127d..=0x127f) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x1280) => {
+            0x1280..0x1284 => {
                 self.periph
-                    .write_intr_block_rf_notif_agg_error_non_fatal30_intr_count_r(size, val);
+                    .write_intr_block_rf_notif_agg_error_non_fatal30_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x1281..=0x1283) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x1284) => {
+            0x1284..0x1288 => {
                 self.periph
-                    .write_intr_block_rf_notif_agg_error_non_fatal31_intr_count_r(size, val);
+                    .write_intr_block_rf_notif_agg_error_non_fatal31_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x1285..=0x1287) => Err(emulator_bus::BusError::StoreAddrMisaligned),
             _ => Err(emulator_bus::BusError::StoreAccessFault),
         }
     }

--- a/registers/generated-emulator/src/otp.rs
+++ b/registers/generated-emulator/src/otp.rs
@@ -11,7 +11,6 @@ pub trait OtpPeripheral {
     fn update_reset(&mut self) {}
     fn read_interrupt_state(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::InterruptState::Register,
@@ -20,7 +19,6 @@ pub trait OtpPeripheral {
     }
     fn write_interrupt_state(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::otp_ctrl::bits::InterruptState::Register,
@@ -29,7 +27,6 @@ pub trait OtpPeripheral {
     }
     fn read_interrupt_enable(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::InterruptEnable::Register,
@@ -38,7 +35,6 @@ pub trait OtpPeripheral {
     }
     fn write_interrupt_enable(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::InterruptEnable::Register,
@@ -47,7 +43,6 @@ pub trait OtpPeripheral {
     }
     fn write_interrupt_test(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::otp_ctrl::bits::InterruptTest::Register,
@@ -56,7 +51,6 @@ pub trait OtpPeripheral {
     }
     fn write_alert_test(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::otp_ctrl::bits::AlertTest::Register,
@@ -65,14 +59,12 @@ pub trait OtpPeripheral {
     }
     fn read_status(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::otp_ctrl::bits::Status::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn read_direct_access_regwen(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::DirectAccessRegwen::Register,
@@ -81,7 +73,6 @@ pub trait OtpPeripheral {
     }
     fn write_direct_access_regwen(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::otp_ctrl::bits::DirectAccessRegwen::Register,
@@ -90,7 +81,6 @@ pub trait OtpPeripheral {
     }
     fn write_direct_access_cmd(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::otp_ctrl::bits::DirectAccessCmd::Register,
@@ -99,7 +89,6 @@ pub trait OtpPeripheral {
     }
     fn read_direct_access_address(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::DirectAccessAddress::Register,
@@ -108,7 +97,6 @@ pub trait OtpPeripheral {
     }
     fn write_direct_access_address(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::otp_ctrl::bits::DirectAccessAddress::Register,
@@ -117,7 +105,6 @@ pub trait OtpPeripheral {
     }
     fn read_check_trigger_regwen(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::CheckTriggerRegwen::Register,
@@ -126,7 +113,6 @@ pub trait OtpPeripheral {
     }
     fn write_check_trigger_regwen(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::otp_ctrl::bits::CheckTriggerRegwen::Register,
@@ -135,7 +121,6 @@ pub trait OtpPeripheral {
     }
     fn write_check_trigger(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::otp_ctrl::bits::CheckTrigger::Register,
@@ -144,45 +129,26 @@ pub trait OtpPeripheral {
     }
     fn write_check_regwen(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::otp_ctrl::bits::CheckRegwen::Register,
         >,
     ) {
     }
-    fn read_check_timeout(&mut self, _size: emulator_types::RvSize) -> emulator_types::RvData {
+    fn read_check_timeout(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_check_timeout(&mut self, _size: emulator_types::RvSize, _val: emulator_types::RvData) {
-    }
-    fn read_integrity_check_period(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_check_timeout(&mut self, _val: emulator_types::RvData) {}
+    fn read_integrity_check_period(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_integrity_check_period(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_consistency_check_period(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_integrity_check_period(&mut self, _val: emulator_types::RvData) {}
+    fn read_consistency_check_period(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_consistency_check_period(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
+    fn write_consistency_check_period(&mut self, _val: emulator_types::RvData) {}
     fn read_vendor_test_read_lock(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::VendorTestReadLock::Register,
@@ -191,7 +157,6 @@ pub trait OtpPeripheral {
     }
     fn write_vendor_test_read_lock(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::otp_ctrl::bits::VendorTestReadLock::Register,
@@ -200,7 +165,6 @@ pub trait OtpPeripheral {
     }
     fn read_non_secret_fuses_read_lock(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::NonSecretFusesReadLock::Register,
@@ -209,7 +173,6 @@ pub trait OtpPeripheral {
     }
     fn write_non_secret_fuses_read_lock(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::otp_ctrl::bits::NonSecretFusesReadLock::Register,
@@ -218,14 +181,12 @@ pub trait OtpPeripheral {
     }
     fn read_csr0(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::otp_ctrl::bits::Csr0::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn write_csr0(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::otp_ctrl::bits::Csr0::Register,
@@ -234,14 +195,12 @@ pub trait OtpPeripheral {
     }
     fn read_csr1(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::otp_ctrl::bits::Csr1::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn write_csr1(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::otp_ctrl::bits::Csr1::Register,
@@ -250,14 +209,12 @@ pub trait OtpPeripheral {
     }
     fn read_csr2(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::otp_ctrl::bits::Csr2::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn write_csr2(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::otp_ctrl::bits::Csr2::Register,
@@ -266,14 +223,12 @@ pub trait OtpPeripheral {
     }
     fn read_csr3(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::otp_ctrl::bits::Csr3::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn write_csr3(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::otp_ctrl::bits::Csr3::Register,
@@ -282,14 +237,12 @@ pub trait OtpPeripheral {
     }
     fn read_csr4(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::otp_ctrl::bits::Csr4::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn write_csr4(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::otp_ctrl::bits::Csr4::Register,
@@ -298,14 +251,12 @@ pub trait OtpPeripheral {
     }
     fn read_csr5(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::otp_ctrl::bits::Csr5::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn write_csr5(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::otp_ctrl::bits::Csr5::Register,
@@ -314,14 +265,12 @@ pub trait OtpPeripheral {
     }
     fn read_csr6(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::otp_ctrl::bits::Csr6::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn write_csr6(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::otp_ctrl::bits::Csr6::Register,
@@ -330,14 +279,12 @@ pub trait OtpPeripheral {
     }
     fn read_csr7(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::otp_ctrl::bits::Csr7::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn read_err_code_rf_err_code_0(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
@@ -346,7 +293,6 @@ pub trait OtpPeripheral {
     }
     fn read_err_code_rf_err_code_1(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
@@ -355,7 +301,6 @@ pub trait OtpPeripheral {
     }
     fn read_err_code_rf_err_code_2(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
@@ -364,7 +309,6 @@ pub trait OtpPeripheral {
     }
     fn read_err_code_rf_err_code_3(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
@@ -373,7 +317,6 @@ pub trait OtpPeripheral {
     }
     fn read_err_code_rf_err_code_4(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
@@ -382,7 +325,6 @@ pub trait OtpPeripheral {
     }
     fn read_err_code_rf_err_code_5(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
@@ -391,7 +333,6 @@ pub trait OtpPeripheral {
     }
     fn read_err_code_rf_err_code_6(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
@@ -400,7 +341,6 @@ pub trait OtpPeripheral {
     }
     fn read_err_code_rf_err_code_7(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
@@ -409,119 +349,60 @@ pub trait OtpPeripheral {
     }
     fn read_err_code_rf_err_code_8(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
     > {
         emulator_bus::ReadWriteRegister::new(0)
     }
-    fn read_dai_wdata_rf_direct_access_wdata_0(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_dai_wdata_rf_direct_access_wdata_0(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_dai_wdata_rf_direct_access_wdata_0(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_dai_wdata_rf_direct_access_wdata_1(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_dai_wdata_rf_direct_access_wdata_0(&mut self, _val: emulator_types::RvData) {}
+    fn read_dai_wdata_rf_direct_access_wdata_1(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_dai_wdata_rf_direct_access_wdata_1(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_dai_rdata_rf_direct_access_rdata_0(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_dai_wdata_rf_direct_access_wdata_1(&mut self, _val: emulator_types::RvData) {}
+    fn read_dai_rdata_rf_direct_access_rdata_0(&mut self) -> emulator_types::RvData {
         0
     }
-    fn read_dai_rdata_rf_direct_access_rdata_1(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_dai_rdata_rf_direct_access_rdata_1(&mut self) -> emulator_types::RvData {
         0
     }
-    fn read_vendor_test_digest_digest_0(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_vendor_test_digest_digest_0(&mut self) -> emulator_types::RvData {
         0
     }
-    fn read_vendor_test_digest_digest_1(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_vendor_test_digest_digest_1(&mut self) -> emulator_types::RvData {
         0
     }
-    fn read_non_secret_fuses_digest_digest_0(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_non_secret_fuses_digest_digest_0(&mut self) -> emulator_types::RvData {
         0
     }
-    fn read_non_secret_fuses_digest_digest_1(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_non_secret_fuses_digest_digest_1(&mut self) -> emulator_types::RvData {
         0
     }
-    fn read_secret0_digest_digest_0(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_secret0_digest_digest_0(&mut self) -> emulator_types::RvData {
         0
     }
-    fn read_secret0_digest_digest_1(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_secret0_digest_digest_1(&mut self) -> emulator_types::RvData {
         0
     }
-    fn read_secret1_digest_digest_0(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_secret1_digest_digest_0(&mut self) -> emulator_types::RvData {
         0
     }
-    fn read_secret1_digest_digest_1(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_secret1_digest_digest_1(&mut self) -> emulator_types::RvData {
         0
     }
-    fn read_secret2_digest_digest_0(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_secret2_digest_digest_0(&mut self) -> emulator_types::RvData {
         0
     }
-    fn read_secret2_digest_digest_1(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_secret2_digest_digest_1(&mut self) -> emulator_types::RvData {
         0
     }
-    fn read_secret3_digest_digest_0(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_secret3_digest_digest_0(&mut self) -> emulator_types::RvData {
         0
     }
-    fn read_secret3_digest_digest_1(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_secret3_digest_digest_1(&mut self) -> emulator_types::RvData {
         0
     }
 }
@@ -534,270 +415,104 @@ impl emulator_bus::Bus for OtpBus {
         size: emulator_types::RvSize,
         addr: emulator_types::RvAddr,
     ) -> Result<emulator_types::RvData, emulator_bus::BusError> {
-        match (size, addr) {
-            (emulator_types::RvSize::Word, 0) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_interrupt_state(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+        if addr & 0x3 != 0 || size != emulator_types::RvSize::Word {
+            return Err(emulator_bus::BusError::LoadAddrMisaligned);
+        }
+        match addr {
+            0..4 => Ok(emulator_types::RvData::from(
+                self.periph.read_interrupt_state().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 1..=3) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 4) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_interrupt_enable(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            4..8 => Ok(emulator_types::RvData::from(
+                self.periph.read_interrupt_enable().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 5..=7) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x10) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_status(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0x10..0x14 => Ok(emulator_types::RvData::from(
+                self.periph.read_status().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0x11..=0x13) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x38) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_direct_access_regwen(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0x38..0x3c => Ok(emulator_types::RvData::from(
+                self.periph.read_direct_access_regwen().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0x39..=0x3b) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x40) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_direct_access_address(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0x40..0x44 => Ok(emulator_types::RvData::from(
+                self.periph.read_direct_access_address().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0x41..=0x43) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x54) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_check_trigger_regwen(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0x54..0x58 => Ok(emulator_types::RvData::from(
+                self.periph.read_check_trigger_regwen().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0x55..=0x57) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (size, 0x60) => Ok(self.periph.read_check_timeout(size)),
-            (_, 0x61..=0x63) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x64) => Ok(self.periph.read_integrity_check_period(size)),
-            (_, 0x65..=0x67) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x68) => Ok(self.periph.read_consistency_check_period(size)),
-            (_, 0x69..=0x6b) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x6c) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_vendor_test_read_lock(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0x60..0x64 => Ok(self.periph.read_check_timeout()),
+            0x64..0x68 => Ok(self.periph.read_integrity_check_period()),
+            0x68..0x6c => Ok(self.periph.read_consistency_check_period()),
+            0x6c..0x70 => Ok(emulator_types::RvData::from(
+                self.periph.read_vendor_test_read_lock().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0x6d..=0x6f) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x70) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_non_secret_fuses_read_lock(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0x70..0x74 => Ok(emulator_types::RvData::from(
+                self.periph.read_non_secret_fuses_read_lock().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0x71..=0x73) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xa4) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_csr0(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0xa4..0xa8 => Ok(emulator_types::RvData::from(
+                self.periph.read_csr0().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0xa5..=0xa7) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xa8) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_csr1(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0xa8..0xac => Ok(emulator_types::RvData::from(
+                self.periph.read_csr1().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0xa9..=0xab) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xac) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_csr2(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0xac..0xb0 => Ok(emulator_types::RvData::from(
+                self.periph.read_csr2().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0xad..=0xaf) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xb0) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_csr3(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0xb0..0xb4 => Ok(emulator_types::RvData::from(
+                self.periph.read_csr3().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0xb1..=0xb3) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xb4) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_csr4(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0xb4..0xb8 => Ok(emulator_types::RvData::from(
+                self.periph.read_csr4().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0xb5..=0xb7) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xb8) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_csr5(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0xb8..0xbc => Ok(emulator_types::RvData::from(
+                self.periph.read_csr5().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0xb9..=0xbb) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xbc) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_csr6(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0xbc..0xc0 => Ok(emulator_types::RvData::from(
+                self.periph.read_csr6().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0xbd..=0xbf) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xc0) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_csr7(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0xc0..0xc4 => Ok(emulator_types::RvData::from(
+                self.periph.read_csr7().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0xc1..=0xc3) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x14) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_err_code_rf_err_code_0(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0x14..0x18 => Ok(emulator_types::RvData::from(
+                self.periph.read_err_code_rf_err_code_0().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0x15..=0x17) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x18) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_err_code_rf_err_code_1(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0x18..0x1c => Ok(emulator_types::RvData::from(
+                self.periph.read_err_code_rf_err_code_1().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0x19..=0x1b) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1c) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_err_code_rf_err_code_2(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0x1c..0x20 => Ok(emulator_types::RvData::from(
+                self.periph.read_err_code_rf_err_code_2().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0x1d..=0x1f) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x20) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_err_code_rf_err_code_3(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0x20..0x24 => Ok(emulator_types::RvData::from(
+                self.periph.read_err_code_rf_err_code_3().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0x21..=0x23) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x24) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_err_code_rf_err_code_4(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0x24..0x28 => Ok(emulator_types::RvData::from(
+                self.periph.read_err_code_rf_err_code_4().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0x25..=0x27) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x28) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_err_code_rf_err_code_5(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0x28..0x2c => Ok(emulator_types::RvData::from(
+                self.periph.read_err_code_rf_err_code_5().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0x29..=0x2b) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x2c) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_err_code_rf_err_code_6(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0x2c..0x30 => Ok(emulator_types::RvData::from(
+                self.periph.read_err_code_rf_err_code_6().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0x2d..=0x2f) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x30) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_err_code_rf_err_code_7(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0x30..0x34 => Ok(emulator_types::RvData::from(
+                self.periph.read_err_code_rf_err_code_7().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0x31..=0x33) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x34) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_err_code_rf_err_code_8(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0x34..0x38 => Ok(emulator_types::RvData::from(
+                self.periph.read_err_code_rf_err_code_8().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0x35..=0x37) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (size, 0x44) => Ok(self.periph.read_dai_wdata_rf_direct_access_wdata_0(size)),
-            (_, 0x45..=0x47) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x48) => Ok(self.periph.read_dai_wdata_rf_direct_access_wdata_1(size)),
-            (_, 0x49..=0x4b) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x4c) => Ok(self.periph.read_dai_rdata_rf_direct_access_rdata_0(size)),
-            (_, 0x4d..=0x4f) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x50) => Ok(self.periph.read_dai_rdata_rf_direct_access_rdata_1(size)),
-            (_, 0x51..=0x53) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x74) => Ok(self.periph.read_vendor_test_digest_digest_0(size)),
-            (_, 0x75..=0x77) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x78) => Ok(self.periph.read_vendor_test_digest_digest_1(size)),
-            (_, 0x79..=0x7b) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x7c) => Ok(self.periph.read_non_secret_fuses_digest_digest_0(size)),
-            (_, 0x7d..=0x7f) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x80) => Ok(self.periph.read_non_secret_fuses_digest_digest_1(size)),
-            (_, 0x81..=0x83) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x84) => Ok(self.periph.read_secret0_digest_digest_0(size)),
-            (_, 0x85..=0x87) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x88) => Ok(self.periph.read_secret0_digest_digest_1(size)),
-            (_, 0x89..=0x8b) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x8c) => Ok(self.periph.read_secret1_digest_digest_0(size)),
-            (_, 0x8d..=0x8f) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x90) => Ok(self.periph.read_secret1_digest_digest_1(size)),
-            (_, 0x91..=0x93) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x94) => Ok(self.periph.read_secret2_digest_digest_0(size)),
-            (_, 0x95..=0x97) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x98) => Ok(self.periph.read_secret2_digest_digest_1(size)),
-            (_, 0x99..=0x9b) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x9c) => Ok(self.periph.read_secret3_digest_digest_0(size)),
-            (_, 0x9d..=0x9f) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0xa0) => Ok(self.periph.read_secret3_digest_digest_1(size)),
-            (_, 0xa1..=0xa3) => Err(emulator_bus::BusError::LoadAddrMisaligned),
+            0x44..0x48 => Ok(self.periph.read_dai_wdata_rf_direct_access_wdata_0()),
+            0x48..0x4c => Ok(self.periph.read_dai_wdata_rf_direct_access_wdata_1()),
+            0x4c..0x50 => Ok(self.periph.read_dai_rdata_rf_direct_access_rdata_0()),
+            0x50..0x54 => Ok(self.periph.read_dai_rdata_rf_direct_access_rdata_1()),
+            0x74..0x78 => Ok(self.periph.read_vendor_test_digest_digest_0()),
+            0x78..0x7c => Ok(self.periph.read_vendor_test_digest_digest_1()),
+            0x7c..0x80 => Ok(self.periph.read_non_secret_fuses_digest_digest_0()),
+            0x80..0x84 => Ok(self.periph.read_non_secret_fuses_digest_digest_1()),
+            0x84..0x88 => Ok(self.periph.read_secret0_digest_digest_0()),
+            0x88..0x8c => Ok(self.periph.read_secret0_digest_digest_1()),
+            0x8c..0x90 => Ok(self.periph.read_secret1_digest_digest_0()),
+            0x90..0x94 => Ok(self.periph.read_secret1_digest_digest_1()),
+            0x94..0x98 => Ok(self.periph.read_secret2_digest_digest_0()),
+            0x98..0x9c => Ok(self.periph.read_secret2_digest_digest_1()),
+            0x9c..0xa0 => Ok(self.periph.read_secret3_digest_digest_0()),
+            0xa0..0xa4 => Ok(self.periph.read_secret3_digest_digest_1()),
             _ => Err(emulator_bus::BusError::LoadAccessFault),
         }
     }
@@ -807,224 +522,125 @@ impl emulator_bus::Bus for OtpBus {
         addr: emulator_types::RvAddr,
         val: emulator_types::RvData,
     ) -> Result<(), emulator_bus::BusError> {
-        match (size, addr) {
-            (emulator_types::RvSize::Word, 0) => {
-                self.periph.write_interrupt_state(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 1..=3) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 4) => {
-                self.periph.write_interrupt_enable(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 5..=7) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 8) => {
-                self.periph.write_interrupt_test(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 9..=0xb) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xc) => {
-                self.periph.write_alert_test(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0xd..=0xf) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x38) => {
-                self.periph.write_direct_access_regwen(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0x39..=0x3b) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x3c) => {
-                self.periph.write_direct_access_cmd(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0x3d..=0x3f) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x40) => {
-                self.periph.write_direct_access_address(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0x41..=0x43) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x54) => {
-                self.periph.write_check_trigger_regwen(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0x55..=0x57) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x58) => {
-                self.periph.write_check_trigger(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0x59..=0x5b) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x5c) => {
-                self.periph.write_check_regwen(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0x5d..=0x5f) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (size, 0x60) => {
-                self.periph.write_check_timeout(size, val);
-                Ok(())
-            }
-            (_, 0x61..=0x63) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x64) => {
-                self.periph.write_integrity_check_period(size, val);
-                Ok(())
-            }
-            (_, 0x65..=0x67) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x68) => {
-                self.periph.write_consistency_check_period(size, val);
-                Ok(())
-            }
-            (_, 0x69..=0x6b) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x6c) => {
-                self.periph.write_vendor_test_read_lock(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0x6d..=0x6f) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x70) => {
-                self.periph.write_non_secret_fuses_read_lock(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0x71..=0x73) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xa4) => {
-                self.periph.write_csr0(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0xa5..=0xa7) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xa8) => {
-                self.periph.write_csr1(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0xa9..=0xab) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xac) => {
-                self.periph.write_csr2(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0xad..=0xaf) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xb0) => {
-                self.periph.write_csr3(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0xb1..=0xb3) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xb4) => {
-                self.periph.write_csr4(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0xb5..=0xb7) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xb8) => {
-                self.periph.write_csr5(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0xb9..=0xbb) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xbc) => {
-                self.periph.write_csr6(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0xbd..=0xbf) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (size, 0x44) => {
+        if addr & 0x3 != 0 || size != emulator_types::RvSize::Word {
+            return Err(emulator_bus::BusError::StoreAddrMisaligned);
+        }
+        match addr {
+            0..4 => {
                 self.periph
-                    .write_dai_wdata_rf_direct_access_wdata_0(size, val);
+                    .write_interrupt_state(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (_, 0x45..=0x47) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x48) => {
+            4..8 => {
                 self.periph
-                    .write_dai_wdata_rf_direct_access_wdata_1(size, val);
+                    .write_interrupt_enable(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (_, 0x49..=0x4b) => Err(emulator_bus::BusError::StoreAddrMisaligned),
+            8..0xc => {
+                self.periph
+                    .write_interrupt_test(emulator_bus::ReadWriteRegister::new(val));
+                Ok(())
+            }
+            0xc..0x10 => {
+                self.periph
+                    .write_alert_test(emulator_bus::ReadWriteRegister::new(val));
+                Ok(())
+            }
+            0x38..0x3c => {
+                self.periph
+                    .write_direct_access_regwen(emulator_bus::ReadWriteRegister::new(val));
+                Ok(())
+            }
+            0x3c..0x40 => {
+                self.periph
+                    .write_direct_access_cmd(emulator_bus::ReadWriteRegister::new(val));
+                Ok(())
+            }
+            0x40..0x44 => {
+                self.periph
+                    .write_direct_access_address(emulator_bus::ReadWriteRegister::new(val));
+                Ok(())
+            }
+            0x54..0x58 => {
+                self.periph
+                    .write_check_trigger_regwen(emulator_bus::ReadWriteRegister::new(val));
+                Ok(())
+            }
+            0x58..0x5c => {
+                self.periph
+                    .write_check_trigger(emulator_bus::ReadWriteRegister::new(val));
+                Ok(())
+            }
+            0x5c..0x60 => {
+                self.periph
+                    .write_check_regwen(emulator_bus::ReadWriteRegister::new(val));
+                Ok(())
+            }
+            0x60..0x64 => {
+                self.periph.write_check_timeout(val);
+                Ok(())
+            }
+            0x64..0x68 => {
+                self.periph.write_integrity_check_period(val);
+                Ok(())
+            }
+            0x68..0x6c => {
+                self.periph.write_consistency_check_period(val);
+                Ok(())
+            }
+            0x6c..0x70 => {
+                self.periph
+                    .write_vendor_test_read_lock(emulator_bus::ReadWriteRegister::new(val));
+                Ok(())
+            }
+            0x70..0x74 => {
+                self.periph
+                    .write_non_secret_fuses_read_lock(emulator_bus::ReadWriteRegister::new(val));
+                Ok(())
+            }
+            0xa4..0xa8 => {
+                self.periph
+                    .write_csr0(emulator_bus::ReadWriteRegister::new(val));
+                Ok(())
+            }
+            0xa8..0xac => {
+                self.periph
+                    .write_csr1(emulator_bus::ReadWriteRegister::new(val));
+                Ok(())
+            }
+            0xac..0xb0 => {
+                self.periph
+                    .write_csr2(emulator_bus::ReadWriteRegister::new(val));
+                Ok(())
+            }
+            0xb0..0xb4 => {
+                self.periph
+                    .write_csr3(emulator_bus::ReadWriteRegister::new(val));
+                Ok(())
+            }
+            0xb4..0xb8 => {
+                self.periph
+                    .write_csr4(emulator_bus::ReadWriteRegister::new(val));
+                Ok(())
+            }
+            0xb8..0xbc => {
+                self.periph
+                    .write_csr5(emulator_bus::ReadWriteRegister::new(val));
+                Ok(())
+            }
+            0xbc..0xc0 => {
+                self.periph
+                    .write_csr6(emulator_bus::ReadWriteRegister::new(val));
+                Ok(())
+            }
+            0x44..0x48 => {
+                self.periph.write_dai_wdata_rf_direct_access_wdata_0(val);
+                Ok(())
+            }
+            0x48..0x4c => {
+                self.periph.write_dai_wdata_rf_direct_access_wdata_1(val);
+                Ok(())
+            }
             _ => Err(emulator_bus::BusError::StoreAccessFault),
         }
     }

--- a/registers/generated-emulator/src/root_bus.rs
+++ b/registers/generated-emulator/src/root_bus.rs
@@ -104,14 +104,14 @@ impl emulator_bus::Bus for AutoRootBus {
                     Err(emulator_bus::BusError::LoadAccessFault)
                 }
             }
-            0x3003_0000..=0x3003_f4fb => {
+            0x3003_0000..=0x3003_f703 => {
                 if let Some(periph) = self.soc_periph.as_mut() {
                     periph.read(size, addr - 0x3003_0000)
                 } else {
                     Err(emulator_bus::BusError::LoadAccessFault)
                 }
             }
-            0x6000_0000..=0x6000_f017 => {
+            0x6000_0000..=0x6001_0403 => {
                 if let Some(periph) = self.el2_pic_periph.as_mut() {
                     periph.read(size, addr - 0x6000_0000)
                 } else {
@@ -188,14 +188,14 @@ impl emulator_bus::Bus for AutoRootBus {
                     Err(emulator_bus::BusError::StoreAccessFault)
                 }
             }
-            0x3003_0000..=0x3003_f4fb => {
+            0x3003_0000..=0x3003_f703 => {
                 if let Some(periph) = self.soc_periph.as_mut() {
                     periph.write(size, addr - 0x3003_0000, val)
                 } else {
                     Err(emulator_bus::BusError::StoreAccessFault)
                 }
             }
-            0x6000_0000..=0x6000_f017 => {
+            0x6000_0000..=0x6001_0403 => {
                 if let Some(periph) = self.el2_pic_periph.as_mut() {
                     periph.write(size, addr - 0x6000_0000, val)
                 } else {

--- a/registers/generated-emulator/src/sha512_acc.rs
+++ b/registers/generated-emulator/src/sha512_acc.rs
@@ -11,55 +11,49 @@ pub trait Sha512AccPeripheral {
     fn update_reset(&mut self) {}
     fn read_lock(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::sha512_acc::bits::Lock::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn write_lock(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::sha512_acc::bits::Lock::Register,
         >,
     ) {
     }
-    fn read_user(&mut self, _size: emulator_types::RvSize) -> emulator_types::RvData {
+    fn read_user(&mut self) -> emulator_types::RvData {
         0
     }
     fn read_mode(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::sha512_acc::bits::Mode::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn write_mode(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::sha512_acc::bits::Mode::Register,
         >,
     ) {
     }
-    fn read_start_address(&mut self, _size: emulator_types::RvSize) -> emulator_types::RvData {
+    fn read_start_address(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_start_address(&mut self, _size: emulator_types::RvSize, _val: emulator_types::RvData) {
-    }
-    fn read_dlen(&mut self, _size: emulator_types::RvSize) -> emulator_types::RvData {
+    fn write_start_address(&mut self, _val: emulator_types::RvData) {}
+    fn read_dlen(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_dlen(&mut self, _size: emulator_types::RvSize, _val: emulator_types::RvData) {}
-    fn read_datain(&mut self, _size: emulator_types::RvSize) -> emulator_types::RvData {
+    fn write_dlen(&mut self, _val: emulator_types::RvData) {}
+    fn read_datain(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_datain(&mut self, _size: emulator_types::RvSize, _val: emulator_types::RvData) {}
+    fn write_datain(&mut self, _val: emulator_types::RvData) {}
     fn read_execute(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::sha512_acc::bits::Execute::Register,
@@ -68,7 +62,6 @@ pub trait Sha512AccPeripheral {
     }
     fn write_execute(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::sha512_acc::bits::Execute::Register,
@@ -77,17 +70,15 @@ pub trait Sha512AccPeripheral {
     }
     fn read_status(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::otp_ctrl::bits::Status::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
-    fn read_digest(&mut self, _size: emulator_types::RvSize) -> emulator_types::RvData {
+    fn read_digest(&mut self) -> emulator_types::RvData {
         0
     }
     fn read_control(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::sha512_acc::bits::Control::Register,
@@ -96,7 +87,6 @@ pub trait Sha512AccPeripheral {
     }
     fn write_control(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::sha512_acc::bits::Control::Register,
@@ -105,14 +95,12 @@ pub trait Sha512AccPeripheral {
     }
     fn read_intr_block_rf_global_intr_en_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::soc::bits::GlobalIntrEnT::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn write_intr_block_rf_global_intr_en_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::GlobalIntrEnT::Register,
@@ -121,14 +109,12 @@ pub trait Sha512AccPeripheral {
     }
     fn read_intr_block_rf_error_intr_en_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::soc::bits::ErrorIntrEnT::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn write_intr_block_rf_error_intr_en_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::ErrorIntrEnT::Register,
@@ -137,14 +123,12 @@ pub trait Sha512AccPeripheral {
     }
     fn read_intr_block_rf_notif_intr_en_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::soc::bits::NotifIntrEnT::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn write_intr_block_rf_notif_intr_en_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::NotifIntrEnT::Register,
@@ -153,28 +137,24 @@ pub trait Sha512AccPeripheral {
     }
     fn read_intr_block_rf_error_global_intr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::soc::bits::GlobalIntrT::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn read_intr_block_rf_notif_global_intr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::soc::bits::GlobalIntrT::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn read_intr_block_rf_error_internal_intr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::soc::bits::ErrorIntrT::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn write_intr_block_rf_error_internal_intr_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::ErrorIntrT::Register,
@@ -183,14 +163,12 @@ pub trait Sha512AccPeripheral {
     }
     fn read_intr_block_rf_notif_internal_intr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::soc::bits::NotifIntrT::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn write_intr_block_rf_notif_internal_intr_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::NotifIntrT::Register,
@@ -199,7 +177,6 @@ pub trait Sha512AccPeripheral {
     }
     fn read_intr_block_rf_error_intr_trig_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::ErrorIntrTrigT::Register,
@@ -208,7 +185,6 @@ pub trait Sha512AccPeripheral {
     }
     fn write_intr_block_rf_error_intr_trig_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::ErrorIntrTrigT::Register,
@@ -217,7 +193,6 @@ pub trait Sha512AccPeripheral {
     }
     fn read_intr_block_rf_notif_intr_trig_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::NotifIntrTrigT::Register,
@@ -226,76 +201,34 @@ pub trait Sha512AccPeripheral {
     }
     fn write_intr_block_rf_notif_intr_trig_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::NotifIntrTrigT::Register,
         >,
     ) {
     }
-    fn read_intr_block_rf_error0_intr_count_r(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_intr_block_rf_error0_intr_count_r(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_intr_block_rf_error0_intr_count_r(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_intr_block_rf_error1_intr_count_r(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_intr_block_rf_error0_intr_count_r(&mut self, _val: emulator_types::RvData) {}
+    fn read_intr_block_rf_error1_intr_count_r(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_intr_block_rf_error1_intr_count_r(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_intr_block_rf_error2_intr_count_r(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_intr_block_rf_error1_intr_count_r(&mut self, _val: emulator_types::RvData) {}
+    fn read_intr_block_rf_error2_intr_count_r(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_intr_block_rf_error2_intr_count_r(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_intr_block_rf_error3_intr_count_r(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_intr_block_rf_error2_intr_count_r(&mut self, _val: emulator_types::RvData) {}
+    fn read_intr_block_rf_error3_intr_count_r(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_intr_block_rf_error3_intr_count_r(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_intr_block_rf_notif_cmd_done_intr_count_r(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_intr_block_rf_error3_intr_count_r(&mut self, _val: emulator_types::RvData) {}
+    fn read_intr_block_rf_notif_cmd_done_intr_count_r(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_intr_block_rf_notif_cmd_done_intr_count_r(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
+    fn write_intr_block_rf_notif_cmd_done_intr_count_r(&mut self, _val: emulator_types::RvData) {}
     fn read_intr_block_rf_error0_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -304,7 +237,6 @@ pub trait Sha512AccPeripheral {
     }
     fn read_intr_block_rf_error1_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -313,7 +245,6 @@ pub trait Sha512AccPeripheral {
     }
     fn read_intr_block_rf_error2_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -322,7 +253,6 @@ pub trait Sha512AccPeripheral {
     }
     fn read_intr_block_rf_error3_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -331,7 +261,6 @@ pub trait Sha512AccPeripheral {
     }
     fn read_intr_block_rf_notif_cmd_done_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -348,202 +277,104 @@ impl emulator_bus::Bus for Sha512AccBus {
         size: emulator_types::RvSize,
         addr: emulator_types::RvAddr,
     ) -> Result<emulator_types::RvData, emulator_bus::BusError> {
-        match (size, addr) {
-            (emulator_types::RvSize::Word, 0) => Ok(emulator_types::RvData::from(
+        if addr & 0x3 != 0 || size != emulator_types::RvSize::Word {
+            return Err(emulator_bus::BusError::LoadAddrMisaligned);
+        }
+        match addr {
+            0..4 => Ok(emulator_types::RvData::from(
+                self.periph.read_lock().reg.get(),
+            )),
+            4..8 => Ok(self.periph.read_user()),
+            8..0xc => Ok(emulator_types::RvData::from(
+                self.periph.read_mode().reg.get(),
+            )),
+            0xc..0x10 => Ok(self.periph.read_start_address()),
+            0x10..0x14 => Ok(self.periph.read_dlen()),
+            0x14..0x18 => Ok(self.periph.read_datain()),
+            0x18..0x1c => Ok(emulator_types::RvData::from(
+                self.periph.read_execute().reg.get(),
+            )),
+            0x1c..0x20 => Ok(emulator_types::RvData::from(
+                self.periph.read_status().reg.get(),
+            )),
+            0x20..0x60 => Ok(self.periph.read_digest()),
+            0x60..0x64 => Ok(emulator_types::RvData::from(
+                self.periph.read_control().reg.get(),
+            )),
+            0x800..0x804 => Ok(emulator_types::RvData::from(
+                self.periph.read_intr_block_rf_global_intr_en_r().reg.get(),
+            )),
+            0x804..0x808 => Ok(emulator_types::RvData::from(
+                self.periph.read_intr_block_rf_error_intr_en_r().reg.get(),
+            )),
+            0x808..0x80c => Ok(emulator_types::RvData::from(
+                self.periph.read_intr_block_rf_notif_intr_en_r().reg.get(),
+            )),
+            0x80c..0x810 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_lock(emulator_types::RvSize::Word)
+                    .read_intr_block_rf_error_global_intr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 1..=3) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (size, 4) => Ok(self.periph.read_user(size)),
-            (_, 5..=7) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (emulator_types::RvSize::Word, 8) => Ok(emulator_types::RvData::from(
+            0x810..0x814 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_mode(emulator_types::RvSize::Word)
+                    .read_intr_block_rf_notif_global_intr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 9..=0xb) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (size, 0xc) => Ok(self.periph.read_start_address(size)),
-            (_, 0xd..=0xf) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x10) => Ok(self.periph.read_dlen(size)),
-            (_, 0x11..=0x13) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x14) => Ok(self.periph.read_datain(size)),
-            (_, 0x15..=0x17) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x18) => Ok(emulator_types::RvData::from(
+            0x814..0x818 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_execute(emulator_types::RvSize::Word)
+                    .read_intr_block_rf_error_internal_intr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x19..=0x1b) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x1c) => Ok(emulator_types::RvData::from(
+            0x818..0x81c => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_status(emulator_types::RvSize::Word)
+                    .read_intr_block_rf_notif_internal_intr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x1d..=0x1f) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (size, 0x20) => Ok(self.periph.read_digest(size)),
-            (_, 0x21..=0x23) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x60) => Ok(emulator_types::RvData::from(
+            0x81c..0x820 => Ok(emulator_types::RvData::from(
+                self.periph.read_intr_block_rf_error_intr_trig_r().reg.get(),
+            )),
+            0x820..0x824 => Ok(emulator_types::RvData::from(
+                self.periph.read_intr_block_rf_notif_intr_trig_r().reg.get(),
+            )),
+            0x900..0x904 => Ok(self.periph.read_intr_block_rf_error0_intr_count_r()),
+            0x904..0x908 => Ok(self.periph.read_intr_block_rf_error1_intr_count_r()),
+            0x908..0x90c => Ok(self.periph.read_intr_block_rf_error2_intr_count_r()),
+            0x90c..0x910 => Ok(self.periph.read_intr_block_rf_error3_intr_count_r()),
+            0x980..0x984 => Ok(self.periph.read_intr_block_rf_notif_cmd_done_intr_count_r()),
+            0xa00..0xa04 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_control(emulator_types::RvSize::Word)
+                    .read_intr_block_rf_error0_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x61..=0x63) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x800) => Ok(emulator_types::RvData::from(
+            0xa04..0xa08 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_global_intr_en_r(emulator_types::RvSize::Word)
+                    .read_intr_block_rf_error1_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x801..=0x803) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x804) => Ok(emulator_types::RvData::from(
+            0xa08..0xa0c => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_error_intr_en_r(emulator_types::RvSize::Word)
+                    .read_intr_block_rf_error2_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x805..=0x807) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x808) => Ok(emulator_types::RvData::from(
+            0xa0c..0xa10 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_notif_intr_en_r(emulator_types::RvSize::Word)
+                    .read_intr_block_rf_error3_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x809..=0x80b) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x80c) => Ok(emulator_types::RvData::from(
+            0xa10..0xa14 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_error_global_intr_r(emulator_types::RvSize::Word)
+                    .read_intr_block_rf_notif_cmd_done_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x80d..=0x80f) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x810) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_intr_block_rf_notif_global_intr_r(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0x811..=0x813) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x814) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_intr_block_rf_error_internal_intr_r(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0x815..=0x817) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x818) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_intr_block_rf_notif_internal_intr_r(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0x819..=0x81b) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x81c) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_intr_block_rf_error_intr_trig_r(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0x81d..=0x81f) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x820) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_intr_block_rf_notif_intr_trig_r(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0x821..=0x823) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (size, 0x900) => Ok(self.periph.read_intr_block_rf_error0_intr_count_r(size)),
-            (_, 0x901..=0x903) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x904) => Ok(self.periph.read_intr_block_rf_error1_intr_count_r(size)),
-            (_, 0x905..=0x907) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x908) => Ok(self.periph.read_intr_block_rf_error2_intr_count_r(size)),
-            (_, 0x909..=0x90b) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x90c) => Ok(self.periph.read_intr_block_rf_error3_intr_count_r(size)),
-            (_, 0x90d..=0x90f) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x980) => Ok(self
-                .periph
-                .read_intr_block_rf_notif_cmd_done_intr_count_r(size)),
-            (_, 0x981..=0x983) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (emulator_types::RvSize::Word, 0xa00) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_intr_block_rf_error0_intr_count_incr_r(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0xa01..=0xa03) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xa04) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_intr_block_rf_error1_intr_count_incr_r(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0xa05..=0xa07) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xa08) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_intr_block_rf_error2_intr_count_incr_r(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0xa09..=0xa0b) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xa0c) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_intr_block_rf_error3_intr_count_incr_r(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0xa0d..=0xa0f) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xa10) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_intr_block_rf_notif_cmd_done_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0xa11..=0xa13) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
             _ => Err(emulator_bus::BusError::LoadAccessFault),
         }
     }
@@ -553,162 +384,103 @@ impl emulator_bus::Bus for Sha512AccBus {
         addr: emulator_types::RvAddr,
         val: emulator_types::RvData,
     ) -> Result<(), emulator_bus::BusError> {
-        match (size, addr) {
-            (emulator_types::RvSize::Word, 0) => {
-                self.periph.write_lock(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
+        if addr & 0x3 != 0 || size != emulator_types::RvSize::Word {
+            return Err(emulator_bus::BusError::StoreAddrMisaligned);
+        }
+        match addr {
+            0..4 => {
+                self.periph
+                    .write_lock(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 1..=3) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 8) => {
-                self.periph.write_mode(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
+            8..0xc => {
+                self.periph
+                    .write_mode(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 9..=0xb) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (size, 0xc) => {
-                self.periph.write_start_address(size, val);
+            0xc..0x10 => {
+                self.periph.write_start_address(val);
                 Ok(())
             }
-            (_, 0xd..=0xf) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x10) => {
-                self.periph.write_dlen(size, val);
+            0x10..0x14 => {
+                self.periph.write_dlen(val);
                 Ok(())
             }
-            (_, 0x11..=0x13) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x14) => {
-                self.periph.write_datain(size, val);
+            0x14..0x18 => {
+                self.periph.write_datain(val);
                 Ok(())
             }
-            (_, 0x15..=0x17) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x18) => {
-                self.periph.write_execute(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
+            0x18..0x1c => {
+                self.periph
+                    .write_execute(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x19..=0x1b) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x60) => {
-                self.periph.write_control(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
+            0x60..0x64 => {
+                self.periph
+                    .write_control(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x61..=0x63) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x800) => {
+            0x800..0x804 => {
                 self.periph.write_intr_block_rf_global_intr_en_r(
-                    emulator_types::RvSize::Word,
                     emulator_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x801..=0x803) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x804) => {
-                self.periph.write_intr_block_rf_error_intr_en_r(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
+            0x804..0x808 => {
+                self.periph
+                    .write_intr_block_rf_error_intr_en_r(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x805..=0x807) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x808) => {
-                self.periph.write_intr_block_rf_notif_intr_en_r(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
+            0x808..0x80c => {
+                self.periph
+                    .write_intr_block_rf_notif_intr_en_r(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x809..=0x80b) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x814) => {
+            0x814..0x818 => {
                 self.periph.write_intr_block_rf_error_internal_intr_r(
-                    emulator_types::RvSize::Word,
                     emulator_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x815..=0x817) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x818) => {
+            0x818..0x81c => {
                 self.periph.write_intr_block_rf_notif_internal_intr_r(
-                    emulator_types::RvSize::Word,
                     emulator_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x819..=0x81b) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x81c) => {
+            0x81c..0x820 => {
                 self.periph.write_intr_block_rf_error_intr_trig_r(
-                    emulator_types::RvSize::Word,
                     emulator_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x81d..=0x81f) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x820) => {
+            0x820..0x824 => {
                 self.periph.write_intr_block_rf_notif_intr_trig_r(
-                    emulator_types::RvSize::Word,
                     emulator_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x821..=0x823) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (size, 0x900) => {
-                self.periph
-                    .write_intr_block_rf_error0_intr_count_r(size, val);
+            0x900..0x904 => {
+                self.periph.write_intr_block_rf_error0_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x901..=0x903) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x904) => {
-                self.periph
-                    .write_intr_block_rf_error1_intr_count_r(size, val);
+            0x904..0x908 => {
+                self.periph.write_intr_block_rf_error1_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x905..=0x907) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x908) => {
-                self.periph
-                    .write_intr_block_rf_error2_intr_count_r(size, val);
+            0x908..0x90c => {
+                self.periph.write_intr_block_rf_error2_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x909..=0x90b) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x90c) => {
-                self.periph
-                    .write_intr_block_rf_error3_intr_count_r(size, val);
+            0x90c..0x910 => {
+                self.periph.write_intr_block_rf_error3_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x90d..=0x90f) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x980) => {
+            0x980..0x984 => {
                 self.periph
-                    .write_intr_block_rf_notif_cmd_done_intr_count_r(size, val);
+                    .write_intr_block_rf_notif_cmd_done_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x981..=0x983) => Err(emulator_bus::BusError::StoreAddrMisaligned),
             _ => Err(emulator_bus::BusError::StoreAccessFault),
         }
     }

--- a/registers/generated-emulator/src/soc.rs
+++ b/registers/generated-emulator/src/soc.rs
@@ -11,7 +11,6 @@ pub trait SocPeripheral {
     fn update_reset(&mut self) {}
     fn read_cptra_hw_error_fatal(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraHwErrorFatal::Register,
@@ -20,7 +19,6 @@ pub trait SocPeripheral {
     }
     fn write_cptra_hw_error_fatal(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::CptraHwErrorFatal::Register,
@@ -29,7 +27,6 @@ pub trait SocPeripheral {
     }
     fn read_cptra_hw_error_non_fatal(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraHwErrorNonFatal::Register,
@@ -38,79 +35,38 @@ pub trait SocPeripheral {
     }
     fn write_cptra_hw_error_non_fatal(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::CptraHwErrorNonFatal::Register,
         >,
     ) {
     }
-    fn read_cptra_fw_error_fatal(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_cptra_fw_error_fatal(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_cptra_fw_error_fatal(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_cptra_fw_error_non_fatal(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_cptra_fw_error_fatal(&mut self, _val: emulator_types::RvData) {}
+    fn read_cptra_fw_error_non_fatal(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_cptra_fw_error_non_fatal(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_cptra_hw_error_enc(&mut self, _size: emulator_types::RvSize) -> emulator_types::RvData {
+    fn write_cptra_fw_error_non_fatal(&mut self, _val: emulator_types::RvData) {}
+    fn read_cptra_hw_error_enc(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_cptra_hw_error_enc(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_cptra_fw_error_enc(&mut self, _size: emulator_types::RvSize) -> emulator_types::RvData {
+    fn write_cptra_hw_error_enc(&mut self, _val: emulator_types::RvData) {}
+    fn read_cptra_fw_error_enc(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_cptra_fw_error_enc(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_cptra_fw_extended_error_info(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_cptra_fw_error_enc(&mut self, _val: emulator_types::RvData) {}
+    fn read_cptra_fw_extended_error_info(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_cptra_fw_extended_error_info(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_cptra_boot_status(&mut self, _size: emulator_types::RvSize) -> emulator_types::RvData {
+    fn write_cptra_fw_extended_error_info(&mut self, _val: emulator_types::RvData) {}
+    fn read_cptra_boot_status(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_cptra_boot_status(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
+    fn write_cptra_boot_status(&mut self, _val: emulator_types::RvData) {}
     fn read_cptra_flow_status(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraFlowStatus::Register,
@@ -119,7 +75,6 @@ pub trait SocPeripheral {
     }
     fn write_cptra_flow_status(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::CptraFlowStatus::Register,
@@ -128,7 +83,6 @@ pub trait SocPeripheral {
     }
     fn read_cptra_reset_reason(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraResetReason::Register,
@@ -137,28 +91,18 @@ pub trait SocPeripheral {
     }
     fn read_cptra_security_state(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraSecurityState::Register,
     > {
         emulator_bus::ReadWriteRegister::new(0)
     }
-    fn read_cptra_mbox_valid_axi_user(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_cptra_mbox_valid_axi_user(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_cptra_mbox_valid_axi_user(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
+    fn write_cptra_mbox_valid_axi_user(&mut self, _val: emulator_types::RvData) {}
     fn read_cptra_mbox_axi_user_lock(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraXxxxAxiUserLock::Register,
@@ -167,28 +111,18 @@ pub trait SocPeripheral {
     }
     fn write_cptra_mbox_axi_user_lock(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::CptraXxxxAxiUserLock::Register,
         >,
     ) {
     }
-    fn read_cptra_trng_valid_axi_user(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_cptra_trng_valid_axi_user(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_cptra_trng_valid_axi_user(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
+    fn write_cptra_trng_valid_axi_user(&mut self, _val: emulator_types::RvData) {}
     fn read_cptra_trng_axi_user_lock(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraXxxxAxiUserLock::Register,
@@ -197,32 +131,24 @@ pub trait SocPeripheral {
     }
     fn write_cptra_trng_axi_user_lock(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::CptraXxxxAxiUserLock::Register,
         >,
     ) {
     }
-    fn read_cptra_trng_data(&mut self, _size: emulator_types::RvSize) -> emulator_types::RvData {
+    fn read_cptra_trng_data(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_cptra_trng_data(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
+    fn write_cptra_trng_data(&mut self, _val: emulator_types::RvData) {}
     fn read_cptra_trng_ctrl(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::soc::bits::CptraTrngCtrl::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn write_cptra_trng_ctrl(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::CptraTrngCtrl::Register,
@@ -231,7 +157,6 @@ pub trait SocPeripheral {
     }
     fn read_cptra_trng_status(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraTrngStatus::Register,
@@ -240,7 +165,6 @@ pub trait SocPeripheral {
     }
     fn write_cptra_trng_status(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::CptraTrngStatus::Register,
@@ -249,7 +173,6 @@ pub trait SocPeripheral {
     }
     fn read_cptra_fuse_wr_done(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraFuseWrDone::Register,
@@ -258,25 +181,18 @@ pub trait SocPeripheral {
     }
     fn write_cptra_fuse_wr_done(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::CptraFuseWrDone::Register,
         >,
     ) {
     }
-    fn read_cptra_timer_config(&mut self, _size: emulator_types::RvSize) -> emulator_types::RvData {
+    fn read_cptra_timer_config(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_cptra_timer_config(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
+    fn write_cptra_timer_config(&mut self, _val: emulator_types::RvData) {}
     fn read_cptra_bootfsm_go(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraBootfsmGo::Register,
@@ -285,28 +201,18 @@ pub trait SocPeripheral {
     }
     fn write_cptra_bootfsm_go(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::CptraBootfsmGo::Register,
         >,
     ) {
     }
-    fn read_cptra_dbg_manuf_service_reg(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_cptra_dbg_manuf_service_reg(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_cptra_dbg_manuf_service_reg(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
+    fn write_cptra_dbg_manuf_service_reg(&mut self, _val: emulator_types::RvData) {}
     fn read_cptra_clk_gating_en(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraClkGatingEn::Register,
@@ -315,57 +221,37 @@ pub trait SocPeripheral {
     }
     fn write_cptra_clk_gating_en(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::CptraClkGatingEn::Register,
         >,
     ) {
     }
-    fn read_cptra_generic_input_wires(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_cptra_generic_input_wires(&mut self) -> emulator_types::RvData {
         0
     }
-    fn read_cptra_generic_output_wires(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_cptra_generic_output_wires(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_cptra_generic_output_wires(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
+    fn write_cptra_generic_output_wires(&mut self, _val: emulator_types::RvData) {}
     fn read_cptra_hw_rev_id(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::soc::bits::CptraHwRevId::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
-    fn read_cptra_fw_rev_id(&mut self, _size: emulator_types::RvSize) -> emulator_types::RvData {
+    fn read_cptra_fw_rev_id(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_cptra_fw_rev_id(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
+    fn write_cptra_fw_rev_id(&mut self, _val: emulator_types::RvData) {}
     fn read_cptra_hw_config(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::soc::bits::CptraHwConfig::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn read_cptra_wdt_timer1_en(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraWdtTimer1En::Register,
@@ -374,7 +260,6 @@ pub trait SocPeripheral {
     }
     fn write_cptra_wdt_timer1_en(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::CptraWdtTimer1En::Register,
@@ -383,7 +268,6 @@ pub trait SocPeripheral {
     }
     fn read_cptra_wdt_timer1_ctrl(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraWdtTimer1Ctrl::Register,
@@ -392,28 +276,18 @@ pub trait SocPeripheral {
     }
     fn write_cptra_wdt_timer1_ctrl(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::CptraWdtTimer1Ctrl::Register,
         >,
     ) {
     }
-    fn read_cptra_wdt_timer1_timeout_period(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_cptra_wdt_timer1_timeout_period(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_cptra_wdt_timer1_timeout_period(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
+    fn write_cptra_wdt_timer1_timeout_period(&mut self, _val: emulator_types::RvData) {}
     fn read_cptra_wdt_timer2_en(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraWdtTimer2En::Register,
@@ -422,7 +296,6 @@ pub trait SocPeripheral {
     }
     fn write_cptra_wdt_timer2_en(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::CptraWdtTimer2En::Register,
@@ -431,7 +304,6 @@ pub trait SocPeripheral {
     }
     fn read_cptra_wdt_timer2_ctrl(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraWdtTimer2Ctrl::Register,
@@ -440,28 +312,18 @@ pub trait SocPeripheral {
     }
     fn write_cptra_wdt_timer2_ctrl(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::CptraWdtTimer2Ctrl::Register,
         >,
     ) {
     }
-    fn read_cptra_wdt_timer2_timeout_period(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_cptra_wdt_timer2_timeout_period(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_cptra_wdt_timer2_timeout_period(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
+    fn write_cptra_wdt_timer2_timeout_period(&mut self, _val: emulator_types::RvData) {}
     fn read_cptra_wdt_status(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraWdtStatus::Register,
@@ -470,28 +332,18 @@ pub trait SocPeripheral {
     }
     fn write_cptra_wdt_status(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::CptraWdtStatus::Register,
         >,
     ) {
     }
-    fn read_cptra_fuse_valid_axi_user(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_cptra_fuse_valid_axi_user(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_cptra_fuse_valid_axi_user(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
+    fn write_cptra_fuse_valid_axi_user(&mut self, _val: emulator_types::RvData) {}
     fn read_cptra_fuse_axi_user_lock(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraXxxxAxiUserLock::Register,
@@ -500,21 +352,18 @@ pub trait SocPeripheral {
     }
     fn write_cptra_fuse_axi_user_lock(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::CptraXxxxAxiUserLock::Register,
         >,
     ) {
     }
-    fn read_cptra_wdt_cfg(&mut self, _size: emulator_types::RvSize) -> emulator_types::RvData {
+    fn read_cptra_wdt_cfg(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_cptra_wdt_cfg(&mut self, _size: emulator_types::RvSize, _val: emulator_types::RvData) {
-    }
+    fn write_cptra_wdt_cfg(&mut self, _val: emulator_types::RvData) {}
     fn read_cptra_i_trng_entropy_config_0(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraItrngEntropyConfig0::Register,
@@ -523,7 +372,6 @@ pub trait SocPeripheral {
     }
     fn write_cptra_i_trng_entropy_config_0(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::CptraItrngEntropyConfig0::Register,
@@ -532,7 +380,6 @@ pub trait SocPeripheral {
     }
     fn read_cptra_i_trng_entropy_config_1(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraItrngEntropyConfig1::Register,
@@ -541,146 +388,76 @@ pub trait SocPeripheral {
     }
     fn write_cptra_i_trng_entropy_config_1(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::CptraItrngEntropyConfig1::Register,
         >,
     ) {
     }
-    fn read_cptra_rsvd_reg(&mut self, _size: emulator_types::RvSize) -> emulator_types::RvData {
+    fn read_cptra_rsvd_reg(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_cptra_rsvd_reg(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_cptra_hw_capabilities(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_cptra_rsvd_reg(&mut self, _val: emulator_types::RvData) {}
+    fn read_cptra_hw_capabilities(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_cptra_hw_capabilities(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_cptra_fw_capabilities(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_cptra_hw_capabilities(&mut self, _val: emulator_types::RvData) {}
+    fn read_cptra_fw_capabilities(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_cptra_fw_capabilities(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
+    fn write_cptra_fw_capabilities(&mut self, _val: emulator_types::RvData) {}
     fn read_cptra_cap_lock(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::soc::bits::CptraXxxxxxxk::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn write_cptra_cap_lock(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::CptraXxxxxxxk::Register,
         >,
     ) {
     }
-    fn read_cptra_owner_pk_hash(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_cptra_owner_pk_hash(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_cptra_owner_pk_hash(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
+    fn write_cptra_owner_pk_hash(&mut self, _val: emulator_types::RvData) {}
     fn read_cptra_owner_pk_hash_lock(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::soc::bits::CptraXxxxxxxk::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn write_cptra_owner_pk_hash_lock(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::CptraXxxxxxxk::Register,
         >,
     ) {
     }
-    fn write_fuse_uds_seed(&mut self, _size: emulator_types::RvSize, _val: emulator_types::RvData) {
-    }
-    fn write_fuse_field_entropy(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_fuse_key_manifest_pk_hash(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_fuse_uds_seed(&mut self, _val: emulator_types::RvData) {}
+    fn write_fuse_field_entropy(&mut self, _val: emulator_types::RvData) {}
+    fn read_fuse_key_manifest_pk_hash(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_fuse_key_manifest_pk_hash(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_fuse_key_manifest_pk_hash_mask(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_fuse_key_manifest_pk_hash(&mut self, _val: emulator_types::RvData) {}
+    fn read_fuse_key_manifest_pk_hash_mask(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_fuse_key_manifest_pk_hash_mask(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_fuse_fmc_key_manifest_svn(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_fuse_key_manifest_pk_hash_mask(&mut self, _val: emulator_types::RvData) {}
+    fn read_fuse_fmc_key_manifest_svn(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_fuse_fmc_key_manifest_svn(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_fuse_runtime_svn(&mut self, _size: emulator_types::RvSize) -> emulator_types::RvData {
+    fn write_fuse_fmc_key_manifest_svn(&mut self, _val: emulator_types::RvData) {}
+    fn read_fuse_runtime_svn(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_fuse_runtime_svn(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
+    fn write_fuse_runtime_svn(&mut self, _val: emulator_types::RvData) {}
     fn read_fuse_anti_rollback_disable(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::FuseAntiRollbackDisable::Register,
@@ -689,52 +466,26 @@ pub trait SocPeripheral {
     }
     fn write_fuse_anti_rollback_disable(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::FuseAntiRollbackDisable::Register,
         >,
     ) {
     }
-    fn read_fuse_idevid_cert_attr(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_fuse_idevid_cert_attr(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_fuse_idevid_cert_attr(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_fuse_idevid_manuf_hsm_id(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_fuse_idevid_cert_attr(&mut self, _val: emulator_types::RvData) {}
+    fn read_fuse_idevid_manuf_hsm_id(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_fuse_idevid_manuf_hsm_id(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_fuse_lms_revocation(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_fuse_idevid_manuf_hsm_id(&mut self, _val: emulator_types::RvData) {}
+    fn read_fuse_lms_revocation(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_fuse_lms_revocation(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
+    fn write_fuse_lms_revocation(&mut self, _val: emulator_types::RvData) {}
     fn read_fuse_mldsa_revocation(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::FuseMldsaRevocation::Register,
@@ -743,7 +494,6 @@ pub trait SocPeripheral {
     }
     fn write_fuse_mldsa_revocation(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::FuseMldsaRevocation::Register,
@@ -752,7 +502,6 @@ pub trait SocPeripheral {
     }
     fn read_fuse_soc_stepping_id(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::FuseSocSteppingId::Register,
@@ -761,182 +510,80 @@ pub trait SocPeripheral {
     }
     fn write_fuse_soc_stepping_id(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::FuseSocSteppingId::Register,
         >,
     ) {
     }
-    fn read_fuse_manuf_dbg_unlock_token(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_fuse_manuf_dbg_unlock_token(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_fuse_manuf_dbg_unlock_token(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_ss_caliptra_base_addr_l(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_fuse_manuf_dbg_unlock_token(&mut self, _val: emulator_types::RvData) {}
+    fn read_ss_caliptra_base_addr_l(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_ss_caliptra_base_addr_l(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_ss_caliptra_base_addr_h(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_ss_caliptra_base_addr_l(&mut self, _val: emulator_types::RvData) {}
+    fn read_ss_caliptra_base_addr_h(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_ss_caliptra_base_addr_h(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_ss_mci_base_addr_l(&mut self, _size: emulator_types::RvSize) -> emulator_types::RvData {
+    fn write_ss_caliptra_base_addr_h(&mut self, _val: emulator_types::RvData) {}
+    fn read_ss_mci_base_addr_l(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_ss_mci_base_addr_l(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_ss_mci_base_addr_h(&mut self, _size: emulator_types::RvSize) -> emulator_types::RvData {
+    fn write_ss_mci_base_addr_l(&mut self, _val: emulator_types::RvData) {}
+    fn read_ss_mci_base_addr_h(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_ss_mci_base_addr_h(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_ss_recovery_ifc_base_addr_l(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_ss_mci_base_addr_h(&mut self, _val: emulator_types::RvData) {}
+    fn read_ss_recovery_ifc_base_addr_l(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_ss_recovery_ifc_base_addr_l(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_ss_recovery_ifc_base_addr_h(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_ss_recovery_ifc_base_addr_l(&mut self, _val: emulator_types::RvData) {}
+    fn read_ss_recovery_ifc_base_addr_h(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_ss_recovery_ifc_base_addr_h(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_ss_otp_fc_base_addr_l(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_ss_recovery_ifc_base_addr_h(&mut self, _val: emulator_types::RvData) {}
+    fn read_ss_otp_fc_base_addr_l(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_ss_otp_fc_base_addr_l(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_ss_otp_fc_base_addr_h(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_ss_otp_fc_base_addr_l(&mut self, _val: emulator_types::RvData) {}
+    fn read_ss_otp_fc_base_addr_h(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_ss_otp_fc_base_addr_h(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_ss_uds_seed_base_addr_l(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_ss_otp_fc_base_addr_h(&mut self, _val: emulator_types::RvData) {}
+    fn read_ss_uds_seed_base_addr_l(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_ss_uds_seed_base_addr_l(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_ss_uds_seed_base_addr_h(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_ss_uds_seed_base_addr_l(&mut self, _val: emulator_types::RvData) {}
+    fn read_ss_uds_seed_base_addr_h(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_ss_uds_seed_base_addr_h(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_ss_prod_debug_unlock_auth_pk_hash_reg_bank_offset(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_ss_uds_seed_base_addr_h(&mut self, _val: emulator_types::RvData) {}
+    fn read_ss_prod_debug_unlock_auth_pk_hash_reg_bank_offset(&mut self) -> emulator_types::RvData {
         0
     }
     fn write_ss_prod_debug_unlock_auth_pk_hash_reg_bank_offset(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
-    fn read_ss_num_of_prod_debug_unlock_auth_pk_hashes(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_ss_num_of_prod_debug_unlock_auth_pk_hashes(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_ss_num_of_prod_debug_unlock_auth_pk_hashes(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
+    fn write_ss_num_of_prod_debug_unlock_auth_pk_hashes(&mut self, _val: emulator_types::RvData) {}
     fn read_ss_debug_intent(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::soc::bits::SsDebugIntent::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
-    fn read_ss_strap_generic(&mut self, _size: emulator_types::RvSize) -> emulator_types::RvData {
+    fn read_ss_strap_generic(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_ss_strap_generic(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
+    fn write_ss_strap_generic(&mut self, _val: emulator_types::RvData) {}
     fn read_ss_dbg_manuf_service_reg_req(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::SsDbgManufServiceRegReq::Register,
@@ -945,7 +592,6 @@ pub trait SocPeripheral {
     }
     fn write_ss_dbg_manuf_service_reg_req(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::SsDbgManufServiceRegReq::Register,
@@ -954,7 +600,6 @@ pub trait SocPeripheral {
     }
     fn read_ss_dbg_manuf_service_reg_rsp(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::SsDbgManufServiceRegRsp::Register,
@@ -963,46 +608,23 @@ pub trait SocPeripheral {
     }
     fn write_ss_dbg_manuf_service_reg_rsp(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::SsDbgManufServiceRegRsp::Register,
         >,
     ) {
     }
-    fn read_ss_soc_dbg_unlock_level(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_ss_soc_dbg_unlock_level(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_ss_soc_dbg_unlock_level(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_ss_generic_fw_exec_ctrl(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_ss_soc_dbg_unlock_level(&mut self, _val: emulator_types::RvData) {}
+    fn read_ss_generic_fw_exec_ctrl(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_ss_generic_fw_exec_ctrl(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn write_internal_obf_key(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
+    fn write_ss_generic_fw_exec_ctrl(&mut self, _val: emulator_types::RvData) {}
+    fn write_internal_obf_key(&mut self, _val: emulator_types::RvData) {}
     fn read_internal_iccm_lock(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::InternalIccmLock::Register,
@@ -1011,7 +633,6 @@ pub trait SocPeripheral {
     }
     fn write_internal_iccm_lock(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::InternalIccmLock::Register,
@@ -1020,7 +641,6 @@ pub trait SocPeripheral {
     }
     fn read_internal_fw_update_reset(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::InternalFwUpdateReset::Register,
@@ -1029,7 +649,6 @@ pub trait SocPeripheral {
     }
     fn write_internal_fw_update_reset(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::InternalFwUpdateReset::Register,
@@ -1038,7 +657,6 @@ pub trait SocPeripheral {
     }
     fn read_internal_fw_update_reset_wait_cycles(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::InternalFwUpdateResetWaitCycles::Register,
@@ -1047,28 +665,18 @@ pub trait SocPeripheral {
     }
     fn write_internal_fw_update_reset_wait_cycles(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::InternalFwUpdateResetWaitCycles::Register,
         >,
     ) {
     }
-    fn read_internal_nmi_vector(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_internal_nmi_vector(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_internal_nmi_vector(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
+    fn write_internal_nmi_vector(&mut self, _val: emulator_types::RvData) {}
     fn read_internal_hw_error_fatal_mask(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::InternalHwErrorFatalMask::Register,
@@ -1077,7 +685,6 @@ pub trait SocPeripheral {
     }
     fn write_internal_hw_error_fatal_mask(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::InternalHwErrorFatalMask::Register,
@@ -1086,7 +693,6 @@ pub trait SocPeripheral {
     }
     fn read_internal_hw_error_non_fatal_mask(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::InternalHwErrorNonFatalMask::Register,
@@ -1095,95 +701,44 @@ pub trait SocPeripheral {
     }
     fn write_internal_hw_error_non_fatal_mask(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::InternalHwErrorNonFatalMask::Register,
         >,
     ) {
     }
-    fn read_internal_fw_error_fatal_mask(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_internal_fw_error_fatal_mask(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_internal_fw_error_fatal_mask(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_internal_fw_error_non_fatal_mask(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_internal_fw_error_fatal_mask(&mut self, _val: emulator_types::RvData) {}
+    fn read_internal_fw_error_non_fatal_mask(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_internal_fw_error_non_fatal_mask(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_internal_rv_mtime_l(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_internal_fw_error_non_fatal_mask(&mut self, _val: emulator_types::RvData) {}
+    fn read_internal_rv_mtime_l(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_internal_rv_mtime_l(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_internal_rv_mtime_h(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_internal_rv_mtime_l(&mut self, _val: emulator_types::RvData) {}
+    fn read_internal_rv_mtime_h(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_internal_rv_mtime_h(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_internal_rv_mtimecmp_l(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_internal_rv_mtime_h(&mut self, _val: emulator_types::RvData) {}
+    fn read_internal_rv_mtimecmp_l(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_internal_rv_mtimecmp_l(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_internal_rv_mtimecmp_h(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_internal_rv_mtimecmp_l(&mut self, _val: emulator_types::RvData) {}
+    fn read_internal_rv_mtimecmp_h(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_internal_rv_mtimecmp_h(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
+    fn write_internal_rv_mtimecmp_h(&mut self, _val: emulator_types::RvData) {}
     fn read_intr_block_rf_global_intr_en_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::soc::bits::GlobalIntrEnT::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn write_intr_block_rf_global_intr_en_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::GlobalIntrEnT::Register,
@@ -1192,14 +747,12 @@ pub trait SocPeripheral {
     }
     fn read_intr_block_rf_error_intr_en_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::soc::bits::ErrorIntrEnT::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn write_intr_block_rf_error_intr_en_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::ErrorIntrEnT::Register,
@@ -1208,14 +761,12 @@ pub trait SocPeripheral {
     }
     fn read_intr_block_rf_notif_intr_en_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::soc::bits::NotifIntrEnT::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn write_intr_block_rf_notif_intr_en_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::NotifIntrEnT::Register,
@@ -1224,28 +775,24 @@ pub trait SocPeripheral {
     }
     fn read_intr_block_rf_error_global_intr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::soc::bits::GlobalIntrT::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn read_intr_block_rf_notif_global_intr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::soc::bits::GlobalIntrT::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn read_intr_block_rf_error_internal_intr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::soc::bits::ErrorIntrT::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn write_intr_block_rf_error_internal_intr_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::ErrorIntrT::Register,
@@ -1254,14 +801,12 @@ pub trait SocPeripheral {
     }
     fn read_intr_block_rf_notif_internal_intr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::soc::bits::NotifIntrT::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
     fn write_intr_block_rf_notif_internal_intr_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::NotifIntrT::Register,
@@ -1270,7 +815,6 @@ pub trait SocPeripheral {
     }
     fn read_intr_block_rf_error_intr_trig_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::ErrorIntrTrigT::Register,
@@ -1279,7 +823,6 @@ pub trait SocPeripheral {
     }
     fn write_intr_block_rf_error_intr_trig_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::ErrorIntrTrigT::Register,
@@ -1288,7 +831,6 @@ pub trait SocPeripheral {
     }
     fn read_intr_block_rf_notif_intr_trig_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::NotifIntrTrigT::Register,
@@ -1297,184 +839,106 @@ pub trait SocPeripheral {
     }
     fn write_intr_block_rf_notif_intr_trig_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::NotifIntrTrigT::Register,
         >,
     ) {
     }
-    fn read_intr_block_rf_error_internal_intr_count_r(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_intr_block_rf_error_internal_intr_count_r(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_intr_block_rf_error_internal_intr_count_r(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_intr_block_rf_error_inv_dev_intr_count_r(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_intr_block_rf_error_internal_intr_count_r(&mut self, _val: emulator_types::RvData) {}
+    fn read_intr_block_rf_error_inv_dev_intr_count_r(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_intr_block_rf_error_inv_dev_intr_count_r(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_intr_block_rf_error_cmd_fail_intr_count_r(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_intr_block_rf_error_inv_dev_intr_count_r(&mut self, _val: emulator_types::RvData) {}
+    fn read_intr_block_rf_error_cmd_fail_intr_count_r(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_intr_block_rf_error_cmd_fail_intr_count_r(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_intr_block_rf_error_bad_fuse_intr_count_r(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_intr_block_rf_error_cmd_fail_intr_count_r(&mut self, _val: emulator_types::RvData) {}
+    fn read_intr_block_rf_error_bad_fuse_intr_count_r(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_intr_block_rf_error_bad_fuse_intr_count_r(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_intr_block_rf_error_iccm_blocked_intr_count_r(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_intr_block_rf_error_bad_fuse_intr_count_r(&mut self, _val: emulator_types::RvData) {}
+    fn read_intr_block_rf_error_iccm_blocked_intr_count_r(&mut self) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_error_iccm_blocked_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
-    fn read_intr_block_rf_error_mbox_ecc_unc_intr_count_r(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_intr_block_rf_error_mbox_ecc_unc_intr_count_r(&mut self) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_error_mbox_ecc_unc_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
     fn read_intr_block_rf_error_wdt_timer1_timeout_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_error_wdt_timer1_timeout_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
     fn read_intr_block_rf_error_wdt_timer2_timeout_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_error_wdt_timer2_timeout_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
-    fn read_intr_block_rf_notif_cmd_avail_intr_count_r(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_intr_block_rf_notif_cmd_avail_intr_count_r(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_intr_block_rf_notif_cmd_avail_intr_count_r(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_intr_block_rf_notif_mbox_ecc_cor_intr_count_r(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_intr_block_rf_notif_cmd_avail_intr_count_r(&mut self, _val: emulator_types::RvData) {}
+    fn read_intr_block_rf_notif_mbox_ecc_cor_intr_count_r(&mut self) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_notif_mbox_ecc_cor_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
-    fn read_intr_block_rf_notif_debug_locked_intr_count_r(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_intr_block_rf_notif_debug_locked_intr_count_r(&mut self) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_notif_debug_locked_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
-    fn read_intr_block_rf_notif_scan_mode_intr_count_r(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_intr_block_rf_notif_scan_mode_intr_count_r(&mut self) -> emulator_types::RvData {
         0
     }
-    fn write_intr_block_rf_notif_scan_mode_intr_count_r(
-        &mut self,
-        _size: emulator_types::RvSize,
-        _val: emulator_types::RvData,
-    ) {
-    }
-    fn read_intr_block_rf_notif_soc_req_lock_intr_count_r(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn write_intr_block_rf_notif_scan_mode_intr_count_r(&mut self, _val: emulator_types::RvData) {}
+    fn read_intr_block_rf_notif_soc_req_lock_intr_count_r(&mut self) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_notif_soc_req_lock_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
-    fn read_intr_block_rf_notif_gen_in_toggle_intr_count_r(
-        &mut self,
-        _size: emulator_types::RvSize,
-    ) -> emulator_types::RvData {
+    fn read_intr_block_rf_notif_gen_in_toggle_intr_count_r(&mut self) -> emulator_types::RvData {
         0
     }
     fn write_intr_block_rf_notif_gen_in_toggle_intr_count_r(
         &mut self,
-        _size: emulator_types::RvSize,
         _val: emulator_types::RvData,
     ) {
     }
     fn read_intr_block_rf_error_internal_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -1483,7 +947,6 @@ pub trait SocPeripheral {
     }
     fn read_intr_block_rf_error_inv_dev_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -1492,7 +955,6 @@ pub trait SocPeripheral {
     }
     fn read_intr_block_rf_error_cmd_fail_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -1501,7 +963,6 @@ pub trait SocPeripheral {
     }
     fn read_intr_block_rf_error_bad_fuse_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -1510,7 +971,6 @@ pub trait SocPeripheral {
     }
     fn read_intr_block_rf_error_iccm_blocked_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -1519,7 +979,6 @@ pub trait SocPeripheral {
     }
     fn read_intr_block_rf_error_mbox_ecc_unc_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -1528,7 +987,6 @@ pub trait SocPeripheral {
     }
     fn read_intr_block_rf_error_wdt_timer1_timeout_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -1537,7 +995,6 @@ pub trait SocPeripheral {
     }
     fn read_intr_block_rf_error_wdt_timer2_timeout_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -1546,7 +1003,6 @@ pub trait SocPeripheral {
     }
     fn read_intr_block_rf_notif_cmd_avail_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -1555,7 +1011,6 @@ pub trait SocPeripheral {
     }
     fn read_intr_block_rf_notif_mbox_ecc_cor_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -1564,7 +1019,6 @@ pub trait SocPeripheral {
     }
     fn read_intr_block_rf_notif_debug_locked_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -1573,7 +1027,6 @@ pub trait SocPeripheral {
     }
     fn read_intr_block_rf_notif_scan_mode_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -1582,7 +1035,6 @@ pub trait SocPeripheral {
     }
     fn read_intr_block_rf_notif_soc_req_lock_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -1591,7 +1043,6 @@ pub trait SocPeripheral {
     }
     fn read_intr_block_rf_notif_gen_in_toggle_intr_count_incr_r(
         &mut self,
-        _size: emulator_types::RvSize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::IntrCountIncrT::Register,
@@ -1608,721 +1059,334 @@ impl emulator_bus::Bus for SocBus {
         size: emulator_types::RvSize,
         addr: emulator_types::RvAddr,
     ) -> Result<emulator_types::RvData, emulator_bus::BusError> {
-        match (size, addr) {
-            (emulator_types::RvSize::Word, 0) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_cptra_hw_error_fatal(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+        if addr & 0x3 != 0 || size != emulator_types::RvSize::Word {
+            return Err(emulator_bus::BusError::LoadAddrMisaligned);
+        }
+        match addr {
+            0..4 => Ok(emulator_types::RvData::from(
+                self.periph.read_cptra_hw_error_fatal().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 1..=3) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 4) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_cptra_hw_error_non_fatal(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            4..8 => Ok(emulator_types::RvData::from(
+                self.periph.read_cptra_hw_error_non_fatal().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 5..=7) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (size, 8) => Ok(self.periph.read_cptra_fw_error_fatal(size)),
-            (_, 9..=0xb) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0xc) => Ok(self.periph.read_cptra_fw_error_non_fatal(size)),
-            (_, 0xd..=0xf) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x10) => Ok(self.periph.read_cptra_hw_error_enc(size)),
-            (_, 0x11..=0x13) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x14) => Ok(self.periph.read_cptra_fw_error_enc(size)),
-            (_, 0x15..=0x17) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x18) => Ok(self.periph.read_cptra_fw_extended_error_info(size)),
-            (_, 0x19..=0x1b) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x38) => Ok(self.periph.read_cptra_boot_status(size)),
-            (_, 0x39..=0x3b) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x3c) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_cptra_flow_status(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            8..0xc => Ok(self.periph.read_cptra_fw_error_fatal()),
+            0xc..0x10 => Ok(self.periph.read_cptra_fw_error_non_fatal()),
+            0x10..0x14 => Ok(self.periph.read_cptra_hw_error_enc()),
+            0x14..0x18 => Ok(self.periph.read_cptra_fw_error_enc()),
+            0x18..0x38 => Ok(self.periph.read_cptra_fw_extended_error_info()),
+            0x38..0x3c => Ok(self.periph.read_cptra_boot_status()),
+            0x3c..0x40 => Ok(emulator_types::RvData::from(
+                self.periph.read_cptra_flow_status().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0x3d..=0x3f) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x40) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_cptra_reset_reason(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0x40..0x44 => Ok(emulator_types::RvData::from(
+                self.periph.read_cptra_reset_reason().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0x41..=0x43) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x44) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_cptra_security_state(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0x44..0x48 => Ok(emulator_types::RvData::from(
+                self.periph.read_cptra_security_state().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0x45..=0x47) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (size, 0x48) => Ok(self.periph.read_cptra_mbox_valid_axi_user(size)),
-            (_, 0x49..=0x4b) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x5c) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_cptra_mbox_axi_user_lock(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0x48..0x5c => Ok(self.periph.read_cptra_mbox_valid_axi_user()),
+            0x5c..0x70 => Ok(emulator_types::RvData::from(
+                self.periph.read_cptra_mbox_axi_user_lock().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0x5d..=0x5f) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (size, 0x70) => Ok(self.periph.read_cptra_trng_valid_axi_user(size)),
-            (_, 0x71..=0x73) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x74) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_cptra_trng_axi_user_lock(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0x70..0x74 => Ok(self.periph.read_cptra_trng_valid_axi_user()),
+            0x74..0x78 => Ok(emulator_types::RvData::from(
+                self.periph.read_cptra_trng_axi_user_lock().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0x75..=0x77) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (size, 0x78) => Ok(self.periph.read_cptra_trng_data(size)),
-            (_, 0x79..=0x7b) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (emulator_types::RvSize::Word, 0xa8) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_cptra_trng_ctrl(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0x78..0xa8 => Ok(self.periph.read_cptra_trng_data()),
+            0xa8..0xac => Ok(emulator_types::RvData::from(
+                self.periph.read_cptra_trng_ctrl().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0xa9..=0xab) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xac) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_cptra_trng_status(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0xac..0xb0 => Ok(emulator_types::RvData::from(
+                self.periph.read_cptra_trng_status().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0xad..=0xaf) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xb0) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_cptra_fuse_wr_done(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0xb0..0xb4 => Ok(emulator_types::RvData::from(
+                self.periph.read_cptra_fuse_wr_done().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0xb1..=0xb3) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (size, 0xb4) => Ok(self.periph.read_cptra_timer_config(size)),
-            (_, 0xb5..=0xb7) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (emulator_types::RvSize::Word, 0xb8) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_cptra_bootfsm_go(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0xb4..0xb8 => Ok(self.periph.read_cptra_timer_config()),
+            0xb8..0xbc => Ok(emulator_types::RvData::from(
+                self.periph.read_cptra_bootfsm_go().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0xb9..=0xbb) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (size, 0xbc) => Ok(self.periph.read_cptra_dbg_manuf_service_reg(size)),
-            (_, 0xbd..=0xbf) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (emulator_types::RvSize::Word, 0xc0) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_cptra_clk_gating_en(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0xbc..0xc0 => Ok(self.periph.read_cptra_dbg_manuf_service_reg()),
+            0xc0..0xc4 => Ok(emulator_types::RvData::from(
+                self.periph.read_cptra_clk_gating_en().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0xc1..=0xc3) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (size, 0xc4) => Ok(self.periph.read_cptra_generic_input_wires(size)),
-            (_, 0xc5..=0xc7) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0xcc) => Ok(self.periph.read_cptra_generic_output_wires(size)),
-            (_, 0xcd..=0xcf) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (emulator_types::RvSize::Word, 0xd4) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_cptra_hw_rev_id(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0xc4..0xcc => Ok(self.periph.read_cptra_generic_input_wires()),
+            0xcc..0xd4 => Ok(self.periph.read_cptra_generic_output_wires()),
+            0xd4..0xd8 => Ok(emulator_types::RvData::from(
+                self.periph.read_cptra_hw_rev_id().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0xd5..=0xd7) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (size, 0xd8) => Ok(self.periph.read_cptra_fw_rev_id(size)),
-            (_, 0xd9..=0xdb) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (emulator_types::RvSize::Word, 0xe0) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_cptra_hw_config(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0xd8..0xe0 => Ok(self.periph.read_cptra_fw_rev_id()),
+            0xe0..0xe4 => Ok(emulator_types::RvData::from(
+                self.periph.read_cptra_hw_config().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0xe1..=0xe3) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xe4) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_cptra_wdt_timer1_en(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0xe4..0xe8 => Ok(emulator_types::RvData::from(
+                self.periph.read_cptra_wdt_timer1_en().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0xe5..=0xe7) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xe8) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_cptra_wdt_timer1_ctrl(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0xe8..0xec => Ok(emulator_types::RvData::from(
+                self.periph.read_cptra_wdt_timer1_ctrl().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0xe9..=0xeb) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (size, 0xec) => Ok(self.periph.read_cptra_wdt_timer1_timeout_period(size)),
-            (_, 0xed..=0xef) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (emulator_types::RvSize::Word, 0xf4) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_cptra_wdt_timer2_en(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0xec..0xf4 => Ok(self.periph.read_cptra_wdt_timer1_timeout_period()),
+            0xf4..0xf8 => Ok(emulator_types::RvData::from(
+                self.periph.read_cptra_wdt_timer2_en().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0xf5..=0xf7) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xf8) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_cptra_wdt_timer2_ctrl(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0xf8..0xfc => Ok(emulator_types::RvData::from(
+                self.periph.read_cptra_wdt_timer2_ctrl().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0xf9..=0xfb) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (size, 0xfc) => Ok(self.periph.read_cptra_wdt_timer2_timeout_period(size)),
-            (_, 0xfd..=0xff) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x104) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_cptra_wdt_status(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0xfc..0x104 => Ok(self.periph.read_cptra_wdt_timer2_timeout_period()),
+            0x104..0x108 => Ok(emulator_types::RvData::from(
+                self.periph.read_cptra_wdt_status().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0x105..=0x107) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (size, 0x108) => Ok(self.periph.read_cptra_fuse_valid_axi_user(size)),
-            (_, 0x109..=0x10b) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x10c) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_cptra_fuse_axi_user_lock(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0x108..0x10c => Ok(self.periph.read_cptra_fuse_valid_axi_user()),
+            0x10c..0x110 => Ok(emulator_types::RvData::from(
+                self.periph.read_cptra_fuse_axi_user_lock().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0x10d..=0x10f) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (size, 0x110) => Ok(self.periph.read_cptra_wdt_cfg(size)),
-            (_, 0x111..=0x113) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x118) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_cptra_i_trng_entropy_config_0(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0x110..0x118 => Ok(self.periph.read_cptra_wdt_cfg()),
+            0x118..0x11c => Ok(emulator_types::RvData::from(
+                self.periph.read_cptra_i_trng_entropy_config_0().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0x119..=0x11b) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x11c) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_cptra_i_trng_entropy_config_1(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0x11c..0x120 => Ok(emulator_types::RvData::from(
+                self.periph.read_cptra_i_trng_entropy_config_1().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0x11d..=0x11f) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (size, 0x120) => Ok(self.periph.read_cptra_rsvd_reg(size)),
-            (_, 0x121..=0x123) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x128) => Ok(self.periph.read_cptra_hw_capabilities(size)),
-            (_, 0x129..=0x12b) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x12c) => Ok(self.periph.read_cptra_fw_capabilities(size)),
-            (_, 0x12d..=0x12f) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x130) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_cptra_cap_lock(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0x120..0x128 => Ok(self.periph.read_cptra_rsvd_reg()),
+            0x128..0x12c => Ok(self.periph.read_cptra_hw_capabilities()),
+            0x12c..0x130 => Ok(self.periph.read_cptra_fw_capabilities()),
+            0x130..0x134 => Ok(emulator_types::RvData::from(
+                self.periph.read_cptra_cap_lock().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0x131..=0x133) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (size, 0x140) => Ok(self.periph.read_cptra_owner_pk_hash(size)),
-            (_, 0x141..=0x143) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x170) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_cptra_owner_pk_hash_lock(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0x140..0x170 => Ok(self.periph.read_cptra_owner_pk_hash()),
+            0x170..0x174 => Ok(emulator_types::RvData::from(
+                self.periph.read_cptra_owner_pk_hash_lock().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0x171..=0x173) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (size, 0x260) => Ok(self.periph.read_fuse_key_manifest_pk_hash(size)),
-            (_, 0x261..=0x263) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x290) => Ok(self.periph.read_fuse_key_manifest_pk_hash_mask(size)),
-            (_, 0x291..=0x293) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x2b4) => Ok(self.periph.read_fuse_fmc_key_manifest_svn(size)),
-            (_, 0x2b5..=0x2b7) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x2b8) => Ok(self.periph.read_fuse_runtime_svn(size)),
-            (_, 0x2b9..=0x2bb) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x2c8) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_fuse_anti_rollback_disable(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0x260..0x290 => Ok(self.periph.read_fuse_key_manifest_pk_hash()),
+            0x290..0x2b0 => Ok(self.periph.read_fuse_key_manifest_pk_hash_mask()),
+            0x2b4..0x2b8 => Ok(self.periph.read_fuse_fmc_key_manifest_svn()),
+            0x2b8..0x2c8 => Ok(self.periph.read_fuse_runtime_svn()),
+            0x2c8..0x2cc => Ok(emulator_types::RvData::from(
+                self.periph.read_fuse_anti_rollback_disable().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0x2c9..=0x2cb) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (size, 0x2cc) => Ok(self.periph.read_fuse_idevid_cert_attr(size)),
-            (_, 0x2cd..=0x2cf) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x32c) => Ok(self.periph.read_fuse_idevid_manuf_hsm_id(size)),
-            (_, 0x32d..=0x32f) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x340) => Ok(self.periph.read_fuse_lms_revocation(size)),
-            (_, 0x341..=0x343) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x344) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_fuse_mldsa_revocation(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0x2cc..0x32c => Ok(self.periph.read_fuse_idevid_cert_attr()),
+            0x32c..0x33c => Ok(self.periph.read_fuse_idevid_manuf_hsm_id()),
+            0x340..0x344 => Ok(self.periph.read_fuse_lms_revocation()),
+            0x344..0x348 => Ok(emulator_types::RvData::from(
+                self.periph.read_fuse_mldsa_revocation().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0x345..=0x347) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x348) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_fuse_soc_stepping_id(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0x348..0x34c => Ok(emulator_types::RvData::from(
+                self.periph.read_fuse_soc_stepping_id().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0x349..=0x34b) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (size, 0x34c) => Ok(self.periph.read_fuse_manuf_dbg_unlock_token(size)),
-            (_, 0x34d..=0x34f) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x500) => Ok(self.periph.read_ss_caliptra_base_addr_l(size)),
-            (_, 0x501..=0x503) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x504) => Ok(self.periph.read_ss_caliptra_base_addr_h(size)),
-            (_, 0x505..=0x507) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x508) => Ok(self.periph.read_ss_mci_base_addr_l(size)),
-            (_, 0x509..=0x50b) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x50c) => Ok(self.periph.read_ss_mci_base_addr_h(size)),
-            (_, 0x50d..=0x50f) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x510) => Ok(self.periph.read_ss_recovery_ifc_base_addr_l(size)),
-            (_, 0x511..=0x513) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x514) => Ok(self.periph.read_ss_recovery_ifc_base_addr_h(size)),
-            (_, 0x515..=0x517) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x518) => Ok(self.periph.read_ss_otp_fc_base_addr_l(size)),
-            (_, 0x519..=0x51b) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x51c) => Ok(self.periph.read_ss_otp_fc_base_addr_h(size)),
-            (_, 0x51d..=0x51f) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x520) => Ok(self.periph.read_ss_uds_seed_base_addr_l(size)),
-            (_, 0x521..=0x523) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x524) => Ok(self.periph.read_ss_uds_seed_base_addr_h(size)),
-            (_, 0x525..=0x527) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x528) => Ok(self
+            0x34c..0x35c => Ok(self.periph.read_fuse_manuf_dbg_unlock_token()),
+            0x500..0x504 => Ok(self.periph.read_ss_caliptra_base_addr_l()),
+            0x504..0x508 => Ok(self.periph.read_ss_caliptra_base_addr_h()),
+            0x508..0x50c => Ok(self.periph.read_ss_mci_base_addr_l()),
+            0x50c..0x510 => Ok(self.periph.read_ss_mci_base_addr_h()),
+            0x510..0x514 => Ok(self.periph.read_ss_recovery_ifc_base_addr_l()),
+            0x514..0x518 => Ok(self.periph.read_ss_recovery_ifc_base_addr_h()),
+            0x518..0x51c => Ok(self.periph.read_ss_otp_fc_base_addr_l()),
+            0x51c..0x520 => Ok(self.periph.read_ss_otp_fc_base_addr_h()),
+            0x520..0x524 => Ok(self.periph.read_ss_uds_seed_base_addr_l()),
+            0x524..0x528 => Ok(self.periph.read_ss_uds_seed_base_addr_h()),
+            0x528..0x52c => Ok(self
                 .periph
-                .read_ss_prod_debug_unlock_auth_pk_hash_reg_bank_offset(size)),
-            (_, 0x529..=0x52b) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x52c) => Ok(self
+                .read_ss_prod_debug_unlock_auth_pk_hash_reg_bank_offset()),
+            0x52c..0x530 => Ok(self
                 .periph
-                .read_ss_num_of_prod_debug_unlock_auth_pk_hashes(size)),
-            (_, 0x52d..=0x52f) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x530) => Ok(emulator_types::RvData::from(
+                .read_ss_num_of_prod_debug_unlock_auth_pk_hashes()),
+            0x530..0x534 => Ok(emulator_types::RvData::from(
+                self.periph.read_ss_debug_intent().reg.get(),
+            )),
+            0x5a0..0x5b0 => Ok(self.periph.read_ss_strap_generic()),
+            0x5c0..0x5c4 => Ok(emulator_types::RvData::from(
+                self.periph.read_ss_dbg_manuf_service_reg_req().reg.get(),
+            )),
+            0x5c4..0x5c8 => Ok(emulator_types::RvData::from(
+                self.periph.read_ss_dbg_manuf_service_reg_rsp().reg.get(),
+            )),
+            0x5c8..0x5d0 => Ok(self.periph.read_ss_soc_dbg_unlock_level()),
+            0x5d0..0x5e0 => Ok(self.periph.read_ss_generic_fw_exec_ctrl()),
+            0x620..0x624 => Ok(emulator_types::RvData::from(
+                self.periph.read_internal_iccm_lock().reg.get(),
+            )),
+            0x624..0x628 => Ok(emulator_types::RvData::from(
+                self.periph.read_internal_fw_update_reset().reg.get(),
+            )),
+            0x628..0x62c => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_ss_debug_intent(emulator_types::RvSize::Word)
+                    .read_internal_fw_update_reset_wait_cycles()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x531..=0x533) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (size, 0x5a0) => Ok(self.periph.read_ss_strap_generic(size)),
-            (_, 0x5a1..=0x5a3) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x5c0) => Ok(emulator_types::RvData::from(
+            0x62c..0x630 => Ok(self.periph.read_internal_nmi_vector()),
+            0x630..0x634 => Ok(emulator_types::RvData::from(
+                self.periph.read_internal_hw_error_fatal_mask().reg.get(),
+            )),
+            0x634..0x638 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_ss_dbg_manuf_service_reg_req(emulator_types::RvSize::Word)
+                    .read_internal_hw_error_non_fatal_mask()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x5c1..=0x5c3) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x5c4) => Ok(emulator_types::RvData::from(
+            0x638..0x63c => Ok(self.periph.read_internal_fw_error_fatal_mask()),
+            0x63c..0x640 => Ok(self.periph.read_internal_fw_error_non_fatal_mask()),
+            0x640..0x644 => Ok(self.periph.read_internal_rv_mtime_l()),
+            0x644..0x648 => Ok(self.periph.read_internal_rv_mtime_h()),
+            0x648..0x64c => Ok(self.periph.read_internal_rv_mtimecmp_l()),
+            0x64c..0x650 => Ok(self.periph.read_internal_rv_mtimecmp_h()),
+            0x800..0x804 => Ok(emulator_types::RvData::from(
+                self.periph.read_intr_block_rf_global_intr_en_r().reg.get(),
+            )),
+            0x804..0x808 => Ok(emulator_types::RvData::from(
+                self.periph.read_intr_block_rf_error_intr_en_r().reg.get(),
+            )),
+            0x808..0x80c => Ok(emulator_types::RvData::from(
+                self.periph.read_intr_block_rf_notif_intr_en_r().reg.get(),
+            )),
+            0x80c..0x810 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_ss_dbg_manuf_service_reg_rsp(emulator_types::RvSize::Word)
+                    .read_intr_block_rf_error_global_intr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x5c5..=0x5c7) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (size, 0x5c8) => Ok(self.periph.read_ss_soc_dbg_unlock_level(size)),
-            (_, 0x5c9..=0x5cb) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x5d0) => Ok(self.periph.read_ss_generic_fw_exec_ctrl(size)),
-            (_, 0x5d1..=0x5d3) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x620) => Ok(emulator_types::RvData::from(
+            0x810..0x814 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_internal_iccm_lock(emulator_types::RvSize::Word)
+                    .read_intr_block_rf_notif_global_intr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x621..=0x623) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x624) => Ok(emulator_types::RvData::from(
+            0x814..0x818 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_internal_fw_update_reset(emulator_types::RvSize::Word)
+                    .read_intr_block_rf_error_internal_intr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x625..=0x627) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x628) => Ok(emulator_types::RvData::from(
+            0x818..0x81c => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_internal_fw_update_reset_wait_cycles(emulator_types::RvSize::Word)
+                    .read_intr_block_rf_notif_internal_intr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0x629..=0x62b) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (size, 0x62c) => Ok(self.periph.read_internal_nmi_vector(size)),
-            (_, 0x62d..=0x62f) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x630) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_internal_hw_error_fatal_mask(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0x81c..0x820 => Ok(emulator_types::RvData::from(
+                self.periph.read_intr_block_rf_error_intr_trig_r().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0x631..=0x633) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x634) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_internal_hw_error_non_fatal_mask(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
+            0x820..0x824 => Ok(emulator_types::RvData::from(
+                self.periph.read_intr_block_rf_notif_intr_trig_r().reg.get(),
             )),
-            (emulator_types::RvSize::Word, 0x635..=0x637) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (size, 0x638) => Ok(self.periph.read_internal_fw_error_fatal_mask(size)),
-            (_, 0x639..=0x63b) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x63c) => Ok(self.periph.read_internal_fw_error_non_fatal_mask(size)),
-            (_, 0x63d..=0x63f) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x640) => Ok(self.periph.read_internal_rv_mtime_l(size)),
-            (_, 0x641..=0x643) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x644) => Ok(self.periph.read_internal_rv_mtime_h(size)),
-            (_, 0x645..=0x647) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x648) => Ok(self.periph.read_internal_rv_mtimecmp_l(size)),
-            (_, 0x649..=0x64b) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x64c) => Ok(self.periph.read_internal_rv_mtimecmp_h(size)),
-            (_, 0x64d..=0x64f) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x800) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_intr_block_rf_global_intr_en_r(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0x801..=0x803) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x804) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_intr_block_rf_error_intr_en_r(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0x805..=0x807) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x808) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_intr_block_rf_notif_intr_en_r(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0x809..=0x80b) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x80c) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_intr_block_rf_error_global_intr_r(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0x80d..=0x80f) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x810) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_intr_block_rf_notif_global_intr_r(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0x811..=0x813) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x814) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_intr_block_rf_error_internal_intr_r(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0x815..=0x817) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x818) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_intr_block_rf_notif_internal_intr_r(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0x819..=0x81b) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x81c) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_intr_block_rf_error_intr_trig_r(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0x81d..=0x81f) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x820) => Ok(emulator_types::RvData::from(
-                self.periph
-                    .read_intr_block_rf_notif_intr_trig_r(emulator_types::RvSize::Word)
-                    .reg
-                    .get(),
-            )),
-            (emulator_types::RvSize::Word, 0x821..=0x823) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (size, 0x900) => Ok(self
+            0x900..0x904 => Ok(self.periph.read_intr_block_rf_error_internal_intr_count_r()),
+            0x904..0x908 => Ok(self.periph.read_intr_block_rf_error_inv_dev_intr_count_r()),
+            0x908..0x90c => Ok(self.periph.read_intr_block_rf_error_cmd_fail_intr_count_r()),
+            0x90c..0x910 => Ok(self.periph.read_intr_block_rf_error_bad_fuse_intr_count_r()),
+            0x910..0x914 => Ok(self
                 .periph
-                .read_intr_block_rf_error_internal_intr_count_r(size)),
-            (_, 0x901..=0x903) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x904) => Ok(self
+                .read_intr_block_rf_error_iccm_blocked_intr_count_r()),
+            0x914..0x918 => Ok(self
                 .periph
-                .read_intr_block_rf_error_inv_dev_intr_count_r(size)),
-            (_, 0x905..=0x907) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x908) => Ok(self
+                .read_intr_block_rf_error_mbox_ecc_unc_intr_count_r()),
+            0x918..0x91c => Ok(self
                 .periph
-                .read_intr_block_rf_error_cmd_fail_intr_count_r(size)),
-            (_, 0x909..=0x90b) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x90c) => Ok(self
+                .read_intr_block_rf_error_wdt_timer1_timeout_intr_count_r()),
+            0x91c..0x920 => Ok(self
                 .periph
-                .read_intr_block_rf_error_bad_fuse_intr_count_r(size)),
-            (_, 0x90d..=0x90f) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x910) => Ok(self
+                .read_intr_block_rf_error_wdt_timer2_timeout_intr_count_r()),
+            0x980..0x984 => Ok(self
                 .periph
-                .read_intr_block_rf_error_iccm_blocked_intr_count_r(size)),
-            (_, 0x911..=0x913) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x914) => Ok(self
+                .read_intr_block_rf_notif_cmd_avail_intr_count_r()),
+            0x984..0x988 => Ok(self
                 .periph
-                .read_intr_block_rf_error_mbox_ecc_unc_intr_count_r(size)),
-            (_, 0x915..=0x917) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x918) => Ok(self
+                .read_intr_block_rf_notif_mbox_ecc_cor_intr_count_r()),
+            0x988..0x98c => Ok(self
                 .periph
-                .read_intr_block_rf_error_wdt_timer1_timeout_intr_count_r(size)),
-            (_, 0x919..=0x91b) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x91c) => Ok(self
+                .read_intr_block_rf_notif_debug_locked_intr_count_r()),
+            0x98c..0x990 => Ok(self
                 .periph
-                .read_intr_block_rf_error_wdt_timer2_timeout_intr_count_r(size)),
-            (_, 0x91d..=0x91f) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x980) => Ok(self
+                .read_intr_block_rf_notif_scan_mode_intr_count_r()),
+            0x990..0x994 => Ok(self
                 .periph
-                .read_intr_block_rf_notif_cmd_avail_intr_count_r(size)),
-            (_, 0x981..=0x983) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x984) => Ok(self
+                .read_intr_block_rf_notif_soc_req_lock_intr_count_r()),
+            0x994..0x998 => Ok(self
                 .periph
-                .read_intr_block_rf_notif_mbox_ecc_cor_intr_count_r(size)),
-            (_, 0x985..=0x987) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x988) => Ok(self
-                .periph
-                .read_intr_block_rf_notif_debug_locked_intr_count_r(size)),
-            (_, 0x989..=0x98b) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x98c) => Ok(self
-                .periph
-                .read_intr_block_rf_notif_scan_mode_intr_count_r(size)),
-            (_, 0x98d..=0x98f) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x990) => Ok(self
-                .periph
-                .read_intr_block_rf_notif_soc_req_lock_intr_count_r(size)),
-            (_, 0x991..=0x993) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (size, 0x994) => Ok(self
-                .periph
-                .read_intr_block_rf_notif_gen_in_toggle_intr_count_r(size)),
-            (_, 0x995..=0x997) => Err(emulator_bus::BusError::LoadAddrMisaligned),
-            (emulator_types::RvSize::Word, 0xa00) => Ok(emulator_types::RvData::from(
+                .read_intr_block_rf_notif_gen_in_toggle_intr_count_r()),
+            0xa00..0xa04 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_error_internal_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_error_internal_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0xa01..=0xa03) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xa04) => Ok(emulator_types::RvData::from(
+            0xa04..0xa08 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_error_inv_dev_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_error_inv_dev_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0xa05..=0xa07) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xa08) => Ok(emulator_types::RvData::from(
+            0xa08..0xa0c => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_error_cmd_fail_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_error_cmd_fail_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0xa09..=0xa0b) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xa0c) => Ok(emulator_types::RvData::from(
+            0xa0c..0xa10 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_error_bad_fuse_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_error_bad_fuse_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0xa0d..=0xa0f) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xa10) => Ok(emulator_types::RvData::from(
+            0xa10..0xa14 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_error_iccm_blocked_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_error_iccm_blocked_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0xa11..=0xa13) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xa14) => Ok(emulator_types::RvData::from(
+            0xa14..0xa18 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_error_mbox_ecc_unc_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_error_mbox_ecc_unc_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0xa15..=0xa17) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xa18) => Ok(emulator_types::RvData::from(
+            0xa18..0xa1c => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_error_wdt_timer1_timeout_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_error_wdt_timer1_timeout_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0xa19..=0xa1b) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xa1c) => Ok(emulator_types::RvData::from(
+            0xa1c..0xa20 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_error_wdt_timer2_timeout_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_error_wdt_timer2_timeout_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0xa1d..=0xa1f) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xa20) => Ok(emulator_types::RvData::from(
+            0xa20..0xa24 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_notif_cmd_avail_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_notif_cmd_avail_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0xa21..=0xa23) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xa24) => Ok(emulator_types::RvData::from(
+            0xa24..0xa28 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_notif_mbox_ecc_cor_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_notif_mbox_ecc_cor_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0xa25..=0xa27) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xa28) => Ok(emulator_types::RvData::from(
+            0xa28..0xa2c => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_notif_debug_locked_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_notif_debug_locked_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0xa29..=0xa2b) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xa2c) => Ok(emulator_types::RvData::from(
+            0xa2c..0xa30 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_notif_scan_mode_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_notif_scan_mode_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0xa2d..=0xa2f) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xa30) => Ok(emulator_types::RvData::from(
+            0xa30..0xa34 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_notif_soc_req_lock_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_notif_soc_req_lock_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0xa31..=0xa33) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xa34) => Ok(emulator_types::RvData::from(
+            0xa34..0xa38 => Ok(emulator_types::RvData::from(
                 self.periph
-                    .read_intr_block_rf_notif_gen_in_toggle_intr_count_incr_r(
-                        emulator_types::RvSize::Word,
-                    )
+                    .read_intr_block_rf_notif_gen_in_toggle_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            (emulator_types::RvSize::Word, 0xa35..=0xa37) => {
-                Err(emulator_bus::BusError::LoadAddrMisaligned)
-            }
             _ => Err(emulator_bus::BusError::LoadAccessFault),
         }
     }
@@ -2332,734 +1396,490 @@ impl emulator_bus::Bus for SocBus {
         addr: emulator_types::RvAddr,
         val: emulator_types::RvData,
     ) -> Result<(), emulator_bus::BusError> {
-        match (size, addr) {
-            (emulator_types::RvSize::Word, 0) => {
-                self.periph.write_cptra_hw_error_fatal(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 1..=3) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 4) => {
-                self.periph.write_cptra_hw_error_non_fatal(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 5..=7) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (size, 8) => {
-                self.periph.write_cptra_fw_error_fatal(size, val);
-                Ok(())
-            }
-            (_, 9..=0xb) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0xc) => {
-                self.periph.write_cptra_fw_error_non_fatal(size, val);
-                Ok(())
-            }
-            (_, 0xd..=0xf) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x10) => {
-                self.periph.write_cptra_hw_error_enc(size, val);
-                Ok(())
-            }
-            (_, 0x11..=0x13) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x14) => {
-                self.periph.write_cptra_fw_error_enc(size, val);
-                Ok(())
-            }
-            (_, 0x15..=0x17) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x18) => {
-                self.periph.write_cptra_fw_extended_error_info(size, val);
-                Ok(())
-            }
-            (_, 0x19..=0x1b) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x38) => {
-                self.periph.write_cptra_boot_status(size, val);
-                Ok(())
-            }
-            (_, 0x39..=0x3b) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x3c) => {
-                self.periph.write_cptra_flow_status(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0x3d..=0x3f) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (size, 0x48) => {
-                self.periph.write_cptra_mbox_valid_axi_user(size, val);
-                Ok(())
-            }
-            (_, 0x49..=0x4b) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x5c) => {
-                self.periph.write_cptra_mbox_axi_user_lock(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0x5d..=0x5f) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (size, 0x70) => {
-                self.periph.write_cptra_trng_valid_axi_user(size, val);
-                Ok(())
-            }
-            (_, 0x71..=0x73) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x74) => {
-                self.periph.write_cptra_trng_axi_user_lock(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0x75..=0x77) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (size, 0x78) => {
-                self.periph.write_cptra_trng_data(size, val);
-                Ok(())
-            }
-            (_, 0x79..=0x7b) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (emulator_types::RvSize::Word, 0xa8) => {
-                self.periph.write_cptra_trng_ctrl(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0xa9..=0xab) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xac) => {
-                self.periph.write_cptra_trng_status(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0xad..=0xaf) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xb0) => {
-                self.periph.write_cptra_fuse_wr_done(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0xb1..=0xb3) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (size, 0xb4) => {
-                self.periph.write_cptra_timer_config(size, val);
-                Ok(())
-            }
-            (_, 0xb5..=0xb7) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (emulator_types::RvSize::Word, 0xb8) => {
-                self.periph.write_cptra_bootfsm_go(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0xb9..=0xbb) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (size, 0xbc) => {
-                self.periph.write_cptra_dbg_manuf_service_reg(size, val);
-                Ok(())
-            }
-            (_, 0xbd..=0xbf) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (emulator_types::RvSize::Word, 0xc0) => {
-                self.periph.write_cptra_clk_gating_en(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0xc1..=0xc3) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (size, 0xcc) => {
-                self.periph.write_cptra_generic_output_wires(size, val);
-                Ok(())
-            }
-            (_, 0xcd..=0xcf) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0xd8) => {
-                self.periph.write_cptra_fw_rev_id(size, val);
-                Ok(())
-            }
-            (_, 0xd9..=0xdb) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (emulator_types::RvSize::Word, 0xe4) => {
-                self.periph.write_cptra_wdt_timer1_en(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0xe5..=0xe7) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xe8) => {
-                self.periph.write_cptra_wdt_timer1_ctrl(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0xe9..=0xeb) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (size, 0xec) => {
-                self.periph.write_cptra_wdt_timer1_timeout_period(size, val);
-                Ok(())
-            }
-            (_, 0xed..=0xef) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (emulator_types::RvSize::Word, 0xf4) => {
-                self.periph.write_cptra_wdt_timer2_en(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0xf5..=0xf7) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0xf8) => {
-                self.periph.write_cptra_wdt_timer2_ctrl(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0xf9..=0xfb) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (size, 0xfc) => {
-                self.periph.write_cptra_wdt_timer2_timeout_period(size, val);
-                Ok(())
-            }
-            (_, 0xfd..=0xff) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x104) => {
-                self.periph.write_cptra_wdt_status(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0x105..=0x107) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (size, 0x108) => {
-                self.periph.write_cptra_fuse_valid_axi_user(size, val);
-                Ok(())
-            }
-            (_, 0x109..=0x10b) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x10c) => {
-                self.periph.write_cptra_fuse_axi_user_lock(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0x10d..=0x10f) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (size, 0x110) => {
-                self.periph.write_cptra_wdt_cfg(size, val);
-                Ok(())
-            }
-            (_, 0x111..=0x113) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x118) => {
-                self.periph.write_cptra_i_trng_entropy_config_0(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0x119..=0x11b) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x11c) => {
-                self.periph.write_cptra_i_trng_entropy_config_1(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0x11d..=0x11f) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (size, 0x120) => {
-                self.periph.write_cptra_rsvd_reg(size, val);
-                Ok(())
-            }
-            (_, 0x121..=0x123) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x128) => {
-                self.periph.write_cptra_hw_capabilities(size, val);
-                Ok(())
-            }
-            (_, 0x129..=0x12b) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x12c) => {
-                self.periph.write_cptra_fw_capabilities(size, val);
-                Ok(())
-            }
-            (_, 0x12d..=0x12f) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x130) => {
-                self.periph.write_cptra_cap_lock(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0x131..=0x133) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (size, 0x140) => {
-                self.periph.write_cptra_owner_pk_hash(size, val);
-                Ok(())
-            }
-            (_, 0x141..=0x143) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x170) => {
-                self.periph.write_cptra_owner_pk_hash_lock(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0x171..=0x173) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (size, 0x200) => {
-                self.periph.write_fuse_uds_seed(size, val);
-                Ok(())
-            }
-            (_, 0x201..=0x203) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x240) => {
-                self.periph.write_fuse_field_entropy(size, val);
-                Ok(())
-            }
-            (_, 0x241..=0x243) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x260) => {
-                self.periph.write_fuse_key_manifest_pk_hash(size, val);
-                Ok(())
-            }
-            (_, 0x261..=0x263) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x290) => {
-                self.periph.write_fuse_key_manifest_pk_hash_mask(size, val);
-                Ok(())
-            }
-            (_, 0x291..=0x293) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x2b4) => {
-                self.periph.write_fuse_fmc_key_manifest_svn(size, val);
-                Ok(())
-            }
-            (_, 0x2b5..=0x2b7) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x2b8) => {
-                self.periph.write_fuse_runtime_svn(size, val);
-                Ok(())
-            }
-            (_, 0x2b9..=0x2bb) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x2c8) => {
-                self.periph.write_fuse_anti_rollback_disable(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0x2c9..=0x2cb) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (size, 0x2cc) => {
-                self.periph.write_fuse_idevid_cert_attr(size, val);
-                Ok(())
-            }
-            (_, 0x2cd..=0x2cf) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x32c) => {
-                self.periph.write_fuse_idevid_manuf_hsm_id(size, val);
-                Ok(())
-            }
-            (_, 0x32d..=0x32f) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x340) => {
-                self.periph.write_fuse_lms_revocation(size, val);
-                Ok(())
-            }
-            (_, 0x341..=0x343) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x344) => {
-                self.periph.write_fuse_mldsa_revocation(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0x345..=0x347) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x348) => {
-                self.periph.write_fuse_soc_stepping_id(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
-                Ok(())
-            }
-            (emulator_types::RvSize::Word, 0x349..=0x34b) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (size, 0x34c) => {
-                self.periph.write_fuse_manuf_dbg_unlock_token(size, val);
-                Ok(())
-            }
-            (_, 0x34d..=0x34f) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x500) => {
-                self.periph.write_ss_caliptra_base_addr_l(size, val);
-                Ok(())
-            }
-            (_, 0x501..=0x503) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x504) => {
-                self.periph.write_ss_caliptra_base_addr_h(size, val);
-                Ok(())
-            }
-            (_, 0x505..=0x507) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x508) => {
-                self.periph.write_ss_mci_base_addr_l(size, val);
-                Ok(())
-            }
-            (_, 0x509..=0x50b) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x50c) => {
-                self.periph.write_ss_mci_base_addr_h(size, val);
-                Ok(())
-            }
-            (_, 0x50d..=0x50f) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x510) => {
-                self.periph.write_ss_recovery_ifc_base_addr_l(size, val);
-                Ok(())
-            }
-            (_, 0x511..=0x513) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x514) => {
-                self.periph.write_ss_recovery_ifc_base_addr_h(size, val);
-                Ok(())
-            }
-            (_, 0x515..=0x517) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x518) => {
-                self.periph.write_ss_otp_fc_base_addr_l(size, val);
-                Ok(())
-            }
-            (_, 0x519..=0x51b) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x51c) => {
-                self.periph.write_ss_otp_fc_base_addr_h(size, val);
-                Ok(())
-            }
-            (_, 0x51d..=0x51f) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x520) => {
-                self.periph.write_ss_uds_seed_base_addr_l(size, val);
-                Ok(())
-            }
-            (_, 0x521..=0x523) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x524) => {
-                self.periph.write_ss_uds_seed_base_addr_h(size, val);
-                Ok(())
-            }
-            (_, 0x525..=0x527) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x528) => {
+        if addr & 0x3 != 0 || size != emulator_types::RvSize::Word {
+            return Err(emulator_bus::BusError::StoreAddrMisaligned);
+        }
+        match addr {
+            0..4 => {
                 self.periph
-                    .write_ss_prod_debug_unlock_auth_pk_hash_reg_bank_offset(size, val);
+                    .write_cptra_hw_error_fatal(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (_, 0x529..=0x52b) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x52c) => {
+            4..8 => {
                 self.periph
-                    .write_ss_num_of_prod_debug_unlock_auth_pk_hashes(size, val);
+                    .write_cptra_hw_error_non_fatal(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (_, 0x52d..=0x52f) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x5a0) => {
-                self.periph.write_ss_strap_generic(size, val);
+            8..0xc => {
+                self.periph.write_cptra_fw_error_fatal(val);
                 Ok(())
             }
-            (_, 0x5a1..=0x5a3) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x5c0) => {
-                self.periph.write_ss_dbg_manuf_service_reg_req(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
+            0xc..0x10 => {
+                self.periph.write_cptra_fw_error_non_fatal(val);
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x5c1..=0x5c3) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x5c4) => {
-                self.periph.write_ss_dbg_manuf_service_reg_rsp(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
+            0x10..0x14 => {
+                self.periph.write_cptra_hw_error_enc(val);
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x5c5..=0x5c7) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (size, 0x5c8) => {
-                self.periph.write_ss_soc_dbg_unlock_level(size, val);
+            0x14..0x18 => {
+                self.periph.write_cptra_fw_error_enc(val);
                 Ok(())
             }
-            (_, 0x5c9..=0x5cb) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x5d0) => {
-                self.periph.write_ss_generic_fw_exec_ctrl(size, val);
+            0x18..0x38 => {
+                self.periph.write_cptra_fw_extended_error_info(val);
                 Ok(())
             }
-            (_, 0x5d1..=0x5d3) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x600) => {
-                self.periph.write_internal_obf_key(size, val);
+            0x38..0x3c => {
+                self.periph.write_cptra_boot_status(val);
                 Ok(())
             }
-            (_, 0x601..=0x603) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x620) => {
-                self.periph.write_internal_iccm_lock(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
+            0x3c..0x40 => {
+                self.periph
+                    .write_cptra_flow_status(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x621..=0x623) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x624) => {
-                self.periph.write_internal_fw_update_reset(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
+            0x48..0x5c => {
+                self.periph.write_cptra_mbox_valid_axi_user(val);
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x625..=0x627) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
+            0x5c..0x70 => {
+                self.periph
+                    .write_cptra_mbox_axi_user_lock(emulator_bus::ReadWriteRegister::new(val));
+                Ok(())
             }
-            (emulator_types::RvSize::Word, 0x628) => {
+            0x70..0x74 => {
+                self.periph.write_cptra_trng_valid_axi_user(val);
+                Ok(())
+            }
+            0x74..0x78 => {
+                self.periph
+                    .write_cptra_trng_axi_user_lock(emulator_bus::ReadWriteRegister::new(val));
+                Ok(())
+            }
+            0x78..0xa8 => {
+                self.periph.write_cptra_trng_data(val);
+                Ok(())
+            }
+            0xa8..0xac => {
+                self.periph
+                    .write_cptra_trng_ctrl(emulator_bus::ReadWriteRegister::new(val));
+                Ok(())
+            }
+            0xac..0xb0 => {
+                self.periph
+                    .write_cptra_trng_status(emulator_bus::ReadWriteRegister::new(val));
+                Ok(())
+            }
+            0xb0..0xb4 => {
+                self.periph
+                    .write_cptra_fuse_wr_done(emulator_bus::ReadWriteRegister::new(val));
+                Ok(())
+            }
+            0xb4..0xb8 => {
+                self.periph.write_cptra_timer_config(val);
+                Ok(())
+            }
+            0xb8..0xbc => {
+                self.periph
+                    .write_cptra_bootfsm_go(emulator_bus::ReadWriteRegister::new(val));
+                Ok(())
+            }
+            0xbc..0xc0 => {
+                self.periph.write_cptra_dbg_manuf_service_reg(val);
+                Ok(())
+            }
+            0xc0..0xc4 => {
+                self.periph
+                    .write_cptra_clk_gating_en(emulator_bus::ReadWriteRegister::new(val));
+                Ok(())
+            }
+            0xcc..0xd4 => {
+                self.periph.write_cptra_generic_output_wires(val);
+                Ok(())
+            }
+            0xd8..0xe0 => {
+                self.periph.write_cptra_fw_rev_id(val);
+                Ok(())
+            }
+            0xe4..0xe8 => {
+                self.periph
+                    .write_cptra_wdt_timer1_en(emulator_bus::ReadWriteRegister::new(val));
+                Ok(())
+            }
+            0xe8..0xec => {
+                self.periph
+                    .write_cptra_wdt_timer1_ctrl(emulator_bus::ReadWriteRegister::new(val));
+                Ok(())
+            }
+            0xec..0xf4 => {
+                self.periph.write_cptra_wdt_timer1_timeout_period(val);
+                Ok(())
+            }
+            0xf4..0xf8 => {
+                self.periph
+                    .write_cptra_wdt_timer2_en(emulator_bus::ReadWriteRegister::new(val));
+                Ok(())
+            }
+            0xf8..0xfc => {
+                self.periph
+                    .write_cptra_wdt_timer2_ctrl(emulator_bus::ReadWriteRegister::new(val));
+                Ok(())
+            }
+            0xfc..0x104 => {
+                self.periph.write_cptra_wdt_timer2_timeout_period(val);
+                Ok(())
+            }
+            0x104..0x108 => {
+                self.periph
+                    .write_cptra_wdt_status(emulator_bus::ReadWriteRegister::new(val));
+                Ok(())
+            }
+            0x108..0x10c => {
+                self.periph.write_cptra_fuse_valid_axi_user(val);
+                Ok(())
+            }
+            0x10c..0x110 => {
+                self.periph
+                    .write_cptra_fuse_axi_user_lock(emulator_bus::ReadWriteRegister::new(val));
+                Ok(())
+            }
+            0x110..0x118 => {
+                self.periph.write_cptra_wdt_cfg(val);
+                Ok(())
+            }
+            0x118..0x11c => {
+                self.periph
+                    .write_cptra_i_trng_entropy_config_0(emulator_bus::ReadWriteRegister::new(val));
+                Ok(())
+            }
+            0x11c..0x120 => {
+                self.periph
+                    .write_cptra_i_trng_entropy_config_1(emulator_bus::ReadWriteRegister::new(val));
+                Ok(())
+            }
+            0x120..0x128 => {
+                self.periph.write_cptra_rsvd_reg(val);
+                Ok(())
+            }
+            0x128..0x12c => {
+                self.periph.write_cptra_hw_capabilities(val);
+                Ok(())
+            }
+            0x12c..0x130 => {
+                self.periph.write_cptra_fw_capabilities(val);
+                Ok(())
+            }
+            0x130..0x134 => {
+                self.periph
+                    .write_cptra_cap_lock(emulator_bus::ReadWriteRegister::new(val));
+                Ok(())
+            }
+            0x140..0x170 => {
+                self.periph.write_cptra_owner_pk_hash(val);
+                Ok(())
+            }
+            0x170..0x174 => {
+                self.periph
+                    .write_cptra_owner_pk_hash_lock(emulator_bus::ReadWriteRegister::new(val));
+                Ok(())
+            }
+            0x200..0x240 => {
+                self.periph.write_fuse_uds_seed(val);
+                Ok(())
+            }
+            0x240..0x260 => {
+                self.periph.write_fuse_field_entropy(val);
+                Ok(())
+            }
+            0x260..0x290 => {
+                self.periph.write_fuse_key_manifest_pk_hash(val);
+                Ok(())
+            }
+            0x290..0x2b0 => {
+                self.periph.write_fuse_key_manifest_pk_hash_mask(val);
+                Ok(())
+            }
+            0x2b4..0x2b8 => {
+                self.periph.write_fuse_fmc_key_manifest_svn(val);
+                Ok(())
+            }
+            0x2b8..0x2c8 => {
+                self.periph.write_fuse_runtime_svn(val);
+                Ok(())
+            }
+            0x2c8..0x2cc => {
+                self.periph
+                    .write_fuse_anti_rollback_disable(emulator_bus::ReadWriteRegister::new(val));
+                Ok(())
+            }
+            0x2cc..0x32c => {
+                self.periph.write_fuse_idevid_cert_attr(val);
+                Ok(())
+            }
+            0x32c..0x33c => {
+                self.periph.write_fuse_idevid_manuf_hsm_id(val);
+                Ok(())
+            }
+            0x340..0x344 => {
+                self.periph.write_fuse_lms_revocation(val);
+                Ok(())
+            }
+            0x344..0x348 => {
+                self.periph
+                    .write_fuse_mldsa_revocation(emulator_bus::ReadWriteRegister::new(val));
+                Ok(())
+            }
+            0x348..0x34c => {
+                self.periph
+                    .write_fuse_soc_stepping_id(emulator_bus::ReadWriteRegister::new(val));
+                Ok(())
+            }
+            0x34c..0x35c => {
+                self.periph.write_fuse_manuf_dbg_unlock_token(val);
+                Ok(())
+            }
+            0x500..0x504 => {
+                self.periph.write_ss_caliptra_base_addr_l(val);
+                Ok(())
+            }
+            0x504..0x508 => {
+                self.periph.write_ss_caliptra_base_addr_h(val);
+                Ok(())
+            }
+            0x508..0x50c => {
+                self.periph.write_ss_mci_base_addr_l(val);
+                Ok(())
+            }
+            0x50c..0x510 => {
+                self.periph.write_ss_mci_base_addr_h(val);
+                Ok(())
+            }
+            0x510..0x514 => {
+                self.periph.write_ss_recovery_ifc_base_addr_l(val);
+                Ok(())
+            }
+            0x514..0x518 => {
+                self.periph.write_ss_recovery_ifc_base_addr_h(val);
+                Ok(())
+            }
+            0x518..0x51c => {
+                self.periph.write_ss_otp_fc_base_addr_l(val);
+                Ok(())
+            }
+            0x51c..0x520 => {
+                self.periph.write_ss_otp_fc_base_addr_h(val);
+                Ok(())
+            }
+            0x520..0x524 => {
+                self.periph.write_ss_uds_seed_base_addr_l(val);
+                Ok(())
+            }
+            0x524..0x528 => {
+                self.periph.write_ss_uds_seed_base_addr_h(val);
+                Ok(())
+            }
+            0x528..0x52c => {
+                self.periph
+                    .write_ss_prod_debug_unlock_auth_pk_hash_reg_bank_offset(val);
+                Ok(())
+            }
+            0x52c..0x530 => {
+                self.periph
+                    .write_ss_num_of_prod_debug_unlock_auth_pk_hashes(val);
+                Ok(())
+            }
+            0x5a0..0x5b0 => {
+                self.periph.write_ss_strap_generic(val);
+                Ok(())
+            }
+            0x5c0..0x5c4 => {
+                self.periph
+                    .write_ss_dbg_manuf_service_reg_req(emulator_bus::ReadWriteRegister::new(val));
+                Ok(())
+            }
+            0x5c4..0x5c8 => {
+                self.periph
+                    .write_ss_dbg_manuf_service_reg_rsp(emulator_bus::ReadWriteRegister::new(val));
+                Ok(())
+            }
+            0x5c8..0x5d0 => {
+                self.periph.write_ss_soc_dbg_unlock_level(val);
+                Ok(())
+            }
+            0x5d0..0x5e0 => {
+                self.periph.write_ss_generic_fw_exec_ctrl(val);
+                Ok(())
+            }
+            0x600..0x620 => {
+                self.periph.write_internal_obf_key(val);
+                Ok(())
+            }
+            0x620..0x624 => {
+                self.periph
+                    .write_internal_iccm_lock(emulator_bus::ReadWriteRegister::new(val));
+                Ok(())
+            }
+            0x624..0x628 => {
+                self.periph
+                    .write_internal_fw_update_reset(emulator_bus::ReadWriteRegister::new(val));
+                Ok(())
+            }
+            0x628..0x62c => {
                 self.periph.write_internal_fw_update_reset_wait_cycles(
-                    emulator_types::RvSize::Word,
                     emulator_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x629..=0x62b) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (size, 0x62c) => {
-                self.periph.write_internal_nmi_vector(size, val);
+            0x62c..0x630 => {
+                self.periph.write_internal_nmi_vector(val);
                 Ok(())
             }
-            (_, 0x62d..=0x62f) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x630) => {
-                self.periph.write_internal_hw_error_fatal_mask(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
+            0x630..0x634 => {
+                self.periph
+                    .write_internal_hw_error_fatal_mask(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x631..=0x633) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x634) => {
+            0x634..0x638 => {
                 self.periph.write_internal_hw_error_non_fatal_mask(
-                    emulator_types::RvSize::Word,
                     emulator_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x635..=0x637) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (size, 0x638) => {
-                self.periph.write_internal_fw_error_fatal_mask(size, val);
+            0x638..0x63c => {
+                self.periph.write_internal_fw_error_fatal_mask(val);
                 Ok(())
             }
-            (_, 0x639..=0x63b) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x63c) => {
-                self.periph
-                    .write_internal_fw_error_non_fatal_mask(size, val);
+            0x63c..0x640 => {
+                self.periph.write_internal_fw_error_non_fatal_mask(val);
                 Ok(())
             }
-            (_, 0x63d..=0x63f) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x640) => {
-                self.periph.write_internal_rv_mtime_l(size, val);
+            0x640..0x644 => {
+                self.periph.write_internal_rv_mtime_l(val);
                 Ok(())
             }
-            (_, 0x641..=0x643) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x644) => {
-                self.periph.write_internal_rv_mtime_h(size, val);
+            0x644..0x648 => {
+                self.periph.write_internal_rv_mtime_h(val);
                 Ok(())
             }
-            (_, 0x645..=0x647) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x648) => {
-                self.periph.write_internal_rv_mtimecmp_l(size, val);
+            0x648..0x64c => {
+                self.periph.write_internal_rv_mtimecmp_l(val);
                 Ok(())
             }
-            (_, 0x649..=0x64b) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x64c) => {
-                self.periph.write_internal_rv_mtimecmp_h(size, val);
+            0x64c..0x650 => {
+                self.periph.write_internal_rv_mtimecmp_h(val);
                 Ok(())
             }
-            (_, 0x64d..=0x64f) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (emulator_types::RvSize::Word, 0x800) => {
+            0x800..0x804 => {
                 self.periph.write_intr_block_rf_global_intr_en_r(
-                    emulator_types::RvSize::Word,
                     emulator_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x801..=0x803) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x804) => {
-                self.periph.write_intr_block_rf_error_intr_en_r(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
+            0x804..0x808 => {
+                self.periph
+                    .write_intr_block_rf_error_intr_en_r(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x805..=0x807) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x808) => {
-                self.periph.write_intr_block_rf_notif_intr_en_r(
-                    emulator_types::RvSize::Word,
-                    emulator_bus::ReadWriteRegister::new(val),
-                );
+            0x808..0x80c => {
+                self.periph
+                    .write_intr_block_rf_notif_intr_en_r(emulator_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x809..=0x80b) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x814) => {
+            0x814..0x818 => {
                 self.periph.write_intr_block_rf_error_internal_intr_r(
-                    emulator_types::RvSize::Word,
                     emulator_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x815..=0x817) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x818) => {
+            0x818..0x81c => {
                 self.periph.write_intr_block_rf_notif_internal_intr_r(
-                    emulator_types::RvSize::Word,
                     emulator_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x819..=0x81b) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x81c) => {
+            0x81c..0x820 => {
                 self.periph.write_intr_block_rf_error_intr_trig_r(
-                    emulator_types::RvSize::Word,
                     emulator_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x81d..=0x81f) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (emulator_types::RvSize::Word, 0x820) => {
+            0x820..0x824 => {
                 self.periph.write_intr_block_rf_notif_intr_trig_r(
-                    emulator_types::RvSize::Word,
                     emulator_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
-            (emulator_types::RvSize::Word, 0x821..=0x823) => {
-                Err(emulator_bus::BusError::StoreAddrMisaligned)
-            }
-            (size, 0x900) => {
+            0x900..0x904 => {
                 self.periph
-                    .write_intr_block_rf_error_internal_intr_count_r(size, val);
+                    .write_intr_block_rf_error_internal_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x901..=0x903) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x904) => {
+            0x904..0x908 => {
                 self.periph
-                    .write_intr_block_rf_error_inv_dev_intr_count_r(size, val);
+                    .write_intr_block_rf_error_inv_dev_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x905..=0x907) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x908) => {
+            0x908..0x90c => {
                 self.periph
-                    .write_intr_block_rf_error_cmd_fail_intr_count_r(size, val);
+                    .write_intr_block_rf_error_cmd_fail_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x909..=0x90b) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x90c) => {
+            0x90c..0x910 => {
                 self.periph
-                    .write_intr_block_rf_error_bad_fuse_intr_count_r(size, val);
+                    .write_intr_block_rf_error_bad_fuse_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x90d..=0x90f) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x910) => {
+            0x910..0x914 => {
                 self.periph
-                    .write_intr_block_rf_error_iccm_blocked_intr_count_r(size, val);
+                    .write_intr_block_rf_error_iccm_blocked_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x911..=0x913) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x914) => {
+            0x914..0x918 => {
                 self.periph
-                    .write_intr_block_rf_error_mbox_ecc_unc_intr_count_r(size, val);
+                    .write_intr_block_rf_error_mbox_ecc_unc_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x915..=0x917) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x918) => {
+            0x918..0x91c => {
                 self.periph
-                    .write_intr_block_rf_error_wdt_timer1_timeout_intr_count_r(size, val);
+                    .write_intr_block_rf_error_wdt_timer1_timeout_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x919..=0x91b) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x91c) => {
+            0x91c..0x920 => {
                 self.periph
-                    .write_intr_block_rf_error_wdt_timer2_timeout_intr_count_r(size, val);
+                    .write_intr_block_rf_error_wdt_timer2_timeout_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x91d..=0x91f) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x980) => {
+            0x980..0x984 => {
                 self.periph
-                    .write_intr_block_rf_notif_cmd_avail_intr_count_r(size, val);
+                    .write_intr_block_rf_notif_cmd_avail_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x981..=0x983) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x984) => {
+            0x984..0x988 => {
                 self.periph
-                    .write_intr_block_rf_notif_mbox_ecc_cor_intr_count_r(size, val);
+                    .write_intr_block_rf_notif_mbox_ecc_cor_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x985..=0x987) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x988) => {
+            0x988..0x98c => {
                 self.periph
-                    .write_intr_block_rf_notif_debug_locked_intr_count_r(size, val);
+                    .write_intr_block_rf_notif_debug_locked_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x989..=0x98b) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x98c) => {
+            0x98c..0x990 => {
                 self.periph
-                    .write_intr_block_rf_notif_scan_mode_intr_count_r(size, val);
+                    .write_intr_block_rf_notif_scan_mode_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x98d..=0x98f) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x990) => {
+            0x990..0x994 => {
                 self.periph
-                    .write_intr_block_rf_notif_soc_req_lock_intr_count_r(size, val);
+                    .write_intr_block_rf_notif_soc_req_lock_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x991..=0x993) => Err(emulator_bus::BusError::StoreAddrMisaligned),
-            (size, 0x994) => {
+            0x994..0x998 => {
                 self.periph
-                    .write_intr_block_rf_notif_gen_in_toggle_intr_count_r(size, val);
+                    .write_intr_block_rf_notif_gen_in_toggle_intr_count_r(val);
                 Ok(())
             }
-            (_, 0x995..=0x997) => Err(emulator_bus::BusError::StoreAddrMisaligned),
             _ => Err(emulator_bus::BusError::StoreAccessFault),
         }
     }


### PR DESCRIPTION
We were ignoring the array dimension, which caused the automatic peripherals to be missing registers.

We also simplified the `match` arms so that there would not be a ridiculous number of arms for the different addresses for large arrays.

While we're here, we can go ahead and remove the `size` paramter from peripheral methods. It's never used as we always have 32-bit registers.