### PR TITLE
Add support for SPDM GET CERTIFICATE command handling

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -104,7 +104,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: parvathib/spdm-emu
-          ref: pbhogaraju/get-digests
+          ref: pbhogaraju/get-certificate
           path: spdm-emu
           submodules: recursive
 

--- a/builder/src/apps.rs
+++ b/builder/src/apps.rs
@@ -160,7 +160,7 @@ fn app_build(
 /* Licensed under the Apache-2.0 license */
 TBF_HEADER_SIZE = 0x{:x};
 FLASH_START = 0x{:x};
-FLASH_LENGTH = 0x16400;
+FLASH_LENGTH = 0x16800;
 RAM_START = 0x{:x};
 RAM_LENGTH = 0x{:x};
 INCLUDE runtime/apps/app_layout.ld",

--- a/runtime/apps/spdm/spdm-lib/src/cert_mgr.rs
+++ b/runtime/apps/spdm/spdm-lib/src/cert_mgr.rs
@@ -5,6 +5,7 @@ use crate::error::SpdmError;
 
 pub const SPDM_MAX_CERT_CHAIN_SLOTS: usize = 8;
 pub const SPDM_MAX_HASH_SIZE: usize = 64;
+pub const SPDM_CERT_CHAIN_HEADER_SIZE: usize = core::mem::size_of::<SpdmCertChainHeader>();
 
 pub type SupportedSlotMask = u8;
 pub type ProvisionedSlotMask = u8;
@@ -51,17 +52,23 @@ impl AsRef<[u8]> for SpdmCertChainData {
     }
 }
 
