### PR TITLE
registers: Support generating emulator peripherals for array registers

### DIFF
--- a/registers/generated-emulator/src/i3c.rs
+++ b/registers/generated-emulator/src/i3c.rs
@@ -9,14 +9,14 @@ pub trait I3cPeripheral {
     fn poll(&mut self) {}
     fn warm_reset(&mut self) {}
     fn update_reset(&mut self) {}
-    fn read_dat(&mut self) -> caliptra_emu_types::RvData {
+    fn read_dat(&mut self, _index: usize) -> caliptra_emu_types::RvData {
         0
     }
-    fn write_dat(&mut self, _val: caliptra_emu_types::RvData) {}
-    fn read_dct(&mut self) -> caliptra_emu_types::RvData {
+    fn write_dat(&mut self, _val: caliptra_emu_types::RvData, _index: usize) {}
+    fn read_dct(&mut self, _index: usize) -> caliptra_emu_types::RvData {
         0
     }
-    fn write_dct(&mut self, _val: caliptra_emu_types::RvData) {}
+    fn write_dct(&mut self, _val: caliptra_emu_types::RvData, _index: usize) {}
     fn read_i3c_base_hci_version(&mut self) -> caliptra_emu_types::RvData {
         0
     }
@@ -1170,8 +1170,8 @@ impl emulator_bus::Bus for I3cBus {
             return Err(emulator_bus::BusError::LoadAddrMisaligned);
         }
         match addr {
-            0x400..0x800 => Ok(self.periph.read_dat()),
-            0x800..0x1000 => Ok(self.periph.read_dct()),
+            0x400..0x800 => Ok(self.periph.read_dat((addr as usize - 0x400) / 4)),
+            0x800..0x1000 => Ok(self.periph.read_dct((addr as usize - 0x800) / 4)),
             0..4 => Ok(self.periph.read_i3c_base_hci_version()),
             4..8 => Ok(caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_base_hc_control().reg.get(),
@@ -1564,11 +1564,11 @@ impl emulator_bus::Bus for I3cBus {
         }
         match addr {
             0x400..0x800 => {
-                self.periph.write_dat(val);
+                self.periph.write_dat(val, (addr as usize - 0x400) / 4);
                 Ok(())
             }
             0x800..0x1000 => {
-                self.periph.write_dct(val);
+                self.periph.write_dct(val, (addr as usize - 0x800) / 4);
                 Ok(())
             }
             4..8 => {

--- a/registers/generated-emulator/src/mci.rs
+++ b/registers/generated-emulator/src/mci.rs
@@ -9,10 +9,10 @@ pub trait MciPeripheral {
     fn poll(&mut self) {}
     fn warm_reset(&mut self) {}
     fn update_reset(&mut self) {}
-    fn read_mcu_sram(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mcu_sram(&mut self, _index: usize) -> caliptra_emu_types::RvData {
         0
     }
-    fn write_mcu_sram(&mut self, _val: caliptra_emu_types::RvData) {}
+    fn write_mcu_sram(&mut self, _val: caliptra_emu_types::RvData, _index: usize) {}
     fn read_mci_reg_hw_capabilities(&mut self) -> caliptra_emu_types::RvData {
         0
     }
@@ -41,10 +41,10 @@ pub trait MciPeripheral {
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
-    fn read_mci_reg_fw_rev_id(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_fw_rev_id(&mut self, _index: usize) -> caliptra_emu_types::RvData {
         0
     }
-    fn write_mci_reg_fw_rev_id(&mut self, _val: caliptra_emu_types::RvData) {}
+    fn write_mci_reg_fw_rev_id(&mut self, _val: caliptra_emu_types::RvData, _index: usize) {}
     fn read_mci_reg_hw_config0(
         &mut self,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::mci::bits::HwConfig0::Register>
@@ -161,10 +161,15 @@ pub trait MciPeripheral {
         0
     }
     fn write_mci_reg_fw_error_enc(&mut self, _val: caliptra_emu_types::RvData) {}
-    fn read_mci_reg_fw_extended_error_info(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_fw_extended_error_info(&mut self, _index: usize) -> caliptra_emu_types::RvData {
         0
     }
-    fn write_mci_reg_fw_extended_error_info(&mut self, _val: caliptra_emu_types::RvData) {}
+    fn write_mci_reg_fw_extended_error_info(
+        &mut self,
+        _val: caliptra_emu_types::RvData,
+        _index: usize,
+    ) {
+    }
     fn read_mci_reg_internal_hw_error_fatal_mask(
         &mut self,
     ) -> emulator_bus::ReadWriteRegister<
@@ -266,10 +271,18 @@ pub trait MciPeripheral {
         >,
     ) {
     }
-    fn read_mci_reg_wdt_timer1_timeout_period(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_wdt_timer1_timeout_period(
+        &mut self,
+        _index: usize,
+    ) -> caliptra_emu_types::RvData {
         0
     }
-    fn write_mci_reg_wdt_timer1_timeout_period(&mut self, _val: caliptra_emu_types::RvData) {}
+    fn write_mci_reg_wdt_timer1_timeout_period(
+        &mut self,
+        _val: caliptra_emu_types::RvData,
+        _index: usize,
+    ) {
+    }
     fn read_mci_reg_wdt_timer2_en(
         &mut self,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::mci::bits::WdtTimer2En::Register>
@@ -298,20 +311,28 @@ pub trait MciPeripheral {
         >,
     ) {
     }
-    fn read_mci_reg_wdt_timer2_timeout_period(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_wdt_timer2_timeout_period(
+        &mut self,
+        _index: usize,
+    ) -> caliptra_emu_types::RvData {
         0
     }
-    fn write_mci_reg_wdt_timer2_timeout_period(&mut self, _val: caliptra_emu_types::RvData) {}
+    fn write_mci_reg_wdt_timer2_timeout_period(
+        &mut self,
+        _val: caliptra_emu_types::RvData,
+        _index: usize,
+    ) {
+    }
     fn read_mci_reg_wdt_status(
         &mut self,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::mci::bits::WdtStatus::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
-    fn read_mci_reg_wdt_cfg(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_wdt_cfg(&mut self, _index: usize) -> caliptra_emu_types::RvData {
         0
     }
-    fn write_mci_reg_wdt_cfg(&mut self, _val: caliptra_emu_types::RvData) {}
+    fn write_mci_reg_wdt_cfg(&mut self, _val: caliptra_emu_types::RvData, _index: usize) {}
     fn read_mci_reg_mcu_timer_config(&mut self) -> caliptra_emu_types::RvData {
         0
     }
@@ -390,12 +411,18 @@ pub trait MciPeripheral {
         0
     }
     fn write_mci_reg_mcu_reset_vector(&mut self, _val: caliptra_emu_types::RvData) {}
-    fn read_mci_reg_mbox0_valid_axi_user(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_mbox0_valid_axi_user(&mut self, _index: usize) -> caliptra_emu_types::RvData {
         0
     }
-    fn write_mci_reg_mbox0_valid_axi_user(&mut self, _val: caliptra_emu_types::RvData) {}
+    fn write_mci_reg_mbox0_valid_axi_user(
+        &mut self,
+        _val: caliptra_emu_types::RvData,
+        _index: usize,
+    ) {
+    }
     fn read_mci_reg_mbox0_axi_user_lock(
         &mut self,
+        _index: usize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::MboxxAxiUserLock::Register,
@@ -408,14 +435,21 @@ pub trait MciPeripheral {
             u32,
             registers_generated::mci::bits::MboxxAxiUserLock::Register,
         >,
+        _index: usize,
     ) {
     }
-    fn read_mci_reg_mbox1_valid_axi_user(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_mbox1_valid_axi_user(&mut self, _index: usize) -> caliptra_emu_types::RvData {
         0
     }
-    fn write_mci_reg_mbox1_valid_axi_user(&mut self, _val: caliptra_emu_types::RvData) {}
+    fn write_mci_reg_mbox1_valid_axi_user(
+        &mut self,
+        _val: caliptra_emu_types::RvData,
+        _index: usize,
+    ) {
+    }
     fn read_mci_reg_mbox1_axi_user_lock(
         &mut self,
+        _index: usize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::MboxxAxiUserLock::Register,
@@ -428,31 +462,42 @@ pub trait MciPeripheral {
             u32,
             registers_generated::mci::bits::MboxxAxiUserLock::Register,
         >,
+        _index: usize,
     ) {
     }
-    fn read_mci_reg_soc_dft_en(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_soc_dft_en(&mut self, _index: usize) -> caliptra_emu_types::RvData {
         0
     }
-    fn write_mci_reg_soc_dft_en(&mut self, _val: caliptra_emu_types::RvData) {}
-    fn read_mci_reg_soc_hw_debug_en(&mut self) -> caliptra_emu_types::RvData {
+    fn write_mci_reg_soc_dft_en(&mut self, _val: caliptra_emu_types::RvData, _index: usize) {}
+    fn read_mci_reg_soc_hw_debug_en(&mut self, _index: usize) -> caliptra_emu_types::RvData {
         0
     }
-    fn write_mci_reg_soc_hw_debug_en(&mut self, _val: caliptra_emu_types::RvData) {}
-    fn read_mci_reg_soc_prod_debug_state(&mut self) -> caliptra_emu_types::RvData {
+    fn write_mci_reg_soc_hw_debug_en(&mut self, _val: caliptra_emu_types::RvData, _index: usize) {}
+    fn read_mci_reg_soc_prod_debug_state(&mut self, _index: usize) -> caliptra_emu_types::RvData {
         0
     }
-    fn write_mci_reg_soc_prod_debug_state(&mut self, _val: caliptra_emu_types::RvData) {}
+    fn write_mci_reg_soc_prod_debug_state(
+        &mut self,
+        _val: caliptra_emu_types::RvData,
+        _index: usize,
+    ) {
+    }
     fn read_mci_reg_fc_fips_zerozation(&mut self) -> caliptra_emu_types::RvData {
         0
     }
     fn write_mci_reg_fc_fips_zerozation(&mut self, _val: caliptra_emu_types::RvData) {}
-    fn read_mci_reg_generic_input_wires(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_generic_input_wires(&mut self, _index: usize) -> caliptra_emu_types::RvData {
         0
     }
-    fn read_mci_reg_generic_output_wires(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_generic_output_wires(&mut self, _index: usize) -> caliptra_emu_types::RvData {
         0
     }
-    fn write_mci_reg_generic_output_wires(&mut self, _val: caliptra_emu_types::RvData) {}
+    fn write_mci_reg_generic_output_wires(
+        &mut self,
+        _val: caliptra_emu_types::RvData,
+        _index: usize,
+    ) {
+    }
     fn read_mci_reg_debug_in(
         &mut self,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::mci::bits::Debug::Register> {
@@ -507,10 +552,18 @@ pub trait MciPeripheral {
         >,
     ) {
     }
-    fn read_mci_reg_prod_debug_unlock_pk_hash_reg(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_prod_debug_unlock_pk_hash_reg(
+        &mut self,
+        _index: usize,
+    ) -> caliptra_emu_types::RvData {
         0
     }
-    fn write_mci_reg_prod_debug_unlock_pk_hash_reg(&mut self, _val: caliptra_emu_types::RvData) {}
+    fn write_mci_reg_prod_debug_unlock_pk_hash_reg(
+        &mut self,
+        _val: caliptra_emu_types::RvData,
+        _index: usize,
+    ) {
+    }
     fn read_mci_reg_intr_block_rf_global_intr_en_r(
         &mut self,
     ) -> emulator_bus::ReadWriteRegister<
@@ -2250,10 +2303,10 @@ pub trait MciPeripheral {
         0
     }
     fn write_mcu_trace_buffer_csr_read_ptr(&mut self, _val: caliptra_emu_types::RvData) {}
-    fn read_mcu_mbox0_csr_mbox_sram(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mcu_mbox0_csr_mbox_sram(&mut self, _index: usize) -> caliptra_emu_types::RvData {
         0
     }
-    fn write_mcu_mbox0_csr_mbox_sram(&mut self, _val: caliptra_emu_types::RvData) {}
+    fn write_mcu_mbox0_csr_mbox_sram(&mut self, _val: caliptra_emu_types::RvData, _index: usize) {}
     fn read_mcu_mbox0_csr_mbox_lock(
         &mut self,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::mbox::bits::MboxLock::Register>
@@ -2341,10 +2394,10 @@ pub trait MciPeripheral {
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
-    fn read_mcu_mbox1_csr_mbox_sram(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mcu_mbox1_csr_mbox_sram(&mut self, _index: usize) -> caliptra_emu_types::RvData {
         0
     }
-    fn write_mcu_mbox1_csr_mbox_sram(&mut self, _val: caliptra_emu_types::RvData) {}
+    fn write_mcu_mbox1_csr_mbox_sram(&mut self, _val: caliptra_emu_types::RvData, _index: usize) {}
     fn read_mcu_mbox1_csr_mbox_lock(
         &mut self,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::mbox::bits::MboxLock::Register>
@@ -2446,7 +2499,7 @@ impl emulator_bus::Bus for MciBus {
             return Err(emulator_bus::BusError::LoadAddrMisaligned);
         }
         match addr {
-            0xc0_0000..0xe0_0000 => Ok(self.periph.read_mcu_sram()),
+            0xc0_0000..0xe0_0000 => Ok(self.periph.read_mcu_sram((addr as usize - 0xc0_0000) / 4)),
             0..4 => Ok(self.periph.read_mci_reg_hw_capabilities()),
             4..8 => Ok(self.periph.read_mci_reg_fw_capabilities()),
             8..0xc => Ok(caliptra_emu_types::RvData::from(
@@ -2455,7 +2508,9 @@ impl emulator_bus::Bus for MciBus {
             0xc..0x10 => Ok(caliptra_emu_types::RvData::from(
                 self.periph.read_mci_reg_hw_rev_id().reg.get(),
             )),
-            0x10..0x18 => Ok(self.periph.read_mci_reg_fw_rev_id()),
+            0x10..0x18 => Ok(self
+                .periph
+                .read_mci_reg_fw_rev_id((addr as usize - 0x10) / 4)),
             0x18..0x1c => Ok(caliptra_emu_types::RvData::from(
                 self.periph.read_mci_reg_hw_config0().reg.get(),
             )),
@@ -2491,7 +2546,9 @@ impl emulator_bus::Bus for MciBus {
             0x54..0x58 => Ok(self.periph.read_mci_reg_fw_error_non_fatal()),
             0x58..0x5c => Ok(self.periph.read_mci_reg_hw_error_enc()),
             0x5c..0x60 => Ok(self.periph.read_mci_reg_fw_error_enc()),
-            0x60..0x80 => Ok(self.periph.read_mci_reg_fw_extended_error_info()),
+            0x60..0x80 => Ok(self
+                .periph
+                .read_mci_reg_fw_extended_error_info((addr as usize - 0x60) / 4)),
             0x80..0x84 => Ok(caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_internal_hw_error_fatal_mask()
@@ -2524,18 +2581,22 @@ impl emulator_bus::Bus for MciBus {
             0xa4..0xa8 => Ok(caliptra_emu_types::RvData::from(
                 self.periph.read_mci_reg_wdt_timer1_ctrl().reg.get(),
             )),
-            0xa8..0xb0 => Ok(self.periph.read_mci_reg_wdt_timer1_timeout_period()),
+            0xa8..0xb0 => Ok(self
+                .periph
+                .read_mci_reg_wdt_timer1_timeout_period((addr as usize - 0xa8) / 4)),
             0xb0..0xb4 => Ok(caliptra_emu_types::RvData::from(
                 self.periph.read_mci_reg_wdt_timer2_en().reg.get(),
             )),
             0xb4..0xb8 => Ok(caliptra_emu_types::RvData::from(
                 self.periph.read_mci_reg_wdt_timer2_ctrl().reg.get(),
             )),
-            0xb8..0xc0 => Ok(self.periph.read_mci_reg_wdt_timer2_timeout_period()),
+            0xb8..0xc0 => Ok(self
+                .periph
+                .read_mci_reg_wdt_timer2_timeout_period((addr as usize - 0xb8) / 4)),
             0xc0..0xc4 => Ok(caliptra_emu_types::RvData::from(
                 self.periph.read_mci_reg_wdt_status().reg.get(),
             )),
-            0xd0..0xd8 => Ok(self.periph.read_mci_reg_wdt_cfg()),
+            0xd0..0xd8 => Ok(self.periph.read_mci_reg_wdt_cfg((addr as usize - 0xd0) / 4)),
             0xe0..0xe4 => Ok(self.periph.read_mci_reg_mcu_timer_config()),
             0xe4..0xe8 => Ok(self.periph.read_mci_reg_mcu_rv_mtime_l()),
             0xe8..0xec => Ok(self.periph.read_mci_reg_mcu_rv_mtime_h()),
@@ -2558,20 +2619,40 @@ impl emulator_bus::Bus for MciBus {
             )),
             0x110..0x114 => Ok(self.periph.read_mci_reg_mcu_nmi_vector()),
             0x114..0x118 => Ok(self.periph.read_mci_reg_mcu_reset_vector()),
-            0x180..0x194 => Ok(self.periph.read_mci_reg_mbox0_valid_axi_user()),
+            0x180..0x194 => Ok(self
+                .periph
+                .read_mci_reg_mbox0_valid_axi_user((addr as usize - 0x180) / 4)),
             0x1a0..0x1b4 => Ok(caliptra_emu_types::RvData::from(
-                self.periph.read_mci_reg_mbox0_axi_user_lock().reg.get(),
+                self.periph
+                    .read_mci_reg_mbox0_axi_user_lock((addr as usize - 0x1a0) / 4)
+                    .reg
+                    .get(),
             )),
-            0x1c0..0x1d4 => Ok(self.periph.read_mci_reg_mbox1_valid_axi_user()),
+            0x1c0..0x1d4 => Ok(self
+                .periph
+                .read_mci_reg_mbox1_valid_axi_user((addr as usize - 0x1c0) / 4)),
             0x1e0..0x1f4 => Ok(caliptra_emu_types::RvData::from(
-                self.periph.read_mci_reg_mbox1_axi_user_lock().reg.get(),
+                self.periph
+                    .read_mci_reg_mbox1_axi_user_lock((addr as usize - 0x1e0) / 4)
+                    .reg
+                    .get(),
             )),
-            0x300..0x308 => Ok(self.periph.read_mci_reg_soc_dft_en()),
-            0x308..0x310 => Ok(self.periph.read_mci_reg_soc_hw_debug_en()),
-            0x310..0x318 => Ok(self.periph.read_mci_reg_soc_prod_debug_state()),
+            0x300..0x308 => Ok(self
+                .periph
+                .read_mci_reg_soc_dft_en((addr as usize - 0x300) / 4)),
+            0x308..0x310 => Ok(self
+                .periph
+                .read_mci_reg_soc_hw_debug_en((addr as usize - 0x308) / 4)),
+            0x310..0x318 => Ok(self
+                .periph
+                .read_mci_reg_soc_prod_debug_state((addr as usize - 0x310) / 4)),
             0x318..0x31c => Ok(self.periph.read_mci_reg_fc_fips_zerozation()),
-            0x400..0x408 => Ok(self.periph.read_mci_reg_generic_input_wires()),
-            0x408..0x410 => Ok(self.periph.read_mci_reg_generic_output_wires()),
+            0x400..0x408 => Ok(self
+                .periph
+                .read_mci_reg_generic_input_wires((addr as usize - 0x400) / 4)),
+            0x408..0x410 => Ok(self
+                .periph
+                .read_mci_reg_generic_output_wires((addr as usize - 0x408) / 4)),
             0x410..0x414 => Ok(caliptra_emu_types::RvData::from(
                 self.periph.read_mci_reg_debug_in().reg.get(),
             )),
@@ -2587,7 +2668,9 @@ impl emulator_bus::Bus for MciBus {
             0x444..0x448 => Ok(caliptra_emu_types::RvData::from(
                 self.periph.read_mci_reg_ss_config_done().reg.get(),
             )),
-            0x480..0x600 => Ok(self.periph.read_mci_reg_prod_debug_unlock_pk_hash_reg()),
+            0x480..0x600 => Ok(self
+                .periph
+                .read_mci_reg_prod_debug_unlock_pk_hash_reg((addr as usize - 0x480) / 4)),
             0x1000..0x1004 => Ok(caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_global_intr_en_r()
@@ -3441,7 +3524,9 @@ impl emulator_bus::Bus for MciBus {
             0x1_0008..0x1_000c => Ok(self.periph.read_mcu_trace_buffer_csr_data()),
             0x1_000c..0x1_0010 => Ok(self.periph.read_mcu_trace_buffer_csr_write_ptr()),
             0x1_0010..0x1_0014 => Ok(self.periph.read_mcu_trace_buffer_csr_read_ptr()),
-            0x40_0000..0x60_0000 => Ok(self.periph.read_mcu_mbox0_csr_mbox_sram()),
+            0x40_0000..0x60_0000 => Ok(self
+                .periph
+                .read_mcu_mbox0_csr_mbox_sram((addr as usize - 0x40_0000) / 4)),
             0x60_0000..0x60_0004 => Ok(caliptra_emu_types::RvData::from(
                 self.periph.read_mcu_mbox0_csr_mbox_lock().reg.get(),
             )),
@@ -3470,7 +3555,9 @@ impl emulator_bus::Bus for MciBus {
             0x60_0024..0x60_0028 => Ok(caliptra_emu_types::RvData::from(
                 self.periph.read_mcu_mbox0_csr_mbox_hw_status().reg.get(),
             )),
-            0x80_0000..0xa0_0000 => Ok(self.periph.read_mcu_mbox1_csr_mbox_sram()),
+            0x80_0000..0xa0_0000 => Ok(self
+                .periph
+                .read_mcu_mbox1_csr_mbox_sram((addr as usize - 0x80_0000) / 4)),
             0xa0_0000..0xa0_0004 => Ok(caliptra_emu_types::RvData::from(
                 self.periph.read_mcu_mbox1_csr_mbox_lock().reg.get(),
             )),
@@ -3513,7 +3600,8 @@ impl emulator_bus::Bus for MciBus {
         }
         match addr {
             0xc0_0000..0xe0_0000 => {
-                self.periph.write_mcu_sram(val);
+                self.periph
+                    .write_mcu_sram(val, (addr as usize - 0xc0_0000) / 4);
                 Ok(())
             }
             0..4 => {
@@ -3530,7 +3618,8 @@ impl emulator_bus::Bus for MciBus {
                 Ok(())
             }
             0x10..0x18 => {
-                self.periph.write_mci_reg_fw_rev_id(val);
+                self.periph
+                    .write_mci_reg_fw_rev_id(val, (addr as usize - 0x10) / 4);
                 Ok(())
             }
             0x20..0x24 => {
@@ -3574,7 +3663,8 @@ impl emulator_bus::Bus for MciBus {
                 Ok(())
             }
             0x60..0x80 => {
-                self.periph.write_mci_reg_fw_extended_error_info(val);
+                self.periph
+                    .write_mci_reg_fw_extended_error_info(val, (addr as usize - 0x60) / 4);
                 Ok(())
             }
             0x80..0x84 => {
@@ -3621,7 +3711,8 @@ impl emulator_bus::Bus for MciBus {
                 Ok(())
             }
             0xa8..0xb0 => {
-                self.periph.write_mci_reg_wdt_timer1_timeout_period(val);
+                self.periph
+                    .write_mci_reg_wdt_timer1_timeout_period(val, (addr as usize - 0xa8) / 4);
                 Ok(())
             }
             0xb0..0xb4 => {
@@ -3635,11 +3726,13 @@ impl emulator_bus::Bus for MciBus {
                 Ok(())
             }
             0xb8..0xc0 => {
-                self.periph.write_mci_reg_wdt_timer2_timeout_period(val);
+                self.periph
+                    .write_mci_reg_wdt_timer2_timeout_period(val, (addr as usize - 0xb8) / 4);
                 Ok(())
             }
             0xd0..0xd8 => {
-                self.periph.write_mci_reg_wdt_cfg(val);
+                self.periph
+                    .write_mci_reg_wdt_cfg(val, (addr as usize - 0xd0) / 4);
                 Ok(())
             }
             0xe0..0xe4 => {
@@ -3692,33 +3785,42 @@ impl emulator_bus::Bus for MciBus {
                 Ok(())
             }
             0x180..0x194 => {
-                self.periph.write_mci_reg_mbox0_valid_axi_user(val);
+                self.periph
+                    .write_mci_reg_mbox0_valid_axi_user(val, (addr as usize - 0x180) / 4);
                 Ok(())
             }
             0x1a0..0x1b4 => {
-                self.periph
-                    .write_mci_reg_mbox0_axi_user_lock(emulator_bus::ReadWriteRegister::new(val));
+                self.periph.write_mci_reg_mbox0_axi_user_lock(
+                    emulator_bus::ReadWriteRegister::new(val),
+                    (addr as usize - 0x1a0) / 4,
+                );
                 Ok(())
             }
             0x1c0..0x1d4 => {
-                self.periph.write_mci_reg_mbox1_valid_axi_user(val);
+                self.periph
+                    .write_mci_reg_mbox1_valid_axi_user(val, (addr as usize - 0x1c0) / 4);
                 Ok(())
             }
             0x1e0..0x1f4 => {
-                self.periph
-                    .write_mci_reg_mbox1_axi_user_lock(emulator_bus::ReadWriteRegister::new(val));
+                self.periph.write_mci_reg_mbox1_axi_user_lock(
+                    emulator_bus::ReadWriteRegister::new(val),
+                    (addr as usize - 0x1e0) / 4,
+                );
                 Ok(())
             }
             0x300..0x308 => {
-                self.periph.write_mci_reg_soc_dft_en(val);
+                self.periph
+                    .write_mci_reg_soc_dft_en(val, (addr as usize - 0x300) / 4);
                 Ok(())
             }
             0x308..0x310 => {
-                self.periph.write_mci_reg_soc_hw_debug_en(val);
+                self.periph
+                    .write_mci_reg_soc_hw_debug_en(val, (addr as usize - 0x308) / 4);
                 Ok(())
             }
             0x310..0x318 => {
-                self.periph.write_mci_reg_soc_prod_debug_state(val);
+                self.periph
+                    .write_mci_reg_soc_prod_debug_state(val, (addr as usize - 0x310) / 4);
                 Ok(())
             }
             0x318..0x31c => {
@@ -3726,7 +3828,8 @@ impl emulator_bus::Bus for MciBus {
                 Ok(())
             }
             0x408..0x410 => {
-                self.periph.write_mci_reg_generic_output_wires(val);
+                self.periph
+                    .write_mci_reg_generic_output_wires(val, (addr as usize - 0x408) / 4);
                 Ok(())
             }
             0x410..0x414 => {
@@ -3750,7 +3853,8 @@ impl emulator_bus::Bus for MciBus {
                 Ok(())
             }
             0x480..0x600 => {
-                self.periph.write_mci_reg_prod_debug_unlock_pk_hash_reg(val);
+                self.periph
+                    .write_mci_reg_prod_debug_unlock_pk_hash_reg(val, (addr as usize - 0x480) / 4);
                 Ok(())
             }
             0x1000..0x1004 => {
@@ -4260,7 +4364,8 @@ impl emulator_bus::Bus for MciBus {
                 Ok(())
             }
             0x40_0000..0x60_0000 => {
-                self.periph.write_mcu_mbox0_csr_mbox_sram(val);
+                self.periph
+                    .write_mcu_mbox0_csr_mbox_sram(val, (addr as usize - 0x40_0000) / 4);
                 Ok(())
             }
             0x60_0008..0x60_000c => {
@@ -4298,7 +4403,8 @@ impl emulator_bus::Bus for MciBus {
                 Ok(())
             }
             0x80_0000..0xa0_0000 => {
-                self.periph.write_mcu_mbox1_csr_mbox_sram(val);
+                self.periph
+                    .write_mcu_mbox1_csr_mbox_sram(val, (addr as usize - 0x80_0000) / 4);
                 Ok(())
             }
             0xa0_0008..0xa0_000c => {

--- a/registers/generated-emulator/src/sha512_acc.rs
+++ b/registers/generated-emulator/src/sha512_acc.rs
@@ -74,7 +74,7 @@ pub trait Sha512AccPeripheral {
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
-    fn read_digest(&mut self) -> caliptra_emu_types::RvData {
+    fn read_digest(&mut self, _index: usize) -> caliptra_emu_types::RvData {
         0
     }
     fn read_control(
@@ -315,7 +315,7 @@ impl emulator_bus::Bus for Sha512AccBus {
             0x1c..0x20 => Ok(caliptra_emu_types::RvData::from(
                 self.periph.read_status().reg.get(),
             )),
-            0x20..0x60 => Ok(self.periph.read_digest()),
+            0x20..0x60 => Ok(self.periph.read_digest((addr as usize - 0x20) / 4)),
             0x60..0x64 => Ok(caliptra_emu_types::RvData::from(
                 self.periph.read_control().reg.get(),
             )),

--- a/registers/generated-emulator/src/soc.rs
+++ b/registers/generated-emulator/src/soc.rs
@@ -57,10 +57,15 @@ pub trait SocPeripheral {
         0
     }
     fn write_cptra_fw_error_enc(&mut self, _val: caliptra_emu_types::RvData) {}
-    fn read_cptra_fw_extended_error_info(&mut self) -> caliptra_emu_types::RvData {
+    fn read_cptra_fw_extended_error_info(&mut self, _index: usize) -> caliptra_emu_types::RvData {
         0
     }
-    fn write_cptra_fw_extended_error_info(&mut self, _val: caliptra_emu_types::RvData) {}
+    fn write_cptra_fw_extended_error_info(
+        &mut self,
+        _val: caliptra_emu_types::RvData,
+        _index: usize,
+    ) {
+    }
     fn read_cptra_boot_status(&mut self) -> caliptra_emu_types::RvData {
         0
     }
@@ -97,12 +102,14 @@ pub trait SocPeripheral {
     > {
         emulator_bus::ReadWriteRegister::new(0)
     }
-    fn read_cptra_mbox_valid_axi_user(&mut self) -> caliptra_emu_types::RvData {
+    fn read_cptra_mbox_valid_axi_user(&mut self, _index: usize) -> caliptra_emu_types::RvData {
         0
     }
-    fn write_cptra_mbox_valid_axi_user(&mut self, _val: caliptra_emu_types::RvData) {}
+    fn write_cptra_mbox_valid_axi_user(&mut self, _val: caliptra_emu_types::RvData, _index: usize) {
+    }
     fn read_cptra_mbox_axi_user_lock(
         &mut self,
+        _index: usize,
     ) -> emulator_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraXxxxAxiUserLock::Register,
@@ -115,6 +122,7 @@ pub trait SocPeripheral {
             u32,
             registers_generated::soc::bits::CptraXxxxAxiUserLock::Register,
         >,
+        _index: usize,
     ) {
     }
     fn read_cptra_trng_valid_axi_user(&mut self) -> caliptra_emu_types::RvData {
@@ -137,10 +145,10 @@ pub trait SocPeripheral {
         >,
     ) {
     }
-    fn read_cptra_trng_data(&mut self) -> caliptra_emu_types::RvData {
+    fn read_cptra_trng_data(&mut self, _index: usize) -> caliptra_emu_types::RvData {
         0
     }
-    fn write_cptra_trng_data(&mut self, _val: caliptra_emu_types::RvData) {}
+    fn write_cptra_trng_data(&mut self, _val: caliptra_emu_types::RvData, _index: usize) {}
     fn read_cptra_trng_ctrl(
         &mut self,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::soc::bits::CptraTrngCtrl::Register>
@@ -227,23 +235,28 @@ pub trait SocPeripheral {
         >,
     ) {
     }
-    fn read_cptra_generic_input_wires(&mut self) -> caliptra_emu_types::RvData {
+    fn read_cptra_generic_input_wires(&mut self, _index: usize) -> caliptra_emu_types::RvData {
         0
     }
-    fn read_cptra_generic_output_wires(&mut self) -> caliptra_emu_types::RvData {
+    fn read_cptra_generic_output_wires(&mut self, _index: usize) -> caliptra_emu_types::RvData {
         0
     }
-    fn write_cptra_generic_output_wires(&mut self, _val: caliptra_emu_types::RvData) {}
+    fn write_cptra_generic_output_wires(
+        &mut self,
+        _val: caliptra_emu_types::RvData,
+        _index: usize,
+    ) {
+    }
     fn read_cptra_hw_rev_id(
         &mut self,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::soc::bits::CptraHwRevId::Register>
     {
         emulator_bus::ReadWriteRegister::new(0)
     }
-    fn read_cptra_fw_rev_id(&mut self) -> caliptra_emu_types::RvData {
+    fn read_cptra_fw_rev_id(&mut self, _index: usize) -> caliptra_emu_types::RvData {
         0
     }
-    fn write_cptra_fw_rev_id(&mut self, _val: caliptra_emu_types::RvData) {}
+    fn write_cptra_fw_rev_id(&mut self, _val: caliptra_emu_types::RvData, _index: usize) {}
     fn read_cptra_hw_config(
         &mut self,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::soc::bits::CptraHwConfig::Register>
@@ -282,10 +295,18 @@ pub trait SocPeripheral {
         >,
     ) {
     }
-    fn read_cptra_wdt_timer1_timeout_period(&mut self) -> caliptra_emu_types::RvData {
+    fn read_cptra_wdt_timer1_timeout_period(
+        &mut self,
+        _index: usize,
+    ) -> caliptra_emu_types::RvData {
         0
     }
-    fn write_cptra_wdt_timer1_timeout_period(&mut self, _val: caliptra_emu_types::RvData) {}
+    fn write_cptra_wdt_timer1_timeout_period(
+        &mut self,
+        _val: caliptra_emu_types::RvData,
+        _index: usize,
+    ) {
+    }
     fn read_cptra_wdt_timer2_en(
         &mut self,
     ) -> emulator_bus::ReadWriteRegister<
@@ -318,10 +339,18 @@ pub trait SocPeripheral {
         >,
     ) {
     }
-    fn read_cptra_wdt_timer2_timeout_period(&mut self) -> caliptra_emu_types::RvData {
+    fn read_cptra_wdt_timer2_timeout_period(
+        &mut self,
+        _index: usize,
+    ) -> caliptra_emu_types::RvData {
         0
     }
-    fn write_cptra_wdt_timer2_timeout_period(&mut self, _val: caliptra_emu_types::RvData) {}
+    fn write_cptra_wdt_timer2_timeout_period(
+        &mut self,
+        _val: caliptra_emu_types::RvData,
+        _index: usize,
+    ) {
+    }
     fn read_cptra_wdt_status(
         &mut self,
     ) -> emulator_bus::ReadWriteRegister<
@@ -358,10 +387,10 @@ pub trait SocPeripheral {
         >,
     ) {
     }
-    fn read_cptra_wdt_cfg(&mut self) -> caliptra_emu_types::RvData {
+    fn read_cptra_wdt_cfg(&mut self, _index: usize) -> caliptra_emu_types::RvData {
         0
     }
-    fn write_cptra_wdt_cfg(&mut self, _val: caliptra_emu_types::RvData) {}
+    fn write_cptra_wdt_cfg(&mut self, _val: caliptra_emu_types::RvData, _index: usize) {}
     fn read_cptra_i_trng_entropy_config_0(
         &mut self,
     ) -> emulator_bus::ReadWriteRegister<
@@ -394,10 +423,10 @@ pub trait SocPeripheral {
         >,
     ) {
     }
-    fn read_cptra_rsvd_reg(&mut self) -> caliptra_emu_types::RvData {
+    fn read_cptra_rsvd_reg(&mut self, _index: usize) -> caliptra_emu_types::RvData {
         0
     }
-    fn write_cptra_rsvd_reg(&mut self, _val: caliptra_emu_types::RvData) {}
+    fn write_cptra_rsvd_reg(&mut self, _val: caliptra_emu_types::RvData, _index: usize) {}
     fn read_cptra_hw_capabilities(&mut self) -> caliptra_emu_types::RvData {
         0
     }
@@ -420,10 +449,10 @@ pub trait SocPeripheral {
         >,
     ) {
     }
-    fn read_cptra_owner_pk_hash(&mut self) -> caliptra_emu_types::RvData {
+    fn read_cptra_owner_pk_hash(&mut self, _index: usize) -> caliptra_emu_types::RvData {
         0
     }
-    fn write_cptra_owner_pk_hash(&mut self, _val: caliptra_emu_types::RvData) {}
+    fn write_cptra_owner_pk_hash(&mut self, _val: caliptra_emu_types::RvData, _index: usize) {}
     fn read_cptra_owner_pk_hash_lock(
         &mut self,
     ) -> emulator_bus::ReadWriteRegister<u32, registers_generated::soc::bits::CptraXxxxxxxk::Register>
@@ -438,12 +467,12 @@ pub trait SocPeripheral {
         >,
     ) {
     }
-    fn write_fuse_uds_seed(&mut self, _val: caliptra_emu_types::RvData) {}
-    fn write_fuse_field_entropy(&mut self, _val: caliptra_emu_types::RvData) {}
-    fn read_fuse_vendor_pk_hash(&mut self) -> caliptra_emu_types::RvData {
+    fn write_fuse_uds_seed(&mut self, _val: caliptra_emu_types::RvData, _index: usize) {}
+    fn write_fuse_field_entropy(&mut self, _val: caliptra_emu_types::RvData, _index: usize) {}
+    fn read_fuse_vendor_pk_hash(&mut self, _index: usize) -> caliptra_emu_types::RvData {
         0
     }
-    fn write_fuse_vendor_pk_hash(&mut self, _val: caliptra_emu_types::RvData) {}
+    fn write_fuse_vendor_pk_hash(&mut self, _val: caliptra_emu_types::RvData, _index: usize) {}
     fn read_fuse_ecc_revocation(
         &mut self,
     ) -> emulator_bus::ReadWriteRegister<
@@ -464,10 +493,10 @@ pub trait SocPeripheral {
         0
     }
     fn write_fuse_fmc_key_manifest_svn(&mut self, _val: caliptra_emu_types::RvData) {}
-    fn read_fuse_runtime_svn(&mut self) -> caliptra_emu_types::RvData {
+    fn read_fuse_runtime_svn(&mut self, _index: usize) -> caliptra_emu_types::RvData {
         0
     }
-    fn write_fuse_runtime_svn(&mut self, _val: caliptra_emu_types::RvData) {}
+    fn write_fuse_runtime_svn(&mut self, _val: caliptra_emu_types::RvData, _index: usize) {}
     fn read_fuse_anti_rollback_disable(
         &mut self,
     ) -> emulator_bus::ReadWriteRegister<
@@ -484,14 +513,14 @@ pub trait SocPeripheral {
         >,
     ) {
     }
-    fn read_fuse_idevid_cert_attr(&mut self) -> caliptra_emu_types::RvData {
+    fn read_fuse_idevid_cert_attr(&mut self, _index: usize) -> caliptra_emu_types::RvData {
         0
     }
-    fn write_fuse_idevid_cert_attr(&mut self, _val: caliptra_emu_types::RvData) {}
-    fn read_fuse_idevid_manuf_hsm_id(&mut self) -> caliptra_emu_types::RvData {
+    fn write_fuse_idevid_cert_attr(&mut self, _val: caliptra_emu_types::RvData, _index: usize) {}
+    fn read_fuse_idevid_manuf_hsm_id(&mut self, _index: usize) -> caliptra_emu_types::RvData {
         0
     }
-    fn write_fuse_idevid_manuf_hsm_id(&mut self, _val: caliptra_emu_types::RvData) {}
+    fn write_fuse_idevid_manuf_hsm_id(&mut self, _val: caliptra_emu_types::RvData, _index: usize) {}
     fn read_fuse_lms_revocation(&mut self) -> caliptra_emu_types::RvData {
         0
     }
@@ -528,10 +557,15 @@ pub trait SocPeripheral {
         >,
     ) {
     }
-    fn read_fuse_manuf_dbg_unlock_token(&mut self) -> caliptra_emu_types::RvData {
+    fn read_fuse_manuf_dbg_unlock_token(&mut self, _index: usize) -> caliptra_emu_types::RvData {
         0
     }
-    fn write_fuse_manuf_dbg_unlock_token(&mut self, _val: caliptra_emu_types::RvData) {}
+    fn write_fuse_manuf_dbg_unlock_token(
+        &mut self,
+        _val: caliptra_emu_types::RvData,
+        _index: usize,
+    ) {
+    }
     fn read_fuse_pqc_key_type(
         &mut self,
     ) -> emulator_bus::ReadWriteRegister<
@@ -548,10 +582,10 @@ pub trait SocPeripheral {
         >,
     ) {
     }
-    fn read_fuse_soc_manifest_svn(&mut self) -> caliptra_emu_types::RvData {
+    fn read_fuse_soc_manifest_svn(&mut self, _index: usize) -> caliptra_emu_types::RvData {
         0
     }
-    fn write_fuse_soc_manifest_svn(&mut self, _val: caliptra_emu_types::RvData) {}
+    fn write_fuse_soc_manifest_svn(&mut self, _val: caliptra_emu_types::RvData, _index: usize) {}
     fn read_fuse_soc_manifest_max_svn(
         &mut self,
     ) -> emulator_bus::ReadWriteRegister<
@@ -636,10 +670,10 @@ pub trait SocPeripheral {
         0
     }
     fn write_ss_caliptra_dma_axi_user(&mut self, _val: caliptra_emu_types::RvData) {}
-    fn read_ss_strap_generic(&mut self) -> caliptra_emu_types::RvData {
+    fn read_ss_strap_generic(&mut self, _index: usize) -> caliptra_emu_types::RvData {
         0
     }
-    fn write_ss_strap_generic(&mut self, _val: caliptra_emu_types::RvData) {}
+    fn write_ss_strap_generic(&mut self, _val: caliptra_emu_types::RvData, _index: usize) {}
     fn read_ss_dbg_manuf_service_reg_req(
         &mut self,
     ) -> emulator_bus::ReadWriteRegister<
@@ -672,14 +706,14 @@ pub trait SocPeripheral {
         >,
     ) {
     }
-    fn read_ss_soc_dbg_unlock_level(&mut self) -> caliptra_emu_types::RvData {
+    fn read_ss_soc_dbg_unlock_level(&mut self, _index: usize) -> caliptra_emu_types::RvData {
         0
     }
-    fn write_ss_soc_dbg_unlock_level(&mut self, _val: caliptra_emu_types::RvData) {}
-    fn read_ss_generic_fw_exec_ctrl(&mut self) -> caliptra_emu_types::RvData {
+    fn write_ss_soc_dbg_unlock_level(&mut self, _val: caliptra_emu_types::RvData, _index: usize) {}
+    fn read_ss_generic_fw_exec_ctrl(&mut self, _index: usize) -> caliptra_emu_types::RvData {
         0
     }
-    fn write_ss_generic_fw_exec_ctrl(&mut self, _val: caliptra_emu_types::RvData) {}
+    fn write_ss_generic_fw_exec_ctrl(&mut self, _val: caliptra_emu_types::RvData, _index: usize) {}
 }
 pub struct SocBus {
     pub periph: Box<dyn SocPeripheral>,
@@ -704,7 +738,9 @@ impl emulator_bus::Bus for SocBus {
             0xc..0x10 => Ok(self.periph.read_cptra_fw_error_non_fatal()),
             0x10..0x14 => Ok(self.periph.read_cptra_hw_error_enc()),
             0x14..0x18 => Ok(self.periph.read_cptra_fw_error_enc()),
-            0x18..0x38 => Ok(self.periph.read_cptra_fw_extended_error_info()),
+            0x18..0x38 => Ok(self
+                .periph
+                .read_cptra_fw_extended_error_info((addr as usize - 0x18) / 4)),
             0x38..0x3c => Ok(self.periph.read_cptra_boot_status()),
             0x3c..0x40 => Ok(caliptra_emu_types::RvData::from(
                 self.periph.read_cptra_flow_status().reg.get(),
@@ -715,15 +751,20 @@ impl emulator_bus::Bus for SocBus {
             0x44..0x48 => Ok(caliptra_emu_types::RvData::from(
                 self.periph.read_cptra_security_state().reg.get(),
             )),
-            0x48..0x5c => Ok(self.periph.read_cptra_mbox_valid_axi_user()),
+            0x48..0x5c => Ok(self
+                .periph
+                .read_cptra_mbox_valid_axi_user((addr as usize - 0x48) / 4)),
             0x5c..0x70 => Ok(caliptra_emu_types::RvData::from(
-                self.periph.read_cptra_mbox_axi_user_lock().reg.get(),
+                self.periph
+                    .read_cptra_mbox_axi_user_lock((addr as usize - 0x5c) / 4)
+                    .reg
+                    .get(),
             )),
             0x70..0x74 => Ok(self.periph.read_cptra_trng_valid_axi_user()),
             0x74..0x78 => Ok(caliptra_emu_types::RvData::from(
                 self.periph.read_cptra_trng_axi_user_lock().reg.get(),
             )),
-            0x78..0xa8 => Ok(self.periph.read_cptra_trng_data()),
+            0x78..0xa8 => Ok(self.periph.read_cptra_trng_data((addr as usize - 0x78) / 4)),
             0xa8..0xac => Ok(caliptra_emu_types::RvData::from(
                 self.periph.read_cptra_trng_ctrl().reg.get(),
             )),
@@ -741,12 +782,16 @@ impl emulator_bus::Bus for SocBus {
             0xc0..0xc4 => Ok(caliptra_emu_types::RvData::from(
                 self.periph.read_cptra_clk_gating_en().reg.get(),
             )),
-            0xc4..0xcc => Ok(self.periph.read_cptra_generic_input_wires()),
-            0xcc..0xd4 => Ok(self.periph.read_cptra_generic_output_wires()),
+            0xc4..0xcc => Ok(self
+                .periph
+                .read_cptra_generic_input_wires((addr as usize - 0xc4) / 4)),
+            0xcc..0xd4 => Ok(self
+                .periph
+                .read_cptra_generic_output_wires((addr as usize - 0xcc) / 4)),
             0xd4..0xd8 => Ok(caliptra_emu_types::RvData::from(
                 self.periph.read_cptra_hw_rev_id().reg.get(),
             )),
-            0xd8..0xe0 => Ok(self.periph.read_cptra_fw_rev_id()),
+            0xd8..0xe0 => Ok(self.periph.read_cptra_fw_rev_id((addr as usize - 0xd8) / 4)),
             0xe0..0xe4 => Ok(caliptra_emu_types::RvData::from(
                 self.periph.read_cptra_hw_config().reg.get(),
             )),
@@ -756,14 +801,18 @@ impl emulator_bus::Bus for SocBus {
             0xe8..0xec => Ok(caliptra_emu_types::RvData::from(
                 self.periph.read_cptra_wdt_timer1_ctrl().reg.get(),
             )),
-            0xec..0xf4 => Ok(self.periph.read_cptra_wdt_timer1_timeout_period()),
+            0xec..0xf4 => Ok(self
+                .periph
+                .read_cptra_wdt_timer1_timeout_period((addr as usize - 0xec) / 4)),
             0xf4..0xf8 => Ok(caliptra_emu_types::RvData::from(
                 self.periph.read_cptra_wdt_timer2_en().reg.get(),
             )),
             0xf8..0xfc => Ok(caliptra_emu_types::RvData::from(
                 self.periph.read_cptra_wdt_timer2_ctrl().reg.get(),
             )),
-            0xfc..0x104 => Ok(self.periph.read_cptra_wdt_timer2_timeout_period()),
+            0xfc..0x104 => Ok(self
+                .periph
+                .read_cptra_wdt_timer2_timeout_period((addr as usize - 0xfc) / 4)),
             0x104..0x108 => Ok(caliptra_emu_types::RvData::from(
                 self.periph.read_cptra_wdt_status().reg.get(),
             )),
@@ -771,34 +820,44 @@ impl emulator_bus::Bus for SocBus {
             0x10c..0x110 => Ok(caliptra_emu_types::RvData::from(
                 self.periph.read_cptra_fuse_axi_user_lock().reg.get(),
             )),
-            0x110..0x118 => Ok(self.periph.read_cptra_wdt_cfg()),
+            0x110..0x118 => Ok(self.periph.read_cptra_wdt_cfg((addr as usize - 0x110) / 4)),
             0x118..0x11c => Ok(caliptra_emu_types::RvData::from(
                 self.periph.read_cptra_i_trng_entropy_config_0().reg.get(),
             )),
             0x11c..0x120 => Ok(caliptra_emu_types::RvData::from(
                 self.periph.read_cptra_i_trng_entropy_config_1().reg.get(),
             )),
-            0x120..0x128 => Ok(self.periph.read_cptra_rsvd_reg()),
+            0x120..0x128 => Ok(self.periph.read_cptra_rsvd_reg((addr as usize - 0x120) / 4)),
             0x128..0x12c => Ok(self.periph.read_cptra_hw_capabilities()),
             0x12c..0x130 => Ok(self.periph.read_cptra_fw_capabilities()),
             0x130..0x134 => Ok(caliptra_emu_types::RvData::from(
                 self.periph.read_cptra_cap_lock().reg.get(),
             )),
-            0x140..0x170 => Ok(self.periph.read_cptra_owner_pk_hash()),
+            0x140..0x170 => Ok(self
+                .periph
+                .read_cptra_owner_pk_hash((addr as usize - 0x140) / 4)),
             0x170..0x174 => Ok(caliptra_emu_types::RvData::from(
                 self.periph.read_cptra_owner_pk_hash_lock().reg.get(),
             )),
-            0x260..0x290 => Ok(self.periph.read_fuse_vendor_pk_hash()),
+            0x260..0x290 => Ok(self
+                .periph
+                .read_fuse_vendor_pk_hash((addr as usize - 0x260) / 4)),
             0x290..0x294 => Ok(caliptra_emu_types::RvData::from(
                 self.periph.read_fuse_ecc_revocation().reg.get(),
             )),
             0x2b4..0x2b8 => Ok(self.periph.read_fuse_fmc_key_manifest_svn()),
-            0x2b8..0x2c8 => Ok(self.periph.read_fuse_runtime_svn()),
+            0x2b8..0x2c8 => Ok(self
+                .periph
+                .read_fuse_runtime_svn((addr as usize - 0x2b8) / 4)),
             0x2c8..0x2cc => Ok(caliptra_emu_types::RvData::from(
                 self.periph.read_fuse_anti_rollback_disable().reg.get(),
             )),
-            0x2cc..0x32c => Ok(self.periph.read_fuse_idevid_cert_attr()),
-            0x32c..0x33c => Ok(self.periph.read_fuse_idevid_manuf_hsm_id()),
+            0x2cc..0x32c => Ok(self
+                .periph
+                .read_fuse_idevid_cert_attr((addr as usize - 0x2cc) / 4)),
+            0x32c..0x33c => Ok(self
+                .periph
+                .read_fuse_idevid_manuf_hsm_id((addr as usize - 0x32c) / 4)),
             0x340..0x344 => Ok(self.periph.read_fuse_lms_revocation()),
             0x344..0x348 => Ok(caliptra_emu_types::RvData::from(
                 self.periph.read_fuse_mldsa_revocation().reg.get(),
@@ -806,11 +865,15 @@ impl emulator_bus::Bus for SocBus {
             0x348..0x34c => Ok(caliptra_emu_types::RvData::from(
                 self.periph.read_fuse_soc_stepping_id().reg.get(),
             )),
-            0x34c..0x38c => Ok(self.periph.read_fuse_manuf_dbg_unlock_token()),
+            0x34c..0x38c => Ok(self
+                .periph
+                .read_fuse_manuf_dbg_unlock_token((addr as usize - 0x34c) / 4)),
             0x38c..0x390 => Ok(caliptra_emu_types::RvData::from(
                 self.periph.read_fuse_pqc_key_type().reg.get(),
             )),
-            0x390..0x3a0 => Ok(self.periph.read_fuse_soc_manifest_svn()),
+            0x390..0x3a0 => Ok(self
+                .periph
+                .read_fuse_soc_manifest_svn((addr as usize - 0x390) / 4)),
             0x3a0..0x3a4 => Ok(caliptra_emu_types::RvData::from(
                 self.periph.read_fuse_soc_manifest_max_svn().reg.get(),
             )),
@@ -834,15 +897,21 @@ impl emulator_bus::Bus for SocBus {
                 self.periph.read_ss_debug_intent().reg.get(),
             )),
             0x534..0x538 => Ok(self.periph.read_ss_caliptra_dma_axi_user()),
-            0x5a0..0x5b0 => Ok(self.periph.read_ss_strap_generic()),
+            0x5a0..0x5b0 => Ok(self
+                .periph
+                .read_ss_strap_generic((addr as usize - 0x5a0) / 4)),
             0x5c0..0x5c4 => Ok(caliptra_emu_types::RvData::from(
                 self.periph.read_ss_dbg_manuf_service_reg_req().reg.get(),
             )),
             0x5c4..0x5c8 => Ok(caliptra_emu_types::RvData::from(
                 self.periph.read_ss_dbg_manuf_service_reg_rsp().reg.get(),
             )),
-            0x5c8..0x5d0 => Ok(self.periph.read_ss_soc_dbg_unlock_level()),
-            0x5d0..0x5e0 => Ok(self.periph.read_ss_generic_fw_exec_ctrl()),
+            0x5c8..0x5d0 => Ok(self
+                .periph
+                .read_ss_soc_dbg_unlock_level((addr as usize - 0x5c8) / 4)),
+            0x5d0..0x5e0 => Ok(self
+                .periph
+                .read_ss_generic_fw_exec_ctrl((addr as usize - 0x5d0) / 4)),
             _ => Err(emulator_bus::BusError::LoadAccessFault),
         }
     }
@@ -883,7 +952,8 @@ impl emulator_bus::Bus for SocBus {
                 Ok(())
             }
             0x18..0x38 => {
-                self.periph.write_cptra_fw_extended_error_info(val);
+                self.periph
+                    .write_cptra_fw_extended_error_info(val, (addr as usize - 0x18) / 4);
                 Ok(())
             }
             0x38..0x3c => {
@@ -896,12 +966,15 @@ impl emulator_bus::Bus for SocBus {
                 Ok(())
             }
             0x48..0x5c => {
-                self.periph.write_cptra_mbox_valid_axi_user(val);
+                self.periph
+                    .write_cptra_mbox_valid_axi_user(val, (addr as usize - 0x48) / 4);
                 Ok(())
             }
             0x5c..0x70 => {
-                self.periph
-                    .write_cptra_mbox_axi_user_lock(emulator_bus::ReadWriteRegister::new(val));
+                self.periph.write_cptra_mbox_axi_user_lock(
+                    emulator_bus::ReadWriteRegister::new(val),
+                    (addr as usize - 0x5c) / 4,
+                );
                 Ok(())
             }
             0x70..0x74 => {
@@ -914,7 +987,8 @@ impl emulator_bus::Bus for SocBus {
                 Ok(())
             }
             0x78..0xa8 => {
-                self.periph.write_cptra_trng_data(val);
+                self.periph
+                    .write_cptra_trng_data(val, (addr as usize - 0x78) / 4);
                 Ok(())
             }
             0xa8..0xac => {
@@ -951,11 +1025,13 @@ impl emulator_bus::Bus for SocBus {
                 Ok(())
             }
             0xcc..0xd4 => {
-                self.periph.write_cptra_generic_output_wires(val);
+                self.periph
+                    .write_cptra_generic_output_wires(val, (addr as usize - 0xcc) / 4);
                 Ok(())
             }
             0xd8..0xe0 => {
-                self.periph.write_cptra_fw_rev_id(val);
+                self.periph
+                    .write_cptra_fw_rev_id(val, (addr as usize - 0xd8) / 4);
                 Ok(())
             }
             0xe4..0xe8 => {
@@ -969,7 +1045,8 @@ impl emulator_bus::Bus for SocBus {
                 Ok(())
             }
             0xec..0xf4 => {
-                self.periph.write_cptra_wdt_timer1_timeout_period(val);
+                self.periph
+                    .write_cptra_wdt_timer1_timeout_period(val, (addr as usize - 0xec) / 4);
                 Ok(())
             }
             0xf4..0xf8 => {
@@ -983,7 +1060,8 @@ impl emulator_bus::Bus for SocBus {
                 Ok(())
             }
             0xfc..0x104 => {
-                self.periph.write_cptra_wdt_timer2_timeout_period(val);
+                self.periph
+                    .write_cptra_wdt_timer2_timeout_period(val, (addr as usize - 0xfc) / 4);
                 Ok(())
             }
             0x104..0x108 => {
@@ -1001,7 +1079,8 @@ impl emulator_bus::Bus for SocBus {
                 Ok(())
             }
             0x110..0x118 => {
-                self.periph.write_cptra_wdt_cfg(val);
+                self.periph
+                    .write_cptra_wdt_cfg(val, (addr as usize - 0x110) / 4);
                 Ok(())
             }
             0x118..0x11c => {
@@ -1015,7 +1094,8 @@ impl emulator_bus::Bus for SocBus {
                 Ok(())
             }
             0x120..0x128 => {
-                self.periph.write_cptra_rsvd_reg(val);
+                self.periph
+                    .write_cptra_rsvd_reg(val, (addr as usize - 0x120) / 4);
                 Ok(())
             }
             0x128..0x12c => {
@@ -1032,7 +1112,8 @@ impl emulator_bus::Bus for SocBus {
                 Ok(())
             }
             0x140..0x170 => {
-                self.periph.write_cptra_owner_pk_hash(val);
+                self.periph
+                    .write_cptra_owner_pk_hash(val, (addr as usize - 0x140) / 4);
                 Ok(())
             }
             0x170..0x174 => {
@@ -1041,15 +1122,18 @@ impl emulator_bus::Bus for SocBus {
                 Ok(())
             }
             0x200..0x240 => {
-                self.periph.write_fuse_uds_seed(val);
+                self.periph
+                    .write_fuse_uds_seed(val, (addr as usize - 0x200) / 4);
                 Ok(())
             }
             0x240..0x260 => {
-                self.periph.write_fuse_field_entropy(val);
+                self.periph
+                    .write_fuse_field_entropy(val, (addr as usize - 0x240) / 4);
                 Ok(())
             }
             0x260..0x290 => {
-                self.periph.write_fuse_vendor_pk_hash(val);
+                self.periph
+                    .write_fuse_vendor_pk_hash(val, (addr as usize - 0x260) / 4);
                 Ok(())
             }
             0x290..0x294 => {
@@ -1062,7 +1146,8 @@ impl emulator_bus::Bus for SocBus {
                 Ok(())
             }
             0x2b8..0x2c8 => {
-                self.periph.write_fuse_runtime_svn(val);
+                self.periph
+                    .write_fuse_runtime_svn(val, (addr as usize - 0x2b8) / 4);
                 Ok(())
             }
             0x2c8..0x2cc => {
@@ -1071,11 +1156,13 @@ impl emulator_bus::Bus for SocBus {
                 Ok(())
             }
             0x2cc..0x32c => {
-                self.periph.write_fuse_idevid_cert_attr(val);
+                self.periph
+                    .write_fuse_idevid_cert_attr(val, (addr as usize - 0x2cc) / 4);
                 Ok(())
             }
             0x32c..0x33c => {
-                self.periph.write_fuse_idevid_manuf_hsm_id(val);
+                self.periph
+                    .write_fuse_idevid_manuf_hsm_id(val, (addr as usize - 0x32c) / 4);
                 Ok(())
             }
             0x340..0x344 => {
@@ -1093,7 +1180,8 @@ impl emulator_bus::Bus for SocBus {
                 Ok(())
             }
             0x34c..0x38c => {
-                self.periph.write_fuse_manuf_dbg_unlock_token(val);
+                self.periph
+                    .write_fuse_manuf_dbg_unlock_token(val, (addr as usize - 0x34c) / 4);
                 Ok(())
             }
             0x38c..0x390 => {
@@ -1102,7 +1190,8 @@ impl emulator_bus::Bus for SocBus {
                 Ok(())
             }
             0x390..0x3a0 => {
-                self.periph.write_fuse_soc_manifest_svn(val);
+                self.periph
+                    .write_fuse_soc_manifest_svn(val, (addr as usize - 0x390) / 4);
                 Ok(())
             }
             0x3a0..0x3a4 => {
@@ -1165,7 +1254,8 @@ impl emulator_bus::Bus for SocBus {
                 Ok(())
             }
             0x5a0..0x5b0 => {
-                self.periph.write_ss_strap_generic(val);
+                self.periph
+                    .write_ss_strap_generic(val, (addr as usize - 0x5a0) / 4);
                 Ok(())
             }
             0x5c0..0x5c4 => {
@@ -1179,11 +1269,13 @@ impl emulator_bus::Bus for SocBus {
                 Ok(())
             }
             0x5c8..0x5d0 => {
-                self.periph.write_ss_soc_dbg_unlock_level(val);
+                self.periph
+                    .write_ss_soc_dbg_unlock_level(val, (addr as usize - 0x5c8) / 4);
                 Ok(())
             }
             0x5d0..0x5e0 => {
-                self.periph.write_ss_generic_fw_exec_ctrl(val);
+                self.periph
+                    .write_ss_generic_fw_exec_ctrl(val, (addr as usize - 0x5d0) / 4);
                 Ok(())
             }
             _ => Err(emulator_bus::BusError::StoreAccessFault),

--- a/registers/generator/src/schema.rs
+++ b/registers/generator/src/schema.rs
@@ -128,6 +128,10 @@ pub struct Register {
 }
 
 impl Register {
+    pub fn is_array(&self) -> bool {
+        self.array_dimensions.iter().product::<u64>() > 1
+    }
+
     pub fn can_read(&self) -> bool {
         self.ty.fields.is_empty() || self.ty.fields.iter().any(|f| f.ty.can_read())
     }


### PR DESCRIPTION
This computes the index into the (flattened) register array and passes it as an argument to the bus peripheral trait.

This doesn't affect any current peripherals but will be necessary for the watchdog timers in the MCI peripheral.