### PR TITLE
New SystemRDL 2.0 parser in winnow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2223,6 +2223,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mcu-registers-systemrdl-new"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "same-file",
+ "winnow 0.7.4",
+]
+
+[[package]]
 name = "mcu-rom-common"
 version = "0.1.0"
 dependencies = [
@@ -3402,7 +3411,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow",
+ "winnow 0.6.20",
 ]
 
 [[package]]
@@ -3773,6 +3782,15 @@ name = "winnow"
 version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "registers/generated-firmware",
     "registers/generator",
     "registers/systemrdl",
+    "registers/systemrdl-new",
     "platforms/emulator/rom",
     "rom",
     "romtime",
@@ -107,9 +108,11 @@ num-derive = "0.4.2"
 num-traits = "0.2"
 portable-atomic = "1.7.0"
 p384 = "0.13.0"
+prettyplease = "0.2.31"
 proc-macro2 = "1.0.66"
 quote = "1.0"
 rand = "0.8.5"
+same-file = "1"
 semver = "1.0.23"
 sec1 = { version = "0.7.3" }
 serde = { version = "1.0.209", features = ["alloc", "derive", "serde_derive"] }
@@ -126,6 +129,7 @@ thiserror-no-std = "2.0.2"
 toml = "0.8.19"
 uuid = { version = "1.10.0", features = ["serde"]}
 walkdir = "2.5.0"
+winnow = "0.7.4"
 zerocopy = { version = "0.8.17", features = ["derive"] }
 zeroize = { version = "1.6.0", default-features = false, features = ["zeroize_derive"] }
 
@@ -151,6 +155,7 @@ pldm-ua = {path = "emulator/bmc/pldm-ua"}
 registers-generated = { path = "registers/generated-firmware" }
 registers-generator = { path = "registers/generator" }
 registers-systemrdl = { path = "registers/systemrdl" }
+registers-systemrdl-new = { path = "registers/systemrdl-new" }
 romtime = { path = "romtime" }
 
 # App related dependencies

--- a/registers/systemrdl-new/Cargo.toml
+++ b/registers/systemrdl-new/Cargo.toml
@@ -1,0 +1,13 @@
+# Licensed under the Apache-2.0 license.
+
+[package]
+name = "mcu-registers-systemrdl-new"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow.workspace = true
+same-file.workspace = true
+winnow.workspace = true

