### PR TITLE
Make Transport genertic and remove thiserror dependency in SPDM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1880,7 +1880,6 @@ dependencies = [
  "libsyscall-caliptra",
  "libtock_platform",
  "libtock_unittest",
- "thiserror-no-std",
  "zerocopy 0.8.23",
 ]
 
@@ -2975,13 +2974,13 @@ dependencies = [
 name = "spdm-lib"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "bitfield",
  "libapi-caliptra",
  "libsyscall-caliptra",
  "libtock_console",
  "libtock_platform",
  "rand",
- "thiserror-no-std",
  "zerocopy 0.8.23",
 ]
 
@@ -3136,26 +3135,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.90",
-]
-
-[[package]]
-name = "thiserror-impl-no-std"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58e6318948b519ba6dc2b442a6d0b904ebfb8d411a3ad3e07843615a72249758"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "thiserror-no-std"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3ad459d94dd517257cc96add8a43190ee620011bb6e6cdc82dafd97dfafafea"
-dependencies = [
- "thiserror-impl-no-std",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,7 +111,6 @@ sudo = "0.6.0"
 strum = "0.24"
 strum_macros = "0.24"
 tempfile = "3.14.0"
-thiserror-no-std = "2.0.2"
 toml = "0.8.19"
 uuid = { version = "1.10.0", features = ["serde"]}
 walkdir = "2.5.0"
@@ -209,7 +208,7 @@ capsules-core = { git = "https://github.com/tock/tock.git", rev = "b128ae817b867
 capsules-extra = { git = "https://github.com/tock/tock.git", rev = "b128ae817b86706c8c4e39d27fae5c54b98659f1" }
 capsules-system = { git = "https://github.com/tock/tock.git", rev = "b128ae817b86706c8c4e39d27fae5c54b98659f1" }
 components = { git = "https://github.com/tock/tock.git", rev = "b128ae817b86706c8c4e39d27fae5c54b98659f1" }
-kernel = { git = "https://github.com/tock/tock.git", rev = "b128ae817b86706c8c4e39d27fae5c54b98659f1"}
+kernel = { git = "https://github.com/tock/tock.git", rev = "b128ae817b86706c8c4e39d27fae5c54b98659f1", features = ["debug_load_processes"]}
 riscv = { git = "https://github.com/tock/tock.git", rev = "b128ae817b86706c8c4e39d27fae5c54b98659f1" }
 riscv-csr = { git = "https://github.com/tock/tock.git", rev = "b128ae817b86706c8c4e39d27fae5c54b98659f1" }
 rv32i = { git = "https://github.com/tock/tock.git", rev = "b128ae817b86706c8c4e39d27fae5c54b98659f1" }

--- a/runtime/userspace/api/caliptra-api/Cargo.toml
+++ b/runtime/userspace/api/caliptra-api/Cargo.toml
@@ -12,7 +12,6 @@ caliptra-error.workspace = true
 libtock_platform.workspace = true
 zerocopy.workspace = true
 libsyscall-caliptra.workspace = true
-thiserror-no-std.workspace = true
 
 [dev-dependencies]
 libtock_unittest.workspace = true

--- a/runtime/userspace/api/caliptra-api/src/crypto/error.rs
+++ b/runtime/userspace/api/caliptra-api/src/crypto/error.rs
@@ -1,22 +1,15 @@
 // Licensed under the Apache-2.0 license
 
-use thiserror_no_std::Error;
-
 use libsyscall_caliptra::mailbox::MailboxError;
 use libtock_platform::ErrorCode;
 
 pub type CryptoResult<T> = Result<T, CryptoError>;
 
-#[derive(Error, Debug)]
+#[derive(Debug)]
 pub enum CryptoError {
-    #[error("Mailbox error {:?}", .0)]
-    MailboxError(#[from] MailboxError),
-    #[error("System call error {:?}", .0)]
-    SyscallError(#[from] ErrorCode),
-    #[error("Invalid argument: {0}")]
+    MailboxError(MailboxError),
+    SyscallError(ErrorCode),
     InvalidArgument(&'static str),
-    #[error("Invalid operation: {0}")]
     InvalidOperation(&'static str),
-    #[error("Invalid response")]
     InvalidResponse,
 }

--- a/runtime/userspace/api/caliptra-api/src/crypto/hash.rs
+++ b/runtime/userspace/api/caliptra-api/src/crypto/hash.rs
@@ -93,13 +93,16 @@ impl HashContext {
         }
 
         let req_bytes = init_req.as_mut_bytes();
-        self.mbox.populate_checksum(CmShaInitReq::ID.0, req_bytes)?;
+        self.mbox
+            .populate_checksum(CmShaInitReq::ID.0, req_bytes)
+            .map_err(CryptoError::SyscallError)?;
 
         let init_rsp_bytes = &mut [0u8; size_of::<CmShaInitResp>()];
 
         self.mbox
             .execute(CmShaInitReq::ID.0, init_req.as_bytes(), init_rsp_bytes)
-            .await?;
+            .await
+            .map_err(CryptoError::MailboxError)?;
 
         let init_rsp = CmShaInitResp::ref_from_bytes(init_rsp_bytes)
             .map_err(|_| CryptoError::InvalidResponse)?;
@@ -136,7 +139,8 @@ impl HashContext {
 
             let req_bytes = update_req.as_mut_bytes();
             self.mbox
-                .populate_checksum(CmShaUpdateReq::ID.0, req_bytes)?;
+                .populate_checksum(CmShaUpdateReq::ID.0, req_bytes)
+                .map_err(CryptoError::SyscallError)?;
 
             let update_rsp_bytes = &mut [0u8; size_of::<CmShaInitResp>()];
 
@@ -146,7 +150,8 @@ impl HashContext {
                     update_req.as_bytes(),
                     update_rsp_bytes,
                 )
-                .await?;
+                .await
+                .map_err(CryptoError::MailboxError)?;
 
             let update_rsp = CmShaInitResp::ref_from_bytes(update_rsp_bytes)
                 .map_err(|_| CryptoError::InvalidResponse)?;
@@ -183,13 +188,15 @@ impl HashContext {
 
         let req_bytes = final_req.as_mut_bytes();
         self.mbox
-            .populate_checksum(CmShaFinalReq::ID.0, req_bytes)?;
+            .populate_checksum(CmShaFinalReq::ID.0, req_bytes)
+            .map_err(CryptoError::SyscallError)?;
 
         let final_rsp_bytes = &mut [0u8; size_of::<CmShaFinalResp>()];
 
         self.mbox
             .execute(CmShaFinalReq::ID.0, final_req.as_bytes(), final_rsp_bytes)
-            .await?;
+            .await
+            .map_err(CryptoError::MailboxError)?;
 
         let final_rsp = CmShaFinalResp::ref_from_bytes(final_rsp_bytes)
             .map_err(|_| CryptoError::InvalidResponse)?;

--- a/runtime/userspace/api/spdm-lib/Cargo.toml
+++ b/runtime/userspace/api/spdm-lib/Cargo.toml
@@ -7,13 +7,13 @@ authors.workspace = true
 edition.workspace = true
 
 [dependencies]
+async-trait.workspace = true
 bitfield.workspace = true
 zerocopy.workspace = true
 libapi-caliptra.workspace = true
 libsyscall-caliptra.workspace = true
 libtock_platform.workspace = true
 libtock_console.workspace = true
-thiserror-no-std.workspace = true
 
 [dev-dependencies]
 rand.workspace = true

--- a/runtime/userspace/api/spdm-lib/src/codec.rs
+++ b/runtime/userspace/api/spdm-lib/src/codec.rs
@@ -1,21 +1,15 @@
 // Licensed under the Apache-2.0 license
 
-use thiserror_no_std::Error;
 use zerocopy::{FromBytes, Immutable, IntoBytes};
 
 pub type CodecResult<T> = Result<T, CodecError>;
 
-#[derive(Error, Debug, PartialEq)]
+#[derive(Debug, PartialEq)]
 pub enum CodecError {
-    #[error("Buffer too small")]
     BufferTooSmall,
-    #[error("Read from buffer bytes error")]
     ReadError,
-    #[error("Write to buffer bytes error")]
     WriteError,
-    #[error("Buffer overflow")]
     BufferOverflow,
-    #[error("Buffer underflow")]
     BufferUnderflow,
 }
 

--- a/runtime/userspace/api/spdm-lib/src/error.rs
+++ b/runtime/userspace/api/spdm-lib/src/error.rs
@@ -1,44 +1,30 @@
 // Licensed under the Apache-2.0 license
 
-use thiserror_no_std::Error;
-
 use crate::cert_mgr::DeviceCertsMgrError;
 use crate::codec::CodecError;
 use crate::commands::error_rsp::ErrorCode;
 use crate::transport::TransportError;
 
-#[derive(Error, Debug)]
+#[derive(Debug)]
 pub enum SpdmError {
-    #[error("Unsupported version")]
     UnsupportedVersion,
-    #[error("Invalid Parameter")]
     InvalidParam,
-    #[error("Encode/Decode error")]
-    Codec(#[from] CodecError),
-    #[error("Transport error")]
-    Transport(#[from] TransportError),
-    #[error("Command handler error")]
-    Command(#[from] CommandError),
-    #[error("Buffer too small")]
+    Codec(CodecError),
+    Transport(TransportError),
+    Command(CommandError),
     BufferTooSmall,
-    #[error("Unsupported request")]
     UnsupportedRequest,
-    #[error("Device Certificate Manager error")]
-    CertMgr(#[from] DeviceCertsMgrError),
+    CertMgr(DeviceCertsMgrError),
 }
 
 pub type SpdmResult<T> = Result<T, SpdmError>;
 
 pub type CommandResult<T> = Result<T, (bool, CommandError)>;
 
-#[derive(Debug, Error, PartialEq)]
+#[derive(Debug, PartialEq)]
 pub enum CommandError {
-    #[error("Buffer too small")]
     BufferTooSmall,
-    #[error("Codec error")]
-    Codec(#[from] CodecError),
-    #[error("Request failed with error code {:?}", .0)]
+    Codec(CodecError),
     ErrorCode(ErrorCode),
-    #[error("Unsupported request")]
     UnsupportedRequest,
 }

--- a/runtime/userspace/api/spdm-lib/src/transport.rs
+++ b/runtime/userspace/api/spdm-lib/src/transport.rs
@@ -1,38 +1,43 @@
 // Licensed under the Apache-2.0 license
 
-use thiserror_no_std::Error;
-
+extern crate alloc;
 use crate::codec::MessageBuf;
 use crate::codec::{Codec, CodecError, CommonCodec, DataKind};
+use alloc::boxed::Box;
+use async_trait::async_trait;
 use bitfield::bitfield;
 use libsyscall_caliptra::mctp::{Mctp, MessageInfo};
 use zerocopy::{FromBytes, Immutable, IntoBytes};
 
 pub type TransportResult<T> = Result<T, TransportError>;
 
-pub enum SpdmTransportType {
-    Mctp,
+#[async_trait]
+pub trait SpdmTransport {
+    async fn send_request<'a>(
+        &mut self,
+        dest_eid: u8,
+        req: &mut MessageBuf<'a>,
+    ) -> TransportResult<()>;
+    async fn receive_response<'a>(&mut self, rsp: &mut MessageBuf<'a>) -> TransportResult<()>;
+    async fn receive_request<'a>(&mut self, req: &mut MessageBuf<'a>) -> TransportResult<()>;
+    async fn send_response<'a>(&mut self, resp: &mut MessageBuf<'a>) -> TransportResult<()>;
+    fn max_message_size(&self) -> TransportResult<usize>;
+    fn header_size(&self) -> usize;
 }
 
-#[derive(Error, Debug)]
+#[derive(Debug)]
 pub enum TransportError {
-    #[error("Driver Error")]
     DriverError,
-    #[error("Buffer too small")]
     BufferTooSmall,
-    #[error("Codec error")]
-    Codec(#[from] CodecError),
-    #[error("Unexpected message type received")]
+    Codec(CodecError),
     UnexpectedMessageType,
-    #[error("Message receive error")]
     ReceiveError,
-    #[error("Message send error")]
     SendError,
-    #[error("Response is not expected")]
     ResponseNotExpected,
-    #[error("No request in flight")]
     NoRequestInFlight,
 }
+
+// MCTP Transport Implementation
 
 bitfield! {
 #[repr(C)]
@@ -75,8 +80,11 @@ impl MctpTransport {
             cur_req_ctx: None,
         }
     }
+}
 
-    pub async fn send_request<'a>(
+#[async_trait]
+impl SpdmTransport for MctpTransport {
+    async fn send_request<'a>(
         &mut self,
         dest_eid: u8,
         req: &mut MessageBuf<'a>,
@@ -86,7 +94,7 @@ impl MctpTransport {
             .msg_type()
             .map_err(|_| TransportError::UnexpectedMessageType)?;
         let header = MctpMsgHdr::new(0, msg_type);
-        header.encode(req)?;
+        header.encode(req).map_err(TransportError::Codec)?;
         let req_len = req.data_len();
         let req_buf = req
             .data(req_len)
@@ -103,7 +111,7 @@ impl MctpTransport {
         Ok(())
     }
 
-    pub async fn receive_response<'a>(&mut self, rsp: &mut MessageBuf<'a>) -> TransportResult<()> {
+    async fn receive_response<'a>(&mut self, rsp: &mut MessageBuf<'a>) -> TransportResult<()> {
         rsp.reset();
 
         let max_len = rsp.capacity();
@@ -131,7 +139,7 @@ impl MctpTransport {
             .map_err(|_| TransportError::BufferTooSmall)?;
 
         // Process the transport message header
-        let header = MctpMsgHdr::decode(rsp)?;
+        let header = MctpMsgHdr::decode(rsp).map_err(TransportError::Codec)?;
         if header.msg_type()
             != self
                 .mctp
@@ -145,7 +153,7 @@ impl MctpTransport {
         Ok(())
     }
 
-    pub async fn receive_request<'a>(&mut self, req: &mut MessageBuf<'a>) -> TransportResult<()> {
+    async fn receive_request<'a>(&mut self, req: &mut MessageBuf<'a>) -> TransportResult<()> {
         req.reset();
 
         let max_len = req.capacity();
@@ -171,7 +179,7 @@ impl MctpTransport {
             .map_err(|_| TransportError::BufferTooSmall)?;
 
         // Process the transport message header
-        let header = MctpMsgHdr::decode(req)?;
+        let header = MctpMsgHdr::decode(req).map_err(TransportError::Codec)?;
 
         if header.msg_type()
             != self
@@ -187,13 +195,13 @@ impl MctpTransport {
         Ok(())
     }
 
-    pub async fn send_response<'a>(&mut self, resp: &mut MessageBuf<'a>) -> TransportResult<()> {
+    async fn send_response<'a>(&mut self, resp: &mut MessageBuf<'a>) -> TransportResult<()> {
         let msg_type = self
             .mctp
             .msg_type()
             .map_err(|_| TransportError::UnexpectedMessageType)?;
         let header = MctpMsgHdr::new(0, msg_type);
-        header.encode(resp)?;
+        header.encode(resp).map_err(TransportError::Codec)?;
 
         let msg_len = resp.msg_len();
         let rsp_buf = resp
@@ -214,7 +222,7 @@ impl MctpTransport {
         Ok(())
     }
 
-    pub fn max_message_size(&self) -> TransportResult<usize> {
+    fn max_message_size(&self) -> TransportResult<usize> {
         let max_size = self
             .mctp
             .max_message_size()
@@ -222,7 +230,7 @@ impl MctpTransport {
         Ok(max_size as usize - self.header_size())
     }
 
-    pub fn header_size(&self) -> usize {
+    fn header_size(&self) -> usize {
         1
     }
 }

--- a/runtime/userspace/apps/spdm/src/main.rs
+++ b/runtime/userspace/apps/spdm/src/main.rs
@@ -13,7 +13,7 @@ use spdm_lib::cert_mgr::DeviceCertsManager;
 use spdm_lib::codec::MessageBuf;
 use spdm_lib::context::SpdmContext;
 use spdm_lib::protocol::*;
-use spdm_lib::transport::MctpTransport;
+use spdm_lib::transport::{MctpTransport, SpdmTransport};
 
 // Caliptra supported SPDM versions
 const SPDM_VERSIONS: &[SpdmVersion] = &[

--- a/runtime/userspace/apps/spdm/src/riscv.rs
+++ b/runtime/userspace/apps/spdm/src/riscv.rs
@@ -9,7 +9,7 @@ use embedded_alloc::Heap;
 use libtock::console::Console;
 use libtock::runtime::{set_main, stack_size};
 
-const HEAP_SIZE: usize = 0x40;
+const HEAP_SIZE: usize = 0xC0;
 #[global_allocator]
 static HEAP: Heap = Heap::empty();
 


### PR DESCRIPTION
This PR 
1. Makes MCTP transport a trait implementation
2. Removes thiserror crate and uses enums to define errors in SPDM