### PR TITLE
Update Calitpra core and zerocopy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,7 +182,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 [[package]]
 name = "caliptra-api"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw.git?rev=2f6de531e321b7bb24b17b1bd02b43d2854aef3a#2f6de531e321b7bb24b17b1bd02b43d2854aef3a"
+source = "git+https://github.com/chipsalliance/caliptra-sw.git?rev=dd307762140a39d5f3841a5e770a6fb8087aca29#dd307762140a39d5f3841a5e770a6fb8087aca29"
 dependencies = [
  "bitflags 2.6.0",
  "caliptra-api-types",
@@ -190,32 +190,36 @@ dependencies = [
  "caliptra-error",
  "caliptra-registers",
  "ureg",
- "zerocopy 0.6.6",
+ "zerocopy 0.8.8",
 ]
 
 [[package]]
 name = "caliptra-api-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw.git?rev=2f6de531e321b7bb24b17b1bd02b43d2854aef3a#2f6de531e321b7bb24b17b1bd02b43d2854aef3a"
+source = "git+https://github.com/chipsalliance/caliptra-sw.git?rev=dd307762140a39d5f3841a5e770a6fb8087aca29#dd307762140a39d5f3841a5e770a6fb8087aca29"
+dependencies = [
+ "caliptra-image-types",
+]
 
 [[package]]
 name = "caliptra-auth-man-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw.git?rev=2f6de531e321b7bb24b17b1bd02b43d2854aef3a#2f6de531e321b7bb24b17b1bd02b43d2854aef3a"
+source = "git+https://github.com/chipsalliance/caliptra-sw.git?rev=dd307762140a39d5f3841a5e770a6fb8087aca29#dd307762140a39d5f3841a5e770a6fb8087aca29"
 dependencies = [
+ "bitfield",
  "bitflags 2.6.0",
  "caliptra-error",
  "caliptra-image-types",
  "caliptra-lms-types",
  "memoffset 0.8.0",
- "zerocopy 0.6.6",
+ "zerocopy 0.8.8",
  "zeroize",
 ]
 
 [[package]]
 name = "caliptra-builder"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw.git?rev=2f6de531e321b7bb24b17b1bd02b43d2854aef3a#2f6de531e321b7bb24b17b1bd02b43d2854aef3a"
+source = "git+https://github.com/chipsalliance/caliptra-sw.git?rev=dd307762140a39d5f3841a5e770a6fb8087aca29#dd307762140a39d5f3841a5e770a6fb8087aca29"
 dependencies = [
  "anyhow",
  "caliptra-image-crypto",
@@ -228,13 +232,13 @@ dependencies = [
  "hex",
  "nix 0.26.4",
  "once_cell",
- "zerocopy 0.6.6",
+ "zerocopy 0.8.8",
 ]
 
 [[package]]
 name = "caliptra-cfi-derive"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw.git?rev=2f6de531e321b7bb24b17b1bd02b43d2854aef3a#2f6de531e321b7bb24b17b1bd02b43d2854aef3a"
+source = "git+https://github.com/chipsalliance/caliptra-sw.git?rev=dd307762140a39d5f3841a5e770a6fb8087aca29#dd307762140a39d5f3841a5e770a6fb8087aca29"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -245,7 +249,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cfi-lib"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw.git?rev=2f6de531e321b7bb24b17b1bd02b43d2854aef3a#2f6de531e321b7bb24b17b1bd02b43d2854aef3a"
+source = "git+https://github.com/chipsalliance/caliptra-sw.git?rev=dd307762140a39d5f3841a5e770a6fb8087aca29#dd307762140a39d5f3841a5e770a6fb8087aca29"
 dependencies = [
  "caliptra-error",
  "caliptra-registers",
@@ -255,7 +259,7 @@ dependencies = [
 [[package]]
 name = "caliptra-coverage"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw.git?rev=2f6de531e321b7bb24b17b1bd02b43d2854aef3a#2f6de531e321b7bb24b17b1bd02b43d2854aef3a"
+source = "git+https://github.com/chipsalliance/caliptra-sw.git?rev=dd307762140a39d5f3841a5e770a6fb8087aca29#dd307762140a39d5f3841a5e770a6fb8087aca29"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -273,7 +277,7 @@ dependencies = [
 [[package]]
 name = "caliptra-drivers"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw.git?rev=2f6de531e321b7bb24b17b1bd02b43d2854aef3a#2f6de531e321b7bb24b17b1bd02b43d2854aef3a"
+source = "git+https://github.com/chipsalliance/caliptra-sw.git?rev=dd307762140a39d5f3841a5e770a6fb8087aca29#dd307762140a39d5f3841a5e770a6fb8087aca29"
 dependencies = [
  "bitfield",
  "bitflags 2.6.0",
@@ -287,14 +291,14 @@ dependencies = [
  "cfg-if",
  "ufmt 0.2.0",
  "ureg",
- "zerocopy 0.6.6",
+ "zerocopy 0.8.8",
  "zeroize",
 ]
 
 [[package]]
 name = "caliptra-emu-bus"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw.git?rev=2f6de531e321b7bb24b17b1bd02b43d2854aef3a#2f6de531e321b7bb24b17b1bd02b43d2854aef3a"
+source = "git+https://github.com/chipsalliance/caliptra-sw.git?rev=dd307762140a39d5f3841a5e770a6fb8087aca29#dd307762140a39d5f3841a5e770a6fb8087aca29"
 dependencies = [
  "caliptra-emu-types",
  "tock-registers",
@@ -304,7 +308,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-cpu"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw.git?rev=2f6de531e321b7bb24b17b1bd02b43d2854aef3a#2f6de531e321b7bb24b17b1bd02b43d2854aef3a"
+source = "git+https://github.com/chipsalliance/caliptra-sw.git?rev=dd307762140a39d5f3841a5e770a6fb8087aca29#dd307762140a39d5f3841a5e770a6fb8087aca29"
 dependencies = [
  "bit-vec",
  "bitfield",
@@ -318,7 +322,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw.git?rev=2f6de531e321b7bb24b17b1bd02b43d2854aef3a#2f6de531e321b7bb24b17b1bd02b43d2854aef3a"
+source = "git+https://github.com/chipsalliance/caliptra-sw.git?rev=dd307762140a39d5f3841a5e770a6fb8087aca29#dd307762140a39d5f3841a5e770a6fb8087aca29"
 dependencies = [
  "aes",
  "cbc",
@@ -330,7 +334,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-derive"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw.git?rev=2f6de531e321b7bb24b17b1bd02b43d2854aef3a#2f6de531e321b7bb24b17b1bd02b43d2854aef3a"
+source = "git+https://github.com/chipsalliance/caliptra-sw.git?rev=dd307762140a39d5f3841a5e770a6fb8087aca29#dd307762140a39d5f3841a5e770a6fb8087aca29"
 dependencies = [
  "caliptra-emu-bus",
  "caliptra-emu-types",
@@ -341,7 +345,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-periph"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw.git?rev=2f6de531e321b7bb24b17b1bd02b43d2854aef3a#2f6de531e321b7bb24b17b1bd02b43d2854aef3a"
+source = "git+https://github.com/chipsalliance/caliptra-sw.git?rev=dd307762140a39d5f3841a5e770a6fb8087aca29#dd307762140a39d5f3841a5e770a6fb8087aca29"
 dependencies = [
  "aes",
  "arrayref",
@@ -357,26 +361,27 @@ dependencies = [
  "fips204",
  "lazy_static",
  "rand",
+ "sha2",
  "sha3",
  "smlang",
  "tock-registers",
- "zerocopy 0.6.6",
+ "zerocopy 0.8.8",
 ]
 
 [[package]]
 name = "caliptra-emu-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw.git?rev=2f6de531e321b7bb24b17b1bd02b43d2854aef3a#2f6de531e321b7bb24b17b1bd02b43d2854aef3a"
+source = "git+https://github.com/chipsalliance/caliptra-sw.git?rev=dd307762140a39d5f3841a5e770a6fb8087aca29#dd307762140a39d5f3841a5e770a6fb8087aca29"
 
 [[package]]
 name = "caliptra-error"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw.git?rev=2f6de531e321b7bb24b17b1bd02b43d2854aef3a#2f6de531e321b7bb24b17b1bd02b43d2854aef3a"
+source = "git+https://github.com/chipsalliance/caliptra-sw.git?rev=dd307762140a39d5f3841a5e770a6fb8087aca29#dd307762140a39d5f3841a5e770a6fb8087aca29"
 
 [[package]]
 name = "caliptra-hw-model"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw.git?rev=2f6de531e321b7bb24b17b1bd02b43d2854aef3a#2f6de531e321b7bb24b17b1bd02b43d2854aef3a"
+source = "git+https://github.com/chipsalliance/caliptra-sw.git?rev=dd307762140a39d5f3841a5e770a6fb8087aca29#dd307762140a39d5f3841a5e770a6fb8087aca29"
 dependencies = [
  "bit-vec",
  "bitfield",
@@ -395,13 +400,13 @@ dependencies = [
  "rand",
  "sha2",
  "ureg",
- "zerocopy 0.6.6",
+ "zerocopy 0.8.8",
 ]
 
 [[package]]
 name = "caliptra-hw-model-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw.git?rev=2f6de531e321b7bb24b17b1bd02b43d2854aef3a#2f6de531e321b7bb24b17b1bd02b43d2854aef3a"
+source = "git+https://github.com/chipsalliance/caliptra-sw.git?rev=dd307762140a39d5f3841a5e770a6fb8087aca29#dd307762140a39d5f3841a5e770a6fb8087aca29"
 dependencies = [
  "caliptra-api-types",
  "rand",
@@ -410,7 +415,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw.git?rev=2f6de531e321b7bb24b17b1bd02b43d2854aef3a#2f6de531e321b7bb24b17b1bd02b43d2854aef3a"
+source = "git+https://github.com/chipsalliance/caliptra-sw.git?rev=dd307762140a39d5f3841a5e770a6fb8087aca29#dd307762140a39d5f3841a5e770a6fb8087aca29"
 dependencies = [
  "anyhow",
  "caliptra-image-gen",
@@ -418,13 +423,13 @@ dependencies = [
  "caliptra-lms-types",
  "cfg-if",
  "openssl",
- "zerocopy 0.6.6",
+ "zerocopy 0.8.8",
 ]
 
 [[package]]
 name = "caliptra-image-elf"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw.git?rev=2f6de531e321b7bb24b17b1bd02b43d2854aef3a#2f6de531e321b7bb24b17b1bd02b43d2854aef3a"
+source = "git+https://github.com/chipsalliance/caliptra-sw.git?rev=dd307762140a39d5f3841a5e770a6fb8087aca29#dd307762140a39d5f3841a5e770a6fb8087aca29"
 dependencies = [
  "anyhow",
  "caliptra-image-gen",
@@ -435,52 +440,58 @@ dependencies = [
 [[package]]
 name = "caliptra-image-fake-keys"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw.git?rev=2f6de531e321b7bb24b17b1bd02b43d2854aef3a#2f6de531e321b7bb24b17b1bd02b43d2854aef3a"
+source = "git+https://github.com/chipsalliance/caliptra-sw.git?rev=dd307762140a39d5f3841a5e770a6fb8087aca29#dd307762140a39d5f3841a5e770a6fb8087aca29"
 dependencies = [
  "caliptra-image-gen",
  "caliptra-image-types",
  "caliptra-lms-types",
- "zerocopy 0.6.6",
+ "zerocopy 0.8.8",
 ]
 
 [[package]]
 name = "caliptra-image-gen"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw.git?rev=2f6de531e321b7bb24b17b1bd02b43d2854aef3a#2f6de531e321b7bb24b17b1bd02b43d2854aef3a"
+source = "git+https://github.com/chipsalliance/caliptra-sw.git?rev=dd307762140a39d5f3841a5e770a6fb8087aca29#dd307762140a39d5f3841a5e770a6fb8087aca29"
 dependencies = [
  "anyhow",
  "bitflags 2.6.0",
  "caliptra-image-types",
  "caliptra-lms-types",
+ "fips204",
  "memoffset 0.8.0",
- "zerocopy 0.6.6",
+ "rand",
+ "zerocopy 0.8.8",
 ]
 
 [[package]]
 name = "caliptra-image-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw.git?rev=2f6de531e321b7bb24b17b1bd02b43d2854aef3a#2f6de531e321b7bb24b17b1bd02b43d2854aef3a"
+source = "git+https://github.com/chipsalliance/caliptra-sw.git?rev=dd307762140a39d5f3841a5e770a6fb8087aca29#dd307762140a39d5f3841a5e770a6fb8087aca29"
 dependencies = [
+ "caliptra-cfi-derive",
+ "caliptra-cfi-lib",
  "caliptra-error",
  "caliptra-lms-types",
  "memoffset 0.8.0",
- "zerocopy 0.6.6",
+ "zerocopy 0.8.8",
  "zeroize",
 ]
 
 [[package]]
 name = "caliptra-lms-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw.git?rev=2f6de531e321b7bb24b17b1bd02b43d2854aef3a#2f6de531e321b7bb24b17b1bd02b43d2854aef3a"
+source = "git+https://github.com/chipsalliance/caliptra-sw.git?rev=dd307762140a39d5f3841a5e770a6fb8087aca29#dd307762140a39d5f3841a5e770a6fb8087aca29"
 dependencies = [
- "zerocopy 0.6.6",
+ "caliptra-cfi-derive",
+ "caliptra-cfi-lib",
+ "zerocopy 0.8.8",
  "zeroize",
 ]
 
 [[package]]
 name = "caliptra-registers"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw.git?rev=2f6de531e321b7bb24b17b1bd02b43d2854aef3a#2f6de531e321b7bb24b17b1bd02b43d2854aef3a"
+source = "git+https://github.com/chipsalliance/caliptra-sw.git?rev=dd307762140a39d5f3841a5e770a6fb8087aca29#dd307762140a39d5f3841a5e770a6fb8087aca29"
 dependencies = [
  "caliptra-registers-latest",
 ]
@@ -488,7 +499,7 @@ dependencies = [
 [[package]]
 name = "caliptra-registers-latest"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw.git?rev=2f6de531e321b7bb24b17b1bd02b43d2854aef3a#2f6de531e321b7bb24b17b1bd02b43d2854aef3a"
+source = "git+https://github.com/chipsalliance/caliptra-sw.git?rev=dd307762140a39d5f3841a5e770a6fb8087aca29#dd307762140a39d5f3841a5e770a6fb8087aca29"
 dependencies = [
  "ureg",
 ]
@@ -525,7 +536,7 @@ dependencies = [
  "i3c-driver",
  "kernel",
  "romtime",
- "zerocopy 0.8.13",
+ "zerocopy 0.8.8",
 ]
 
 [[package]]
@@ -974,7 +985,7 @@ dependencies = [
  "strum_macros",
  "tempfile",
  "tock-registers",
- "zerocopy 0.8.13",
+ "zerocopy 0.8.8",
 ]
 
 [[package]]
@@ -1046,7 +1057,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tock-registers",
- "zerocopy 0.8.13",
+ "zerocopy 0.8.8",
 ]
 
 [[package]]
@@ -1121,9 +1132,9 @@ dependencies = [
 
 [[package]]
 name = "fips204"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1909118ec7b649ae9feef77fa0548384e8d550af0497ad4de32f82252c44435"
+checksum = "c9fb5a367b9846933e271a3c2a992930743f82ae5e8cb7faa780715a80fa0b15"
 dependencies = [
  "rand_core",
  "sha2",
@@ -1482,7 +1493,7 @@ dependencies = [
  "libsyscall-caliptra",
  "libtock_platform",
  "libtock_unittest",
- "zerocopy 0.8.13",
+ "zerocopy 0.8.8",
 ]
 
 [[package]]
@@ -2661,7 +2672,7 @@ dependencies = [
  "gdbstub_arch",
  "hex",
  "tock-registers",
- "zerocopy 0.8.13",
+ "zerocopy 0.8.8",
 ]
 
 [[package]]
@@ -2820,7 +2831,7 @@ checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 [[package]]
 name = "ureg"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw.git?rev=2f6de531e321b7bb24b17b1bd02b43d2854aef3a#2f6de531e321b7bb24b17b1bd02b43d2854aef3a"
+source = "git+https://github.com/chipsalliance/caliptra-sw.git?rev=dd307762140a39d5f3841a5e770a6fb8087aca29#dd307762140a39d5f3841a5e770a6fb8087aca29"
 
 [[package]]
 name = "utf8parse"
@@ -3068,17 +3079,7 @@ dependencies = [
  "tempfile",
  "toml",
  "walkdir",
- "zerocopy 0.8.13",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854e949ac82d619ee9a14c66a1b674ac730422372ccb759ce0c39cabcf2bf8e6"
-dependencies = [
- "byteorder 1.5.0",
- "zerocopy-derive 0.6.6",
+ "zerocopy 0.8.8",
 ]
 
 [[package]]
@@ -3093,22 +3094,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.13"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67914ab451f3bfd2e69e5e9d2ef3858484e7074d63f204fd166ec391b54de21d"
+checksum = "5a4e33e6dce36f2adba29746927f8e848ba70989fdb61c772773bbdda8b5d6a7"
 dependencies = [
- "zerocopy-derive 0.8.13",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "125139de3f6b9d625c39e2efdd73d41bdac468ccd556556440e322be0e1bbd91"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.90",
+ "zerocopy-derive 0.8.8",
 ]
 
 [[package]]
@@ -3124,9 +3114,9 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.13"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7988d73a4303ca289df03316bc490e934accf371af6bc745393cf3c2c5c4f25d"
+checksum = "3cd137b4cc21bde6ecce3bbbb3350130872cda0be2c6888874279ea76e17d4c1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,7 @@ tempfile = "3.14.0"
 toml = "0.8.19"
 uuid = { version = "1.10.0", features = ["serde"]}
 walkdir = "2.5.0"
-zerocopy = { version = "0.8.7", features = ["derive"] }
+zerocopy = { version = "0.8.8", features = ["derive"] }
 zeroize = { version = "1.6.0", default-features = false, features = ["zeroize_derive"] }
 
 # local dependencies
@@ -138,13 +138,13 @@ libsyscall-caliptra = { path = "runtime/apps/syscall" }
 libapi-caliptra = { path = "runtime/apps/api" }
 
 # caliptra dependencies; keep git revs in sync
-caliptra-api-types = { git = "https://github.com/chipsalliance/caliptra-sw.git", rev = "2f6de531e321b7bb24b17b1bd02b43d2854aef3a" }
-caliptra-emu-bus = { git = "https://github.com/chipsalliance/caliptra-sw.git", rev = "2f6de531e321b7bb24b17b1bd02b43d2854aef3a" }
-caliptra-emu-cpu = { git = "https://github.com/chipsalliance/caliptra-sw.git", rev = "2f6de531e321b7bb24b17b1bd02b43d2854aef3a" }
-caliptra-emu-periph = { git = "https://github.com/chipsalliance/caliptra-sw.git", rev = "2f6de531e321b7bb24b17b1bd02b43d2854aef3a" }
-caliptra-emu-types = { git = "https://github.com/chipsalliance/caliptra-sw.git", rev = "2f6de531e321b7bb24b17b1bd02b43d2854aef3a" }
-caliptra-hw-model = { git = "https://github.com/chipsalliance/caliptra-sw.git", rev = "2f6de531e321b7bb24b17b1bd02b43d2854aef3a" }
-caliptra-registers = { git = "https://github.com/chipsalliance/caliptra-sw.git", rev = "2f6de531e321b7bb24b17b1bd02b43d2854aef3a" }
+caliptra-api-types = { git = "https://github.com/chipsalliance/caliptra-sw.git", rev = "dd307762140a39d5f3841a5e770a6fb8087aca29" }
+caliptra-emu-bus = { git = "https://github.com/chipsalliance/caliptra-sw.git", rev = "dd307762140a39d5f3841a5e770a6fb8087aca29" }
+caliptra-emu-cpu = { git = "https://github.com/chipsalliance/caliptra-sw.git", rev = "dd307762140a39d5f3841a5e770a6fb8087aca29" }
+caliptra-emu-periph = { git = "https://github.com/chipsalliance/caliptra-sw.git", rev = "dd307762140a39d5f3841a5e770a6fb8087aca29" }
+caliptra-emu-types = { git = "https://github.com/chipsalliance/caliptra-sw.git", rev = "dd307762140a39d5f3841a5e770a6fb8087aca29" }
+caliptra-hw-model = { git = "https://github.com/chipsalliance/caliptra-sw.git", rev = "dd307762140a39d5f3841a5e770a6fb8087aca29" }
+caliptra-registers = { git = "https://github.com/chipsalliance/caliptra-sw.git", rev = "dd307762140a39d5f3841a5e770a6fb8087aca29" }
 
 # tock dependencies; keep git revs in sync
 capsules-core = { git = "https://github.com/tock/tock.git", rev = "b128ae817b86706c8c4e39d27fae5c54b98659f1" }

--- a/emulator/caliptra/src/caliptra.rs
+++ b/emulator/caliptra/src/caliptra.rs
@@ -221,7 +221,7 @@ pub fn start_caliptra(
                 .try_into()
                 .expect("mfg_pk_hash must be 48 bytes"),
         );
-        soc_ifc.fuse_key_manifest_pk_hash().write(&mfg_pk_hash);
+        soc_ifc.fuse_vendor_pk_hash().write(&mfg_pk_hash);
     }
 
     if !owner_pk_hash.is_empty() {
@@ -230,7 +230,7 @@ pub fn start_caliptra(
                 .try_into()
                 .expect("owner_pk_hash must be 48 bytes"),
         );
-        soc_ifc.fuse_owner_pk_hash().write(&owner_pk_hash);
+        soc_ifc.cptra_owner_pk_hash().write(&owner_pk_hash);
     }
 
     // Populate DBG_MANUF_SERVICE_REG


### PR DESCRIPTION
Caliptra recently updated zerocopy to 0.8.8, so we can sync up our versions now.