### PR TITLE
[FW Update Agent] Implement RequestFirmwareData and TransferComplete PLDM Commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2532,6 +2532,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "serde",
+ "tempfile",
  "toml",
  "uuid",
 ]
@@ -2555,11 +2556,13 @@ dependencies = [
 name = "pldm-ua"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "log",
  "pldm-common",
  "pldm-fw-pkg",
  "simple_logger",
  "smlang 0.8.0",
+ "uuid",
 ]
 
 [[package]]

--- a/emulator/bmc/pldm-fw-pkg/Cargo.toml
+++ b/emulator/bmc/pldm-fw-pkg/Cargo.toml
@@ -19,3 +19,4 @@ crc.workspace = true
 clap.workspace = true
 num-traits.workspace = true
 num-derive.workspace = true
+tempfile.workspace = true

--- a/emulator/bmc/pldm-fw-pkg/src/main.rs
+++ b/emulator/bmc/pldm-fw-pkg/src/main.rs
@@ -89,7 +89,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         Some(("decode", sub_matches)) => {
             let package_path = sub_matches.get_one("package").unwrap();
             let output_dir = sub_matches.get_one("dir").unwrap();
-            FirmwareManifest::decode_firmware_package(package_path, output_dir)
+            FirmwareManifest::decode_firmware_package(package_path, Some(output_dir))
                 .expect("Failed to decode the firmware package");
             println!("Decoded FirmwarePackage to directory: {}", output_dir);
         }

