### PR TITLE
[FW Update Agent] Implement PASS_COMPONENT and UPDATE_COMPONENT PLDM Commands

### DIFF
--- a/common/pldm/src/message/firmware_update/pass_component.rs
+++ b/common/pldm/src/message/firmware_update/pass_component.rs
@@ -119,7 +119,7 @@ impl PldmCodec for PassComponentTableRequest {
         })
     }
 }
-#[derive(Debug, Clone, FromBytes, IntoBytes, Immutable, PartialEq)]
+#[derive(Debug, Clone, FromBytes, IntoBytes, Immutable, PartialEq, Default)]
 #[repr(C, packed)]
 pub struct PassComponentTableResponse {
     pub hdr: PldmMsgHeader<[u8; PLDM_MSG_HEADER_LEN]>,

--- a/common/pldm/src/message/firmware_update/request_update.rs
+++ b/common/pldm/src/message/firmware_update/request_update.rs
@@ -127,7 +127,7 @@ impl PldmCodec for RequestUpdateRequest {
     }
 }
 
-#[derive(Debug, Copy, Clone, FromBytes, IntoBytes, Immutable, PartialEq)]
+#[derive(Debug, Copy, Clone, FromBytes, IntoBytes, Immutable, PartialEq, Default)]
 #[repr(C, packed)]
 pub struct RequestUpdateResponseFixed {
     pub hdr: PldmMsgHeader<[u8; PLDM_MSG_HEADER_LEN]>,
@@ -136,7 +136,7 @@ pub struct RequestUpdateResponseFixed {
     pub fd_will_send_pkg_data_cmd: u8,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct RequestUpdateResponse {
     pub fixed: RequestUpdateResponseFixed,
     // This field is only present if FDWillSendGetPackageDataCommand is set to 0x02.

--- a/common/pldm/src/protocol/firmware_update.rs
+++ b/common/pldm/src/protocol/firmware_update.rs
@@ -680,7 +680,7 @@ pub enum ComponentResponse {
 }
 
 #[repr(u8)]
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum ComponentResponseCode {
     CompCanBeUpdated = 0x00,
     CompComparisonStampIdentical = 0x01,

--- a/emulator/bmc/pldm-ua/src/update_sm.rs
+++ b/emulator/bmc/pldm-ua/src/update_sm.rs
@@ -8,9 +8,11 @@ use pldm_common::codec::PldmCodec;
 use pldm_common::message::firmware_update as pldm_packet;
 use pldm_common::protocol::base::{
     InstanceId, PldmBaseCompletionCode, PldmMsgHeader, PldmMsgType, PldmSupportedType,
+    TransferRespFlag,
 };
 use pldm_common::protocol::firmware_update::{
-    ComponentParameterEntry, FwUpdateCmd, PldmFirmwareString, VersionStringType,
+    ComponentClassification, ComponentCompatibilityResponse, ComponentParameterEntry,
+    ComponentResponseCode, FwUpdateCmd, PldmFirmwareString, UpdateOptionFlags, VersionStringType,
     PLDM_FWUP_IMAGE_SET_VER_STR_MAX_LEN,
 };
 use pldm_fw_pkg::manifest::{ComponentImageInformation, FirmwareDeviceIdRecord};
@@ -31,13 +33,15 @@ statemachine! {
         ReceivedQueryDeviceIdentifiers + SendGetFirmwareParameters / on_send_get_firmware_parameters = GetFirmwareParametersSent,
         GetFirmwareParametersSent + GetFirmwareParametersResponse(pldm_packet::get_fw_params::GetFirmwareParametersResponse)  / on_get_firmware_parameters_response = ReceivedFirmwareParameters,
         ReceivedFirmwareParameters + SendRequestUpdate / on_send_request_update = RequestUpdateSent,
-        RequestUpdateSent + RequestUpdateResponse(pldm_packet::request_update::RequestUpdateResponse) / on_request_update_response = ReceivedRequestUpdateResponse,
-        ReceivedRequestUpdateResponse + SendPassComponentRequest / on_send_pass_component_request = LearnComponents,
-        LearnComponents + PassComponentResponse(pldm_packet::pass_component::PassComponentTableResponse) [!are_all_components_passed] / on_pass_component_response = LearnComponents,
-        LearnComponents + PassComponentResponse(pldm_packet::pass_component::PassComponentTableResponse) [are_all_components_passed] / on_pass_component_response = ReadyXfer,
+        RequestUpdateSent + RequestUpdateResponse(pldm_packet::request_update::RequestUpdateResponse) / on_request_update_response = LearnComponents,
+        LearnComponents + SendPassComponentRequest [!are_all_components_passed] / on_send_pass_component_request = LearnComponents,
+        LearnComponents + SendPassComponentRequest [are_all_components_passed]  / on_all_components_passed = ReadyXfer,
+        LearnComponents + PassComponentResponse(pldm_packet::pass_component::PassComponentTableResponse) / on_pass_component_response = LearnComponents,
         LearnComponents + CancelUpdateOrTimeout  / on_stop_update = Idle,
 
-        ReadyXfer + UpdateComponent / on_update_component = Download,
+        ReadyXfer + SendUpdateComponent / on_send_update_component = ReadyXfer,
+        ReadyXfer + UpdateComponentResponse(pldm_packet::update_component::UpdateComponentResponse) / on_update_component_response = ReadyXfer,
+        ReadyXfer + StartDownload / on_start_download = Download,
         ReadyXfer + CancelUpdateComponent  / on_stop_update = Idle,
 
         Download + RequestFirmwareData / on_request_firmware = Download,
@@ -139,12 +143,12 @@ fn is_pkg_device_id_in_response(
 }
 pub trait StateMachineActions {
     // Guards
-    fn are_all_components_passed(
-        &self,
-        _ctx: &InnerContext<impl PldmSocket>,
-        _response: &pldm_packet::pass_component::PassComponentTableResponse,
-    ) -> Result<bool, ()> {
-        Ok(true)
+    fn are_all_components_passed(&self, ctx: &InnerContext<impl PldmSocket>) -> Result<bool, ()> {
+        if ctx.component_response_codes.len() >= ctx.components.len() {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
     }
 
     // Actions
@@ -179,10 +183,158 @@ pub trait StateMachineActions {
 
     fn on_send_pass_component_request(
         &mut self,
-        _ctx: &mut InnerContext<impl PldmSocket>,
+        ctx: &mut InnerContext<impl PldmSocket>,
     ) -> Result<(), ()> {
-        // TODO
+        let num_of_components_to_pass = ctx.components.len();
+        let num_components_passed = ctx.component_response_codes.len();
+
+        if num_components_passed >= num_of_components_to_pass {
+            info!("All components passed");
+            return Ok(());
+        }
+
+        let component_idx: usize;
+        let pass_component_flag: TransferRespFlag;
+
+        if num_of_components_to_pass == 0 {
+            error!("No components to pass");
+            return Err(());
+        } else if num_of_components_to_pass == 1 {
+            component_idx = 0;
+            pass_component_flag = TransferRespFlag::StartAndEnd;
+        } else if num_components_passed == 0 {
+            component_idx = 0;
+            pass_component_flag = TransferRespFlag::Start;
+        } else if num_components_passed < num_of_components_to_pass - 1 {
+            component_idx = 0;
+            pass_component_flag = TransferRespFlag::Middle;
+        } else if num_components_passed == num_of_components_to_pass - 1 {
+            component_idx = 0;
+            pass_component_flag = TransferRespFlag::End;
+        } else {
+            // This should never happen
+            error!("Unhandled case");
+            return Err(());
+        }
+        debug!(
+            "Passing component: {} Flag: {:?}",
+            component_idx, pass_component_flag
+        );
+        let component = &ctx.components[component_idx];
+        let component_version_string = component.version_string.clone().unwrap_or("".to_string());
+        let request = pldm_packet::pass_component::PassComponentTableRequest::new(
+            ctx.instance_id,
+            PldmMsgType::Request,
+            pass_component_flag,
+            ComponentClassification::try_from(component.classification).map_err(|_| ())?,
+            component.identifier,
+            0, // todo: support classification index
+            component.comparison_stamp.unwrap(),
+            &PldmFirmwareString {
+                str_type: component.version_string_type as u8,
+                str_len: component_version_string.len() as u8,
+                str_data: {
+                    let mut arr = [0u8; PLDM_FWUP_IMAGE_SET_VER_STR_MAX_LEN];
+                    arr[..component_version_string.len()]
+                        .copy_from_slice(component_version_string.as_bytes());
+                    arr
+                },
+            },
+        );
+        send_request_helper(&ctx.socket, &request)
+    }
+
+    fn on_next_component(&mut self, ctx: &mut InnerContext<impl PldmSocket>) -> Result<(), ()> {
+        ctx.current_component_index = self.find_next_component_to_update(ctx);
+        if ctx.current_component_index.is_none() {
+            error!("No component to update");
+            // TODO, send Activate
+            return Err(());
+        } else {
+            ctx.event_queue
+                .send(PldmEvents::Update(Events::SendUpdateComponent))
+                .map_err(|_| ())?;
+        }
         Ok(())
+    }
+
+    fn on_all_components_passed(
+        &mut self,
+        ctx: &mut InnerContext<impl PldmSocket>,
+    ) -> Result<(), ()> {
+        self.on_next_component(ctx)
+    }
+
+    fn find_next_component_to_update(&self, ctx: &InnerContext<impl PldmSocket>) -> Option<usize> {
+        // Find the next component to update
+        for (i, item) in ctx.component_response_codes.iter().enumerate() {
+            if *item == ComponentResponseCode::CompCanBeUpdated {
+                return Some(i);
+            }
+        }
+        None
+    }
+
+    fn on_send_update_component(
+        &mut self,
+        ctx: &mut InnerContext<impl PldmSocket>,
+    ) -> Result<(), ()> {
+        if ctx.current_component_index.is_none() {
+            error!("No component to update");
+            return Err(());
+        }
+        let component = &ctx.components[ctx.current_component_index.unwrap()];
+        let request = pldm_packet::update_component::UpdateComponentRequest::new(
+            ctx.instance_id,
+            PldmMsgType::Request,
+            ComponentClassification::try_from(component.classification).map_err(|_| ())?,
+            component.identifier,
+            0, // not supported
+            component.comparison_stamp.unwrap_or(0),
+            component.size,
+            UpdateOptionFlags(component.options as u32),
+            &PldmFirmwareString {
+                str_type: component.version_string_type as u8,
+                str_len: component
+                    .version_string
+                    .clone()
+                    .unwrap_or("".to_string())
+                    .len() as u8,
+                str_data: {
+                    let mut arr = [0u8; PLDM_FWUP_IMAGE_SET_VER_STR_MAX_LEN];
+                    if let Some(ref component) = component.version_string {
+                        arr[..component.len()].copy_from_slice(component.as_bytes());
+                    }
+                    arr
+                },
+            },
+        );
+        send_request_helper(&ctx.socket, &request)
+    }
+
+    fn on_update_component_response(
+        &mut self,
+        ctx: &mut InnerContext<impl PldmSocket>,
+        response: pldm_packet::update_component::UpdateComponentResponse,
+    ) -> Result<(), ()> {
+        if response.completion_code == PldmBaseCompletionCode::Success as u8
+            && response.comp_compatibility_resp
+                == ComponentCompatibilityResponse::CompCanBeUpdated as u8
+        {
+            info!("UpdateComponent response success, start download");
+            ctx.event_queue
+                .send(PldmEvents::Update(Events::StartDownload))
+                .map_err(|_| ())?;
+
+            Ok(())
+        } else {
+            error!("UpdateComponent response failed, continuing to next component");
+            // Mark the component as can not be updated
+            if let Some(index) = ctx.current_component_index {
+                ctx.component_response_codes[index] = ComponentResponseCode::CompNotSupported;
+            }
+            self.on_next_component(ctx)
+        }
     }
 
     fn on_query_device_identifiers_response(
@@ -371,14 +523,31 @@ pub trait StateMachineActions {
 
     fn on_pass_component_response(
         &mut self,
-        _ctx: &mut InnerContext<impl PldmSocket>,
-        _response: pldm_packet::pass_component::PassComponentTableResponse,
+        ctx: &mut InnerContext<impl PldmSocket>,
+        response: pldm_packet::pass_component::PassComponentTableResponse,
     ) -> Result<(), ()> {
-        // TODO
+        // If unsuccessful, stop the update
+        if response.completion_code != PldmBaseCompletionCode::Success as u8 {
+            error!("PassComponent response failed");
+            ctx.event_queue
+                .send(PldmEvents::Update(Events::StopUpdate))
+                .map_err(|_| ())?;
+            return Err(());
+        }
+
+        // Record the response code
+        ctx.component_response_codes
+            .push(ComponentResponseCode::try_from(response.comp_resp_code).map_err(|_| ())?);
+
+        // Send the next component info
+        ctx.event_queue
+            .send(PldmEvents::Update(Events::SendPassComponentRequest))
+            .map_err(|_| ())?;
+
         Ok(())
     }
 
-    fn on_update_component(&mut self, _ctx: &mut InnerContext<impl PldmSocket>) -> Result<(), ()> {
+    fn on_start_download(&mut self, _ctx: &mut InnerContext<impl PldmSocket>) -> Result<(), ()> {
         // TODO
         Ok(())
     }
@@ -486,6 +655,9 @@ pub fn process_packet(packet: &RxPacket) -> Result<PldmEvents, ()> {
             FwUpdateCmd::PassComponentTable => {
                 packet_to_event(&header, packet, true, Events::PassComponentResponse)
             }
+            FwUpdateCmd::UpdateComponent => {
+                packet_to_event(&header, packet, true, Events::UpdateComponentResponse)
+            }
             _ => {
                 debug!("Unknown firmware update command");
                 Err(())
@@ -508,6 +680,11 @@ pub struct InnerContext<S: PldmSocket> {
     pub device_id: Option<FirmwareDeviceIdRecord>,
     // The components that need to be updated
     pub components: Vec<ComponentImageInformation>,
+    // The device responses to the component info passed
+    pub component_response_codes: Vec<ComponentResponseCode>,
+    // The current component being updated
+    // This an index to the components vector
+    pub current_component_index: Option<usize>,
 }
 
 pub struct Context<T: StateMachineActions, S: PldmSocket> {
@@ -531,6 +708,8 @@ impl<T: StateMachineActions, S: PldmSocket> Context<T, S> {
                 instance_id: 0,
                 device_id: None,
                 components: Vec::new(),
+                component_response_codes: Vec::new(),
+                current_component_index: None,
             },
         }
     }
@@ -570,8 +749,11 @@ impl<T: StateMachineActions, S: PldmSocket> StateMachineContext for Context<T, S
         on_get_firmware_parameters_response(response : pldm_packet::get_fw_params::GetFirmwareParametersResponse) -> Result<(), ()>,
         on_request_update_response(response: pldm_packet::request_update::RequestUpdateResponse) -> Result<(),()>,
         on_send_pass_component_request() -> Result<(),()>,
+        on_all_components_passed() -> Result<(),()>,
+        on_send_update_component() -> Result<(),()>,
         on_pass_component_response(response : pldm_packet::pass_component::PassComponentTableResponse) -> Result<(),()>,
-        on_update_component() -> Result<(),()>,
+        on_start_download() -> Result<(),()>,
+        on_update_component_response(response : pldm_packet::update_component::UpdateComponentResponse) -> Result<(),()>,
         on_request_firmware() -> Result<(),()>,
         on_transfer_fail() -> Result<(),()>,
         on_transfer_success() -> Result<(),()>,
@@ -587,6 +769,6 @@ impl<T: StateMachineActions, S: PldmSocket> StateMachineContext for Context<T, S
 
     // Guards
     delegate_to_inner_guard! {
-        are_all_components_passed(response : &pldm_packet::pass_component::PassComponentTableResponse) -> Result<bool, ()>,
+        are_all_components_passed() -> Result<bool, ()>,
     }
 }

--- a/emulator/bmc/pldm-ua/src/update_sm.rs
+++ b/emulator/bmc/pldm-ua/src/update_sm.rs
@@ -213,8 +213,7 @@ pub trait StateMachineActions {
             pass_component_flag = TransferRespFlag::End;
         } else {
             // This should never happen
-            error!("Unhandled case");
-            return Err(());
+            panic!("Unhandled case");
         }
         debug!(
             "Passing component: {} Flag: {:?}",

--- a/emulator/bmc/pldm-ua/tests/test_pass_component_table.rs
+++ b/emulator/bmc/pldm-ua/tests/test_pass_component_table.rs
@@ -1,0 +1,313 @@
+// Licensed under the Apache-2.0 license
+
+#[cfg(test)]
+mod common;
+
+use common::CustomDiscoverySm;
+use pldm_common::message::firmware_update::{
+    get_fw_params::GetFirmwareParametersResponse,
+    pass_component::{PassComponentTableRequest, PassComponentTableResponse},
+    query_devid::QueryDeviceIdentifiersResponse,
+    request_update::RequestUpdateResponse,
+};
+use pldm_common::protocol::{
+    base::{PldmBaseCompletionCode, TransferRespFlag},
+    firmware_update::{
+        ComponentClassification, ComponentResponse, ComponentResponseCode, FwUpdateCmd,
+    },
+};
+use pldm_fw_pkg::manifest::{
+    ComponentImageInformation, Descriptor, DescriptorType, FirmwareDeviceIdRecord,
+};
+use pldm_fw_pkg::FirmwareManifest;
+use pldm_ua::{daemon::Options, events::PldmEvents, transport::PldmSocket, update_sm};
+
+// Test UUID
+pub const TEST_UUID: [u8; 16] = [
+    0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0,
+];
+
+/* Override the Update SM, go directly to PassComponents */
+struct UpdateSmBypassed {}
+impl update_sm::StateMachineActions for UpdateSmBypassed {
+    fn on_start_update(
+        &mut self,
+        ctx: &mut update_sm::InnerContext<impl PldmSocket>,
+    ) -> Result<(), ()> {
+        ctx.device_id = Some(ctx.pldm_fw_pkg.firmware_device_id_records[0].clone());
+        ctx.components = ctx.pldm_fw_pkg.component_image_information.clone();
+        ctx.event_queue
+            .send(PldmEvents::Update(
+                update_sm::Events::QueryDeviceIdentifiersResponse(QueryDeviceIdentifiersResponse {
+                    ..Default::default()
+                }),
+            ))
+            .map_err(|_| ())?;
+        Ok(())
+    }
+    fn on_query_device_identifiers_response(
+        &mut self,
+        ctx: &mut update_sm::InnerContext<impl PldmSocket>,
+        _response: QueryDeviceIdentifiersResponse,
+    ) -> Result<(), ()> {
+        ctx.event_queue
+            .send(PldmEvents::Update(
+                update_sm::Events::SendGetFirmwareParameters,
+            ))
+            .map_err(|_| ())?;
+        Ok(())
+    }
+    fn on_send_get_firmware_parameters(
+        &mut self,
+        ctx: &mut update_sm::InnerContext<impl PldmSocket>,
+    ) -> Result<(), ()> {
+        ctx.event_queue
+            .send(PldmEvents::Update(
+                update_sm::Events::GetFirmwareParametersResponse(GetFirmwareParametersResponse {
+                    ..Default::default()
+                }),
+            ))
+            .map_err(|_| ())
+    }
+    fn on_get_firmware_parameters_response(
+        &mut self,
+        ctx: &mut update_sm::InnerContext<impl PldmSocket>,
+        _response: pldm_common::message::firmware_update::get_fw_params::GetFirmwareParametersResponse,
+    ) -> Result<(), ()> {
+        ctx.event_queue
+            .send(PldmEvents::Update(update_sm::Events::SendRequestUpdate))
+            .map_err(|_| ())
+    }
+    fn on_send_request_update(
+        &mut self,
+        ctx: &mut update_sm::InnerContext<impl PldmSocket>,
+    ) -> Result<(), ()> {
+        ctx.event_queue
+            .send(PldmEvents::Update(
+                update_sm::Events::RequestUpdateResponse(RequestUpdateResponse {
+                    ..Default::default()
+                }),
+            ))
+            .map_err(|_| ())
+    }
+    fn on_request_update_response(
+        &mut self,
+        ctx: &mut update_sm::InnerContext<impl PldmSocket>,
+        _response: RequestUpdateResponse,
+    ) -> Result<(), ()> {
+        ctx.event_queue
+            .send(PldmEvents::Update(
+                update_sm::Events::SendPassComponentRequest,
+            ))
+            .map_err(|_| ())
+    }
+    fn on_send_update_component(
+        &mut self,
+        _ctx: &mut update_sm::InnerContext<impl PldmSocket>,
+    ) -> Result<(), ()> {
+        // Do nothing
+        Ok(())
+    }
+}
+
+#[test]
+fn test_pass_one_component() {
+    let pldm_fw_pkg = FirmwareManifest {
+        firmware_device_id_records: vec![FirmwareDeviceIdRecord {
+            initial_descriptor: Descriptor {
+                descriptor_type: DescriptorType::Uuid,
+                descriptor_data: TEST_UUID.to_vec(),
+            },
+            component_image_set_version_string_type: pldm_fw_pkg::manifest::StringType::Utf8,
+            component_image_set_version_string: Some("1.1.0".to_string()),
+            applicable_components: Some(vec![0]),
+            ..Default::default()
+        }],
+        component_image_information: vec![ComponentImageInformation {
+            classification: ComponentClassification::Firmware as u16,
+            identifier: 0x0001,
+            comparison_stamp: Some(0x00010101),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+
+    // Setup the test environment
+    let mut setup = common::setup(Options {
+        pldm_fw_pkg: Some(pldm_fw_pkg.clone()),
+        discovery_sm_actions: CustomDiscoverySm {},
+        update_sm_actions: UpdateSmBypassed {},
+        fd_tid: 0x01,
+    });
+
+    // Receive PassComponent request
+    let request: PassComponentTableRequest = setup
+        .receive_request(&setup.fd_sock, FwUpdateCmd::PassComponentTable as u8)
+        .unwrap();
+
+    assert_eq!(
+        request.fixed.transfer_flag,
+        TransferRespFlag::StartAndEnd as u8
+    );
+
+    // Send PassComponent response
+    let response = PassComponentTableResponse::new(
+        request.fixed.hdr.instance_id(),
+        PldmBaseCompletionCode::Success as u8,
+        ComponentResponse::CompCanBeUpdated,
+        ComponentResponseCode::CompCanBeUpdated,
+    );
+
+    setup.send_response(&setup.fd_sock, &response);
+
+    setup.wait_for_state_transition(update_sm::States::ReadyXfer);
+
+    setup.daemon.stop();
+}
+
+#[test]
+fn test_pass_two_components() {
+    let pldm_fw_pkg = FirmwareManifest {
+        firmware_device_id_records: vec![FirmwareDeviceIdRecord {
+            initial_descriptor: Descriptor {
+                descriptor_type: DescriptorType::Uuid,
+                descriptor_data: TEST_UUID.to_vec(),
+            },
+            component_image_set_version_string_type: pldm_fw_pkg::manifest::StringType::Utf8,
+            component_image_set_version_string: Some("1.1.0".to_string()),
+            applicable_components: Some(vec![0]),
+            ..Default::default()
+        }],
+        component_image_information: vec![
+            ComponentImageInformation {
+                classification: ComponentClassification::Firmware as u16,
+                identifier: 0x0001,
+                comparison_stamp: Some(0x00010101),
+                ..Default::default()
+            },
+            ComponentImageInformation {
+                classification: ComponentClassification::Firmware as u16,
+                identifier: 0x0002,
+                comparison_stamp: Some(0x00010101),
+                ..Default::default()
+            },
+        ],
+        ..Default::default()
+    };
+
+    // Setup the test environment
+    let mut setup = common::setup(Options {
+        pldm_fw_pkg: Some(pldm_fw_pkg.clone()),
+        discovery_sm_actions: CustomDiscoverySm {},
+        update_sm_actions: UpdateSmBypassed {},
+        fd_tid: 0x01,
+    });
+
+    // Receive PassComponent request
+    let request: PassComponentTableRequest = setup
+        .receive_request(&setup.fd_sock, FwUpdateCmd::PassComponentTable as u8)
+        .unwrap();
+
+    assert_eq!(request.fixed.transfer_flag, TransferRespFlag::Start as u8);
+
+    // Send PassComponent response
+    let response = PassComponentTableResponse::new(
+        request.fixed.hdr.instance_id(),
+        PldmBaseCompletionCode::Success as u8,
+        ComponentResponse::CompCanBeUpdated,
+        ComponentResponseCode::CompCanBeUpdated,
+    );
+
+    setup.send_response(&setup.fd_sock, &response);
+
+    let request: PassComponentTableRequest = setup
+        .receive_request(&setup.fd_sock, FwUpdateCmd::PassComponentTable as u8)
+        .unwrap();
+    assert_eq!(request.fixed.transfer_flag, TransferRespFlag::End as u8);
+
+    setup.send_response(&setup.fd_sock, &response);
+
+    setup.wait_for_state_transition(update_sm::States::ReadyXfer);
+
+    setup.daemon.stop();
+}
+
+#[test]
+fn test_pass_three_components() {
+    let pldm_fw_pkg = FirmwareManifest {
+        firmware_device_id_records: vec![FirmwareDeviceIdRecord {
+            initial_descriptor: Descriptor {
+                descriptor_type: DescriptorType::Uuid,
+                descriptor_data: TEST_UUID.to_vec(),
+            },
+            component_image_set_version_string_type: pldm_fw_pkg::manifest::StringType::Utf8,
+            component_image_set_version_string: Some("1.1.0".to_string()),
+            applicable_components: Some(vec![0]),
+            ..Default::default()
+        }],
+        component_image_information: vec![
+            ComponentImageInformation {
+                classification: ComponentClassification::Firmware as u16,
+                identifier: 0x0001,
+                comparison_stamp: Some(0x00010101),
+                ..Default::default()
+            },
+            ComponentImageInformation {
+                classification: ComponentClassification::Firmware as u16,
+                identifier: 0x0002,
+                comparison_stamp: Some(0x00010101),
+                ..Default::default()
+            },
+            ComponentImageInformation {
+                classification: ComponentClassification::Firmware as u16,
+                identifier: 0x0003,
+                comparison_stamp: Some(0x00010101),
+                ..Default::default()
+            },
+        ],
+        ..Default::default()
+    };
+
+    // Setup the test environment
+    let mut setup = common::setup(Options {
+        pldm_fw_pkg: Some(pldm_fw_pkg.clone()),
+        discovery_sm_actions: CustomDiscoverySm {},
+        update_sm_actions: UpdateSmBypassed {},
+        fd_tid: 0x01,
+    });
+
+    // Receive PassComponent request
+    let request: PassComponentTableRequest = setup
+        .receive_request(&setup.fd_sock, FwUpdateCmd::PassComponentTable as u8)
+        .unwrap();
+
+    assert_eq!(request.fixed.transfer_flag, TransferRespFlag::Start as u8);
+
+    // Send PassComponent response
+    let response = PassComponentTableResponse::new(
+        request.fixed.hdr.instance_id(),
+        PldmBaseCompletionCode::Success as u8,
+        ComponentResponse::CompCanBeUpdated,
+        ComponentResponseCode::CompCanBeUpdated,
+    );
+
+    setup.send_response(&setup.fd_sock, &response);
+
+    let request: PassComponentTableRequest = setup
+        .receive_request(&setup.fd_sock, FwUpdateCmd::PassComponentTable as u8)
+        .unwrap();
+    assert_eq!(request.fixed.transfer_flag, TransferRespFlag::Middle as u8);
+
+    setup.send_response(&setup.fd_sock, &response);
+
+    let request: PassComponentTableRequest = setup
+        .receive_request(&setup.fd_sock, FwUpdateCmd::PassComponentTable as u8)
+        .unwrap();
+    assert_eq!(request.fixed.transfer_flag, TransferRespFlag::End as u8);
+
+    setup.send_response(&setup.fd_sock, &response);
+
+    setup.wait_for_state_transition(update_sm::States::ReadyXfer);
+
+    setup.daemon.stop();
+}

--- a/emulator/bmc/pldm-ua/tests/test_update_component.rs
+++ b/emulator/bmc/pldm-ua/tests/test_update_component.rs
@@ -1,0 +1,272 @@
+// Licensed under the Apache-2.0 license
+
+#[cfg(test)]
+mod common;
+
+use common::CustomDiscoverySm;
+use pldm_common::message::firmware_update::{
+    get_fw_params::GetFirmwareParametersResponse,
+    pass_component::PassComponentTableResponse,
+    query_devid::QueryDeviceIdentifiersResponse,
+    request_update::RequestUpdateResponse,
+    update_component::{UpdateComponentRequest, UpdateComponentResponse},
+};
+use pldm_common::protocol::base::PldmBaseCompletionCode;
+use pldm_common::protocol::firmware_update::{
+    ComponentClassification, ComponentCompatibilityResponse, ComponentCompatibilityResponseCode,
+    ComponentResponseCode, FwUpdateCmd, UpdateOptionFlags,
+};
+use pldm_fw_pkg::manifest::{
+    ComponentImageInformation, Descriptor, DescriptorType, FirmwareDeviceIdRecord,
+};
+use pldm_fw_pkg::FirmwareManifest;
+use pldm_ua::{daemon::Options, events::PldmEvents, transport::PldmSocket, update_sm};
+
+// Test UUID
+pub const TEST_UUID: [u8; 16] = [
+    0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0,
+];
+
+/* Override the Update SM, go directly to UpdateComponent */
+struct UpdateSmBypassed {}
+impl update_sm::StateMachineActions for UpdateSmBypassed {
+    fn on_start_update(
+        &mut self,
+        ctx: &mut update_sm::InnerContext<impl PldmSocket>,
+    ) -> Result<(), ()> {
+        ctx.device_id = Some(ctx.pldm_fw_pkg.firmware_device_id_records[0].clone());
+        ctx.components = ctx.pldm_fw_pkg.component_image_information.clone();
+        for _ in &ctx.components {
+            ctx.component_response_codes
+                .push(ComponentResponseCode::CompCanBeUpdated);
+        }
+        ctx.event_queue
+            .send(PldmEvents::Update(
+                update_sm::Events::QueryDeviceIdentifiersResponse(QueryDeviceIdentifiersResponse {
+                    ..Default::default()
+                }),
+            ))
+            .map_err(|_| ())?;
+        Ok(())
+    }
+    fn on_query_device_identifiers_response(
+        &mut self,
+        ctx: &mut update_sm::InnerContext<impl PldmSocket>,
+        _response: QueryDeviceIdentifiersResponse,
+    ) -> Result<(), ()> {
+        ctx.event_queue
+            .send(PldmEvents::Update(
+                update_sm::Events::SendGetFirmwareParameters,
+            ))
+            .map_err(|_| ())?;
+        Ok(())
+    }
+    fn on_send_get_firmware_parameters(
+        &mut self,
+        ctx: &mut update_sm::InnerContext<impl PldmSocket>,
+    ) -> Result<(), ()> {
+        ctx.event_queue
+            .send(PldmEvents::Update(
+                update_sm::Events::GetFirmwareParametersResponse(GetFirmwareParametersResponse {
+                    ..Default::default()
+                }),
+            ))
+            .map_err(|_| ())
+    }
+    fn on_get_firmware_parameters_response(
+        &mut self,
+        ctx: &mut update_sm::InnerContext<impl PldmSocket>,
+        _response: pldm_common::message::firmware_update::get_fw_params::GetFirmwareParametersResponse,
+    ) -> Result<(), ()> {
+        ctx.event_queue
+            .send(PldmEvents::Update(update_sm::Events::SendRequestUpdate))
+            .map_err(|_| ())
+    }
+    fn on_send_request_update(
+        &mut self,
+        ctx: &mut update_sm::InnerContext<impl PldmSocket>,
+    ) -> Result<(), ()> {
+        ctx.event_queue
+            .send(PldmEvents::Update(
+                update_sm::Events::RequestUpdateResponse(RequestUpdateResponse {
+                    ..Default::default()
+                }),
+            ))
+            .map_err(|_| ())
+    }
+    fn on_request_update_response(
+        &mut self,
+        ctx: &mut update_sm::InnerContext<impl PldmSocket>,
+        _response: RequestUpdateResponse,
+    ) -> Result<(), ()> {
+        ctx.event_queue
+            .send(PldmEvents::Update(
+                update_sm::Events::SendPassComponentRequest,
+            ))
+            .map_err(|_| ())
+    }
+    fn on_send_pass_component_request(
+        &mut self,
+        ctx: &mut update_sm::InnerContext<impl PldmSocket>,
+    ) -> Result<(), ()> {
+        ctx.event_queue
+            .send(PldmEvents::Update(
+                update_sm::Events::PassComponentResponse(PassComponentTableResponse {
+                    ..Default::default()
+                }),
+            ))
+            .map_err(|_| ())
+    }
+    fn are_all_components_passed(
+        &self,
+        _ctx: &update_sm::InnerContext<impl PldmSocket>,
+    ) -> Result<bool, ()> {
+        Ok(true)
+    }
+    fn on_start_download(
+        &mut self,
+        _ctx: &mut update_sm::InnerContext<impl PldmSocket>,
+    ) -> Result<(), ()> {
+        // Bypass the download step
+        Ok(())
+    }
+}
+
+#[test]
+fn test_update_one_component() {
+    let pldm_fw_pkg = FirmwareManifest {
+        firmware_device_id_records: vec![FirmwareDeviceIdRecord {
+            initial_descriptor: Descriptor {
+                descriptor_type: DescriptorType::Uuid,
+                descriptor_data: TEST_UUID.to_vec(),
+            },
+            component_image_set_version_string_type: pldm_fw_pkg::manifest::StringType::Utf8,
+            component_image_set_version_string: Some("1.1.0".to_string()),
+            applicable_components: Some(vec![0]),
+            ..Default::default()
+        }],
+        component_image_information: vec![ComponentImageInformation {
+            classification: ComponentClassification::Firmware as u16,
+            identifier: 0x0001,
+            comparison_stamp: Some(0x00010101),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+
+    // Setup the test environment
+    let mut setup = common::setup(Options {
+        pldm_fw_pkg: Some(pldm_fw_pkg.clone()),
+        discovery_sm_actions: CustomDiscoverySm {},
+        update_sm_actions: UpdateSmBypassed {},
+        fd_tid: 0x01,
+    });
+
+    // Receive UpdateComponent request
+    let request: UpdateComponentRequest = setup
+        .receive_request(&setup.fd_sock, FwUpdateCmd::UpdateComponent as u8)
+        .unwrap();
+
+    let comp_identifier = request.fixed.comp_identifier;
+    assert_eq!(comp_identifier, 0x0001);
+
+    // Send UpdateComponent response
+    let response = UpdateComponentResponse::new(
+        request.fixed.hdr.instance_id(),
+        PldmBaseCompletionCode::Success as u8,
+        ComponentCompatibilityResponse::CompCanBeUpdated,
+        ComponentCompatibilityResponseCode::NoResponseCode,
+        UpdateOptionFlags(0),
+        0,
+        None,
+    );
+
+    setup.send_response(&setup.fd_sock, &response);
+
+    setup.wait_for_state_transition(update_sm::States::Download);
+
+    setup.daemon.stop();
+}
+
+#[test]
+fn test_update_two_components() {
+    let pldm_fw_pkg = FirmwareManifest {
+        firmware_device_id_records: vec![FirmwareDeviceIdRecord {
+            initial_descriptor: Descriptor {
+                descriptor_type: DescriptorType::Uuid,
+                descriptor_data: TEST_UUID.to_vec(),
+            },
+            component_image_set_version_string_type: pldm_fw_pkg::manifest::StringType::Utf8,
+            component_image_set_version_string: Some("1.1.0".to_string()),
+            applicable_components: Some(vec![0]),
+            ..Default::default()
+        }],
+        component_image_information: vec![
+            ComponentImageInformation {
+                classification: ComponentClassification::Firmware as u16,
+                identifier: 0x0001,
+                comparison_stamp: Some(0x00010101),
+                ..Default::default()
+            },
+            ComponentImageInformation {
+                classification: ComponentClassification::Firmware as u16,
+                identifier: 0x0002,
+                comparison_stamp: Some(0x00010101),
+                ..Default::default()
+            },
+        ],
+        ..Default::default()
+    };
+
+    // Setup the test environment
+    let mut setup = common::setup(Options {
+        pldm_fw_pkg: Some(pldm_fw_pkg.clone()),
+        discovery_sm_actions: CustomDiscoverySm {},
+        update_sm_actions: UpdateSmBypassed {},
+        fd_tid: 0x01,
+    });
+
+    // Receive UpdateComponent request
+    let request: UpdateComponentRequest = setup
+        .receive_request(&setup.fd_sock, FwUpdateCmd::UpdateComponent as u8)
+        .unwrap();
+
+    let comp_identifier = request.fixed.comp_identifier;
+    assert_eq!(comp_identifier, 0x0001);
+
+    // Send UpdateComponent response with can not be updated response code
+    let response = UpdateComponentResponse::new(
+        request.fixed.hdr.instance_id(),
+        PldmBaseCompletionCode::Success as u8,
+        ComponentCompatibilityResponse::CompCannotBeUpdated,
+        ComponentCompatibilityResponseCode::CompComparisonStampLower,
+        UpdateOptionFlags(0),
+        0,
+        None,
+    );
+    setup.send_response(&setup.fd_sock, &response);
+
+    // Should receive the next UpdateComponent request
+    let request: UpdateComponentRequest = setup
+        .receive_request(&setup.fd_sock, FwUpdateCmd::UpdateComponent as u8)
+        .unwrap();
+
+    let comp_identifier = request.fixed.comp_identifier;
+    assert_eq!(comp_identifier, 0x0002);
+
+    let response = UpdateComponentResponse::new(
+        request.fixed.hdr.instance_id(),
+        PldmBaseCompletionCode::Success as u8,
+        ComponentCompatibilityResponse::CompCanBeUpdated,
+        ComponentCompatibilityResponseCode::NoResponseCode,
+        UpdateOptionFlags(0),
+        0,
+        None,
+    );
+
+    setup.send_response(&setup.fd_sock, &response);
+
+    setup.wait_for_state_transition(update_sm::States::Download);
+
+    setup.daemon.stop();
+}


### PR DESCRIPTION

Support for PLDM PASS_COMPONENT and UPDATE_COMPONENT commands.

PASS_COMPONENT command passes the metadata of each component that needs to be updated one by one to the FD.

UPDATE_COMPONENT indicates to the FD which component will be updated.

Add unit tests for these 2 commands.