### PR TITLE
Align App binaries to 4-bytes

### DIFF
--- a/builder/src/apps.rs
+++ b/builder/src/apps.rs
@@ -113,7 +113,12 @@ fn app_build_tbf(
     }
 
     // read the flat binary
-    let b = std::fs::read(&app_bin)?;
+    let mut b = std::fs::read(&app_bin)?;
+
+    while b.len() % 4 != 0 {
+        b.push(0);
+    }
+
     let total_size = b.len() + tbf_header_size;
 
     tbf.set_total_size(total_size as u32);


### PR DESCRIPTION
When the App binaries are not aligned to 4-bytes, tock throws an "App flash length not supported by MPU." error.

To fix this we will pad the App binary until it is aligned to 4-bytes, so that the next App's TBF will also be aligned to 4-bytes

The layout would be:

TBF for App1
App1.bin
TBF for App2
App2.bin
...

TBF is 132 bytes which is 4-byte aligned, so we just need to make sure that the app binaries are 4-bytes aligned.