### PR TITLE
Refactor MCTP tests in emulator to use common functions

### DIFF
--- a/emulator/app/src/i3c_socket.rs
+++ b/emulator/app/src/i3c_socket.rs
@@ -179,21 +179,22 @@ pub(crate) fn run_tests(
     let addr = SocketAddr::from(([127, 0, 0, 1], port));
     let stream = TcpStream::connect(addr).unwrap();
     std::thread::spawn(move || {
-        let mut test_runner = TestRunner::new(stream, target_addr.into(), running_clone, tests);
+        let mut test_runner = MctpTestRunner::new(stream, target_addr.into(), running_clone, tests);
         test_runner.run_tests();
     });
 }
 
 #[derive(Debug, Clone)]
-pub enum TestState {
+pub enum MctpTestState {
     Start,
-    SendPrivateWrite,
-    WaitForIbi,
-    ReceivePrivateRead,
+    SendReq,
+    ReceiveResp,
+    ReceiveReq,
+    SendResp,
     Finish,
 }
 
-struct TestRunner {
+struct MctpTestRunner {
     stream: TcpStream,
     target_addr: u8,
     passed: usize,
@@ -201,7 +202,7 @@ struct TestRunner {
     tests: Vec<Box<dyn TestTrait + Send>>,
 }
 
-impl TestRunner {
+impl MctpTestRunner {
     pub fn new(
         stream: TcpStream,
         target_addr: u8,

--- a/emulator/app/src/tests/mctp_ctrl_cmd.rs
+++ b/emulator/app/src/tests/mctp_ctrl_cmd.rs
@@ -84,15 +84,12 @@ impl MCTPCtrlCmdTests {
                 SetEIDAllocStatus::NoEIDPool,
                 TEST_TARGET_EID,
             ),
-            MCTPCtrlCmdTests::SetEIDForce => {
-                // self.mctp_util.set_src_eid(TEST_TARGET_EID);
-                set_eid_resp_bytes(
-                    CmdCompletionCode::Success,
-                    SetEIDStatus::Accepted,
-                    SetEIDAllocStatus::NoEIDPool,
-                    TEST_TARGET_EID + 1,
-                )
-            }
+            MCTPCtrlCmdTests::SetEIDForce => set_eid_resp_bytes(
+                CmdCompletionCode::Success,
+                SetEIDStatus::Accepted,
+                SetEIDAllocStatus::NoEIDPool,
+                TEST_TARGET_EID + 1,
+            ),
             MCTPCtrlCmdTests::SetEIDNullFail => set_eid_resp_bytes(
                 CmdCompletionCode::ErrorInvalidData,
                 SetEIDStatus::Rejected,

--- a/emulator/app/src/tests/mctp_ctrl_cmd.rs
+++ b/emulator/app/src/tests/mctp_ctrl_cmd.rs
@@ -1,11 +1,8 @@
 // Licensed under the Apache-2.0 license
 
-use crate::i3c_socket::{
-    receive_ibi, receive_private_read, send_private_write, TestState, TestTrait,
-};
-use crate::tests::mctp_util::base_protocol::{
-    MCTPHdr, MCTPMsgHdr, LOCAL_TEST_ENDPOINT_EID, MCTP_HDR_SIZE, MCTP_MSG_HDR_SIZE,
-};
+use crate::i3c_socket::{MctpTestState, TestTrait};
+use crate::tests::mctp_util::base_protocol::{MCTPMsgHdr, MCTP_MSG_HDR_SIZE};
+use crate::tests::mctp_util::common::MctpUtil;
 use crate::tests::mctp_util::ctrl_protocol::*;
 use std::net::TcpStream;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -16,15 +13,13 @@ use zerocopy::IntoBytes;
 
 const TEST_TARGET_EID: u8 = 0xA;
 
-type MCTPCtrlPacket = (
-    MCTPHdr<[u8; MCTP_HDR_SIZE]>,
+type MCTPCtrlMsg = (
     MCTPMsgHdr<[u8; MCTP_MSG_HDR_SIZE]>,
     MCTPCtrlMsgHdr<[u8; MCTP_CTRL_MSG_HDR_SIZE]>,
     Vec<u8>,
 );
 
-const MCTP_HDR_OFFSET: usize = 0;
-const MCTP_MSG_HDR_OFFSET: usize = MCTP_HDR_OFFSET + MCTP_HDR_SIZE;
+const MCTP_MSG_HDR_OFFSET: usize = 0;
 const MCTP_CTRL_MSG_HDR_OFFSET: usize = MCTP_MSG_HDR_OFFSET + MCTP_MSG_HDR_SIZE;
 const MCTP_CTRL_PAYLOAD_OFFSET: usize = MCTP_CTRL_MSG_HDR_OFFSET + MCTP_CTRL_MSG_HDR_SIZE;
 
@@ -41,19 +36,19 @@ pub(crate) enum MCTPCtrlCmdTests {
 impl MCTPCtrlCmdTests {
     pub fn generate_tests() -> Vec<Box<dyn TestTrait + Send>> {
         MCTPCtrlCmdTests::iter()
-            .map(|test_id| {
+            .enumerate()
+            .map(|(i, test_id)| {
                 let test_name = test_id.name();
-                let req_data = test_id.generate_request_packet();
-                let resp_data = test_id.generate_response_packet();
-                Box::new(Test::new(test_name, req_data, resp_data)) as Box<dyn TestTrait + Send>
+                let req_msg = test_id.generate_request_msg();
+                let resp_msg = test_id.generate_response_msg();
+                let msg_tag = (i % 4) as u8;
+                Box::new(Test::new(test_name, req_msg, resp_msg, msg_tag))
+                    as Box<dyn TestTrait + Send>
             })
             .collect()
     }
 
-    fn generate_request_packet(&self) -> Vec<u8> {
-        let mut mctp_hdr = MCTPHdr::new();
-        mctp_hdr.prepare_header(0, LOCAL_TEST_ENDPOINT_EID, 1, 1, 0, 1, self.msg_tag());
-
+    fn generate_request_msg(&self) -> Vec<u8> {
         let mctp_common_msg_hdr = MCTPMsgHdr::new();
 
         let mut mctp_ctrl_msg_hdr = MCTPCtrlMsgHdr::new();
@@ -63,7 +58,6 @@ impl MCTPCtrlCmdTests {
         let req_data = match self {
             MCTPCtrlCmdTests::SetEID => set_eid_req_bytes(SetEIDOp::SetEID, TEST_TARGET_EID),
             MCTPCtrlCmdTests::SetEIDForce => {
-                mctp_hdr.set_dest_eid(TEST_TARGET_EID);
                 set_eid_req_bytes(SetEIDOp::ForceEID, TEST_TARGET_EID + 1)
             }
             MCTPCtrlCmdTests::SetEIDNullFail => set_eid_req_bytes(SetEIDOp::SetEID, 0),
@@ -73,19 +67,10 @@ impl MCTPCtrlCmdTests {
                 vec![]
             }
         };
-
-        MCTPCtrlCmdTests::generate_packet((
-            mctp_hdr,
-            mctp_common_msg_hdr,
-            mctp_ctrl_msg_hdr,
-            req_data,
-        ))
+        MCTPCtrlCmdTests::generate_msg((mctp_common_msg_hdr, mctp_ctrl_msg_hdr, req_data))
     }
 
-    fn generate_response_packet(&self) -> Vec<u8> {
-        let mut mctp_hdr = MCTPHdr::new();
-        mctp_hdr.prepare_header(LOCAL_TEST_ENDPOINT_EID, 0, 1, 1, 0, 0, self.msg_tag());
-
+    fn generate_response_msg(&self) -> Vec<u8> {
         let mctp_common_msg_hdr = MCTPMsgHdr::new();
 
         let mut mctp_ctrl_msg_hdr = MCTPCtrlMsgHdr::new();
@@ -100,7 +85,7 @@ impl MCTPCtrlCmdTests {
                 TEST_TARGET_EID,
             ),
             MCTPCtrlCmdTests::SetEIDForce => {
-                mctp_hdr.set_src_eid(TEST_TARGET_EID);
+                // self.mctp_util.set_src_eid(TEST_TARGET_EID);
                 set_eid_resp_bytes(
                     CmdCompletionCode::Success,
                     SetEIDStatus::Accepted,
@@ -131,33 +116,24 @@ impl MCTPCtrlCmdTests {
             }
         };
 
-        MCTPCtrlCmdTests::generate_packet((
-            mctp_hdr,
-            mctp_common_msg_hdr,
-            mctp_ctrl_msg_hdr,
-            resp_data,
-        ))
+        MCTPCtrlCmdTests::generate_msg((mctp_common_msg_hdr, mctp_ctrl_msg_hdr, resp_data))
     }
 
-    fn generate_packet(mctp_packet: MCTPCtrlPacket) -> Vec<u8> {
-        let mut pkt: Vec<u8> = vec![0; MCTP_CTRL_PAYLOAD_OFFSET + mctp_packet.3.len()];
+    fn generate_msg(mctp_msg: MCTPCtrlMsg) -> Vec<u8> {
+        let mut pkt: Vec<u8> = vec![0; MCTP_CTRL_PAYLOAD_OFFSET + mctp_msg.2.len()];
 
-        mctp_packet
+        mctp_msg
             .0
-            .write_to(&mut pkt[0..MCTP_HDR_SIZE])
-            .expect("mctp header write failed");
-        mctp_packet
-            .1
             .write_to(&mut pkt[MCTP_MSG_HDR_OFFSET..MCTP_MSG_HDR_OFFSET + MCTP_MSG_HDR_SIZE])
             .expect("mctp common msg header write failed");
-        mctp_packet
-            .2
+        mctp_msg
+            .1
             .write_to(
                 &mut pkt
                     [MCTP_CTRL_MSG_HDR_OFFSET..MCTP_CTRL_MSG_HDR_OFFSET + MCTP_CTRL_MSG_HDR_SIZE],
             )
             .expect("mctp ctrl msg header write failed");
-        pkt[MCTP_CTRL_PAYLOAD_OFFSET..].copy_from_slice(&mctp_packet.3);
+        pkt[MCTP_CTRL_PAYLOAD_OFFSET..].copy_from_slice(&mctp_msg.2);
         pkt
     }
 
@@ -169,17 +145,6 @@ impl MCTPCtrlCmdTests {
             MCTPCtrlCmdTests::SetEIDBroadcastFail => "SetEIDBroadcastFail",
             MCTPCtrlCmdTests::SetEIDInvalidFail => "SetEIDInvalidFail",
             MCTPCtrlCmdTests::GetEID => "GetEID",
-        }
-    }
-
-    fn msg_tag(&self) -> u8 {
-        match self {
-            MCTPCtrlCmdTests::SetEID => 0,
-            MCTPCtrlCmdTests::SetEIDForce => 1,
-            MCTPCtrlCmdTests::SetEIDNullFail => 2,
-            MCTPCtrlCmdTests::SetEIDBroadcastFail => 3,
-            MCTPCtrlCmdTests::SetEIDInvalidFail => 4,
-            MCTPCtrlCmdTests::GetEID => 5,
         }
     }
 
@@ -198,26 +163,37 @@ impl MCTPCtrlCmdTests {
 #[derive(Debug, Clone)]
 struct Test {
     name: String,
-    state: TestState,
-    pvt_write_data: Vec<u8>,
-    pvt_read_data: Vec<u8>,
+    test_state: MctpTestState,
+    req_msg: Vec<u8>,
+    resp_msg: Vec<u8>,
+    msg_tag: u8,
+    mctp_util: MctpUtil,
     passed: bool,
 }
 
 impl Test {
-    fn new(name: &str, pvt_write_data: Vec<u8>, pvt_read_data: Vec<u8>) -> Self {
+    fn new(name: &str, req_msg: Vec<u8>, resp_msg: Vec<u8>, msg_tag: u8) -> Self {
         Self {
             name: name.to_string(),
-            state: TestState::Start,
-            pvt_write_data,
-            pvt_read_data,
+            test_state: MctpTestState::Start,
+            req_msg,
+            resp_msg,
+            msg_tag,
+            mctp_util: MctpUtil::new(),
             passed: false,
         }
     }
 
     fn check_response(&mut self, data: &[u8]) {
-        if data.len() == self.pvt_read_data.len() && data == self.pvt_read_data {
+        if data.len() == self.resp_msg.len() && data == self.resp_msg {
             self.passed = true;
+        }
+    }
+
+    fn pre_process(&mut self) {
+        match self.name.as_str() {
+            "SetEID" => {}
+            _ => self.mctp_util.set_dest_eid(TEST_TARGET_EID),
         }
     }
 }
@@ -230,28 +206,34 @@ impl TestTrait for Test {
     fn run_test(&mut self, running: Arc<AtomicBool>, stream: &mut TcpStream, target_addr: u8) {
         stream.set_nonblocking(true).unwrap();
         while running.load(Ordering::Relaxed) {
-            match self.state {
-                TestState::Start => {
+            match self.test_state {
+                MctpTestState::Start => {
                     println!("Starting test: {}", self.name);
-                    self.state = TestState::SendPrivateWrite;
+                    self.test_state = MctpTestState::SendReq;
                 }
-                TestState::SendPrivateWrite => {
-                    if send_private_write(stream, target_addr, self.pvt_write_data.clone()) {
-                        self.state = TestState::WaitForIbi;
+                MctpTestState::SendReq => {
+                    self.pre_process();
+                    self.mctp_util.send_request(
+                        self.msg_tag,
+                        self.req_msg.as_slice(),
+                        running.clone(),
+                        stream,
+                        target_addr,
+                    );
+                    self.test_state = MctpTestState::ReceiveResp;
+                }
+                MctpTestState::ReceiveResp => {
+                    let resp_msg =
+                        self.mctp_util
+                            .receive_response(running.clone(), stream, target_addr);
+
+                    if !resp_msg.is_empty() {
+                        self.check_response(&resp_msg);
+                        self.passed = true;
                     }
+                    self.test_state = MctpTestState::Finish;
                 }
-                TestState::WaitForIbi => {
-                    if receive_ibi(stream, target_addr) {
-                        self.state = TestState::ReceivePrivateRead;
-                    }
-                }
-                TestState::ReceivePrivateRead => {
-                    if let Some(data) = receive_private_read(stream, target_addr) {
-                        self.check_response(data.as_slice());
-                        self.state = TestState::Finish;
-                    }
-                }
-                TestState::Finish => {
+                MctpTestState::Finish => {
                     println!(
                         "Test {} : {}",
                         self.name,
@@ -259,6 +241,7 @@ impl TestTrait for Test {
                     );
                     break;
                 }
+                _ => {}
             }
         }
     }

--- a/emulator/app/src/tests/mctp_loopback.rs
+++ b/emulator/app/src/tests/mctp_loopback.rs
@@ -1,7 +1,6 @@
 // Licensed under the Apache-2.0 license
 
 use crate::i3c_socket::{MctpTestState, TestTrait};
-// use crate::tests::mctp_util::base_protocol::{MCTPHdr, MCTP_HDR_SIZE};
 use crate::tests::mctp_util::common::MctpUtil;
 use std::net::TcpStream;
 use std::sync::atomic::{AtomicBool, Ordering};

--- a/emulator/app/src/tests/mctp_loopback.rs
+++ b/emulator/app/src/tests/mctp_loopback.rs
@@ -1,14 +1,11 @@
 // Licensed under the Apache-2.0 license
 
-use crate::i3c_socket::{
-    receive_ibi, receive_private_read, send_private_write, TestState, TestTrait,
-};
-use crate::tests::mctp_util::base_protocol::{MCTPHdr, MCTP_HDR_SIZE};
-use std::collections::VecDeque;
+use crate::i3c_socket::{MctpTestState, TestTrait};
+// use crate::tests::mctp_util::base_protocol::{MCTPHdr, MCTP_HDR_SIZE};
+use crate::tests::mctp_util::common::MctpUtil;
 use std::net::TcpStream;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-use zerocopy::FromBytes;
 
 pub fn generate_tests() -> Vec<Box<dyn TestTrait + Send>> {
     vec![Box::new(Test::new("MctpMultiPktTest")) as Box<dyn TestTrait + Send>]
@@ -16,8 +13,9 @@ pub fn generate_tests() -> Vec<Box<dyn TestTrait + Send>> {
 
 struct Test {
     test_name: String,
-    state: TestState,
-    loopbak_pkts: VecDeque<Vec<u8>>,
+    test_state: MctpTestState,
+    loopback_msg: Vec<u8>,
+    mctp_util: MctpUtil,
     passed: bool,
 }
 
@@ -25,31 +23,11 @@ impl Test {
     fn new(test_name: &str) -> Self {
         Test {
             test_name: test_name.to_string(),
-            state: TestState::Start,
-            loopbak_pkts: VecDeque::new(),
+            test_state: MctpTestState::Start,
+            loopback_msg: Vec::new(),
+            mctp_util: MctpUtil::new(),
             passed: false,
         }
-    }
-
-    fn process_received_packet(&mut self, data: Vec<u8>) {
-        let mut resp_pkt = data.clone();
-        let mctp_hdr: &mut MCTPHdr<[u8; MCTP_HDR_SIZE]> =
-            MCTPHdr::mut_from_bytes(&mut resp_pkt[0..MCTP_HDR_SIZE]).unwrap();
-        if mctp_hdr.som() == 1 {
-            self.loopbak_pkts.clear();
-        }
-        let src_eid = mctp_hdr.src_eid();
-        mctp_hdr.set_src_eid(mctp_hdr.dest_eid());
-        mctp_hdr.set_dest_eid(src_eid);
-        mctp_hdr.set_tag_owner(0);
-
-        if mctp_hdr.eom() == 1 {
-            self.state = TestState::SendPrivateWrite;
-        } else {
-            self.state = TestState::WaitForIbi;
-        }
-
-        self.loopbak_pkts.push_back(resp_pkt);
     }
 }
 
@@ -60,36 +38,34 @@ impl TestTrait for Test {
 
     fn run_test(&mut self, running: Arc<AtomicBool>, stream: &mut TcpStream, target_addr: u8) {
         stream.set_nonblocking(true).unwrap();
+
         while running.load(Ordering::Relaxed) {
-            match self.state {
-                TestState::Start => {
+            match self.test_state {
+                MctpTestState::Start => {
                     println!("Starting test: {}", self.test_name);
-                    self.state = TestState::WaitForIbi;
+                    self.test_state = MctpTestState::ReceiveReq;
                 }
-                TestState::SendPrivateWrite => {
-                    if let Some(write_pkt) = self.loopbak_pkts.pop_front() {
-                        if send_private_write(stream, target_addr, write_pkt) {
-                            self.state = TestState::SendPrivateWrite;
-                        } else {
-                            self.state = TestState::Finish;
-                        }
-                    } else {
-                        self.state = TestState::WaitForIbi;
-                    }
+                MctpTestState::ReceiveReq => {
+                    self.loopback_msg =
+                        self.mctp_util
+                            .receive_request(running.clone(), stream, target_addr);
+                    self.test_state = MctpTestState::SendResp;
                 }
-                TestState::WaitForIbi => {
-                    if receive_ibi(stream, target_addr) {
-                        self.state = TestState::ReceivePrivateRead;
-                    }
+                MctpTestState::SendResp => {
+                    self.mctp_util.send_response(
+                        self.loopback_msg.as_slice(),
+                        running.clone(),
+                        stream,
+                        target_addr,
+                    );
+
+                    self.test_state = MctpTestState::ReceiveReq;
                 }
-                TestState::ReceivePrivateRead => {
-                    if let Some(data) = receive_private_read(stream, target_addr) {
-                        self.process_received_packet(data);
-                    }
-                }
-                TestState::Finish => {
+                MctpTestState::Finish => {
                     self.passed = true;
+                    break;
                 }
+                _ => {}
             }
         }
     }

--- a/emulator/app/src/tests/mctp_util/common.rs
+++ b/emulator/app/src/tests/mctp_util/common.rs
@@ -1,0 +1,439 @@
+// Licensed under the Apache-2.0 license
+
+use crate::i3c_socket::{receive_ibi, receive_private_read, send_private_write};
+use crate::tests::mctp_util::base_protocol::{MCTPHdr, LOCAL_TEST_ENDPOINT_EID, MCTP_HDR_SIZE};
+
+use std::collections::VecDeque;
+use std::net::TcpStream;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use zerocopy::{FromBytes, IntoBytes};
+
+#[derive(Debug, Clone)]
+pub struct MctpUtil {
+    dest_eid: u8,
+    src_eid: u8,
+    msg_tag: u8,
+    tag_owner: u8,
+    pkt_payload_size: usize,
+}
+
+#[derive(Debug, Clone)]
+enum I3cControllerState {
+    Start,
+    SendPrivateWrite,
+    WaitForIbi,
+    ReceivePrivateRead,
+    Finish,
+}
+
+impl MctpUtil {
+    pub fn new() -> MctpUtil {
+        MctpUtil {
+            dest_eid: 0,
+            src_eid: LOCAL_TEST_ENDPOINT_EID,
+            msg_tag: 8,
+            tag_owner: 1,
+            pkt_payload_size: 64,
+        }
+    }
+
+    pub fn new_req(&mut self, msg_tag: u8) {
+        self.msg_tag = msg_tag;
+        self.tag_owner = 1;
+    }
+
+    pub fn new_resp(&mut self) {
+        std::mem::swap(&mut self.src_eid, &mut self.dest_eid);
+        self.tag_owner = 0;
+    }
+
+    #[allow(dead_code)]
+    pub fn set_tag_owner(&mut self, owner: u8) {
+        self.tag_owner = owner;
+    }
+
+    #[allow(dead_code)]
+    pub fn get_tag_owner(&self) -> u8 {
+        self.tag_owner
+    }
+
+    #[allow(dead_code)]
+    pub fn set_dest_eid(&mut self, eid: u8) {
+        self.dest_eid = eid;
+    }
+
+    #[allow(dead_code)]
+    pub fn get_dest_eid(&self) -> u8 {
+        self.dest_eid
+    }
+
+    #[allow(dead_code)]
+    pub fn set_src_eid(&mut self, eid: u8) {
+        self.src_eid = eid;
+    }
+
+    #[allow(dead_code)]
+    pub fn set_pkt_payload_size(&mut self, size: usize) {
+        self.pkt_payload_size = size;
+    }
+
+    #[allow(dead_code)]
+    pub fn get_pkt_payload_size(&self) -> usize {
+        self.pkt_payload_size
+    }
+
+    #[allow(dead_code)]
+    pub fn set_msg_tag(&mut self, tag: u8) {
+        self.msg_tag = tag;
+    }
+
+    #[allow(dead_code)]
+    pub fn get_msg_tag(&self) -> u8 {
+        self.msg_tag
+    }
+
+    /// Sends a single packet message to the target address and waits for a response.
+    /// Retries up to 10 times if no response is received.
+    /// This function will block until a response is received or the retry limit is reached.
+    ///
+    /// # Arguments
+    /// * `msg_tag` - The message tag to be used for the request
+    /// * `msg` - The message to be sent
+    /// * `running` - A flag to indicate if the emulator running status
+    /// * `stream` - The TCP stream to I3C socket
+    /// * `target_addr` - The target address of the I3C device
+    ///
+    /// # Returns
+    /// * `Option<Vec<u8>>` - The response message if received, otherwise None
+    pub fn wait_for_responder(
+        &mut self,
+        msg_tag: u8,
+        msg: &[u8],
+        running: Arc<AtomicBool>,
+        stream: &mut TcpStream,
+        target_addr: u8,
+    ) -> Option<Vec<u8>> {
+        self.new_req(msg_tag);
+        let pkts = self.packetize(msg);
+        assert!(pkts.len() == 1, "Only one packet is expected in message");
+        let mut i3c_state = I3cControllerState::Start;
+        let msg_type = msg[0];
+
+        let mut retry = 10;
+
+        while running.load(Ordering::Relaxed) && retry > 0 {
+            match i3c_state {
+                I3cControllerState::Start => {
+                    i3c_state = I3cControllerState::SendPrivateWrite;
+                }
+
+                I3cControllerState::SendPrivateWrite => {
+                    let write_pkt = pkts.front().unwrap().clone();
+                    if send_private_write(stream, target_addr, write_pkt) {
+                        i3c_state = I3cControllerState::WaitForIbi;
+                        std::thread::sleep(std::time::Duration::from_secs(5));
+                    }
+                }
+                I3cControllerState::WaitForIbi => {
+                    if receive_ibi(stream, target_addr) {
+                        i3c_state = I3cControllerState::ReceivePrivateRead;
+                    } else {
+                        retry -= 1;
+                        println!("MCTP_UTIL: IBI not received. Retrying...");
+                        i3c_state = I3cControllerState::SendPrivateWrite;
+                    }
+                }
+                I3cControllerState::ReceivePrivateRead => {
+                    if let Some(data) = receive_private_read(stream, target_addr) {
+                        if data[4] == msg_type {
+                            let mut resp_pkts = VecDeque::new();
+                            resp_pkts.push_back(data);
+                            self.new_resp();
+                            let resp = self.assemble(resp_pkts);
+                            return Some(resp);
+                        }
+
+                        i3c_state = I3cControllerState::Finish;
+                    }
+                }
+                I3cControllerState::Finish => {
+                    break;
+                }
+            }
+        }
+
+        None
+    }
+
+    /// Send a request to the target address
+    /// This function will block until the request message is sent
+    ///
+    /// # Arguments
+    /// * `msg_tag` - The message tag to be used for the request
+    /// * `msg` - The message to be sent
+    /// * `running` - A flag to indicate if the emulator running status
+    /// * `stream` - The TCP stream to I3C socket
+    /// * `target_addr` - The target address of the I3C device
+    pub fn send_request(
+        &mut self,
+        msg_tag: u8,
+        msg: &[u8],
+        running: Arc<AtomicBool>,
+        stream: &mut TcpStream,
+        target_addr: u8,
+    ) {
+        self.new_req(msg_tag);
+        let pkts = self.packetize(msg);
+        self.send_packets(pkts, running, stream, target_addr);
+    }
+
+    /// Send a response to the target address
+    /// This function will block until the response message is sent
+    ///
+    /// # Arguments
+    /// * `msg` - The message to be sent
+    /// * `running` - A flag to indicate if the emulator running status
+    /// * `stream` - The TCP stream to I3C socket
+    /// * `target_addr` - The target address of the I3C device
+    pub fn send_response(
+        &mut self,
+        msg: &[u8],
+        running: Arc<AtomicBool>,
+        stream: &mut TcpStream,
+        target_addr: u8,
+    ) {
+        self.new_resp();
+        let pkts = self.packetize(msg);
+        self.send_packets(pkts, running, stream, target_addr);
+    }
+
+    /// Receive a response from target address and return the assembled message
+    /// This function will block until the response is received
+    ///
+    /// # Arguments
+    /// * `running` - A flag to indicate if the emulator running status
+    /// * `stream` - The TCP stream to I3C socket
+    /// * `target_addr` - The target address of the I3C device
+    ///
+    /// # Returns
+    /// * `Vec<u8>` - The assembled response message
+    ///
+    pub fn receive_response(
+        &mut self,
+        running: Arc<AtomicBool>,
+        stream: &mut TcpStream,
+        target_addr: u8,
+    ) -> Vec<u8> {
+        self.new_resp();
+        let pkts = self.receive_packets(running, stream, target_addr, false);
+        self.assemble(pkts)
+    }
+
+    /// Receive a request and return the assembled message
+    /// This function will block until the request is received
+    ///
+    /// # Arguments
+    /// * `running` - A flag to indicate if the emulator running status
+    /// * `stream` - The TCP stream to I3C socket
+    /// * `target_addr` - The target address of the I3C device
+    ///
+    /// # Returns
+    /// * `Vec<u8>` - The assembled request message
+    pub fn receive_request(
+        &mut self,
+        running: Arc<AtomicBool>,
+        stream: &mut TcpStream,
+        target_addr: u8,
+    ) -> Vec<u8> {
+        // Msg tag will be assigned by the sender (device in this case)
+        self.new_req(8);
+        let pkts = self.receive_packets(running, stream, target_addr, true);
+        self.assemble(pkts)
+    }
+
+    fn receive_packets(
+        &mut self,
+        running: Arc<AtomicBool>,
+        stream: &mut TcpStream,
+        target_addr: u8,
+        req: bool,
+    ) -> VecDeque<Vec<u8>> {
+        let mut i3c_state = I3cControllerState::WaitForIbi;
+        let mut pkts: VecDeque<Vec<u8>> = VecDeque::new();
+        stream.set_nonblocking(true).unwrap();
+
+        while running.load(Ordering::Relaxed) {
+            match i3c_state {
+                I3cControllerState::WaitForIbi => {
+                    if receive_ibi(stream, target_addr) {
+                        i3c_state = I3cControllerState::ReceivePrivateRead;
+                    }
+                }
+                I3cControllerState::ReceivePrivateRead => {
+                    if let Some(data) = receive_private_read(stream, target_addr) {
+                        if self.receive_packet(&mut pkts, data, req) {
+                            break;
+                        } else {
+                            i3c_state = I3cControllerState::WaitForIbi;
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        pkts
+    }
+
+    fn receive_packet(&mut self, pkts: &mut VecDeque<Vec<u8>>, data: Vec<u8>, req: bool) -> bool {
+        let mut last_pkt = false;
+        let mut pkt = data.clone();
+        let mctp_hdr: &mut MCTPHdr<[u8; MCTP_HDR_SIZE]> =
+            MCTPHdr::mut_from_bytes(&mut pkt[0..MCTP_HDR_SIZE]).unwrap();
+
+        if mctp_hdr.som() == 1 {
+            pkts.clear();
+            if req {
+                self.msg_tag = mctp_hdr.msg_tag();
+                self.src_eid = mctp_hdr.src_eid();
+                self.dest_eid = mctp_hdr.dest_eid();
+            }
+        }
+
+        assert!(self.msg_tag == mctp_hdr.msg_tag());
+        assert!(self.tag_owner == mctp_hdr.tag_owner());
+
+        if mctp_hdr.eom() == 1 {
+            last_pkt = true;
+        }
+        pkts.push_back(pkt);
+        last_pkt
+    }
+
+    fn generate_mctp_packet(&self, index: usize, payload: Vec<u8>, last: bool) -> Vec<u8> {
+        let mut pkt: Vec<u8> = vec![0; MCTP_HDR_SIZE + payload.len()];
+        let pkt_seq: u8 = (index % 4) as u8;
+        let som = if index == 0 { 1 } else { 0 };
+        let eom = if last { 1 } else { 0 };
+        let mut mctp_hdr = MCTPHdr::new();
+        mctp_hdr.prepare_header(
+            self.dest_eid,
+            self.src_eid,
+            som,
+            eom,
+            pkt_seq,
+            self.tag_owner,
+            self.msg_tag,
+        );
+        mctp_hdr
+            .write_to(&mut pkt[0..MCTP_HDR_SIZE])
+            .expect("mctp header write failed");
+        pkt[MCTP_HDR_SIZE..].copy_from_slice(&payload[..]);
+        pkt
+    }
+
+    fn packetize(&self, message: &[u8]) -> VecDeque<Vec<u8>> {
+        assert!(self.msg_tag <= 7, "A valid msg tag is required");
+        let pkt_payloads: Vec<Vec<u8>> = message
+            .chunks(self.pkt_payload_size)
+            .map(|chunk| chunk.to_vec())
+            .collect();
+
+        let n = pkt_payloads.len() - 1;
+
+        let processed_payloads: Vec<Vec<u8>> = pkt_payloads
+            .into_iter()
+            .enumerate()
+            .map(|(i, payload)| self.generate_mctp_packet(i, payload, n == i))
+            .collect();
+
+        let mctp_pkts: VecDeque<Vec<u8>> = processed_payloads.into_iter().collect();
+        mctp_pkts
+    }
+
+    fn assemble(&self, packets: VecDeque<Vec<u8>>) -> Vec<u8> {
+        let mut msg: Vec<u8> = Vec::new();
+        for (i, pkt) in packets.iter().enumerate() {
+            let mctp_hdr: MCTPHdr<[u8; MCTP_HDR_SIZE]> =
+                MCTPHdr::read_from_bytes(&pkt[0..MCTP_HDR_SIZE]).unwrap();
+            if i == 0 {
+                assert!(mctp_hdr.som() == 1);
+            }
+            if i == packets.len() - 1 {
+                assert!(mctp_hdr.eom() == 1);
+            }
+            let seq_num = (i % 4) as u8;
+            assert!(mctp_hdr.dest_eid() == self.dest_eid);
+            assert!(mctp_hdr.tag_owner() == self.tag_owner);
+            assert!(mctp_hdr.msg_tag() == self.msg_tag);
+            assert!(mctp_hdr.pkt_seq() == seq_num);
+
+            msg.extend_from_slice(&pkt[MCTP_HDR_SIZE..]);
+        }
+        msg
+    }
+
+    fn send_packets(
+        &mut self,
+        pkts: VecDeque<Vec<u8>>,
+        running: Arc<AtomicBool>,
+        stream: &mut TcpStream,
+        target_addr: u8,
+    ) {
+        let mut pkts = pkts;
+        stream.set_nonblocking(true).unwrap();
+        while running.load(Ordering::Relaxed) {
+            if let Some(write_pkt) = pkts.pop_front() {
+                if !send_private_write(stream, target_addr, write_pkt) {
+                    break;
+                }
+            } else {
+                break;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_mctp_packetize_assembly() {
+        assert!(verify_packetize_assembly(4096, 0, 64));
+        assert!(verify_packetize_assembly(1000, 1, 64));
+        assert!(verify_packetize_assembly(64, 2, 64));
+        assert!(verify_packetize_assembly(63, 3, 64));
+        assert!(verify_packetize_assembly(1, 4, 64));
+        assert!(verify_packetize_assembly(4096, 5, 256));
+        assert!(verify_packetize_assembly(4095, 6, 256));
+    }
+
+    fn verify_packetize_assembly(msg_size: usize, tag: u8, pkt_payload_size: usize) -> bool {
+        let msg_buf: Vec<u8> = (0..msg_size).map(|_| rand::random::<u8>()).collect();
+
+        let mut mctp = MctpUtil::new();
+        mctp.set_pkt_payload_size(pkt_payload_size);
+        mctp.set_msg_tag(tag);
+
+        let expected_packets = (msg_size + pkt_payload_size - 1) / pkt_payload_size;
+
+        let packets = mctp.packetize(&msg_buf);
+        if packets.len() != expected_packets {
+            println!(
+                "MCTP_UTIL: Expected {} packets, but got {}",
+                expected_packets,
+                packets.len()
+            );
+            return false;
+        }
+
+        let assembled_msg = mctp.assemble(packets);
+        if assembled_msg != msg_buf {
+            println!("MCTP_UTIL: Assembled message does not match original message");
+            return false;
+        }
+        return true;
+    }
+}

--- a/emulator/app/src/tests/mctp_util/mod.rs
+++ b/emulator/app/src/tests/mctp_util/mod.rs
@@ -3,3 +3,4 @@
 pub mod base_protocol;
 #[macro_use]
 pub mod ctrl_protocol;
+pub mod common;

--- a/runtime/capsules/src/test/mctp.rs
+++ b/runtime/capsules/src/test/mctp.rs
@@ -83,16 +83,15 @@ impl<'a> MCTPRxClient for MockMctp<'a> {
         msg_len: usize,
         _recv_time: u32,
     ) {
-        println!(
-            "Received message from EID: {} with message type: {} and message tag: {} msg_len: {}",
-            src_eid, msg_type, msg_tag, msg_len
-        );
-
         if msg_type != self.msg_type as u8
             || src_eid != MCTP_TEST_REMOTE_EID
             || msg_tag != self.msg_tag.get()
             || msg_len != TEST_MSG_LEN_ARR[self.cur_idx.get()]
         {
+            println!(
+            "FAILED! Received message from EID/expected: {}/{} with message type/expected: {}/{} and message tag/expected: {}/{} msg_len/expected: {}/{}",
+            src_eid, MCTP_TEST_REMOTE_EID, msg_type, self.msg_type as u8, msg_tag, self.msg_tag.get(), msg_len, TEST_MSG_LEN_ARR[self.cur_idx.get()]
+        );
             self.test_client.map(|client| {
                 client.test_result(false, self.cur_idx.get() + 1, TEST_MSG_LEN_ARR.len());
             });


### PR DESCRIPTION
This PR refactors the existing MCTP tests in the emulator to use common MCTP utility framework. 
This common MCTP framework allows MCTP protocol validators to send and receive messages seamlessly, without needing to manage the details of the underlying MCTP base protocol or the I3C protocol.