### PR TITLE
Run Caliptra Core by default; autobuild its FW

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2193,10 +2193,19 @@ name = "mcu-builder"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "caliptra-auth-man-gen",
+ "caliptra-auth-man-types",
+ "caliptra-builder",
+ "caliptra-image-crypto",
+ "caliptra-image-fake-keys",
+ "caliptra-image-gen",
+ "caliptra-image-types",
  "elf 0.7.4",
  "emulator-consts",
+ "hex",
  "semver",
  "walkdir",
+ "zerocopy 0.8.23",
 ]
 
 [[package]]
@@ -3226,30 +3235,7 @@ version = "0.1.0"
 name = "tests-integration"
 version = "0.1.0"
 dependencies = [
- "caliptra-auth-man-gen",
- "caliptra-auth-man-types",
- "caliptra-builder",
- "caliptra-emu-cpu",
- "caliptra-emu-periph",
- "caliptra-emu-types",
- "caliptra-image-crypto",
- "caliptra-image-fake-keys",
- "caliptra-image-gen",
- "caliptra-image-types",
- "clap 4.5.23",
- "ctrlc",
- "elf 0.7.4",
- "emulator-bus",
- "emulator-caliptra",
- "emulator-cpu",
- "emulator-periph",
- "emulator-registers-generated",
- "gdbstub",
- "gdbstub_arch",
- "hex",
  "mcu-builder",
- "tock-registers",
- "zerocopy 0.8.23",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -24,6 +24,23 @@ cargo xtask precheckin
 
 Commands such as `cargo b` and `cargo t` will also work, but won't execute the extra tests and RISC-V firmware builds.
 
+## Running the emulators
+
+Both the Caliptra Core and MCU emulator will run if you use the `runtime` xtask:
+
+```shell
+cargo xtask runtime
+```
+
+By default, Caliptra runs in passive mode, but active mode is also support via a command-line flag:
+
+```shell
+cargo xtask runtime --active-mode
+```
+
+This uses the full [active, or subsystem, mode boot flow](https://chipsalliance.github.io/caliptra-mcu-sw/rom.html#cold-boot-flow).
+
+
 ## Documentation
 
 The specification is published [here](https://chipsalliance.github.io/caliptra-mcu-sw/).

--- a/builder/Cargo.toml
+++ b/builder/Cargo.toml
@@ -6,7 +6,16 @@ edition = "2021"
 
 [dependencies]
 anyhow.workspace = true
+caliptra-auth-man-gen.workspace = true
+caliptra-auth-man-types.workspace = true
+caliptra-builder.workspace = true
+caliptra-image-crypto.workspace = true
+caliptra-image-fake-keys.workspace = true
+caliptra-image-gen.workspace = true
+caliptra-image-types.workspace = true
 elf.workspace = true
 emulator-consts.workspace = true
+hex.workspace = true
 semver.workspace = true
 walkdir.workspace = true
+zerocopy.workspace = true

--- a/builder/src/caliptra.rs
+++ b/builder/src/caliptra.rs
@@ -1,0 +1,209 @@
+// Licensed under the Apache-2.0 license
+
+//! Wrappers around the Caliptra builder library to make it easier to build
+//! the ROM, firwmare, and SoC manifest.
+
+use crate::PROJECT_ROOT;
+use anyhow::{bail, Result};
+use caliptra_auth_man_gen::{
+    AuthManifestGenerator, AuthManifestGeneratorConfig, AuthManifestGeneratorKeyConfig,
+};
+use caliptra_auth_man_types::{
+    AuthManifestFlags, AuthManifestImageMetadata, AuthManifestPrivKeys, AuthManifestPubKeys,
+    AuthorizationManifest, ImageMetadataFlags,
+};
+use caliptra_image_crypto::RustCrypto as Crypto;
+use caliptra_image_fake_keys::*;
+use caliptra_image_gen::{from_hw_format, ImageGeneratorCrypto};
+use caliptra_image_types::FwVerificationPqcKeyType;
+use hex::ToHex;
+use std::path::PathBuf;
+use zerocopy::IntoBytes;
+
+pub struct CaliptraBuilder {
+    active_mode: bool,
+    caliptra_rom: Option<PathBuf>,
+    caliptra_firmware: Option<PathBuf>,
+    soc_manifest: Option<PathBuf>,
+    vendor_pk_hash: Option<String>,
+    mcu_firmware: Option<PathBuf>,
+}
+
+impl CaliptraBuilder {
+    pub fn new(
+        active_mode: bool,
+        caliptra_rom: Option<PathBuf>,
+        caliptra_firmware: Option<PathBuf>,
+        soc_manifest: Option<PathBuf>,
+        vendor_pk_hash: Option<String>,
+        mcu_firmware: Option<PathBuf>,
+    ) -> Self {
+        Self {
+            active_mode,
+            caliptra_rom,
+            caliptra_firmware,
+            soc_manifest,
+            vendor_pk_hash,
+            mcu_firmware,
+        }
+    }
+
+    pub fn get_caliptra_rom(&self) -> Result<PathBuf> {
+        if let Some(caliptra_rom) = &self.caliptra_rom {
+            if !caliptra_rom.exists() {
+                bail!("Caliptra ROM file not found: {:?}", caliptra_rom);
+            }
+            Ok(caliptra_rom.clone())
+        } else {
+            Self::compile_caliptra_rom()
+        }
+    }
+
+    pub fn get_caliptra_fw(&mut self) -> Result<PathBuf> {
+        if let Some(caliptra_firmware) = self.caliptra_firmware.as_ref() {
+            if !caliptra_firmware.exists() {
+                bail!("Caliptra runtime bundle not found: {:?}", caliptra_firmware);
+            }
+            if self.active_mode && self.vendor_pk_hash.is_none() {
+                bail!("Vendor public key hash is required for active mode if Caliptra FW is passed as an argument");
+            }
+        } else {
+            let (path, vendor_pk_hash) = Self::compile_caliptra_fw()?;
+            self.vendor_pk_hash = Some(vendor_pk_hash);
+            self.caliptra_firmware = Some(path);
+        }
+        Ok(self.caliptra_firmware.clone().unwrap())
+    }
+
+    pub fn get_soc_manifest(&mut self) -> Result<PathBuf> {
+        if self.soc_manifest.is_none() {
+            let _ = self.get_caliptra_fw()?;
+        }
+        // check if we wrote it already when compiling the firmware
+        if self.soc_manifest.is_none() {
+            if self.mcu_firmware.is_none() {
+                bail!("MCU firmware is required to build SoC manifest");
+            }
+            let path = Self::write_soc_manifest(self.mcu_firmware.as_ref().unwrap())?;
+            self.soc_manifest = Some(path);
+        }
+        Ok(self.soc_manifest.clone().unwrap())
+    }
+
+    pub fn get_vendor_pk_hash(&mut self) -> Result<&str> {
+        if self.vendor_pk_hash.is_none() {
+            let _ = self.get_caliptra_fw()?;
+        }
+        Ok(self.vendor_pk_hash.as_ref().unwrap())
+    }
+
+    fn write_soc_manifest(runtime_path: &PathBuf) -> Result<PathBuf> {
+        const IMAGE_SOURCE_IN_REQUEST: u32 = 1;
+        let data = std::fs::read(runtime_path).unwrap();
+        let mut flags = ImageMetadataFlags(0);
+        flags.set_image_source(IMAGE_SOURCE_IN_REQUEST);
+        let crypto = Crypto::default();
+        let digest = from_hw_format(&crypto.sha384_digest(&data)?);
+        let metadata = vec![AuthManifestImageMetadata {
+            fw_id: 0,
+            flags: flags.0,
+            digest,
+        }];
+        let manifest = Self::create_auth_manifest_with_metadata(metadata);
+
+        let path = PROJECT_ROOT.join("target").join("soc-manifest");
+        std::fs::write(&path, manifest.as_bytes())?;
+        Ok(path)
+    }
+
+    fn compile_caliptra_rom() -> Result<PathBuf> {
+        let rom_bytes = caliptra_builder::rom_for_fw_integration_tests()?;
+        let path = PROJECT_ROOT.join("target").join("caliptra-rom.bin");
+        std::fs::write(&path, rom_bytes)?;
+        Ok(path)
+    }
+
+    fn compile_caliptra_fw() -> Result<(PathBuf, String)> {
+        let opts = caliptra_builder::ImageOptions {
+            pqc_key_type: FwVerificationPqcKeyType::LMS,
+            ..Default::default()
+        };
+        let bundle = caliptra_builder::build_and_sign_image(
+            &caliptra_builder::firmware::FMC_WITH_UART,
+            &caliptra_builder::firmware::APP_WITH_UART,
+            opts,
+        )?;
+        let crypto = Crypto::default();
+        let vendor_pk_hash = from_hw_format(
+            &crypto.sha384_digest(bundle.manifest.preamble.vendor_pub_key_info.as_bytes())?,
+        )
+        .encode_hex();
+        let fw_bytes = bundle.to_bytes()?;
+        let path = PROJECT_ROOT.join("target").join("caliptra-fw-bundle.bin");
+        std::fs::write(&path, fw_bytes)?;
+        Ok((path, vendor_pk_hash))
+    }
+
+    pub fn create_auth_manifest_with_metadata(
+        image_metadata_list: Vec<AuthManifestImageMetadata>,
+    ) -> AuthorizationManifest {
+        let vendor_fw_key_info: AuthManifestGeneratorKeyConfig = AuthManifestGeneratorKeyConfig {
+            pub_keys: AuthManifestPubKeys {
+                ecc_pub_key: VENDOR_ECC_KEY_0_PUBLIC,
+                lms_pub_key: VENDOR_LMS_KEY_0_PUBLIC,
+            },
+            priv_keys: Some(AuthManifestPrivKeys {
+                ecc_priv_key: VENDOR_ECC_KEY_0_PRIVATE,
+                lms_priv_key: VENDOR_LMS_KEY_0_PRIVATE,
+            }),
+        };
+
+        let vendor_man_key_info: AuthManifestGeneratorKeyConfig = AuthManifestGeneratorKeyConfig {
+            pub_keys: AuthManifestPubKeys {
+                ecc_pub_key: VENDOR_ECC_KEY_1_PUBLIC,
+                lms_pub_key: VENDOR_LMS_KEY_1_PUBLIC,
+            },
+            priv_keys: Some(AuthManifestPrivKeys {
+                ecc_priv_key: VENDOR_ECC_KEY_1_PRIVATE,
+                lms_priv_key: VENDOR_LMS_KEY_1_PRIVATE,
+            }),
+        };
+
+        let owner_fw_key_info: Option<AuthManifestGeneratorKeyConfig> =
+            Some(AuthManifestGeneratorKeyConfig {
+                pub_keys: AuthManifestPubKeys {
+                    ecc_pub_key: OWNER_ECC_KEY_PUBLIC,
+                    lms_pub_key: OWNER_LMS_KEY_PUBLIC,
+                },
+                priv_keys: Some(AuthManifestPrivKeys {
+                    ecc_priv_key: OWNER_ECC_KEY_PRIVATE,
+                    lms_priv_key: OWNER_LMS_KEY_PRIVATE,
+                }),
+            });
+
+        let owner_man_key_info: Option<AuthManifestGeneratorKeyConfig> =
+            Some(AuthManifestGeneratorKeyConfig {
+                pub_keys: AuthManifestPubKeys {
+                    ecc_pub_key: OWNER_ECC_KEY_PUBLIC,
+                    lms_pub_key: OWNER_LMS_KEY_PUBLIC,
+                },
+                priv_keys: Some(AuthManifestPrivKeys {
+                    ecc_priv_key: OWNER_ECC_KEY_PRIVATE,
+                    lms_priv_key: OWNER_LMS_KEY_PRIVATE,
+                }),
+            });
+
+        let gen_config: AuthManifestGeneratorConfig = AuthManifestGeneratorConfig {
+            vendor_fw_key_info,
+            vendor_man_key_info,
+            owner_fw_key_info,
+            owner_man_key_info,
+            image_metadata_list,
+            version: 1,
+            flags: AuthManifestFlags::VENDOR_SIGNATURE_REQUIRED,
+        };
+
+        let gen = AuthManifestGenerator::new(Crypto::default());
+        gen.generate(&gen_config).unwrap()
+    }
+}

--- a/builder/src/lib.rs
+++ b/builder/src/lib.rs
@@ -1,10 +1,12 @@
 // Licensed under the Apache-2.0 license
 
 mod apps;
+mod caliptra;
 mod rom;
 mod runtime;
 mod tbf;
 
+pub use caliptra::CaliptraBuilder;
 pub use rom::rom_build;
 pub use runtime::{runtime_build_no_apps, runtime_build_with_apps};
 

--- a/emulator/app/src/main.rs
+++ b/emulator/app/src/main.rs
@@ -323,6 +323,11 @@ fn run(cli: Emulator, capture_uart_output: bool) -> io::Result<Vec<u8>> {
             rom: cli.caliptra_rom.unwrap(),
             device_lifecycle: Some("production".into()),
             active_mode,
+            firmware: if active_mode {
+                None
+            } else {
+                cli.caliptra_firmware.clone()
+            },
             ..Default::default()
         })
         .expect("Failed to start Caliptra CPU");

--- a/tests/integration/Cargo.toml
+++ b/tests/integration/Cargo.toml
@@ -8,27 +8,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-caliptra-auth-man-gen.workspace = true
-caliptra-auth-man-types.workspace = true
-caliptra-builder.workspace = true
-caliptra-emu-cpu.workspace = true
-caliptra-emu-periph.workspace = true
-caliptra-emu-types.workspace = true
-caliptra-image-crypto.workspace = true
-caliptra-image-fake-keys.workspace = true
-caliptra-image-gen.workspace = true
-caliptra-image-types.workspace = true
-clap.workspace = true
-ctrlc.workspace = true
-elf.workspace = true
-emulator-bus.workspace = true
-emulator-caliptra.workspace = true
-emulator-cpu.workspace = true
-emulator-periph.workspace = true
-emulator-registers-generated.workspace = true
-gdbstub_arch.workspace = true
-gdbstub.workspace = true
-hex.workspace = true
 mcu-builder.workspace = true
-tock-registers.workspace = true
-zerocopy.workspace = true

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -57,9 +57,6 @@ enum Commands {
 
         #[arg(long)]
         vendor_pk_hash: Option<String>,
-
-        #[arg(long)]
-        owner_pk_hash: Option<String>,
     },
     /// Build Runtime image
     RuntimeBuild {


### PR DESCRIPTION
Caliptra Core will now always run, since we will start using it soon for mailbox commands.

To make it easier to use, we now automatically build Caliptra ROM, FW, and SoC manifest if they are not passed in.

I factored out the `CaliptraBuilder` struct to make it easier for it to reason about when to automatically build the FW if not provided, when to build the SoC manifest if not provided, etc.