+#[repr(C, packed)]
+pub struct SpdmCertChainHeader {
+    pub length: u16,
+    pub reserved: u16,
+}
+
 // Represents the buffer for the SPDM certificate chain base format as defined in SPDM Specification 1.3.2 Table 33.
 // This buffer contains the total length of the certificate chain (2 bytes), reserved bytes (2 bytes) and the root certificate hash.
 pub struct SpdmCertChainBaseBuffer {
-    pub data: [u8; 4 + SPDM_MAX_HASH_SIZE],
+    pub data: [u8; SPDM_CERT_CHAIN_HEADER_SIZE + SPDM_MAX_HASH_SIZE],
     pub length: u16,
 }
 
 impl Default for SpdmCertChainBaseBuffer {
     fn default() -> Self {
         SpdmCertChainBaseBuffer {
-            data: [0u8; 4 + SPDM_MAX_HASH_SIZE],
+            data: [0u8; SPDM_CERT_CHAIN_HEADER_SIZE + SPDM_MAX_HASH_SIZE],
             length: 0u16,
         }
     }
@@ -81,7 +88,8 @@ impl SpdmCertChainBaseBuffer {
             return Err(SpdmError::InvalidParam);
         }
 
-        let total_len = (cert_chain_data_len + root_hash.len() + 4) as u16;
+        let total_len =
+            (cert_chain_data_len + root_hash.len() + SPDM_CERT_CHAIN_HEADER_SIZE) as u16;
         let mut cert_chain_base_buf = SpdmCertChainBaseBuffer::default();
         let mut pos = 0;
 
@@ -107,14 +115,17 @@ impl SpdmCertChainBaseBuffer {
 }
 
 pub struct SpdmCertChainBuffer {
-    pub data: [u8; 4 + SPDM_MAX_HASH_SIZE + config::MAX_CERT_CHAIN_DATA_SIZE],
+    pub data:
+        [u8; SPDM_CERT_CHAIN_HEADER_SIZE + SPDM_MAX_HASH_SIZE + config::MAX_CERT_CHAIN_DATA_SIZE],
     pub length: u16,
 }
 
 impl Default for SpdmCertChainBuffer {
     fn default() -> Self {
         SpdmCertChainBuffer {
-            data: [0u8; 4 + SPDM_MAX_HASH_SIZE + config::MAX_CERT_CHAIN_DATA_SIZE],
+            data: [0u8; SPDM_CERT_CHAIN_HEADER_SIZE
+                + SPDM_MAX_HASH_SIZE
+                + config::MAX_CERT_CHAIN_DATA_SIZE],
             length: 0u16,
         }
     }
@@ -131,10 +142,11 @@ impl SpdmCertChainBuffer {
         if cert_chain_data.len() > config::MAX_CERT_CHAIN_DATA_SIZE
             || root_hash.len() > SPDM_MAX_HASH_SIZE
         {
-            return Err(SpdmError::InvalidParam);
+            Err(SpdmError::InvalidParam)?;
         }
 
-        let total_len = (cert_chain_data.len() + root_hash.len() + 4) as u16;
+        let total_len =
+            (cert_chain_data.len() + root_hash.len() + SPDM_CERT_CHAIN_HEADER_SIZE) as u16;
         let mut cert_chain_buf = SpdmCertChainBuffer::default();
         let mut pos = 0;
 
@@ -438,10 +450,13 @@ mod test {
         let root_hash = [0xAAu8; SPDM_MAX_HASH_SIZE];
         let cert_chain_base_buf =
             SpdmCertChainBaseBuffer::new(root_cert_len, root_hash.as_ref()).unwrap();
-        assert_eq!(cert_chain_base_buf.length, 4 + root_hash.len() as u16);
+        assert_eq!(
+            cert_chain_base_buf.length,
+            (SPDM_CERT_CHAIN_HEADER_SIZE + root_hash.len()) as u16
+        );
         assert_eq!(
             cert_chain_base_buf.as_ref()[..2],
-            ((root_cert_len + 4 + root_hash.len()) as u16).to_le_bytes()
+            ((root_cert_len + SPDM_CERT_CHAIN_HEADER_SIZE + root_hash.len()) as u16).to_le_bytes()
         );
         assert_eq!(cert_chain_base_buf.as_ref()[2..4], [0, 0]);
         assert_eq!(&cert_chain_base_buf.as_ref()[4..], &root_hash[..]);

--- a/runtime/apps/spdm/spdm-lib/src/commands/certificate_rsp.rs
+++ b/runtime/apps/spdm/spdm-lib/src/commands/certificate_rsp.rs
@@ -1,0 +1,322 @@
+// Licensed under the Apache-2.0 license
+
+use crate::cert_mgr::{
+    CertChainSlotState, SpdmCertChainBuffer, SpdmCertChainData, SPDM_MAX_CERT_CHAIN_SLOTS,
+};
+use crate::codec::{Codec, CodecError, CodecResult, CommonCodec, DataKind, MessageBuf};
+use crate::commands::digests_rsp::SpdmDigest;
+use crate::commands::error_rsp::ErrorCode;
+use crate::config::MAX_SPDM_CERT_PORTION_LEN;
+use crate::context::SpdmContext;
+use crate::error::{CommandError, CommandResult, SpdmError, SpdmResult};
+use crate::protocol::algorithms::BaseHashAlgoType;
+use crate::protocol::common::SpdmMsgHdr;
+use crate::protocol::version::SpdmVersion;
+use crate::state::ConnectionState;
+use libtock_platform::Syscalls;
+use zerocopy::{FromBytes, Immutable, IntoBytes};
+
+const GET_CERTIFICATE_REQUEST_ATTRIBUTES_SLOT_SIZE_REQUESTED: u8 = 0x01;
+
+#[derive(FromBytes, IntoBytes, Immutable)]
+#[repr(packed)]
+pub struct GetCertificateReq {
+    pub slot_id: u8,
+    pub param2: u8,
+    pub offset: u16,
+    pub length: u16,
+}
+
+impl GetCertificateReq {
+    pub fn new(slot_id: u8, param2: u8, offset: u16, length: u16) -> Self {
+        Self {
+            slot_id,
+            param2,
+            offset,
+            length,
+        }
+    }
+}
+
+impl CommonCodec for GetCertificateReq {
+    const DATA_KIND: DataKind = DataKind::Payload;
+}
+
+#[derive(IntoBytes, FromBytes, Immutable)]
+#[repr(packed)]
+pub struct GetCertificateRespCommon {
+    pub slot_id: u8,
+    pub param2: u8,
+    pub portion_length: u16,
+    pub remainder_length: u16,
+}
+
+impl CommonCodec for GetCertificateRespCommon {
+    const DATA_KIND: DataKind = DataKind::Payload;
+}
+
+pub struct GetCertificateResp<'a> {
+    pub common: GetCertificateRespCommon,
+    pub cert_chain_portion: &'a [u8],
+}
+
+impl<'a> GetCertificateResp<'a> {
+    pub fn new(
+        slot_id: u8,
+        param2: u8,
+        cert_chain_portion: &'a [u8],
+        remainder_length: u16,
+    ) -> SpdmResult<Self> {
+        if cert_chain_portion.len() > crate::config::MAX_SPDM_CERT_PORTION_LEN {
+            return Err(SpdmError::InvalidParam);
+        }
+        let common = GetCertificateRespCommon {
+            slot_id,
+            param2,
+            portion_length: cert_chain_portion.len() as u16,
+            remainder_length,
+        };
+        Ok(Self {
+            common,
+            cert_chain_portion,
+        })
+    }
+}
+
+impl<'a> Codec for GetCertificateResp<'a> {
+    fn encode(&self, buffer: &mut MessageBuf) -> CodecResult<usize> {
+        let mut len = 0;
+        len += self.common.encode(buffer)?;
+
+        let portion_length =
+            (self.common.portion_length as usize).min(self.cert_chain_portion.len());
+        buffer.put_data(portion_length)?;
+
+        let payload = buffer.data_mut(portion_length)?;
+        self.cert_chain_portion[..portion_length]
+            .write_to(payload)
+            .map_err(|_| CodecError::WriteError)?;
+
+        buffer.pull_data(portion_length)?;
+        len += portion_length;
+
+        Ok(len)
+    }
+
+    fn decode(_data: &mut MessageBuf) -> CodecResult<Self> {
+        // Decoding is not required for SPDM responder
+        unimplemented!()
+    }
+}
+
+pub(crate) fn handle_certificates<'a, S: Syscalls>(
+    ctx: &mut SpdmContext<'a, S>,
+    spdm_hdr: SpdmMsgHdr,
+    req_payload: &mut MessageBuf<'a>,
+) -> CommandResult<()> {
+    // Validate the state
+    if ctx.state.connection_info.state() < ConnectionState::AfterNegotiateAlgorithms {
+        Err(ctx.generate_error_response(req_payload, ErrorCode::UnexpectedRequest, 0, None))?;
+    }
+
+    // Validate the version
+    let connection_version = ctx.state.connection_info.version_number();
+    match spdm_hdr.version() {
+        Ok(version) if version == connection_version => {}
+        _ => Err(ctx.generate_error_response(req_payload, ErrorCode::VersionMismatch, 0, None))?,
+    }
+
+    // Check if the certificate capability is supported.
+    if ctx.local_capabilities.flags.cert_cap() == 0 {
+        Err(ctx.generate_error_response(req_payload, ErrorCode::UnsupportedRequest, 0, None))?;
+    }
+
+    let req = GetCertificateReq::decode(req_payload).map_err(|_| {
+        ctx.generate_error_response(req_payload, ErrorCode::InvalidRequest, 0, None)
+    })?;
+
+    let slot_id = req.slot_id;
+    if slot_id >= SPDM_MAX_CERT_CHAIN_SLOTS as u8 {
+        return Err(ctx.generate_error_response(req_payload, ErrorCode::InvalidRequest, 0, None));
+    }
+
+    // Check if the slot is provisioned. Otherwise, return an InvalidRequest error.
+    let slot_mask = 1 << slot_id;
+    let (_, provisioned_slot_mask) = ctx
+        .device_certs_manager
+        .get_cert_chain_slot_mask()
+        .map_err(|_| ctx.generate_error_response(req_payload, ErrorCode::Unspecified, 0, None))?;
+    if provisioned_slot_mask & slot_mask == 0 {
+        return Err(ctx.generate_error_response(req_payload, ErrorCode::InvalidRequest, 0, None));
+    }
+
+    let hash_type = ctx
+        .get_select_hash_algo()
+        .map_err(|_| ctx.generate_error_response(req_payload, ErrorCode::Unspecified, 0, None))?;
+
+    let cert_chain_buffer = construct_cert_chain_buffer(ctx, hash_type, slot_id)
+        .map_err(|_| ctx.generate_error_response(req_payload, ErrorCode::Unspecified, 0, None))?;
+
+    let mut offset = req.offset;
+    let mut length = req.length;
+
+    // When SlotSizeRequested=1b in the GET_CERTIFICATE request, the Responder shall return
+    // the number of bytes available for certificate chain storage in the RemainderLength field of the response.
+    if connection_version >= SpdmVersion::V13
+        && req.param2 & GET_CERTIFICATE_REQUEST_ATTRIBUTES_SLOT_SIZE_REQUESTED != 0
+    {
+        offset = 0;
+        length = 0;
+    }
+
+    if offset >= cert_chain_buffer.length {
+        Err(ctx.generate_error_response(req_payload, ErrorCode::InvalidRequest, 0, None))?;
+    }
+
+    if length > MAX_SPDM_CERT_PORTION_LEN as u16 && ctx.local_capabilities.flags.chunk_cap() == 0 {
+        length = MAX_SPDM_CERT_PORTION_LEN as u16;
+    }
+
+    if length > cert_chain_buffer.length - offset {
+        length = cert_chain_buffer.length - offset;
+    }
+
+    let portion_length = length;
+    let remainder_length = cert_chain_buffer.length - (length + offset);
+
+    // construct the portion of cert data
+    let mut cert_portion = [0u8; MAX_SPDM_CERT_PORTION_LEN];
+    cert_portion[..portion_length as usize].copy_from_slice(
+        &cert_chain_buffer.as_ref()[offset as usize..(offset + portion_length) as usize],
+    );
+
+    // Prepare the response buffer
+    ctx.prepare_response_buffer(req_payload)?;
+
+    // Set the param2 field if the connection version is V13 or higher and multi-key capability is supported
+    let mut param2 = 0;
+    if connection_version >= SpdmVersion::V13 && ctx.local_capabilities.flags.multi_key_cap() != 0 {
+        let mut cert_chain_slot_state = CertChainSlotState::default();
+        ctx.device_certs_manager
+            .get_cert_chain_slot_state(slot_id, &mut cert_chain_slot_state)
+            .map_err(|_| {
+                ctx.generate_error_response(req_payload, ErrorCode::InvalidRequest, 0, None)
+            })?;
+
+        if let Some(cert_model) = cert_chain_slot_state.cert_model {
+            param2 = cert_model as u8;
+        }
+    }
+
+    // Fill the response buffer
+    fill_certificate_response(
+        ctx,
+        slot_id,
+        param2,
+        &cert_portion[..portion_length as usize],
+        remainder_length,
+        req_payload,
+    )?;
+
+    // TODO: transcript manager and session support
+
+    // Set the connection state to AfterCertificate
+    if ctx.state.connection_info.state() < ConnectionState::AfterCertificate {
+        ctx.state
+            .connection_info
+            .set_state(ConnectionState::AfterCertificate);
+    }
+
+    Ok(())
+}
+
+fn construct_cert_chain_buffer<S: Syscalls>(
+    ctx: &mut SpdmContext<S>,
+    hash_type: BaseHashAlgoType,
+    slot_id: u8,
+) -> SpdmResult<SpdmCertChainBuffer> {
+    let mut cert_chain_data = SpdmCertChainData::default();
+    let mut root_hash = SpdmDigest::default();
+    let root_cert_len = ctx
+        .device_certs_manager
+        .construct_cert_chain_data(slot_id, &mut cert_chain_data)
+        .map_err(SpdmError::CertMgr)?;
+
+    // Get the hash of root_cert
+    ctx.hash_engine
+        .hash_all(
+            &cert_chain_data.as_ref()[..root_cert_len],
+            hash_type,
+            &mut root_hash,
+        )
+        .map_err(SpdmError::HashEngine)?;
+
+    // Construct the cert chain buffer
+    let cert_chain_buffer = SpdmCertChainBuffer::new(cert_chain_data.as_ref(), root_hash.as_ref())
+        .map_err(|_| SpdmError::InvalidParam)?;
+
+    Ok(cert_chain_buffer)
+}
+
+fn fill_certificate_response<S: Syscalls>(
+    ctx: &SpdmContext<S>,
+    slot_id: u8,
+    param2: u8,
+    cert_chain_portion: &[u8],
+    remainder_length: u16,
+    rsp: &mut MessageBuf,
+) -> CommandResult<()> {
+    // Construct the response
+    let resp = GetCertificateResp::new(slot_id, param2, cert_chain_portion, remainder_length)
+        .map_err(|_| (false, CommandError::BufferTooSmall))?;
+    let payload_len = resp
+        .encode(rsp)
+        .map_err(|_| ctx.generate_error_response(rsp, ErrorCode::InvalidRequest, 0, None))?;
+
+    // Push data offset up by total payload length
+    rsp.push_data(payload_len)
+        .map_err(|_| (false, CommandError::BufferTooSmall))?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_encode_get_cert_chain_resp() {
+        let cert_chain_portion = [0xaau8; MAX_SPDM_CERT_PORTION_LEN];
+        let remainder_length = 0;
+        let slot_id = 0;
+
+        let resp =
+            GetCertificateResp::new(slot_id, 0, &cert_chain_portion, remainder_length).unwrap();
+        let mut bytes = [0u8; 1024];
+        let mut buffer = MessageBuf::new(&mut bytes);
+        let encoded_len = resp.encode(&mut buffer).unwrap();
+
+        assert_eq!(
+            encoded_len,
+            core::mem::size_of::<GetCertificateRespCommon>() + cert_chain_portion.len() as usize
+        );
+        assert_eq!(encoded_len, buffer.msg_len());
+        assert_eq!(encoded_len, buffer.data_offset());
+
+        // Verify the encoded data
+        assert_eq!(buffer.total_message()[0], resp.common.slot_id);
+        assert_eq!(buffer.total_message()[1], resp.common.param2);
+        assert_eq!(
+            buffer.total_message()[2..4],
+            resp.common.portion_length.to_le_bytes()
+        );
+        assert_eq!(
+            buffer.total_message()[4..6],
+            resp.common.remainder_length.to_le_bytes()
+        );
+        assert_eq!(
+            buffer.total_message()[core::mem::size_of::<GetCertificateRespCommon>()..],
+            cert_chain_portion
+        );
+    }
+}

--- a/runtime/apps/spdm/spdm-lib/src/commands/certificate_rsp.rs
+++ b/runtime/apps/spdm/spdm-lib/src/commands/certificate_rsp.rs
@@ -121,9 +121,8 @@ pub(crate) fn handle_certificates<'a, S: Syscalls>(
 
     // Validate the version
     let connection_version = ctx.state.connection_info.version_number();
-    match spdm_hdr.version() {
-        Ok(version) if version == connection_version => {}
-        _ => Err(ctx.generate_error_response(req_payload, ErrorCode::VersionMismatch, 0, None))?,
+    if spdm_hdr.version().ok() != Some(connection_version) {
+        Err(ctx.generate_error_response(req_payload, ErrorCode::VersionMismatch, 0, None))?;
     }
 
     // Check if the certificate capability is supported.

--- a/runtime/apps/spdm/spdm-lib/src/commands/mod.rs
+++ b/runtime/apps/spdm/spdm-lib/src/commands/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod algorithms_rsp;
 pub mod capabilities_rsp;
+pub mod certificate_rsp;
 pub mod digests_rsp;
 pub mod error_rsp;
 pub mod version_rsp;

--- a/runtime/apps/spdm/spdm-lib/src/config.rs
+++ b/runtime/apps/spdm/spdm-lib/src/config.rs
@@ -10,6 +10,9 @@ pub const MAX_CERT_CHAIN_DATA_SIZE: usize = MAX_DER_CERT_LENGTH * MAX_CERT_COUNT
 // Only support slot 0 for now. Adjust this when we support multiple slots.
 pub const CERT_CHAIN_SLOT_MASK: u8 = 0x01;
 
+// Maximum size of a certificate portion in bytes. Adjust as needed.
+pub const MAX_SPDM_CERT_PORTION_LEN: usize = 512;
+
 // This is a hard-coded test device ID cert for development and testing.
 // Refactor out when we have real mechanism to retrieve the certificate chain.
 pub static TEST_DEVID_CERT_DER: [u8; 651] = [

--- a/runtime/apps/spdm/spdm-lib/src/context.rs
+++ b/runtime/apps/spdm/spdm-lib/src/context.rs
@@ -5,7 +5,9 @@ use crate::cert_mgr::{SpdmCertChainBaseBuffer, SpdmCertChainData};
 use crate::codec::{Codec, MessageBuf};
 use crate::commands::digests_rsp::SpdmDigest;
 use crate::commands::error_rsp::{fill_error_response, ErrorCode};
-use crate::commands::{algorithms_rsp, capabilities_rsp, digests_rsp, version_rsp};
+use crate::commands::{
+    algorithms_rsp, capabilities_rsp, certificate_rsp, digests_rsp, version_rsp,
+};
 use crate::error::*;
 use crate::hash_op::HashEngine;
 use crate::protocol::algorithms::*;
@@ -98,6 +100,10 @@ impl<'a, S: Syscalls> SpdmContext<'a, S> {
                 algorithms_rsp::handle_negotiate_algorithms(self, req_msg_header, req)?
             }
             ReqRespCode::GetDigests => digests_rsp::handle_digests(self, req_msg_header, req)?,
+
+            ReqRespCode::GetCertificate => {
+                certificate_rsp::handle_certificates(self, req_msg_header, req)?
+            }
             _ => Err((false, CommandError::UnsupportedRequest))?,
         }
         Ok(resp_code)
@@ -137,6 +143,25 @@ impl<'a, S: Syscalls> SpdmContext<'a, S> {
             .prepare_response_buffer(msg_buf)
             .map_err(|_| (false, CommandError::BufferTooSmall));
         fill_error_response(msg_buf, error_code, error_data, extended_data)
+    }
+
+    pub fn get_select_hash_algo(&self) -> SpdmResult<BaseHashAlgoType> {
+        let peer_algorithms = self.state.connection_info.peer_algorithms();
+        let local_algorithms = &self.local_algorithms.device_algorithms;
+        let algorithm_priority_table = &self.local_algorithms.algorithm_priority_table;
+
+        let base_hash_sel = local_algorithms.base_hash_algo.prioritize(
+            &peer_algorithms.base_hash_algo,
+            algorithm_priority_table.base_hash_algo,
+        );
+
+        // Ensure BaseHashSel has exactly one bit set
+        if base_hash_sel.0.count_ones() != 1 {
+            return Err(SpdmError::InvalidParam);
+        }
+
+        BaseHashAlgoType::try_from(base_hash_sel.0.trailing_zeros() as u8)
+            .map_err(|_| SpdmError::InvalidParam)
     }
 
     pub fn get_certificate_chain_digest(

--- a/runtime/apps/spdm/spdm-lib/src/protocol/common.rs
+++ b/runtime/apps/spdm/spdm-lib/src/protocol/common.rs
@@ -15,6 +15,8 @@ pub(crate) enum ReqRespCode {
     Algorithmes = 0x63,
     GetDigests = 0x81,
     Digests = 0x01,
+    GetCertificate = 0x82,
+    Certificate = 0x02,
     Error = 0x7F,
 }
 
@@ -30,6 +32,8 @@ impl TryFrom<u8> for ReqRespCode {
             0x63 => Ok(ReqRespCode::Algorithmes),
             0x81 => Ok(ReqRespCode::GetDigests),
             0x01 => Ok(ReqRespCode::Digests),
+            0x82 => Ok(ReqRespCode::GetCertificate),
+            0x02 => Ok(ReqRespCode::Certificate),
             0x7F => Ok(ReqRespCode::Error),
             _ => Err(SpdmError::UnsupportedRequest),
         }
@@ -49,6 +53,7 @@ impl ReqRespCode {
             ReqRespCode::GetCapabilities => Ok(ReqRespCode::Capabilities),
             ReqRespCode::NegotiateAlgorithms => Ok(ReqRespCode::Algorithmes),
             ReqRespCode::GetDigests => Ok(ReqRespCode::Digests),
+            ReqRespCode::GetCertificate => Ok(ReqRespCode::Certificate),
             ReqRespCode::Error => Ok(ReqRespCode::Error),
             _ => Err(SpdmError::UnsupportedRequest),
         }


### PR DESCRIPTION
This PR introduces support for handling the SPDM `get-certificate` command and minor adjustments to `get-digest` command due to the relocation of common functions.