### PR TITLE
Fix panic when 2 apps sends mailbox commands at the same time

### DIFF
--- a/runtime/kernel/capsules/src/mailbox.rs
+++ b/runtime/kernel/capsules/src/mailbox.rs
@@ -88,6 +88,9 @@ impl<'a, A: Alarm<'a>> Mailbox<'a, A> {
     fn enqueue_command(&self, command: u32, processid: ProcessId) -> Result<(), ErrorCode> {
         // Check if we're already executing a mailbox command.
         if self.current_app.is_some() {
+            let _ = self.apps.enter(processid, |_app, kernel_data| {
+                kernel_data.schedule_upcall(upcall::COMMAND_DONE, (0, 0, 0))
+            });
             return Err(ErrorCode::BUSY);
         }
         self.apps.enter(processid, |_app, kernel_data| {


### PR DESCRIPTION
- If mailbox driver is busy, still set the future to make sure, it gets cleaned up after syscall. Syscall will wait for future even if the command fails.
- Add retries to mailbox calls when it's busy