### PR TITLE
Fix intermittent failures in MCTP message protocol tests.

### DIFF
--- a/emulator/app/src/i3c_socket.rs
+++ b/emulator/app/src/i3c_socket.rs
@@ -174,10 +174,12 @@ pub(crate) trait TestTrait {
 
 pub(crate) fn run_tests(
     running: Arc<AtomicBool>,
+    test_running: Arc<AtomicBool>,
     port: u16,
     target_addr: DynamicI3cAddress,
     tests: Vec<Box<dyn TestTrait + Send>>,
 ) {
+    test_running.store(true, Ordering::Relaxed);
     let running_clone = running.clone();
     let addr = SocketAddr::from(([127, 0, 0, 1], port));
     let stream = TcpStream::connect(addr).unwrap();
@@ -190,6 +192,7 @@ pub(crate) fn run_tests(
     std::thread::spawn(move || {
         let mut test_runner = MctpTestRunner::new(stream, target_addr.into(), running_clone, tests);
         test_runner.run_tests();
+        test_running.store(false, Ordering::Relaxed);
     });
 
     if cfg!(feature = "test-spdm-validator") {
@@ -243,6 +246,8 @@ impl MctpTestRunner {
             self.passed,
             self.tests.len()
         );
+        println!("MctpTestRunner: Stopping Emulator");
+
         self.running.store(false, Ordering::Relaxed);
         if self.passed == self.tests.len() {
             exit(0);

--- a/emulator/app/src/main.rs
+++ b/emulator/app/src/main.rs
@@ -422,8 +422,6 @@ fn run(cli: Emulator, capture_uart_output: bool) -> io::Result<Vec<u8>> {
     let i3c_dynamic_address = i3c.get_dynamic_address().unwrap();
     let test_running = Arc::new(AtomicBool::new(true));
 
-
-
     if cfg!(feature = "test-mctp-ctrl-cmds") {
         i3c_controller.start();
         println!(
@@ -505,7 +503,11 @@ fn run(cli: Emulator, capture_uart_output: bool) -> io::Result<Vec<u8>> {
         let pldm_socket = pldm_transport
             .create_socket(EndpointId(0), EndpointId(1))
             .unwrap();
-        tests::pldm_fw_update_test::PldmFwUpdateTest::run(pldm_socket, running.clone(), test_running.clone());
+        tests::pldm_fw_update_test::PldmFwUpdateTest::run(
+            pldm_socket,
+            running.clone(),
+            test_running.clone(),
+        );
     }
 
     let create_flash_controller = |default_path: &str, error_irq: u8, event_irq: u8| {
@@ -703,8 +705,7 @@ fn run(cli: Emulator, capture_uart_output: bool) -> io::Result<Vec<u8>> {
     }
 
     while test_running.load(std::sync::atomic::Ordering::Relaxed) {
-       
-        std::thread::sleep(std::time::Duration::from_millis(500));  
+        std::thread::sleep(std::time::Duration::from_millis(500));
     }
 
     Ok(uart_output.map(|o| o.borrow().clone()).unwrap_or_default())

--- a/emulator/app/src/tests/mctp_util/common.rs
+++ b/emulator/app/src/tests/mctp_util/common.rs
@@ -316,14 +316,12 @@ impl MctpUtil {
                 I3cControllerState::WaitForIbi => {
                     if receive_ibi(stream, target_addr) {
                         i3c_state = I3cControllerState::ReceivePrivateRead;
-                    } else {
-                        if retry_count > 0 {
-                            std::thread::sleep(std::time::Duration::from_millis(300));
-                            retry -= 1;
-                            if retry == 0 {
-                                println!("MCTP_UTIL: IBI not received. Exiting...");
-                                break;
-                            }
+                    } else if retry_count > 0 {
+                        std::thread::sleep(std::time::Duration::from_millis(300));
+                        retry -= 1;
+                        if retry == 0 {
+                            println!("MCTP_UTIL: IBI not received. Exiting...");
+                            break;
                         }
                     }
                 }

--- a/emulator/app/src/tests/pldm_fw_update_test.rs
+++ b/emulator/app/src/tests/pldm_fw_update_test.rs
@@ -159,7 +159,8 @@ impl PldmFwUpdateTest {
         res
     }
 
-    pub fn run(socket: MctpPldmSocket, running: Arc<AtomicBool>) {
+    pub fn run(socket: MctpPldmSocket, running: Arc<AtomicBool>, test_running: Arc<AtomicBool>) {
+        test_running.store(true, Ordering::Relaxed);
         std::thread::spawn(move || {
             print!("Emulator: Running PLDM Loopback Test: ",);
             let mut test = PldmFwUpdateTest::new(socket, running);
@@ -169,6 +170,7 @@ impl PldmFwUpdateTest {
             } else {
                 println!("Passed");
             }
+            test_running.store(false, Ordering::Relaxed);
             test.running.store(false, Ordering::Relaxed);
         });
     }

--- a/emulator/app/src/tests/pldm_request_response_test.rs
+++ b/emulator/app/src/tests/pldm_request_response_test.rs
@@ -91,7 +91,8 @@ impl PldmRequestResponseTest {
         Ok(())
     }
 
-    pub fn run(socket: MctpPldmSocket, running: Arc<AtomicBool>) {
+    pub fn run(socket: MctpPldmSocket, running: Arc<AtomicBool>, test_running: Arc<AtomicBool>) {
+        test_running.store(true, Ordering::Relaxed);
         std::thread::spawn(move || {
             print!("Emulator: Running PLDM Loopback Test: ",);
             let mut test = PldmRequestResponseTest::new(socket, running);
@@ -101,6 +102,7 @@ impl PldmRequestResponseTest {
             } else {
                 println!("Passed");
             }
+            test_running.store(false, Ordering::Relaxed);
             test.running.store(false, Ordering::Relaxed);
         });
     }

--- a/emulator/app/src/tests/spdm_validator.rs
+++ b/emulator/app/src/tests/spdm_validator.rs
@@ -43,6 +43,7 @@ struct Test {
     mctp_util: MctpUtil,
     responder_ready: bool,
     passed: bool,
+    cmd_retry_count: u8,
 }
 
 #[derive(Debug, Copy, Clone, Default, FromBytes, IntoBytes, Immutable)]
@@ -65,6 +66,7 @@ impl Test {
             mctp_util: MctpUtil::new(),
             responder_ready: false,
             passed: false,
+            cmd_retry_count: 5,
         }
     }
 
@@ -148,7 +150,7 @@ impl Test {
         target_addr: u8,
     ) {
         i3c_stream.set_nonblocking(true).unwrap();
-        println!("Test: Sending message to target {:x?}", self.cur_req_msg);
+        println!("SPDM_SERVER: Sending message to target {:x?}", self.cur_req_msg);
         self.mctp_test_state = MctpTestState::Start;
 
         while running.load(Ordering::Relaxed) {
@@ -168,16 +170,24 @@ impl Test {
                 }
 
                 MctpTestState::ReceiveResp => {
-                    println!("Test: receive_response");
+                    println!("SPDM_SERVER: receive_response from target");
                     let resp_msg =
                         self.mctp_util
                             .receive_response(running.clone(), i3c_stream, target_addr);
                     if !resp_msg.is_empty() {
-                        println!("Test: response received, marking finished");
+                        println!("SPDM_SERVER: response received from target, marking finished");
                         self.cur_resp_msg = resp_msg;
                         self.mctp_test_state = MctpTestState::Finish;
                     } else {
-                        println!("Test: no response received");
+                        println!("SPDM_SERVER: no response received from target");
+                        self.cmd_retry_count -= 1;
+                        if self.cmd_retry_count == 0 {
+                            println!("SPDM_SERVER: no response received from target, marking finished");
+                            self.mctp_test_state = MctpTestState::Finish;
+                        } else {
+                            println!("SPDM_SERVER: retrying command");
+                            self.mctp_test_state = MctpTestState::SendReq;
+                        }
                     }
                 }
 

--- a/emulator/app/src/tests/spdm_validator.rs
+++ b/emulator/app/src/tests/spdm_validator.rs
@@ -150,7 +150,10 @@ impl Test {
         target_addr: u8,
     ) {
         i3c_stream.set_nonblocking(true).unwrap();
-        println!("SPDM_SERVER: Sending message to target {:x?}", self.cur_req_msg);
+        println!(
+            "SPDM_SERVER: Sending message to target {:x?}",
+            self.cur_req_msg
+        );
         self.mctp_test_state = MctpTestState::Start;
 
         while running.load(Ordering::Relaxed) {
@@ -182,7 +185,9 @@ impl Test {
                         println!("SPDM_SERVER: no response received from target");
                         self.cmd_retry_count -= 1;
                         if self.cmd_retry_count == 0 {
-                            println!("SPDM_SERVER: no response received from target, marking finished");
+                            println!(
+                                "SPDM_SERVER: no response received from target, marking finished"
+                            );
                             self.mctp_test_state = MctpTestState::Finish;
                         } else {
                             println!("SPDM_SERVER: retrying command");


### PR DESCRIPTION
The PR addresses the following to fix intermittent failures in MCTP message protocol tests
* Adds retry mechanism for SPDM commands
* Ensure main thread waits for tests to complete
* Make the prints in SPDM validator integration tests uniform