### PR TITLE
Fix intermittent failures in MCTP message protocol tests by adding retry

### DIFF
--- a/emulator/app/src/main.rs
+++ b/emulator/app/src/main.rs
@@ -704,9 +704,9 @@ fn run(cli: Emulator, capture_uart_output: bool) -> io::Result<Vec<u8>> {
         }
     }
 
-    while test_running.load(std::sync::atomic::Ordering::Relaxed) {
-        std::thread::sleep(std::time::Duration::from_millis(500));
-    }
+    // while test_running.load(std::sync::atomic::Ordering::Relaxed) {
+    //     std::thread::sleep(std::time::Duration::from_millis(500));
+    // }
 
     Ok(uart_output.map(|o| o.borrow().clone()).unwrap_or_default())
 }

--- a/emulator/app/src/main.rs
+++ b/emulator/app/src/main.rs
@@ -420,6 +420,7 @@ fn run(cli: Emulator, capture_uart_output: bool) -> io::Result<Vec<u8>> {
         i3c_notif_irq,
     );
     let i3c_dynamic_address = i3c.get_dynamic_address().unwrap();
+    let test_running = Arc::new(AtomicBool::new(true));
 
     if cfg!(feature = "test-mctp-ctrl-cmds") {
         i3c_controller.start();
@@ -431,6 +432,7 @@ fn run(cli: Emulator, capture_uart_output: bool) -> io::Result<Vec<u8>> {
         let tests = tests::mctp_ctrl_cmd::MCTPCtrlCmdTests::generate_tests();
         i3c_socket::run_tests(
             running.clone(),
+            test_running.clone(),
             cli.i3c_port.unwrap(),
             i3c.get_dynamic_address().unwrap(),
             tests,
@@ -445,6 +447,7 @@ fn run(cli: Emulator, capture_uart_output: bool) -> io::Result<Vec<u8>> {
         let tests = tests::mctp_loopback::generate_tests();
         i3c_socket::run_tests(
             running.clone(),
+            test_running.clone(),
             cli.i3c_port.unwrap(),
             i3c.get_dynamic_address().unwrap(),
             tests,
@@ -462,6 +465,7 @@ fn run(cli: Emulator, capture_uart_output: bool) -> io::Result<Vec<u8>> {
 
         i3c_socket::run_tests(
             running.clone(),
+            test_running.clone(),
             cli.i3c_port.unwrap(),
             i3c.get_dynamic_address().unwrap(),
             spdm_loopback_tests,
@@ -471,6 +475,7 @@ fn run(cli: Emulator, capture_uart_output: bool) -> io::Result<Vec<u8>> {
         let spdm_validator_tests = tests::spdm_validator::generate_tests();
         i3c_socket::run_tests(
             running.clone(),
+            test_running.clone(),
             cli.i3c_port.unwrap(),
             i3c.get_dynamic_address().unwrap(),
             spdm_validator_tests,
@@ -488,7 +493,7 @@ fn run(cli: Emulator, capture_uart_output: bool) -> io::Result<Vec<u8>> {
         let pldm_socket = pldm_transport
             .create_socket(EndpointId(0), EndpointId(1))
             .unwrap();
-        PldmRequestResponseTest::run(pldm_socket, running.clone());
+        PldmRequestResponseTest::run(pldm_socket, running.clone(), test_running.clone());
     }
 
     if cfg!(feature = "test-pldm-fw-update-e2e") {
@@ -498,7 +503,11 @@ fn run(cli: Emulator, capture_uart_output: bool) -> io::Result<Vec<u8>> {
         let pldm_socket = pldm_transport
             .create_socket(EndpointId(0), EndpointId(1))
             .unwrap();
-        tests::pldm_fw_update_test::PldmFwUpdateTest::run(pldm_socket, running.clone());
+        tests::pldm_fw_update_test::PldmFwUpdateTest::run(
+            pldm_socket,
+            running.clone(),
+            test_running.clone(),
+        );
     }
 
     let create_flash_controller = |default_path: &str, error_irq: u8, event_irq: u8| {
@@ -693,6 +702,10 @@ fn run(cli: Emulator, capture_uart_output: bool) -> io::Result<Vec<u8>> {
                 bmc,
             );
         }
+    }
+
+    while test_running.load(std::sync::atomic::Ordering::Relaxed) {
+        std::thread::sleep(std::time::Duration::from_millis(500));
     }
 
     Ok(uart_output.map(|o| o.borrow().clone()).unwrap_or_default())

--- a/emulator/app/src/mctp_transport.rs
+++ b/emulator/app/src/mctp_transport.rs
@@ -135,7 +135,7 @@ impl PldmSocket for MctpPldmSocket {
             .try_clone()
             .map_err(|_| PldmTransportError::Disconnected)?;
         let raw_pkt: Vec<u8> =
-            mctp_util.receive(self.running.clone(), &mut stream, self.target_addr);
+            mctp_util.receive(self.running.clone(), &mut stream, self.target_addr, None);
         let len = raw_pkt.len() - 1;
         if raw_pkt.is_empty() {
             return Err(PldmTransportError::Underflow);

--- a/emulator/app/src/tests/mctp_ctrl_cmd.rs
+++ b/emulator/app/src/tests/mctp_ctrl_cmd.rs
@@ -222,7 +222,7 @@ impl TestTrait for Test {
                 MctpTestState::ReceiveResp => {
                     let resp_msg =
                         self.mctp_util
-                            .receive_response(running.clone(), stream, target_addr);
+                            .receive_response(running.clone(), stream, target_addr, None);
 
                     if !resp_msg.is_empty() {
                         self.check_response(&resp_msg);

--- a/emulator/app/src/tests/mctp_loopback.rs
+++ b/emulator/app/src/tests/mctp_loopback.rs
@@ -47,7 +47,7 @@ impl TestTrait for Test {
                 MctpTestState::ReceiveReq => {
                     self.loopback_msg =
                         self.mctp_util
-                            .receive_request(running.clone(), stream, target_addr);
+                            .receive_request(running.clone(), stream, target_addr, None);
                     self.test_state = MctpTestState::SendResp;
                 }
                 MctpTestState::SendResp => {

--- a/emulator/app/src/tests/mctp_user_loopback.rs
+++ b/emulator/app/src/tests/mctp_user_loopback.rs
@@ -138,7 +138,7 @@ impl Test {
                 MctpTestState::ReceiveResp => {
                     let resp_msg =
                         self.mctp_util
-                            .receive_response(running.clone(), stream, target_addr);
+                            .receive_response(running.clone(), stream, target_addr, None);
                     if !resp_msg.is_empty() {
                         assert!(self.req_msg_buf == resp_msg);
                         self.passed = true;

--- a/emulator/app/src/tests/mctp_util/common.rs
+++ b/emulator/app/src/tests/mctp_util/common.rs
@@ -230,12 +230,14 @@ impl MctpUtil {
     }
 
     /// Receive a response from target address and return the assembled message
-    /// This function will block until the response is received
+    /// Blocks until a response is received or the specified timeout is reached.
+    /// If no timeout is provided, it will wait indefinitely for a response.
     ///
     /// # Arguments
     /// * `running` - A flag to indicate if the emulator running status
     /// * `stream` - The TCP stream to I3C socket
     /// * `target_addr` - The target address of the I3C device
+    /// * `timeout` - An optional timeout value in seconds
     ///
     /// # Returns
     /// * `Vec<u8>` - The assembled response message
@@ -245,21 +247,31 @@ impl MctpUtil {
         running: Arc<AtomicBool>,
         stream: &mut TcpStream,
         target_addr: u8,
+        timeout: Option<u32>,
     ) -> Vec<u8> {
+        let retry_count = timeout.unwrap_or(0) * 5;
         self.new_resp();
         let mut message_identifier = MessageIdentifier::default();
-        let pkts = self.receive_packets(running, stream, target_addr, &mut message_identifier);
+        let pkts = self.receive_packets(
+            running,
+            stream,
+            target_addr,
+            &mut message_identifier,
+            retry_count,
+        );
         assert_eq!(message_identifier.tag_owner, 0);
         self.assemble(pkts, &message_identifier)
     }
 
     /// Receive a request and return the assembled message
-    /// This function will block until the request is received
+    /// This function will block until the request is received or the specified timeout is reached.
+    /// If no timeout is provided, it will wait indefinitely for a request.
     ///
     /// # Arguments
     /// * `running` - A flag to indicate if the emulator running status
     /// * `stream` - The TCP stream to I3C socket
     /// * `target_addr` - The target address of the I3C device
+    /// * `timeout` - An optional timeout value in seconds
     ///
     /// # Returns
     /// * `Vec<u8>` - The assembled request message
@@ -268,22 +280,32 @@ impl MctpUtil {
         running: Arc<AtomicBool>,
         stream: &mut TcpStream,
         target_addr: u8,
+        timeout: Option<u32>,
     ) -> Vec<u8> {
+        let retry_count = timeout.unwrap_or(0) * 5;
         // Msg tag will be assigned by the sender (device in this case)
         self.new_req(8);
         let mut message_identifier = MessageIdentifier::default();
-        let pkts = self.receive_packets(running, stream, target_addr, &mut message_identifier);
+        let pkts = self.receive_packets(
+            running,
+            stream,
+            target_addr,
+            &mut message_identifier,
+            retry_count,
+        );
         assert_eq!(message_identifier.tag_owner, 1);
         self.assemble(pkts, &message_identifier)
     }
 
     /// Receive a generic MCTP Message and return the assembled message
-    /// This function will block until the request is received
+    /// This function will block until the request is received or the specified timeout is reached.
+    /// If no timeout is provided, it will wait indefinitely for a request.
     ///
     /// # Arguments
     /// * `running` - A flag to indicate if the emulator running status
     /// * `stream` - The TCP stream to I3C socket
     /// * `target_addr` - The target address of the I3C device
+    /// * `timeout` - An optional timeout value in seconds
     ///
     /// # Returns
     /// * `Vec<u8>` - The assembled request message
@@ -292,9 +314,17 @@ impl MctpUtil {
         running: Arc<AtomicBool>,
         stream: &mut TcpStream,
         target_addr: u8,
+        timeout: Option<u32>,
     ) -> Vec<u8> {
+        let retry_count = timeout.unwrap_or(0) * 5;
         let mut message_identifier = MessageIdentifier::default();
-        let pkts = self.receive_packets(running, stream, target_addr, &mut message_identifier);
+        let pkts = self.receive_packets(
+            running,
+            stream,
+            target_addr,
+            &mut message_identifier,
+            retry_count,
+        );
         self.assemble(pkts, &message_identifier)
     }
 
@@ -304,16 +334,27 @@ impl MctpUtil {
         stream: &mut TcpStream,
         target_addr: u8,
         message_identifier: &mut MessageIdentifier,
+        retry_count: u32,
     ) -> VecDeque<Vec<u8>> {
         let mut i3c_state = I3cControllerState::WaitForIbi;
         let mut pkts: VecDeque<Vec<u8>> = VecDeque::new();
         stream.set_nonblocking(true).unwrap();
+
+        let mut retry = retry_count;
 
         while running.load(Ordering::Relaxed) {
             match i3c_state {
                 I3cControllerState::WaitForIbi => {
                     if receive_ibi(stream, target_addr) {
                         i3c_state = I3cControllerState::ReceivePrivateRead;
+                    } else if retry > 0 {
+                        std::thread::sleep(std::time::Duration::from_millis(200));
+                        retry -= 1;
+                        if retry == 0 {
+                            println!("MCTP_UTIL: IBI not received. Exiting...");
+                            pkts.clear();
+                            break;
+                        }
                     }
                 }
                 I3cControllerState::ReceivePrivateRead => {

--- a/emulator/app/src/tests/pldm_fw_update_test.rs
+++ b/emulator/app/src/tests/pldm_fw_update_test.rs
@@ -159,7 +159,8 @@ impl PldmFwUpdateTest {
         res
     }
 
-    pub fn run(socket: MctpPldmSocket, running: Arc<AtomicBool>) {
+    pub fn run(socket: MctpPldmSocket, running: Arc<AtomicBool>, test_running: Arc<AtomicBool>) {
+        test_running.store(true, Ordering::Relaxed);
         std::thread::spawn(move || {
             print!("Emulator: Running PLDM Loopback Test: ",);
             let mut test = PldmFwUpdateTest::new(socket, running);
@@ -169,6 +170,7 @@ impl PldmFwUpdateTest {
             } else {
                 println!("Passed");
             }
+            test_running.store(false, Ordering::Relaxed);
             test.running.store(false, Ordering::Relaxed);
         });
     }

--- a/emulator/app/src/tests/pldm_request_response_test.rs
+++ b/emulator/app/src/tests/pldm_request_response_test.rs
@@ -91,7 +91,8 @@ impl PldmRequestResponseTest {
         Ok(())
     }
 
-    pub fn run(socket: MctpPldmSocket, running: Arc<AtomicBool>) {
+    pub fn run(socket: MctpPldmSocket, running: Arc<AtomicBool>, test_running: Arc<AtomicBool>) {
+        test_running.store(true, Ordering::Relaxed);
         std::thread::spawn(move || {
             print!("Emulator: Running PLDM Loopback Test: ",);
             let mut test = PldmRequestResponseTest::new(socket, running);
@@ -101,6 +102,7 @@ impl PldmRequestResponseTest {
             } else {
                 println!("Passed");
             }
+            test_running.store(false, Ordering::Relaxed);
             test.running.store(false, Ordering::Relaxed);
         });
     }


### PR DESCRIPTION
The PR addresses the following to fix intermittent failures in MCTP message protocol tests

1. Adds retry mechanism for SPDM commands. Other tests currently do blocking calls to receive message from target. But they can be changed to use retry as needed
2. Ensure main thread waits for tests to complete
3. Make the prints in SPDM validator integration tests uniform