### PR TITLE
[FW Update Agent] Implement PLDM Firmware Update Inventory Commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2437,6 +2437,7 @@ version = "0.1.0"
 dependencies = [
  "log",
  "pldm-common",
+ "pldm-fw-pkg",
  "simple_logger",
  "smlang 0.8.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,6 +136,7 @@ i3c-driver = { path = "runtime/i3c" }
 libtockasync = { path = "runtime/apps/libtockasync" }
 mcu-rom-common = { path = "rom" }
 pldm-common = { path = "common/pldm"}
+pldm-fw-pkg = { path = "emulator/bmc/pldm-fw-pkg" }
 pldm-ua = {path = "emulator/bmc/pldm-ua"}
 registers-generated = { path = "registers/generated-firmware" }
 registers-generator = { path = "registers/generator" }

--- a/common/pldm/src/message/firmware_update/query_devid.rs
+++ b/common/pldm/src/message/firmware_update/query_devid.rs
@@ -29,7 +29,7 @@ impl QueryDeviceIdentifiersRequest {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Default)]
 #[repr(C)]
 pub struct QueryDeviceIdentifiersResponse {
     pub hdr: PldmMsgHeader<[u8; PLDM_MSG_HEADER_LEN]>,

--- a/common/pldm/src/message/firmware_update/request_fw_data.rs
+++ b/common/pldm/src/message/firmware_update/request_fw_data.rs
@@ -52,7 +52,7 @@ pub struct RequestFirmwareDataResponse<'a> {
     pub data: &'a [u8],
 }
 
