### PR TITLE
[FW Update Agent] Support Post Download PLDM Commands

### DIFF
--- a/emulator/bmc/pldm-ua/src/lib.rs
+++ b/emulator/bmc/pldm-ua/src/lib.rs
@@ -4,5 +4,6 @@
 pub mod daemon;
 pub mod discovery_sm;
 pub mod events;
+pub mod timer;
 pub mod transport;
 pub mod update_sm;

--- a/emulator/bmc/pldm-ua/src/timer.rs
+++ b/emulator/bmc/pldm-ua/src/timer.rs
@@ -1,0 +1,224 @@
+// Licensed under the Apache-2.0 license
+
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
+
+/// A oneshot timer that executes a callback after a specified duration.
+pub struct Timer {
+    cancel_tx: Option<mpsc::Sender<()>>,
+}
+
+impl Default for Timer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Timer {
+    /// Creates a new `Timer` instance.
+    ///
+    /// The timer starts in an idle state and must be scheduled using `schedule()`.
+    ///
+    /// # Returns
+    /// A new instance of `Timer`.
+    pub fn new() -> Self {
+        Self { cancel_tx: None }
+    }
+
+    /// Schedules a callback to be executed after the specified duration.
+    ///
+    /// If a timer is already running, it is **cancelled** before scheduling a new one.
+    ///
+    /// # Parameters
+    /// - `duration`: The duration after which the callback should be executed.
+    /// - `context`: Shared data passed to the callback.
+    /// - `callback`: A function that executes when the timer fires.
+    pub fn schedule<F, G>(&mut self, duration: Duration, context: G, callback: F)
+    where
+        F: FnOnce(G) + Send + 'static,
+        G: Send + 'static,
+    {
+        // Cancel any running timer before scheduling a new one
+        self.cancel();
+
+        let (tx, rx) = mpsc::channel();
+        self.cancel_tx = Some(tx);
+
+        thread::spawn(move || {
+            let result = rx.recv_timeout(duration);
+            if result.is_err() {
+                // Timer expired, execute callback
+                callback(context);
+            }
+            // Otherwise, the timer was cancelled
+            // and we do nothing.
+        });
+    }
+
+    /// Cancels the currently running timer, if any.
+    /// This prevents the scheduled callback from executing.
+    pub fn cancel(&mut self) {
+        if let Some(tx) = self.cancel_tx.take() {
+            let _ = tx.send(()); // Send cancel signal
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+    use std::time::Instant;
+
+    #[test]
+    fn test_timer_executes_successfully() {
+        let mut timer = Timer::new();
+        let shared_data = Arc::new(Mutex::new(0));
+        let shared_data_clone = shared_data.clone();
+
+        timer.schedule(Duration::from_millis(100), shared_data_clone, |context| {
+            let mut data = context.lock().unwrap();
+            *data += 1;
+        });
+
+        // Wait for timer to execute
+        thread::sleep(Duration::from_millis(200));
+
+        assert_eq!(
+            *shared_data.lock().unwrap(),
+            1,
+            "Timer callback should have executed"
+        );
+    }
+
+    #[test]
+    fn test_timer_is_cancelled() {
+        let mut timer = Timer::new();
+        let shared_data = Arc::new(Mutex::new(0));
+        let shared_data_clone = shared_data.clone();
+
+        timer.schedule(Duration::from_millis(100), shared_data_clone, |context| {
+            let mut data = context.lock().unwrap();
+            *data += 1;
+        });
+
+        // Cancel the timer before it executes
+        thread::sleep(Duration::from_millis(50));
+        timer.cancel();
+
+        // Wait to ensure the timer had time to fire
+        thread::sleep(Duration::from_millis(150));
+
+        assert_eq!(
+            *shared_data.lock().unwrap(),
+            0,
+            "Timer callback should NOT have executed"
+        );
+    }
+
+    #[test]
+    fn test_multiple_timers_can_be_scheduled() {
+        let mut timer1 = Timer::new();
+        let mut timer2 = Timer::new();
+        let shared_data = Arc::new(Mutex::new(0));
+
+        let shared_data_clone1 = shared_data.clone();
+        let shared_data_clone2 = shared_data.clone();
+
+        let start_time = Instant::now();
+
+        timer1.schedule(Duration::from_millis(100), shared_data_clone1, |context| {
+            let mut data = context.lock().unwrap();
+            *data += 1;
+        });
+
+        timer2.schedule(Duration::from_millis(200), shared_data_clone2, |context| {
+            let mut data = context.lock().unwrap();
+            *data += 2;
+        });
+
+        // Wait for both timers to execute
+        thread::sleep(Duration::from_millis(300));
+
+        let elapsed = start_time.elapsed();
+        assert!(
+            elapsed >= Duration::from_millis(200),
+            "Both timers should have executed"
+        );
+
+        assert_eq!(
+            *shared_data.lock().unwrap(),
+            3,
+            "Both timer callbacks should have executed correctly"
+        );
+    }
+
+    #[test]
+    fn test_timer_interval_is_correct() {
+        let mut timer = Timer::new();
+        let start_time = Arc::new(Mutex::new(None)); // Shared state to store the start time
+        let start_time_clone = start_time.clone();
+
+        let duration = Duration::from_millis(200);
+
+        timer.schedule(duration, start_time_clone, |context| {
+            let mut start = context.lock().unwrap();
+            *start = Some(Instant::now());
+        });
+
+        let global_start = Instant::now();
+
+        // Wait a bit longer than the timer duration
+        thread::sleep(duration + Duration::from_millis(50));
+
+        let elapsed = start_time.lock().unwrap();
+
+        assert!(
+            elapsed.is_some(),
+            "Timer callback should have been executed"
+        );
+
+        let elapsed_time = elapsed.unwrap().duration_since(global_start);
+
+        // Allow a small margin due to OS scheduling delays
+        let tolerance = Duration::from_millis(20);
+
+        assert!(
+            elapsed_time >= duration && elapsed_time <= duration + tolerance,
+            "Expected execution time: ~{:?}, but got: {:?}",
+            duration,
+            elapsed_time
+        );
+    }
+
+    #[test]
+    fn test_rescheduling_cancels_previous_timer() {
+        let mut timer = Timer::new();
+        let shared_data = Arc::new(Mutex::new(0));
+
+        let shared_data_clone1 = shared_data.clone();
+        timer.schedule(Duration::from_millis(500), shared_data_clone1, |context| {
+            let mut data = context.lock().unwrap();
+            *data += 1;
+        });
+
+        thread::sleep(Duration::from_millis(200)); // Wait before rescheduling
+
+        let shared_data_clone2 = shared_data.clone();
+        timer.schedule(Duration::from_millis(300), shared_data_clone2, |context| {
+            let mut data = context.lock().unwrap();
+            *data += 10;
+        });
+
+        // Wait enough time for the second timer to fire
+        thread::sleep(Duration::from_millis(400));
+
+        // The first timer should have been cancelled, so `shared_data` should be 10, not 11.
+        assert_eq!(
+            *shared_data.lock().unwrap(),
+            10,
+            "First timer should have been cancelled"
+        );
+    }
+}

--- a/emulator/bmc/pldm-ua/tests/test_post_download.rs
+++ b/emulator/bmc/pldm-ua/tests/test_post_download.rs
@@ -1,0 +1,957 @@
+// Licensed under the Apache-2.0 license
+
+#[cfg(test)]
+mod common;
+use common::CustomDiscoverySm;
+use pldm_common::{
+    message::firmware_update::{
+        activate_fw::{ActivateFirmwareRequest, ActivateFirmwareResponse},
+        apply_complete::{ApplyCompleteRequest, ApplyCompleteResponse, ApplyResult},
+        get_fw_params::GetFirmwareParametersResponse,
+        get_status::{
+            AuxState, AuxStateStatus, GetStatusRequest, GetStatusResponse, ProgressPercent,
+            ReasonCode, UpdateOptionResp,
+        },
+        pass_component::PassComponentTableResponse,
+        query_devid::QueryDeviceIdentifiersResponse,
+        request_cancel::{CancelUpdateComponentRequest, CancelUpdateComponentResponse},
+        request_update::RequestUpdateResponse,
+        update_component::{UpdateComponentRequest, UpdateComponentResponse},
+        verify_complete::{VerifyCompleteRequest, VerifyCompleteResponse, VerifyResult},
+    },
+    protocol::{
+        base::{PldmBaseCompletionCode, PldmMsgType},
+        firmware_update::{
+            ComponentActivationMethods, ComponentCompatibilityResponse,
+            ComponentCompatibilityResponseCode, ComponentResponseCode, FirmwareDeviceState,
+            FwUpdateCmd, UpdateOptionFlags,
+        },
+    },
+};
+use pldm_fw_pkg::{
+    manifest::{ComponentImageInformation, FirmwareDeviceIdRecord, PackageHeaderInformation},
+    FirmwareManifest,
+};
+use pldm_ua::{daemon::Options, events::PldmEvents, transport::PldmSocket, update_sm};
+
+// Test UUID
+pub const TEST_UUID: [u8; 16] = [
+    0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0,
+];
+
+const SELF_ACTIVATION_FIELD_BIT: u16 = 0x0001;
+const SELF_ACTIVATION_FIELD_MASK: u16 = 0x0001;
+
+/* Override the Update SM, go directly to TransferComplete */
+struct UpdateSmBypassed {}
+impl update_sm::StateMachineActions for UpdateSmBypassed {
+    fn on_start_update(
+        &mut self,
+        ctx: &mut update_sm::InnerContext<impl PldmSocket>,
+    ) -> Result<(), ()> {
+        ctx.device_id = Some(ctx.pldm_fw_pkg.firmware_device_id_records[0].clone());
+        ctx.components = ctx.pldm_fw_pkg.component_image_information.clone();
+        for _ in &ctx.components {
+            ctx.component_response_codes
+                .push(ComponentResponseCode::CompCanBeUpdated);
+        }
+        ctx.current_component_index = Some(0);
+        ctx.event_queue
+            .send(PldmEvents::Update(
+                update_sm::Events::QueryDeviceIdentifiersResponse(QueryDeviceIdentifiersResponse {
+                    ..Default::default()
+                }),
+            ))
+            .map_err(|_| ())?;
+        Ok(())
+    }
+    fn on_query_device_identifiers_response(
+        &mut self,
+        ctx: &mut update_sm::InnerContext<impl PldmSocket>,
+        _response: QueryDeviceIdentifiersResponse,
+    ) -> Result<(), ()> {
+        ctx.event_queue
+            .send(PldmEvents::Update(
+                update_sm::Events::SendGetFirmwareParameters,
+            ))
+            .map_err(|_| ())?;
+        Ok(())
+    }
+    fn on_send_get_firmware_parameters(
+        &mut self,
+        ctx: &mut update_sm::InnerContext<impl PldmSocket>,
+    ) -> Result<(), ()> {
+        ctx.event_queue
+            .send(PldmEvents::Update(
+                update_sm::Events::GetFirmwareParametersResponse(GetFirmwareParametersResponse {
+                    ..Default::default()
+                }),
+            ))
+            .map_err(|_| ())
+    }
+    fn on_get_firmware_parameters_response(
+        &mut self,
+        ctx: &mut update_sm::InnerContext<impl PldmSocket>,
+        _response: pldm_common::message::firmware_update::get_fw_params::GetFirmwareParametersResponse,
+    ) -> Result<(), ()> {
+        ctx.event_queue
+            .send(PldmEvents::Update(update_sm::Events::SendRequestUpdate))
+            .map_err(|_| ())
+    }
+    fn on_send_request_update(
+        &mut self,
+        ctx: &mut update_sm::InnerContext<impl PldmSocket>,
+    ) -> Result<(), ()> {
+        ctx.event_queue
+            .send(PldmEvents::Update(
+                update_sm::Events::RequestUpdateResponse(RequestUpdateResponse {
+                    ..Default::default()
+                }),
+            ))
+            .map_err(|_| ())
+    }
+    fn on_request_update_response(
+        &mut self,
+        ctx: &mut update_sm::InnerContext<impl PldmSocket>,
+        _response: RequestUpdateResponse,
+    ) -> Result<(), ()> {
+        ctx.event_queue
+            .send(PldmEvents::Update(
+                update_sm::Events::SendPassComponentRequest,
+            ))
+            .map_err(|_| ())
+    }
+    fn on_send_pass_component_request(
+        &mut self,
+        ctx: &mut update_sm::InnerContext<impl PldmSocket>,
+    ) -> Result<(), ()> {
+        ctx.event_queue
+            .send(PldmEvents::Update(
+                update_sm::Events::PassComponentResponse(PassComponentTableResponse {
+                    ..Default::default()
+                }),
+            ))
+            .map_err(|_| ())
+    }
+    fn are_all_components_passed(
+        &self,
+        _ctx: &update_sm::InnerContext<impl PldmSocket>,
+    ) -> Result<bool, ()> {
+        Ok(true)
+    }
+    fn on_all_components_passed(
+        &mut self,
+        ctx: &mut update_sm::InnerContext<impl PldmSocket>,
+    ) -> Result<(), ()> {
+        ctx.event_queue
+            .send(PldmEvents::Update(update_sm::Events::StartDownload))
+            .map_err(|_| ())
+    }
+    fn on_start_download(
+        &mut self,
+        ctx: &mut update_sm::InnerContext<impl PldmSocket>,
+    ) -> Result<(), ()> {
+        ctx.event_queue
+            .send(PldmEvents::Update(update_sm::Events::TransferCompletePass))
+            .map_err(|_| ())
+    }
+}
+
+#[test]
+fn test_one_component_activate() {
+    let activation_option: u16 = SELF_ACTIVATION_FIELD_MASK << SELF_ACTIVATION_FIELD_BIT;
+    let pldm_fw_pkg = FirmwareManifest {
+        package_header_information: PackageHeaderInformation {
+            ..Default::default()
+        },
+        firmware_device_id_records: vec![FirmwareDeviceIdRecord {
+            ..Default::default()
+        }],
+        downstream_device_id_records: None,
+        component_image_information: vec![ComponentImageInformation {
+            identifier: 0x0002,
+            options: 0x0000,
+            requested_activation_method: activation_option,
+            ..Default::default()
+        }],
+    };
+
+    // Setup the test environment
+    let mut setup = common::setup(Options {
+        pldm_fw_pkg: Some(pldm_fw_pkg.clone()),
+        discovery_sm_actions: CustomDiscoverySm {},
+        update_sm_actions: UpdateSmBypassed {},
+        fd_tid: 0x01,
+    });
+
+    setup.wait_for_state_transition(update_sm::States::Verify);
+
+    let mut instance_id = 0u8;
+    let request = VerifyCompleteRequest::new(
+        instance_id,
+        PldmMsgType::Request,
+        VerifyResult::VerifySuccess,
+    );
+    setup.send_response(&setup.fd_sock, &request);
+
+    let _: VerifyCompleteResponse = setup
+        .receive_request(&setup.fd_sock, FwUpdateCmd::VerifyComplete as u8)
+        .unwrap();
+    setup.wait_for_state_transition(update_sm::States::Apply);
+
+    instance_id += 1;
+
+    let request = ApplyCompleteRequest::new(
+        instance_id,
+        PldmMsgType::Request,
+        ApplyResult::ApplySuccess,
+        ComponentActivationMethods(0),
+    );
+    setup.send_response(&setup.fd_sock, &request);
+
+    let _: ApplyCompleteResponse = setup
+        .receive_request(&setup.fd_sock, FwUpdateCmd::ApplyComplete as u8)
+        .unwrap();
+
+    setup.wait_for_state_transition(update_sm::States::Activate);
+
+    let request: ActivateFirmwareRequest = setup
+        .receive_request(&setup.fd_sock, FwUpdateCmd::ActivateFirmware as u8)
+        .unwrap();
+
+    let response = ActivateFirmwareResponse::new(
+        request.hdr.instance_id(),
+        PldmBaseCompletionCode::Success as u8,
+        5,
+    );
+
+    setup.send_response(&setup.fd_sock, &response);
+
+    // Don't respond for 2 seconds
+    std::thread::sleep(std::time::Duration::from_secs(2));
+
+    // Expect a GetStatusRequest
+    let request: GetStatusRequest = setup
+        .receive_request(&setup.fd_sock, FwUpdateCmd::GetStatus as u8)
+        .unwrap();
+
+    // Send a GetStatusResponse with a progress of 80%
+    let response = GetStatusResponse::new(
+        request.hdr.instance_id(),
+        PldmBaseCompletionCode::Success as u8,
+        FirmwareDeviceState::Activate,
+        FirmwareDeviceState::Apply,
+        AuxState::OperationInProgress,
+        AuxStateStatus::AuxStateInProgressOrSuccess,
+        ProgressPercent::new(80).unwrap(),
+        ReasonCode::ActivateFw,
+        UpdateOptionResp::NoForceUpdate,
+    );
+
+    setup.send_response(&setup.fd_sock, &response);
+
+    // Check that the state machine is still in the Activate state
+    setup.wait_for_state_transition(update_sm::States::Activate);
+
+    // Expect another GetStatusRequest
+    let request: GetStatusRequest = setup
+        .receive_request(&setup.fd_sock, FwUpdateCmd::GetStatus as u8)
+        .unwrap();
+
+    // Send a GetStatusResponse with a progress of 100%
+    let response = GetStatusResponse::new(
+        request.hdr.instance_id(),
+        PldmBaseCompletionCode::Success as u8,
+        FirmwareDeviceState::Idle,
+        FirmwareDeviceState::Activate,
+        AuxState::OperationSuccessful,
+        AuxStateStatus::AuxStateInProgressOrSuccess,
+        ProgressPercent::new(100).unwrap(),
+        ReasonCode::ActivateFw,
+        UpdateOptionResp::NoForceUpdate,
+    );
+
+    setup.send_response(&setup.fd_sock, &response);
+
+    setup.wait_for_state_transition(update_sm::States::Done);
+
+    setup.daemon.stop();
+}
+
+#[test]
+fn test_one_component_verify_failed() {
+    let activation_option: u16 = SELF_ACTIVATION_FIELD_MASK << SELF_ACTIVATION_FIELD_BIT;
+    let pldm_fw_pkg = FirmwareManifest {
+        package_header_information: PackageHeaderInformation {
+            ..Default::default()
+        },
+        firmware_device_id_records: vec![FirmwareDeviceIdRecord {
+            ..Default::default()
+        }],
+        downstream_device_id_records: None,
+        component_image_information: vec![ComponentImageInformation {
+            identifier: 0x0002,
+            options: 0x0000,
+            requested_activation_method: activation_option,
+            ..Default::default()
+        }],
+    };
+
+    // Setup the test environment
+    let mut setup = common::setup(Options {
+        pldm_fw_pkg: Some(pldm_fw_pkg.clone()),
+        discovery_sm_actions: CustomDiscoverySm {},
+        update_sm_actions: UpdateSmBypassed {},
+        fd_tid: 0x01,
+    });
+
+    setup.wait_for_state_transition(update_sm::States::Verify);
+
+    let instance_id = 0u8;
+    let request = VerifyCompleteRequest::new(
+        instance_id,
+        PldmMsgType::Request,
+        VerifyResult::VerifyErrorVerificationFailure,
+    );
+    setup.send_response(&setup.fd_sock, &request);
+
+    let _: VerifyCompleteResponse = setup
+        .receive_request(&setup.fd_sock, FwUpdateCmd::VerifyComplete as u8)
+        .unwrap();
+
+    // Expect a CancelUpdateComponentRequest
+    let request: CancelUpdateComponentRequest = setup
+        .receive_request(&setup.fd_sock, FwUpdateCmd::CancelUpdateComponent as u8)
+        .unwrap();
+
+    let response = CancelUpdateComponentResponse::new(
+        request.hdr.instance_id(),
+        PldmBaseCompletionCode::Success as u8,
+    );
+    setup.send_response(&setup.fd_sock, &response);
+
+    setup.wait_for_state_transition(update_sm::States::Idle);
+
+    setup.daemon.stop();
+}
+
+#[test]
+fn test_one_component_apply_failed() {
+    let activation_option: u16 = SELF_ACTIVATION_FIELD_MASK << SELF_ACTIVATION_FIELD_BIT;
+    let pldm_fw_pkg = FirmwareManifest {
+        package_header_information: PackageHeaderInformation {
+            ..Default::default()
+        },
+        firmware_device_id_records: vec![FirmwareDeviceIdRecord {
+            ..Default::default()
+        }],
+        downstream_device_id_records: None,
+        component_image_information: vec![ComponentImageInformation {
+            identifier: 0x0002,
+            options: 0x0000,
+            requested_activation_method: activation_option,
+            ..Default::default()
+        }],
+    };
+
+    // Setup the test environment
+    let mut setup = common::setup(Options {
+        pldm_fw_pkg: Some(pldm_fw_pkg.clone()),
+        discovery_sm_actions: CustomDiscoverySm {},
+        update_sm_actions: UpdateSmBypassed {},
+        fd_tid: 0x01,
+    });
+
+    setup.wait_for_state_transition(update_sm::States::Verify);
+
+    let instance_id = 0u8;
+    let request = VerifyCompleteRequest::new(
+        instance_id,
+        PldmMsgType::Request,
+        VerifyResult::VerifySuccess,
+    );
+    setup.send_response(&setup.fd_sock, &request);
+
+    let _: VerifyCompleteResponse = setup
+        .receive_request(&setup.fd_sock, FwUpdateCmd::VerifyComplete as u8)
+        .unwrap();
+
+    setup.wait_for_state_transition(update_sm::States::Apply);
+
+    let instance_id = 1u8;
+    let request = ApplyCompleteRequest::new(
+        instance_id,
+        PldmMsgType::Request,
+        ApplyResult::ApplyFailureMemoryIssue,
+        ComponentActivationMethods(0),
+    );
+    setup.send_response(&setup.fd_sock, &request);
+
+    let _: ApplyCompleteResponse = setup
+        .receive_request(&setup.fd_sock, FwUpdateCmd::ApplyComplete as u8)
+        .unwrap();
+
+    // Expect a CancelUpdateComponentRequest
+    let request: CancelUpdateComponentRequest = setup
+        .receive_request(&setup.fd_sock, FwUpdateCmd::CancelUpdateComponent as u8)
+        .unwrap();
+
+    let response = CancelUpdateComponentResponse::new(
+        request.hdr.instance_id(),
+        PldmBaseCompletionCode::Success as u8,
+    );
+    setup.send_response(&setup.fd_sock, &response);
+
+    setup.wait_for_state_transition(update_sm::States::Idle);
+
+    setup.daemon.stop();
+}
+
+#[test]
+fn test_apply_complete_with_activation_modification() {
+    let activation_option: u16 = SELF_ACTIVATION_FIELD_MASK << SELF_ACTIVATION_FIELD_BIT;
+    let pldm_fw_pkg = FirmwareManifest {
+        package_header_information: PackageHeaderInformation {
+            ..Default::default()
+        },
+        firmware_device_id_records: vec![FirmwareDeviceIdRecord {
+            ..Default::default()
+        }],
+        downstream_device_id_records: None,
+        component_image_information: vec![ComponentImageInformation {
+            identifier: 0x0002,
+            options: 0x0000,
+            requested_activation_method: activation_option,
+            ..Default::default()
+        }],
+    };
+
+    // Setup the test environment
+    let mut setup = common::setup(Options {
+        pldm_fw_pkg: Some(pldm_fw_pkg.clone()),
+        discovery_sm_actions: CustomDiscoverySm {},
+        update_sm_actions: UpdateSmBypassed {},
+        fd_tid: 0x01,
+    });
+
+    setup.wait_for_state_transition(update_sm::States::Verify);
+
+    let instance_id = 0u8;
+    let request = VerifyCompleteRequest::new(
+        instance_id,
+        PldmMsgType::Request,
+        VerifyResult::VerifySuccess,
+    );
+    setup.send_response(&setup.fd_sock, &request);
+
+    let _: VerifyCompleteResponse = setup
+        .receive_request(&setup.fd_sock, FwUpdateCmd::VerifyComplete as u8)
+        .unwrap();
+
+    setup.wait_for_state_transition(update_sm::States::Apply);
+
+    let instance_id = 1u8;
+    let mut new_activation_method = ComponentActivationMethods(0);
+    new_activation_method.set_automatic(true);
+
+    let request = ApplyCompleteRequest::new(
+        instance_id,
+        PldmMsgType::Request,
+        ApplyResult::ApplySuccessWithActivationMethod,
+        new_activation_method,
+    );
+    setup.send_response(&setup.fd_sock, &request);
+
+    let _: ApplyCompleteResponse = setup
+        .receive_request(&setup.fd_sock, FwUpdateCmd::ApplyComplete as u8)
+        .unwrap();
+
+    let request: ActivateFirmwareRequest = setup
+        .receive_request(&setup.fd_sock, FwUpdateCmd::ActivateFirmware as u8)
+        .unwrap();
+
+    // ActivateRequest should indicate that self-activation is not requested
+    assert_eq!(request.self_contained_activation_req, 0x00);
+
+    let response = ActivateFirmwareResponse::new(
+        request.hdr.instance_id(),
+        PldmBaseCompletionCode::Success as u8,
+        0,
+    );
+    setup.send_response(&setup.fd_sock, &response);
+
+    // Since there's nothing to activate, we should be done
+    setup.wait_for_state_transition(update_sm::States::Done);
+    setup.daemon.stop();
+}
+
+#[test]
+fn test_two_components_activate() {
+    let activation_option: u16 = SELF_ACTIVATION_FIELD_MASK << SELF_ACTIVATION_FIELD_BIT;
+    let pldm_fw_pkg = FirmwareManifest {
+        package_header_information: PackageHeaderInformation {
+            ..Default::default()
+        },
+        firmware_device_id_records: vec![FirmwareDeviceIdRecord {
+            ..Default::default()
+        }],
+        downstream_device_id_records: None,
+        component_image_information: vec![
+            ComponentImageInformation {
+                identifier: 0x0002,
+                options: 0x0000,
+                requested_activation_method: activation_option,
+                ..Default::default()
+            },
+            ComponentImageInformation {
+                identifier: 0x0003,
+                options: 0x0000,
+                requested_activation_method: activation_option,
+                ..Default::default()
+            },
+        ],
+    };
+
+    // Setup the test environment
+    let mut setup = common::setup(Options {
+        pldm_fw_pkg: Some(pldm_fw_pkg.clone()),
+        discovery_sm_actions: CustomDiscoverySm {},
+        update_sm_actions: UpdateSmBypassed {},
+        fd_tid: 0x01,
+    });
+
+    setup.wait_for_state_transition(update_sm::States::Verify);
+
+    let mut instance_id = 0u8;
+    let request = VerifyCompleteRequest::new(
+        instance_id,
+        PldmMsgType::Request,
+        VerifyResult::VerifySuccess,
+    );
+    setup.send_response(&setup.fd_sock, &request);
+
+    let _: VerifyCompleteResponse = setup
+        .receive_request(&setup.fd_sock, FwUpdateCmd::VerifyComplete as u8)
+        .unwrap();
+
+    setup.wait_for_state_transition(update_sm::States::Apply);
+
+    instance_id += 1;
+    let request = ApplyCompleteRequest::new(
+        instance_id,
+        PldmMsgType::Request,
+        ApplyResult::ApplySuccess,
+        ComponentActivationMethods(0),
+    );
+    setup.send_response(&setup.fd_sock, &request);
+
+    let _: ApplyCompleteResponse = setup
+        .receive_request(&setup.fd_sock, FwUpdateCmd::ApplyComplete as u8)
+        .unwrap();
+
+    // UA should send UpdateComponent for the next component
+    let request: UpdateComponentRequest = setup
+        .receive_request(&setup.fd_sock, FwUpdateCmd::UpdateComponent as u8)
+        .unwrap();
+    let request_comp_identifier = request.fixed.comp_identifier;
+    assert_eq!(request_comp_identifier, 0x0003);
+
+    let response = UpdateComponentResponse::new(
+        request.fixed.hdr.instance_id(),
+        PldmBaseCompletionCode::Success as u8,
+        ComponentCompatibilityResponse::CompCanBeUpdated,
+        ComponentCompatibilityResponseCode::NoResponseCode,
+        UpdateOptionFlags(0),
+        0,
+        None,
+    );
+
+    setup.send_response(&setup.fd_sock, &response);
+
+    // Download starts here, and will go straight to Verify since we bypassed the download
+    setup.wait_for_state_transition(update_sm::States::Verify);
+
+    instance_id += request.fixed.hdr.instance_id() + 1;
+    let request = VerifyCompleteRequest::new(
+        instance_id,
+        PldmMsgType::Request,
+        VerifyResult::VerifySuccess,
+    );
+    setup.send_response(&setup.fd_sock, &request);
+
+    let _: VerifyCompleteResponse = setup
+        .receive_request(&setup.fd_sock, FwUpdateCmd::VerifyComplete as u8)
+        .unwrap();
+
+    setup.wait_for_state_transition(update_sm::States::Apply);
+
+    instance_id += 1;
+    let request = ApplyCompleteRequest::new(
+        instance_id,
+        PldmMsgType::Request,
+        ApplyResult::ApplySuccess,
+        ComponentActivationMethods(0),
+    );
+    setup.send_response(&setup.fd_sock, &request);
+
+    let _: ApplyCompleteResponse = setup
+        .receive_request(&setup.fd_sock, FwUpdateCmd::ApplyComplete as u8)
+        .unwrap();
+
+    // Since all components are applied, SM should now be in the Activate state
+    setup.wait_for_state_transition(update_sm::States::Activate);
+
+    let request: ActivateFirmwareRequest = setup
+        .receive_request(&setup.fd_sock, FwUpdateCmd::ActivateFirmware as u8)
+        .unwrap();
+    assert_ne!(request.self_contained_activation_req, 0x00);
+
+    let response = ActivateFirmwareResponse::new(
+        request.hdr.instance_id(),
+        PldmBaseCompletionCode::Success as u8,
+        5,
+    );
+
+    setup.send_response(&setup.fd_sock, &response);
+
+    // Don't respond for 2 seconds
+    std::thread::sleep(std::time::Duration::from_secs(2));
+
+    // Expect a GetStatusRequest
+    let request: GetStatusRequest = setup
+        .receive_request(&setup.fd_sock, FwUpdateCmd::GetStatus as u8)
+        .unwrap();
+
+    // Send a GetStatusResponse with a progress of 80%
+    let response = GetStatusResponse::new(
+        request.hdr.instance_id(),
+        PldmBaseCompletionCode::Success as u8,
+        FirmwareDeviceState::Activate,
+        FirmwareDeviceState::Apply,
+        AuxState::OperationInProgress,
+        AuxStateStatus::AuxStateInProgressOrSuccess,
+        ProgressPercent::new(80).unwrap(),
+        ReasonCode::ActivateFw,
+        UpdateOptionResp::NoForceUpdate,
+    );
+
+    setup.send_response(&setup.fd_sock, &response);
+
+    // Check that the state machine is still in the Activate state
+    setup.wait_for_state_transition(update_sm::States::Activate);
+
+    // Expect another GetStatusRequest
+    let request: GetStatusRequest = setup
+        .receive_request(&setup.fd_sock, FwUpdateCmd::GetStatus as u8)
+        .unwrap();
+
+    // Send a GetStatusResponse with a progress of 100%
+    let response = GetStatusResponse::new(
+        request.hdr.instance_id(),
+        PldmBaseCompletionCode::Success as u8,
+        FirmwareDeviceState::Idle,
+        FirmwareDeviceState::Activate,
+        AuxState::OperationSuccessful,
+        AuxStateStatus::AuxStateInProgressOrSuccess,
+        ProgressPercent::new(100).unwrap(),
+        ReasonCode::ActivateFw,
+        UpdateOptionResp::NoForceUpdate,
+    );
+
+    setup.send_response(&setup.fd_sock, &response);
+
+    setup.wait_for_state_transition(update_sm::States::Done);
+
+    setup.daemon.stop();
+}
+
+#[test]
+fn test_two_components_no_self_activation() {
+    let activation_option: u16 = 0x0000;
+    let pldm_fw_pkg = FirmwareManifest {
+        package_header_information: PackageHeaderInformation {
+            ..Default::default()
+        },
+        firmware_device_id_records: vec![FirmwareDeviceIdRecord {
+            ..Default::default()
+        }],
+        downstream_device_id_records: None,
+        component_image_information: vec![
+            ComponentImageInformation {
+                identifier: 0x0002,
+                options: 0x0000,
+                requested_activation_method: activation_option,
+                ..Default::default()
+            },
+            ComponentImageInformation {
+                identifier: 0x0003,
+                options: 0x0000,
+                requested_activation_method: activation_option,
+                ..Default::default()
+            },
+        ],
+    };
+
+    // Setup the test environment
+    let mut setup = common::setup(Options {
+        pldm_fw_pkg: Some(pldm_fw_pkg.clone()),
+        discovery_sm_actions: CustomDiscoverySm {},
+        update_sm_actions: UpdateSmBypassed {},
+        fd_tid: 0x01,
+    });
+
+    setup.wait_for_state_transition(update_sm::States::Verify);
+
+    let mut instance_id = 0u8;
+    let request = VerifyCompleteRequest::new(
+        instance_id,
+        PldmMsgType::Request,
+        VerifyResult::VerifySuccess,
+    );
+    setup.send_response(&setup.fd_sock, &request);
+
+    let _: VerifyCompleteResponse = setup
+        .receive_request(&setup.fd_sock, FwUpdateCmd::VerifyComplete as u8)
+        .unwrap();
+
+    setup.wait_for_state_transition(update_sm::States::Apply);
+
+    instance_id += 1;
+    let request = ApplyCompleteRequest::new(
+        instance_id,
+        PldmMsgType::Request,
+        ApplyResult::ApplySuccess,
+        ComponentActivationMethods(0),
+    );
+    setup.send_response(&setup.fd_sock, &request);
+
+    let _: ApplyCompleteResponse = setup
+        .receive_request(&setup.fd_sock, FwUpdateCmd::ApplyComplete as u8)
+        .unwrap();
+
+    // UA should send UpdateComponent for the next component
+    let request: UpdateComponentRequest = setup
+        .receive_request(&setup.fd_sock, FwUpdateCmd::UpdateComponent as u8)
+        .unwrap();
+    let request_comp_identifier = request.fixed.comp_identifier;
+    assert_eq!(request_comp_identifier, 0x0003);
+
+    let response = UpdateComponentResponse::new(
+        request.fixed.hdr.instance_id(),
+        PldmBaseCompletionCode::Success as u8,
+        ComponentCompatibilityResponse::CompCanBeUpdated,
+        ComponentCompatibilityResponseCode::NoResponseCode,
+        UpdateOptionFlags(0),
+        0,
+        None,
+    );
+    setup.send_response(&setup.fd_sock, &response);
+    // Download starts here, and will go straight to Verify since we bypassed the download
+    setup.wait_for_state_transition(update_sm::States::Verify);
+    instance_id += request.fixed.hdr.instance_id() + 1;
+    let request = VerifyCompleteRequest::new(
+        instance_id,
+        PldmMsgType::Request,
+        VerifyResult::VerifySuccess,
+    );
+    setup.send_response(&setup.fd_sock, &request);
+    let _: VerifyCompleteResponse = setup
+        .receive_request(&setup.fd_sock, FwUpdateCmd::VerifyComplete as u8)
+        .unwrap();
+    setup.wait_for_state_transition(update_sm::States::Apply);
+    instance_id += 1;
+    let request = ApplyCompleteRequest::new(
+        instance_id,
+        PldmMsgType::Request,
+        ApplyResult::ApplySuccess,
+        ComponentActivationMethods(0),
+    );
+    setup.send_response(&setup.fd_sock, &request);
+    let _: ApplyCompleteResponse = setup
+        .receive_request(&setup.fd_sock, FwUpdateCmd::ApplyComplete as u8)
+        .unwrap();
+    // Since all components are applied, SM should now be in the Activate state
+    let request: ActivateFirmwareRequest = setup
+        .receive_request(&setup.fd_sock, FwUpdateCmd::ActivateFirmware as u8)
+        .unwrap();
+
+    assert_eq!(request.self_contained_activation_req, 0x00);
+    let response = ActivateFirmwareResponse::new(
+        request.hdr.instance_id(),
+        PldmBaseCompletionCode::Success as u8,
+        0,
+    );
+    setup.send_response(&setup.fd_sock, &response);
+    setup.wait_for_state_transition(update_sm::States::Done);
+    setup.daemon.stop();
+}
+
+#[test]
+fn test_two_components_one_activate() {
+    let activation_option: u16 = SELF_ACTIVATION_FIELD_MASK << SELF_ACTIVATION_FIELD_BIT;
+    let pldm_fw_pkg = FirmwareManifest {
+        package_header_information: PackageHeaderInformation {
+            ..Default::default()
+        },
+        firmware_device_id_records: vec![FirmwareDeviceIdRecord {
+            ..Default::default()
+        }],
+        downstream_device_id_records: None,
+        component_image_information: vec![
+            ComponentImageInformation {
+                identifier: 0x0002,
+                options: 0x0000,
+                requested_activation_method: activation_option,
+                ..Default::default()
+            },
+            ComponentImageInformation {
+                identifier: 0x0003,
+                options: 0x0000,
+                requested_activation_method: 0x0000,
+                ..Default::default()
+            },
+        ],
+    };
+
+    // Setup the test environment
+    let mut setup = common::setup(Options {
+        pldm_fw_pkg: Some(pldm_fw_pkg.clone()),
+        discovery_sm_actions: CustomDiscoverySm {},
+        update_sm_actions: UpdateSmBypassed {},
+        fd_tid: 0x01,
+    });
+
+    setup.wait_for_state_transition(update_sm::States::Verify);
+
+    let mut instance_id = 0u8;
+    let request = VerifyCompleteRequest::new(
+        instance_id,
+        PldmMsgType::Request,
+        VerifyResult::VerifySuccess,
+    );
+    setup.send_response(&setup.fd_sock, &request);
+
+    let _: VerifyCompleteResponse = setup
+        .receive_request(&setup.fd_sock, FwUpdateCmd::VerifyComplete as u8)
+        .unwrap();
+
+    setup.wait_for_state_transition(update_sm::States::Apply);
+
+    instance_id += 1;
+    let request = ApplyCompleteRequest::new(
+        instance_id,
+        PldmMsgType::Request,
+        ApplyResult::ApplySuccess,
+        ComponentActivationMethods(0),
+    );
+    setup.send_response(&setup.fd_sock, &request);
+
+    let _: ApplyCompleteResponse = setup
+        .receive_request(&setup.fd_sock, FwUpdateCmd::ApplyComplete as u8)
+        .unwrap();
+
+    // UA should send UpdateComponent for the next component
+    let request: UpdateComponentRequest = setup
+        .receive_request(&setup.fd_sock, FwUpdateCmd::UpdateComponent as u8)
+        .unwrap();
+    let request_comp_identifier = request.fixed.comp_identifier;
+    assert_eq!(request_comp_identifier, 0x0003);
+
+    let response = UpdateComponentResponse::new(
+        request.fixed.hdr.instance_id(),
+        PldmBaseCompletionCode::Success as u8,
+        ComponentCompatibilityResponse::CompCanBeUpdated,
+        ComponentCompatibilityResponseCode::NoResponseCode,
+        UpdateOptionFlags(0),
+        0,
+        None,
+    );
+    setup.send_response(&setup.fd_sock, &response);
+    // Download starts here, and will go straight to Verify since we bypassed the download
+    setup.wait_for_state_transition(update_sm::States::Verify);
+    instance_id += request.fixed.hdr.instance_id() + 1;
+    let request = VerifyCompleteRequest::new(
+        instance_id,
+        PldmMsgType::Request,
+        VerifyResult::VerifySuccess,
+    );
+    setup.send_response(&setup.fd_sock, &request);
+    let _: VerifyCompleteResponse = setup
+        .receive_request(&setup.fd_sock, FwUpdateCmd::VerifyComplete as u8)
+        .unwrap();
+    setup.wait_for_state_transition(update_sm::States::Apply);
+    instance_id += 1;
+    let request = ApplyCompleteRequest::new(
+        instance_id,
+        PldmMsgType::Request,
+        ApplyResult::ApplySuccess,
+        ComponentActivationMethods(0),
+    );
+    setup.send_response(&setup.fd_sock, &request);
+    let _: ApplyCompleteResponse = setup
+        .receive_request(&setup.fd_sock, FwUpdateCmd::ApplyComplete as u8)
+        .unwrap();
+    // Since all components are applied, SM should now be in the Activate state
+    let request: ActivateFirmwareRequest = setup
+        .receive_request(&setup.fd_sock, FwUpdateCmd::ActivateFirmware as u8)
+        .unwrap();
+    assert_ne!(request.self_contained_activation_req, 0x00);
+
+    let response = ActivateFirmwareResponse::new(
+        request.hdr.instance_id(),
+        PldmBaseCompletionCode::Success as u8,
+        5,
+    );
+
+    setup.send_response(&setup.fd_sock, &response);
+
+    // Don't respond for 2 seconds
+    std::thread::sleep(std::time::Duration::from_secs(2));
+
+    // Expect a GetStatusRequest
+    let request: GetStatusRequest = setup
+        .receive_request(&setup.fd_sock, FwUpdateCmd::GetStatus as u8)
+        .unwrap();
+
+    // Send a GetStatusResponse with a progress of 80%
+    let response = GetStatusResponse::new(
+        request.hdr.instance_id(),
+        PldmBaseCompletionCode::Success as u8,
+        FirmwareDeviceState::Activate,
+        FirmwareDeviceState::Apply,
+        AuxState::OperationInProgress,
+        AuxStateStatus::AuxStateInProgressOrSuccess,
+        ProgressPercent::new(80).unwrap(),
+        ReasonCode::ActivateFw,
+        UpdateOptionResp::NoForceUpdate,
+    );
+
+    setup.send_response(&setup.fd_sock, &response);
+
+    // Check that the state machine is still in the Activate state
+    setup.wait_for_state_transition(update_sm::States::Activate);
+
+    // Expect another GetStatusRequest
+    let request: GetStatusRequest = setup
+        .receive_request(&setup.fd_sock, FwUpdateCmd::GetStatus as u8)
+        .unwrap();
+
+    // Send a GetStatusResponse with a progress of 100%
+    let response = GetStatusResponse::new(
+        request.hdr.instance_id(),
+        PldmBaseCompletionCode::Success as u8,
+        FirmwareDeviceState::Idle,
+        FirmwareDeviceState::Activate,
+        AuxState::OperationSuccessful,
+        AuxStateStatus::AuxStateInProgressOrSuccess,
+        ProgressPercent::new(100).unwrap(),
+        ReasonCode::ActivateFw,
+        UpdateOptionResp::NoForceUpdate,
+    );
+
+    setup.send_response(&setup.fd_sock, &response);
+
+    setup.wait_for_state_transition(update_sm::States::Done);
+
+    setup.daemon.stop();
+}


### PR DESCRIPTION
Implement the VerifyComplete, ApplyComplete, ActivateFw and CancelUpdateComponent, GetStatus PLDM Commands.

After download is completed, update_sm will wait for VerifyComplete from device, then the ApplyComplete. If there are no more components to update, the update_sm will send an ActivateFw.

If the device has components with 'self-activation' flag set, update_sm will send periodically GetStatus commands until it gets a response that the device has succesfully activated the Firmware.

If there are any failures, in Verify, Apply or Activate stages, the update_sm will send a CancelUpdateComponent and will terminate the update.

A timer module is created to support the timer related actions in the update_sm.