### PR TITLE
Downgrade cmake to 3.x so that SPDM validator can run

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -39,8 +39,15 @@ jobs:
       - name: Install required packages
         run: |
           sudo apt-get update -qy && \
-          sudo apt-get install -qy build-essential curl gcc-multilib gcc-riscv64-unknown-elf git rustup
+          sudo apt-get install -qy build-essential curl gcc-multilib gcc-riscv64-unknown-elf git rustup &&
           rustup toolchain install -c clippy,rust-src,llvm-tools,rustfmt,rustc-dev
+
+      - name: Install cmake 3.x
+        run: |
+          wget https://github.com/Kitware/CMake/releases/download/v3.31.6/cmake-3.31.6-linux-x86_64.tar.gz &&
+          mkdir -p /opt/cmake &&
+          tar xvzf cmake-3.31.6-linux-x86_64.tar.gz -C /opt/cmake --strip-components=1 &&
+          echo "/opt/cmake/bin" >> $GITHUB_PATH
 
       - name: Restore sccache binary
         uses: actions/cache/restore@v3


### PR DESCRIPTION
The SPDM validator's file were built with an old version of CMake (<= 3.5). CMake (in 4.0.0) just dropped support for those build scripts.

So, we download and install the last version of CMake 3.x that supports the SPVM validator build scripts as part of our CI pipeline.