-impl<'a> RequestFirmwareDataResponse<'a> {
+impl RequestFirmwareDataResponse<'_> {
     pub fn new(
         instance_id: InstanceId,
         completion_code: u8,
@@ -77,7 +77,7 @@ impl<'a> RequestFirmwareDataResponse<'a> {
     }
 }
 
-impl<'a> PldmCodec for RequestFirmwareDataResponse<'a> {
+impl PldmCodec for RequestFirmwareDataResponse<'_> {
     fn encode(&self, buffer: &mut [u8]) -> Result<usize, PldmCodecError> {
         if buffer.len() < self.codec_size_in_bytes() {
             return Err(PldmCodecError::BufferTooShort);

--- a/common/pldm/src/protocol/base.rs
+++ b/common/pldm/src/protocol/base.rs
@@ -186,7 +186,7 @@ impl TryFrom<u8> for TransferRespFlag {
 
 bitfield! {
     #[repr(C)]
-    #[derive(Copy, Clone, FromBytes, IntoBytes, Immutable, PartialEq)]
+    #[derive(Copy, Clone, FromBytes, IntoBytes, Immutable, PartialEq, Default)]
     pub struct PldmMsgHeader([u8]);
     impl Debug;
     pub u8, instance_id, set_instance_id: 4, 0;

--- a/common/pldm/src/protocol/firmware_update.rs
+++ b/common/pldm/src/protocol/firmware_update.rs
@@ -12,6 +12,7 @@ pub const PLDM_FWUP_BASELINE_TRANSFER_SIZE: usize = 32;
 pub const PLDM_FWUP_MAX_PADDING_SIZE: usize = PLDM_FWUP_BASELINE_TRANSFER_SIZE;
 pub const PLDM_FWUP_IMAGE_SET_VER_STR_MAX_LEN: usize = 255;
 pub const DESCRIPTOR_DATA_MAX_LEN: usize = 64; // Arbitrary limit for static storage
+pub const MAX_COMPONENT_COUNT: usize = 8; // Arbitrary limit, change as needed
 
 #[repr(u8)]
 pub enum FwUpdateCmd {
@@ -270,6 +271,16 @@ pub struct Descriptor {
     pub descriptor_data: [u8; DESCRIPTOR_DATA_MAX_LEN],
 }
 
+impl Default for Descriptor {
+    fn default() -> Self {
+        Descriptor {
+            descriptor_type: 0,
+            descriptor_length: 0,
+            descriptor_data: [0; DESCRIPTOR_DATA_MAX_LEN],
+        }
+    }
+}
+
 impl Descriptor {
     pub fn new_empty() -> Self {
         Descriptor {
@@ -360,7 +371,7 @@ impl PldmCodec for Descriptor {
 }
 
 bitfield! {
-    #[derive(Clone, Copy, FromBytes, IntoBytes, Immutable, PartialEq, Eq)]
+    #[derive(Clone, Copy, FromBytes, IntoBytes, Immutable, PartialEq, Eq, Default)]
     pub struct FirmwareDeviceCapability(u32);
     impl Debug;
     pub u32, reserved, _: 31, 10;
@@ -481,7 +492,7 @@ impl<'a> PldmFirmwareVersion<'a> {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, FromBytes, IntoBytes, Immutable)]
+#[derive(Debug, Clone, PartialEq, Eq, FromBytes, IntoBytes, Immutable, Copy)]
 #[repr(C, packed)]
 pub struct ComponentParameterEntryFixed {
     pub comp_classification: u16,
@@ -499,12 +510,36 @@ pub struct ComponentParameterEntryFixed {
     pub capabilities_during_update: FirmwareDeviceCapability,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 #[repr(C)]
 pub struct ComponentParameterEntry {
     pub comp_param_entry_fixed: ComponentParameterEntryFixed,
     pub active_comp_ver_str: [u8; PLDM_FWUP_IMAGE_SET_VER_STR_MAX_LEN],
     pub pending_comp_ver_str: Option<[u8; PLDM_FWUP_IMAGE_SET_VER_STR_MAX_LEN]>,
+}
+
+impl Default for ComponentParameterEntry {
+    fn default() -> Self {
+        ComponentParameterEntry {
+            comp_param_entry_fixed: ComponentParameterEntryFixed {
+                comp_classification: 0,
+                comp_identifier: 0,
+                comp_classification_index: 0,
+                active_comp_comparison_stamp: 0,
+                active_comp_ver_str_type: 0,
+                active_comp_ver_str_len: 0,
+                active_comp_release_date: [0; PLDM_FWUP_COMPONENT_RELEASE_DATA_LEN],
+                pending_comp_comparison_stamp: 0,
+                pending_comp_ver_str_type: 0,
+                pending_comp_ver_str_len: 0,
+                pending_comp_release_date: [0; PLDM_FWUP_COMPONENT_RELEASE_DATA_LEN],
+                comp_activation_methods: ComponentActivationMethods(0),
+                capabilities_during_update: FirmwareDeviceCapability(0),
+            },
+            active_comp_ver_str: [0; PLDM_FWUP_IMAGE_SET_VER_STR_MAX_LEN],
+            pending_comp_ver_str: None,
+        }
+    }
 }
 
 impl ComponentParameterEntry {

--- a/emulator/bmc/pldm-fw-pkg/src/manifest.rs
+++ b/emulator/bmc/pldm-fw-pkg/src/manifest.rs
@@ -19,7 +19,7 @@ use uuid::Uuid;
 
 use crc::{Crc, CRC_32_ISO_HDLC};
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct FirmwareManifest {
     pub package_header_information: PackageHeaderInformation,
     pub firmware_device_id_records: Vec<FirmwareDeviceIdRecord>,
@@ -27,7 +27,7 @@ pub struct FirmwareManifest {
     pub component_image_information: Vec<ComponentImageInformation>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct PackageHeaderInformation {
     pub package_header_identifier: Uuid,
     pub package_header_format_revision: u8,
@@ -38,7 +38,7 @@ pub struct PackageHeaderInformation {
     pub package_header_size: u16,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct FirmwareDeviceIdRecord {
     pub firmware_device_package_data: Option<Vec<u8>>,
     pub device_update_option_flags: u32,
@@ -50,7 +50,7 @@ pub struct FirmwareDeviceIdRecord {
     pub reference_manifest_data: Option<Vec<u8>>,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct DownstreamDeviceIdRecord {
     pub update_option_flags: u32, // bitfield32
     pub self_contained_activation_min_version_string_type: StringType,
@@ -62,7 +62,7 @@ pub struct DownstreamDeviceIdRecord {
     pub reference_manifest_data: Option<Vec<u8>>, // Optional reference manifest
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct ComponentImageInformation {
     pub image_location: String,
     pub classification: u16,
@@ -121,7 +121,7 @@ fn get_pldm_version(uuid: Uuid) -> PldmVersion {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, FromPrimitive, ToPrimitive)]
+#[derive(Debug, Clone, Copy, PartialEq, FromPrimitive, ToPrimitive, Default)]
 pub enum DescriptorType {
     PciVendorId = 0x0000,
     IanaEnterpriseId = 0x0001,
@@ -143,6 +143,7 @@ pub enum DescriptorType {
     IeeeEui64Id = 0x010A,
     PciRevisionIdRange = 0x010B,
     VendorDefined = 0x8000,
+    #[default]
     Unknown = 0xFFFF,
 }
 
@@ -230,16 +231,17 @@ impl<'de> Deserialize<'de> for DescriptorType {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Default, Clone)]
 pub struct Descriptor {
     pub descriptor_type: DescriptorType,
     pub descriptor_data: Vec<u8>, // Variable length payload
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, FromPrimitive, ToPrimitive)]
+#[derive(Debug, Copy, Clone, PartialEq, FromPrimitive, ToPrimitive, Default)]
 pub enum StringType {
     Unknown = 0,
     Ascii = 1,
+    #[default]
     Utf8 = 2,
     Utf16 = 3,
     Utf16Le = 4,

--- a/emulator/bmc/pldm-ua/Cargo.toml
+++ b/emulator/bmc/pldm-ua/Cargo.toml
@@ -9,6 +9,7 @@ authors.workspace = true
 [dependencies]
 log.workspace = true
 pldm-common.workspace = true
+pldm-fw-pkg.workspace = true
 smlang.workspace = true
 
 [dev-dependencies]

--- a/emulator/bmc/pldm-ua/src/daemon.rs
+++ b/emulator/bmc/pldm-ua/src/daemon.rs
@@ -3,18 +3,34 @@
 use crate::discovery_sm;
 use crate::events::PldmEvents;
 use crate::transport::{PldmSocket, RxPacket};
-use log::{debug, error, info};
+use crate::update_sm;
+use log::{debug, error, info, warn};
+use pldm_fw_pkg::manifest::FirmwareDeviceIdRecord;
+use pldm_fw_pkg::FirmwareManifest;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{self, Receiver, Sender};
+use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
 
 /// `PldmDaemon` represents a process that provides PLDM Discovery and Firmware Update Agent services.
 /// It manages the event loop and the reception loop for processing PLDM events and packets.
-pub struct PldmDaemon {
+pub struct PldmDaemon<
+    S: PldmSocket + Send + 'static,
+    D: discovery_sm::StateMachineActions + Send + 'static,
+    U: update_sm::StateMachineActions + Send + 'static,
+> {
     event_loop_handle: Option<JoinHandle<()>>,
     event_queue_tx: Option<Sender<PldmEvents>>,
+    update_sm: Arc<Mutex<update_sm::StateMachine<update_sm::Context<U, S>>>>,
+    _phantom: std::marker::PhantomData<D>,
 }
 
-impl PldmDaemon {
+impl<
+        S: PldmSocket + Send + 'static,
+        D: discovery_sm::StateMachineActions + Send + 'static,
+        U: update_sm::StateMachineActions + Send + 'static,
+    > PldmDaemon<S, D, U>
+{
     /// Runs the PLDM daemon.
     ///
     /// This function starts the PLDM daemon by spawning two threads:
@@ -29,34 +45,58 @@ impl PldmDaemon {
     /// # Returns
     ///
     /// Returns an instance of `PldmDaemon`.
-    pub fn run<
-        S: PldmSocket + Send + 'static,
-        D: discovery_sm::StateMachineActions + Send + 'static,
-    >(
-        socket: S,
-        opts: Options<D>,
-    ) -> Self {
+    pub fn run(socket: S, opts: Options<D, U>) -> Result<Self, ()> {
         info!("PldmDaemon is running...");
+
+        if opts.pldm_fw_pkg.is_none() {
+            warn!("PLDM firmware package is not provided.");
+            return Err(());
+        }
 
         let (event_queue_tx, event_queue_rx) = mpsc::channel();
         let event_queue_tx_clone1 = event_queue_tx.clone();
         let event_queue_tx_clone2 = event_queue_tx.clone();
+        let event_queue_tx_clone3 = event_queue_tx.clone();
+        let event_queue_tx_clone4 = event_queue_tx.clone();
         let socket_clone1 = socket.clone();
 
+        let discovery_sm = Arc::new(Mutex::new(discovery_sm::StateMachine::new(
+            discovery_sm::Context::new(
+                opts.discovery_sm_actions,
+                socket.clone(),
+                opts.fd_tid,
+                event_queue_tx_clone1,
+            ),
+        )));
+
+        let update_sm = Arc::new(Mutex::new(update_sm::StateMachine::new(
+            update_sm::Context::new(
+                opts.update_sm_actions,
+                socket_clone1.clone(),
+                opts.pldm_fw_pkg.unwrap(),
+                event_queue_tx_clone4,
+            ),
+        )));
+
+        let update_sm_clone = update_sm.clone();
+        let running = Arc::new(AtomicBool::new(true));
+
         std::thread::spawn(move || {
-            PldmDaemon::rx_loop(socket_clone1, event_queue_tx_clone1).unwrap();
+            let _ = PldmDaemon::<S, D, U>::rx_loop(socket_clone1, event_queue_tx_clone3);
         });
 
         event_queue_tx.send(PldmEvents::Start).unwrap();
 
         let event_handle = std::thread::spawn(move || {
-            PldmDaemon::event_loop(socket, event_queue_rx, opts).unwrap();
+            let _ = PldmDaemon::event_loop(event_queue_rx, discovery_sm, update_sm_clone, running);
         });
 
-        Self {
+        Ok(Self {
             event_loop_handle: Some(event_handle),
             event_queue_tx: Some(event_queue_tx_clone2),
-        }
+            update_sm,
+            _phantom: std::marker::PhantomData,
+        })
     }
 
     /// Stops the PLDM daemon.
@@ -71,8 +111,15 @@ impl PldmDaemon {
         }
     }
 
+    pub fn cancel_update(&mut self) {
+        let update_sm = &mut *self.update_sm.lock().unwrap();
+        update_sm
+            .process_event(update_sm::Events::StopUpdate)
+            .unwrap();
+    }
+
     /// This thread receives PLDM packets and enqueues the corresponding events for processing.
-    fn rx_loop<S: PldmSocket>(socket: S, event_queue_tx: Sender<PldmEvents>) -> Result<(), ()> {
+    fn rx_loop(socket: S, event_queue_tx: Sender<PldmEvents>) -> Result<(), ()> {
         loop {
             match socket.receive(None).map_err(|_| ()) {
                 Ok(rx_pkt) => {
@@ -90,36 +137,45 @@ impl PldmDaemon {
     }
 
     /// This thread processes PLDM events including dispatching events to the appropriate state machine.
-    fn event_loop<S: PldmSocket, D: discovery_sm::StateMachineActions>(
-        socket: S,
+    fn event_loop(
         event_queue_rx: Receiver<PldmEvents>,
-        options: Options<D>,
+        discovery_sm: Arc<Mutex<discovery_sm::StateMachine<discovery_sm::Context<D, S>>>>,
+        update_sm: Arc<Mutex<update_sm::StateMachine<update_sm::Context<U, S>>>>,
+        running: Arc<AtomicBool>,
     ) -> Result<(), ()> {
-        let mut discovery_sm = discovery_sm::StateMachine::new(discovery_sm::Context::new(
-            options.discovery_sm_actions,
-            socket,
-            options.fd_tid,
-        ));
-
-        while *discovery_sm.state() != discovery_sm::States::Done {
+        while running.load(Ordering::Relaxed) {
             let ev = event_queue_rx.recv().ok();
             if let Some(ev) = ev {
-                info!("Event Loop processing event: {:?}", ev);
+                debug!("Event Loop processing event: {:?}", ev);
                 match ev {
                     PldmEvents::Start => {
                         // Start Discovery
+                        let discovery_sm = &mut *discovery_sm.lock().unwrap();
                         discovery_sm
                             .process_event(discovery_sm::Events::StartDiscovery)
                             .unwrap();
                     }
                     PldmEvents::Discovery(sm_event) => {
+                        let discovery_sm = &mut *discovery_sm.lock().unwrap();
                         debug!("Discovery state machine state: {:?}", discovery_sm.state());
                         if discovery_sm.process_event(sm_event).is_err() {
                             error!("Error processing discovery event");
                             // Continue to process other events
                         }
                     }
+                    PldmEvents::Update(sm_event) => {
+                        let update_sm = &mut *update_sm.lock().unwrap();
+                        debug!(
+                            "Firmware update state machine state: {:?}",
+                            update_sm.state()
+                        );
+                        if update_sm.process_event(sm_event).is_err() {
+                            error!("Error processing firmware update event");
+                            // Continue to process other events
+                        }
+                    }
                     PldmEvents::Stop => {
+                        running.store(false, Ordering::Relaxed);
                         break;
                     }
                 }
@@ -135,24 +191,43 @@ impl PldmDaemon {
         if let Ok(event) = event {
             return Ok(event);
         }
+        let event = update_sm::process_packet(packet);
+        if let Ok(event) = event {
+            return Ok(event);
+        }
         error!("Unhandled packet: {}", packet);
         Err(())
     }
+
+    pub fn get_update_sm_state(&self) -> update_sm::States {
+        let update_sm = &*self.update_sm.lock().unwrap();
+        (*update_sm.state()).clone()
+    }
+
+    pub fn get_device_id(&self) -> Option<FirmwareDeviceIdRecord> {
+        let update_sm = &*self.update_sm.lock().unwrap();
+        update_sm.context().inner_ctx.device_id.clone()
+    }
 }
 
-pub struct Options<D: discovery_sm::StateMachineActions> {
+pub struct Options<D: discovery_sm::StateMachineActions, U: update_sm::StateMachineActions> {
     // Actions for the discovery state machine that can be customized as needed
     // Otherwise, the default actions will be used
     pub discovery_sm_actions: D,
 
     // The TID to be assigned to the firmware device
     pub fd_tid: u8,
+    // Actions for the update state machine that can be customized as needed
+    pub update_sm_actions: U,
+    pub pldm_fw_pkg: Option<FirmwareManifest>,
 }
 
-impl Default for Options<discovery_sm::DefaultActions> {
+impl Default for Options<discovery_sm::DefaultActions, update_sm::DefaultActions> {
     fn default() -> Self {
         Self {
             discovery_sm_actions: discovery_sm::DefaultActions {},
+            update_sm_actions: update_sm::DefaultActions {},
+            pldm_fw_pkg: None,
             fd_tid: 0,
         }
     }

--- a/emulator/bmc/pldm-ua/src/events.rs
+++ b/emulator/bmc/pldm-ua/src/events.rs
@@ -1,6 +1,7 @@
 // Licensed under the Apache-2.0 license
 
 /// Define the events processed by the PLDM Daemon
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, Default)]
 pub enum PldmEvents {
     #[default]
@@ -10,4 +11,6 @@ pub enum PldmEvents {
     Stop,
     /// Discovery state machine events
     Discovery(crate::discovery_sm::Events),
+    /// Firmware Update state machine events
+    Update(crate::update_sm::Events),
 }

--- a/emulator/bmc/pldm-ua/src/lib.rs
+++ b/emulator/bmc/pldm-ua/src/lib.rs
@@ -5,3 +5,4 @@ pub mod daemon;
 pub mod discovery_sm;
 pub mod events;
 pub mod transport;
+pub mod update_sm;

--- a/emulator/bmc/pldm-ua/src/update_sm.rs
+++ b/emulator/bmc/pldm-ua/src/update_sm.rs
@@ -1,0 +1,592 @@
+// Licensed under the Apache-2.0 license
+
+use crate::events::PldmEvents;
+use crate::transport::MAX_PLDM_PAYLOAD_SIZE;
+use crate::transport::{PldmSocket, RxPacket};
+use log::{debug, error, info};
+use pldm_common::codec::PldmCodec;
+use pldm_common::message::firmware_update as pldm_packet;
+use pldm_common::protocol::base::{
+    InstanceId, PldmBaseCompletionCode, PldmMsgHeader, PldmMsgType, PldmSupportedType,
+};
+use pldm_common::protocol::firmware_update::{
+    ComponentParameterEntry, FwUpdateCmd, PldmFirmwareString, VersionStringType,
+    PLDM_FWUP_IMAGE_SET_VER_STR_MAX_LEN,
+};
+use pldm_fw_pkg::manifest::{ComponentImageInformation, FirmwareDeviceIdRecord};
+use pldm_fw_pkg::FirmwareManifest;
+use smlang::statemachine;
+use std::sync::mpsc::Sender;
+
+const MAX_TRANSFER_SIZE: u32 = 64;
+const MAX_OUTSTANDING_TRANSFER_REQ: u8 = 1;
+
+// Define the state machine
+statemachine! {
+    derive_states: [Debug, Clone],
+    derive_events: [Clone, Debug],
+    transitions: {
+        *Idle + StartUpdate  / on_start_update = QueryDeviceIdentifiersSent,
+        QueryDeviceIdentifiersSent + QueryDeviceIdentifiersResponse(pldm_packet::query_devid::QueryDeviceIdentifiersResponse) / on_query_device_identifiers_response = ReceivedQueryDeviceIdentifiers,
+        ReceivedQueryDeviceIdentifiers + SendGetFirmwareParameters / on_send_get_firmware_parameters = GetFirmwareParametersSent,
+        GetFirmwareParametersSent + GetFirmwareParametersResponse(pldm_packet::get_fw_params::GetFirmwareParametersResponse)  / on_get_firmware_parameters_response = ReceivedFirmwareParameters,
+        ReceivedFirmwareParameters + SendRequestUpdate / on_send_request_update = RequestUpdateSent,
+        RequestUpdateSent + RequestUpdateResponse(pldm_packet::request_update::RequestUpdateResponse) / on_request_update_response = ReceivedRequestUpdateResponse,
+        ReceivedRequestUpdateResponse + SendPassComponentRequest / on_send_pass_component_request = LearnComponents,
+        LearnComponents + PassComponentResponse(pldm_packet::pass_component::PassComponentTableResponse) [!are_all_components_passed] / on_pass_component_response = LearnComponents,
+        LearnComponents + PassComponentResponse(pldm_packet::pass_component::PassComponentTableResponse) [are_all_components_passed] / on_pass_component_response = ReadyXfer,
+        LearnComponents + CancelUpdateOrTimeout  / on_stop_update = Idle,
+
+        ReadyXfer + UpdateComponent / on_update_component = Download,
+        ReadyXfer + CancelUpdateComponent  / on_stop_update = Idle,
+
+        Download + RequestFirmwareData / on_request_firmware = Download,
+        Download + TransferCompleteFail / on_transfer_fail = Idle,
+        Download + TransferCompletePass / on_transfer_success = Verify,
+        Download + CancelUpdate  / on_stop_update = Idle,
+
+        Verify + GetStatus / on_get_status = Verify,
+        Verify + VerifyCompletePass / on_verify_success = Apply,
+        Verify + VerifyCompleteFail / on_verify_fail = Idle,
+        Verify + CancelUpdate  / on_stop_update = Idle,
+
+        Apply + GetStatus / on_get_status = Apply,
+        Apply + ApplyCompleteFail / on_apply_fail = Idle,
+        Apply + ApplyCompletePass / on_apply_success = Activate,
+        Apply + CancelUpdateComponent  / on_stop_update = Idle,
+
+        Activate + GetStatus / on_get_status = Activate,
+        Activate + GetMetaData / on_get_metadata = Activate,
+        Activate + ActivateFirmware / on_activate_firmware = Idle,
+        Activate + CancelUpdate  / on_stop_update = Idle,
+
+        _ + StopUpdate / on_stop_update = Done
+    }
+}
+
+fn send_request_helper<S: PldmSocket, P: PldmCodec>(socket: &S, message: &P) -> Result<(), ()> {
+    let mut buffer = [0u8; MAX_PLDM_PAYLOAD_SIZE];
+    let sz = message.encode(&mut buffer).map_err(|_| ())?;
+    socket.send(&buffer[..sz]).map_err(|_| ())?;
+    debug!("Sent request: {:?}", std::any::type_name::<P>());
+    Ok(())
+}
+
+fn is_pkg_descriptor_in_response_descriptor(
+    pkg_descriptor: &pldm_fw_pkg::manifest::Descriptor,
+    response_descriptor: &pldm_common::protocol::firmware_update::Descriptor,
+) -> bool {
+    if response_descriptor.descriptor_type != pkg_descriptor.descriptor_type as u16 {
+        return false;
+    }
+    if response_descriptor.descriptor_length != pkg_descriptor.descriptor_data.len() as u16 {
+        return false;
+    }
+    if &response_descriptor.descriptor_data[..response_descriptor.descriptor_length as usize]
+        != pkg_descriptor.descriptor_data.as_slice()
+    {
+        return false;
+    }
+    true
+}
+
+fn is_pkg_device_id_in_response(
+    pkg_dev_id: &FirmwareDeviceIdRecord,
+    response: &pldm_packet::query_devid::QueryDeviceIdentifiersResponse,
+) -> bool {
+    if response.descriptor_count < 1 {
+        error!("No descriptors in response");
+        return false;
+    }
+
+    // Check initial descriptor
+    if !is_pkg_descriptor_in_response_descriptor(
+        &pkg_dev_id.initial_descriptor,
+        &response.initial_descriptor,
+    ) {
+        error!("Initial descriptor does not match");
+        return false;
+    }
+
+    // Check additional descriptors
+    if let Some(additional_descriptors) = &pkg_dev_id.additional_descriptors {
+        if response.descriptor_count < additional_descriptors.len() as u8 + 1 {
+            error!("Not enough descriptors in response");
+            return false;
+        }
+
+        for additional_descriptor in additional_descriptors {
+            let mut additional_descriptor_in_response = false;
+            if let Some(response_descriptors) = &response.additional_descriptors {
+                for i in 0..response.descriptor_count {
+                    if is_pkg_descriptor_in_response_descriptor(
+                        additional_descriptor,
+                        &response_descriptors[i as usize],
+                    ) {
+                        additional_descriptor_in_response = true;
+                        break;
+                    }
+                }
+            }
+
+            if !additional_descriptor_in_response {
+                error!("Additional descriptor not found in response");
+                return false;
+            }
+        }
+    }
+    true
+}
+pub trait StateMachineActions {
+    // Guards
+    fn are_all_components_passed(
+        &self,
+        _ctx: &InnerContext<impl PldmSocket>,
+        _response: &pldm_packet::pass_component::PassComponentTableResponse,
+    ) -> Result<bool, ()> {
+        Ok(true)
+    }
+
+    // Actions
+    fn on_start_update(&mut self, ctx: &mut InnerContext<impl PldmSocket>) -> Result<(), ()> {
+        send_request_helper(
+            &ctx.socket,
+            &pldm_packet::query_devid::QueryDeviceIdentifiersRequest::new(
+                ctx.instance_id,
+                PldmMsgType::Request,
+            ),
+        )
+    }
+    fn on_request_update_response(
+        &mut self,
+        ctx: &mut InnerContext<impl PldmSocket>,
+        response: pldm_packet::request_update::RequestUpdateResponse,
+    ) -> Result<(), ()> {
+        if response.fixed.completion_code == PldmBaseCompletionCode::Success as u8 {
+            info!("RequestUpdate response success");
+            ctx.event_queue
+                .send(PldmEvents::Update(Events::SendPassComponentRequest))
+                .map_err(|_| ())?;
+            Ok(())
+        } else {
+            error!("RequestUpdate response failed");
+            ctx.event_queue
+                .send(PldmEvents::Update(Events::StopUpdate))
+                .map_err(|_| ())?;
+            Err(())
+        }
+    }
+
+    fn on_send_pass_component_request(
+        &mut self,
+        _ctx: &mut InnerContext<impl PldmSocket>,
+    ) -> Result<(), ()> {
+        // TODO
+        Ok(())
+    }
+
+    fn on_query_device_identifiers_response(
+        &mut self,
+        ctx: &mut InnerContext<impl PldmSocket>,
+        response: pldm_packet::query_devid::QueryDeviceIdentifiersResponse,
+    ) -> Result<(), ()> {
+        for pkg_dev_id in &ctx.pldm_fw_pkg.firmware_device_id_records {
+            if is_pkg_device_id_in_response(pkg_dev_id, &response) {
+                ctx.device_id = Some(pkg_dev_id.clone());
+                break;
+            }
+        }
+        if ctx.device_id.is_some() {
+            ctx.event_queue
+                .send(PldmEvents::Update(Events::SendGetFirmwareParameters))
+                .map_err(|_| ())?;
+            Ok(())
+        } else {
+            error!("No matching device id found");
+            ctx.event_queue
+                .send(PldmEvents::Update(Events::StopUpdate))
+                .map_err(|_| ())?;
+            Err(())
+        }
+    }
+
+    fn on_send_get_firmware_parameters(
+        &mut self,
+        ctx: &mut InnerContext<impl PldmSocket>,
+    ) -> Result<(), ()> {
+        send_request_helper(
+            &ctx.socket,
+            &pldm_packet::get_fw_params::GetFirmwareParametersRequest::new(
+                ctx.instance_id,
+                PldmMsgType::Request,
+            ),
+        )
+    }
+
+    fn on_send_request_update(
+        &mut self,
+        ctx: &mut InnerContext<impl PldmSocket>,
+    ) -> Result<(), ()> {
+        if let Some(dev_id_record) = ctx.device_id.as_ref() {
+            let version_string: PldmFirmwareString =
+                match dev_id_record.component_image_set_version_string {
+                    Some(ref version_string) => PldmFirmwareString {
+                        str_type: dev_id_record.component_image_set_version_string_type as u8,
+                        str_len: version_string.len() as u8,
+                        str_data: {
+                            let mut arr = [0u8; PLDM_FWUP_IMAGE_SET_VER_STR_MAX_LEN];
+                            arr[..version_string.len()].copy_from_slice(version_string.as_bytes());
+                            arr
+                        },
+                    },
+                    None => PldmFirmwareString {
+                        str_type: VersionStringType::Unspecified as u8,
+                        str_len: 0,
+                        str_data: [0u8; PLDM_FWUP_IMAGE_SET_VER_STR_MAX_LEN],
+                    },
+                };
+            send_request_helper(
+                &ctx.socket,
+                &pldm_packet::request_update::RequestUpdateRequest::new(
+                    ctx.instance_id,
+                    PldmMsgType::Request,
+                    MAX_TRANSFER_SIZE,
+                    ctx.components.len() as u16,
+                    MAX_OUTSTANDING_TRANSFER_REQ,
+                    0, // pkg_data_len is optional, not supported
+                    &version_string,
+                ),
+            )
+        } else {
+            error!("Cannot send RequestUpdate request, no device id found");
+            Err(())
+        }
+    }
+
+    fn find_component_in_package(
+        pkg_components: &[pldm_fw_pkg::manifest::ComponentImageInformation],
+        comp_entry: &ComponentParameterEntry,
+    ) -> Result<usize, ()> {
+        // iterate over the components in the package and get the index
+        for (i, item) in pkg_components.iter().enumerate() {
+            let pkg_component = item;
+            if pkg_component.classification != comp_entry.comp_param_entry_fixed.comp_classification
+            {
+                continue;
+            }
+
+            if pkg_component.identifier != comp_entry.comp_param_entry_fixed.comp_identifier {
+                continue;
+            }
+            return Ok(i);
+        }
+
+        Err(())
+    }
+
+    fn is_in_device_applicable_components(
+        comp_index: usize,
+        device_id_record: &FirmwareDeviceIdRecord,
+    ) -> bool {
+        if let Some(applicable_components) = &device_id_record.applicable_components {
+            if !applicable_components.is_empty() {
+                for item in applicable_components {
+                    if *item == comp_index as u8 {
+                        return true;
+                    }
+                }
+            }
+        }
+        false
+    }
+
+    fn is_need_component_update(
+        pkg_component: &ComponentImageInformation,
+        comp_entry: &ComponentParameterEntry,
+    ) -> bool {
+        if let Some(comp_timestamp) = pkg_component.comparison_stamp {
+            let device_comp_timestamp = comp_entry
+                .comp_param_entry_fixed
+                .active_comp_comparison_stamp;
+            info!(
+                "Component id: {}, Package timestamp : {} , Device timestamp : {}",
+                pkg_component.identifier, comp_timestamp, device_comp_timestamp
+            );
+            if comp_timestamp <= device_comp_timestamp {
+                info!("Component is already up to date");
+                return false;
+            }
+        }
+        true
+    }
+
+    fn on_get_firmware_parameters_response(
+        &mut self,
+        ctx: &mut InnerContext<impl PldmSocket>,
+        response: pldm_packet::get_fw_params::GetFirmwareParametersResponse,
+    ) -> Result<(), ()> {
+        for i in 0..response.parms.params_fixed.comp_count {
+            if let Ok(comp_idx) = Self::find_component_in_package(
+                &ctx.pldm_fw_pkg.component_image_information,
+                &response.parms.comp_param_table[i as usize],
+            ) {
+                if Self::is_in_device_applicable_components(
+                    comp_idx,
+                    ctx.device_id.as_ref().unwrap(),
+                ) {
+                    info!(
+                        "Component id: {} is in applicable components",
+                        ctx.pldm_fw_pkg.component_image_information[comp_idx].identifier
+                    );
+                } else {
+                    info!(
+                        "Component id: {} is not applicable",
+                        ctx.pldm_fw_pkg.component_image_information[comp_idx].identifier
+                    );
+                    continue;
+                }
+                let component = &ctx.pldm_fw_pkg.component_image_information[comp_idx];
+                if Self::is_need_component_update(
+                    component,
+                    &response.parms.comp_param_table[i as usize],
+                ) {
+                    info!("Component id: {} will be updated,", component.identifier);
+                    ctx.components.push(component.clone());
+                }
+            }
+        }
+
+        if !ctx.components.is_empty() {
+            ctx.event_queue
+                .send(PldmEvents::Update(Events::SendRequestUpdate))
+                .map_err(|_| ())
+        } else {
+            info!("No component needs update");
+            ctx.event_queue
+                .send(PldmEvents::Update(Events::StopUpdate))
+                .map_err(|_| ())?;
+            Err(())
+        }
+    }
+
+    fn on_pass_component_response(
+        &mut self,
+        _ctx: &mut InnerContext<impl PldmSocket>,
+        _response: pldm_packet::pass_component::PassComponentTableResponse,
+    ) -> Result<(), ()> {
+        // TODO
+        Ok(())
+    }
+
+    fn on_update_component(&mut self, _ctx: &mut InnerContext<impl PldmSocket>) -> Result<(), ()> {
+        // TODO
+        Ok(())
+    }
+
+    fn on_request_firmware(&mut self, _ctx: &mut InnerContext<impl PldmSocket>) -> Result<(), ()> {
+        // TODO
+        Ok(())
+    }
+
+    fn on_transfer_fail(&mut self, _ctx: &mut InnerContext<impl PldmSocket>) -> Result<(), ()> {
+        // TODO
+        Ok(())
+    }
+
+    fn on_transfer_success(&mut self, _ctx: &mut InnerContext<impl PldmSocket>) -> Result<(), ()> {
+        // TODO
+        Ok(())
+    }
+
+    fn on_get_status(&mut self, _ctx: &mut InnerContext<impl PldmSocket>) -> Result<(), ()> {
+        // TODO
+        Ok(())
+    }
+
+    fn on_verify_success(&mut self, _ctx: &mut InnerContext<impl PldmSocket>) -> Result<(), ()> {
+        // TODO
+        Ok(())
+    }
+
+    fn on_verify_fail(&mut self, _ctx: &mut InnerContext<impl PldmSocket>) -> Result<(), ()> {
+        // TODO
+        Ok(())
+    }
+
+    fn on_apply_success(&mut self, _ctx: &mut InnerContext<impl PldmSocket>) -> Result<(), ()> {
+        // TODO
+        Ok(())
+    }
+
+    fn on_apply_fail(&mut self, _ctx: &mut InnerContext<impl PldmSocket>) -> Result<(), ()> {
+        // TODO
+        Ok(())
+    }
+
+    fn on_activate_firmware(&mut self, _ctx: &mut InnerContext<impl PldmSocket>) -> Result<(), ()> {
+        // TODO
+        Ok(())
+    }
+
+    fn on_get_metadata(&mut self, _ctx: &mut InnerContext<impl PldmSocket>) -> Result<(), ()> {
+        // TODO
+        Ok(())
+    }
+
+    fn on_stop_update(&mut self, _ctx: &mut InnerContext<impl PldmSocket>) -> Result<(), ()> {
+        // TODO
+        Ok(())
+    }
+}
+
+fn packet_to_event<T: PldmCodec>(
+    header: &PldmMsgHeader<impl AsRef<[u8]>>,
+    packet: &RxPacket,
+    is_response: bool,
+    event_constructor: fn(T) -> Events,
+) -> Result<PldmEvents, ()> {
+    debug!("Parsing command: {:?}", std::any::type_name::<T>());
+    if is_response && !(header.rq() == 0 && header.datagram() == 0) {
+        error!("Not a response");
+        return Err(());
+    }
+
+    let response = T::decode(&packet.payload.data[..packet.payload.len]).map_err(|_| ())?;
+    Ok(PldmEvents::Update(event_constructor(response)))
+}
+
+pub fn process_packet(packet: &RxPacket) -> Result<PldmEvents, ()> {
+    debug!("Handling packet: {}", packet);
+    let header = PldmMsgHeader::decode(&packet.payload.data[..packet.payload.len])
+        .map_err(|_| (error!("Error decoding packet!")))?;
+    if !header.is_hdr_ver_valid() {
+        error!("Invalid header version!");
+        return Err(());
+    }
+    if header.pldm_type() != PldmSupportedType::FwUpdate as u8 {
+        info!("Not a discovery message");
+        return Err(());
+    }
+
+    // Convert packet to state machine event
+    match FwUpdateCmd::try_from(header.cmd_code()) {
+        Ok(cmd) => match cmd {
+            FwUpdateCmd::QueryDeviceIdentifiers => packet_to_event(
+                &header,
+                packet,
+                true,
+                Events::QueryDeviceIdentifiersResponse,
+            ),
+            FwUpdateCmd::GetFirmwareParameters => {
+                packet_to_event(&header, packet, true, Events::GetFirmwareParametersResponse)
+            }
+            FwUpdateCmd::RequestUpdate => {
+                packet_to_event(&header, packet, true, Events::RequestUpdateResponse)
+            }
+            FwUpdateCmd::PassComponentTable => {
+                packet_to_event(&header, packet, true, Events::PassComponentResponse)
+            }
+            _ => {
+                debug!("Unknown firmware update command");
+                Err(())
+            }
+        },
+        Err(_) => Err(()),
+    }
+}
+
+// Implement the context struct
+pub struct DefaultActions;
+impl StateMachineActions for DefaultActions {}
+
+pub struct InnerContext<S: PldmSocket> {
+    socket: S,
+    pub pldm_fw_pkg: FirmwareManifest,
+    pub event_queue: Sender<PldmEvents>,
+    instance_id: InstanceId,
+    // The device id of the firmware device
+    pub device_id: Option<FirmwareDeviceIdRecord>,
+    // The components that need to be updated
+    pub components: Vec<ComponentImageInformation>,
+}
+
+pub struct Context<T: StateMachineActions, S: PldmSocket> {
+    inner: T,
+    pub inner_ctx: InnerContext<S>,
+}
+
+impl<T: StateMachineActions, S: PldmSocket> Context<T, S> {
+    pub fn new(
+        context: T,
+        socket: S,
+        pldm_fw_pkg: FirmwareManifest,
+        event_queue: Sender<PldmEvents>,
+    ) -> Self {
+        Self {
+            inner: context,
+            inner_ctx: InnerContext {
+                socket,
+                pldm_fw_pkg,
+                event_queue,
+                instance_id: 0,
+                device_id: None,
+                components: Vec::new(),
+            },
+        }
+    }
+}
+
+// Macros to delegate the state machine actions to the custom StateMachineActions passed to the state machine
+// This allows overriding the implementation of the actions and guards
+macro_rules! delegate_to_inner_action {
+    ($($fn_name:ident ($($arg:ident : $arg_ty:ty),*) -> $ret:ty),* $(,)?) => {
+        $(
+            fn $fn_name(&mut self, $($arg: $arg_ty),*) -> $ret {
+                debug!("Fw Upgrade Action: {}", stringify!($fn_name));
+                self.inner.$fn_name(&mut self.inner_ctx, $($arg),*)
+            }
+        )*
+    };
+}
+
+macro_rules! delegate_to_inner_guard {
+    ($($fn_name:ident ($($arg:ident : $arg_ty:ty),*) -> $ret:ty),* $(,)?) => {
+        $(
+            fn $fn_name(&self, $($arg: $arg_ty),*) -> $ret {
+                debug!("Fw Upgrade Guard: {}", stringify!($fn_name));
+                self.inner.$fn_name(&self.inner_ctx, $($arg),*)
+            }
+        )*
+    };
+}
+
+impl<T: StateMachineActions, S: PldmSocket> StateMachineContext for Context<T, S> {
+    // Actions with packet events
+    delegate_to_inner_action! {
+        on_start_update() -> Result<(),()>,
+        on_query_device_identifiers_response(response : pldm_packet::query_devid::QueryDeviceIdentifiersResponse) -> Result<(),()>,
+        on_send_get_firmware_parameters() -> Result<(),()>,
+        on_send_request_update() -> Result<(),()>,
+        on_get_firmware_parameters_response(response : pldm_packet::get_fw_params::GetFirmwareParametersResponse) -> Result<(), ()>,
+        on_request_update_response(response: pldm_packet::request_update::RequestUpdateResponse) -> Result<(),()>,
+        on_send_pass_component_request() -> Result<(),()>,
+        on_pass_component_response(response : pldm_packet::pass_component::PassComponentTableResponse) -> Result<(),()>,
+        on_update_component() -> Result<(),()>,
+        on_request_firmware() -> Result<(),()>,
+        on_transfer_fail() -> Result<(),()>,
+        on_transfer_success() -> Result<(),()>,
+        on_get_status() -> Result<(),()>,
+        on_stop_update() -> Result<(),()>,
+        on_verify_success() -> Result<(),()>,
+        on_verify_fail() -> Result<(),()>,
+        on_apply_success() -> Result<(),()>,
+        on_apply_fail() -> Result<(),()>,
+        on_activate_firmware() -> Result<(),()>,
+        on_get_metadata() -> Result<(),()>,
+    }
+
+    // Guards
+    delegate_to_inner_guard! {
+        are_all_components_passed(response : &pldm_packet::pass_component::PassComponentTableResponse) -> Result<bool, ()>,
+    }
+}

--- a/emulator/bmc/pldm-ua/tests/test_device_identifier.rs
+++ b/emulator/bmc/pldm-ua/tests/test_device_identifier.rs
@@ -1,0 +1,403 @@
+// Licensed under the Apache-2.0 license
+
+#[cfg(test)]
+mod mock_transport;
+use std::time::Duration;
+
+use log::{error, LevelFilter};
+use mock_transport::{MockPldmSocket, MockTransport};
+use pldm_common::message::firmware_update::get_fw_params::FirmwareParameters;
+use pldm_common::message::firmware_update::query_devid::{
+    QueryDeviceIdentifiersRequest, QueryDeviceIdentifiersResponse,
+};
+use pldm_common::protocol::base::{PldmBaseCompletionCode, PldmMsgHeader};
+use pldm_common::protocol::firmware_update::FwUpdateCmd;
+use pldm_fw_pkg::manifest::{Descriptor, DescriptorType, FirmwareDeviceIdRecord};
+use pldm_fw_pkg::FirmwareManifest;
+use pldm_ua::events::PldmEvents;
+use simple_logger::SimpleLogger;
+
+use pldm_common::codec::PldmCodec;
+use pldm_ua::daemon::{Options, PldmDaemon};
+use pldm_ua::transport::{PldmSocket, PldmTransport};
+use pldm_ua::{discovery_sm, update_sm};
+
+struct TestSetup<
+    D: discovery_sm::StateMachineActions + Send + 'static,
+    U: update_sm::StateMachineActions + Send + 'static,
+> {
+    pub fd_sock: MockPldmSocket,
+    pub daemon: PldmDaemon<MockPldmSocket, D, U>,
+}
+
+// Test UUID
+const TEST_UUID: [u8; 16] = [
+    0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0,
+];
+
+const TEST_UUID2: [u8; 16] = [
+    0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xFF,
+];
+
+const TEST_UUID3: [u8; 16] = [
+    0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0x00,
+];
+
+fn setup<
+    D: discovery_sm::StateMachineActions + Send + 'static,
+    U: update_sm::StateMachineActions + Send + 'static,
+>(
+    daemon_options: Options<D, U>,
+) -> TestSetup<D, U> {
+    // Initialize log level to info (only once)
+    let _ = SimpleLogger::new().with_level(LevelFilter::Info).init();
+
+    // Setup the PLDM transport
+    let transport = MockTransport::new();
+
+    // Define the update agent endpoint id
+    let ua_sid = pldm_ua::transport::EndpointId(0x01);
+
+    // Define the device endpoint id
+    let fd_sid = pldm_ua::transport::EndpointId(0x02);
+
+    // Create socket used by the PLDM daemon (update agent)
+    let ua_sock = transport.create_socket(ua_sid, fd_sid).unwrap();
+
+    // Create socket to be used by the device (FD)
+    let fd_sock = transport.create_socket(fd_sid, ua_sid).unwrap();
+
+    // Run the PLDM daemon
+    let daemon = PldmDaemon::run(ua_sock.clone(), daemon_options).unwrap();
+
+    TestSetup { fd_sock, daemon }
+}
+
+impl<
+        D: discovery_sm::StateMachineActions + Send + 'static,
+        U: update_sm::StateMachineActions + Send + 'static,
+    > TestSetup<D, U>
+{
+    fn wait_for_state_transition(&self, expected_state: update_sm::States) -> Result<(), ()> {
+        let timeout = Duration::from_secs(5);
+        let start_time = std::time::Instant::now();
+
+        while start_time.elapsed() < timeout {
+            if self.daemon.get_update_sm_state() == expected_state {
+                return Ok(());
+            }
+            std::thread::sleep(Duration::from_millis(100));
+        }
+        Err(())
+    }
+}
+
+/* Override the Discovery SM. Skip the discovery process by starting firmware update immediately when discovery is kicked-off */
+struct CustomDiscoverySm {}
+impl discovery_sm::StateMachineActions for CustomDiscoverySm {
+    fn on_start_discovery(
+        &self,
+        ctx: &discovery_sm::InnerContext<impl PldmSocket>,
+    ) -> Result<(), ()> {
+        ctx.event_queue
+            .send(PldmEvents::Update(update_sm::Events::StartUpdate))
+            .map_err(|_| ())?;
+        Ok(())
+    }
+}
+
+fn send_response<P: PldmCodec>(socket: &MockPldmSocket, response: &P) {
+    let mut buffer = [0u8; 512];
+    let sz = response.encode(&mut buffer).unwrap();
+    socket.send(&buffer[..sz]).unwrap();
+}
+
+fn receive_request<P: PldmCodec>(socket: &MockPldmSocket, cmd_code: u8) -> Result<P, ()> {
+    let request = socket.receive(None).unwrap();
+
+    let header = PldmMsgHeader::decode(&request.payload.data[..request.payload.len])
+        .map_err(|_| (error!("Error decoding packet!")))?;
+    if !header.is_hdr_ver_valid() {
+        error!("Invalid header version!");
+        return Err(());
+    }
+    if header.cmd_code() != cmd_code {
+        error!("Invalid command code!");
+        return Err(());
+    }
+
+    P::decode(&request.payload.data[..request.payload.len])
+        .map_err(|_| (error!("Error decoding packet!")))
+}
+
+fn encode_descriptor(
+    pkg_descriptor: &pldm_fw_pkg::manifest::Descriptor,
+) -> Result<pldm_common::protocol::firmware_update::Descriptor, ()> {
+    let descriptor = pldm_common::protocol::firmware_update::Descriptor {
+        descriptor_type: pkg_descriptor.descriptor_type as u16,
+        descriptor_length: pkg_descriptor.descriptor_data.len() as u16,
+        descriptor_data: {
+            let mut array = [0u8; 64];
+            let data_slice = pkg_descriptor.descriptor_data.as_slice();
+            let len = data_slice.len().min(64);
+            array[..len].copy_from_slice(&data_slice[..len]);
+            array
+        },
+    };
+    Ok(descriptor)
+}
+
+#[test]
+fn test_valid_device_identifier_one_descriptor() {
+    let pldm_fw_pkg = FirmwareManifest {
+        firmware_device_id_records: vec![FirmwareDeviceIdRecord {
+            initial_descriptor: Descriptor {
+                descriptor_type: DescriptorType::Uuid,
+                descriptor_data: TEST_UUID.to_vec(),
+            },
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+
+    // Setup the test environment
+    let mut setup = setup(Options {
+        pldm_fw_pkg: Some(pldm_fw_pkg.clone()),
+        discovery_sm_actions: CustomDiscoverySm {},
+        update_sm_actions: update_sm::DefaultActions {},
+        fd_tid: 0x02,
+    });
+
+    // Receive QueryDeviceIdentifiers request
+    let request: QueryDeviceIdentifiersRequest =
+        receive_request(&setup.fd_sock, FwUpdateCmd::QueryDeviceIdentifiers as u8).unwrap();
+
+    let initial_descriptor =
+        encode_descriptor(&pldm_fw_pkg.firmware_device_id_records[0].initial_descriptor).unwrap();
+
+    let response = QueryDeviceIdentifiersResponse::new(
+        request.hdr.instance_id(),
+        PldmBaseCompletionCode::Success as u8,
+        std::mem::size_of::<pldm_common::protocol::firmware_update::Descriptor>() as u32,
+        1,
+        &initial_descriptor,
+        None,
+    )
+    .unwrap();
+
+    // Send the response
+    send_response(&setup.fd_sock, &response);
+
+    assert!(setup
+        .wait_for_state_transition(update_sm::States::GetFirmwareParametersSent,)
+        .is_ok());
+
+    assert!(setup.daemon.get_device_id().is_some());
+
+    setup.daemon.stop();
+}
+
+#[test]
+fn test_valid_device_identifier_not_matched() {
+    let pldm_fw_pkg = FirmwareManifest {
+        firmware_device_id_records: vec![FirmwareDeviceIdRecord {
+            initial_descriptor: Descriptor {
+                descriptor_type: DescriptorType::Uuid,
+                descriptor_data: TEST_UUID.to_vec(),
+            },
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+
+    // Setup the test environment
+    let mut setup = setup(Options {
+        pldm_fw_pkg: Some(pldm_fw_pkg.clone()),
+        discovery_sm_actions: CustomDiscoverySm {},
+        update_sm_actions: update_sm::DefaultActions {},
+        fd_tid: 0x02,
+    });
+
+    // Receive QueryDeviceIdentifiers request
+    let request: QueryDeviceIdentifiersRequest =
+        receive_request(&setup.fd_sock, FwUpdateCmd::QueryDeviceIdentifiers as u8).unwrap();
+
+    let response_id_record = FirmwareDeviceIdRecord {
+        initial_descriptor: Descriptor {
+            descriptor_type: DescriptorType::Uuid,
+            descriptor_data: TEST_UUID2.to_vec(),
+        },
+        ..Default::default()
+    };
+    let initial_descriptor = encode_descriptor(&response_id_record.initial_descriptor).unwrap();
+
+    let response = QueryDeviceIdentifiersResponse::new(
+        request.hdr.instance_id(),
+        PldmBaseCompletionCode::Success as u8,
+        std::mem::size_of::<pldm_common::protocol::firmware_update::Descriptor>() as u32,
+        1,
+        &initial_descriptor,
+        None,
+    )
+    .unwrap();
+
+    // Send the response
+    send_response(&setup.fd_sock, &response);
+
+    setup
+        .wait_for_state_transition(update_sm::States::Done)
+        .unwrap();
+
+    assert!(setup.daemon.get_device_id().is_none());
+
+    setup.daemon.stop();
+}
+
+#[test]
+fn test_multiple_device_identifiers() {
+    let pldm_fw_pkg = FirmwareManifest {
+        firmware_device_id_records: vec![FirmwareDeviceIdRecord {
+            initial_descriptor: Descriptor {
+                descriptor_type: DescriptorType::Uuid,
+                descriptor_data: TEST_UUID.to_vec(),
+            },
+            additional_descriptors: Some(vec![
+                Descriptor {
+                    descriptor_type: DescriptorType::Uuid,
+                    descriptor_data: TEST_UUID2.to_vec(),
+                },
+                Descriptor {
+                    descriptor_type: DescriptorType::Uuid,
+                    descriptor_data: TEST_UUID3.to_vec(),
+                },
+            ]),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+
+    // Setup the test environment
+    let mut setup = setup(Options {
+        pldm_fw_pkg: Some(pldm_fw_pkg.clone()),
+        discovery_sm_actions: CustomDiscoverySm {},
+        update_sm_actions: update_sm::DefaultActions {},
+        fd_tid: 0x02,
+    });
+
+    // Receive QueryDeviceIdentifiers request
+    let request: QueryDeviceIdentifiersRequest =
+        receive_request(&setup.fd_sock, FwUpdateCmd::QueryDeviceIdentifiers as u8).unwrap();
+
+    let initial_descriptor_response = encode_descriptor(&Descriptor {
+        descriptor_type: DescriptorType::Uuid,
+        descriptor_data: TEST_UUID.to_vec(),
+    })
+    .unwrap();
+    let additional_descriptor_response1 = encode_descriptor(&Descriptor {
+        descriptor_type: DescriptorType::Uuid,
+        descriptor_data: TEST_UUID2.to_vec(),
+    })
+    .unwrap();
+    let additional_descriptor_response2 = encode_descriptor(&Descriptor {
+        descriptor_type: DescriptorType::Uuid,
+        descriptor_data: TEST_UUID3.to_vec(),
+    })
+    .unwrap();
+
+    let response = QueryDeviceIdentifiersResponse::new(
+        request.hdr.instance_id(),
+        PldmBaseCompletionCode::Success as u8,
+        std::mem::size_of::<pldm_common::protocol::firmware_update::Descriptor>() as u32,
+        3,
+        &initial_descriptor_response,
+        Some(&[
+            additional_descriptor_response1,
+            additional_descriptor_response2,
+        ]),
+    )
+    .unwrap();
+
+    // Send the response
+    send_response(&setup.fd_sock, &response);
+
+    assert!(setup
+        .wait_for_state_transition(update_sm::States::GetFirmwareParametersSent,)
+        .is_ok());
+
+    assert!(setup.daemon.get_device_id().is_some());
+
+    setup.daemon.stop();
+}
+
+#[test]
+fn test_send_get_fw_parameter_after_response() {
+    let pldm_fw_pkg = FirmwareManifest {
+        firmware_device_id_records: vec![FirmwareDeviceIdRecord {
+            initial_descriptor: Descriptor {
+                descriptor_type: DescriptorType::Uuid,
+                descriptor_data: TEST_UUID.to_vec(),
+            },
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+
+    struct UpdateSmIgnoreFirmwareParamsResponse {}
+    impl update_sm::StateMachineActions for UpdateSmIgnoreFirmwareParamsResponse {
+        fn on_get_firmware_parameters_response(
+            &mut self,
+            _ctx: &mut update_sm::InnerContext<impl PldmSocket>,
+            _response : pldm_common::message::firmware_update::get_fw_params::GetFirmwareParametersResponse,
+        ) -> Result<(), ()> {
+            Ok(())
+        }
+    }
+
+    let mut setup = setup(Options {
+        pldm_fw_pkg: Some(pldm_fw_pkg.clone()),
+        discovery_sm_actions: CustomDiscoverySm {},
+        update_sm_actions: UpdateSmIgnoreFirmwareParamsResponse {},
+        fd_tid: 0x02,
+    });
+
+    // Receive QueryDeviceIdentifiers request
+    let request: QueryDeviceIdentifiersRequest =
+        receive_request(&setup.fd_sock, FwUpdateCmd::QueryDeviceIdentifiers as u8).unwrap();
+
+    let initial_descriptor =
+        encode_descriptor(&pldm_fw_pkg.firmware_device_id_records[0].initial_descriptor).unwrap();
+
+    let response = QueryDeviceIdentifiersResponse::new(
+        request.hdr.instance_id(),
+        PldmBaseCompletionCode::Success as u8,
+        std::mem::size_of::<pldm_common::protocol::firmware_update::Descriptor>() as u32,
+        1,
+        &initial_descriptor,
+        None,
+    )
+    .unwrap();
+
+    // Send the QueryDeviceIdentifiers response
+    send_response(&setup.fd_sock, &response);
+
+    // Receive the GetFwParameters request
+    let request: pldm_common::message::firmware_update::get_fw_params::GetFirmwareParametersRequest =
+        receive_request(&setup.fd_sock, FwUpdateCmd::GetFirmwareParameters as u8).unwrap();
+
+    // Send the GetFwParameters response
+    let response =
+        pldm_common::message::firmware_update::get_fw_params::GetFirmwareParametersResponse::new(
+            request.hdr.instance_id(),
+            PldmBaseCompletionCode::Success as u8,
+            &FirmwareParameters {
+                ..Default::default()
+            },
+        );
+    send_response(&setup.fd_sock, &response);
+
+    assert!(setup
+        .wait_for_state_transition(update_sm::States::ReceivedFirmwareParameters,)
+        .is_ok());
+
+    setup.daemon.stop();
+}

--- a/emulator/bmc/pldm-ua/tests/test_get_fw_parameters.rs
+++ b/emulator/bmc/pldm-ua/tests/test_get_fw_parameters.rs
@@ -1,0 +1,517 @@
+// Licensed under the Apache-2.0 license
+
+#[cfg(test)]
+mod tests {}
+mod mock_transport;
+use std::time::Duration;
+
+use log::{error, LevelFilter};
+use mock_transport::{MockPldmSocket, MockTransport};
+use pldm_common::message::firmware_update::get_fw_params::{
+    FirmwareParameters, GetFirmwareParametersRequest, GetFirmwareParametersResponse,
+};
+use pldm_common::message::firmware_update::query_devid::QueryDeviceIdentifiersResponse;
+use pldm_common::protocol::base::{PldmBaseCompletionCode, PldmMsgHeader};
+use pldm_common::protocol::firmware_update::{
+    ComponentActivationMethods, ComponentClassification, ComponentParameterEntry,
+    ComponentParameterEntryFixed, FirmwareDeviceCapability, FwUpdateCmd, PldmFirmwareString,
+    VersionStringType, PLDM_FWUP_IMAGE_SET_VER_STR_MAX_LEN,
+};
+use pldm_fw_pkg::manifest::{
+    ComponentImageInformation, Descriptor, DescriptorType, FirmwareDeviceIdRecord,
+};
+use pldm_fw_pkg::FirmwareManifest;
+use pldm_ua::events::PldmEvents;
+use simple_logger::SimpleLogger;
+
+use pldm_common::codec::PldmCodec;
+use pldm_ua::daemon::{Options, PldmDaemon};
+use pldm_ua::transport::{PldmSocket, PldmTransport};
+use pldm_ua::{discovery_sm, update_sm};
+
+struct TestSetup<
+    D: discovery_sm::StateMachineActions + Send + 'static,
+    U: update_sm::StateMachineActions + Send + 'static,
+> {
+    pub fd_sock: MockPldmSocket,
+    pub daemon: PldmDaemon<MockPldmSocket, D, U>,
+}
+
+// Test UUID
+const TEST_UUID: [u8; 16] = [
+    0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0,
+];
+
+fn setup<
+    D: discovery_sm::StateMachineActions + Send + 'static,
+    U: update_sm::StateMachineActions + Send + 'static,
+>(
+    daemon_options: Options<D, U>,
+) -> TestSetup<D, U> {
+    // Initialize log level to info (only once)
+    let _ = SimpleLogger::new().with_level(LevelFilter::Info).init();
+
+    // Setup the PLDM transport
+    let transport = MockTransport::new();
+
+    // Define the update agent endpoint id
+    let ua_sid = pldm_ua::transport::EndpointId(0x01);
+
+    // Define the device endpoint id
+    let fd_sid = pldm_ua::transport::EndpointId(0x02);
+
+    // Create socket used by the PLDM daemon (update agent)
+    let ua_sock = transport.create_socket(ua_sid, fd_sid).unwrap();
+
+    // Create socket to be used by the device (FD)
+    let fd_sock = transport.create_socket(fd_sid, ua_sid).unwrap();
+
+    // Run the PLDM daemon
+    let daemon = PldmDaemon::run(ua_sock.clone(), daemon_options).unwrap();
+
+    TestSetup { fd_sock, daemon }
+}
+
+impl<
+        D: discovery_sm::StateMachineActions + Send + 'static,
+        U: update_sm::StateMachineActions + Send + 'static,
+    > TestSetup<D, U>
+{
+    fn wait_for_state_transition(&self, expected_state: update_sm::States) {
+        let timeout = Duration::from_secs(5);
+        let start_time = std::time::Instant::now();
+
+        while start_time.elapsed() < timeout {
+            if self.daemon.get_update_sm_state() == expected_state {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(100));
+        }
+        assert_eq!(
+            self.daemon.get_update_sm_state(),
+            expected_state,
+            "Timed out waiting for state transition"
+        );
+    }
+}
+
+/* Override the Discovery SM, when started, discovery will immediately start firmware update and skip the
+discovery process. */
+struct CustomDiscoverySm {}
+impl discovery_sm::StateMachineActions for CustomDiscoverySm {
+    fn on_start_discovery(
+        &self,
+        ctx: &discovery_sm::InnerContext<impl PldmSocket>,
+    ) -> Result<(), ()> {
+        ctx.event_queue
+            .send(PldmEvents::Update(update_sm::Events::StartUpdate))
+            .map_err(|_| ())?;
+        Ok(())
+    }
+}
+
+/* Override the Update SM, and bypass the QueryDeviceIdentifier exchange and go straight to GetFirmwareParameters */
+struct UpdateSmBypassQueryDevId {
+    expected_num_components_to_update: usize,
+}
+impl update_sm::StateMachineActions for UpdateSmBypassQueryDevId {
+    fn on_start_update(
+        &mut self,
+        ctx: &mut update_sm::InnerContext<impl PldmSocket>,
+    ) -> Result<(), ()> {
+        ctx.device_id = Some(FirmwareDeviceIdRecord {
+            applicable_components: Some(vec![0, 1, 2]),
+            ..Default::default()
+        });
+        ctx.event_queue
+            .send(PldmEvents::Update(
+                update_sm::Events::QueryDeviceIdentifiersResponse(QueryDeviceIdentifiersResponse {
+                    ..Default::default()
+                }),
+            ))
+            .map_err(|_| ())?;
+        Ok(())
+    }
+    fn on_query_device_identifiers_response(
+        &mut self,
+        ctx: &mut update_sm::InnerContext<impl PldmSocket>,
+        _response: QueryDeviceIdentifiersResponse,
+    ) -> Result<(), ()> {
+        ctx.event_queue
+            .send(PldmEvents::Update(
+                update_sm::Events::SendGetFirmwareParameters,
+            ))
+            .map_err(|_| ())?;
+        Ok(())
+    }
+    fn on_stop_update(
+        &mut self,
+        ctx: &mut update_sm::InnerContext<impl PldmSocket>,
+    ) -> Result<(), ()> {
+        // When the state machine is stopped, verify the number of components to update
+        assert_eq!(self.expected_num_components_to_update, ctx.components.len());
+        Ok(())
+    }
+}
+
+fn send_response<P: PldmCodec>(socket: &MockPldmSocket, response: &P) {
+    let mut buffer = [0u8; 512];
+    let sz = response.encode(&mut buffer).unwrap();
+    socket.send(&buffer[..sz]).unwrap();
+}
+
+fn receive_request<P: PldmCodec>(socket: &MockPldmSocket, cmd_code: u8) -> Result<P, ()> {
+    let request = socket.receive(None).unwrap();
+
+    let header = PldmMsgHeader::decode(&request.payload.data[..request.payload.len])
+        .map_err(|_| (error!("Error decoding packet!")))?;
+    if !header.is_hdr_ver_valid() {
+        error!("Invalid header version!");
+        return Err(());
+    }
+    if header.cmd_code() != cmd_code {
+        error!("Invalid command code!");
+        return Err(());
+    }
+
+    P::decode(&request.payload.data[..request.payload.len])
+        .map_err(|_| (error!("Error decoding packet!")))
+}
+
+const COMPONENT_ACTIVE_VER_STR: &str = "1.1.0";
+
+const CALIPTRA_FW_COMP_IDENTIFIER: u16 = 0x0001;
+const CALIPTRA_FW_ACTIVE_COMP_STAMP: u32 = 0x00010105;
+const CALIPTRA_FW_ACTIVE_VER_STR: &str = "caliptra-fmc-1.1.0";
+const CALIPTRA_FW_RELEASE_DATE: [u8; 8] = *b"20250210";
+const EMPTY_RELEASE_DATE: [u8; 8] = *b"\0\0\0\0\0\0\0\0";
+
+fn get_caliptra_component_fw_params() -> ComponentParameterEntry {
+    ComponentParameterEntry {
+        comp_param_entry_fixed: ComponentParameterEntryFixed {
+            comp_classification: ComponentClassification::Firmware as u16,
+            comp_identifier: CALIPTRA_FW_COMP_IDENTIFIER,
+            comp_classification_index: 0u8,
+            active_comp_comparison_stamp: CALIPTRA_FW_ACTIVE_COMP_STAMP,
+            active_comp_ver_str_type: VersionStringType::Utf8 as u8,
+            active_comp_ver_str_len: CALIPTRA_FW_ACTIVE_VER_STR.len() as u8,
+            active_comp_release_date: CALIPTRA_FW_RELEASE_DATE,
+            pending_comp_comparison_stamp: 0u32,
+            pending_comp_ver_str_type: VersionStringType::Unspecified as u8,
+            pending_comp_ver_str_len: 0,
+            pending_comp_release_date: EMPTY_RELEASE_DATE,
+            comp_activation_methods: ComponentActivationMethods(0),
+            capabilities_during_update: FirmwareDeviceCapability(0),
+        },
+        active_comp_ver_str: {
+            let mut active_comp_ver_str = [0u8; PLDM_FWUP_IMAGE_SET_VER_STR_MAX_LEN];
+            active_comp_ver_str[..CALIPTRA_FW_ACTIVE_VER_STR.len()]
+                .copy_from_slice(CALIPTRA_FW_ACTIVE_VER_STR.as_bytes());
+            active_comp_ver_str
+        },
+        pending_comp_ver_str: None,
+    }
+}
+
+const SOC_MANIFEST_COMP_IDENTIFIER: u16 = 0x0003;
+const SOC_MANIFEST_ACTIVE_COMP_STAMP: u32 = 0x00010101;
+const SOC_MANIFEST_ACTIVE_VER_STR: &str = "caliptra-fmc-1.1.0";
+const SOC_MANIFEST_RELEASE_DATE: [u8; 8] = *b"20250210";
+
+fn get_soc_manifest_component_fw_params() -> ComponentParameterEntry {
+    ComponentParameterEntry {
+        comp_param_entry_fixed: ComponentParameterEntryFixed {
+            comp_classification: ComponentClassification::Other as u16,
+            comp_identifier: SOC_MANIFEST_COMP_IDENTIFIER,
+            comp_classification_index: 0u8,
+            active_comp_comparison_stamp: SOC_MANIFEST_ACTIVE_COMP_STAMP,
+            active_comp_ver_str_type: VersionStringType::Utf8 as u8,
+            active_comp_ver_str_len: SOC_MANIFEST_ACTIVE_VER_STR.len() as u8,
+            active_comp_release_date: SOC_MANIFEST_RELEASE_DATE,
+            pending_comp_comparison_stamp: 0u32,
+            pending_comp_ver_str_type: VersionStringType::Unspecified as u8,
+            pending_comp_ver_str_len: 0,
+            pending_comp_release_date: EMPTY_RELEASE_DATE,
+            comp_activation_methods: ComponentActivationMethods(0),
+            capabilities_during_update: FirmwareDeviceCapability(0),
+        },
+        active_comp_ver_str: {
+            let mut active_comp_ver_str = [0u8; PLDM_FWUP_IMAGE_SET_VER_STR_MAX_LEN];
+            active_comp_ver_str[..SOC_MANIFEST_ACTIVE_VER_STR.len()]
+                .copy_from_slice(SOC_MANIFEST_ACTIVE_VER_STR.as_bytes());
+            active_comp_ver_str
+        },
+        pending_comp_ver_str: None,
+    }
+}
+
+fn get_pldm_fw_pkg_caliptra_only(comp_stamp: Option<u32>) -> FirmwareManifest {
+    FirmwareManifest {
+        firmware_device_id_records: vec![FirmwareDeviceIdRecord {
+            initial_descriptor: Descriptor {
+                descriptor_type: DescriptorType::Uuid,
+                descriptor_data: TEST_UUID.to_vec(),
+            },
+            component_image_set_version_string_type: pldm_fw_pkg::manifest::StringType::Utf8,
+            component_image_set_version_string: Some(COMPONENT_ACTIVE_VER_STR.to_string()),
+            applicable_components: Some(vec![0]),
+            ..Default::default()
+        }],
+        component_image_information: vec![ComponentImageInformation {
+            classification: ComponentClassification::Firmware as u16,
+            identifier: CALIPTRA_FW_COMP_IDENTIFIER,
+            comparison_stamp: comp_stamp,
+            ..Default::default()
+        }],
+        ..Default::default()
+    }
+}
+
+fn get_pldm_fw_pkg_caliptra_and_manifest(
+    caliptra_comp_stamp: Option<u32>,
+    manifest_comp_stamp: Option<u32>,
+) -> FirmwareManifest {
+    FirmwareManifest {
+        firmware_device_id_records: vec![FirmwareDeviceIdRecord {
+            initial_descriptor: Descriptor {
+                descriptor_type: DescriptorType::Uuid,
+                descriptor_data: TEST_UUID.to_vec(),
+            },
+            component_image_set_version_string_type: pldm_fw_pkg::manifest::StringType::Utf8,
+            component_image_set_version_string: Some(COMPONENT_ACTIVE_VER_STR.to_string()),
+            applicable_components: Some(vec![0, 1]),
+            ..Default::default()
+        }],
+        component_image_information: vec![
+            ComponentImageInformation {
+                classification: ComponentClassification::Firmware as u16,
+                identifier: CALIPTRA_FW_COMP_IDENTIFIER,
+                comparison_stamp: caliptra_comp_stamp,
+                ..Default::default()
+            },
+            ComponentImageInformation {
+                classification: ComponentClassification::Other as u16,
+                identifier: SOC_MANIFEST_COMP_IDENTIFIER,
+                comparison_stamp: manifest_comp_stamp,
+                ..Default::default()
+            },
+        ],
+        ..Default::default()
+    }
+}
+
+#[test]
+fn test_caliptra_fw_update() {
+    // PLDM firmware package contains Caliptra Firmware with current active version + 1
+    let pldm_fw_pkg = get_pldm_fw_pkg_caliptra_only(Some(CALIPTRA_FW_ACTIVE_COMP_STAMP + 1));
+
+    // Setup the test environment
+    let mut setup = setup(Options {
+        pldm_fw_pkg: Some(pldm_fw_pkg.clone()),
+        discovery_sm_actions: CustomDiscoverySm {},
+        update_sm_actions: UpdateSmBypassQueryDevId {
+            expected_num_components_to_update: 1,
+        },
+        fd_tid: 0x01,
+    });
+
+    // Receive QueryDeviceIdentifiers request
+    let request: GetFirmwareParametersRequest =
+        receive_request(&setup.fd_sock, FwUpdateCmd::GetFirmwareParameters as u8).unwrap();
+
+    let caliptra_comp_fw_params = get_caliptra_component_fw_params();
+    let params = FirmwareParameters::new(
+        FirmwareDeviceCapability(0x0010),
+        1,
+        &PldmFirmwareString::new("UTF-8", COMPONENT_ACTIVE_VER_STR).unwrap(),
+        &PldmFirmwareString::new("UTF-8", "").unwrap(),
+        &[caliptra_comp_fw_params],
+    );
+
+    let response = GetFirmwareParametersResponse::new(
+        request.hdr.instance_id(),
+        PldmBaseCompletionCode::Success as u8,
+        &params,
+    );
+
+    send_response(&setup.fd_sock, &response);
+
+    setup.wait_for_state_transition(update_sm::States::RequestUpdateSent);
+
+    setup.daemon.stop();
+}
+
+#[test]
+fn test_caliptra_fw_incorrect_id() {
+    let pldm_fw_pkg = get_pldm_fw_pkg_caliptra_only(Some(CALIPTRA_FW_ACTIVE_COMP_STAMP + 1));
+
+    // Setup the test environment
+    let mut setup = setup(Options {
+        pldm_fw_pkg: Some(pldm_fw_pkg.clone()),
+        discovery_sm_actions: CustomDiscoverySm {},
+        update_sm_actions: UpdateSmBypassQueryDevId {
+            expected_num_components_to_update: 0,
+        },
+        fd_tid: 0x01,
+    });
+
+    // Receive QueryDeviceIdentifiers request
+    let request: GetFirmwareParametersRequest =
+        receive_request(&setup.fd_sock, FwUpdateCmd::GetFirmwareParameters as u8).unwrap();
+
+    let mut caliptra_comp_fw_params = get_caliptra_component_fw_params();
+    caliptra_comp_fw_params
+        .comp_param_entry_fixed
+        .comp_identifier = 0x0002;
+    let params = FirmwareParameters::new(
+        FirmwareDeviceCapability(0x0010),
+        1,
+        &PldmFirmwareString::new("UTF-8", COMPONENT_ACTIVE_VER_STR).unwrap(),
+        &PldmFirmwareString::new("UTF-8", "").unwrap(),
+        &[caliptra_comp_fw_params],
+    );
+
+    let response = GetFirmwareParametersResponse::new(
+        request.hdr.instance_id(),
+        PldmBaseCompletionCode::Success as u8,
+        &params,
+    );
+
+    send_response(&setup.fd_sock, &response);
+
+    setup.wait_for_state_transition(update_sm::States::Done);
+
+    setup.daemon.stop();
+}
+
+#[test]
+fn test_caliptra_fw_update_same_version() {
+    let pldm_fw_pkg = get_pldm_fw_pkg_caliptra_only(Some(CALIPTRA_FW_ACTIVE_COMP_STAMP));
+
+    // Setup the test environment
+    let mut setup = setup(Options {
+        pldm_fw_pkg: Some(pldm_fw_pkg.clone()),
+        discovery_sm_actions: CustomDiscoverySm {},
+        update_sm_actions: UpdateSmBypassQueryDevId {
+            expected_num_components_to_update: 0,
+        },
+        fd_tid: 0x01,
+    });
+
+    // Receive QueryDeviceIdentifiers request
+    let request: GetFirmwareParametersRequest =
+        receive_request(&setup.fd_sock, FwUpdateCmd::GetFirmwareParameters as u8).unwrap();
+
+    let caliptra_comp_fw_params = get_caliptra_component_fw_params();
+    let params = FirmwareParameters::new(
+        FirmwareDeviceCapability(0x0010),
+        1,
+        &PldmFirmwareString::new("UTF-8", COMPONENT_ACTIVE_VER_STR).unwrap(),
+        &PldmFirmwareString::new("UTF-8", "").unwrap(),
+        &[caliptra_comp_fw_params],
+    );
+
+    let response = GetFirmwareParametersResponse::new(
+        request.hdr.instance_id(),
+        PldmBaseCompletionCode::Success as u8,
+        &params,
+    );
+
+    send_response(&setup.fd_sock, &response);
+
+    setup.wait_for_state_transition(update_sm::States::Done);
+
+    setup.daemon.stop();
+}
+
+#[test]
+fn test_caliptra_fw_caliptra_and_manifest() {
+    let pldm_fw_pkg = get_pldm_fw_pkg_caliptra_and_manifest(
+        Some(CALIPTRA_FW_ACTIVE_COMP_STAMP + 1),
+        Some(SOC_MANIFEST_ACTIVE_COMP_STAMP + 1),
+    );
+
+    // Setup the test environment
+    let mut setup = setup(Options {
+        pldm_fw_pkg: Some(pldm_fw_pkg.clone()),
+        discovery_sm_actions: CustomDiscoverySm {},
+        update_sm_actions: UpdateSmBypassQueryDevId {
+            expected_num_components_to_update: 2,
+        },
+        fd_tid: 0x01,
+    });
+
+    // Receive QueryDeviceIdentifiers request
+    let request: GetFirmwareParametersRequest =
+        receive_request(&setup.fd_sock, FwUpdateCmd::GetFirmwareParameters as u8).unwrap();
+
+    let caliptra_fw_params = get_caliptra_component_fw_params();
+    let manifest_fw_params = get_soc_manifest_component_fw_params();
+    let params = FirmwareParameters::new(
+        FirmwareDeviceCapability(0x0010),
+        2,
+        &PldmFirmwareString::new("UTF-8", COMPONENT_ACTIVE_VER_STR).unwrap(),
+        &PldmFirmwareString::new("UTF-8", "").unwrap(),
+        &[caliptra_fw_params, manifest_fw_params],
+    );
+
+    let response = GetFirmwareParametersResponse::new(
+        request.hdr.instance_id(),
+        PldmBaseCompletionCode::Success as u8,
+        &params,
+    );
+
+    send_response(&setup.fd_sock, &response);
+
+    setup.wait_for_state_transition(update_sm::States::RequestUpdateSent);
+
+    setup.daemon.stop();
+}
+
+#[test]
+fn test_caliptra_fw_caliptra_same_version_and_manifest_diff_version() {
+    let pldm_fw_pkg = get_pldm_fw_pkg_caliptra_and_manifest(
+        Some(CALIPTRA_FW_ACTIVE_COMP_STAMP),
+        Some(SOC_MANIFEST_ACTIVE_COMP_STAMP + 1),
+    );
+
+    // Setup the test environment
+    let mut setup = setup(Options {
+        pldm_fw_pkg: Some(pldm_fw_pkg.clone()),
+        discovery_sm_actions: CustomDiscoverySm {},
+        update_sm_actions: UpdateSmBypassQueryDevId {
+            expected_num_components_to_update: 1,
+        },
+        fd_tid: 0x01,
+    });
+
+    // Receive QueryDeviceIdentifiers request
+    let request: GetFirmwareParametersRequest =
+        receive_request(&setup.fd_sock, FwUpdateCmd::GetFirmwareParameters as u8).unwrap();
+
+    let caliptra_fw_params = get_caliptra_component_fw_params();
+    let manifest_fw_params = get_soc_manifest_component_fw_params();
+    let params = FirmwareParameters::new(
+        FirmwareDeviceCapability(0x0010),
+        2,
+        &PldmFirmwareString::new("UTF-8", COMPONENT_ACTIVE_VER_STR).unwrap(),
+        &PldmFirmwareString::new("UTF-8", "").unwrap(),
+        &[caliptra_fw_params, manifest_fw_params],
+    );
+
+    let response = GetFirmwareParametersResponse::new(
+        request.hdr.instance_id(),
+        PldmBaseCompletionCode::Success as u8,
+        &params,
+    );
+
+    send_response(&setup.fd_sock, &response);
+
+    setup.wait_for_state_transition(update_sm::States::RequestUpdateSent);
+
+    setup.daemon.cancel_update();
+
+    setup.wait_for_state_transition(update_sm::States::Done);
+
+    setup.daemon.stop();
+}

--- a/emulator/bmc/pldm-ua/tests/test_request_update.rs
+++ b/emulator/bmc/pldm-ua/tests/test_request_update.rs
@@ -1,0 +1,296 @@
+// Licensed under the Apache-2.0 license
+
+#[cfg(test)]
+mod tests {}
+mod mock_transport;
+use std::time::Duration;
+
+use log::{error, LevelFilter};
+use mock_transport::{MockPldmSocket, MockTransport};
+use pldm_common::message::firmware_update::get_fw_params::GetFirmwareParametersResponse;
+use pldm_common::message::firmware_update::query_devid::QueryDeviceIdentifiersResponse;
+use pldm_common::message::firmware_update::request_update::{
+    RequestUpdateRequest, RequestUpdateResponse,
+};
+use pldm_common::protocol::base::{PldmBaseCompletionCode, PldmMsgHeader};
+use pldm_common::protocol::firmware_update::{ComponentClassification, FwUpdateCmd};
+use pldm_fw_pkg::manifest::{
+    ComponentImageInformation, Descriptor, DescriptorType, FirmwareDeviceIdRecord,
+};
+use pldm_fw_pkg::FirmwareManifest;
+use pldm_ua::events::PldmEvents;
+use simple_logger::SimpleLogger;
+
+use pldm_common::codec::PldmCodec;
+use pldm_ua::daemon::{Options, PldmDaemon};
+use pldm_ua::transport::{PldmSocket, PldmTransport};
+use pldm_ua::{discovery_sm, update_sm};
+
+struct TestSetup<
+    D: discovery_sm::StateMachineActions + Send + 'static,
+    U: update_sm::StateMachineActions + Send + 'static,
+> {
+    pub fd_sock: MockPldmSocket,
+    pub daemon: PldmDaemon<MockPldmSocket, D, U>,
+}
+
+// Test UUID
+const TEST_UUID: [u8; 16] = [
+    0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0,
+];
+
+fn setup<
+    D: discovery_sm::StateMachineActions + Send + 'static,
+    U: update_sm::StateMachineActions + Send + 'static,
+>(
+    daemon_options: Options<D, U>,
+) -> TestSetup<D, U> {
+    // Initialize log level to info (only once)
+    let _ = SimpleLogger::new().with_level(LevelFilter::Info).init();
+
+    // Setup the PLDM transport
+    let transport = MockTransport::new();
+
+    // Define the update agent endpoint id
+    let ua_sid = pldm_ua::transport::EndpointId(0x01);
+
+    // Define the device endpoint id
+    let fd_sid = pldm_ua::transport::EndpointId(0x02);
+
+    // Create socket used by the PLDM daemon (update agent)
+    let ua_sock = transport.create_socket(ua_sid, fd_sid).unwrap();
+
+    // Create socket to be used by the device (FD)
+    let fd_sock = transport.create_socket(fd_sid, ua_sid).unwrap();
+
+    // Run the PLDM daemon
+    let daemon = PldmDaemon::run(ua_sock.clone(), daemon_options).unwrap();
+
+    TestSetup { fd_sock, daemon }
+}
+
+impl<
+        D: discovery_sm::StateMachineActions + Send + 'static,
+        U: update_sm::StateMachineActions + Send + 'static,
+    > TestSetup<D, U>
+{
+    fn wait_for_state_transition(&self, expected_state: update_sm::States) {
+        let timeout = Duration::from_secs(5);
+        let start_time = std::time::Instant::now();
+
+        while start_time.elapsed() < timeout {
+            if self.daemon.get_update_sm_state() == expected_state {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(100));
+        }
+        assert_eq!(
+            self.daemon.get_update_sm_state(),
+            expected_state,
+            "Timed out waiting for state transition"
+        );
+    }
+}
+
+/* Override the Discovery SM, when started, discovery will immediately start firmware update and skip the
+discovery process. */
+struct CustomDiscoverySm {}
+impl discovery_sm::StateMachineActions for CustomDiscoverySm {
+    fn on_start_discovery(
+        &self,
+        ctx: &discovery_sm::InnerContext<impl PldmSocket>,
+    ) -> Result<(), ()> {
+        ctx.event_queue
+            .send(PldmEvents::Update(update_sm::Events::StartUpdate))
+            .map_err(|_| ())?;
+        Ok(())
+    }
+}
+
+/* Override the Update SM, bypass QueryDeviceIdentifiers and GetFirmwareParameters */
+struct UpdateSmBypassed {}
+impl update_sm::StateMachineActions for UpdateSmBypassed {
+    fn on_start_update(
+        &mut self,
+        ctx: &mut update_sm::InnerContext<impl PldmSocket>,
+    ) -> Result<(), ()> {
+        ctx.device_id = Some(ctx.pldm_fw_pkg.firmware_device_id_records[0].clone());
+        ctx.components = ctx.pldm_fw_pkg.component_image_information.clone();
+        ctx.event_queue
+            .send(PldmEvents::Update(
+                update_sm::Events::QueryDeviceIdentifiersResponse(QueryDeviceIdentifiersResponse {
+                    ..Default::default()
+                }),
+            ))
+            .map_err(|_| ())?;
+        Ok(())
+    }
+    fn on_query_device_identifiers_response(
+        &mut self,
+        ctx: &mut update_sm::InnerContext<impl PldmSocket>,
+        _response: QueryDeviceIdentifiersResponse,
+    ) -> Result<(), ()> {
+        ctx.event_queue
+            .send(PldmEvents::Update(
+                update_sm::Events::SendGetFirmwareParameters,
+            ))
+            .map_err(|_| ())?;
+        Ok(())
+    }
+    fn on_send_get_firmware_parameters(
+        &mut self,
+        ctx: &mut update_sm::InnerContext<impl PldmSocket>,
+    ) -> Result<(), ()> {
+        ctx.event_queue
+            .send(PldmEvents::Update(
+                update_sm::Events::GetFirmwareParametersResponse(GetFirmwareParametersResponse {
+                    ..Default::default()
+                }),
+            ))
+            .map_err(|_| ())
+    }
+    fn on_get_firmware_parameters_response(
+        &mut self,
+        ctx: &mut update_sm::InnerContext<impl PldmSocket>,
+        _response: pldm_common::message::firmware_update::get_fw_params::GetFirmwareParametersResponse,
+    ) -> Result<(), ()> {
+        ctx.event_queue
+            .send(PldmEvents::Update(update_sm::Events::SendRequestUpdate))
+            .map_err(|_| ())
+    }
+}
+
+fn send_response<P: PldmCodec>(socket: &MockPldmSocket, response: &P) {
+    let mut buffer = [0u8; 512];
+    let sz = response.encode(&mut buffer).unwrap();
+    socket.send(&buffer[..sz]).unwrap();
+}
+
+fn receive_request<P: PldmCodec>(socket: &MockPldmSocket, cmd_code: u8) -> Result<P, ()> {
+    let request = socket.receive(None).unwrap();
+
+    let header = PldmMsgHeader::decode(&request.payload.data[..request.payload.len])
+        .map_err(|_| (error!("Error decoding packet!")))?;
+    if !header.is_hdr_ver_valid() {
+        error!("Invalid header version!");
+        return Err(());
+    }
+    if header.cmd_code() != cmd_code {
+        error!("Invalid command code!");
+        return Err(());
+    }
+
+    P::decode(&request.payload.data[..request.payload.len])
+        .map_err(|_| (error!("Error decoding packet!")))
+}
+
+const COMPONENT_ACTIVE_VER_STR: &str = "1.1.0";
+const CALIPTRA_FW_COMP_IDENTIFIER: u16 = 0x0001;
+const CALIPTRA_FW_ACTIVE_COMP_STAMP: u32 = 0x00010105;
+const SOC_MANIFEST_COMP_IDENTIFIER: u16 = 0x0003;
+const SOC_MANIFEST_ACTIVE_COMP_STAMP: u32 = 0x00010101;
+
+fn get_pldm_fw_pkg_caliptra_and_manifest(
+    caliptra_comp_stamp: Option<u32>,
+    manifest_comp_stamp: Option<u32>,
+) -> FirmwareManifest {
+    FirmwareManifest {
+        firmware_device_id_records: vec![FirmwareDeviceIdRecord {
+            initial_descriptor: Descriptor {
+                descriptor_type: DescriptorType::Uuid,
+                descriptor_data: TEST_UUID.to_vec(),
+            },
+            component_image_set_version_string_type: pldm_fw_pkg::manifest::StringType::Utf8,
+            component_image_set_version_string: Some(COMPONENT_ACTIVE_VER_STR.to_string()),
+            applicable_components: Some(vec![0, 1]),
+            ..Default::default()
+        }],
+        component_image_information: vec![
+            ComponentImageInformation {
+                classification: ComponentClassification::Firmware as u16,
+                identifier: CALIPTRA_FW_COMP_IDENTIFIER,
+                comparison_stamp: caliptra_comp_stamp,
+                ..Default::default()
+            },
+            ComponentImageInformation {
+                classification: ComponentClassification::Other as u16,
+                identifier: SOC_MANIFEST_COMP_IDENTIFIER,
+                comparison_stamp: manifest_comp_stamp,
+                ..Default::default()
+            },
+        ],
+        ..Default::default()
+    }
+}
+
+#[test]
+fn test_request_update_receive_ok() {
+    // PLDM firmware package contains Caliptra Firmware with current active version + 1
+    let pldm_fw_pkg = get_pldm_fw_pkg_caliptra_and_manifest(
+        Some(CALIPTRA_FW_ACTIVE_COMP_STAMP + 1),
+        Some(SOC_MANIFEST_ACTIVE_COMP_STAMP + 1),
+    );
+
+    // Setup the test environment
+    let mut setup = setup(Options {
+        pldm_fw_pkg: Some(pldm_fw_pkg.clone()),
+        discovery_sm_actions: CustomDiscoverySm {},
+        update_sm_actions: UpdateSmBypassed {},
+        fd_tid: 0x01,
+    });
+
+    // Receive RequestUpdate request
+    let request: RequestUpdateRequest =
+        receive_request(&setup.fd_sock, FwUpdateCmd::RequestUpdate as u8).unwrap();
+
+    // Send RequestUpdate response
+    let response = RequestUpdateResponse::new(
+        request.fixed.hdr.instance_id(),
+        PldmBaseCompletionCode::Success as u8,
+        0,
+        0,
+        None,
+    );
+
+    send_response(&setup.fd_sock, &response);
+
+    setup.wait_for_state_transition(update_sm::States::LearnComponents);
+
+    setup.daemon.stop();
+}
+
+#[test]
+fn test_request_update_receive_fail() {
+    // PLDM firmware package contains Caliptra Firmware with current active version + 1
+    let pldm_fw_pkg = get_pldm_fw_pkg_caliptra_and_manifest(
+        Some(CALIPTRA_FW_ACTIVE_COMP_STAMP + 1),
+        Some(SOC_MANIFEST_ACTIVE_COMP_STAMP + 1),
+    );
+
+    // Setup the test environment
+    let mut setup = setup(Options {
+        pldm_fw_pkg: Some(pldm_fw_pkg.clone()),
+        discovery_sm_actions: CustomDiscoverySm {},
+        update_sm_actions: UpdateSmBypassed {},
+        fd_tid: 0x01,
+    });
+
+    // Receive RequestUpdate request
+    let request: RequestUpdateRequest =
+        receive_request(&setup.fd_sock, FwUpdateCmd::RequestUpdate as u8).unwrap();
+
+    // Send RequestUpdate response
+    let response = RequestUpdateResponse::new(
+        request.fixed.hdr.instance_id(),
+        PldmBaseCompletionCode::Error as u8,
+        0,
+        0,
+        None,
+    );
+
+    send_response(&setup.fd_sock, &response);
+
+    setup.wait_for_state_transition(update_sm::States::Done);
+
+    setup.daemon.stop();
+}


### PR DESCRIPTION
1. Add Update Agent State machine template
2. Implement the following commands: QueryDeviceIdentifier
GetFirmwareParameters
RequestUpdate
3. Change FirmwareParameters struct, support more than 1 component entry since Caliptra Firmware Package will include Caliptra FMC, SoC Manifest, MCU RT and other SoC images
4. Add Update Agent SM events to Daemon
5. Store discovery_sm and update_sm in the Daemon so that unit tests can get the states of the SMs
6. Add unit tests