### PR TITLE
Fix deadlock on when receiving and sending MCTP messages at the same …

### DIFF
--- a/emulator/app/src/mctp_transport.rs
+++ b/emulator/app/src/mctp_transport.rs
@@ -8,6 +8,7 @@
 use crate::tests::mctp_util::common::MctpUtil;
 use core::time::Duration;
 use emulator_periph::DynamicI3cAddress;
+
 use pldm_common::util::mctp_transport::{MctpCommonHeader, MCTP_PLDM_MSG_TYPE};
 use pldm_ua::transport::{
     EndpointId, Payload, PldmSocket, PldmTransport, PldmTransportError, RxPacket,
@@ -15,7 +16,14 @@ use pldm_ua::transport::{
 };
 use std::net::{SocketAddr, TcpStream};
 use std::sync::atomic::AtomicBool;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Condvar, Mutex};
+
+#[derive(Debug, PartialEq, Clone)]
+enum MctpPldmSocketState {
+    Idle,
+    FirstResponse,
+    DuplexReady,
+}
 
 pub struct MctpPldmSocket {
     source: EndpointId,
@@ -23,30 +31,34 @@ pub struct MctpPldmSocket {
     target_addr: u8,
     msg_tag: u8,
     running: Arc<AtomicBool>,
-    context: Arc<Mutex<MctpPldmSocketData>>,
+    context: Arc<(Mutex<MctpPldmSocketData>, Condvar)>,
+    stream: TcpStream,
 }
 
 struct MctpPldmSocketData {
-    stream: TcpStream,
+    state: MctpPldmSocketState,
     first_response: Option<Vec<u8>>,
-    wait_for_responder: bool,
-    mctp_util: MctpUtil,
 }
 
 impl PldmSocket for MctpPldmSocket {
     fn send(&self, payload: &[u8]) -> Result<(), PldmTransportError> {
-        let context = &mut *self.context.lock().unwrap();
-        let mctp_util = &mut context.mctp_util;
+        let mut mctp_util = MctpUtil::new();
 
-        let mut mctp_common_headeer = MctpCommonHeader(0);
-        mctp_common_headeer.set_ic(0);
-        mctp_common_headeer.set_msg_type(MCTP_PLDM_MSG_TYPE);
+        let mut mctp_common_header = MctpCommonHeader(0);
+        mctp_common_header.set_ic(0);
+        mctp_common_header.set_msg_type(MCTP_PLDM_MSG_TYPE);
 
         let mut mctp_payload: Vec<u8> = Vec::new();
-        mctp_payload.push(mctp_common_headeer.0);
+        mctp_payload.push(mctp_common_header.0);
         mctp_payload.extend_from_slice(payload);
 
-        if context.wait_for_responder {
+        let mut stream = self
+            .stream
+            .try_clone()
+            .map_err(|_| PldmTransportError::Disconnected)?;
+        let (context_lock, cvar) = &*self.context;
+        let context = &mut *context_lock.lock().unwrap();
+        if context.state == MctpPldmSocketState::Idle {
             /* If this is the first time we are sending a request,
              * we need to make sure that the responder is ready
              * so we wait for a response for the first message
@@ -56,26 +68,25 @@ impl PldmSocket for MctpPldmSocket {
                 self.msg_tag,
                 mctp_payload.as_mut_slice(),
                 self.running.clone(),
-                &mut context.stream,
+                &mut stream,
                 self.target_addr,
             );
-
             context.first_response.replace(response.unwrap());
-
-            context.wait_for_responder = false;
+            context.state = MctpPldmSocketState::FirstResponse;
+            cvar.notify_all();
         } else if payload[0] & 0x80 == 0x80 {
             mctp_util.send_request(
                 self.msg_tag,
                 mctp_payload.as_mut_slice(),
                 self.running.clone(),
-                &mut context.stream,
+                &mut stream,
                 self.target_addr,
             );
         } else {
             mctp_util.send_response(
                 mctp_payload.as_mut_slice(),
                 self.running.clone(),
-                &mut context.stream,
+                &mut stream,
                 self.target_addr,
             );
         }
@@ -84,26 +95,47 @@ impl PldmSocket for MctpPldmSocket {
     }
 
     fn receive(&self, _timeout: Option<Duration>) -> Result<RxPacket, PldmTransportError> {
-        let context = &mut *self.context.lock().unwrap();
-        if let Some(response) = context.first_response.as_mut() {
-            let mut data = [0u8; MAX_PLDM_PAYLOAD_SIZE];
-            // Skip the first byte containing the MCTP common header
-            // and only return the PLDM payload
-            data[..response.len() - 1].copy_from_slice(&response[1..]);
-            let ret = RxPacket {
-                src: self.dest,
-                payload: Payload {
-                    data,
-                    len: response.len() - 1,
-                },
-            };
-            context.first_response = None;
-            return Ok(ret);
+        {
+            let (context_lock, cvar) = &*self.context;
+            let mut context = context_lock.lock().unwrap();
+            if context.state == MctpPldmSocketState::FirstResponse
+                || context.state == MctpPldmSocketState::Idle
+            {
+                if context.first_response.is_none() {
+                    // Wait for the first response from the responder in the sending thread
+                    context = cvar.wait(context).unwrap();
+                }
+                // Wait for the first response
+                if let Some(response) = context.first_response.as_mut() {
+                    let mut data = [0u8; MAX_PLDM_PAYLOAD_SIZE];
+                    // Skip the first byte containing the MCTP common header
+                    // and only return the PLDM payload
+                    data[..response.len() - 1].copy_from_slice(&response[1..]);
+                    let ret = RxPacket {
+                        src: self.dest,
+                        payload: Payload {
+                            data,
+                            len: response.len() - 1,
+                        },
+                    };
+                    context.first_response = None;
+                    context.state = MctpPldmSocketState::DuplexReady;
+                    return Ok(ret);
+                } else {
+                    return Err(PldmTransportError::Disconnected);
+                }
+            }
         }
 
-        let mctp_util = &mut context.mctp_util;
+        // We are in duplex mode, so we can receive packets
+        // without waiting for the first response
+        let mut mctp_util = MctpUtil::new();
+        let mut stream = self
+            .stream
+            .try_clone()
+            .map_err(|_| PldmTransportError::Disconnected)?;
         let raw_pkt: Vec<u8> =
-            mctp_util.receive(self.running.clone(), &mut context.stream, self.target_addr);
+            mctp_util.receive(self.running.clone(), &mut stream, self.target_addr);
         let len = raw_pkt.len() - 1;
         if raw_pkt.is_empty() {
             return Err(PldmTransportError::Underflow);
@@ -135,6 +167,7 @@ impl PldmSocket for MctpPldmSocket {
             msg_tag: self.msg_tag,
             running: self.running.clone(),
             context: self.context.clone(),
+            stream: self.stream.try_clone().unwrap(),
         }
     }
 }
@@ -160,7 +193,6 @@ impl PldmTransport<MctpPldmSocket> for MctpTransport {
         let addr = SocketAddr::from(([127, 0, 0, 1], self.port));
         let stream = TcpStream::connect(addr).map_err(|_| PldmTransportError::Disconnected)?;
         let running = Arc::new(AtomicBool::new(true));
-        let mctp_util = MctpUtil::new();
         let msg_tag = 0u8;
         Ok(MctpPldmSocket {
             source,
@@ -168,12 +200,14 @@ impl PldmTransport<MctpPldmSocket> for MctpTransport {
             target_addr: self.target_addr.into(),
             msg_tag,
             running,
-            context: Arc::new(Mutex::new(MctpPldmSocketData {
-                stream,
-                first_response: None,
-                wait_for_responder: true,
-                mctp_util,
-            })),
+            stream,
+            context: Arc::new((
+                Mutex::new(MctpPldmSocketData {
+                    state: MctpPldmSocketState::Idle,
+                    first_response: None,
+                }),
+                Condvar::new(),
+            )),
         })
     }
 }


### PR DESCRIPTION
…time

The MCTP transport allows users to spawn two threads: one for TX and one for RX. Both threads shared the same context variable, which contained the MCTP utility, the I3C TCP stream, and the first_response variable.

This led to a deadlock scenario where:

* The RX thread locks context first.
* The TX thread also attempts to lock context.
* Since during the first message exchange, RX typically waits for a message before TX sends one, both threads could get stuck.

Solution:
* Removed unnecessary dependencies.
* Separate MCTP utility instances for TX and RX, as they don’t share data.
* Cloned the I3C TCP stream for independent TX and RX access, avoiding a shared lock.
* Introduced a conditional variable to protect first_response: The RX thread waits for first_response using cvar.wait(), releasing its lock.
The TX thread can then set first_response without causing a deadlock. This ensures proper synchronization while allowing concurr