### PR TITLE
Prevent image-loader app from exiting when test is successful

### DIFF
--- a/platforms/emulator/runtime/userspace/apps/image-loader/src/main.rs
+++ b/platforms/emulator/runtime/userspace/apps/image-loader/src/main.rs
@@ -85,9 +85,18 @@ pub(crate) async fn async_main() {
 
 #[embassy_executor::task]
 async fn image_loading_task() {
-    match image_loading().await {
-        Ok(_) => romtime::test_exit(0),
-        Err(_) => romtime::test_exit(1),
+    #[cfg(any(
+        feature = "test-pldm-streaming-boot",
+        feature = "test-flash-based-boot",
+        feature = "test-pldm-discovery",
+        feature = "test-pldm-fw-update",
+        feature = "test-pldm-fw-update-e2e",
+    ))]
+    {
+        match image_loading().await {
+            Ok(_) => romtime::test_exit(0),
+            Err(_) => romtime::test_exit(1),
+        }
     }
 }
 


### PR DESCRIPTION
    Image-loader app will execute test_exit(0) even there are no integ tests
    related to it are running, this causes other integ tests to exit
    immediately (e.g. SPDM_VALIDATOR).

    Add a condition to check if the integ test features flags are set before
    deciding if exit is needed.