--- a/emulator/bmc/pldm-fw-pkg/src/manifest.rs
+++ b/emulator/bmc/pldm-fw-pkg/src/manifest.rs
@@ -1579,7 +1579,7 @@ impl ComponentImageInformation {
 
     fn verify(&self) -> Result<(), String> {
         if let Some(image_location) = &self.image_location {
-            // Verify image_location length is less than 255
+            // Verify file exists in the image location
             if fs::metadata(image_location).is_err() {
                 return Err(format!(
                     "Component image file does not exist: {}",

--- a/emulator/bmc/pldm-fw-pkg/src/manifest.rs
+++ b/emulator/bmc/pldm-fw-pkg/src/manifest.rs
@@ -64,7 +64,7 @@ pub struct DownstreamDeviceIdRecord {
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct ComponentImageInformation {
-    pub image_location: String,
+    pub image_location: Option<String>,
     pub classification: u16,
     pub identifier: u16,
     pub comparison_stamp: Option<u32>, // Optional uint32 based on ComponentOptions
@@ -77,6 +77,8 @@ pub struct ComponentImageInformation {
     pub offset: u32,  // Offset to the start of the image
     #[serde(skip)]
     pub size: u32,    // Size of the image
+    #[serde(skip)]
+    pub image_data: Option<Vec<u8>>, // Optional image data, to be filled when package is decoded
 }
 
 #[derive(Debug, PartialEq)]
@@ -462,10 +464,22 @@ impl FirmwareManifest {
 
         // For each component, read the image data from the file and append to the image_data buffer
         for component in &self.component_image_information {
-            let mut file = File::open(&component.image_location)?;
-            let mut data = Vec::new();
-            file.read_to_end(&mut data)?;
-            image_data.append(&mut data);
+            if let Some(location) = &component.image_location {
+                // Read the image data from the file
+                let mut file = File::open(location)?;
+                let mut data = Vec::new();
+                file.read_to_end(&mut data)?;
+                image_data.append(&mut data);
+            } else if let Some(data) = &component.image_data {
+                // If image_data is provided, use it directly
+                let mut data = data.clone();
+                image_data.append(&mut data);
+            } else {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "No image data or location provided for component",
+                ));
+            }
         }
 
         // Calculate the checksum of the package header
@@ -501,24 +515,27 @@ impl FirmwareManifest {
 
     pub fn decode_firmware_package(
         fw_package_file_path: &String,
-        output_dir_path: &String,
+        output_dir_path: Option<&String>,
     ) -> io::Result<Self> {
-        match fs::metadata(output_dir_path) {
-            Ok(metadata) => {
-                if !metadata.is_dir() {
+        if let Some(output_dir_path) = output_dir_path {
+            match fs::metadata(output_dir_path) {
+                Ok(metadata) => {
+                    if !metadata.is_dir() {
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidInput,
+                            format!("{} is not a directory", output_dir_path),
+                        ));
+                    }
+                }
+                Err(_) => {
                     return Err(io::Error::new(
                         io::ErrorKind::InvalidInput,
-                        format!("{} is not a directory", output_dir_path),
+                        format!("{} does not exist", output_dir_path),
                     ));
                 }
             }
-            Err(_) => {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidInput,
-                    format!("{} does not exist", output_dir_path),
-                ));
-            }
         }
+
         let bin_file = File::open(fw_package_file_path)?;
         let mut reader = BufReader::new(bin_file);
 
@@ -603,12 +620,16 @@ impl FirmwareManifest {
             let mut image_data = vec![0u8; size];
             // Read the image data from the reader
             reader.read_exact(&mut image_data)?;
-            // Write the image data to a file, the filename has a prefix of img_xx where xx is the component identifier
-            let file_path = format!("{}/img_{:02}.bin", output_dir_path, component_idx);
-            let mut file = File::create(&file_path)?;
-            file.write_all(&image_data)?;
-            // Update the image location of the component to the filename
-            component.image_location = file_path;
+            if output_dir_path.is_some() {
+                // Write the image data to a file, the filename has a prefix of img_xx where xx is the component identifier
+                let file_path =
+                    format!("{}/img_{:02}.bin", output_dir_path.unwrap(), component_idx);
+                let mut file = File::create(&file_path)?;
+                file.write_all(&image_data)?;
+                // Update the image location of the component to the filename
+                component.image_location = Some(file_path);
+            }
+            component.image_data = Some(image_data);
         }
 
         let manifest = FirmwareManifest {
@@ -618,10 +639,12 @@ impl FirmwareManifest {
             component_image_information,
         };
 
-        let manifest_data = toml::to_string(&manifest).expect("Failed to encode TOML");
-        let file_path = format!("{}/manifest.toml", output_dir_path);
-        let mut file = File::create(&file_path)?;
-        file.write_all(manifest_data.as_bytes())?;
+        if let Some(output_dir_path) = output_dir_path {
+            let manifest_data = toml::to_string(&manifest).expect("Failed to encode TOML");
+            let file_path = format!("{}/manifest.toml", output_dir_path);
+            let mut file = File::create(&file_path)?;
+            file.write_all(manifest_data.as_bytes())?;
+        }
 
         Ok(manifest)
     }
@@ -1396,8 +1419,12 @@ impl ComponentImageInformation {
         writer.write_all(&offset.to_le_bytes())?;
 
         // Encode size (u32)
-        let metadata = std::fs::metadata(&self.image_location)?;
-        let file_size = metadata.len() as u32;
+        let mut file_size = 0u32;
+        if let Some(image_location) = &self.image_location {
+            file_size = image_location.len() as u32;
+        } else if let Some(image_data) = &self.image_data {
+            file_size = image_data.len() as u32;
+        }
         writer.write_all(&file_size.to_le_bytes())?;
 
         // Encode version_string_type (u8)
@@ -1506,10 +1533,8 @@ impl ComponentImageInformation {
             None
         };
 
-        let image_location = String::from("");
-
         Ok(ComponentImageInformation {
-            image_location,
+            image_location: None,
             classification,
             identifier,
             comparison_stamp,
@@ -1520,6 +1545,7 @@ impl ComponentImageInformation {
             opaque_data,
             offset,
             size,
+            image_data: None,
         })
     }
 
@@ -1552,12 +1578,16 @@ impl ComponentImageInformation {
     }
 
     fn verify(&self) -> Result<(), String> {
-        // Verify image_location exists
-        if fs::metadata(&self.image_location).is_err() {
-            return Err(format!(
-                "Component image file does not exist: {}",
-                self.image_location
-            ));
+        if let Some(image_location) = &self.image_location {
+            // Verify image_location length is less than 255
+            if fs::metadata(image_location).is_err() {
+                return Err(format!(
+                    "Component image file does not exist: {}",
+                    image_location
+                ));
+            }
+        } else if self.image_data.is_none() {
+            return Err("Component image location or image data must be provided.".to_string());
         }
         // Verify version_string length is less than 255
         if let Some(ref version_string) = self.version_string {

--- a/emulator/bmc/pldm-fw-pkg/tests/test_decode.rs
+++ b/emulator/bmc/pldm-fw-pkg/tests/test_decode.rs
@@ -1,11 +1,6 @@
 // Licensed under the Apache-2.0 license
 
 use chrono::Utc;
-/*++
-
-Licensed under the Apache-2.0 license.
-
---*/
 use pldm_fw_pkg::{
     manifest::{
         ComponentImageInformation, Descriptor, DescriptorType, FirmwareDeviceIdRecord,

--- a/emulator/bmc/pldm-fw-pkg/tests/test_decode.rs
+++ b/emulator/bmc/pldm-fw-pkg/tests/test_decode.rs
@@ -1,0 +1,202 @@
+// Licensed under the Apache-2.0 license
+
+use chrono::Utc;
+/*++
+
+Licensed under the Apache-2.0 license.
+
+--*/
+use pldm_fw_pkg::{
+    manifest::{
+        ComponentImageInformation, Descriptor, DescriptorType, FirmwareDeviceIdRecord,
+        PackageHeaderInformation, StringType,
+    },
+    FirmwareManifest,
+};
+use uuid::Uuid;
+
+#[test]
+fn test_encode_decode_firmware_package() {
+    // Define a sample FirmwareManifest instance
+    let manifest = FirmwareManifest {
+        package_header_information: PackageHeaderInformation {
+            package_header_identifier: Uuid::parse_str("7B291C996DB64208801B02026E463C78").unwrap(),
+            package_header_format_revision: 1,
+            package_release_date_time: Utc::now(),
+            package_version_string_type: StringType::Utf8,
+            package_version_string: Some("1.0.0".to_string()),
+            package_header_size: 0, // This will be computed during encoding
+        },
+        firmware_device_id_records: vec![FirmwareDeviceIdRecord {
+            firmware_device_package_data: Some(vec![0x01, 0x02, 0x03, 0x04]),
+            device_update_option_flags: 0xFFFF_FFFF,
+            component_image_set_version_string_type: StringType::Ascii,
+            component_image_set_version_string: Some("ComponentV1".to_string()),
+            applicable_components: Some(vec![0x00]),
+            initial_descriptor: Descriptor {
+                descriptor_type: DescriptorType::Uuid,
+                descriptor_data: vec![0xAA, 0xBB, 0xCC],
+            },
+            additional_descriptors: None,
+            reference_manifest_data: None,
+        }],
+        downstream_device_id_records: None,
+        component_image_information: vec![ComponentImageInformation {
+            image_location: None,
+            classification: 0x0001,
+            identifier: 0x0002,
+            comparison_stamp: Some(999),
+            options: 0xAABB,
+            requested_activation_method: 0x1122,
+            version_string_type: StringType::Utf8,
+            version_string: Some("FirmwareV1".to_string()),
+            opaque_data: Some(vec![0x77, 0x88, 0x99]),
+            offset: 0, // Will be calculated in encoding
+            size: 256,
+            image_data: Some(vec![0x55u8; 256]),
+        }],
+    };
+
+    // Create a temporary file to store the encoded firmware package, use NamedTempFile
+    let temp_file = tempfile::NamedTempFile::new().unwrap();
+    let temp_path = temp_file.path().to_path_buf();
+    let temp_path_str = temp_path.to_str().unwrap();
+    println!("Temporary file path: {}", temp_path_str);
+    // Encode the firmware package to the temporary file
+    let result = FirmwareManifest::generate_firmware_package(&manifest, &temp_path_str.to_string());
+    assert!(
+        result.is_ok(),
+        "Failed to encode firmware package: {:?}",
+        result.err()
+    );
+    println!("Encoded firmware package to: {}", temp_path_str);
+    // Decode the firmware package from the temporary file
+    let decoded_manifest =
+        FirmwareManifest::decode_firmware_package(&temp_path_str.to_string(), None);
+    assert!(
+        decoded_manifest.is_ok(),
+        "Failed to decode firmware package: {:?}",
+        decoded_manifest.err()
+    );
+    let decoded_manifest = decoded_manifest.unwrap();
+
+    // Verify that the decoded manifest matches the original
+    assert_eq!(
+        decoded_manifest
+            .package_header_information
+            .package_header_identifier,
+        manifest
+            .package_header_information
+            .package_header_identifier
+    );
+    assert_eq!(
+        decoded_manifest
+            .package_header_information
+            .package_header_format_revision,
+        manifest
+            .package_header_information
+            .package_header_format_revision
+    );
+    assert_eq!(
+        decoded_manifest
+            .package_header_information
+            .package_version_string_type,
+        manifest
+            .package_header_information
+            .package_version_string_type
+    );
+    assert_eq!(
+        decoded_manifest
+            .package_header_information
+            .package_version_string,
+        manifest.package_header_information.package_version_string
+    );
+    assert_eq!(
+        decoded_manifest.firmware_device_id_records.len(),
+        manifest.firmware_device_id_records.len()
+    );
+    assert_eq!(
+        decoded_manifest.component_image_information.len(),
+        manifest.component_image_information.len()
+    );
+    assert_eq!(
+        decoded_manifest.firmware_device_id_records[0].firmware_device_package_data,
+        manifest.firmware_device_id_records[0].firmware_device_package_data
+    );
+    assert_eq!(
+        decoded_manifest.firmware_device_id_records[0].device_update_option_flags,
+        manifest.firmware_device_id_records[0].device_update_option_flags
+    );
+    assert_eq!(
+        decoded_manifest.firmware_device_id_records[0].component_image_set_version_string_type,
+        manifest.firmware_device_id_records[0].component_image_set_version_string_type
+    );
+    assert_eq!(
+        decoded_manifest.firmware_device_id_records[0].component_image_set_version_string,
+        manifest.firmware_device_id_records[0].component_image_set_version_string
+    );
+    assert_eq!(
+        decoded_manifest.firmware_device_id_records[0].applicable_components,
+        manifest.firmware_device_id_records[0].applicable_components
+    );
+    assert_eq!(
+        decoded_manifest.firmware_device_id_records[0]
+            .initial_descriptor
+            .descriptor_type,
+        manifest.firmware_device_id_records[0]
+            .initial_descriptor
+            .descriptor_type
+    );
+    assert_eq!(
+        decoded_manifest.firmware_device_id_records[0]
+            .initial_descriptor
+            .descriptor_data,
+        manifest.firmware_device_id_records[0]
+            .initial_descriptor
+            .descriptor_data
+    );
+    assert_eq!(
+        decoded_manifest.component_image_information[0].classification,
+        manifest.component_image_information[0].classification
+    );
+    assert_eq!(
+        decoded_manifest.component_image_information[0].identifier,
+        manifest.component_image_information[0].identifier
+    );
+    assert_eq!(
+        decoded_manifest.component_image_information[0].comparison_stamp,
+        manifest.component_image_information[0].comparison_stamp
+    );
+    assert_eq!(
+        decoded_manifest.component_image_information[0].options,
+        manifest.component_image_information[0].options
+    );
+    assert_eq!(
+        decoded_manifest.component_image_information[0].requested_activation_method,
+        manifest.component_image_information[0].requested_activation_method
+    );
+    assert_eq!(
+        decoded_manifest.component_image_information[0].version_string_type,
+        manifest.component_image_information[0].version_string_type
+    );
+    assert_eq!(
+        decoded_manifest.component_image_information[0].version_string,
+        manifest.component_image_information[0].version_string
+    );
+    assert_eq!(
+        decoded_manifest.component_image_information[0].opaque_data,
+        manifest.component_image_information[0].opaque_data
+    );
+    assert_eq!(
+        decoded_manifest.component_image_information[0].image_data,
+        manifest.component_image_information[0].image_data
+    );
+    assert_eq!(
+        decoded_manifest.component_image_information[0].size,
+        manifest.component_image_information[0].size
+    );
+    assert_eq!(
+        decoded_manifest.component_image_information[0].image_data,
+        manifest.component_image_information[0].image_data
+    );
+}

--- a/emulator/bmc/pldm-fw-pkg/tests/test_encode.rs
+++ b/emulator/bmc/pldm-fw-pkg/tests/test_encode.rs
@@ -193,7 +193,10 @@ fn test_parse_valid_manifest_all_fields_present() {
 
     // Verify component_image_information (First component)
     let component_1 = &parsed_manifest.component_image_information[0];
-    assert_eq!(component_1.image_location, "tests/manifests/img_128.bin");
+    assert_eq!(
+        component_1.image_location.as_ref().unwrap(),
+        "tests/manifests/img_128.bin"
+    );
     assert_eq!(component_1.classification, 0x0001);
     assert_eq!(component_1.identifier, 0x0010);
     assert_eq!(component_1.comparison_stamp.unwrap(), 12345);
@@ -208,7 +211,10 @@ fn test_parse_valid_manifest_all_fields_present() {
 
     // Verify component_image_information (Second component)
     let component_2 = &parsed_manifest.component_image_information[1];
-    assert_eq!(component_2.image_location, "tests/manifests/img_512.bin");
+    assert_eq!(
+        component_2.image_location.as_ref().unwrap(),
+        "tests/manifests/img_512.bin"
+    );
     assert_eq!(component_2.classification, 0xFFFF);
     assert_eq!(component_2.identifier, 0x0020);
     assert_eq!(component_2.comparison_stamp.unwrap(), 54321);
@@ -361,7 +367,10 @@ fn test_parse_valid_manifest_no_downstream_one_component() {
     // Verify component_image_information (First component)
     assert_eq!(parsed_manifest.component_image_information.len(), 1);
     let component_1 = &parsed_manifest.component_image_information[0];
-    assert_eq!(component_1.image_location, "tests/manifests/img_128.bin");
+    assert_eq!(
+        component_1.image_location.as_ref().unwrap(),
+        "tests/manifests/img_128.bin"
+    );
     assert_eq!(component_1.classification, 0x0001);
     assert_eq!(component_1.identifier, 0x0010);
     assert_eq!(component_1.comparison_stamp.unwrap(), 12345);

--- a/emulator/bmc/pldm-ua/Cargo.toml
+++ b/emulator/bmc/pldm-ua/Cargo.toml
@@ -13,6 +13,8 @@ pldm-fw-pkg.workspace = true
 smlang.workspace = true
 
 [dev-dependencies]
+chrono.workspace = true
 simple_logger.workspace = true
+uuid.workspace = true
 
 

--- a/emulator/bmc/pldm-ua/src/update_sm.rs
+++ b/emulator/bmc/pldm-ua/src/update_sm.rs
@@ -6,21 +6,24 @@ use crate::transport::{PldmSocket, RxPacket};
 use log::{debug, error, info};
 use pldm_common::codec::PldmCodec;
 use pldm_common::message::firmware_update as pldm_packet;
+use pldm_common::message::firmware_update::transfer_complete::TransferResult;
 use pldm_common::protocol::base::{
     InstanceId, PldmBaseCompletionCode, PldmMsgHeader, PldmMsgType, PldmSupportedType,
     TransferRespFlag,
 };
 use pldm_common::protocol::firmware_update::{
     ComponentClassification, ComponentCompatibilityResponse, ComponentParameterEntry,
-    ComponentResponseCode, FwUpdateCmd, PldmFirmwareString, UpdateOptionFlags, VersionStringType,
-    PLDM_FWUP_IMAGE_SET_VER_STR_MAX_LEN,
+    ComponentResponseCode, FwUpdateCmd, FwUpdateCompletionCode, PldmFirmwareString,
+    UpdateOptionFlags, VersionStringType, PLDM_FWUP_IMAGE_SET_VER_STR_MAX_LEN,
 };
 use pldm_fw_pkg::manifest::{ComponentImageInformation, FirmwareDeviceIdRecord};
 use pldm_fw_pkg::FirmwareManifest;
 use smlang::statemachine;
+use std::cmp::{max, min};
 use std::sync::mpsc::Sender;
 
-const MAX_TRANSFER_SIZE: u32 = 64;
+const MAX_TRANSFER_SIZE: u32 = 64; // Maximum bytes to transfer in one request
+const BASELINE_TRANSFER_SIZE: u32 = 32; // Minimum bytes to transfer in one request
 const MAX_OUTSTANDING_TRANSFER_REQ: u8 = 1;
 
 // Define the state machine
@@ -44,7 +47,8 @@ statemachine! {
         ReadyXfer + StartDownload / on_start_download = Download,
         ReadyXfer + CancelUpdateComponent  / on_stop_update = Idle,
 
-        Download + RequestFirmwareData / on_request_firmware = Download,
+        Download + RequestFirmwareData(pldm_packet::request_fw_data::RequestFirmwareDataRequest) / on_request_firmware = Download,
+        Download + TransferComplete(pldm_packet::transfer_complete::TransferCompleteRequest) / on_transfer_complete_request = Download,
         Download + TransferCompleteFail / on_transfer_fail = Idle,
         Download + TransferCompletePass / on_transfer_success = Verify,
         Download + CancelUpdate  / on_stop_update = Idle,
@@ -551,18 +555,100 @@ pub trait StateMachineActions {
         Ok(())
     }
 
-    fn on_request_firmware(&mut self, _ctx: &mut InnerContext<impl PldmSocket>) -> Result<(), ()> {
-        // TODO
-        Ok(())
+    fn on_request_firmware(
+        &mut self,
+        ctx: &mut InnerContext<impl PldmSocket>,
+        request: pldm_packet::request_fw_data::RequestFirmwareDataRequest,
+    ) -> Result<(), ()> {
+        if request.length > MAX_TRANSFER_SIZE || request.length < BASELINE_TRANSFER_SIZE {
+            error!("RequestFirmwareDataRequest length is invalid");
+            let response = pldm_packet::request_fw_data::RequestFirmwareDataResponse::new(
+                request.hdr.instance_id(),
+                PldmBaseCompletionCode::InvalidLength as u8,
+                &[],
+            );
+            return send_request_helper(&ctx.socket, &response);
+        }
+
+        let component = &ctx.components[ctx.current_component_index.unwrap()];
+        if let Some(data) = &component.image_data {
+            if (request.offset + request.length) as usize
+                >= data.len() + BASELINE_TRANSFER_SIZE as usize
+            {
+                error!("RequestFirmwareDataRequest offset is out of bounds");
+                let response = pldm_packet::request_fw_data::RequestFirmwareDataResponse::new(
+                    request.hdr.instance_id(),
+                    FwUpdateCompletionCode::DataOutOfRange as u8,
+                    &[],
+                );
+                return send_request_helper(&ctx.socket, &response);
+            }
+            let mut buffer = [0u8; MAX_TRANSFER_SIZE as usize];
+            let mut to_copy = min(
+                data.len() as i32 - request.offset as i32,
+                request.length as i32,
+            );
+            to_copy = max(to_copy, 0); // Ensure to_copy is not negative
+            let mut to_pad = min(
+                0,
+                request.length as i32 - (data.len() as i32 - request.offset as i32),
+            );
+            to_pad = max(to_pad, 0); // Ensure to_pad is not negative
+
+            if to_copy > 0 {
+                buffer[..to_copy as usize].copy_from_slice(
+                    &data[request.offset as usize..(request.offset as usize + to_copy as usize)],
+                );
+            }
+            if to_pad > 0 {
+                buffer[to_copy as usize..(to_copy + to_pad) as usize].fill(0);
+            }
+
+            let response = pldm_packet::request_fw_data::RequestFirmwareDataResponse::new(
+                request.hdr.instance_id(),
+                PldmBaseCompletionCode::Success as u8,
+                &buffer[..request.length as usize],
+            );
+            send_request_helper(&ctx.socket, &response)
+        } else {
+            error!("No image data found, make sure the image is decoded correctly");
+            Err(())
+        }
     }
 
-    fn on_transfer_fail(&mut self, _ctx: &mut InnerContext<impl PldmSocket>) -> Result<(), ()> {
-        // TODO
+    fn on_transfer_complete_request(
+        &mut self,
+        ctx: &mut InnerContext<impl PldmSocket>,
+        request: pldm_packet::transfer_complete::TransferCompleteRequest,
+    ) -> Result<(), ()> {
+        let response = pldm_packet::transfer_complete::TransferCompleteResponse::new(
+            request.hdr.instance_id(),
+            PldmBaseCompletionCode::Success as u8,
+        );
+        send_request_helper(&ctx.socket, &response)?;
+
+        if request.tranfer_result == TransferResult::TransferSuccess as u8 {
+            info!("Transfer complete success");
+            ctx.event_queue
+                .send(PldmEvents::Update(Events::TransferCompletePass))
+                .map_err(|_| ())?;
+        } else {
+            error!("Transfer complete failed");
+            ctx.event_queue
+                .send(PldmEvents::Update(Events::TransferCompleteFail))
+                .map_err(|_| ())?;
+        }
+        Ok(())
+    }
+    fn on_transfer_fail(&mut self, ctx: &mut InnerContext<impl PldmSocket>) -> Result<(), ()> {
+        let request =
+            pldm_packet::request_cancel::CancelUpdateComponentRequest::new(0, PldmMsgType::Request);
+        send_request_helper(&ctx.socket, &request)?;
         Ok(())
     }
 
     fn on_transfer_success(&mut self, _ctx: &mut InnerContext<impl PldmSocket>) -> Result<(), ()> {
-        // TODO
+        // No action, wait for VerifyComplete from device
         Ok(())
     }
 
@@ -656,6 +742,12 @@ pub fn process_packet(packet: &RxPacket) -> Result<PldmEvents, ()> {
             }
             FwUpdateCmd::UpdateComponent => {
                 packet_to_event(&header, packet, true, Events::UpdateComponentResponse)
+            }
+            FwUpdateCmd::RequestFirmwareData => {
+                packet_to_event(&header, packet, false, Events::RequestFirmwareData)
+            }
+            FwUpdateCmd::TransferComplete => {
+                packet_to_event(&header, packet, false, Events::TransferComplete)
             }
             _ => {
                 debug!("Unknown firmware update command");
@@ -753,7 +845,8 @@ impl<T: StateMachineActions, S: PldmSocket> StateMachineContext for Context<T, S
         on_pass_component_response(response : pldm_packet::pass_component::PassComponentTableResponse) -> Result<(),()>,
         on_start_download() -> Result<(),()>,
         on_update_component_response(response : pldm_packet::update_component::UpdateComponentResponse) -> Result<(),()>,
-        on_request_firmware() -> Result<(),()>,
+        on_request_firmware(request: pldm_packet::request_fw_data::RequestFirmwareDataRequest) -> Result<(),()>,
+        on_transfer_complete_request(request: pldm_packet::transfer_complete::TransferCompleteRequest) -> Result<(),()>,
         on_transfer_fail() -> Result<(),()>,
         on_transfer_success() -> Result<(),()>,
         on_get_status() -> Result<(),()>,

--- a/emulator/bmc/pldm-ua/src/update_sm.rs
+++ b/emulator/bmc/pldm-ua/src/update_sm.rs
@@ -590,7 +590,7 @@ pub trait StateMachineActions {
             );
             to_copy = max(to_copy, 0); // Ensure to_copy is not negative
             let mut to_pad = min(
-                0,
+                request.length as i32,
                 request.length as i32 - (data.len() as i32 - request.offset as i32),
             );
             to_pad = max(to_pad, 0); // Ensure to_pad is not negative

--- a/emulator/bmc/pldm-ua/tests/test_download.rs
+++ b/emulator/bmc/pldm-ua/tests/test_download.rs
@@ -1,0 +1,372 @@
+// Licensed under the Apache-2.0 license
+
+#[cfg(test)]
+mod common;
+
+use std::cmp::min;
+
+use chrono::Utc;
+use common::CustomDiscoverySm;
+use pldm_common::{
+    codec::PldmCodec,
+    message::firmware_update::{
+        get_fw_params::GetFirmwareParametersResponse,
+        pass_component::PassComponentTableResponse,
+        query_devid::QueryDeviceIdentifiersResponse,
+        request_fw_data::{RequestFirmwareDataRequest, RequestFirmwareDataResponseFixed},
+        request_update::RequestUpdateResponse,
+        transfer_complete::{TransferCompleteRequest, TransferResult},
+    },
+    protocol::{
+        base::{PldmMsgHeader, PldmMsgType, PldmSupportedType},
+        firmware_update::{ComponentResponseCode, FwUpdateCmd},
+    },
+};
+use pldm_fw_pkg::{
+    manifest::{
+        ComponentImageInformation, Descriptor, DescriptorType, FirmwareDeviceIdRecord,
+        PackageHeaderInformation, StringType,
+    },
+    FirmwareManifest,
+};
+use pldm_ua::{daemon::Options, events::PldmEvents, transport::PldmSocket, update_sm};
+use uuid::Uuid;
+
+// Test UUID
+pub const TEST_UUID: [u8; 16] = [
+    0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0,
+];
+const BASELINE_TRANSFER_SIZE: u32 = 32;
+
+/* Override the Update SM, go directly to UpdateComponent */
+struct UpdateSmBypassed {}
+impl update_sm::StateMachineActions for UpdateSmBypassed {
+    fn on_start_update(
+        &mut self,
+        ctx: &mut update_sm::InnerContext<impl PldmSocket>,
+    ) -> Result<(), ()> {
+        ctx.device_id = Some(ctx.pldm_fw_pkg.firmware_device_id_records[0].clone());
+        ctx.components = ctx.pldm_fw_pkg.component_image_information.clone();
+        for _ in &ctx.components {
+            ctx.component_response_codes
+                .push(ComponentResponseCode::CompCanBeUpdated);
+        }
+        ctx.current_component_index = Some(0);
+        ctx.event_queue
+            .send(PldmEvents::Update(
+                update_sm::Events::QueryDeviceIdentifiersResponse(QueryDeviceIdentifiersResponse {
+                    ..Default::default()
+                }),
+            ))
+            .map_err(|_| ())?;
+        Ok(())
+    }
+    fn on_query_device_identifiers_response(
+        &mut self,
+        ctx: &mut update_sm::InnerContext<impl PldmSocket>,
+        _response: QueryDeviceIdentifiersResponse,
+    ) -> Result<(), ()> {
+        ctx.event_queue
+            .send(PldmEvents::Update(
+                update_sm::Events::SendGetFirmwareParameters,
+            ))
+            .map_err(|_| ())?;
+        Ok(())
+    }
+    fn on_send_get_firmware_parameters(
+        &mut self,
+        ctx: &mut update_sm::InnerContext<impl PldmSocket>,
+    ) -> Result<(), ()> {
+        ctx.event_queue
+            .send(PldmEvents::Update(
+                update_sm::Events::GetFirmwareParametersResponse(GetFirmwareParametersResponse {
+                    ..Default::default()
+                }),
+            ))
+            .map_err(|_| ())
+    }
+    fn on_get_firmware_parameters_response(
+        &mut self,
+        ctx: &mut update_sm::InnerContext<impl PldmSocket>,
+        _response: pldm_common::message::firmware_update::get_fw_params::GetFirmwareParametersResponse,
+    ) -> Result<(), ()> {
+        ctx.event_queue
+            .send(PldmEvents::Update(update_sm::Events::SendRequestUpdate))
+            .map_err(|_| ())
+    }
+    fn on_send_request_update(
+        &mut self,
+        ctx: &mut update_sm::InnerContext<impl PldmSocket>,
+    ) -> Result<(), ()> {
+        ctx.event_queue
+            .send(PldmEvents::Update(
+                update_sm::Events::RequestUpdateResponse(RequestUpdateResponse {
+                    ..Default::default()
+                }),
+            ))
+            .map_err(|_| ())
+    }
+    fn on_request_update_response(
+        &mut self,
+        ctx: &mut update_sm::InnerContext<impl PldmSocket>,
+        _response: RequestUpdateResponse,
+    ) -> Result<(), ()> {
+        ctx.event_queue
+            .send(PldmEvents::Update(
+                update_sm::Events::SendPassComponentRequest,
+            ))
+            .map_err(|_| ())
+    }
+    fn on_send_pass_component_request(
+        &mut self,
+        ctx: &mut update_sm::InnerContext<impl PldmSocket>,
+    ) -> Result<(), ()> {
+        ctx.event_queue
+            .send(PldmEvents::Update(
+                update_sm::Events::PassComponentResponse(PassComponentTableResponse {
+                    ..Default::default()
+                }),
+            ))
+            .map_err(|_| ())
+    }
+    fn are_all_components_passed(
+        &self,
+        _ctx: &update_sm::InnerContext<impl PldmSocket>,
+    ) -> Result<bool, ()> {
+        Ok(true)
+    }
+    fn on_all_components_passed(
+        &mut self,
+        ctx: &mut update_sm::InnerContext<impl PldmSocket>,
+    ) -> Result<(), ()> {
+        ctx.event_queue
+            .send(PldmEvents::Update(update_sm::Events::StartDownload))
+            .map_err(|_| ())
+    }
+}
+
+#[test]
+fn test_download_size_divisible_by_transfer_size() {
+    let pldm_fw_pkg = FirmwareManifest {
+        package_header_information: PackageHeaderInformation {
+            package_header_identifier: Uuid::parse_str("7B291C996DB64208801B02026E463C78").unwrap(),
+            package_header_format_revision: 1,
+            package_release_date_time: Utc::now(),
+            package_version_string_type: StringType::Utf8,
+            package_version_string: Some("1.0.0".to_string()),
+            package_header_size: 0, // This will be computed during encoding
+        },
+        firmware_device_id_records: vec![FirmwareDeviceIdRecord {
+            firmware_device_package_data: Some(vec![0x01, 0x02, 0x03, 0x04]),
+            device_update_option_flags: 0xFFFF_FFFF,
+            component_image_set_version_string_type: StringType::Ascii,
+            component_image_set_version_string: Some("ComponentV1".to_string()),
+            applicable_components: Some(vec![0x00]),
+            initial_descriptor: Descriptor {
+                descriptor_type: DescriptorType::Uuid,
+                descriptor_data: vec![0xAA, 0xBB, 0xCC],
+            },
+            additional_descriptors: None,
+            reference_manifest_data: None,
+        }],
+        downstream_device_id_records: None,
+        component_image_information: vec![ComponentImageInformation {
+            image_location: None, // Use image_data
+            classification: 0x0001,
+            identifier: 0x0002,
+            comparison_stamp: Some(999),
+            options: 0xAABB,
+            requested_activation_method: 0x1122,
+            version_string_type: StringType::Utf8,
+            version_string: Some("FirmwareV1".to_string()),
+            opaque_data: Some(vec![0x77, 0x88, 0x99]),
+            offset: 0, // Will be calculated in encoding
+            size: 256,
+            image_data: Some(vec![0x55u8; 256]),
+        }],
+    };
+
+    // Setup the test environment
+    let mut setup = common::setup(Options {
+        pldm_fw_pkg: Some(pldm_fw_pkg.clone()),
+        discovery_sm_actions: CustomDiscoverySm {},
+        update_sm_actions: UpdateSmBypassed {},
+        fd_tid: 0x01,
+    });
+
+    setup.wait_for_state_transition(update_sm::States::Download);
+
+    let mut instance_id = 0u8;
+    let mut downloaded_data: Vec<u8> = Vec::new();
+    let mut offset = 0u32;
+    while offset < pldm_fw_pkg.component_image_information[0].size {
+        let length = min(
+            BASELINE_TRANSFER_SIZE,
+            pldm_fw_pkg.component_image_information[0].size + BASELINE_TRANSFER_SIZE - offset,
+        );
+
+        let request =
+            RequestFirmwareDataRequest::new(instance_id, PldmMsgType::Request, offset, length);
+
+        setup.send_response(&setup.fd_sock, &request);
+
+        let response = setup.fd_sock.receive(None).unwrap();
+
+        let header = PldmMsgHeader::decode(&response.payload.data[..response.payload.len])
+            .map_err(|_| ())
+            .unwrap();
+
+        assert!(header.is_hdr_ver_valid(), "Invalid header version!");
+        assert_eq!(header.instance_id(), instance_id);
+        assert!(!header.is_request());
+        assert_eq!(header.pldm_type(), PldmSupportedType::FwUpdate as u8);
+        assert_eq!(header.cmd_code(), FwUpdateCmd::RequestFirmwareData as u8);
+
+        assert!(response.payload.len > core::mem::size_of::<RequestFirmwareDataResponseFixed>());
+
+        let data = &response.payload.data
+            [core::mem::size_of::<RequestFirmwareDataResponseFixed>()..response.payload.len];
+
+        downloaded_data.extend_from_slice(data);
+
+        instance_id += 1;
+        offset += length;
+    }
+
+    assert!(downloaded_data.len() >= pldm_fw_pkg.component_image_information[0].size as usize);
+
+    assert_eq!(
+        downloaded_data[..pldm_fw_pkg.component_image_information[0].size as usize],
+        pldm_fw_pkg.component_image_information[0]
+            .image_data
+            .as_ref()
+            .unwrap()[..]
+    );
+
+    let request = TransferCompleteRequest::new(
+        instance_id,
+        PldmMsgType::Request,
+        TransferResult::TransferSuccess,
+    );
+
+    setup.send_response(&setup.fd_sock, &request);
+
+    setup.wait_for_state_transition(update_sm::States::Verify);
+
+    setup.daemon.stop();
+}
+
+#[test]
+fn test_download_size_not_divisible_by_transfer_size() {
+    let mut image_data = vec![0x55u8; 128];
+    image_data.extend(vec![0xAAu8, 129]);
+
+    let pldm_fw_pkg = FirmwareManifest {
+        package_header_information: PackageHeaderInformation {
+            package_header_identifier: Uuid::parse_str("7B291C996DB64208801B02026E463C78").unwrap(),
+            package_header_format_revision: 1,
+            package_release_date_time: Utc::now(),
+            package_version_string_type: StringType::Utf8,
+            package_version_string: Some("1.0.0".to_string()),
+            package_header_size: 0, // This will be computed during encoding
+        },
+        firmware_device_id_records: vec![FirmwareDeviceIdRecord {
+            firmware_device_package_data: Some(vec![0x01, 0x02, 0x03, 0x04]),
+            device_update_option_flags: 0xFFFF_FFFF,
+            component_image_set_version_string_type: StringType::Ascii,
+            component_image_set_version_string: Some("ComponentV1".to_string()),
+            applicable_components: Some(vec![0x00]),
+            initial_descriptor: Descriptor {
+                descriptor_type: DescriptorType::Uuid,
+                descriptor_data: vec![0xAA, 0xBB, 0xCC],
+            },
+            additional_descriptors: None,
+            reference_manifest_data: None,
+        }],
+        downstream_device_id_records: None,
+        component_image_information: vec![ComponentImageInformation {
+            image_location: None, // Use image_data
+            classification: 0x0001,
+            identifier: 0x0002,
+            comparison_stamp: Some(999),
+            options: 0xAABB,
+            requested_activation_method: 0x1122,
+            version_string_type: StringType::Utf8,
+            version_string: Some("FirmwareV1".to_string()),
+            opaque_data: Some(vec![0x77, 0x88, 0x99]),
+            offset: 0, // Will be calculated in encoding
+            size: image_data.len() as u32,
+            image_data: Some(image_data),
+        }],
+    };
+
+    // Setup the test environment
+    let mut setup = common::setup(Options {
+        pldm_fw_pkg: Some(pldm_fw_pkg.clone()),
+        discovery_sm_actions: CustomDiscoverySm {},
+        update_sm_actions: UpdateSmBypassed {},
+        fd_tid: 0x01,
+    });
+
+    setup.wait_for_state_transition(update_sm::States::Download);
+
+    let mut instance_id = 0u8;
+    let mut offset = 0u32;
+    let mut downloaded_data: Vec<u8> = Vec::new();
+    while offset < pldm_fw_pkg.component_image_information[0].size {
+        let length = min(
+            BASELINE_TRANSFER_SIZE,
+            pldm_fw_pkg.component_image_information[0].size + BASELINE_TRANSFER_SIZE - offset,
+        );
+
+        let request =
+            RequestFirmwareDataRequest::new(instance_id, PldmMsgType::Request, offset, length);
+
+        setup.send_response(&setup.fd_sock, &request);
+
+        let response = setup.fd_sock.receive(None).unwrap();
+
+        let header = PldmMsgHeader::decode(&response.payload.data[..response.payload.len])
+            .map_err(|_| ())
+            .unwrap();
+
+        assert!(header.is_hdr_ver_valid(), "Invalid header version!");
+        assert_eq!(header.instance_id(), instance_id);
+        assert!(!header.is_request());
+        assert_eq!(header.pldm_type(), PldmSupportedType::FwUpdate as u8);
+        assert_eq!(header.cmd_code(), FwUpdateCmd::RequestFirmwareData as u8);
+
+        assert!(response.payload.len > core::mem::size_of::<RequestFirmwareDataResponseFixed>());
+
+        let data = &response.payload.data
+            [core::mem::size_of::<RequestFirmwareDataResponseFixed>()..response.payload.len];
+
+        downloaded_data.extend_from_slice(data);
+
+        instance_id += 1;
+        offset += length;
+    }
+
+    assert!(downloaded_data.len() >= pldm_fw_pkg.component_image_information[0].size as usize);
+
+    assert_eq!(
+        downloaded_data[..pldm_fw_pkg.component_image_information[0].size as usize],
+        pldm_fw_pkg.component_image_information[0]
+            .image_data
+            .as_ref()
+            .unwrap()[..]
+    );
+
+    // Simulate a transfer error
+    let request = TransferCompleteRequest::new(
+        instance_id,
+        PldmMsgType::Request,
+        TransferResult::TransferErrorImageCorrupt,
+    );
+
+    setup.send_response(&setup.fd_sock, &request);
+
+    setup.wait_for_state_transition(update_sm::States::Idle);
+
+    setup.daemon.stop();
+}


### PR DESCRIPTION

Support for downloading the PLDM Firmware by implementing the RequestFirmwareData and TransferComplete PLDM commands. Some changes are also needed in the pldm-fw-pkg lib.

1. Changes in PLDM-FW-PKG lib.

(The PLDM-FW-PKG library is responsible for encoding and decoding PLDM FW package files. In PLDM FW update, this lib is used to decode the package file, so that the firmware content can be retrieved by the update agent)

- Currently, when the pldm-fw-pkg library decodes a PLDM package file, it will copy the firmware binaries in the pldm-fw-pkg into separate files, it will also return a FirmwareManifest struct that contains the file paths of the binaries created. In this patch, the firmware binary is stored into separate local buffers within the FirmwareManifest struct, so that the PLDM Update Agent module can retrieved the firmware directly from the buffers instead of reading from files.

- Made it optional to write the decoded FW binaries into files.

- Added a unit test to encode a PLDM Firmware package into a package file and then decoding it, and verify if the contents are the same.

2. Changes in PLDM-UA lib.

(The PLDM Update Agent library implementing the PLDM FW update protocol)

- Added command handling of RequestFirmwareData and TransferComplete in the update state machine

- Added unit test to simulate downloading firmware