### PR TITLE
Fix PLDM encoding of GetFirmwareParameters command

### DIFF
--- a/xtask/src/pldm_fw_pkg.rs
+++ b/xtask/src/pldm_fw_pkg.rs
@@ -21,19 +21,13 @@ pub(crate) fn create(manifest_path: &str, output_path: &str) -> Result<()> {
     Ok(())
 }
 
-pub(crate) fn decode(manifest_path: &str, output_path: &str) -> Result<()> {
-    let firmware_manifest = FirmwareManifest::parse_manifest_file(&manifest_path.to_string());
+pub(crate) fn decode(pldm_package_path: &str, output_path: &str) -> Result<()> {
+    let firmware_manifest = FirmwareManifest::decode_firmware_package(
+        &pldm_package_path.to_string(),
+        Some(&output_path.to_string()),
+    );
     if firmware_manifest.is_err() {
-        bail!("Failed to parse manifest file: {}", manifest_path);
-    }
-    let result = firmware_manifest
-        .unwrap()
-        .generate_firmware_package(&output_path.to_string());
-    if result.is_err() {
-        bail!(
-            "Failed to generate firmware package: {}",
-            result.unwrap_err()
-        );
+        bail!("Failed to parse PLDM package file: {}", pldm_package_path);
     }
     println!("Decoded FirmwarePackage to binary file: {}", output_path);
     Ok(())


### PR DESCRIPTION
GetFirmwareParameter command's active version string has a dynamic length and should be encoded/decoded manually. Currently, it's inside the fixed parameters struct which is encoded/decoded by zerocopy. As a fix, this string is moved out of the fixed parameters struct.

Also fixed the xtask command to decode the PLDM FW package, it was calling the incorrect function to decode the FW package. It was calling to decode a manifest file, but the function is for decoding the firmware package