### PR TITLE
spdm: Set exit status correctly; fix target address in tests

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -73,8 +73,10 @@ jobs:
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
 
-      - name: Do a quick build to ensure the right toolchain is installed
-        run: cargo b
+      - name: Install the toolchain and components
+        run: |
+          rustup toolchain install nightly-2024-10-01-x86_64-unknown-linux-gnu
+          rustup component add --toolchain nightly-2024-10-01-x86_64-unknown-linux-gnu clippy rust-src llvm-tools rustfmt rustc-dev
 
       - name: Check that Cargo.lock doesn't need to be updated
           # Note: this isn't the same as checking that Cargo.lock is up to date

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -72,6 +72,10 @@ jobs:
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
+
+      - name: Do a quick build to ensure the right toolchain is installed
+        run: cargo b
+
       - name: Check that Cargo.lock doesn't need to be updated
           # Note: this isn't the same as checking that Cargo.lock is up to date
           # (cargo update --locked), which makes sure that every package is the

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -120,12 +120,6 @@ jobs:
           cargo --config "$EXTRA_CARGO_CONFIG" xtask test
           sccache --show-stats
 
-      # - name: display SPDM Validator test results
+      # - name: Display SPDM Validator test results
       #   run: |
       #     cat $GITHUB_WORKSPACE/test.log
-      #     if grep -q "fail: 0" $GITHUB_WORKSPACE/test.log; then
-      #     echo "All tests passed."
-      #     else
-      #     echo "Some tests failed."
-      #     exit 1
-      #     fi

--- a/emulator/app/src/tests/mctp_util/common.rs
+++ b/emulator/app/src/tests/mctp_util/common.rs
@@ -132,7 +132,7 @@ impl MctpUtil {
                     let write_pkt = pkts.front().unwrap().clone();
                     if send_private_write(stream, target_addr, write_pkt) {
                         i3c_state = I3cControllerState::WaitForIbi;
-                        std::thread::sleep(std::time::Duration::from_secs(5));
+                        std::thread::sleep(std::time::Duration::from_millis(500));
                     }
                 }
                 I3cControllerState::WaitForIbi => {
@@ -279,7 +279,9 @@ impl MctpUtil {
                         }
                     }
                 }
-                _ => {}
+                _ => {
+                    panic!("Unknown state {:?}", i3c_state);
+                }
             }
         }
 

--- a/emulator/app/src/tests/spdm_validator.rs
+++ b/emulator/app/src/tests/spdm_validator.rs
@@ -176,8 +176,9 @@ impl Test {
                         println!("Test: response received, marking finished");
                         self.cur_resp_msg = resp_msg;
                         self.mctp_test_state = MctpTestState::Finish;
+                    } else {
+                        println!("Test: no response received");
                     }
-                    println!("Test: no response received");
                 }
 
                 MctpTestState::Finish => {

--- a/emulator/app/src/tests/spdm_validator.rs
+++ b/emulator/app/src/tests/spdm_validator.rs
@@ -148,7 +148,7 @@ impl Test {
         target_addr: u8,
     ) {
         i3c_stream.set_nonblocking(true).unwrap();
-        println!("Sending message to target {:X?}", self.cur_req_msg);
+        println!("Test: Sending message to target {:x?}", self.cur_req_msg);
         self.mctp_test_state = MctpTestState::Start;
 
         while running.load(Ordering::Relaxed) {
@@ -168,19 +168,24 @@ impl Test {
                 }
 
                 MctpTestState::ReceiveResp => {
+                    println!("Test: receive_response");
                     let resp_msg =
                         self.mctp_util
-                            .receive_response(running.clone(), i3c_stream, self.msg_tag);
+                            .receive_response(running.clone(), i3c_stream, target_addr);
                     if !resp_msg.is_empty() {
+                        println!("Test: response received, marking finished");
                         self.cur_resp_msg = resp_msg;
                         self.mctp_test_state = MctpTestState::Finish;
                     }
+                    println!("Test: no response received");
                 }
 
                 MctpTestState::Finish => {
                     break;
                 }
-                _ => {}
+                _ => {
+                    panic!("Unknown state: {:?}", self.mctp_test_state);
+                }
             }
         }
     }
@@ -239,7 +244,7 @@ impl Test {
                     );
                     if let Some(resp_msg) = result {
                         println!("SPDM_SERVER: Received response from target {:?}", resp_msg);
-                        assert!(resp_msg[0] == self.cur_req_msg[0]);
+                        assert_eq!(resp_msg[0], self.cur_req_msg[0]);
                         self.cur_resp_msg = resp_msg;
                         self.responder_ready = true;
                     } else {

--- a/runtime/capsules/src/mctp/driver.rs
+++ b/runtime/capsules/src/mctp/driver.rs
@@ -279,7 +279,7 @@ impl<'a> SyscallDriver for MCTPDriver<'a> {
     ///         Otherwise, replaces the pending rx operation context with the new one.
     ///         When a new message is received from peer EID, the metadata is compared with the pending rx operation context.
     ///         If the metadata matches, the message is copied to the process buffer and the upcall is scheduled.
-    ///        
+    ///
     ///
     /// - `3`: Send Request Message.
     /// - `4`: Send Response Message.
@@ -452,12 +452,12 @@ impl<'a> MCTPRxClient for MCTPDriver<'a> {
                 app.pending_rx = None;
                 let msg_info =
                     (src_eid as usize) << 16 | (msg_type as usize) << 8 | (msg_tag as usize);
-                kernel_data
-                    .schedule_upcall(
-                        upcall::MESSAGE_RECEIVED,
-                        (msg_len, recv_time as usize, msg_info),
-                    )
-                    .ok();
+                if let Err(e) = kernel_data.schedule_upcall(
+                    upcall::MESSAGE_RECEIVED,
+                    (msg_len, recv_time as usize, msg_info),
+                ) {
+                    panic!("MCTPDriver::receive upcall schedule failed: {:?}", e);
+                }
             }
         });
     }


### PR DESCRIPTION
This fixes a few issues

* We cancel the test if it hangs for more than 30 seconds
* We correct the target address (instead of the tag) when launching the test
* We reduce the wait from 5 seconds to 0.5 after sending a message
* If scheduling an upcall fails, we panic instead of ignoring the error.
* If the test fails, we set the exit code correctly.

I believe the SPDM validator test was failing before, but the exit code was not being set, so it appeared to be passing.

However, the SPDM validator test is still failing, but I believe it is correct to still be failing, since the failure is on a message type that we do not support yet. So, I've left the test disabled for now.

(It looks like Cargo will no longer automatically install the toolchain and needed modules, so I updated GHA to do that manually.)