### PR TITLE
Additional Integration test cases for flash and streaming boot

### DIFF
--- a/runtime/userspace/api/caliptra-api/src/image_loading/pldm_fdops.rs
+++ b/runtime/userspace/api/caliptra-api/src/image_loading/pldm_fdops.rs
@@ -130,7 +130,9 @@ impl FdOps for StreamingFdOps {
                     + core::mem::size_of::<FlashHeader>()) as u32
             {
                 // Image size is too small
-                return Err(FdOpsError::ComponentError);
+                // Return Ok with response code here to allow PLDM lib to pass it to UA
+                // Returning an Err is considered fatal and will cause PLDM lib to halt PLDM process
+                return Ok(ComponentResponseCode::CompPrerequisitesNotMet);
             }
         }
 

--- a/tests/integration/src/lib.rs
+++ b/tests/integration/src/lib.rs
@@ -1,14 +1,8 @@
 // Licensed under the Apache-2.0 license
-
+mod test_soc_boot;
 #[cfg(test)]
 mod test {
-    use chrono::{TimeZone, Utc};
     use mcu_builder::{CaliptraBuilder, SocImage, TARGET};
-    use pldm_fw_pkg::manifest::{
-        ComponentImageInformation, Descriptor, DescriptorType, FirmwareDeviceIdRecord,
-        PackageHeaderInformation, StringType,
-    };
-    use pldm_fw_pkg::FirmwareManifest;
     use std::process::ExitStatus;
     use std::sync::atomic::AtomicU32;
     use std::sync::Mutex;
@@ -36,9 +30,10 @@ mod test {
     }
 
     // only build the ROM once
-    static ROM: LazyLock<PathBuf> = LazyLock::new(compile_rom);
+    pub static ROM: LazyLock<PathBuf> = LazyLock::new(compile_rom);
 
-    static TEST_LOCK: LazyLock<Mutex<AtomicU32>> = LazyLock::new(|| Mutex::new(AtomicU32::new(0)));
+    pub static TEST_LOCK: LazyLock<Mutex<AtomicU32>> =
+        LazyLock::new(|| Mutex::new(AtomicU32::new(0)));
 
     fn compile_rom() -> PathBuf {
         mcu_builder::rom_build().expect("ROM build failed");
@@ -47,7 +42,7 @@ mod test {
         output
     }
 
-    fn compile_runtime(feature: &str, example_app: bool) -> PathBuf {
+    pub fn compile_runtime(feature: &str, example_app: bool) -> PathBuf {
         let output = target_binary(&format!("runtime-{}.bin", feature));
         let output_name = format!("{}", output.display());
         mcu_builder::runtime_build_with_apps(&[feature], Some(&output_name), example_app)
@@ -57,7 +52,7 @@ mod test {
     }
 
     #[allow(clippy::too_many_arguments)]
-    fn run_runtime(
+    pub fn run_runtime(
         feature: &str,
         rom_path: PathBuf,
         runtime_path: PathBuf,
@@ -244,188 +239,5 @@ mod test {
 
         // force the compiler to keep the lock
         lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    }
-
-    fn test_streaming_boot(is_flash: bool) {
-        const CALIPTRA_EXTERNAL_RAM_BASE: u64 = 0x8000_0000;
-        let lock = TEST_LOCK.lock().unwrap();
-        lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        let feature = if is_flash {
-            "test-flash-based-boot".to_string()
-        } else {
-            "test-pldm-streaming-boot".to_string()
-        };
-
-        // Define test firmware contents
-        let soc_image_fw_1 = [0x55u8; 512]; // Example firmware data for SOC image 1
-        let soc_image_fw_2 = [0xAAu8; 256]; // Example firmware data for SOC image 2
-
-        // Create temporary files for SOC images
-        let soc_image_path_1 =
-            tempfile::NamedTempFile::new().expect("Failed to create temp file 1");
-        let soc_image_path_2 =
-            tempfile::NamedTempFile::new().expect("Failed to create temp file 2");
-
-        // get pathbuf of the temp files
-        let soc_images_paths = vec![
-            soc_image_path_1.path().to_path_buf(),
-            soc_image_path_2.path().to_path_buf(),
-        ];
-
-        println!("SOC image paths: {:?}", soc_images_paths);
-
-        // Write firmware data to the temporary files
-        std::fs::write(soc_image_path_1.path(), soc_image_fw_1)
-            .expect("Failed to write temp file 1");
-        std::fs::write(soc_image_path_2.path(), soc_image_fw_2)
-            .expect("Failed to write temp file 2");
-
-        let caliptra_image = None;
-
-        // Create a flash image with only the SOC images
-        let flash_image_path = tempfile::NamedTempFile::new()
-            .expect("Failed to create flash image file")
-            .path()
-            .to_str()
-            .unwrap()
-            .to_string();
-        mcu_builder::flash_image::flash_image_create(
-            &caliptra_image,
-            &caliptra_image,
-            &caliptra_image,
-            &Some(
-                soc_images_paths
-                    .iter()
-                    .map(|p| p.to_string_lossy().to_string())
-                    .collect(),
-            ),
-            flash_image_path.as_str(),
-        )
-        .expect("Failed to create flash image");
-
-        println!("Flash image path: {:?}", flash_image_path);
-
-        // Read the contents of the flash image
-        let flash_image =
-            std::fs::read(flash_image_path.clone()).expect("Failed to read flash image");
-
-        // Define the PLDM Firmware package manifest
-        // This an arbitrary UUID, it should match the one in the device' fw_params definition.
-        pub const DEVICE_UUID: [u8; 16] = [
-            0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E,
-            0x0F, 0x10,
-        ];
-        let pldm_fw_pkg: FirmwareManifest = FirmwareManifest {
-            package_header_information: PackageHeaderInformation {
-                package_header_identifier: uuid::Uuid::parse_str(
-                    "7B291C996DB64208801B02026E463C78",
-                )
-                .unwrap(),
-                package_header_format_revision: 1,
-                package_release_date_time: Utc.with_ymd_and_hms(2025, 3, 1, 0, 0, 0).unwrap(),
-                package_version_string_type: StringType::Utf8,
-                package_version_string: Some("0.0.0-release".to_string()),
-                package_header_size: 0, // This will be computed during encoding
-            },
-
-            firmware_device_id_records: vec![FirmwareDeviceIdRecord {
-                firmware_device_package_data: None,
-                device_update_option_flags: 0x0,
-                component_image_set_version_string_type: StringType::Utf8,
-                component_image_set_version_string: Some("1.2.0".to_string()),
-                applicable_components: Some(vec![0]),
-                // The descriptor should match the device's ID record found in runtime/apps/pldm/pldm-lib/src/config.rs
-                initial_descriptor: Descriptor {
-                    descriptor_type: DescriptorType::Uuid,
-                    descriptor_data: DEVICE_UUID.to_vec(),
-                },
-                additional_descriptors: None,
-                reference_manifest_data: None,
-            }],
-            downstream_device_id_records: None,
-            component_image_information: vec![ComponentImageInformation {
-                // Classification and identifier should match the device's component image information found in runtime/apps/pldm/pldm-lib/src/config.rs
-                classification: 0x000A, // Firmware
-                identifier: 0xffff,
-
-                // Comparison stamp should be greater than the device's comparison stamp
-                comparison_stamp: Some(0xffffffff),
-                options: 0x0,
-                requested_activation_method: 0x0002,
-                version_string_type: StringType::Utf8,
-                version_string: Some("soc-fw-1.2".to_string()),
-
-                size: flash_image.len() as u32,
-                image_data: Some(flash_image),
-                ..Default::default()
-            }],
-        };
-
-        // Write the PLDM package to a temporary file
-        let pldm_fw_pkg_path = tempfile::NamedTempFile::new()
-            .expect("Failed to create temp file")
-            .path()
-            .to_str()
-            .unwrap()
-            .to_string();
-        pldm_fw_pkg
-            .generate_firmware_package(&pldm_fw_pkg_path)
-            .expect("Failed to generate firmware package");
-
-        println!("PLDM Firmware Package: {:?}", pldm_fw_pkg_path);
-
-        println!("Compiling test firmware {}", &feature);
-        let test_runtime = compile_runtime(&feature, false);
-        let i3c_port = "65534".to_string();
-
-        let streaming_boot = if is_flash {
-            None
-        } else {
-            Some(PathBuf::from(pldm_fw_pkg_path))
-        };
-        let flash_image = if is_flash {
-            Some(PathBuf::from(flash_image_path.clone()))
-        } else {
-            None
-        };
-
-        let soc_images = Some(vec![
-            SocImage {
-                path: soc_image_path_1.path().to_path_buf(),
-                load_addr: CALIPTRA_EXTERNAL_RAM_BASE,
-                image_id: 4096,
-            },
-            SocImage {
-                path: soc_image_path_2.path().to_path_buf(),
-                load_addr: CALIPTRA_EXTERNAL_RAM_BASE + soc_image_fw_1.len() as u64,
-                image_id: 4097,
-            },
-        ]);
-
-        let test = run_runtime(
-            &feature,
-            ROM.to_path_buf(),
-            test_runtime,
-            i3c_port,
-            true,
-            false,
-            soc_images,
-            streaming_boot,
-            flash_image,
-        );
-        assert_eq!(0, test.code().unwrap_or_default());
-
-        // force the compiler to keep the lock
-        lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    }
-
-    #[test]
-    fn test_pldm_streaming_boot() {
-        test_streaming_boot(false);
-    }
-
-    #[test]
-    fn test_flash_based_boot() {
-        test_streaming_boot(true);
     }
 }

--- a/tests/integration/src/test_soc_boot.rs
+++ b/tests/integration/src/test_soc_boot.rs
@@ -1,0 +1,395 @@
+// Licensed under the Apache-2.0 license
+
+#[cfg(test)]
+mod test {
+    use crate::test::{compile_runtime, run_runtime, ROM, TEST_LOCK};
+    use chrono::{TimeZone, Utc};
+    use mcu_builder::SocImage;
+    use pldm_fw_pkg::manifest::{
+        ComponentImageInformation, Descriptor, DescriptorType, FirmwareDeviceIdRecord,
+        PackageHeaderInformation, StringType,
+    };
+    use pldm_fw_pkg::FirmwareManifest;
+    use std::path::PathBuf;
+    use std::process::ExitStatus;
+    const CALIPTRA_EXTERNAL_RAM_BASE: u64 = 0x8000_0000;
+
+    #[derive(Clone)]
+    struct TestOptions {
+        feature: &'static str,
+        runtime: PathBuf,
+        i3c_port: u32,
+        soc_images: Vec<SocImage>,
+        flash_image_path: Option<PathBuf>,
+        pldm_fw_pkg_path: Option<PathBuf>,
+    }
+
+    macro_rules! run_test {
+        ($func:ident, $($args:expr),*) => {{
+            println!("Running {}...", stringify!($func));
+            $func($($args),*);
+        }};
+    }
+
+    // Helper function to create a flash image from the provided SOC images
+    fn create_flash_image(soc_images: Vec<Vec<u8>>) -> (Vec<PathBuf>, PathBuf) {
+        let soc_images_paths: Vec<PathBuf> = soc_images
+            .iter()
+            .map(|image| {
+                let soc_image_path = tempfile::NamedTempFile::new()
+                    .expect("Failed to create temp file")
+                    .path()
+                    .to_path_buf();
+                std::fs::write(soc_image_path.clone(), image).expect("Failed to write temp file");
+                soc_image_path
+            })
+            .collect();
+
+        let flash_image_path = tempfile::NamedTempFile::new()
+            .expect("Failed to create flash image file")
+            .path()
+            .to_path_buf();
+
+        mcu_builder::flash_image::flash_image_create(
+            &None,
+            &None,
+            &None,
+            &Some(
+                soc_images_paths
+                    .iter()
+                    .map(|p| p.to_string_lossy().to_string())
+                    .collect(),
+            ),
+            flash_image_path.to_str().unwrap(),
+        )
+        .expect("Failed to create flash image");
+        println!("Flash image path: {:?}", flash_image_path);
+        (soc_images_paths, flash_image_path)
+    }
+
+    // Helper function to create a PLDM firmware package from the provided manifest
+    fn create_pldm_fw_package(manifest: &FirmwareManifest) -> PathBuf {
+        let pldm_fw_pkg_path = tempfile::NamedTempFile::new()
+            .expect("Failed to create temp file")
+            .path()
+            .to_str()
+            .unwrap()
+            .to_string();
+        manifest
+            .generate_firmware_package(&pldm_fw_pkg_path)
+            .expect("Failed to generate firmware package");
+        println!("PLDM Firmware Package: {:?}", pldm_fw_pkg_path);
+        PathBuf::from(pldm_fw_pkg_path)
+    }
+
+    // Helper function to retrieve the streaming boot PLDM firmware manifest
+    // Identifier and classification should match the device's component image information
+    // found in platforms/emulator/runtime/userspace/apps/image-loader/src/config.rs
+    fn get_streaming_boot_pldm_fw_manifest(dev_uuid: &[u8], image: &[u8]) -> FirmwareManifest {
+        FirmwareManifest {
+            package_header_information: PackageHeaderInformation {
+                package_header_identifier: uuid::Uuid::parse_str(
+                    "7B291C996DB64208801B02026E463C78",
+                )
+                .unwrap(),
+                package_header_format_revision: 1,
+                package_release_date_time: Utc.with_ymd_and_hms(2025, 3, 1, 0, 0, 0).unwrap(),
+                package_version_string_type: StringType::Utf8,
+                package_version_string: Some("0.0.0-release".to_string()),
+                package_header_size: 0, // This will be computed during encoding
+            },
+
+            firmware_device_id_records: vec![FirmwareDeviceIdRecord {
+                firmware_device_package_data: None,
+                device_update_option_flags: 0x0,
+                component_image_set_version_string_type: StringType::Utf8,
+                component_image_set_version_string: Some("1.2.0".to_string()),
+                applicable_components: Some(vec![0]),
+                // The descriptor should match the device's ID record found in runtime/apps/pldm/pldm-lib/src/config.rs
+                initial_descriptor: Descriptor {
+                    descriptor_type: DescriptorType::Uuid,
+                    descriptor_data: dev_uuid.to_vec(),
+                },
+                additional_descriptors: None,
+                reference_manifest_data: None,
+            }],
+            downstream_device_id_records: None,
+            component_image_information: vec![ComponentImageInformation {
+                // Classification and identifier should match the device's component image information found in runtime/apps/pldm/pldm-lib/src/config.rs
+                classification: 0x000A, // Firmware
+                identifier: 0xffff,
+
+                // Comparison stamp should be greater than the device's comparison stamp
+                comparison_stamp: Some(0xffffffff),
+                options: 0x0,
+                requested_activation_method: 0x0002,
+                version_string_type: StringType::Utf8,
+                version_string: Some("soc-fw-1.2".to_string()),
+
+                size: image.len() as u32,
+                image_data: Some(image.to_vec()),
+                ..Default::default()
+            }],
+        }
+    }
+
+    // Helper function to retrieve the device UUID
+    fn get_device_uuid() -> [u8; 16] {
+        // This an arbitrary UUID that should match the one used in the device's ID record
+        // found in platforms/emulator/runtime/userspace/apps/image-loader/src/config.rs
+        [
+            0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E,
+            0x0F, 0x10,
+        ]
+    }
+
+    fn run_runtime_with_options(opts: TestOptions) -> ExitStatus {
+        run_runtime(
+            opts.feature,
+            ROM.to_path_buf(),
+            opts.runtime.clone(),
+            opts.i3c_port.to_string(),
+            true,
+            false,
+            Some(opts.soc_images.clone()),
+            opts.pldm_fw_pkg_path.clone(),
+            opts.flash_image_path.clone(),
+        )
+    }
+
+    /// Test case: happy path
+    fn test_successful_boot(opts: TestOptions) {
+        let test = run_runtime_with_options(opts);
+        assert_eq!(0, test.code().unwrap_or_default());
+    }
+
+    // Test case: Image ID in the SOC manifest is different from the one being authorized in the firmware
+    fn test_boot_invalid_image_id(opts: TestOptions) {
+        let mut new_options = opts.clone();
+        new_options.soc_images[0].image_id = 0xDEAD; // Change the image ID to an invalid one
+
+        let test = run_runtime_with_options(new_options);
+        assert_ne!(0, test.code().unwrap_or_default());
+    }
+
+    // Test case: The FW to be streamed has been altered making it unauthorized
+    fn test_boot_unathorized_image(opts: TestOptions) {
+        let mut new_options = opts.clone();
+
+        // Create another flash image with a different content
+        let soc_image_fw_1 = [0xDEu8; 512];
+        let soc_image_fw_2 = [0xADu8; 256];
+        let (_, flash_image_path) =
+            create_flash_image(vec![soc_image_fw_1.to_vec(), soc_image_fw_2.to_vec()]);
+
+        // Generate the corresponding PLDM package for the altered flash image
+        new_options.pldm_fw_pkg_path = if opts.pldm_fw_pkg_path.is_some() {
+            let device_uuid = get_device_uuid();
+            let flash_image =
+                std::fs::read(flash_image_path.clone()).expect("Failed to read flash image");
+            let pldm_manifest = get_streaming_boot_pldm_fw_manifest(&device_uuid, &flash_image);
+            Some(create_pldm_fw_package(&pldm_manifest))
+        } else {
+            None
+        };
+
+        new_options.flash_image_path = if opts.flash_image_path.is_some() {
+            Some(flash_image_path)
+        } else {
+            None
+        };
+
+        let test = run_runtime_with_options(new_options);
+        assert_ne!(0, test.code().unwrap_or_default());
+    }
+
+    // Test case: The load address in the SOC manifest is not a valid addressable AXI address
+    fn test_invalid_load_address(opts: TestOptions) {
+        let mut new_options = opts.clone();
+        // Change the load address in the SOC manifest to an invalid one
+        new_options.soc_images[0].load_addr = 0xffff; // Invalid load address
+
+        let test = run_runtime_with_options(new_options);
+        assert_ne!(0, test.code().unwrap_or_default());
+    }
+
+    // Test case: The PLDM descriptor in the PLDM package is different from the device's descriptor
+    fn test_incorrect_pldm_descriptor(opts: TestOptions) {
+        let mut new_options = opts.clone();
+
+        // Generate another PLDM Package with a different descriptor
+        let mut device_uuid = get_device_uuid();
+        device_uuid[0] = 0xFF; // Change the first byte of the UUID
+
+        let soc_image_fw_1 = [0x55u8; 512]; // Example firmware data for SOC image 1
+        let soc_image_fw_2 = [0xAAu8; 256]; // Example firmware data for SOC image 2
+        let (_, flash_image_path) =
+            create_flash_image(vec![soc_image_fw_1.to_vec(), soc_image_fw_2.to_vec()]);
+
+        new_options.pldm_fw_pkg_path = if opts.pldm_fw_pkg_path.is_some() {
+            let flash_image = std::fs::read(flash_image_path).expect("Failed to read flash image");
+            let pldm_manifest = get_streaming_boot_pldm_fw_manifest(&device_uuid, &flash_image);
+            Some(create_pldm_fw_package(&pldm_manifest))
+        } else {
+            None
+        };
+
+        let test = run_runtime_with_options(new_options);
+        assert_ne!(0, test.code().unwrap_or_default());
+    }
+
+    // Test case: The PLDM component ID in the PLDM package is not valid
+    fn test_incorrect_pldm_component_id(opts: TestOptions) {
+        let mut new_options = opts.clone();
+        let device_uuid = get_device_uuid();
+        let soc_image_fw_1 = [0x55u8; 512]; // Example firmware data for SOC image 1
+        let soc_image_fw_2 = [0xAAu8; 256]; // Example firmware data for SOC image 2
+        let (_, flash_image_path) =
+            create_flash_image(vec![soc_image_fw_1.to_vec(), soc_image_fw_2.to_vec()]);
+
+        new_options.pldm_fw_pkg_path = if opts.pldm_fw_pkg_path.is_some() {
+            let flash_image = std::fs::read(flash_image_path).expect("Failed to read flash image");
+            let mut pldm_manifest = get_streaming_boot_pldm_fw_manifest(&device_uuid, &flash_image);
+            pldm_manifest.component_image_information[0].identifier = 0xDEAD; // Change the component ID to an invalid one
+            Some(create_pldm_fw_package(&pldm_manifest))
+        } else {
+            None
+        };
+
+        let test = run_runtime_with_options(new_options);
+        assert_ne!(0, test.code().unwrap_or_default());
+    }
+
+    // Test case: Corrupted PLDM FW package
+    fn test_corrupted_pldm_fw_package(opts: TestOptions) {
+        let mut new_options = opts.clone();
+        let device_uuid = get_device_uuid();
+        let soc_image_fw_1 = [0x55u8; 512]; // Example firmware data for SOC image 1
+        let soc_image_fw_2 = [0xAAu8; 256]; // Example firmware data for SOC image 2
+        let (_, flash_image_path) =
+            create_flash_image(vec![soc_image_fw_1.to_vec(), soc_image_fw_2.to_vec()]);
+
+        new_options.pldm_fw_pkg_path = if opts.pldm_fw_pkg_path.is_some() {
+            let flash_image = std::fs::read(flash_image_path).expect("Failed to read flash image");
+            let mut pldm_manifest = get_streaming_boot_pldm_fw_manifest(&device_uuid, &flash_image);
+            pldm_manifest.component_image_information[0].image_data = Some(vec![0x00]); // Remove the image data to simulate corruption
+            Some(create_pldm_fw_package(&pldm_manifest))
+        } else {
+            None
+        };
+
+        let test = run_runtime_with_options(new_options);
+        assert_ne!(0, test.code().unwrap_or_default());
+    }
+
+    // Test case: PLDM FW package has lower version than device's active image version
+    fn test_lower_version_pldm_fw_package(opts: TestOptions) {
+        let mut new_options = opts.clone();
+        let device_uuid = get_device_uuid();
+        let soc_image_fw_1 = [0x55u8; 512]; // Example firmware data for SOC image 1
+        let soc_image_fw_2 = [0xAAu8; 256]; // Example firmware data for SOC image 2
+        let (_, flash_image_path) =
+            create_flash_image(vec![soc_image_fw_1.to_vec(), soc_image_fw_2.to_vec()]);
+
+        new_options.pldm_fw_pkg_path = if opts.pldm_fw_pkg_path.is_some() {
+            let flash_image = std::fs::read(flash_image_path).expect("Failed to read flash image");
+            let mut pldm_manifest = get_streaming_boot_pldm_fw_manifest(&device_uuid, &flash_image);
+            pldm_manifest.component_image_information[0].options = 0x0001; // Enable comparison stamp option
+            pldm_manifest.component_image_information[0].comparison_stamp = Some(0x00000000); // Set a lower version
+            Some(create_pldm_fw_package(&pldm_manifest))
+        } else {
+            None
+        };
+
+        let test = run_runtime_with_options(new_options);
+        assert_ne!(0, test.code().unwrap_or_default());
+    }
+
+    // Common test function for both flash-based and streaming boot
+    fn test_soc_boot(is_flash_based_boot: bool) {
+        let lock = TEST_LOCK.lock().unwrap();
+        let feature = if is_flash_based_boot {
+            "test-flash-based-boot"
+        } else {
+            "test-pldm-streaming-boot"
+        };
+        let i3c_port = 65500;
+
+        // Compile the runtime once with the appropriate feature
+        let test_runtime = compile_runtime(feature, false);
+
+        // Generate a valid flash image file
+        let soc_image_fw_1 = [0x55u8; 512]; // Example firmware data for SOC image 1
+        let soc_image_fw_2 = [0xAAu8; 256]; // Example firmware data for SOC image 2
+        let (soc_images_paths, flash_image_path) =
+            create_flash_image(vec![soc_image_fw_1.to_vec(), soc_image_fw_2.to_vec()]);
+
+        // Generate the corresponding PLDM package from the flash image
+        let pldm_fw_pkg_path = if is_flash_based_boot {
+            None
+        } else {
+            let device_uuid = get_device_uuid();
+            let flash_image =
+                std::fs::read(flash_image_path.clone()).expect("Failed to read flash image");
+            let pldm_manifest = get_streaming_boot_pldm_fw_manifest(&device_uuid, &flash_image);
+            Some(create_pldm_fw_package(&pldm_manifest))
+        };
+
+        // For non flash-based boot, the flash image path is not needeed to be passed to the emulator
+        // as the firmware will be streamed from the PLDM package
+        let flash_image_path = if is_flash_based_boot {
+            Some(flash_image_path)
+        } else {
+            None
+        };
+
+        // Create SOC image metadata that will be written to the SoC manifest
+        let soc_images = vec![
+            SocImage {
+                path: soc_images_paths[0].clone(),
+                load_addr: CALIPTRA_EXTERNAL_RAM_BASE,
+                image_id: 4096,
+            },
+            SocImage {
+                path: soc_images_paths[1].clone(),
+                load_addr: CALIPTRA_EXTERNAL_RAM_BASE + soc_image_fw_1.len() as u64,
+                image_id: 4097,
+            },
+        ];
+
+        // These are the options for a successful boot
+        // Each test case will override the options to simulate different scenarios
+        let pass_options = TestOptions {
+            feature,
+            runtime: test_runtime.clone(),
+            i3c_port,
+            soc_images: soc_images.clone(),
+            flash_image_path: flash_image_path.clone(),
+            pldm_fw_pkg_path: pldm_fw_pkg_path.clone(),
+        };
+
+        run_test!(test_successful_boot, pass_options.clone());
+        run_test!(test_boot_invalid_image_id, pass_options.clone());
+        run_test!(test_boot_unathorized_image, pass_options.clone());
+        run_test!(test_invalid_load_address, pass_options.clone());
+
+        if !is_flash_based_boot {
+            // Streaming boot-only tests
+            run_test!(test_incorrect_pldm_descriptor, pass_options.clone());
+            run_test!(test_incorrect_pldm_component_id, pass_options.clone());
+            run_test!(test_corrupted_pldm_fw_package, pass_options.clone());
+            run_test!(test_lower_version_pldm_fw_package, pass_options.clone());
+        }
+        lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    #[test]
+    fn test_flash_soc_boot() {
+        test_soc_boot(true);
+    }
+
+    #[test]
+    fn test_streaming_soc_boot() {
+        test_soc_boot(false);
+    }
+}


### PR DESCRIPTION
* Add test cases to simulate invalid configurations

- incorrect image id
- unauthorized fw data
- incorrect load address
- incorrect PLDM descriptor
- incorrect PLDM component ID
- corrupted PLDM package
- PLDM package has lower version than device's

* Have the PLDM UA emulator exit with an error code when it detects an
error. This allows the integ test to check for errors.

* Fixed an issue in the image loader PLDM handle_component ops where it
returns with an Err() instead with an Ok(response_code).

* Fixed the issue that sometimes emulator exits early
This was caused by the MCU emulator throwing a Memory Load Access Fault
when handling external interrupt. In some cases, the mode is still in
User mode before accessing the interrupt vector table causing an access fault.
To fix the issue, the mode is elevated to Machine mode first before accessing
the interrupt vector table when handling external interrupts.