--- a/registers/systemrdl-new/src/ast.rs
+++ b/registers/systemrdl-new/src/ast.rs
@@ -1,0 +1,625 @@
+// Licensed under the Apache-2.0 license.
+
+//! Abstract Syntax Tree (AST) for SystemRDL parser.
+
+use crate::parser::{root, tokens};
+use crate::{token_iter::TokenIter, Bits, FileSource, Token, TokenKind, Tokens};
+use std::path::Path;
+use winnow::Parser;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PrecedenceType {
+    Hw,
+    Sw,
+}
+
+impl From<&str> for PrecedenceType {
+    fn from(s: &str) -> Self {
+        match s {
+            "hw" => PrecedenceType::Hw,
+            "sw" => PrecedenceType::Sw,
+            _ => panic!("Invalid precedence type"),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Default, Debug, Eq, PartialEq)]
+pub enum AccessType {
+    #[default]
+    Rw,
+    R,
+    W,
+    Rw1,
+    W1,
+    Na,
+}
+
+impl From<&str> for AccessType {
+    fn from(s: &str) -> Self {
+        match s {
+            "rw" => AccessType::Rw,
+            "wr" => AccessType::Rw,
+            "r" => AccessType::R,
+            "w" => AccessType::W,
+            "rw1" => AccessType::Rw1,
+            "w1" => AccessType::W1,
+            "na" => AccessType::Na,
+            _ => panic!("Invalid access type"),
+        }
+    }
+}
+
+#[allow(clippy::enum_variant_names)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum OnReadType {
+    RClr,
+    RSet,
+    RUser,
+}
+
+impl From<&str> for OnReadType {
+    fn from(s: &str) -> Self {
+        match s {
+            "rclr" => OnReadType::RClr,
+            "rset" => OnReadType::RSet,
+            "ruser" => OnReadType::RUser,
+            _ => panic!("Invalid on read type"),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum OnWriteType {
+    WoSet,
+    WoClr,
+    Wot,
+    Wzs,
+    Wzc,
+    Wzt,
+    WClr,
+    WSet,
+    WUser,
+}
+
+impl From<&str> for OnWriteType {
+    fn from(s: &str) -> Self {
+        match s {
+            "woset" => OnWriteType::WoSet,
+            "woclr" => OnWriteType::WoClr,
+            "wot" => OnWriteType::Wot,
+            "wzs" => OnWriteType::Wzs,
+            "wzc" => OnWriteType::Wzc,
+            "wzt" => OnWriteType::Wzt,
+            "wclr" => OnWriteType::WClr,
+            "wset" => OnWriteType::WSet,
+            "wuser" => OnWriteType::WUser,
+            _ => panic!("Invalid on write type"),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AddressingType {
+    Compact,
+    RegAlign,
+    FullAlign,
+}
+
+impl From<&str> for AddressingType {
+    fn from(s: &str) -> Self {
+        match s {
+            "compact" => AddressingType::Compact,
+            "regalign" => AddressingType::RegAlign,
+            "fullalign" => AddressingType::FullAlign,
+            _ => panic!("Invalid addressing type"),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub enum InterruptType {
+    #[default]
+    Level,
+    PosEdge,
+    NegEdge,
+    BothEdge,
+    NonSticky,
+    Sticky,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ComponentType {
+    Field,
+    Reg,
+    RegFile,
+    AddrMap,
+    Signal,
+    Enum,
+    EnumVariant,
+    Mem,
+    Constraint,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum IntegerType {
+    Bit,
+    Longint,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum BasicDataType {
+    IntegerType(IntegerType),
+    UnsignedIntegerType(IntegerType),
+    String,
+    Boolean,
+    Identifier(String),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Root {
+    pub descriptions: Vec<Description>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum Description {
+    ComponentDef(Component),
+    EnumDef(EnumDef),
+    PropertyDefinition(PropertyDefinition),
+    StructDef(StructDef),
+    ConstraintDef(ConstraintDef),
+    ExplicitComponentInst(ExplicitComponentInst),
+    PropertyAssignment(PropertyAssignment),
+}
+
+impl Root {
+    pub fn from_file(file_source: &dyn FileSource, name: &Path) -> Result<Self, anyhow::Error> {
+        let mut tokens = vec![];
+        let mut iter = TokenIter::from_path(file_source, name)?;
+        loop {
+            let t = iter.next();
+            if t == TokenKind::EndOfFile {
+                break;
+            }
+            let span = iter.last_span();
+            // TODO: this span could refer to the previous file if the fifo was not empty; we should return the correct string in that case
+            tokens.push(Token {
+                kind: t,
+                raw: &(iter.current_file_contents()[span.start..span.end]),
+            });
+        }
+        let tokens = Tokens::new(&tokens);
+        root.parse(tokens).map_err(|e| {
+            let t = &e.input()[0];
+            anyhow::format_err!("Error parsing input at: `{}` token: {:?}", t.raw, t.kind)
+        })
+    }
+}
+
+impl std::str::FromStr for Root {
+    type Err = anyhow::Error;
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        let tokens = tokens
+            .parse(input.trim_end())
+            .map_err(|e| anyhow::format_err!("{e}"))?;
+        let tokens = Tokens::new(&tokens);
+        root.parse(tokens).map_err(|e| {
+            let t = &e.input()[0];
+            anyhow::format_err!("Error parsing input at: `{}` token: {:?}", t.raw, t.kind)
+        })
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum DataType {
+    BasicDataType(BasicDataType),
+    AccessType,
+    AddressingType,
+    OnReadType,
+    OnWriteType,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ArrayType {}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum ParamDefElem {
+    ParamDefElem(DataType, String, Option<ArrayType>, Option<ConstantExpr>),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct EnumEntry {
+    pub id: String,
+    pub expr: Option<ConstantExpr>,
+    pub property_assignments: Vec<ExplicitPropertyAssignment>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum ExplicitPropertyAssignment {
+    Assignment(IdentityOrPropKeyword, Option<PropAssignmentRhs>),
+    EncodeAssignment(String),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum PropAssignmentRhs {
+    ConstantExpr(ConstantExpr),
+    PrecedenceType(PrecedenceType),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct EnumDef {
+    pub id: String,
+    pub body: Vec<EnumEntry>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct StructDef {
+    pub id: String,
+    pub base: Option<String>,
+    pub body: Vec<StructElem>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct StructElem {
+    pub struct_type: StructType,
+    pub id: String,
+    pub array_type: Option<ArrayType>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum StructType {
+    DataType(DataType),
+    ComponentType(ComponentType),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum ConstraintDef {
+    Exp(String, ConstraintBody, Vec<String>),
+    Anon(ConstraintBody, Vec<String>),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum ConstraintLhs {
+    This,
+    InstanceRef(InstanceRef),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum ConstraintElem {
+    ConstantExpr(ConstantExpr),
+    ConstraintPropAssignment(ConstraintPropAssignment),
+    ConstraintInsideValues(ConstraintLhs, Vec<ConstraintValue>),
+    ConstraintInsideId(ConstraintLhs, String),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ConstraintPropAssignment {
+    pub id: String,
+    pub expr: ConstantExpr,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum ConstraintValue {
+    ConstantExpr(ConstantExpr),
+    Range(ConstantExpr, ConstantExpr),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ConstraintBody {
+    pub elements: Vec<ConstraintElem>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ExplicitComponentInst {
+    pub component_inst_type: Option<ComponentInstType>,
+    pub component_inst_alias: Option<ComponentInstAlias>,
+    pub id: String,
+    pub component_insts: ComponentInsts,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ComponentInstAlias {
+    pub id: String,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum PropertyAssignment {
+    ExplicitOrDefaultPropAssignment(ExplicitOrDefaultPropAssignment),
+    PostPropAssignment(PostPropAssignment),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ExplicitPropModifier {
+    pub prop_mod: PropMod,
+    pub id: String,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum PropMod {
+    PosEdge,
+    NegEdge,
+    BothEdge,
+    Level,
+    NonSticky,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum ExplicitOrDefaultPropAssignment {
+    ExplicitPropModifier(Option<DefaultKeyword>, ExplicitPropModifier),
+    ExplicitPropAssignment(Option<DefaultKeyword>, ExplicitPropertyAssignment),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct DefaultKeyword {}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum PostPropAssignment {
+    PropRef(PropRef, Option<PropAssignmentRhs>),
+    PostEncodeAssignment(PostEncodeAssignment),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct PropRef {
+    pub iref: InstanceRef,
+    pub id_or_prop: IdentityOrPropKeyword,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct PostEncodeAssignment {
+    pub iref: InstanceRef,
+    pub id: String,
+}
+#[derive(Clone, Debug, PartialEq)]
+pub enum ComponentBodyElem {
+    ComponentDef(Component),
+    EnumDef(EnumDef),
+    StructDef(StructDef),
+    ConstraintDef(ConstraintDef),
+    ExplicitComponentInst(ExplicitComponentInst),
+    PropertyAssignment(PropertyAssignment),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ComponentBody {
+    pub elements: Vec<ComponentBodyElem>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum ParamDef {
+    Params(Vec<ParamDefElem>),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum ComponentDef {
+    Named(ComponentType, String, Option<ParamDef>, ComponentBody),
+    Anon(ComponentType, ComponentBody),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum ComponentInstType {
+    Internal,
+    External,
+}
+#[derive(Clone, Debug, PartialEq)]
+pub struct ParamElem {
+    pub id: String,
+    pub param_value: ConstantExpr,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ComponentInsts {
+    pub param_insts: Vec<ParamElem>,
+    pub component_insts: Vec<ComponentInst>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum PrimaryLiteral {
+    Number(u64),
+    Bits(Bits),
+    StringLiteral(String),
+    BooleanLiteral(bool),
+    AccessTypeLiteral(AccessType),
+    OnReadTypeLiteral(OnReadType),
+    OnWriteTypeLiteral(OnWriteType),
+    AddressingTypeLiteral(AddressingType),
+    EnumeratorLiteral(String, String),
+    This,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum ConstantPrimary {
+    Base(ConstantPrimaryBase),
+    Cast(ConstantPrimaryBase, Box<ConstantExpr>),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum ConstantPrimaryBase {
+    PrimaryLiteral(PrimaryLiteral),
+    ConstantConcat(Vec<ConstantExpr>),
+    ConstantMultipleConcat(Box<ConstantExpr>, Vec<ConstantExpr>),
+    ConstantExpr(Box<ConstantExpr>),
+    SimpleTypeCast(IntegerType, Box<ConstantExpr>),
+    BooleanCast(Box<ConstantExpr>),
+    InstanceOrPropRef(InstanceOrPropRef),
+    StructLiteral(String, Vec<StructLiteralElement>),
+    ArrayLiteral(Vec<ConstantExpr>),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct InstanceRef {
+    pub elements: Vec<InstanceRefElement>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct InstanceRefElement {
+    pub id: String,
+    pub arrays: Vec<ConstantExpr>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum IdentityOrPropKeyword {
+    Id(String),
+    PropKeyword(PropKeyword),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum PropKeyword {
+    Sw,
+    Hw,
+    RClr,
+    RSet,
+    WoClr,
+    WoSet,
+}
+
+impl std::fmt::Display for PropKeyword {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PropKeyword::Sw => f.write_str("sw"),
+            PropKeyword::Hw => f.write_str("hw"),
+            PropKeyword::RClr => f.write_str("rclr"),
+            PropKeyword::RSet => f.write_str("rset"),
+            PropKeyword::WoClr => f.write_str("woclr"),
+            PropKeyword::WoSet => f.write_str("woset"),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct InstanceOrPropRef {
+    pub iref: InstanceRef,
+    pub id_or_prop: Option<IdentityOrPropKeyword>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct StructLiteralElement {
+    pub id: String,
+    pub expr: ConstantExpr,
+}
+
+#[allow(unused)]
+#[derive(Clone, Debug, PartialEq)]
+pub enum UnaryOp {
+    LogicalNot,
+    Plus,
+    Minus,
+    Not,
+    And,
+    Nand,
+    Or,
+    Nor,
+    Xor,
+    Xnor,
+}
+
+#[allow(unused)]
+#[derive(Clone, Debug, PartialEq)]
+pub enum BinaryOp {
+    AndAnd,
+    OrOr,
+    LessThan,
+    GreaterThan,
+    LessThanOrEqual,
+    GreaterThanOrEqual,
+    EqualsEquals,
+    NotEquals,
+    RightShift,
+    LeftShift,
+    And,
+    Or,
+    Xor,
+    Xnor,
+    Times,
+    Divide,
+    Modulus,
+    Plus,
+    Minus,
+    Power,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum ConstantExpr {
+    ConstantPrimary(ConstantPrimary, Option<Box<ConstantExprContinue>>),
+    UnaryOp(
+        UnaryOp,
+        Box<ConstantExpr>,
+        Option<Box<ConstantExprContinue>>,
+    ),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum ConstantExprContinue {
+    BinaryOp(
+        BinaryOp,
+        Box<ConstantExpr>,
+        Option<Box<ConstantExprContinue>>,
+    ),
+    TernaryOp(
+        Box<ConstantExpr>,
+        Box<ConstantExpr>,
+        Option<Box<ConstantExprContinue>>,
+    ),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum ArrayOrRange {
+    Array(Vec<ConstantExpr>),
+    Range(Range),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ComponentInst {
+    pub id: String,
+    pub array_or_range: Option<ArrayOrRange>,
+    pub equals: Option<ConstantExpr>,
+    pub at: Option<ConstantExpr>,
+    pub plus_equals: Option<ConstantExpr>,
+    pub percent_equals: Option<ConstantExpr>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum Range {
+    Range(ConstantExpr, ConstantExpr),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Component {
+    pub def: ComponentDef,
+    pub inst_type: Option<ComponentInstType>,
+    pub insts: Option<ComponentInsts>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum PropertyCompType {
+    ComponentType(ComponentType),
+    Constraint,
+    All,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum PropertyAttribute {
+    PropertyType(PropertyType),
+    PropertyUsage(Vec<PropertyCompType>),
+    PropertyDefault(ConstantExpr),
+    PropertyConstraint,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct PropertyType {
+    pub property_data_type: PropertyDataType,
+    pub array_type: Option<ArrayType>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum PropertyDataType {
+    ComponentPrimaryType(ComponentType),
+    Ref,
+    Number,
+    BasicDataType(BasicDataType),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct PropertyDefinition {
+    pub id: String,
+    pub body: Vec<PropertyAttribute>,
+}

--- a/registers/systemrdl-new/src/bits.rs
+++ b/registers/systemrdl-new/src/bits.rs
@@ -1,0 +1,128 @@
+// Licensed under the Apache-2.0 license.
+
+use std::{fmt::Display, str::FromStr};
+
+fn mask(w: u64) -> Result<u64, ()> {
+    if w > 64 {
+        return Err(());
+    }
+    if w == 64 {
+        return Ok(0xffff_ffff_ffff_ffff);
+    }
+    Ok((1 << w) - 1)
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct Bits {
+    w: u64,
+    val: u64,
+}
+impl Bits {
+    pub fn new(w: u64, val: u64) -> Bits {
+        let mask = if w < 64 {
+            (1 << w) - 1
+        } else {
+            0xffff_ffff_ffff_ffff
+        };
+        Self { w, val: val & mask }
+    }
+    pub fn w(&self) -> u64 {
+        self.w
+    }
+    pub fn val(&self) -> u64 {
+        self.val
+    }
+}
+impl FromStr for Bits {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, ()> {
+        let Some(i) = s.find(|ch: char| !ch.is_numeric()) else {
+            return Err(());
+        };
+        let w = u64::from_str(&s[0..i]).map_err(|_| ())?;
+        let mut i = s[i..].chars();
+        if i.next() != Some('\'') {
+            return Err(());
+        }
+        let radix = match i.next() {
+            Some('b') => 2,
+            Some('o') => 8,
+            Some('d') => 10,
+            Some('h') => 16,
+            _ => return Err(()),
+        };
+
+        let str_val = i.as_str().replace('_', "");
+        let val = u64::from_str_radix(&str_val, radix).map_err(|_| ())?;
+        if val > mask(w)? {
+            return Err(());
+        }
+        Ok(Bits::new(w, val))
+    }
+}
+impl Display for Bits {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}'x{:x}", self.w, self.val)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        assert_eq!(Bits { w: 1, val: 0 }, Bits::new(1, 0));
+        assert_eq!(Bits { w: 1, val: 1 }, Bits::new(1, 1));
+        assert_eq!(Bits { w: 1, val: 0 }, Bits::new(1, 2));
+        assert_eq!(Bits { w: 1, val: 1 }, Bits::new(1, 3));
+
+        assert_eq!(Bits { w: 2, val: 0 }, Bits::new(2, 0));
+        assert_eq!(Bits { w: 2, val: 1 }, Bits::new(2, 1));
+        assert_eq!(Bits { w: 2, val: 2 }, Bits::new(2, 2));
+        assert_eq!(Bits { w: 2, val: 3 }, Bits::new(2, 3));
+        assert_eq!(Bits { w: 2, val: 0 }, Bits::new(2, 4));
+
+        assert_eq!(
+            Bits {
+                w: 64,
+                val: 0xffff_ffff_ffff_ffff
+            },
+            Bits::new(64, 0xffff_ffff_ffff_ffff)
+        );
+    }
+
+    #[test]
+    fn test_from_str() {
+        assert_eq!(Ok(Bits::new(1, 0)), Bits::from_str("1'b0"));
+        assert_eq!(Ok(Bits::new(1, 1)), Bits::from_str("1'b1"));
+        assert_eq!(Err(()), Bits::from_str("1'b2"));
+
+        assert_eq!(Ok(Bits::new(3, 0o0)), Bits::from_str("3'o0"));
+        assert_eq!(Ok(Bits::new(3, 0o7)), Bits::from_str("3'o7"));
+        assert_eq!(Err(()), Bits::from_str("3'o8"));
+        assert_eq!(Err(()), Bits::from_str("3'o10"));
+        assert_eq!(Ok(Bits::new(12, 0o7263)), Bits::from_str("12'o7263"));
+
+        assert_eq!(Ok(Bits::new(4, 0)), Bits::from_str("4'd0"));
+        assert_eq!(Ok(Bits::new(4, 9)), Bits::from_str("4'd9"));
+        assert_eq!(Err(()), Bits::from_str("4'da"));
+        assert_eq!(Ok(Bits::new(4, 10)), Bits::from_str("4'd10"));
+        assert_eq!(Ok(Bits::new(12, 139)), Bits::from_str("12'd139"));
+
+        assert_eq!(Ok(Bits::new(4, 0x0)), Bits::from_str("4'h0"));
+        assert_eq!(Ok(Bits::new(4, 0xf)), Bits::from_str("4'hf"));
+        assert_eq!(Ok(Bits::new(4, 0xf)), Bits::from_str("4'hF"));
+        assert_eq!(Err(()), Bits::from_str("4'h10"));
+        assert_eq!(Ok(Bits::new(32, 0xf00d)), Bits::from_str("32'hf00d"));
+        assert_eq!(
+            Ok(Bits::new(32, 0xf00d_baaf)),
+            Bits::from_str("32'hf00d_baaf")
+        );
+        assert_eq!(
+            Ok(Bits::new(32, 0xf00d_baaf)),
+            Bits::from_str("32'hf0_0d_ba_af")
+        );
+    }
+}

--- a/registers/systemrdl-new/src/file_source.rs
+++ b/registers/systemrdl-new/src/file_source.rs
@@ -1,0 +1,90 @@
+// Licensed under the Apache-2.0 license
+
+use crate::string_arena::StringArena;
+use core::panic;
+use same_file::is_same_file;
+use std::{cell::RefCell, path::Path};
+
+#[cfg(test)]
+use std::{
+    collections::HashMap,
+    io::{Error, ErrorKind},
+    path::PathBuf,
+};
+
+pub trait FileSource {
+    fn read_to_string(&self, path: &Path) -> std::io::Result<&str>;
+}
+
+#[derive(Default)]
+pub struct FsFileSource {
+    arena: StringArena,
+    patches: RefCell<Vec<(String, String, String)>>,
+}
+
+fn trim_lines(s: &str) -> String {
+    s.lines().map(|l| l.trim()).collect::<Vec<_>>().join("\n")
+}
+
+impl FsFileSource {
+    pub fn new() -> Self {
+        FsFileSource {
+            arena: StringArena::new(),
+            patches: RefCell::new(Vec::new()),
+        }
+    }
+
+    pub fn add_patch(&self, path: &Path, from: &str, to: &str) {
+        self.patches.borrow_mut().push((
+            path.display().to_string(),
+            trim_lines(from),
+            trim_lines(to),
+        ));
+    }
+}
+
+impl FileSource for FsFileSource {
+    fn read_to_string(&self, path: &Path) -> std::io::Result<&str> {
+        let mut contents = trim_lines(&std::fs::read_to_string(path)?);
+        for (patch_path, from, to) in self.patches.borrow().iter() {
+            if is_same_file(path, patch_path).unwrap_or_default() {
+                if !contents.contains(from) {
+                    panic!("Patch {:?} not found in file: {}", from, path.display());
+                }
+                let before = contents.clone();
+                contents = contents.replace(from, to);
+                if before == contents {
+                    panic!("Patch {:?} did not change file: {}", from, path.display());
+                }
+            }
+        }
+        Ok(self.arena.add(contents))
+    }
+}
+
+#[cfg(test)]
+pub struct MemFileSource {
+    arena: crate::string_arena::StringArena,
+    map: HashMap<PathBuf, String>,
+}
+#[cfg(test)]
+impl MemFileSource {
+    #[allow(unused)]
+    pub fn from_entries(entries: &[(PathBuf, String)]) -> Self {
+        Self {
+            arena: StringArena::new(),
+            map: entries.iter().cloned().collect(),
+        }
+    }
+}
+#[cfg(test)]
+impl FileSource for MemFileSource {
+    fn read_to_string(&self, path: &Path) -> std::io::Result<&str> {
+        Ok(self.arena.add(
+            self.map
+                .get(path)
+                .ok_or(Error::new(ErrorKind::NotFound, path.to_string_lossy()))?
+                .clone(),
+        ))
+    }
+}

--- a/registers/systemrdl-new/src/lexer.rs
+++ b/registers/systemrdl-new/src/lexer.rs
@@ -1,0 +1,339 @@
+// Licensed under the Apache-2.0 license.
+
+use crate::{token::TokenKind, Bits};
+use std::str::{Chars, FromStr};
+
+pub type Span = std::ops::Range<usize>;
+
+pub struct Lexer<'a> {
+    start_ptr: *const u8,
+    token_start_ptr: *const u8,
+    iter: std::str::Chars<'a>,
+}
+impl<'a> Lexer<'a> {
+    pub fn new(s: &'a str) -> Self {
+        Self {
+            start_ptr: s.as_bytes().as_ptr(),
+            token_start_ptr: s.as_bytes().as_ptr(),
+            iter: s.chars(),
+        }
+    }
+
+    pub fn span(&self) -> Span {
+        Span {
+            start: self.token_start_ptr as usize - self.start_ptr as usize,
+            end: self.iter.as_str().as_ptr() as usize - self.start_ptr as usize,
+        }
+    }
+}
+impl<'a> Iterator for Lexer<'a> {
+    type Item = TokenKind<'a>;
+
+    fn next(&mut self) -> Option<TokenKind<'a>> {
+        let mut iter = self.iter.clone();
+        loop {
+            let result = match iter.next() {
+                Some(' ' | '\t' | '\n' | '\r') => Some(TokenKind::Skip),
+                Some('/') => {
+                    match iter.next() {
+                        Some('*') => {
+                            // skip comments
+                            loop {
+                                match iter.next() {
+                                    Some('*') => match iter.next() {
+                                        Some('/') => break Some(TokenKind::Skip),
+                                        Some(_) => continue,
+                                        None => break Some(TokenKind::Error),
+                                    },
+                                    Some(_) => continue,
+                                    None => break Some(TokenKind::Error),
+                                }
+                            }
+                        }
+                        Some('/') => loop {
+                            match iter.next() {
+                                Some('\n') => break Some(TokenKind::Skip),
+                                Some(_) => continue,
+                                None => break None,
+                            }
+                        },
+                        _ => Some(TokenKind::Error),
+                    }
+                }
+                Some('"') => loop {
+                    match iter.next() {
+                        Some('"') => {
+                            break Some(TokenKind::StringLiteral(str_between(&self.iter, &iter)))
+                        }
+                        Some('\\') => match iter.next() {
+                            Some(_) => continue,
+                            None => break Some(TokenKind::Error),
+                        },
+                        Some(_) => continue,
+                        None => break Some(TokenKind::Error),
+                    }
+                },
+                Some(ch) if ch.is_ascii_alphabetic() || ch == '_' => {
+                    next_while(&mut iter, |ch| ch.is_ascii_alphanumeric() || ch == '_');
+                    let ident = str_between(&self.iter, &iter);
+                    match ident {
+                        "field" => Some(TokenKind::Field),
+                        "internal" => Some(TokenKind::Internal),
+                        "external" => Some(TokenKind::External),
+                        "reg" => Some(TokenKind::Reg),
+                        "regfile" => Some(TokenKind::RegFile),
+                        "addrmap" => Some(TokenKind::AddrMap),
+                        "signal" => Some(TokenKind::Signal),
+                        "enum" => Some(TokenKind::Enum),
+                        "mem" => Some(TokenKind::Mem),
+                        "constraint" => Some(TokenKind::Constraint),
+                        "true" => Some(TokenKind::True),
+                        "false" => Some(TokenKind::False),
+                        "na" | "rw" | "wr" | "r" | "w" | "rw1" | "w1" => {
+                            Some(TokenKind::AccessTypeLiteral(ident.into()))
+                        }
+                        "rclr" | "rset" | "ruser" => {
+                            Some(TokenKind::OnReadTypeLiteral(ident.into()))
+                        }
+                        "woset" | "woclr" | "wot" | "wzs" | "wzc" | "wzt" | "wclr" | "wset"
+                        | "wuser" => Some(TokenKind::OnWriteTypeLiteral(ident.into())),
+                        "compact" | "regalign" | "fullalign" => {
+                            Some(TokenKind::AddressingTypeLiteral(ident.into()))
+                        }
+                        "hw" | "sw" => Some(TokenKind::PrecedenceTypeLiteral(ident.into())),
+                        "accesstype" => Some(TokenKind::AccessType),
+                        "addressingtype" => Some(TokenKind::AddressingType),
+                        "onreadtype" => Some(TokenKind::OnReadType),
+                        "onwritetype" => Some(TokenKind::OnWriteType),
+                        "string" => Some(TokenKind::String),
+                        "boolean" => Some(TokenKind::Boolean),
+                        "unsigned" => Some(TokenKind::Unsigned),
+                        "bit" => Some(TokenKind::Bit),
+                        "longint" => Some(TokenKind::Longint),
+                        "this" => Some(TokenKind::This),
+                        "encode" => Some(TokenKind::Encode),
+                        "struct" => Some(TokenKind::Struct),
+                        "abstract" => Some(TokenKind::Abstract),
+                        "inside" => Some(TokenKind::Inside),
+                        "alias" => Some(TokenKind::Alias),
+                        "default" => Some(TokenKind::Default),
+                        "posedge" => Some(TokenKind::PosEdge),
+                        "negedge" => Some(TokenKind::NegEdge),
+                        "bothedge" => Some(TokenKind::BothEdge),
+                        "level" => Some(TokenKind::Level),
+                        "nonsticky" => Some(TokenKind::NonSticky),
+                        "property" => Some(TokenKind::Property),
+                        "type" => Some(TokenKind::Type),
+                        "ref" => Some(TokenKind::Ref),
+                        "number" => Some(TokenKind::Number_),
+                        "componentwidth" => Some(TokenKind::ComponentWidth),
+                        "component" => Some(TokenKind::Component),
+                        "all" => Some(TokenKind::All),
+                        _ => Some(TokenKind::Identifier(ident)),
+                    }
+                }
+                Some(ch) if ch.is_ascii_digit() => {
+                    if ch == '0' && iter.peek() == Some('x') {
+                        iter.next();
+                        let num_start = iter.clone();
+                        next_while(&mut iter, |ch| ch.is_ascii_hexdigit() || ch == '_');
+                        Some(parse_num(str_between(&num_start, &iter), 16))
+                    } else {
+                        next_while(&mut iter, |ch| ch.is_ascii_digit() || ch == '_');
+                        let mut peek = iter.clone();
+                        if let Some('\'') = peek.next() {
+                            iter = peek;
+                            next_while(&mut iter, |ch| {
+                                ch == 'b' || ch == 'o' || ch == 'd' || ch == 'h'
+                            });
+                            next_while(&mut iter, |ch| ch.is_ascii_hexdigit() || ch == '_');
+                            match Bits::from_str(str_between(&self.iter, &iter)) {
+                                Ok(bits) => Some(TokenKind::Bits(bits)),
+                                Err(_) => Some(TokenKind::Error),
+                            }
+                        } else {
+                            Some(parse_num(str_between(&self.iter, &iter), 10))
+                        }
+                    }
+                }
+                Some('!') => match iter.next() {
+                    Some('=') => Some(TokenKind::NotEquals),
+                    _ => Some(TokenKind::Error),
+                },
+                Some('&') => match iter.peek() {
+                    Some('&') => {
+                        iter.next();
+                        Some(TokenKind::AndAnd)
+                    }
+                    _ => Some(TokenKind::And),
+                },
+                Some('|') => match iter.peek() {
+                    Some('|') => {
+                        iter.next();
+                        Some(TokenKind::OrOr)
+                    }
+                    _ => Some(TokenKind::Or),
+                },
+                Some('{') => Some(TokenKind::BraceOpen),
+                Some('}') => Some(TokenKind::BraceClose),
+                Some('[') => Some(TokenKind::BracketOpen),
+                Some(']') => Some(TokenKind::BracketClose),
+                Some('(') => Some(TokenKind::ParenOpen),
+                Some(')') => Some(TokenKind::ParenClose),
+                Some(';') => Some(TokenKind::Semicolon),
+                Some(',') => Some(TokenKind::Comma),
+                Some('.') => Some(TokenKind::Period),
+                Some('=') => match iter.peek() {
+                    Some('=') => {
+                        iter.next();
+                        Some(TokenKind::EqualsEquals)
+                    }
+                    _ => Some(TokenKind::Equals),
+                },
+                Some('@') => Some(TokenKind::At),
+                Some('#') => Some(TokenKind::Hash),
+                Some(':') => Some(TokenKind::Colon),
+                Some('?') => Some(TokenKind::QuestionMark),
+                Some('\'') => Some(TokenKind::Quote),
+                Some('`') => {
+                    let keyword_start = iter.clone();
+                    next_while(&mut iter, |ch| ch.is_ascii_alphabetic() || ch == '_');
+                    match str_between(&keyword_start, &iter) {
+                        "include" => Some(TokenKind::PreprocInclude),
+                        "ifndef" => Some(TokenKind::PreprocIfndef),
+                        "define" => Some(TokenKind::PreprocDefine),
+                        "endif" => Some(TokenKind::PreprocEndif),
+                        _ => Some(TokenKind::Error),
+                    }
+                }
+                Some('+') => match iter.next() {
+                    Some('=') => Some(TokenKind::PlusEqual),
+                    _ => return Some(TokenKind::Error),
+                },
+                Some('%') => match iter.next() {
+                    Some('=') => Some(TokenKind::PercentEqual),
+                    _ => Some(TokenKind::Error),
+                },
+                Some('-') => match iter.next() {
+                    Some('>') => Some(TokenKind::Pointer),
+                    _ => Some(TokenKind::Error),
+                },
+                None => None,
+                _ => Some(TokenKind::Error),
+            };
+            match result {
+                Some(TokenKind::Skip) => {
+                    self.iter = iter.clone();
+                    continue;
+                }
+                Some(token) => {
+                    self.token_start_ptr = self.iter.as_str().as_ptr();
+                    self.iter = iter;
+                    return Some(token);
+                }
+                None => return None,
+            }
+        }
+    }
+}
+
+fn next_while(iter: &mut Chars, mut f: impl FnMut(char) -> bool) {
+    loop {
+        let mut peek = iter.clone();
+        if let Some(ch) = peek.next() {
+            if f(ch) {
+                *iter = peek;
+                continue;
+            } else {
+                break;
+            }
+        } else {
+            break;
+        }
+    }
+}
+
+fn parse_num(s: &str, radix: u32) -> TokenKind {
+    let replaced;
+    let s = if s.contains('_') {
+        replaced = s.replace('_', "");
+        &replaced
+    } else {
+        s
+    };
+    if let Ok(val) = u64::from_str_radix(s, radix) {
+        TokenKind::Number(val)
+    } else {
+        TokenKind::Error
+    }
+}
+
+trait PeekableChar {
+    fn peek(&self) -> Option<char>;
+}
+impl PeekableChar for std::str::Chars<'_> {
+    fn peek(&self) -> Option<char> {
+        self.clone().next()
+    }
+}
+fn str_between<'a>(start: &Chars<'a>, end: &Chars<'a>) -> &'a str {
+    let first_ptr = start.as_str().as_ptr();
+    let second_ptr = end.as_str().as_ptr();
+    &start.as_str()[0..second_ptr as usize - first_ptr as usize]
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_foo() {
+        let tokens: Vec<TokenKind> = Lexer::new("!= && ? __id external field 35\tiDentifier2_ 0x24\n\r 0xf00_bad 100_200 2'b01 5'o27 4'd9 16'h1caf 32'h3CAB_FFB0 /* ignore comment */ %= // line comment\n += \"string 1\" \"string\\\"2\" {}[]();:,.=@#reg field regfile addrmap signal enum mem constraint").take(42).collect();
+        assert_eq!(
+            tokens,
+            vec![
+                TokenKind::NotEquals,
+                TokenKind::AndAnd,
+                TokenKind::QuestionMark,
+                TokenKind::Identifier("__id"),
+                TokenKind::External,
+                TokenKind::Field,
+                TokenKind::Number(35),
+                TokenKind::Identifier("iDentifier2_"),
+                TokenKind::Number(0x24),
+                TokenKind::Number(0xf00bad),
+                TokenKind::Number(100_200),
+                TokenKind::Bits(Bits::new(2, 1)),
+                TokenKind::Bits(Bits::new(5, 0o27)),
+                TokenKind::Bits(Bits::new(4, 9)),
+                TokenKind::Bits(Bits::new(16, 0x1caf)),
+                TokenKind::Bits(Bits::new(32, 0x3cab_ffb0)),
+                TokenKind::PercentEqual,
+                TokenKind::PlusEqual,
+                TokenKind::StringLiteral("\"string 1\""),
+                TokenKind::StringLiteral("\"string\\\"2\""),
+                TokenKind::BraceOpen,
+                TokenKind::BraceClose,
+                TokenKind::BracketOpen,
+                TokenKind::BracketClose,
+                TokenKind::ParenOpen,
+                TokenKind::ParenClose,
+                TokenKind::Semicolon,
+                TokenKind::Colon,
+                TokenKind::Comma,
+                TokenKind::Period,
+                TokenKind::Equals,
+                TokenKind::At,
+                TokenKind::Hash,
+                TokenKind::Reg,
+                TokenKind::Field,
+                TokenKind::RegFile,
+                TokenKind::AddrMap,
+                TokenKind::Signal,
+                TokenKind::Enum,
+                TokenKind::Mem,
+                TokenKind::Constraint,
+            ]
+        );
+    }
+}

--- a/registers/systemrdl-new/src/lib.rs
+++ b/registers/systemrdl-new/src/lib.rs
@@ -1,0 +1,17 @@
+// Licensed under the Apache-2.0 license.
+
+//! General-purpose parser for systemrdl files.
+
+pub mod ast;
+mod bits;
+mod file_source;
+mod lexer;
+mod parser;
+mod string_arena;
+mod token;
+mod token_iter;
+
+pub use bits::Bits;
+pub use file_source::{FileSource, FsFileSource};
+pub use parser::parse;
+pub use token::*;

--- a/registers/systemrdl-new/src/parser.rs
+++ b/registers/systemrdl-new/src/parser.rs
@@ -1,0 +1,1784 @@
+// Licensed under the Apache-2.0 license.
+
+//! Contains the winnow parser production rules for the SystemRDL language.
+
+use crate::ast::*;
+use crate::lexer::Lexer;
+use crate::token::TokenKind;
+use crate::token::{Token, Tokens};
+use winnow::combinator::{alt, fail, opt, preceded, repeat, separated, terminated};
+use winnow::error::ParserError;
+use winnow::stream::Stream;
+use winnow::{Parser, Result};
+
+fn identifier(i: &mut Tokens) -> Result<String> {
+    match i.next_token() {
+        Some(Token {
+            kind: TokenKind::Identifier(id),
+            ..
+        }) => Ok(id.to_string()),
+        _ => fail.parse_next(i)?,
+    }
+}
+
+// component_type ::=
+//     component_primary_type
+//   | signal
+// component_primary_type ::= addrmap | regfile | reg | field | mem
+fn component_type(i: &mut Tokens<'_>) -> Result<ComponentType> {
+    let ct = match i.next_token() {
+        Some(Token {
+            kind: TokenKind::Reg,
+            ..
+        }) => ComponentType::Reg,
+        Some(Token {
+            kind: TokenKind::RegFile,
+            ..
+        }) => ComponentType::RegFile,
+        Some(Token {
+            kind: TokenKind::Signal,
+            ..
+        }) => ComponentType::Signal,
+        Some(Token {
+            kind: TokenKind::Mem,
+            ..
+        }) => ComponentType::Mem,
+        Some(Token {
+            kind: TokenKind::Field,
+            ..
+        }) => ComponentType::Field,
+        Some(Token {
+            kind: TokenKind::AddrMap,
+            ..
+        }) => ComponentType::AddrMap,
+        _ => fail.parse_next(i)?,
+    };
+    Ok(ct)
+}
+
+// component_primary_type ::= addrmap | regfile | reg | field | mem
+fn component_primary_type(i: &mut Tokens<'_>) -> Result<ComponentType> {
+    let ct = match i.next_token() {
+        Some(Token {
+            kind: TokenKind::Reg,
+            ..
+        }) => ComponentType::Reg,
+        Some(Token {
+            kind: TokenKind::RegFile,
+            ..
+        }) => ComponentType::RegFile,
+        Some(Token {
+            kind: TokenKind::Mem,
+            ..
+        }) => ComponentType::Mem,
+        Some(Token {
+            kind: TokenKind::Field,
+            ..
+        }) => ComponentType::Field,
+        Some(Token {
+            kind: TokenKind::AddrMap,
+            ..
+        }) => ComponentType::AddrMap,
+        _ => fail.parse_next(i)?,
+    };
+    Ok(ct)
+}
+
+// signing ::= unsigned
+fn signing(i: &mut Tokens<'_>) -> Result<()> {
+    TokenKind::Unsigned.parse_next(i)?;
+    Ok(())
+}
+
+// integer_vector_type ::= bit
+fn integer_type_bit(i: &mut Tokens<'_>) -> Result<IntegerType> {
+    TokenKind::Bit.parse_next(i).map(|_| IntegerType::Bit)
+}
+
+// integer_atom_type ::= longint
+fn integer_type_longint(i: &mut Tokens<'_>) -> Result<IntegerType> {
+    TokenKind::Longint.parse_next(i).map(|_| IntegerType::Bit)
+}
+
+// simple_type ::= integer_type
+// integer_type ::=
+//     integer_vector_type
+//   | integer_atom_type
+fn simple_type(i: &mut Tokens<'_>) -> Result<IntegerType> {
+    alt((integer_type_bit, integer_type_longint, fail)).parse_next(i)
+}
+
+// basic_data_type ::=
+//     simple_type [ signing ]
+fn basic_data_type_simple_type_signing(i: &mut Tokens<'_>) -> Result<BasicDataType> {
+    let (st, s) = (simple_type, opt(signing)).parse_next(i)?;
+    match s {
+        Some(_) => Ok(BasicDataType::UnsignedIntegerType(st)),
+        _ => Ok(BasicDataType::IntegerType(st)),
+    }
+}
+
+// basic_data_type ::=
+//   | string
+fn basic_data_type_string(i: &mut Tokens<'_>) -> Result<BasicDataType> {
+    let _ = TokenKind::String.parse_next(i)?;
+    Ok(BasicDataType::String)
+}
+
+// basic_data_type ::=
+//   | boolean
+fn basic_data_type_boolean(i: &mut Tokens<'_>) -> Result<BasicDataType> {
+    let _ = TokenKind::Boolean.parse_next(i)?;
+    Ok(BasicDataType::Boolean)
+}
+
+// basic_data_type ::=
+//   | id
+fn basic_data_type_id(i: &mut Tokens<'_>) -> Result<BasicDataType> {
+    let x = identifier.parse_next(i)?;
+    Ok(BasicDataType::Identifier(x))
+}
+
+// basic_data_type ::=
+//     simple_type [ signing ]
+//   | string
+//   | boolean
+//   | id
+fn basic_data_type(i: &mut Tokens<'_>) -> Result<BasicDataType> {
+    alt((
+        basic_data_type_simple_type_signing,
+        basic_data_type_string,
+        basic_data_type_boolean,
+        basic_data_type_id,
+        fail,
+    ))
+    .parse_next(i)
+}
+
+// data_type ::=
+//   | accesstype
+fn data_type_basic_data_type(i: &mut Tokens<'_>) -> Result<DataType> {
+    basic_data_type.parse_next(i).map(DataType::BasicDataType)
+}
+
+// data_type ::=
+//   | accesstype
+fn data_type_accesstype(i: &mut Tokens<'_>) -> Result<DataType> {
+    TokenKind::AccessType
+        .parse_next(i)
+        .map(|_| DataType::AccessType)
+}
+
+// data_type ::=
+//   | addressingtype
+fn data_type_adressingtype(i: &mut Tokens<'_>) -> Result<DataType> {
+    TokenKind::AddressingType
+        .parse_next(i)
+        .map(|_| DataType::AddressingType)
+}
+
+// data_type ::=
+//   | onreadtype
+fn data_type_onreadtype(i: &mut Tokens<'_>) -> Result<DataType> {
+    TokenKind::OnReadType
+        .parse_next(i)
+        .map(|_| DataType::OnReadType)
+}
+
+// data_type ::=
+//   | onwritetype
+fn data_type_onwritetype(i: &mut Tokens<'_>) -> Result<DataType> {
+    TokenKind::OnWriteType
+        .parse_next(i)
+        .map(|_| DataType::OnWriteType)
+}
+
+// data_type ::=
+//     basic_data_type
+//   | accesstype
+//   | addressingtype
+//   | onreadtype
+//   | onwritetype
+fn data_type(i: &mut Tokens<'_>) -> Result<DataType> {
+    alt((
+        data_type_basic_data_type,
+        data_type_accesstype,
+        data_type_adressingtype,
+        data_type_onreadtype,
+        data_type_onwritetype,
+        fail,
+    ))
+    .parse_next(i)
+}
+
+// array_type ::= [ ]
+fn array_type(i: &mut Tokens<'_>) -> Result<ArrayType> {
+    let _ = (TokenKind::BracketOpen, TokenKind::BracketClose).parse_next(i)?;
+    Ok(ArrayType {})
+}
+
+// param_def_elem ::= data_type id [ array_type ] [ = constant_expression ]
+fn param_def_elem(i: &mut Tokens<'_>) -> Result<ParamDefElem> {
+    let (dt, id, at, expr) = (
+        data_type,
+        identifier,
+        opt(array_type),
+        opt(preceded(TokenKind::Equals, constant_expr)),
+    )
+        .parse_next(i)?;
+    Ok(ParamDefElem::ParamDefElem(dt, id, at, expr))
+}
+
+// param_def ::= # ( param_def_elem { , param_def_elem } )
+fn param_def(i: &mut Tokens<'_>) -> Result<ParamDef> {
+    let (_, _, params, _) = (
+        TokenKind::Hash,
+        TokenKind::ParenOpen,
+        separated(1.., param_def_elem, TokenKind::Comma),
+        TokenKind::ParenClose,
+    )
+        .parse_next(i)?;
+    Ok(ParamDef::Params(params))
+}
+
+// component_body ::= { { component_body_elem } }
+fn component_body(i: &mut Tokens<'_>) -> Result<ComponentBody> {
+    let (_, elements, _) = (
+        TokenKind::BraceOpen,
+        repeat(0.., component_body_elem),
+        TokenKind::BraceClose,
+    )
+        .parse_next(i)?;
+
+    Ok(ComponentBody { elements })
+}
+
+fn explicit_encode_assignment(i: &mut Tokens<'_>) -> Result<String> {
+    let (_, _, id) = (TokenKind::Encode, TokenKind::Equals, identifier).parse_next(i)?;
+    Ok(id)
+}
+
+// prop_assignment_lhs ::=
+//     prop_keyword
+//   | id
+fn prop_assignment_lhs(i: &mut Tokens<'_>) -> Result<IdentityOrPropKeyword> {
+    id_or_prop_keyword.parse_next(i)
+}
+
+// precedencetype_literal ::= hw | sw
+fn precedence_type(i: &mut Tokens<'_>) -> Result<PrecedenceType> {
+    match i.next_token() {
+        Some(Token {
+            kind: TokenKind::PrecedenceTypeLiteral(x),
+            ..
+        }) => Ok(*x),
+        _ => fail.parse_next(i),
+    }
+}
+
+// prop_assignment_rhs ::=
+//     constant_expression
+//   | precedencetype_literal
+fn prop_assignment_rhs(i: &mut Tokens<'_>) -> Result<PropAssignmentRhs> {
+    if let Some(x) = opt(constant_expr).parse_next(i)? {
+        Ok(PropAssignmentRhs::ConstantExpr(x))
+    } else if let Some(x) = opt(precedence_type).parse_next(i)? {
+        Ok(PropAssignmentRhs::PrecedenceType(x))
+    } else {
+        fail.parse_next(i)
+    }
+}
+
+// explicit_prop_assignment ::=
+//     prop_assignment_lhs [ = prop_assignment_rhs ]
+//   | explicit_encode_assignment
+fn explicit_prop_assignment(i: &mut Tokens<'_>) -> Result<ExplicitPropertyAssignment> {
+    if let Some((lhs, rhs)) = opt((
+        prop_assignment_lhs,
+        opt(preceded(TokenKind::Equals, prop_assignment_rhs)),
+    ))
+    .parse_next(i)?
+    {
+        Ok(ExplicitPropertyAssignment::Assignment(lhs, rhs))
+    } else if let Some(id) = opt(explicit_encode_assignment).parse_next(i)? {
+        Ok(ExplicitPropertyAssignment::EncodeAssignment(id))
+    } else {
+        fail.parse_next(i)
+    }
+}
+
+// enum_property_assignment ::= { { explicit_prop_assignment ; } }
+fn enum_property_assignment(i: &mut Tokens<'_>) -> Result<Vec<ExplicitPropertyAssignment>> {
+    let (_, assignments, _) = (
+        TokenKind::BraceOpen,
+        repeat(
+            0..,
+            terminated(explicit_prop_assignment, TokenKind::Semicolon),
+        ),
+        TokenKind::BraceClose,
+    )
+        .parse_next(i)?;
+    Ok(assignments)
+}
+
+// enum_entry ::= id [ = constant_expression ] [ enum_property_assignment ] ;
+fn enum_entry(i: &mut Tokens<'_>) -> Result<EnumEntry> {
+    let (id, expr, props, _) = (
+        identifier,
+        opt((TokenKind::Equals, constant_expr)),
+        opt(enum_property_assignment),
+        TokenKind::Semicolon,
+    )
+        .parse_next(i)?;
+    Ok(EnumEntry {
+        id,
+        expr: expr.map(|(_, expr)| expr),
+        property_assignments: props.unwrap_or_default(),
+    })
+}
+
+// enum_body ::= { enum_entry { enum_entry } }
+fn enum_body(i: &mut Tokens<'_>) -> Result<Vec<EnumEntry>> {
+    let (_, elements, _) = (
+        TokenKind::BraceOpen,
+        repeat(1.., enum_entry),
+        TokenKind::BraceClose,
+    )
+        .parse_next(i)?;
+    Ok(elements)
+}
+
+// enum_def ::= enum id enum_body ;
+fn enum_def(i: &mut Tokens<'_>) -> Result<EnumDef> {
+    let (_, id, body, _) =
+        (TokenKind::Enum, identifier, enum_body, TokenKind::Semicolon).parse_next(i)?;
+    Ok(EnumDef { id, body })
+}
+
+// struct_type ::=
+//     data_type
+//   | component_type
+fn struct_type(i: &mut Tokens<'_>) -> Result<StructType> {
+    if let Some(data_type) = opt(data_type).parse_next(i)? {
+        Ok(StructType::DataType(data_type))
+    } else if let Some(component_type) = opt(component_type).parse_next(i)? {
+        Ok(StructType::ComponentType(component_type))
+    } else {
+        fail.parse_next(i)
+    }
+}
+
+// struct_elem ::= struct_type id [ array_type ] ;
+fn struct_elem(i: &mut Tokens<'_>) -> Result<StructElem> {
+    let (struct_type, id, array_type, _) = (
+        struct_type,
+        identifier,
+        opt(array_type),
+        TokenKind::Semicolon,
+    )
+        .parse_next(i)?;
+    Ok(StructElem {
+        struct_type,
+        id,
+        array_type,
+    })
+}
+
+// struct_body ::= { { struct_elem } }
+fn struct_body(i: &mut Tokens<'_>) -> Result<Vec<StructElem>> {
+    let (_, elements, _) = (
+        TokenKind::BraceOpen,
+        repeat(0.., struct_elem),
+        TokenKind::BraceClose,
+    )
+        .parse_next(i)?;
+    Ok(elements)
+}
+
+// struct_def ::= [ abstract ] struct id [ : id ] struct_body ;
+fn struct_def(i: &mut Tokens<'_>) -> Result<StructDef> {
+    let (_, _, id, base, body, _) = (
+        opt(TokenKind::Abstract),
+        TokenKind::Struct,
+        identifier,
+        opt((TokenKind::Colon, identifier)),
+        struct_body,
+        TokenKind::Semicolon,
+    )
+        .parse_next(i)?;
+    Ok(StructDef {
+        id,
+        base: base.map(|x| x.1),
+        body,
+    })
+}
+
+// constraint_lhs ::=
+//     this
+//  | instance_ref
+fn constraint_lhs(i: &mut Tokens<'_>) -> Result<ConstraintLhs> {
+    if opt(TokenKind::This).parse_next(i)?.is_some() {
+        Ok(ConstraintLhs::This)
+    } else if let Some(iref) = opt(instance_ref).parse_next(i)? {
+        Ok(ConstraintLhs::InstanceRef(iref))
+    } else {
+        fail.parse_next(i)
+    }
+}
+
+// constraint_prop_assignment ::= id = constant_expression
+fn constraint_prop_assignment(i: &mut Tokens<'_>) -> Result<ConstraintPropAssignment> {
+    let (id, _, expr) = (identifier, TokenKind::Equals, constant_expr).parse_next(i)?;
+    Ok(ConstraintPropAssignment { id, expr })
+}
+
+// constraint_value ::=
+//     constant_expression
+//   | [ constant_expression : constant_expression ]
+fn constraint_value(i: &mut Tokens<'_>) -> Result<ConstraintValue> {
+    if let Some(x) = opt(constant_expr).parse_next(i)? {
+        Ok(ConstraintValue::ConstantExpr(x))
+    } else if let Some((_, a, _, b, _)) = opt((
+        TokenKind::BracketOpen,
+        constant_expr,
+        TokenKind::Colon,
+        constant_expr,
+        TokenKind::BracketClose,
+    ))
+    .parse_next(i)?
+    {
+        return Ok(ConstraintValue::Range(a, b));
+    } else {
+        fail.parse_next(i)
+    }
+}
+
+// constraint_values ::= constraint_value { , constraint_value }
+fn constraint_values(i: &mut Tokens<'_>) -> Result<Vec<ConstraintValue>> {
+    separated(1.., constraint_value, TokenKind::Comma).parse_next(i)
+}
+
+// constraint_elem ::=
+//     constant_expression
+//   | constraint_prop_assignment
+//   | constraint_lhs inside { constraint_values }
+//   | constraint_lhs inside id
+fn constraint_elem(i: &mut Tokens<'_>) -> Result<ConstraintElem> {
+    if let Some(x) = opt(constant_expr).parse_next(i)? {
+        Ok(ConstraintElem::ConstantExpr(x))
+    } else if let Some(x) = opt(constraint_prop_assignment).parse_next(i)? {
+        Ok(ConstraintElem::ConstraintPropAssignment(x))
+    } else if let Some((lhs, _, _, values, _)) = opt((
+        constraint_lhs,
+        TokenKind::Inside,
+        TokenKind::BracketOpen,
+        constraint_values,
+        TokenKind::BracketClose,
+    ))
+    .parse_next(i)?
+    {
+        Ok(ConstraintElem::ConstraintInsideValues(lhs, values))
+    } else if let Some((lhs, _, id)) =
+        opt((constraint_lhs, TokenKind::Inside, identifier)).parse_next(i)?
+    {
+        Ok(ConstraintElem::ConstraintInsideId(lhs, id))
+    } else {
+        fail.parse_next(i)
+    }
+}
+
+// constraint_body ::= { { constraint_elem ; } }
+fn constraint_body(i: &mut Tokens<'_>) -> Result<ConstraintBody> {
+    let (_, elements, _) = (
+        TokenKind::BraceOpen,
+        repeat(0.., terminated(constraint_elem, TokenKind::Semicolon)),
+        TokenKind::BraceClose,
+    )
+        .parse_next(i)?;
+    Ok(ConstraintBody { elements })
+}
+
+// constraint_insts ::= id { , id }
+fn constraint_insts(i: &mut Tokens<'_>) -> Result<Vec<String>> {
+    separated(1.., identifier, TokenKind::Comma).parse_next(i)
+}
+
+// constraint_def_exp ::= id constraint_body [ constraint_insts ]
+fn constraint_def_exp(i: &mut Tokens<'_>) -> Result<ConstraintDef> {
+    let (id, body, insts) = (identifier, constraint_body, opt(constraint_insts)).parse_next(i)?;
+    Ok(ConstraintDef::Exp(id, body, insts.unwrap_or_default()))
+}
+
+// constraint_def_anon ::= constraint_body constraint_insts
+fn constraint_def_anon(i: &mut Tokens<'_>) -> Result<ConstraintDef> {
+    let (body, insts) = (constraint_body, constraint_insts).parse_next(i)?;
+    Ok(ConstraintDef::Anon(body, insts))
+}
+
+// constraint_def ::=
+//     constraint constraint_def_exp ;
+//   | constraint constraint_def_anon ;
+fn constraint_def(i: &mut Tokens<'_>) -> Result<ConstraintDef> {
+    preceded(
+        TokenKind::Constraint,
+        terminated(
+            alt((constraint_def_exp, constraint_def_anon)),
+            TokenKind::Semicolon,
+        ),
+    )
+    .parse_next(i)
+}
+
+// component_inst_alias ::= alias id
+fn component_inst_alias(i: &mut Tokens<'_>) -> Result<ComponentInstAlias> {
+    preceded(TokenKind::Alias, identifier)
+        .parse_next(i)
+        .map(|id| ComponentInstAlias { id })
+}
+
+// explicit_component_inst ::= [ component_inst_type ] [ component_inst_alias ] id component_insts ;
+fn explicit_component_inst(i: &mut Tokens<'_>) -> Result<ExplicitComponentInst> {
+    let (component_inst_type, component_inst_alias, id, component_insts) = terminated(
+        (
+            opt(component_inst_type),
+            opt(component_inst_alias),
+            identifier,
+            component_insts,
+        ),
+        TokenKind::Semicolon,
+    )
+    .parse_next(i)?;
+
+    Ok(ExplicitComponentInst {
+        component_inst_type,
+        component_inst_alias,
+        id,
+        component_insts,
+    })
+}
+
+// prop_mod ::= posedge | negedge | bothedge | level | nonsticky
+fn prop_mod(i: &mut Tokens<'_>) -> Result<PropMod> {
+    match i.next_token() {
+        Some(Token {
+            kind: TokenKind::PosEdge,
+            ..
+        }) => Ok(PropMod::PosEdge),
+        Some(Token {
+            kind: TokenKind::NegEdge,
+            ..
+        }) => Ok(PropMod::NegEdge),
+        Some(Token {
+            kind: TokenKind::BothEdge,
+            ..
+        }) => Ok(PropMod::BothEdge),
+        Some(Token {
+            kind: TokenKind::Level,
+            ..
+        }) => Ok(PropMod::Level),
+        Some(Token {
+            kind: TokenKind::NonSticky,
+            ..
+        }) => Ok(PropMod::NonSticky),
+        _ => fail.parse_next(i),
+    }
+}
+
+// explicit_prop_modifier ::= prop_mod id
+fn explicit_prop_modifier(i: &mut Tokens<'_>) -> Result<ExplicitPropModifier> {
+    let (prop_mod, id) = (prop_mod, identifier).parse_next(i)?;
+    Ok(ExplicitPropModifier { prop_mod, id })
+}
+
+// default
+fn default(i: &mut Tokens<'_>) -> Result<DefaultKeyword> {
+    TokenKind::Default.parse_next(i).map(|_| DefaultKeyword {})
+}
+
+// explicit_or_default_prop_assignment ::=
+//     [ default ] explicit_prop_modifier ;
+fn explicit_or_default_prop_assignment_explicit_prop_modifier(
+    i: &mut Tokens<'_>,
+) -> Result<ExplicitOrDefaultPropAssignment> {
+    let (default, explicit_prop_modifier) =
+        terminated((opt(default), explicit_prop_modifier), TokenKind::Semicolon).parse_next(i)?;
+    Ok(ExplicitOrDefaultPropAssignment::ExplicitPropModifier(
+        default,
+        explicit_prop_modifier,
+    ))
+}
+
+// explicit_or_default_prop_assignment ::=
+//     [ default ] explicit_prop_assignment ;
+fn explicit_or_default_prop_assignment_explicit_prop_assignment(
+    i: &mut Tokens<'_>,
+) -> Result<ExplicitOrDefaultPropAssignment> {
+    let (default, explicit_prop_assignment) = terminated(
+        (opt(default), explicit_prop_assignment),
+        TokenKind::Semicolon,
+    )
+    .parse_next(i)?;
+    Ok(ExplicitOrDefaultPropAssignment::ExplicitPropAssignment(
+        default,
+        explicit_prop_assignment,
+    ))
+}
+
+// explicit_or_default_prop_assignment ::=
+//     [ default ] explicit_prop_modifier ;
+//   | [ default ] explicit_prop_assignment ;
+fn explicit_or_default_prop_assignment(i: &mut Tokens<'_>) -> Result<PropertyAssignment> {
+    alt((
+        explicit_or_default_prop_assignment_explicit_prop_modifier,
+        explicit_or_default_prop_assignment_explicit_prop_assignment,
+        fail,
+    ))
+    .parse_next(i)
+    .map(PropertyAssignment::ExplicitOrDefaultPropAssignment)
+}
+
+// prop_ref ::=
+//     instance_ref -> prop_keyword
+//   | instance_ref -> id
+fn prop_ref(i: &mut Tokens<'_>) -> Result<PropRef> {
+    let (iref, id_or_prop) = (
+        terminated(instance_ref, TokenKind::Pointer),
+        id_or_prop_keyword,
+    )
+        .parse_next(i)?;
+    Ok(PropRef { iref, id_or_prop })
+}
+
+// post_encode_assignment ::= instance_ref -> encode = id
+fn post_encode_assignment(i: &mut Tokens<'_>) -> Result<PostEncodeAssignment> {
+    let (iref, _, _, _, id) = (
+        instance_ref,
+        TokenKind::Pointer,
+        TokenKind::Encode,
+        TokenKind::Equals,
+        identifier,
+    )
+        .parse_next(i)?;
+    Ok(PostEncodeAssignment { iref, id })
+}
+
+// post_prop_assignment ::=
+//     prop_ref [ = prop_assignment_rhs ] ;
+fn post_prop_assignment_prop_ref(i: &mut Tokens<'_>) -> Result<PostPropAssignment> {
+    let rhs = opt(preceded(TokenKind::Equals, prop_assignment_rhs));
+    let (prop_ref, rhs) = terminated((prop_ref, rhs), TokenKind::Semicolon).parse_next(i)?;
+    Ok(PostPropAssignment::PropRef(prop_ref, rhs))
+}
+
+// post_prop_assignment ::=
+//   | post_encode_assignment ;
+fn post_prop_assignment_post_encode_assignment(i: &mut Tokens<'_>) -> Result<PostPropAssignment> {
+    let post_encode_assignment =
+        terminated(post_encode_assignment, TokenKind::Semicolon).parse_next(i)?;
+
+    Ok(PostPropAssignment::PostEncodeAssignment(
+        post_encode_assignment,
+    ))
+}
+// post_prop_assignment ::=
+//     prop_ref [ = prop_assignment_rhs ] ;
+//   | post_encode_assignment ;
+fn post_prop_assignment(i: &mut Tokens<'_>) -> Result<PropertyAssignment> {
+    alt((
+        post_prop_assignment_prop_ref,
+        post_prop_assignment_post_encode_assignment,
+        fail,
+    ))
+    .parse_next(i)
+    .map(PropertyAssignment::PostPropAssignment)
+}
+
+// property_assignment ::=
+//     explicit_or_default_prop_assignment
+//   | post_prop_assignment
+fn property_assignment(i: &mut Tokens<'_>) -> Result<PropertyAssignment> {
+    alt((
+        explicit_or_default_prop_assignment,
+        post_prop_assignment,
+        fail,
+    ))
+    .parse_next(i)
+}
+
+// component_body_elem ::=
+//     component_def
+fn component_body_elem_component_def(i: &mut Tokens<'_>) -> Result<ComponentBodyElem> {
+    component_def
+        .parse_next(i)
+        .map(ComponentBodyElem::ComponentDef)
+}
+
+// component_body_elem ::=
+//   | enum_def
+fn component_body_elem_enum_def(i: &mut Tokens<'_>) -> Result<ComponentBodyElem> {
+    enum_def.parse_next(i).map(ComponentBodyElem::EnumDef)
+}
+
+// component_body_elem ::=
+//   | struct_def
+fn component_body_elem_struct_def(i: &mut Tokens<'_>) -> Result<ComponentBodyElem> {
+    struct_def.parse_next(i).map(ComponentBodyElem::StructDef)
+}
+
+// component_body_elem ::=
+//   | constraint_def
+fn component_body_elem_constraint_def(i: &mut Tokens<'_>) -> Result<ComponentBodyElem> {
+    constraint_def
+        .parse_next(i)
+        .map(ComponentBodyElem::ConstraintDef)
+}
+
+// component_body_elem ::=
+//   | explicit_component_inst
+fn component_body_elem_explicit_component_inst(i: &mut Tokens<'_>) -> Result<ComponentBodyElem> {
+    explicit_component_inst
+        .parse_next(i)
+        .map(ComponentBodyElem::ExplicitComponentInst)
+}
+
+// component_body_elem ::=
+//   | property_assignment
+fn component_body_elem_property_assignment(i: &mut Tokens<'_>) -> Result<ComponentBodyElem> {
+    property_assignment
+        .parse_next(i)
+        .map(ComponentBodyElem::PropertyAssignment)
+}
+
+// component_body_elem ::=
+//     component_def
+//   | enum_def
+//   | struct_def
+//   | constraint_def
+//   | explicit_component_inst
+//   | property_assignment
+fn component_body_elem(i: &mut Tokens<'_>) -> Result<ComponentBodyElem> {
+    alt((
+        component_body_elem_component_def,
+        component_body_elem_enum_def,
+        component_body_elem_struct_def,
+        component_body_elem_constraint_def,
+        component_body_elem_explicit_component_inst,
+        component_body_elem_property_assignment,
+        fail,
+    ))
+    .parse_next(i)
+}
+
+// component_named_def ::= component_type id [ param_def ] component_body
+fn component_named_def(i: &mut Tokens<'_>) -> Result<ComponentDef> {
+    let (ct, id, pd, body) =
+        (component_type, identifier, opt(param_def), component_body).parse_next(i)?;
+
+    Ok(ComponentDef::Named(ct, id, pd, body))
+}
+
+// component_anon_def::= component_type component_body
+fn component_anon_def(i: &mut Tokens<'_>) -> Result<ComponentDef> {
+    let (ct, body) = (component_type, component_body).parse_next(i)?;
+    Ok(ComponentDef::Anon(ct, body))
+}
+
+// component_inst_type ::= external | internal
+fn component_inst_type(i: &mut Tokens<'_>) -> Result<ComponentInstType> {
+    match i.next_token() {
+        Some(Token {
+            kind: TokenKind::Internal,
+            ..
+        }) => Ok(ComponentInstType::Internal),
+        Some(Token {
+            kind: TokenKind::External,
+            ..
+        }) => Ok(ComponentInstType::External),
+        _ => fail.parse_next(i),
+    }
+}
+
+// param_elem ::= . id ( param_value )
+fn param_elem(i: &mut Tokens<'_>) -> Result<ParamElem> {
+    let (_, id, _, param_value, _) = (
+        TokenKind::Period,
+        identifier,
+        TokenKind::ParenOpen,
+        constant_expr,
+        TokenKind::ParenClose,
+    )
+        .parse_next(i)?;
+    Ok(ParamElem { id, param_value })
+}
+
+// param_inst ::= # ( param_elem { , param_elem } )
+fn param_inst(i: &mut Tokens<'_>) -> Result<Vec<ParamElem>> {
+    let (_, _, params, _) = (
+        TokenKind::Hash,
+        TokenKind::ParenOpen,
+        separated(1.., param_elem, TokenKind::Comma),
+        TokenKind::ParenClose,
+    )
+        .parse_next(i)?;
+    Ok(params)
+}
+
+// component_insts ::= [ param_inst ] component_inst { , component_inst }
+fn component_insts(i: &mut Tokens<'_>) -> Result<ComponentInsts> {
+    let param_insts = opt(param_inst).parse_next(i)?.unwrap_or_default();
+    let component_insts = separated(1.., component_inst, TokenKind::Comma).parse_next(i)?;
+    Ok(ComponentInsts {
+        param_insts,
+        component_insts,
+    })
+}
+
+// primary_literal ::=
+//     number
+//   | string_literal
+//   | boolean_literal
+//   | accesstype_literal
+//   | onreadtype_literal
+//   | onwritetype_literal
+//   | addressingtype_literal
+//   | enumerator_literal
+//   | this
+fn primary_literal(i: &mut Tokens<'_>) -> Result<PrimaryLiteral> {
+    match i.next_token() {
+        Some(Token {
+            kind: TokenKind::Number(n),
+            ..
+        }) => Ok(PrimaryLiteral::Number(*n)),
+        Some(Token {
+            kind: TokenKind::Bits(b),
+            ..
+        }) => Ok(PrimaryLiteral::Bits(*b)),
+        Some(Token {
+            kind: TokenKind::StringLiteral(s),
+            ..
+        }) => Ok(PrimaryLiteral::StringLiteral(s.to_string())),
+        Some(Token {
+            kind: TokenKind::True,
+            ..
+        }) => Ok(PrimaryLiteral::BooleanLiteral(true)),
+        Some(Token {
+            kind: TokenKind::False,
+            ..
+        }) => Ok(PrimaryLiteral::BooleanLiteral(false)),
+        Some(Token {
+            kind: TokenKind::AccessTypeLiteral(x),
+            ..
+        }) => Ok(PrimaryLiteral::AccessTypeLiteral(*x)),
+        Some(Token {
+            kind: TokenKind::OnReadTypeLiteral(x),
+            ..
+        }) => Ok(PrimaryLiteral::OnReadTypeLiteral(*x)),
+        Some(Token {
+            kind: TokenKind::OnWriteTypeLiteral(x),
+            ..
+        }) => Ok(PrimaryLiteral::OnWriteTypeLiteral(*x)),
+        Some(Token {
+            kind: TokenKind::AddressingTypeLiteral(x),
+            ..
+        }) => Ok(PrimaryLiteral::AddressingTypeLiteral(*x)),
+        Some(Token {
+            kind: TokenKind::This,
+            ..
+        }) => Ok(PrimaryLiteral::This),
+        _ => {
+            let (a, _, _, b) =
+                (identifier, TokenKind::Colon, TokenKind::Colon, identifier).parse_next(i)?;
+            Ok(PrimaryLiteral::EnumeratorLiteral(a, b))
+        }
+    }
+}
+
+// constant_concatenation ::= { constant_expression { , constant_expression } }
+fn constant_concat(i: &mut Tokens<'_>) -> Result<Vec<ConstantExpr>> {
+    preceded(
+        TokenKind::BraceOpen,
+        terminated(
+            separated(1.., constant_expr, TokenKind::Comma),
+            TokenKind::BraceClose,
+        ),
+    )
+    .parse_next(i)
+}
+
+// constant_multiple_concatenation ::= { constant_expression constant_concatenation }
+fn constant_multiple_concat(i: &mut Tokens<'_>) -> Result<ConstantPrimaryBase> {
+    let (_, expr, constants, _) = (
+        TokenKind::BraceOpen,
+        constant_expr,
+        constant_concat,
+        TokenKind::BraceClose,
+    )
+        .parse_next(i)?;
+    Ok(ConstantPrimaryBase::ConstantMultipleConcat(
+        Box::new(expr),
+        constants,
+    ))
+}
+
+// instance_ref_element ::= id { array }
+fn instance_ref_element(i: &mut Tokens<'_>) -> Result<InstanceRefElement> {
+    let (id, arrays) = (identifier, repeat(0.., array)).parse_next(i)?;
+    Ok(InstanceRefElement { id, arrays })
+}
+
+// instance_ref ::= instance_ref_element { . instance_ref_element }
+fn instance_ref(i: &mut Tokens<'_>) -> Result<InstanceRef> {
+    let elements = separated(1.., instance_ref_element, TokenKind::Period).parse_next(i)?;
+    Ok(InstanceRef { elements })
+}
+
+fn id_or_prop_keyword(i: &mut Tokens<'_>) -> Result<IdentityOrPropKeyword> {
+    match i.next_token() {
+        Some(Token {
+            kind: TokenKind::Identifier(id),
+            ..
+        }) => Ok(IdentityOrPropKeyword::Id(id.to_string())),
+        Some(Token {
+            kind: TokenKind::PrecedenceTypeLiteral(PrecedenceType::Hw),
+            ..
+        }) => Ok(IdentityOrPropKeyword::PropKeyword(PropKeyword::Hw)),
+        Some(Token {
+            kind: TokenKind::PrecedenceTypeLiteral(PrecedenceType::Sw),
+            ..
+        }) => Ok(IdentityOrPropKeyword::PropKeyword(PropKeyword::Sw)),
+        Some(Token {
+            kind: TokenKind::OnReadTypeLiteral(OnReadType::RClr),
+            ..
+        }) => Ok(IdentityOrPropKeyword::PropKeyword(PropKeyword::RClr)),
+        Some(Token {
+            kind: TokenKind::OnReadTypeLiteral(OnReadType::RSet),
+            ..
+        }) => Ok(IdentityOrPropKeyword::PropKeyword(PropKeyword::RSet)),
+        Some(Token {
+            kind: TokenKind::OnWriteTypeLiteral(OnWriteType::WoClr),
+            ..
+        }) => Ok(IdentityOrPropKeyword::PropKeyword(PropKeyword::WoClr)),
+        Some(Token {
+            kind: TokenKind::OnWriteTypeLiteral(OnWriteType::WoSet),
+            ..
+        }) => Ok(IdentityOrPropKeyword::PropKeyword(PropKeyword::WoSet)),
+        _ => fail.parse_next(i)?,
+    }
+}
+
+// instance_or_prop_ref ::=
+//     instance_ref -> prop_keyword
+//   | instance_ref -> id
+//   | instance_ref
+fn instance_or_prop_ref(i: &mut Tokens<'_>) -> Result<InstanceOrPropRef> {
+    let (iref, id_or_prop) = (
+        instance_ref,
+        opt(preceded(TokenKind::Pointer, id_or_prop_keyword)),
+    )
+        .parse_next(i)?;
+    Ok(InstanceOrPropRef { iref, id_or_prop })
+}
+
+// struct_literal ::= id '{ struct_literal_body }
+fn struct_literal(i: &mut Tokens<'_>) -> Result<ConstantPrimaryBase> {
+    let (id, _, _, body, _) = (
+        identifier,
+        TokenKind::Quote,
+        TokenKind::BraceOpen,
+        struct_literal_body,
+        TokenKind::BraceClose,
+    )
+        .parse_next(i)?;
+    Ok(ConstantPrimaryBase::StructLiteral(id, body))
+}
+
+// struct_literal_elem ::= id : constant_expression
+fn struct_literal_element(i: &mut Tokens<'_>) -> Result<StructLiteralElement> {
+    let (id, _, expr) = (identifier, TokenKind::Colon, constant_expr).parse_next(i)?;
+    Ok(StructLiteralElement { id, expr })
+}
+
+// struct_literal_body ::= [ struct_literal_elem { , struct_literal_elem } ]
+fn struct_literal_body(i: &mut Tokens<'_>) -> Result<Vec<StructLiteralElement>> {
+    separated(0.., struct_literal_element, TokenKind::Comma).parse_next(i)
+}
+
+// array_literal_body ::= constant_expression { , constant_expression }
+fn array_literal_body(i: &mut Tokens<'_>) -> Result<Vec<ConstantExpr>> {
+    separated(1.., constant_expr, TokenKind::Comma).parse_next(i)
+}
+
+// array_literal ::= '{ array_literal_body }
+fn array_literal(i: &mut Tokens<'_>) -> Result<ConstantPrimaryBase> {
+    let (_, _, exprs, _) = (
+        TokenKind::Quote,
+        TokenKind::BraceOpen,
+        array_literal_body,
+        TokenKind::BraceClose,
+    )
+        .parse_next(i)?;
+    Ok(ConstantPrimaryBase::ArrayLiteral(exprs))
+}
+
+fn simple_type_cast(i: &mut Tokens<'_>) -> Result<ConstantPrimaryBase> {
+    let (st, expr) = (simple_type, cast_expr).parse_next(i)?;
+    Ok(ConstantPrimaryBase::SimpleTypeCast(st, Box::new(expr)))
+}
+
+fn boolean_cast(i: &mut Tokens<'_>) -> Result<ConstantPrimaryBase> {
+    let (_, expr) = (TokenKind::Boolean, cast_expr).parse_next(i)?;
+    Ok(ConstantPrimaryBase::BooleanCast(Box::new(expr)))
+}
+
+// constant_primary_base ::= constant_primary
+//     primary_literal
+//   | constant_concatenation
+//   | constant_multiple_concatenation
+//   | ( constant_expression )
+//   | simple_type ' ( constant_expression )
+//   | boolean ' ( constant_expression )
+//   | instance_or_prop_ref
+//   | struct_literal
+//   | array_literal
+fn constant_primary_base(i: &mut Tokens<'_>) -> Result<ConstantPrimaryBase> {
+    if let Some(x) = opt(primary_literal).parse_next(i)? {
+        Ok(ConstantPrimaryBase::PrimaryLiteral(x))
+    } else if let Some(cc) = opt(constant_concat).parse_next(i)? {
+        Ok(ConstantPrimaryBase::ConstantConcat(cc))
+    } else if let Some(cc) = opt(constant_multiple_concat).parse_next(i)? {
+        Ok(cc)
+    } else if let Some((_, cc, _)) =
+        opt((TokenKind::ParenOpen, constant_expr, TokenKind::ParenClose)).parse_next(i)?
+    {
+        Ok(ConstantPrimaryBase::ConstantExpr(Box::new(cc)))
+    } else if let Some(cc) = opt(simple_type_cast).parse_next(i)? {
+        Ok(cc)
+    } else if let Some(cc) = opt(boolean_cast).parse_next(i)? {
+        Ok(cc)
+    } else if let Some(x) = opt(instance_or_prop_ref).parse_next(i)? {
+        Ok(ConstantPrimaryBase::InstanceOrPropRef(x))
+    } else if let Some(x) = opt(struct_literal).parse_next(i)? {
+        Ok(x)
+    } else if let Some(x) = opt(array_literal).parse_next(i)? {
+        Ok(x)
+    } else {
+        fail.parse_next(i)
+    }
+}
+
+// cast_expr ::= ' ( constant_expression )
+fn cast_expr(i: &mut Tokens<'_>) -> Result<ConstantExpr> {
+    let (_, _, expr, _) = (
+        TokenKind::Quote,
+        TokenKind::ParenOpen,
+        constant_expr,
+        TokenKind::ParenClose,
+    )
+        .parse_next(i)?;
+    Ok(expr)
+}
+
+// constant_primary ::= constant_primary_base [ cast_expr ]
+fn constant_primary(i: &mut Tokens<'_>) -> Result<ConstantPrimary> {
+    let (constant_primary_base, cast_expr) =
+        (constant_primary_base, opt(cast_expr)).parse_next(i)?;
+
+    Ok(match cast_expr {
+        Some(cast_expr) => ConstantPrimary::Cast(constant_primary_base, Box::new(cast_expr)),
+        None => ConstantPrimary::Base(constant_primary_base),
+    })
+}
+
+// unary_operator :
+//     ! | + | - | ~ | & | ~& | | | ~| | ^ | ~^ | ^~
+fn unary_operator(i: &mut Tokens<'_>) -> Result<UnaryOp> {
+    match i.next_token() {
+        Some(Token {
+            kind: TokenKind::And,
+            ..
+        }) => Ok(UnaryOp::And),
+        Some(Token {
+            kind: TokenKind::Or,
+            ..
+        }) => Ok(UnaryOp::Or),
+        // not supported by our lexer
+        // Some(Token::Not) => Ok(UnaryOp::LogicalNot),
+        // Some(Token::Plus) => Ok(UnaryOp::Plus),
+        // Some(Token::Minus) => Ok(UnaryOp::Minus),
+        // Some(Token::BitwiseNot) => Ok(UnaryOp::Not),
+        // Some(Token::Nand) => Ok(UnaryOp::Nand),
+        // Some(Token::Nor) => Ok(UnaryOp::Nor),
+        // Some(Token::Xor) => Ok(UnaryOp::Xor),
+        // Some(Token::Xnor) => Ok(UnaryOp::Xnor),
+        _ => fail.parse_next(i)?,
+    }
+}
+
+// binary_operator ::=
+//     && | || | < | > | <= | >= | == | != | >> | <<
+//   | & | | | ^ | ~^| ^~ | * | / | % | + | - | **
+fn binary_operator(i: &mut Tokens<'_>) -> Result<BinaryOp> {
+    match i.next_token() {
+        Some(Token {
+            kind: TokenKind::AndAnd,
+            ..
+        }) => Ok(BinaryOp::AndAnd),
+        Some(Token {
+            kind: TokenKind::OrOr,
+            ..
+        }) => Ok(BinaryOp::OrOr),
+        // Some(Token::LessThan) => Ok(BinaryOp::LessThan),
+        // Some(Token::GreaterThan) => Ok(BinaryOp::GreaterThan),
+        // Some(Token::LessThanOrEqual) => Ok(BinaryOp::LessThanOrEqual),
+        // Some(Token::GreaterThanOrEqual) => Ok(BinaryOp::GreaterThanOrEqual),
+        // Some(Token::RightShift) => Ok(BinaryOp::RightShift),
+        // Some(Token::LeftShift) => Ok(BinaryOp::LeftShift),
+        Some(Token {
+            kind: TokenKind::And,
+            ..
+        }) => Ok(BinaryOp::And),
+        Some(Token {
+            kind: TokenKind::Or,
+            ..
+        }) => Ok(BinaryOp::Or),
+        // Some(Token::Xor) => Ok(BinaryOp::Xor),
+        // Some(Token::Xnor) => Ok(BinaryOp::Xnor),
+        // Some(Token::Times) => Ok(BinaryOp::Times),
+        // Some(Token::Divide) => Ok(BinaryOp::Divide),
+        // Some(Token::Modulus) => Ok(BinaryOp::Modulus),
+        // Some(Token::Plus) => Ok(BinaryOp::Plus),
+        // Some(Token::Minus) => Ok(BinaryOp::Minus),
+        // Some(Token::Power) => Ok(BinaryOp::Power),
+        Some(Token {
+            kind: TokenKind::EqualsEquals,
+            ..
+        }) => Ok(BinaryOp::EqualsEquals),
+        Some(Token {
+            kind: TokenKind::NotEquals,
+            ..
+        }) => Ok(BinaryOp::NotEquals),
+        _ => fail.parse_next(i)?,
+    }
+}
+
+// constant_expression ::=
+//     constant_primary [ constant_expression_continue ]
+fn constant_expr_constant_primary(i: &mut Tokens<'_>) -> Result<ConstantExpr> {
+    let (constant_primary, constant_expr_continue) =
+        (constant_primary, opt(constant_expr_continue)).parse_next(i)?;
+    Ok(ConstantExpr::ConstantPrimary(
+        constant_primary,
+        constant_expr_continue.map(Box::new),
+    ))
+}
+
+// constant_expression ::=
+//   | unary_operator constant_primary [ constant_expression_continue ]
+fn constant_expr_unary_operator_constant_primary(i: &mut Tokens<'_>) -> Result<ConstantExpr> {
+    let (op, x, cont) =
+        (unary_operator, constant_expr, opt(constant_expr_continue)).parse_next(i)?;
+    Ok(ConstantExpr::UnaryOp(op, Box::new(x), cont.map(Box::new)))
+}
+
+// constant_expression_continue ::=
+//   | binary_operator constant_expression [ constant_expression_continue ]
+fn constant_expr_binary(i: &mut Tokens<'_>) -> Result<ConstantExprContinue> {
+    let (op, b, cont) =
+        (binary_operator, constant_expr, opt(constant_expr_continue)).parse_next(i)?;
+    Ok(ConstantExprContinue::BinaryOp(
+        op,
+        Box::new(b),
+        cont.map(Box::new),
+    ))
+}
+
+// constant_expression_continue ::=
+//   | ? constant_expression : constant_expression [ constant_expression_continue ]
+fn constant_expr_ternary(i: &mut Tokens<'_>) -> Result<ConstantExprContinue> {
+    let (_, b, _, c, cont) = (
+        TokenKind::QuestionMark,
+        constant_expr,
+        TokenKind::Colon,
+        constant_expr,
+        opt(constant_expr_continue),
+    )
+        .parse_next(i)?;
+    Ok(ConstantExprContinue::TernaryOp(
+        Box::new(b),
+        Box::new(c),
+        cont.map(Box::new),
+    ))
+}
+
+// constant_expression_continue ::=
+//   | binary_operator constant_expression [ constant_expression_continue ]
+//   | ? constant_expression : constant_expression [ constant_expression_continue ]
+fn constant_expr_continue(i: &mut Tokens<'_>) -> Result<ConstantExprContinue> {
+    alt((constant_expr_binary, constant_expr_ternary, fail)).parse_next(i)
+}
+
+// constant_expression ::=
+//     constant_primary [ constant_expression_continue ]
+//   | unary_operator constant_primary [ constant_expression_continue ]
+
+fn constant_expr(i: &mut Tokens<'_>) -> Result<ConstantExpr> {
+    alt((
+        constant_expr_constant_primary,
+        constant_expr_unary_operator_constant_primary,
+        fail,
+    ))
+    .parse_next(i)
+}
+
+// array ::= [ constant_expression ]
+fn array(i: &mut Tokens<'_>) -> Result<ConstantExpr> {
+    let (_, expr, _) = (
+        TokenKind::BracketOpen,
+        constant_expr,
+        TokenKind::BracketClose,
+    )
+        .parse_next(i)?;
+    Ok(expr)
+}
+
+// range ::= [ constant_expression : constant_expression ]
+fn range(i: &mut Tokens<'_>) -> Result<Range> {
+    let (_, a, _, b, _) = (
+        TokenKind::BracketOpen,
+        constant_expr,
+        TokenKind::Colon,
+        constant_expr,
+        TokenKind::BracketClose,
+    )
+        .parse_next(i)?;
+    Ok(Range::Range(a, b))
+}
+
+// component_inst_array_or_range ::=
+//     array { array }
+//   | range
+fn component_inst_array_or_range(i: &mut Tokens<'_>) -> Result<ArrayOrRange> {
+    if let Some(x) = opt(repeat(1.., array)).parse_next(i)? {
+        Ok(ArrayOrRange::Array(x))
+    } else if let Some(y) = opt(range).parse_next(i)? {
+        Ok(ArrayOrRange::Range(y))
+    } else {
+        fail.parse_next(i)
+    }
+}
+
+// component_inst ::=
+//   id [ component_inst_array_or_range ]
+//   [ = constant_expression ]
+//   [ @ constant_expression ]
+//   [ += constant_expression ]
+//   [ %= constant_expression ]
+fn component_inst(i: &mut Tokens<'_>) -> Result<ComponentInst> {
+    let (id, array_or_range, equals, at, plus_equals, percent_equals) = (
+        identifier,
+        opt(component_inst_array_or_range),
+        opt(preceded(TokenKind::Equals, constant_expr)),
+        opt(preceded(TokenKind::At, constant_expr)),
+        opt(preceded(TokenKind::PlusEqual, constant_expr)),
+        opt(preceded(TokenKind::PercentEqual, constant_expr)),
+    )
+        .parse_next(i)?;
+
+    Ok(ComponentInst {
+        id,
+        array_or_range,
+        equals,
+        at,
+        plus_equals,
+        percent_equals,
+    })
+}
+
+// component_def ::=
+//     component_named_def component_inst_type component_insts ;
+fn named_insttype_component(i: &mut Tokens<'_>) -> Result<Component> {
+    let (def, inst_type, insts, _) = (
+        component_named_def,
+        component_inst_type,
+        component_insts,
+        TokenKind::Semicolon,
+    )
+        .parse_next(i)?;
+    Ok(Component {
+        def,
+        inst_type: Some(inst_type),
+        insts: Some(insts),
+    })
+}
+
+// component_def ::=
+//   | component_anon_def component_inst_type component_insts ;
+fn anon_insttype_component(i: &mut Tokens<'_>) -> Result<Component> {
+    let (def, inst_type, insts, _) = (
+        component_anon_def,
+        component_inst_type,
+        component_insts,
+        TokenKind::Semicolon,
+    )
+        .parse_next(i)?;
+    Ok(Component {
+        def,
+        inst_type: Some(inst_type),
+        insts: Some(insts),
+    })
+}
+
+// component_def ::=
+//   | component_named_def [ component_insts ] ;
+fn named_component(i: &mut Tokens<'_>) -> Result<Component> {
+    let (def, insts, _) = (
+        component_named_def,
+        opt(component_insts),
+        TokenKind::Semicolon,
+    )
+        .parse_next(i)?;
+    Ok(Component {
+        def,
+        inst_type: None,
+        insts,
+    })
+}
+
+// component_def ::=
+//   | component_anon_def component_insts ;
+fn anon_component(i: &mut Tokens<'_>) -> Result<Component> {
+    let (def, insts, _) =
+        (component_anon_def, component_insts, TokenKind::Semicolon).parse_next(i)?;
+    Ok(Component {
+        def,
+        inst_type: None,
+        insts: Some(insts),
+    })
+}
+
+// component_def ::=
+//   | component_inst_type component_named_def component_insts ;
+fn insttype_named_component(i: &mut Tokens<'_>) -> Result<Component> {
+    let (inst_type, def, insts, _) = (
+        component_inst_type,
+        component_named_def,
+        component_insts,
+        TokenKind::Semicolon,
+    )
+        .parse_next(i)?;
+    Ok(Component {
+        def,
+        inst_type: Some(inst_type),
+        insts: Some(insts),
+    })
+}
+
+// component_def ::=
+//   | component_inst_type component_anon_def component_insts ;
+fn insttype_anon_component(i: &mut Tokens<'_>) -> Result<Component> {
+    let (inst_type, def, insts, _) = (
+        component_inst_type,
+        component_anon_def,
+        component_insts,
+        TokenKind::Semicolon,
+    )
+        .parse_next(i)?;
+    Ok(Component {
+        def,
+        inst_type: Some(inst_type),
+        insts: Some(insts),
+    })
+}
+
+// component_def ::=
+//     component_named_def component_inst_type component_insts ;
+//   | component_anon_def component_inst_type component_insts ;
+//   | component_named_def [ component_insts ] ;
+//   | component_anon_def component_insts ;
+//   | component_inst_type component_named_def component_insts ;
+//   | component_inst_type component_anon_def component_insts ;
+fn component_def(i: &mut Tokens<'_>) -> Result<Component> {
+    alt((
+        named_insttype_component,
+        anon_insttype_component,
+        named_component,
+        anon_component,
+        insttype_named_component,
+        insttype_anon_component,
+    ))
+    .parse_next(i)
+}
+
+// property_data_type ::=
+//     component_primary_type
+fn property_data_type_component_primary_type(i: &mut Tokens<'_>) -> Result<PropertyDataType> {
+    component_primary_type
+        .parse_next(i)
+        .map(PropertyDataType::ComponentPrimaryType)
+}
+
+// property_data_type ::=
+//   | ref
+fn property_data_type_ref(i: &mut Tokens<'_>) -> Result<PropertyDataType> {
+    TokenKind::Ref.parse_next(i).map(|_| PropertyDataType::Ref)
+}
+
+// property_data_type ::=
+//   | number
+fn property_data_type_number(i: &mut Tokens<'_>) -> Result<PropertyDataType> {
+    TokenKind::Number_
+        .parse_next(i)
+        .map(|_| PropertyDataType::Number)
+}
+
+// property_data_type ::=
+//   | basic_data_type
+fn property_data_type_basic_data_type(i: &mut Tokens<'_>) -> Result<PropertyDataType> {
+    basic_data_type
+        .parse_next(i)
+        .map(PropertyDataType::BasicDataType)
+}
+
+// property_data_type ::=
+//     component_primary_type
+//   | ref
+//   | number
+//   | basic_data_type
+fn property_data_type(i: &mut Tokens<'_>) -> Result<PropertyDataType> {
+    alt((
+        property_data_type_component_primary_type,
+        property_data_type_ref,
+        property_data_type_number,
+        property_data_type_basic_data_type,
+    ))
+    .parse_next(i)
+}
+
+// property_type ::= type = property_data_type [ array_type ] ;
+fn property_type(i: &mut Tokens<'_>) -> Result<PropertyType> {
+    let (_, _, property_data_type, array_type, _) = (
+        TokenKind::Type,
+        TokenKind::Equals,
+        property_data_type,
+        opt(array_type),
+        TokenKind::Semicolon,
+    )
+        .parse_next(i)?;
+    Ok(PropertyType {
+        property_data_type,
+        array_type,
+    })
+}
+
+// property_attribute ::=
+//     property_type
+fn property_attribute_property_type(i: &mut Tokens<'_>) -> Result<PropertyAttribute> {
+    property_type
+        .parse_next(i)
+        .map(PropertyAttribute::PropertyType)
+}
+
+// property_comp_type ::=
+//     component_type
+fn property_comp_type_component_type(i: &mut Tokens<'_>) -> Result<PropertyCompType> {
+    component_type
+        .parse_next(i)
+        .map(PropertyCompType::ComponentType)
+}
+
+// property_comp_type ::=
+//   | constraint
+fn property_comp_type_constraint(i: &mut Tokens<'_>) -> Result<PropertyCompType> {
+    TokenKind::Constraint
+        .parse_next(i)
+        .map(|_| PropertyCompType::Constraint)
+}
+
+// property_comp_type ::=
+//   | all
+fn property_comp_type_all(i: &mut Tokens<'_>) -> Result<PropertyCompType> {
+    TokenKind::All.parse_next(i).map(|_| PropertyCompType::All)
+}
+
+// property_comp_type ::=
+//     component_type
+//   | constraint
+//   | all
+fn property_comp_type(i: &mut Tokens<'_>) -> Result<PropertyCompType> {
+    alt((
+        property_comp_type_component_type,
+        property_comp_type_constraint,
+        property_comp_type_all,
+        fail,
+    ))
+    .parse_next(i)
+}
+
+// property_comp_types ::= property_comp_type { | property_comp_type }
+fn property_comp_types(i: &mut Tokens<'_>) -> Result<Vec<PropertyCompType>> {
+    separated(1.., property_comp_type, TokenKind::Or).parse_next(i)
+}
+
+// property_usage ::= component = property_comp_types ;
+fn property_attribute_property_usage(i: &mut Tokens<'_>) -> Result<PropertyAttribute> {
+    let (_, _, property_comp_types, _) = (
+        TokenKind::Component,
+        TokenKind::Equals,
+        property_comp_types,
+        TokenKind::Semicolon,
+    )
+        .parse_next(i)?;
+    Ok(PropertyAttribute::PropertyUsage(property_comp_types))
+}
+
+// property_default ::= default = constant_expression ;
+fn property_attribute_property_default(i: &mut Tokens<'_>) -> Result<PropertyAttribute> {
+    let (_, _, constant_expr, _) = (
+        TokenKind::Default,
+        TokenKind::Equals,
+        constant_expr,
+        TokenKind::Semicolon,
+    )
+        .parse_next(i)?;
+    Ok(PropertyAttribute::PropertyDefault(constant_expr))
+}
+
+// property_constraint_type::= componentwidth
+fn property_constraint_type(i: &mut Tokens<'_>) -> Result<()> {
+    TokenKind::ComponentWidth.parse_next(i).map(|_| ())
+}
+
+// property_constraint::= constraint = property_constraint_type ;
+fn property_attribute_property_constraint(i: &mut Tokens<'_>) -> Result<PropertyAttribute> {
+    (
+        TokenKind::Constraint,
+        TokenKind::Equals,
+        property_constraint_type,
+        TokenKind::Semicolon,
+    )
+        .parse_next(i)
+        .map(|_| PropertyAttribute::PropertyConstraint)
+}
+
+// property_attribute ::=
+//     property_type
+//   | property_usage
+//   | property_default
+//   | property_constraint
+fn property_attribute(i: &mut Tokens<'_>) -> Result<PropertyAttribute> {
+    alt((
+        property_attribute_property_type,
+        property_attribute_property_usage,
+        property_attribute_property_default,
+        property_attribute_property_constraint,
+        fail,
+    ))
+    .parse_next(i)
+}
+
+// property_body ::= property_attribute { property_attribute }
+fn property_body(i: &mut Tokens<'_>) -> Result<Vec<PropertyAttribute>> {
+    repeat(1.., property_attribute).parse_next(i)
+}
+
+// property_definition ::= property id { property_body } ;
+fn property_definition(i: &mut Tokens<'_>) -> Result<PropertyDefinition> {
+    let (_, id, _, body, _, _) = (
+        TokenKind::Property,
+        identifier,
+        TokenKind::BraceOpen,
+        property_body,
+        TokenKind::BraceClose,
+        TokenKind::Semicolon,
+    )
+        .parse_next(i)?;
+    Ok(PropertyDefinition { id, body })
+}
+
+// description ::=
+//     component_def
+fn description_component_def(i: &mut Tokens<'_>) -> Result<Description> {
+    component_def.parse_next(i).map(Description::ComponentDef)
+}
+
+// description ::=
+//   | enum_def
+fn description_enum_def(i: &mut Tokens<'_>) -> Result<Description> {
+    enum_def.parse_next(i).map(Description::EnumDef)
+}
+
+// description ::=
+//   | property_definition
+fn description_property_definition(i: &mut Tokens<'_>) -> Result<Description> {
+    property_definition
+        .parse_next(i)
+        .map(Description::PropertyDefinition)
+}
+
+// description ::=
+//   | struct_def
+fn description_struct_def(i: &mut Tokens<'_>) -> Result<Description> {
+    struct_def.parse_next(i).map(Description::StructDef)
+}
+
+// description ::=
+//   | constraint_def
+fn description_constraint_def(i: &mut Tokens<'_>) -> Result<Description> {
+    constraint_def.parse_next(i).map(Description::ConstraintDef)
+}
+
+// description ::=
+//   | explicit_component_inst
+fn description_explicit_component_inst(i: &mut Tokens<'_>) -> Result<Description> {
+    explicit_component_inst
+        .parse_next(i)
+        .map(Description::ExplicitComponentInst)
+}
+
+// description ::=
+//   | explicit_component_inst
+fn description_property_assignment(i: &mut Tokens<'_>) -> Result<Description> {
+    property_assignment
+        .parse_next(i)
+        .map(Description::PropertyAssignment)
+}
+
+// description ::=
+//     component_def
+//   | enum_def
+//   | property_definition
+//   | struct_def
+//   | constraint_def
+//   | explicit_component_inst
+//   | property_assignment
+fn description(i: &mut Tokens<'_>) -> Result<Description> {
+    alt((
+        description_component_def,
+        description_enum_def,
+        description_property_definition,
+        description_struct_def,
+        description_constraint_def,
+        description_explicit_component_inst,
+        description_property_assignment,
+        fail,
+    ))
+    .parse_next(i)
+}
+
+// root ::= { description }
+pub(crate) fn root(i: &mut Tokens<'_>) -> Result<Root> {
+    let descriptions = repeat(0.., description).parse_next(i)?;
+    Ok(Root { descriptions })
+}
+
+/// Lex string to tokens
+pub(crate) fn tokens<'s>(i: &mut &'s str) -> Result<Vec<Token<'s>>> {
+    repeat(1.., token).parse_next(i)
+}
+
+pub(crate) fn token<'s>(i: &mut &'s str) -> Result<Token<'s>> {
+    let mut l = Lexer::new(i);
+    let x = l.next();
+    match x {
+        Some(kind) => {
+            let r = l.span();
+            let token = Token {
+                kind,
+                raw: &i[l.span()],
+            };
+            *i = &i[r.end..];
+            Ok(token)
+        }
+        _ => Err(ParserError::from_input(i)),
+    }
+}
+
+/// Parses a string into a Root RDL object.
+pub fn parse(input: &str) -> std::result::Result<Root, anyhow::Error> {
+    input.parse::<Root>()
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_binary_expr() {
+        let tokens = tokens
+            .parse("1'b1 & 4'h2")
+            .map_err(|e| anyhow::format_err!("{e}"))
+            .unwrap();
+        println!("tokens: {:?}", tokens);
+        let tokens = Tokens::new(&tokens);
+        let result = constant_expr
+            .parse(tokens)
+            .map_err(|e| {
+                let t = &e.input()[0];
+                anyhow::format_err!("Error parsing input at: `{}` token: {:?}", t.raw, t.kind)
+            })
+            .unwrap();
+
+        println!("{:?}", result);
+    }
+
+    #[test]
+    fn test_addr_map() {
+        let result = parse(
+            r#"
+        addrmap {
+            reg { field {} f; } a;
+        } mcu;"#,
+        );
+        println!("{:?}", result);
+        result.unwrap();
+    }
+
+    #[test]
+    fn test_mcu_map() {
+        let result = parse(
+            r#"
+        addrmap {
+            reg { field {} f; } a;
+            I3CCSR I3CCSR @ 0x2000_4000;
+            mci_top mci_top @ 0x2100_0000;
+        } mcu;
+          "#,
+        );
+        println!("{:?}", result);
+        result.unwrap();
+    }
+
+    #[test]
+    fn test_big() {
+        let input = r#"
+            addrmap {
+                addressing = compact;
+                lsb0 = true;
+
+                default regwidth = 32;
+
+                reg { field {} f; } a;
+
+                reg {
+                    name = "Status register";
+                    desc = "Status of the peripheral";
+                    field {sw = r; hw = w;} READY = 1'b0;
+                    field {hwclr; sw = r; hw = w;} VALID = 1'b0;
+                    field {sw = rw; hw = rw;} ID[23:16] = 0xd2;
+                } STATUS;
+
+                reg {
+                    enum mode_t {
+                        ALERT;
+                        TIRED = 2'd1;
+                        SLEEPING = 2'd2 {
+                            desc = "Power consumption is minimal";
+                        };
+                    };
+                    field {encode=mode_t;} MODE = 4'hf;
+                } MODE @0x1000;
+            } my_addrmap;"#;
+        let result = parse(input).unwrap();
+        println!("{:?}", result);
+    }
+}

--- a/registers/systemrdl-new/src/string_arena.rs
+++ b/registers/systemrdl-new/src/string_arena.rs
@@ -1,0 +1,44 @@
+// Licensed under the Apache-2.0 license
+
+use std::collections::HashSet;
+
+// TODO: Consider using elsa/FrozenVec to remove unsafe code
+#[derive(Default)]
+pub struct StringArena {
+    // SAFETY: To maintain soundness, strings in this HashSet MUST NOT be removed or mutated.
+    strings: std::cell::RefCell<HashSet<String>>,
+}
+impl StringArena {
+    #[allow(dead_code)]
+    pub fn new() -> Self {
+        Default::default()
+    }
+    pub fn add<'a>(&'a self, s: String) -> &'a str {
+        let mut map = self.strings.borrow_mut();
+        if let Some(existing) = map.get(&s) {
+            unsafe { std::mem::transmute::<&'_ str, &'a str>(existing.as_str()) }
+        } else {
+            let slice = unsafe { std::mem::transmute::<&'_ str, &'a str>(s.as_str()) };
+            map.insert(s);
+            slice
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn foo() {
+        let arena = StringArena::new();
+        let a = arena.add("Hello world".into());
+        let b = arena.add("Foo".into());
+        let c = arena.add("Foo".into());
+        assert_eq!(a, "Hello world");
+        assert_eq!(b, "Foo");
+        assert_eq!(c, "Foo");
+        assert_eq!(b.as_ptr(), c.as_ptr());
+        drop(arena);
+    }
+}

--- a/registers/systemrdl-new/src/token.rs
+++ b/registers/systemrdl-new/src/token.rs
@@ -1,0 +1,164 @@
+// Licensed under the Apache-2.0 license.
+
+use crate::ast::{AccessType, AddressingType, OnReadType, OnWriteType, PrecedenceType};
+use crate::Bits;
+use std::fmt::Display;
+use winnow::Parser;
+use winnow::Result;
+use winnow::{error::ContextError, stream::TokenSlice, token::literal};
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct Token<'s> {
+    pub kind: TokenKind<'s>,
+    pub raw: &'s str,
+}
+
+impl<'a> Display for Token<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.raw)
+    }
+}
+impl<'a> std::fmt::Debug for Token<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?} {}", self.kind, self.raw)
+    }
+}
+
+impl<'s> PartialEq<TokenKind<'s>> for Token<'s> {
+    fn eq(&self, other: &TokenKind) -> bool {
+        self.kind == *other
+    }
+}
+
+pub type Tokens<'i> = TokenSlice<'i, Token<'i>>;
+
+impl winnow::stream::ContainsToken<&'_ Token<'_>> for TokenKind<'_> {
+    #[inline(always)]
+    fn contains_token(&self, token: &'_ Token<'_>) -> bool {
+        *self == token.kind
+    }
+}
+
+impl winnow::stream::ContainsToken<&'_ Token<'_>> for &'_ [TokenKind<'_>] {
+    #[inline]
+    fn contains_token(&self, token: &'_ Token<'_>) -> bool {
+        self.iter().any(|t| *t == token.kind)
+    }
+}
+
+impl<const LEN: usize> winnow::stream::ContainsToken<&'_ Token<'_>> for &'_ [TokenKind<'_>; LEN] {
+    #[inline]
+    fn contains_token(&self, token: &'_ Token<'_>) -> bool {
+        self.iter().any(|t| *t == token.kind)
+    }
+}
+
+impl<const LEN: usize> winnow::stream::ContainsToken<&'_ Token<'_>> for [TokenKind<'_>; LEN] {
+    #[inline]
+    fn contains_token(&self, token: &'_ Token<'_>) -> bool {
+        self.iter().any(|t| *t == token.kind)
+    }
+}
+
+impl<'i> Parser<Tokens<'i>, &'i Token<'i>, ContextError> for TokenKind<'i> {
+    fn parse_next(&mut self, input: &mut Tokens<'i>) -> Result<&'i Token<'i>> {
+        literal(self.clone()).parse_next(input).map(|t| &t[0])
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum TokenKind<'a> {
+    Field,
+    Internal,
+    External,
+    Reg,
+    RegFile,
+    AddrMap,
+    Signal,
+    Enum,
+    Mem,
+    Constraint,
+    All,
+
+    BraceOpen,
+    BraceClose,
+    BracketOpen,
+    BracketClose,
+    ParenOpen,
+    ParenClose,
+    Semicolon,
+    Comma,
+    Period,
+    Equals,
+    EqualsEquals,
+    NotEquals,
+    At,
+    Colon,
+    Hash,
+    Pointer,
+    PlusEqual,
+    PercentEqual,
+    QuestionMark,
+    AndAnd,
+    OrOr,
+    Quote,
+    Or,
+    And,
+
+    Identifier(&'a str),
+    StringLiteral(&'a str),
+    AccessTypeLiteral(AccessType),
+    OnReadTypeLiteral(OnReadType),
+    OnWriteTypeLiteral(OnWriteType),
+    AddressingTypeLiteral(AddressingType),
+    PrecedenceTypeLiteral(PrecedenceType),
+    Number(u64),
+    Bits(Bits),
+    True,
+    False,
+    This,
+    AccessType,
+    AddressingType,
+    OnReadType,
+    OnWriteType,
+    String,
+    Boolean,
+    Unsigned,
+    Bit,
+    Longint,
+    Encode,
+    Struct,
+    Abstract,
+    Inside,
+    Alias,
+    Default,
+    PosEdge,
+    NegEdge,
+    BothEdge,
+    Level,
+    NonSticky,
+    Property,
+    Type,
+    Ref,
+    Number_,
+    Component,
+    ComponentWidth,
+
+    EndOfFile,
+    Skip,
+
+    PreprocInclude,
+    UnableToOpenFile(&'a str),
+    IncludeDepthLimitReached,
+    PreprocDefine,
+    PreprocIfndef,
+    PreprocEndif,
+
+    Error,
+}
+
+impl TokenKind<'_> {
+    pub fn is_identifier(&self) -> bool {
+        matches!(self, Self::Identifier(_))
+    }
+}

--- a/registers/systemrdl-new/src/token_iter.rs
+++ b/registers/systemrdl-new/src/token_iter.rs
@@ -1,0 +1,173 @@
+// Licensed under the Apache-2.0 license.
+
+use anyhow::bail;
+
+use crate::file_source::FileSource;
+use crate::lexer::{Lexer, Span};
+use crate::token::TokenKind;
+use std::collections::{HashSet, VecDeque};
+use std::path::{Path, PathBuf};
+
+struct IncludeStackEntry<'a> {
+    lex: Lexer<'a>,
+    file_path: PathBuf,
+    file_contents: &'a str,
+}
+
+pub fn parse_str_literal(s: &str) -> Result<String, anyhow::Error> {
+    if s.len() < 2 || !s.starts_with('"') || !s.ends_with('"') {
+        bail!("Bad string literal: {}", s);
+    }
+    Ok(s[1..s.len() - 1]
+        .replace("\\\"", "\"")
+        .replace("\\\\", "\\"))
+}
+
+pub struct TokenIter<'a> {
+    lex: Lexer<'a>,
+    fifo: VecDeque<(TokenKind<'a>, Span)>,
+    last_span: Span,
+
+    current_file_contents: &'a str,
+    current_file_path: PathBuf,
+    file_source: Option<&'a dyn FileSource>,
+    iter_stack: Vec<IncludeStackEntry<'a>>,
+    defines: HashSet<String>,
+}
+impl<'a> TokenIter<'a> {
+    pub fn from_path(file_source: &'a dyn FileSource, file_path: &Path) -> std::io::Result<Self> {
+        let file_contents = file_source.read_to_string(file_path)?;
+        let lex = Lexer::new(file_contents);
+        Ok(Self {
+            lex,
+            fifo: VecDeque::new(),
+            last_span: 0..0,
+
+            current_file_path: file_path.into(),
+            current_file_contents: file_contents,
+            iter_stack: Vec::new(),
+            file_source: Some(file_source),
+            defines: HashSet::new(),
+        })
+    }
+
+    #[allow(unused)]
+    pub fn from_str(s: &'a str) -> Self {
+        Self {
+            lex: Lexer::new(s),
+            fifo: Default::default(),
+            last_span: Default::default(),
+
+            current_file_path: Default::default(),
+            current_file_contents: s,
+            file_source: Default::default(),
+            iter_stack: Default::default(),
+            defines: Default::default(),
+        }
+    }
+
+    fn lex_next(&mut self) -> Option<TokenKind<'a>> {
+        const INCLUDE_DEPTH_LIMIT: usize = 100;
+
+        loop {
+            match self.lex.next() {
+                Some(TokenKind::PreprocIfndef) => {
+                    let Some(TokenKind::Identifier(name)) = self.lex.next() else {
+                        return Some(TokenKind::Error);
+                    };
+                    if self.defines.contains(name) {
+                        // skip to the endif
+                        while !matches!(self.lex.next(), Some(TokenKind::PreprocEndif)) {}
+                    }
+                    continue;
+                }
+                Some(TokenKind::PreprocDefine) => {
+                    let Some(TokenKind::Identifier(name)) = self.lex.next() else {
+                        return Some(TokenKind::Error);
+                    };
+                    self.defines.insert(name.to_string());
+                    continue;
+                }
+                Some(TokenKind::PreprocEndif) => {
+                    continue;
+                }
+                Some(TokenKind::PreprocInclude) => {
+                    let Some(TokenKind::StringLiteral(filename)) = self.lex.next() else {
+                        return Some(TokenKind::Error);
+                    };
+                    let Some(file_source) = self.file_source else {
+                        return Some(TokenKind::UnableToOpenFile(filename));
+                    };
+                    let Ok(parsed_filename) = parse_str_literal(filename) else {
+                        return Some(TokenKind::UnableToOpenFile(filename));
+                    };
+                    let file_path = if let Some(parent) = self.current_file_path.parent() {
+                        parent.join(parsed_filename)
+                    } else {
+                        PathBuf::from(parsed_filename)
+                    };
+
+                    let Ok(file_contents) = file_source.read_to_string(&file_path) else {
+                        return Some(TokenKind::UnableToOpenFile(filename));
+                    };
+                    if self.iter_stack.len() >= INCLUDE_DEPTH_LIMIT {
+                        return Some(TokenKind::IncludeDepthLimitReached);
+                    }
+                    let old_lex = std::mem::replace(&mut self.lex, Lexer::new(file_contents));
+                    let old_file_path =
+                        std::mem::replace(&mut self.current_file_path, filename.into());
+                    let old_file_contents =
+                        std::mem::replace(&mut self.current_file_contents, file_contents);
+                    self.iter_stack.push(IncludeStackEntry {
+                        lex: old_lex,
+                        file_path: old_file_path,
+                        file_contents: old_file_contents,
+                    });
+                    self.current_file_path = file_path;
+                    // Retry with new lexer
+                    continue;
+                }
+                None => {
+                    let stack_entry = self.iter_stack.pop()?;
+                    // this file was included from another file; resume
+                    // processing the original file.
+                    self.lex = stack_entry.lex;
+                    self.current_file_path = stack_entry.file_path;
+                    self.current_file_contents = stack_entry.file_contents;
+                    continue;
+                }
+                token => return token,
+            }
+        }
+    }
+
+    fn next_token_raw(&mut self) -> (TokenKind<'a>, Span) {
+        match self.lex_next() {
+            Some(t) => (t, self.lex.span()),
+            None => (TokenKind::EndOfFile, Span::default()),
+        }
+    }
+
+    pub fn next(&mut self) -> TokenKind<'a> {
+        let (next, span) = if self.fifo.is_empty() {
+            self.next_token_raw()
+        } else {
+            self.fifo.pop_front().unwrap()
+        };
+        self.last_span = span;
+        next
+    }
+
+    pub fn last_span(&self) -> &Span {
+        &self.last_span
+    }
+
+    pub fn current_file_contents(&self) -> &'a str {
+        self.current_file_contents
+    }
+
+    #[allow(unused)]
+    pub fn current_file_path(&self) -> &Path {
+        &self.current_file_path
+    }
+}


### PR DESCRIPTION
Uses the [winnow](https://crates.io/crates/winnow) parser-combinator library to write a new SystemRDL parser.

The new RDL changes to our registers, in particular MCI, don't show up with the existing parser. The existing parser is a bit of a hack, and skips over a lot of the pieces of the spec that we don't support.

The generator also makes a lot of assumptions about how the RDL files are structured, and those those assumptions don't seem to hold for the new RDL as well.

So, I started a (mostly) from-scratch rewrite of the entire parser using `winnow`, which allows us to implement a parser for the entire SystemRDL 2.0 grammar. The grammar is virtually identical to what appears in the [SystemRDL 2.0
specification](https://www.accellera.org/images/downloads/standards/systemrdl/SystemRDL_2.0_Jan2018.pdf), other than changes to make it parseable in an LL-style that `winnow` supports (notably, I removed some left recursion manually).

This keeps the existing lexer code and expands it to support all of the keywords in the spec.

I have already started working on a new generator using this library, but I will check that in a separate PR.

(`ast.rs` and `parser.rs` are the new files, the rest are copied with some slight modification.)