### PR TITLE
rom: Don't allow panics

### DIFF
--- a/rom/src/fuses.rs
+++ b/rom/src/fuses.rs
@@ -20,7 +20,7 @@ impl Otp {
 
     pub fn init(&self) -> Result<(), McuError> {
         if self.registers.status.get() & 0x1fff != 0 {
-            romtime::println!("OTP error: {:x}", self.registers.status.get());
+            romtime::println!("OTP error: {}", self.registers.status.get());
             return Err(McuError::FusesError);
         }
 
@@ -82,7 +82,7 @@ impl Otp {
         {}
 
         if let Some(err) = self.check_error() {
-            romtime::println!("Error reading fuses: {:x}", err);
+            romtime::println!("Error reading fuses: {}", err);
             return Err(McuError::FusesError);
         }
         Ok(self.registers.dai_rdata_rf_direct_access_rdata_0.get())

--- a/rom/src/io.rs
+++ b/rom/src/io.rs
@@ -3,24 +3,7 @@
 // Copyright Tock Contributors 2022.
 // Copyright (c) 2024 Antmicro <www.antmicro.com>
 
-use core::panic::PanicInfo;
 use core::ptr::{read_volatile, write_volatile};
-
-/// Panic handler.
-///
-#[cfg(not(test))]
-#[no_mangle]
-#[panic_handler]
-pub fn panic_fmt(_pi: &PanicInfo) -> ! {
-    // TODO: use ufmt / caliptra driver
-    write(b"Panic!\r\n");
-
-    // Cause the emulator to exit
-    unsafe {
-        write_volatile(0x1000_2000 as *mut u32, 0);
-    }
-    unreachable!()
-}
 
 pub fn write(buf: &[u8]) {
     for b in buf {

--- a/rom/src/main.rs
+++ b/rom/src/main.rs
@@ -36,3 +36,42 @@ pub extern "C" fn main() {
 pub extern "C" fn main() {
     // no-op on x86 just to keep the build clean
 }
+
+#[no_mangle]
+#[inline(never)]
+#[cfg(target_arch = "riscv32")]
+fn panic_is_possible() {
+    core::hint::black_box(());
+    // The existence of this symbol is used to inform test_panic_missing
+    // that panics are possible. Do not remove or rename this symbol.
+}
+
+#[panic_handler]
+#[inline(never)]
+#[cfg(target_arch = "riscv32")]
+fn rom_panic(_: &core::panic::PanicInfo) -> ! {
+    panic_is_possible();
+    io::write(b"Panic!\r\n");
+
+    fatal_error();
+}
+
+#[cfg(target_arch = "riscv32")]
+#[inline(never)]
+#[allow(dead_code)]
+#[allow(clippy::empty_loop)]
+pub(crate) fn fatal_error() -> ! {
+    // Cause the emulator to exit
+    unsafe {
+        core::ptr::write_volatile(0x1000_2000 as *mut u32, 1);
+    }
+    loop {}
+}
+
+#[cfg(not(target_arch = "riscv32"))]
+#[inline(never)]
+#[allow(dead_code)]
+#[allow(clippy::empty_loop)]
+pub(crate) fn fatal_error() -> ! {
+    loop {}
+}


### PR DESCRIPTION
In the ROM, we don't want to allow panics: we want to know explicitly any time we can reach a fatal error.

So we add a similar to test to Caliptra's to scan the ROM ELF for a symbol we inject when a panic is possible:
https://github.com/chipsalliance/caliptra-sw/blob/main/rom/dev/tests/rom_integration_tests/test_panic_missing.rs

We had to remove the usage of `{:x}` in formatting calls in the ROM, since current versions of Rust (incorrectly?) think it can panic.

Runtime will be allowed to panic, though we should take care to minimize the amount of calls, since we cannot reasonably recover from a kernel panic, but it is probably not possible to remove all panics from Tock.