### PR TITLE
hw/model: Add in basic emulated and FPGA hardware models

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -727,6 +727,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "caliptra-test-harness-types"
+version = "0.1.0"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2c0c6a81f569e72622001fab3732a21a1be4c78a#2c0c6a81f569e72622001fab3732a21a1be4c78a"
+
+[[package]]
 name = "caliptra-x509"
 version = "0.1.0"
 source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2c0c6a81f569e72622001fab3732a21a1be4c78a#2c0c6a81f569e72622001fab3732a21a1be4c78a"
@@ -1608,6 +1613,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2236,7 +2251,38 @@ dependencies = [
 name = "mcu-hw-model"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "bit-vec",
+ "bitfield",
+ "caliptra-api",
+ "caliptra-api-types",
+ "caliptra-builder",
+ "caliptra-emu-bus",
+ "caliptra-emu-cpu",
+ "caliptra-emu-periph",
+ "caliptra-emu-types",
+ "caliptra-hw-model",
+ "caliptra-hw-model-types",
+ "caliptra-image-types",
+ "caliptra-registers",
+ "caliptra-test-harness-types",
+ "emulator-bmc",
+ "emulator-bus",
+ "emulator-cpu",
+ "emulator-periph",
+ "emulator-registers-generated",
+ "libc",
+ "mcu-builder",
+ "mcu-config",
+ "mcu-config-fpga",
+ "nix 0.26.4",
+ "rand",
+ "registers-generated",
+ "sha2",
  "tock-registers",
+ "uio",
+ "ureg",
+ "zerocopy 0.8.23",
 ]
 
 [[package]]
@@ -3565,6 +3611,17 @@ version = "0.1.0"
 name = "ufmt-write"
 version = "0.1.0"
 source = "git+https://github.com/korran/ufmt.git?rev=1d0743c1ffffc68bc05ca8eeb81c166192863f33#1d0743c1ffffc68bc05ca8eeb81c166192863f33"
+
+[[package]]
+name = "uio"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe6429670644060fac2d02d8d284c7f9369a1e71948a654d7f064dbba07fb508"
+dependencies = [
+ "fs2",
+ "libc",
+ "nix 0.26.4",
+]
 
 [[package]]
 name = "unicase"

--- a/hw/model/Cargo.toml
+++ b/hw/model/Cargo.toml
@@ -5,5 +5,45 @@ name = "mcu-hw-model"
 version.workspace = true
 edition.workspace = true
 
+[features]
+default = []
+fpga_realtime = ["dep:uio", "dep:mcu-config-fpga"]
+itrng = []
+
 [dependencies]
+anyhow.workspace = true
+bit-vec.workspace = true
+bitfield.workspace = true
+caliptra-api-types.workspace = true
+caliptra-api.workspace = true
+caliptra-emu-bus.workspace = true
+caliptra-emu-cpu.workspace = true
+caliptra-emu-periph.workspace = true
+caliptra-emu-types.workspace = true
+caliptra-hw-model.workspace = true
+caliptra-hw-model-types.workspace = true
+caliptra-image-types.workspace = true
+caliptra-registers.workspace = true
+emulator-bmc.workspace = true
+emulator-bus.workspace = true
+emulator-cpu.workspace = true
+emulator-periph.workspace = true
+libc.workspace = true
+mcu-builder.workspace = true
+nix.workspace = true
+rand.workspace = true
+mcu-config.workspace = true
+mcu-config-fpga = { workspace = true, optional = true }
+emulator-registers-generated.workspace = true
+registers-generated.workspace = true
+sha2.workspace = true
 tock-registers.workspace = true
+uio = { workspace = true, optional = true }
+ureg.workspace = true
+zerocopy.workspace = true
+
+[dev-dependencies]
+caliptra-builder.workspace = true
+caliptra-registers.workspace = true
+caliptra-test-harness-types.workspace = true
+nix.workspace = true

--- a/hw/model/src/bus_logger.rs
+++ b/hw/model/src/bus_logger.rs
@@ -61,10 +61,6 @@ impl<TBus: Bus> BusLogger<TBus> {
         addr: RvAddr,
         result: Result<RvData, caliptra_emu_bus::BusError>,
     ) {
-        if addr < 0x1000_0000 {
-            // Don't care about memory
-            return;
-        }
         if let Some(log) = &mut self.log {
             let size = usize::from(size);
             match result {
@@ -121,18 +117,23 @@ impl<TBus: Bus> Bus for BusLogger<TBus> {
         self.log_write("UC", size, addr, val, result);
         result
     }
+
     fn poll(&mut self) {
         self.bus.poll();
     }
+
     fn warm_reset(&mut self) {
         self.bus.warm_reset();
     }
+
     fn update_reset(&mut self) {
         self.bus.update_reset();
     }
+
     fn incoming_event(&mut self, event: Rc<caliptra_emu_bus::Event>) {
         self.bus.incoming_event(event);
     }
+
     fn register_outgoing_events(
         &mut self,
         sender: std::sync::mpsc::Sender<caliptra_emu_bus::Event>,

--- a/hw/model/src/bus_logger.rs
+++ b/hw/model/src/bus_logger.rs
@@ -1,0 +1,142 @@
+// Licensed under the Apache-2.0 license
+
+use std::{
+    cell::RefCell,
+    fs::File,
+    io::{BufWriter, Write},
+    path::Path,
+    rc::Rc,
+};
+
+use caliptra_emu_bus::{Bus, BusError};
+use caliptra_emu_types::{RvAddr, RvData, RvSize};
+
+#[derive(Clone)]
+pub struct LogFile(Rc<RefCell<BufWriter<File>>>);
+impl LogFile {
+    pub fn open(path: &Path) -> std::io::Result<Self> {
+        Ok(Self(Rc::new(RefCell::new(BufWriter::new(File::create(
+            path,
+        )?)))))
+    }
+}
+impl Write for LogFile {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.borrow_mut().write(buf)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.0.borrow_mut().flush()
+    }
+}
+
+pub struct NullBus();
+impl Bus for NullBus {
+    fn read(&mut self, _size: RvSize, _addr: RvAddr) -> Result<RvData, caliptra_emu_bus::BusError> {
+        Err(BusError::LoadAccessFault)
+    }
+
+    fn write(
+        &mut self,
+        _size: RvSize,
+        _addr: RvAddr,
+        _val: RvData,
+    ) -> Result<(), caliptra_emu_bus::BusError> {
+        Err(BusError::StoreAccessFault)
+    }
+}
+
+pub struct BusLogger<TBus: Bus> {
+    pub bus: TBus,
+    pub log: Option<LogFile>,
+}
+impl<TBus: Bus> BusLogger<TBus> {
+    pub fn new(bus: TBus) -> Self {
+        Self { bus, log: None }
+    }
+    pub fn log_read(
+        &mut self,
+        bus_name: &str,
+        size: RvSize,
+        addr: RvAddr,
+        result: Result<RvData, caliptra_emu_bus::BusError>,
+    ) {
+        if addr < 0x1000_0000 {
+            // Don't care about memory
+            return;
+        }
+        if let Some(log) = &mut self.log {
+            let size = usize::from(size);
+            match result {
+                Ok(val) => {
+                    writeln!(log, "{bus_name}  read{size} *0x{addr:08x} -> 0x{val:x}").unwrap()
+                }
+                Err(e) => {
+                    writeln!(log, "{bus_name}  read{size}  *0x{addr:08x} ***FAULT {e:?}").unwrap()
+                }
+            }
+        }
+    }
+    pub fn log_write(
+        &mut self,
+        bus_name: &str,
+        size: RvSize,
+        addr: RvAddr,
+        val: RvData,
+        result: Result<(), caliptra_emu_bus::BusError>,
+    ) {
+        if addr < 0x1000_0000 {
+            // Don't care about memory
+            return;
+        }
+        if let Some(log) = &mut self.log {
+            let size = usize::from(size);
+            match result {
+                Ok(()) => {
+                    writeln!(log, "{bus_name} write{size} *0x{addr:08x} <- 0x{val:x}").unwrap()
+                }
+                Err(e) => writeln!(
+                    log,
+                    "{bus_name} write{size} *0x{addr:08x} <- 0x{val:x} ***FAULT {e:?}"
+                )
+                .unwrap(),
+            }
+        }
+    }
+}
+impl<TBus: Bus> Bus for BusLogger<TBus> {
+    fn read(&mut self, size: RvSize, addr: RvAddr) -> Result<RvData, caliptra_emu_bus::BusError> {
+        let result = self.bus.read(size, addr);
+        self.log_read("UC", size, addr, result);
+        result
+    }
+
+    fn write(
+        &mut self,
+        size: RvSize,
+        addr: RvAddr,
+        val: RvData,
+    ) -> Result<(), caliptra_emu_bus::BusError> {
+        let result = self.bus.write(size, addr, val);
+        self.log_write("UC", size, addr, val, result);
+        result
+    }
+    fn poll(&mut self) {
+        self.bus.poll();
+    }
+    fn warm_reset(&mut self) {
+        self.bus.warm_reset();
+    }
+    fn update_reset(&mut self) {
+        self.bus.update_reset();
+    }
+    fn incoming_event(&mut self, event: Rc<caliptra_emu_bus::Event>) {
+        self.bus.incoming_event(event);
+    }
+    fn register_outgoing_events(
+        &mut self,
+        sender: std::sync::mpsc::Sender<caliptra_emu_bus::Event>,
+    ) {
+        self.bus.register_outgoing_events(sender);
+    }
+}

--- a/hw/model/src/bus_logger_mcu.rs
+++ b/hw/model/src/bus_logger_mcu.rs
@@ -49,6 +49,7 @@ impl<TBus: Bus> McuBusLogger<TBus> {
     pub fn new(bus: TBus) -> Self {
         Self { bus, log: None }
     }
+
     pub fn log_read(
         &mut self,
         bus_name: &str,
@@ -56,10 +57,6 @@ impl<TBus: Bus> McuBusLogger<TBus> {
         addr: RvAddr,
         result: Result<RvData, BusError>,
     ) {
-        if addr < 0x1000_0000 {
-            // Don't care about memory
-            return;
-        }
         if let Some(log) = &mut self.log {
             let size = usize::from(size);
             match result {
@@ -72,6 +69,7 @@ impl<TBus: Bus> McuBusLogger<TBus> {
             }
         }
     }
+
     pub fn log_write(
         &mut self,
         bus_name: &str,
@@ -80,10 +78,6 @@ impl<TBus: Bus> McuBusLogger<TBus> {
         val: RvData,
         result: Result<(), BusError>,
     ) {
-        if addr < 0x1000_0000 {
-            // Don't care about memory
-            return;
-        }
         if let Some(log) = &mut self.log {
             let size = usize::from(size);
             match result {
@@ -111,18 +105,23 @@ impl<TBus: Bus> Bus for McuBusLogger<TBus> {
         self.log_write("UC", size, addr, val, result);
         result
     }
+
     fn poll(&mut self) {
         self.bus.poll();
     }
+
     fn warm_reset(&mut self) {
         self.bus.warm_reset();
     }
+
     fn update_reset(&mut self) {
         self.bus.update_reset();
     }
+
     fn incoming_event(&mut self, event: Rc<caliptra_emu_bus::Event>) {
         self.bus.incoming_event(event);
     }
+
     fn register_outgoing_events(
         &mut self,
         sender: std::sync::mpsc::Sender<caliptra_emu_bus::Event>,

--- a/hw/model/src/bus_logger_mcu.rs
+++ b/hw/model/src/bus_logger_mcu.rs
@@ -1,0 +1,132 @@
+// Licensed under the Apache-2.0 license
+
+use caliptra_emu_types::{RvAddr, RvData, RvSize};
+use emulator_bus::{Bus, BusError};
+use std::{
+    cell::RefCell,
+    fs::File,
+    io::{BufWriter, Write},
+    path::Path,
+    rc::Rc,
+};
+
+#[derive(Clone)]
+pub struct LogFile(Rc<RefCell<BufWriter<File>>>);
+impl LogFile {
+    #[allow(dead_code)]
+    pub fn open(path: &Path) -> std::io::Result<Self> {
+        Ok(Self(Rc::new(RefCell::new(BufWriter::new(File::create(
+            path,
+        )?)))))
+    }
+}
+impl Write for LogFile {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.borrow_mut().write(buf)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.0.borrow_mut().flush()
+    }
+}
+
+pub struct NullBus();
+impl Bus for NullBus {
+    fn read(&mut self, _size: RvSize, _addr: RvAddr) -> Result<RvData, BusError> {
+        Err(BusError::LoadAccessFault)
+    }
+
+    fn write(&mut self, _size: RvSize, _addr: RvAddr, _val: RvData) -> Result<(), BusError> {
+        Err(BusError::StoreAccessFault)
+    }
+}
+
+pub struct McuBusLogger<TBus: Bus> {
+    pub bus: TBus,
+    pub log: Option<LogFile>,
+}
+impl<TBus: Bus> McuBusLogger<TBus> {
+    pub fn new(bus: TBus) -> Self {
+        Self { bus, log: None }
+    }
+    pub fn log_read(
+        &mut self,
+        bus_name: &str,
+        size: RvSize,
+        addr: RvAddr,
+        result: Result<RvData, BusError>,
+    ) {
+        if addr < 0x1000_0000 {
+            // Don't care about memory
+            return;
+        }
+        if let Some(log) = &mut self.log {
+            let size = usize::from(size);
+            match result {
+                Ok(val) => {
+                    writeln!(log, "{bus_name}  read{size} *0x{addr:08x} -> 0x{val:x}").unwrap()
+                }
+                Err(e) => {
+                    writeln!(log, "{bus_name}  read{size}  *0x{addr:08x} ***FAULT {e:?}").unwrap()
+                }
+            }
+        }
+    }
+    pub fn log_write(
+        &mut self,
+        bus_name: &str,
+        size: RvSize,
+        addr: RvAddr,
+        val: RvData,
+        result: Result<(), BusError>,
+    ) {
+        if addr < 0x1000_0000 {
+            // Don't care about memory
+            return;
+        }
+        if let Some(log) = &mut self.log {
+            let size = usize::from(size);
+            match result {
+                Ok(()) => {
+                    writeln!(log, "{bus_name} write{size} *0x{addr:08x} <- 0x{val:x}").unwrap()
+                }
+                Err(e) => writeln!(
+                    log,
+                    "{bus_name} write{size} *0x{addr:08x} <- 0x{val:x} ***FAULT {e:?}"
+                )
+                .unwrap(),
+            }
+        }
+    }
+}
+impl<TBus: Bus> Bus for McuBusLogger<TBus> {
+    fn read(&mut self, size: RvSize, addr: RvAddr) -> Result<RvData, BusError> {
+        let result = self.bus.read(size, addr);
+        self.log_read("UC", size, addr, result);
+        result
+    }
+
+    fn write(&mut self, size: RvSize, addr: RvAddr, val: RvData) -> Result<(), BusError> {
+        let result = self.bus.write(size, addr, val);
+        self.log_write("UC", size, addr, val, result);
+        result
+    }
+    fn poll(&mut self) {
+        self.bus.poll();
+    }
+    fn warm_reset(&mut self) {
+        self.bus.warm_reset();
+    }
+    fn update_reset(&mut self) {
+        self.bus.update_reset();
+    }
+    fn incoming_event(&mut self, event: Rc<caliptra_emu_bus::Event>) {
+        self.bus.incoming_event(event);
+    }
+    fn register_outgoing_events(
+        &mut self,
+        sender: std::sync::mpsc::Sender<caliptra_emu_bus::Event>,
+    ) {
+        self.bus.register_outgoing_events(sender);
+    }
+}

--- a/hw/model/src/lib.rs
+++ b/hw/model/src/lib.rs
@@ -1,3 +1,319 @@
 // Licensed under the Apache-2.0 license
 
+use anyhow::{bail, Result};
+pub use api::mailbox::mbox_write_fifo;
+pub use api_types::{DbgManufServiceRegReq, DeviceLifecycle, Fuses, SecurityState, U4};
+use caliptra_api as api;
+use caliptra_api_types as api_types;
+use caliptra_emu_bus::Event;
+pub use caliptra_emu_cpu::{CodeRange, ImageInfo, StackInfo, StackRange};
+use caliptra_hw_model_types::{
+    ErrorInjectionMode, EtrngResponse, HexBytes, HexSlice, RandomEtrngResponses, RandomNibbles,
+    DEFAULT_CPTRA_OBF_KEY,
+};
+use caliptra_registers::soc_ifc::regs::{
+    CptraItrngEntropyConfig0WriteVal, CptraItrngEntropyConfig1WriteVal,
+};
+pub use model_emulated::ModelEmulated;
+use output::ExitStatus;
+pub use output::Output;
+use rand::{rngs::StdRng, SeedableRng};
+use std::io::{stdout, ErrorKind};
+use std::path::PathBuf;
+use std::str::FromStr;
+use std::sync::mpsc;
+
+mod bus_logger;
+mod bus_logger_mcu;
+mod model_emulated;
+#[cfg(feature = "fpga_realtime")]
+mod model_fpga_realtime;
+mod output;
 mod xi3c;
+
+pub enum ShaAccMode {
+    Sha384Stream,
+    Sha512Stream,
+}
+
+#[cfg(feature = "fpga_realtime")]
+pub use model_fpga_realtime::ModelFpgaRealtime;
+
+/// Ideally, general-purpose functions would return `impl HwModel` instead of
+/// `DefaultHwModel` to prevent users from calling functions that aren't
+/// available on all HwModel implementations.
+///
+/// Unfortunately, rust-analyzer (used by IDEs) can't fully resolve associated
+/// types from `impl Trait`, so such functions should use `DefaultHwModel`.
+/// Users should treat `DefaultHwModel` as if it were `impl HwModel`.
+#[cfg(not(feature = "fpga_realtime"))]
+pub type DefaultHwModel = ModelEmulated;
+
+#[cfg(feature = "fpga_realtime")]
+pub type DefaultHwModel = ModelFpgaRealtime;
+
+pub const DEFAULT_APB_PAUSER: u32 = 0x01;
+
+const EXPECTED_CALIPTRA_BOOT_TIME_IN_CYCLES: u64 = 40_000_000; // 40 million cycles
+
+pub struct InitParams<'a> {
+    // The contents of the Caliptra ROM
+    pub caliptra_rom: &'a [u8],
+    // Caliptra's firmware bundle.
+    pub caliptra_firmware: &'a [u8],
+    // The contents of the MCU ROM
+    pub mcu_rom: &'a [u8],
+    // The contents of the MCU firmware
+    pub mcu_firmware: &'a [u8],
+
+    // The initial contents of the DCCM SRAM
+    pub caliptra_dccm: &'a [u8],
+
+    // The initial contents of the ICCM SRAM
+    pub caliptra_iccm: &'a [u8],
+
+    pub log_writer: Box<dyn std::io::Write>,
+
+    pub security_state: SecurityState,
+
+    pub dbg_manuf_service: DbgManufServiceRegReq,
+
+    pub active_mode: bool,
+
+    // Keypairs for production debug unlock levels, from low to high
+    // ECC384 and MLDSA87 keypairs
+    pub prod_dbg_unlock_keypairs: Vec<(&'a [u8; 96], &'a [u8; 2592])>,
+
+    pub debug_intent: bool,
+
+    // The silicon obfuscation key passed to caliptra_top.
+    pub cptra_obf_key: [u32; 8],
+
+    // 4-bit nibbles of raw entropy to feed into the internal TRNG (ENTROPY_SRC
+    // peripheral).
+    pub itrng_nibbles: Box<dyn Iterator<Item = u8> + Send>,
+
+    // Pre-conditioned TRNG responses to return over the soc_ifc CPTRA_TRNG_DATA
+    // registers in response to requests via CPTRA_TRNG_STATUS
+    pub etrng_responses: Box<dyn Iterator<Item = EtrngResponse> + Send>,
+
+    // If true (and the HwModel supports it), initialize the SRAM with random
+    // data. This will likely result in a ECC double-bit error if the CPU
+    // attempts to read uninitialized memory.
+    pub random_sram_puf: bool,
+
+    // A trace path to use. If None, the CPTRA_TRACE_PATH environment variable
+    // will be used
+    pub trace_path: Option<PathBuf>,
+
+    // Information about the stack Caliptra is using. When set the emulator will check if the stack
+    // overflows.
+    pub stack_info: Option<StackInfo>,
+}
+impl<'a> Default for InitParams<'a> {
+    fn default() -> Self {
+        let seed = std::env::var("CPTRA_TRNG_SEED")
+            .ok()
+            .and_then(|s| u64::from_str(&s).ok());
+        let itrng_nibbles: Box<dyn Iterator<Item = u8> + Send> = if let Some(seed) = seed {
+            Box::new(RandomNibbles(StdRng::seed_from_u64(seed)))
+        } else {
+            Box::new(RandomNibbles(StdRng::from_entropy()))
+        };
+        let etrng_responses: Box<dyn Iterator<Item = EtrngResponse> + Send> =
+            if let Some(seed) = seed {
+                Box::new(RandomEtrngResponses(StdRng::seed_from_u64(seed)))
+            } else {
+                Box::new(RandomEtrngResponses::new_from_stdrng())
+            };
+        Self {
+            caliptra_rom: Default::default(),
+            caliptra_firmware: Default::default(),
+            mcu_rom: Default::default(),
+            mcu_firmware: Default::default(),
+            caliptra_dccm: Default::default(),
+            caliptra_iccm: Default::default(),
+            log_writer: Box::new(stdout()),
+            security_state: *SecurityState::default()
+                .set_device_lifecycle(DeviceLifecycle::Unprovisioned),
+            dbg_manuf_service: Default::default(),
+            active_mode: false,
+            prod_dbg_unlock_keypairs: Default::default(),
+            debug_intent: false,
+            cptra_obf_key: DEFAULT_CPTRA_OBF_KEY,
+            itrng_nibbles,
+            etrng_responses,
+            random_sram_puf: true,
+            trace_path: None,
+            stack_info: None,
+        }
+    }
+}
+
+pub struct InitParamsSummary {
+    rom_sha384: [u8; 48],
+    obf_key: [u32; 8],
+    security_state: SecurityState,
+}
+impl std::fmt::Debug for InitParamsSummary {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("InitParamsSummary")
+            .field("rom_sha384", &HexBytes(&self.rom_sha384))
+            .field("obf_key", &HexSlice(&self.obf_key))
+            .field("security_state", &self.security_state)
+            .finish()
+    }
+}
+
+fn trace_path_or_env(trace_path: Option<PathBuf>) -> Option<PathBuf> {
+    if let Some(trace_path) = trace_path {
+        return Some(trace_path);
+    }
+    std::env::var("CPTRA_TRACE_PATH").ok().map(PathBuf::from)
+}
+
+pub struct BootParams<'a> {
+    pub fuses: Fuses,
+    pub fw_image: Option<&'a [u8]>,
+    pub initial_dbg_manuf_service_reg: u32,
+    pub initial_repcnt_thresh_reg: Option<CptraItrngEntropyConfig1WriteVal>,
+    pub initial_adaptp_thresh_reg: Option<CptraItrngEntropyConfig0WriteVal>,
+    pub valid_axi_user: Vec<u32>,
+    pub wdt_timeout_cycles: u64,
+    // SoC manifest passed via the recovery interface
+    pub soc_manifest: Option<&'a [u8]>,
+    // MCU firmware image passed via the recovery interface
+    pub mcu_fw_image: Option<&'a [u8]>,
+}
+
+impl<'a> Default for BootParams<'a> {
+    fn default() -> Self {
+        Self {
+            fuses: Default::default(),
+            fw_image: Default::default(),
+            initial_dbg_manuf_service_reg: Default::default(),
+            initial_repcnt_thresh_reg: Default::default(),
+            initial_adaptp_thresh_reg: Default::default(),
+            valid_axi_user: vec![0, 1, 2, 3, 4],
+            wdt_timeout_cycles: EXPECTED_CALIPTRA_BOOT_TIME_IN_CYCLES,
+            soc_manifest: Default::default(),
+            mcu_fw_image: Default::default(),
+        }
+    }
+}
+
+// Represents a emulator or simulation of the caliptra core hardware, to be called
+// from tests. Typically, test cases should use [`crate::new()`] to create a model
+// based on the cargo features (and any model-specific environment variables).
+pub trait McuHwModel {
+    /// Create a model. Most high-level tests should use [`new()`]
+    /// instead.
+    fn new_unbooted(params: InitParams) -> Result<Self>
+    where
+        Self: Sized;
+
+    /// The type name of this model
+    fn type_name(&self) -> &'static str;
+
+    /// Step execution ahead one clock cycle.
+    fn step(&mut self);
+
+    /// Any UART-ish output written by the microcontroller will be available here.
+    fn output(&mut self) -> &mut Output;
+
+    /// Execute until the result of `predicate` becomes true.
+    fn step_until(&mut self, mut predicate: impl FnMut(&mut Self) -> bool) {
+        while !predicate(self) {
+            self.step();
+        }
+    }
+
+    /// Returns true if the microcontroller has signalled that it is ready for
+    /// firmware to be written to the mailbox. For RTL implementations, this
+    /// should come via a caliptra_top wire rather than an APB register.
+    fn ready_for_fw(&self) -> bool;
+
+    fn step_until_exit_success(&mut self) -> std::io::Result<()> {
+        self.copy_output_until_exit_success(std::io::Sink::default())
+    }
+
+    fn copy_output_until_exit_success(
+        &mut self,
+        mut w: impl std::io::Write,
+    ) -> std::io::Result<()> {
+        loop {
+            if !self.output().peek().is_empty() {
+                w.write_all(self.output().take(usize::MAX).as_bytes())?;
+            }
+            match self.output().exit_status() {
+                Some(ExitStatus::Passed) => return Ok(()),
+                Some(ExitStatus::Failed) => {
+                    return Err(std::io::Error::new(
+                        ErrorKind::Other,
+                        "firmware exited with failure",
+                    ))
+                }
+                None => {}
+            }
+            self.step();
+        }
+    }
+
+    fn step_until_exit_failure(&mut self) -> Result<()> {
+        loop {
+            match self.output().exit_status() {
+                Some(ExitStatus::Failed) => return Ok(()),
+                Some(ExitStatus::Passed) => {
+                    bail!("firmware exited with success when failure was expected",);
+                }
+                None => {}
+            }
+            self.step();
+        }
+    }
+
+    /// Execute until the output buffer starts with `expected_output`
+    fn step_until_output(&mut self, expected_output: &str) -> Result<()> {
+        self.step_until(|m| m.output().peek().len() >= expected_output.len());
+        if &self.output().peek()[..expected_output.len()] != expected_output {
+            bail!(
+                "expected output {:?}, was {:?}",
+                expected_output,
+                self.output().peek()
+            );
+        }
+        Ok(())
+    }
+
+    /// Execute until the output buffer starts with `expected_output`, and remove it
+    /// from the output buffer.
+    fn step_until_output_and_take(&mut self, expected_output: &str) -> Result<()> {
+        self.step_until_output(expected_output)?;
+        self.output().take(expected_output.len());
+        Ok(())
+    }
+
+    // Execute (at least) until the output provided substr is written to the
+    // output. Additional data may be present in the output after the provided
+    // substr, which often happens with the fpga_realtime hardware model.
+    //
+    // This function will not match any data in the output that was written
+    // before this function was called.
+    fn step_until_output_contains(&mut self, substr: &str) -> Result<()> {
+        self.output().set_search_term(substr);
+        self.step_until(|m| m.output().search_matched());
+        Ok(())
+    }
+
+    fn cover_fw_mage(&mut self, _image: &[u8]) {}
+
+    fn tracing_hint(&mut self, enable: bool);
+
+    fn ecc_error_injection(&mut self, _mode: ErrorInjectionMode) {}
+
+    fn set_axi_user(&mut self, axi_user: u32);
+
+    fn events_from_caliptra(&mut self) -> Vec<Event>;
+
+    fn events_to_caliptra(&mut self) -> mpsc::Sender<Event>;
+}

--- a/hw/model/src/model_emulated.rs
+++ b/hw/model/src/model_emulated.rs
@@ -31,6 +31,8 @@ use std::path::PathBuf;
 use std::rc::Rc;
 use std::sync::mpsc;
 
+const DEFAULT_AXI_PAUSER: u32 = 0xaaaa_aaaa;
+
 /// Emulated model
 pub struct ModelEmulated {
     caliptra_cpu: CaliptraCpu<BusLogger<CaliptraRootBus>>,
@@ -122,9 +124,9 @@ impl McuHwModel for ModelEmulated {
             dccm_dest.copy_from_slice(params.caliptra_dccm);
         }
         let _soc_to_caliptra_bus =
-            root_bus.soc_to_caliptra_bus(MailboxRequester::SocUser(0xaaaa_aaaa));
+            root_bus.soc_to_caliptra_bus(MailboxRequester::SocUser(DEFAULT_AXI_PAUSER));
         let soc_to_caliptra_bus2 =
-            root_bus.soc_to_caliptra_bus(MailboxRequester::SocUser(0xaaaa_aaaa));
+            root_bus.soc_to_caliptra_bus(MailboxRequester::SocUser(DEFAULT_AXI_PAUSER));
         let (events_to_caliptra, events_from_caliptra, caliptra_cpu) = {
             let mut cpu = CaliptraCpu::new(BusLogger::new(root_bus), clock);
             if let Some(stack_info) = params.stack_info {
@@ -237,6 +239,7 @@ impl McuHwModel for ModelEmulated {
         let iccm_image = &fw_image[IMAGE_MANIFEST_BYTE_SIZE..];
         self.iccm_image_tag = Some(hash_slice(iccm_image));
     }
+
     fn tracing_hint(&mut self, enable: bool) {
         if enable == self.caliptra_trace_fn.is_some() {
             // No change

--- a/hw/model/src/model_emulated.rs
+++ b/hw/model/src/model_emulated.rs
@@ -1,0 +1,342 @@
+// Licensed under the Apache-2.0 license
+
+use crate::bus_logger::BusLogger;
+use crate::bus_logger::LogFile;
+use crate::bus_logger_mcu::McuBusLogger;
+use crate::trace_path_or_env;
+use crate::InitParams;
+use crate::McuHwModel;
+use crate::Output;
+use anyhow::Result;
+use caliptra_emu_bus::Clock;
+use caliptra_emu_bus::Event;
+use caliptra_emu_cpu::{Cpu as CaliptraCpu, InstrTracer as CaliptraInstrTracer};
+use caliptra_emu_periph::ActionCb;
+use caliptra_emu_periph::MailboxRequester;
+use caliptra_emu_periph::ReadyForFwCb;
+use caliptra_emu_periph::{CaliptraRootBus, CaliptraRootBusArgs, TbServicesCb};
+use caliptra_hw_model::ModelError;
+use caliptra_hw_model_types::ErrorInjectionMode;
+use caliptra_image_types::IMAGE_MANIFEST_BYTE_SIZE;
+use emulator_bus::BusConverter;
+use emulator_bus::Clock as McuClock;
+use emulator_cpu::{Cpu as McuCpu, InstrTracer as McuInstrTracer, Pic};
+use emulator_periph::{I3c, I3cController, Mci, McuRootBus, McuRootBusArgs, Otp};
+use emulator_registers_generated::root_bus::AutoRootBus;
+use std::cell::Cell;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::Hasher;
+use std::io::Write;
+use std::path::PathBuf;
+use std::rc::Rc;
+use std::sync::mpsc;
+
+/// Emulated model
+pub struct ModelEmulated {
+    caliptra_cpu: CaliptraCpu<BusLogger<CaliptraRootBus>>,
+    mcu_cpu: McuCpu<McuBusLogger<AutoRootBus>>,
+    output: Output,
+    caliptra_trace_fn: Option<Box<CaliptraInstrTracer<'static>>>,
+    mcu_trace_fn: Option<Box<McuInstrTracer<'static>>>,
+    ready_for_fw: Rc<Cell<bool>>,
+    cpu_enabled: Rc<Cell<bool>>,
+    trace_path: Option<PathBuf>,
+
+    // Keep this even when not including the coverage feature to keep the
+    // interface consistent
+    _rom_image_tag: u64,
+    iccm_image_tag: Option<u64>,
+
+    events_to_caliptra: mpsc::Sender<Event>,
+    events_from_caliptra: mpsc::Receiver<Event>,
+    collected_events_from_caliptra: Vec<Event>,
+}
+
+fn hash_slice(slice: &[u8]) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    std::hash::Hash::hash_slice(slice, &mut hasher);
+    hasher.finish()
+}
+
+impl McuHwModel for ModelEmulated {
+    fn new_unbooted(params: InitParams) -> Result<Self>
+    where
+        Self: Sized,
+    {
+        let clock = Clock::new();
+        let timer = clock.timer();
+
+        let ready_for_fw = Rc::new(Cell::new(false));
+        let ready_for_fw_clone = ready_for_fw.clone();
+
+        let cpu_enabled = Rc::new(Cell::new(false));
+        let cpu_enabled_cloned = cpu_enabled.clone();
+
+        let output = Output::new(params.log_writer);
+
+        let output_sink = output.sink().clone();
+
+        let bus_args = CaliptraRootBusArgs {
+            rom: params.caliptra_rom.into(),
+            tb_services_cb: TbServicesCb::new(move |ch| {
+                output_sink.set_now(timer.now());
+                output_sink.push_uart_char(ch);
+            }),
+            ready_for_fw_cb: ReadyForFwCb::new(move |_| {
+                ready_for_fw_clone.set(true);
+            }),
+            bootfsm_go_cb: ActionCb::new(move || {
+                cpu_enabled_cloned.set(true);
+            }),
+            security_state: params.security_state,
+            dbg_manuf_service_req: params.dbg_manuf_service,
+            subsystem_mode: params.active_mode,
+            prod_dbg_unlock_keypairs: params.prod_dbg_unlock_keypairs,
+            debug_intent: params.debug_intent,
+            cptra_obf_key: params.cptra_obf_key,
+
+            itrng_nibbles: Some(params.itrng_nibbles),
+            etrng_responses: params.etrng_responses,
+            ..CaliptraRootBusArgs::default()
+        };
+        let mut root_bus = CaliptraRootBus::new(&clock, bus_args);
+
+        root_bus
+            .soc_reg
+            .set_hw_config((1 | if params.active_mode { 1 << 5 } else { 0 }).into());
+
+        {
+            let mut iccm_ram = root_bus.iccm.ram().borrow_mut();
+            let Some(iccm_dest) = iccm_ram.data_mut().get_mut(0..params.caliptra_iccm.len()) else {
+                return Err(ModelError::ProvidedIccmTooLarge.into());
+            };
+            iccm_dest.copy_from_slice(params.caliptra_iccm);
+
+            let Some(dccm_dest) = root_bus
+                .dccm
+                .data_mut()
+                .get_mut(0..params.caliptra_dccm.len())
+            else {
+                return Err(ModelError::ProvidedDccmTooLarge.into());
+            };
+            dccm_dest.copy_from_slice(params.caliptra_dccm);
+        }
+        let _soc_to_caliptra_bus =
+            root_bus.soc_to_caliptra_bus(MailboxRequester::SocUser(0xaaaa_aaaa));
+        let soc_to_caliptra_bus2 =
+            root_bus.soc_to_caliptra_bus(MailboxRequester::SocUser(0xaaaa_aaaa));
+        let (events_to_caliptra, events_from_caliptra, caliptra_cpu) = {
+            let mut cpu = CaliptraCpu::new(BusLogger::new(root_bus), clock);
+            if let Some(stack_info) = params.stack_info {
+                cpu.with_stack_info(stack_info);
+            }
+            let (events_to_caliptra, events_from_caliptra) = cpu.register_events();
+            (events_to_caliptra, events_from_caliptra, cpu)
+        };
+
+        let mut hasher = DefaultHasher::new();
+        std::hash::Hash::hash_slice(params.caliptra_rom, &mut hasher);
+        let image_tag = hasher.finish();
+
+        // this just immediately exits
+        let _mcu_firmware = [0xb7, 0xf6, 0x00, 0x20, 0x94, 0xc2];
+
+        let clock = Rc::new(McuClock::new());
+        let pic = Rc::new(Pic::new());
+        let bus_args = McuRootBusArgs {
+            rom: params.mcu_rom.into(),
+            pic: pic.clone(),
+            clock: clock.clone(),
+            ..Default::default()
+        };
+        let mcu_root_bus = McuRootBus::new(bus_args).unwrap();
+        let mut i3c_controller = I3cController::default();
+        let i3c_error_irq = pic.register_irq(McuRootBus::I3C_ERROR_IRQ);
+        let i3c_notif_irq = pic.register_irq(McuRootBus::I3C_NOTIF_IRQ);
+        let i3c = I3c::new(
+            &clock.clone(),
+            &mut i3c_controller,
+            i3c_error_irq,
+            i3c_notif_irq,
+        );
+        let otp = Otp::new(&clock.clone(), None, None, None)?;
+        let mci = Mci::new(&clock.clone());
+
+        let delegates: Vec<Box<dyn emulator_bus::Bus>> = vec![
+            Box::new(mcu_root_bus),
+            Box::new(BusConverter::new(Box::new(soc_to_caliptra_bus2))),
+        ];
+
+        let auto_root_bus = AutoRootBus::new(
+            delegates,
+            None,
+            Some(Box::new(i3c)),
+            None,
+            None,
+            Some(Box::new(mci)),
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(Box::new(otp)),
+            None,
+        );
+
+        let mut mcu_cpu = McuCpu::new(McuBusLogger::new(auto_root_bus), clock, pic);
+        mcu_cpu.register_events();
+
+        let mut m = ModelEmulated {
+            output,
+            caliptra_cpu,
+            mcu_cpu,
+            caliptra_trace_fn: None,
+            mcu_trace_fn: None,
+            ready_for_fw,
+            cpu_enabled,
+            trace_path: trace_path_or_env(params.trace_path),
+            _rom_image_tag: image_tag,
+            iccm_image_tag: None,
+            events_to_caliptra,
+            events_from_caliptra,
+            collected_events_from_caliptra: vec![],
+        };
+        // Turn tracing on if the trace path was set
+        m.tracing_hint(true);
+
+        Ok(m)
+    }
+
+    fn type_name(&self) -> &'static str {
+        "ModelEmulated"
+    }
+
+    fn ready_for_fw(&self) -> bool {
+        self.ready_for_fw.get()
+    }
+
+    fn step(&mut self) {
+        if self.cpu_enabled.get() {
+            self.caliptra_cpu
+                .step(self.caliptra_trace_fn.as_deref_mut());
+            self.mcu_cpu.step(self.mcu_trace_fn.as_deref_mut());
+        }
+        // TODO: route events between MCU and Caliptra Core
+        let events = self.events_from_caliptra.try_iter().collect::<Vec<_>>();
+        self.collected_events_from_caliptra.extend(events);
+    }
+
+    fn output(&mut self) -> &mut Output {
+        // In case the caller wants to log something, make sure the log has the
+        // correct time.env::
+        self.output.sink().set_now(self.caliptra_cpu.clock.now());
+        &mut self.output
+    }
+
+    fn cover_fw_mage(&mut self, fw_image: &[u8]) {
+        let iccm_image = &fw_image[IMAGE_MANIFEST_BYTE_SIZE..];
+        self.iccm_image_tag = Some(hash_slice(iccm_image));
+    }
+    fn tracing_hint(&mut self, enable: bool) {
+        if enable == self.caliptra_trace_fn.is_some() {
+            // No change
+            return;
+        }
+        self.caliptra_trace_fn = None;
+        self.caliptra_cpu.bus.log = None;
+        let Some(trace_path) = &self.trace_path else {
+            return;
+        };
+
+        let mut log = match LogFile::open(trace_path) {
+            Ok(file) => file,
+            Err(e) => {
+                eprintln!("Unable to open file {trace_path:?}: {e}");
+                return;
+            }
+        };
+        self.caliptra_cpu.bus.log = Some(log.clone());
+        self.caliptra_trace_fn = Some(Box::new(move |pc, _instr| {
+            writeln!(log, "pc=0x{pc:x}").unwrap();
+        }))
+    }
+
+    fn ecc_error_injection(&mut self, mode: ErrorInjectionMode) {
+        match mode {
+            ErrorInjectionMode::None => {
+                self.caliptra_cpu
+                    .bus
+                    .bus
+                    .iccm
+                    .ram()
+                    .borrow_mut()
+                    .error_injection = 0;
+                self.caliptra_cpu.bus.bus.dccm.error_injection = 0;
+            }
+            ErrorInjectionMode::IccmDoubleBitEcc => {
+                self.caliptra_cpu
+                    .bus
+                    .bus
+                    .iccm
+                    .ram()
+                    .borrow_mut()
+                    .error_injection = 2;
+            }
+            ErrorInjectionMode::DccmDoubleBitEcc => {
+                self.caliptra_cpu.bus.bus.dccm.error_injection = 8;
+            }
+        }
+    }
+
+    fn set_axi_user(&mut self, _axi_user: u32) {
+        unimplemented!();
+    }
+
+    fn events_from_caliptra(&mut self) -> Vec<Event> {
+        self.collected_events_from_caliptra.drain(..).collect()
+    }
+
+    fn events_to_caliptra(&mut self) -> mpsc::Sender<Event> {
+        self.events_to_caliptra.clone()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{DefaultHwModel, InitParams, McuHwModel};
+
+    #[test]
+    fn test_new_unbooted() {
+        let mcu_rom = mcu_builder::rom_build(None).expect("Could not build MCU ROM");
+        let mcu_runtime = &mcu_builder::runtime_build_with_apps(&[], None, false, None, None)
+            .expect("Could not build MCU runtime");
+        let mut caliptra_builder =
+            mcu_builder::CaliptraBuilder::new(true, None, None, None, None, None, None);
+        let caliptra_rom = caliptra_builder
+            .get_caliptra_rom()
+            .expect("Could not build Caliptra ROM");
+        let caliptra_fw = caliptra_builder
+            .get_caliptra_fw()
+            .expect("Could not build Caliptra FW bundle");
+        let _vendor_pk_hash = caliptra_builder
+            .get_vendor_pk_hash()
+            .expect("Could not get vendor PK hash");
+
+        let caliptra_rom = std::fs::read(caliptra_rom).unwrap();
+        let caliptra_fw = std::fs::read(caliptra_fw).unwrap();
+        let mcu_rom = std::fs::read(mcu_rom).unwrap();
+        let mcu_runtime = std::fs::read(mcu_runtime).unwrap();
+
+        let mut model = DefaultHwModel::new_unbooted(InitParams {
+            caliptra_rom: &caliptra_rom,
+            caliptra_firmware: &caliptra_fw,
+            mcu_rom: &mcu_rom,
+            mcu_firmware: &mcu_runtime,
+            ..Default::default()
+        })
+        .unwrap();
+        for _ in 0..1000 {
+            model.step();
+        }
+    }
+}

--- a/hw/model/src/model_fpga_realtime.rs
+++ b/hw/model/src/model_fpga_realtime.rs
@@ -1,0 +1,462 @@
+// Licensed under the Apache-2.0 license
+
+use crate::InitParams;
+use crate::McuHwModel;
+use crate::Output;
+use anyhow::{anyhow, Error, Result};
+use bitfield::bitfield;
+use caliptra_emu_bus::Event;
+use std::sync::mpsc;
+use uio::{UioDevice, UioError};
+
+// UIO mapping indices
+const FPGA_WRAPPER_MAPPING: (usize, usize) = (0, 0);
+const CALIPTRA_MAPPING: (usize, usize) = (0, 1);
+const CALIPTRA_ROM_MAPPING: (usize, usize) = (0, 2);
+const I3C_CONTROLLER_MAPPING: (usize, usize) = (0, 3);
+const MCU_SRAM_MAPPING: (usize, usize) = (0, 4);
+const _SS_MAPPING: (usize, usize) = (1, 0);
+const MCU_ROM_MAPPING: (usize, usize) = (1, 1);
+const I3C_TARGET_MAPPING: (usize, usize) = (1, 2);
+const MCI_MAPPING: (usize, usize) = (1, 3);
+
+const DEFAULT_AXI_PAUSER: u32 = 0x1;
+
+fn fmt_uio_error(err: UioError) -> Error {
+    anyhow!("{err:?}")
+}
+
+// FPGA wrapper register offsets
+const _FPGA_WRAPPER_MAGIC_OFFSET: isize = 0x0000 / 4;
+const _FPGA_WRAPPER_VERSION_OFFSET: isize = 0x0004 / 4;
+const FPGA_WRAPPER_CONTROL_OFFSET: isize = 0x0008 / 4;
+const _FPGA_WRAPPER_STATUS_OFFSET: isize = 0x000C / 4;
+const FPGA_WRAPPER_PAUSER_OFFSET: isize = 0x0010 / 4;
+const _FPGA_WRAPPER_ITRNG_DIV_OFFSET: isize = 0x0014 / 4;
+const FPGA_WRAPPER_CYCLE_COUNT_OFFSET: isize = 0x0018 / 4;
+const _FPGA_WRAPPER_GENERIC_INPUT_OFFSET: isize = 0x0030 / 4;
+const _FPGA_WRAPPER_GENERIC_OUTPUT_OFFSET: isize = 0x0038 / 4;
+const _FPGA_WRAPPER_DEOBF_KEY_OFFSET: isize = 0x0040 / 4;
+const _FPGA_WRAPPER_CSR_HMAC_KEY_OFFSET: isize = 0x0060 / 4;
+
+const _FPGA_WRAPPER_LSU_USER_OFFSET: isize = 0x0100 / 4;
+const _FPGA_WRAPPER_IFU_USER_OFFSET: isize = 0x0104 / 4;
+const _FPGA_WRAPPER_CLP_USER_OFFSET: isize = 0x0108 / 4;
+const _FPGA_WRAPPER_SOC_CFG_USER_OFFSET: isize = 0x010C / 4;
+const _FPGA_WRAPPER_SRAM_CFG_USER_OFFSET: isize = 0x0110 / 4;
+const FPGA_WRAPPER_MCU_RESET_VECTOR_OFFSET: isize = 0x0114 / 4;
+const _FPGA_WRAPPER_MCI_ERROR: isize = 0x0118 / 4;
+const _FPGA_WRAPPER_MCU_CONFIG: isize = 0x011C / 4;
+const _FPGA_WRAPPER_MCI_GENERIC_INPUT_WIRES_0_OFFSET: isize = 0x0120 / 4;
+const _FPGA_WRAPPER_MCI_GENERIC_INPUT_WIRES_1_OFFSET: isize = 0x0124 / 4;
+const _FPGA_WRAPPER_MCI_GENERIC_OUTPUT_WIRES_0_OFFSET: isize = 0x0128 / 4;
+const _FPGA_WRAPPER_MCI_GENERIC_OUTPUT_WIRES_1_OFFSET: isize = 0x012C / 4;
+const _FPGA_WRAPPER_LOG_FIFO_DATA_OFFSET: isize = 0x1000 / 4;
+const _FPGA_WRAPPER_LOG_FIFO_STATUS_OFFSET: isize = 0x1004 / 4;
+const _FPGA_WRAPPER_ITRNG_FIFO_DATA_OFFSET: isize = 0x1008 / 4;
+const _FPGA_WRAPPER_ITRNG_FIFO_STATUS_OFFSET: isize = 0x100C / 4;
+const FPGA_WRAPPER_MCU_LOG_FIFO_DATA_OFFSET: isize = 0x1010 / 4;
+const FPGA_WRAPPER_MCU_LOG_FIFO_STATUS_OFFSET: isize = 0x1018 / 4;
+
+bitfield! {
+    #[derive(Debug, PartialEq, Eq, Clone, Copy)]
+    /// Wrapper wires -> Caliptra
+    pub struct GpioOutput(u32);
+    cptra_pwrgood, set_cptra_pwrgood: 0, 0;
+    cptra_rst_b, set_cptra_rst_b: 1, 1;
+    debug_locked, set_debug_locked: 2, 2;
+    device_lifecycle, set_device_lifecycle: 4, 3;
+}
+
+bitfield! {
+    #[derive(Debug, PartialEq, Eq, Clone, Copy)]
+    /// Wrapper wires <- Caliptra
+    pub struct GpioInput(u32);
+    cptra_error_fatal, _: 0, 0;
+    cptra_error_non_fatal, _: 1, 1;
+    ready_for_fuses, _: 2, 2;
+    ready_for_fw, _: 3, 3;
+    ready_for_runtime, _: 4, 4;
+}
+
+bitfield! {
+    #[derive(Debug, PartialEq, Eq, Clone, Copy)]
+    /// Log FIFO data
+    pub struct FifoData(u32);
+    log_fifo_char, _: 7, 0;
+    log_fifo_valid, _: 8, 8;
+}
+
+bitfield! {
+    #[derive(Debug, PartialEq, Eq, Clone, Copy)]
+    /// Log FIFO status
+    pub struct FifoStatus(u32);
+    log_fifo_empty, _: 0, 0;
+    log_fifo_full, _: 1, 1;
+}
+
+bitfield! {
+    #[derive(Debug, PartialEq, Eq, Clone, Copy)]
+    /// ITRNG FIFO status
+    pub struct TrngFifoStatus(u32);
+    trng_fifo_empty, _: 0, 0;
+    trng_fifo_full, _: 1, 1;
+    trng_fifo_reset, set_trng_fifo_reset: 2, 2;
+}
+
+pub struct ModelFpgaRealtime {
+    devs: [UioDevice; 2],
+    // mmio uio pointers
+    wrapper: *mut u32,
+    caliptra_mmio: *mut u32,
+    caliptra_rom_backdoor: *mut u8,
+    mcu_rom_backdoor: *mut u8,
+    mcu_sram_backdoor: *mut u8,
+    mci: *mut u32,
+    i3c_mmio: *mut u32,
+    i3c_controller_mmio: *mut u32,
+
+    output: Output,
+}
+
+impl ModelFpgaRealtime {
+    fn set_subsystem_reset(&mut self, reset: bool) {
+        let value = if reset { 0 } else { 3 };
+        unsafe {
+            core::ptr::write_volatile(self.wrapper.offset(FPGA_WRAPPER_CONTROL_OFFSET), value);
+        }
+    }
+
+    fn clear_log_fifo(&mut self) {
+        // clear Caliptra log FIFO
+        // loop {
+        //     let fifodata = unsafe {
+        //         FifoData(
+        //             self.wrapper
+        //                 .offset(FPGA_WRAPPER_LOG_FIFO_DATA_OFFSET)
+        //                 .read_volatile(),
+        //         )
+        //     };
+        //     if fifodata.log_fifo_valid() == 0 {
+        //         break;
+        //     }
+        // }
+        // clear MCU log FIFO
+        loop {
+            let fifosts = unsafe {
+                FifoStatus(
+                    self.wrapper
+                        .offset(FPGA_WRAPPER_MCU_LOG_FIFO_STATUS_OFFSET)
+                        .read_volatile(),
+                )
+            };
+            if fifosts.log_fifo_empty() == 1 {
+                break;
+            }
+            let fifodata = unsafe {
+                FifoData(
+                    self.wrapper
+                        .offset(FPGA_WRAPPER_MCU_LOG_FIFO_DATA_OFFSET)
+                        .read_volatile(),
+                )
+            };
+            if fifodata.log_fifo_valid() == 0 {
+                return;
+            }
+        }
+    }
+
+    fn handle_log(&mut self) {
+        // Check if the FIFO is full (which probably means there was an overrun)
+        // let fifosts = unsafe {
+        //     FifoStatus(
+        //         self.wrapper
+        //             .offset(FPGA_WRAPPER_LOG_FIFO_STATUS_OFFSET)
+        //             .read_volatile(),
+        //     )
+        // };
+        // if fifosts.log_fifo_full() != 0 {
+        //     panic!("FPGA log Caliptra FIFO overran");
+        // }
+        // // Check and empty log Caliptra FIFO
+        // loop {
+        //     let fifodata = unsafe {
+        //         FifoData(
+        //             self.wrapper
+        //                 .offset(FPGA_WRAPPER_LOG_FIFO_DATA_OFFSET)
+        //                 .read_volatile(),
+        //         )
+        //     };
+        //     // Add byte to log if it is valid
+        //     if fifodata.log_fifo_valid() != 0 {
+        //         self.output()
+        //             .sink()
+        //             .push_uart_char(fifodata.log_fifo_char().try_into().unwrap());
+        //     } else {
+        //         break;
+        //     }
+        // }
+        // Check if the FIFO is full (which probably means there was an overrun)
+        loop {
+            let fifosts = unsafe {
+                FifoStatus(
+                    self.wrapper
+                        .offset(FPGA_WRAPPER_MCU_LOG_FIFO_STATUS_OFFSET)
+                        .read_volatile(),
+                )
+            };
+            if fifosts.log_fifo_full() != 0 {
+                panic!("FPGA log MCU FIFO overran");
+            }
+            if fifosts.log_fifo_empty() == 1 {
+                break;
+            }
+            let fifodata = unsafe {
+                FifoData(
+                    self.wrapper
+                        .offset(FPGA_WRAPPER_MCU_LOG_FIFO_DATA_OFFSET)
+                        .read_volatile(),
+                )
+            };
+            // Add byte to log if it is valid
+            if fifodata.log_fifo_valid() != 0 {
+                self.output()
+                    .sink()
+                    .push_uart_char(fifodata.log_fifo_char().try_into().unwrap());
+            } else {
+                break;
+            }
+        }
+    }
+
+    // UIO crate doesn't provide a way to unmap memory.
+    fn unmap_mapping(&self, addr: *mut u32, mapping: (usize, usize)) {
+        let map_size = self.devs[mapping.0].map_size(mapping.1).unwrap();
+
+        unsafe {
+            nix::sys::mman::munmap(addr as *mut libc::c_void, map_size).unwrap();
+        }
+    }
+}
+
+impl McuHwModel for ModelFpgaRealtime {
+    fn step(&mut self) {
+        self.handle_log();
+    }
+
+    fn new_unbooted(params: InitParams) -> Result<Self>
+    where
+        Self: Sized,
+    {
+        let output = Output::new(params.log_writer);
+        let dev0 = UioDevice::blocking_new(0)?;
+        let dev1 = UioDevice::blocking_new(1)?;
+        let devs = [dev0, dev1];
+
+        let wrapper = devs[FPGA_WRAPPER_MAPPING.0]
+            .map_mapping(FPGA_WRAPPER_MAPPING.1)
+            .map_err(fmt_uio_error)? as *mut u32;
+        let caliptra_rom_backdoor = devs[CALIPTRA_ROM_MAPPING.0]
+            .map_mapping(CALIPTRA_ROM_MAPPING.1)
+            .map_err(fmt_uio_error)? as *mut u8;
+        let mcu_sram_backdoor = devs[MCU_SRAM_MAPPING.0]
+            .map_mapping(MCU_SRAM_MAPPING.1)
+            .map_err(fmt_uio_error)? as *mut u8;
+        let mcu_rom_backdoor = devs[MCU_ROM_MAPPING.0]
+            .map_mapping(MCU_ROM_MAPPING.1)
+            .map_err(fmt_uio_error)? as *mut u8;
+        let mci = devs[MCI_MAPPING.0]
+            .map_mapping(MCI_MAPPING.1)
+            .map_err(fmt_uio_error)? as *mut u32;
+        let caliptra_mmio = devs[CALIPTRA_MAPPING.0]
+            .map_mapping(CALIPTRA_MAPPING.1)
+            .map_err(fmt_uio_error)? as *mut u32;
+        let i3c_mmio = devs[I3C_TARGET_MAPPING.0]
+            .map_mapping(I3C_TARGET_MAPPING.1)
+            .map_err(fmt_uio_error)? as *mut u32;
+        let i3c_controller_mmio = devs[I3C_CONTROLLER_MAPPING.0]
+            .map_mapping(I3C_CONTROLLER_MAPPING.1)
+            .map_err(fmt_uio_error)? as *mut u32;
+
+        // TODO: initialize this after the I3C target is configured.
+        // let i3c_controller = xi3c::Controller::new(i3c_controller_mmio);
+
+        let mut m = Self {
+            devs,
+            wrapper,
+            caliptra_mmio,
+            caliptra_rom_backdoor,
+            mcu_rom_backdoor,
+            mcu_sram_backdoor,
+            mci,
+            i3c_mmio,
+            i3c_controller_mmio,
+
+            output,
+        };
+
+        println!("Clearing fifo");
+        // Sometimes there's garbage in here; clean it out
+        m.clear_log_fifo();
+
+        println!("Putting subsystem into reset");
+        m.set_subsystem_reset(true);
+
+        println!("new_unbooted");
+
+        // Set initial PAUSER
+        m.set_axi_user(DEFAULT_AXI_PAUSER);
+
+        println!("AXI user written");
+
+        // Write ROM images over backdoors
+        // ensure that they are 8-byte aligned to write to AXI
+        // let mut caliptra_rom_data = params.caliptra_rom.to_vec();
+        // while caliptra_rom_data.len() % 8 != 0 {
+        //     caliptra_rom_data.push(0);
+        // }
+        let mut mcu_rom_data = params.mcu_rom.to_vec();
+        while mcu_rom_data.len() % 8 != 0 {
+            mcu_rom_data.push(0);
+        }
+
+        // copy the ROM data
+        // let caliptra_rom_slice = unsafe {
+        //     core::slice::from_raw_parts_mut(m.caliptra_rom_backdoor, caliptra_rom_data.len())
+        // };
+        // println!("Writing Caliptra ROM");
+        // TODO: this crashes the FPGA
+        // caliptra_rom_slice.copy_from_slice(&caliptra_rom_data);
+        println!("Writing MCU ROM");
+        let mcu_rom_slice =
+            unsafe { core::slice::from_raw_parts_mut(m.mcu_rom_backdoor, mcu_rom_data.len()) };
+        mcu_rom_slice.copy_from_slice(&mcu_rom_data);
+
+        // set the reset vector to point to the ROM backdoor
+        println!("Writing MCU reset vector");
+        unsafe {
+            core::ptr::write_volatile(
+                m.wrapper.offset(FPGA_WRAPPER_MCU_RESET_VECTOR_OFFSET),
+                mcu_config_fpga::FPGA_MEMORY_MAP.rom_offset,
+            )
+        };
+
+        println!("Taking subsystem out of reset");
+        m.set_subsystem_reset(false);
+
+        // TODO: finish testing active mode
+        println!("Writing MCU firmware to SRAM");
+        // For now, we copy the runtime directly into the SRAM
+        let mut fw_data = params.mcu_firmware.to_vec();
+        while fw_data.len() % 8 != 0 {
+            fw_data.push(0);
+        }
+        // TODO: remove this offset 0x80 and add 128 bytes of padding to the beginning of the firmware
+        let sram_slice = unsafe {
+            core::slice::from_raw_parts_mut(m.mcu_sram_backdoor.offset(0x80), fw_data.len())
+        };
+        sram_slice.copy_from_slice(&fw_data);
+
+        println!("Done starting MCU");
+
+        Ok(m)
+    }
+
+    fn type_name(&self) -> &'static str {
+        "ModelFpgaRealtime"
+    }
+
+    fn output(&mut self) -> &mut crate::Output {
+        let cycle = unsafe {
+            self.wrapper
+                .offset(FPGA_WRAPPER_CYCLE_COUNT_OFFSET)
+                .read_volatile()
+        };
+        self.output.sink().set_now(u64::from(cycle));
+        &mut self.output
+    }
+
+    fn ready_for_fw(&self) -> bool {
+        true
+    }
+
+    fn tracing_hint(&mut self, _enable: bool) {
+        // Do nothing; we don't support tracing yet
+    }
+
+    fn set_axi_user(&mut self, pauser: u32) {
+        unsafe {
+            self.wrapper
+                .offset(FPGA_WRAPPER_PAUSER_OFFSET)
+                .write_volatile(pauser);
+        }
+    }
+
+    fn events_from_caliptra(&mut self) -> Vec<Event> {
+        todo!()
+    }
+
+    fn events_to_caliptra(&mut self) -> mpsc::Sender<Event> {
+        todo!()
+    }
+}
+
+impl Drop for ModelFpgaRealtime {
+    fn drop(&mut self) {
+        // Unmap UIO memory space so that the file lock is released
+        self.unmap_mapping(self.wrapper, FPGA_WRAPPER_MAPPING);
+        self.unmap_mapping(self.caliptra_mmio, CALIPTRA_MAPPING);
+        self.unmap_mapping(self.caliptra_rom_backdoor as *mut u32, CALIPTRA_ROM_MAPPING);
+        self.unmap_mapping(self.mcu_rom_backdoor as *mut u32, MCU_ROM_MAPPING);
+        self.unmap_mapping(self.mcu_sram_backdoor as *mut u32, MCU_SRAM_MAPPING);
+        self.unmap_mapping(self.mci, MCI_MAPPING);
+        self.unmap_mapping(self.i3c_mmio, I3C_TARGET_MAPPING);
+        self.unmap_mapping(self.i3c_controller_mmio, I3C_CONTROLLER_MAPPING);
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{DefaultHwModel, InitParams, McuHwModel};
+
+    #[test]
+    fn test_new_unbooted() {
+        let mcu_rom = mcu_builder::rom_build(Some("fpga")).expect("Could not build MCU ROM");
+        let mcu_runtime = &mcu_builder::runtime_build_with_apps(
+            &[],
+            Some("fpga-runtime.bin"),
+            false,
+            Some("fpga"),
+            Some(&mcu_config_fpga::FPGA_MEMORY_MAP),
+        )
+        .expect("Could not build MCU runtime");
+        let mut caliptra_builder =
+            mcu_builder::CaliptraBuilder::new(true, None, None, None, None, None, None);
+        let caliptra_rom = caliptra_builder
+            .get_caliptra_rom()
+            .expect("Could not build Caliptra ROM");
+        let caliptra_fw = caliptra_builder
+            .get_caliptra_fw()
+            .expect("Could not build Caliptra FW bundle");
+        let _vendor_pk_hash = caliptra_builder
+            .get_vendor_pk_hash()
+            .expect("Could not get vendor PK hash");
+
+        let caliptra_rom = std::fs::read(caliptra_rom).unwrap();
+        let caliptra_fw = std::fs::read(caliptra_fw).unwrap();
+        let mcu_rom = std::fs::read(mcu_rom).unwrap();
+        let mcu_runtime = std::fs::read(mcu_runtime).unwrap();
+
+        let mut model = DefaultHwModel::new_unbooted(InitParams {
+            caliptra_rom: &caliptra_rom,
+            caliptra_firmware: &caliptra_fw,
+            mcu_rom: &mcu_rom,
+            mcu_firmware: &mcu_runtime,
+            ..Default::default()
+        })
+        .unwrap();
+        for _ in 0..1_000_000 {
+            model.step();
+        }
+    }
+}

--- a/hw/model/src/output.rs
+++ b/hw/model/src/output.rs
@@ -1,0 +1,409 @@
+// Licensed under the Apache-2.0 license
+
+use std::fmt::Display;
+use std::io::LineWriter;
+use std::{
+    cell::{Cell, RefCell},
+    io::Write,
+    rc::Rc,
+};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ExitStatus {
+    Passed,
+    Failed,
+}
+
+struct OutputSinkImpl {
+    exit_status: Cell<Option<ExitStatus>>,
+    new_uart_output: Cell<String>,
+    log_writer: RefCell<LineWriter<Box<dyn std::io::Write>>>,
+    at_start_of_line: Cell<bool>,
+    now: Cell<u64>,
+    next_write_needs_time_prefix: Cell<bool>,
+}
+
+struct PrettyU64(u64);
+impl Display for PrettyU64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        const RANKS: [u64; 7] = [
+            1_000_000_000_000_000_000,
+            1_000_000_000_000_000,
+            1_000_000_000_000,
+            1_000_000_000,
+            1_000_000,
+            1_000,
+            1,
+        ];
+        const PADDING_RANK: u64 = 1_000_000_000;
+        let mut prev_numbers = false;
+        for rank in RANKS {
+            if (self.0 / rank) > 0 || rank == 1 {
+                if prev_numbers {
+                    write!(f, "{:03}", (self.0 / rank) % 1000)?;
+                } else if rank >= PADDING_RANK {
+                    write!(f, "{}", (self.0 / rank) % 1000)?;
+                } else {
+                    write!(f, "{:>3}", (self.0 / rank) % 1000)?;
+                }
+                if rank > 1 {
+                    write!(f, ",")?;
+                }
+                prev_numbers = true;
+            } else if rank < PADDING_RANK {
+                write!(f, "    ")?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[test]
+fn test_pretty_u64() {
+    assert_eq!(PrettyU64(0).to_string(), "          0");
+    assert_eq!(PrettyU64(1).to_string(), "          1");
+    assert_eq!(PrettyU64(999).to_string(), "        999");
+    assert_eq!(PrettyU64(1_000).to_string(), "      1,000");
+    assert_eq!(PrettyU64(1_001).to_string(), "      1,001");
+    assert_eq!(PrettyU64(999_999).to_string(), "    999,999");
+    assert_eq!(PrettyU64(1_000_000).to_string(), "  1,000,000");
+    assert_eq!(PrettyU64(1_000_001).to_string(), "  1,000,001");
+    assert_eq!(PrettyU64(999_999_999).to_string(), "999,999,999");
+    assert_eq!(PrettyU64(1_999_999_999).to_string(), "1,999,999,999");
+}
+
+#[derive(Clone)]
+pub struct OutputSink(Rc<OutputSinkImpl>);
+impl OutputSink {
+    pub fn set_now(&self, now: u64) {
+        self.0.now.set(now);
+    }
+    pub fn now(&self) -> u64 {
+        self.0.now.get()
+    }
+    pub fn push_uart_char(&self, ch: u8) {
+        const UART_LOG_PREFIX: &[u8] = b"UART: ";
+
+        const TESTCASE_FAILED: u8 = 0x01;
+        const TESTCASE_PASSED: u8 = 0xff;
+
+        match ch {
+            TESTCASE_PASSED => {
+                // This is the same string as printed by the verilog test-bench
+                self.0
+                    .log_writer
+                    .borrow_mut()
+                    .write_all(b"* TESTCASE PASSED\n")
+                    .unwrap();
+                self.0.exit_status.set(Some(ExitStatus::Passed));
+            }
+            TESTCASE_FAILED => {
+                // This is the same string as printed by the verilog test-bench
+                self.0
+                    .log_writer
+                    .borrow_mut()
+                    .write_all(b"* TESTCASE FAILED\n")
+                    .unwrap();
+                self.0.exit_status.set(Some(ExitStatus::Failed));
+            }
+            0x20..=0x7f | b'\r' | b'\n' | b'\t' => {
+                let mut s = self.0.new_uart_output.take();
+                s.push(ch as char);
+                self.0.new_uart_output.set(s);
+
+                let log_writer = &mut self.0.log_writer.borrow_mut();
+                if self.0.at_start_of_line.get() {
+                    log_writer.flush().unwrap();
+                    write!(log_writer, "{} ", PrettyU64(self.0.now.get())).unwrap();
+                    log_writer.write_all(UART_LOG_PREFIX).unwrap();
+                    self.0.at_start_of_line.set(false);
+                }
+                log_writer.write_all(&[ch]).unwrap();
+                if ch == b'\n' {
+                    self.0.at_start_of_line.set(true);
+                }
+            }
+            _ => {
+                writeln!(
+                    self.0.log_writer.borrow_mut(),
+                    "Unknown generic load 0x{ch:02x}"
+                )
+                .unwrap();
+            }
+        }
+    }
+}
+impl std::io::Write for &OutputSink {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        let log_writer = &mut self.0.log_writer.borrow_mut();
+        // Write a time prefix in front of every line
+        for line in buf.split_inclusive(|ch| *ch == b'\n') {
+            if self.0.next_write_needs_time_prefix.get() {
+                write!(log_writer, "{} ", PrettyU64(self.0.now.get())).unwrap();
+                self.0.next_write_needs_time_prefix.set(false);
+            }
+            log_writer.write_all(line)?;
+            if line.ends_with(b"\n") {
+                self.0.next_write_needs_time_prefix.set(true);
+            }
+        }
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.0.log_writer.borrow_mut().flush()
+    }
+}
+
+pub struct Output {
+    output: String,
+    sink: OutputSink,
+
+    search_term: Option<String>,
+    search_pos: usize, // Position to start searching from
+    search_matched: bool,
+}
+impl Output {
+    pub fn new(log_writer: impl std::io::Write + 'static) -> Self {
+        Self::new_internal(Box::new(log_writer))
+    }
+    fn new_internal(log_writer: Box<dyn std::io::Write>) -> Self {
+        Self {
+            output: "".into(),
+            sink: OutputSink(Rc::new(OutputSinkImpl {
+                new_uart_output: Default::default(),
+                log_writer: RefCell::new(LineWriter::new(log_writer)),
+                exit_status: Cell::new(None),
+                at_start_of_line: Cell::new(true),
+                now: Cell::new(0),
+                next_write_needs_time_prefix: Cell::new(true),
+            })),
+            search_term: None,
+            search_pos: 0,
+            search_matched: false,
+        }
+    }
+    pub fn sink(&self) -> &OutputSink {
+        &self.sink
+    }
+    pub fn logger(&self) -> impl std::io::Write + '_ {
+        &self.sink
+    }
+
+    /// Peek at all the output captured so far
+    pub fn peek(&mut self) -> &str {
+        self.process_new_data();
+        &self.output
+    }
+
+    /// Take at most `limit` characters from the output
+    pub fn take(&mut self, limit: usize) -> String {
+        self.process_new_data();
+        if self.output.len() <= limit {
+            std::mem::take(&mut self.output)
+        } else {
+            let remaining = self.output[limit..].to_string();
+            let mut result = std::mem::replace(&mut self.output, remaining);
+            result.truncate(limit);
+            result
+        }
+    }
+
+    fn process_new_data(&mut self) {
+        let new_data = self.sink.0.new_uart_output.take();
+        let new_data_len = new_data.len();
+        if new_data_len == 0 {
+            return;
+        }
+
+        if self.output.is_empty() {
+            self.output = new_data;
+        } else {
+            self.output.push_str(&new_data);
+        }
+
+        if let Some(term) = &self.search_term {
+            if !self.search_matched {
+                self.search_matched = self.output[self.search_pos..].contains(term);
+                self.search_pos = self.output.len().saturating_sub(term.len());
+                if self.search_matched {
+                    self.search_term = None;
+                }
+            }
+        }
+    }
+
+    pub(crate) fn set_search_term(&mut self, search_term: &str) {
+        self.process_new_data();
+        self.search_term = Some(search_term.to_string());
+        self.search_pos = self.output.len();
+        self.search_matched = false;
+    }
+
+    pub(crate) fn search_matched(&mut self) -> bool {
+        self.process_new_data();
+        self.search_matched
+    }
+
+    /// Returns true if the caliptra microcontroller has signalled that it wants to exit
+    /// (this only makes sense when running test cases on the microcontroller)
+    pub fn exit_requested(&self) -> bool {
+        self.exit_status().is_some()
+    }
+
+    pub fn exit_status(&self) -> Option<ExitStatus> {
+        self.sink.0.exit_status.get()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use std::io::Sink;
+
+    use super::*;
+
+    #[derive(Clone)]
+    pub struct Log {
+        log: Rc<RefCell<Vec<u8>>>,
+    }
+    impl Log {
+        /// Construct an empty `Log`.
+        pub fn new() -> Self {
+            Self {
+                log: Rc::new(RefCell::new(vec![])),
+            }
+        }
+        fn into_string(self) -> String {
+            String::from_utf8(self.log.take()).unwrap()
+        }
+    }
+    impl Default for Log {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+    impl std::io::Write for Log {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            std::io::Write::write(&mut *self.log.borrow_mut(), buf)
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            std::io::Write::flush(&mut *self.log.borrow_mut())
+        }
+    }
+
+    #[test]
+    fn test_take() {
+        let log = Log::new();
+        let mut out = Output::new(log.clone());
+
+        out.sink().set_now(0);
+        out.sink().push_uart_char(b'h');
+        out.sink().set_now(1);
+        out.sink().push_uart_char(b'i');
+        out.sink().push_uart_char(b'!');
+        out.sink().push_uart_char(b'\n');
+
+        assert_eq!(&out.take(2), "hi");
+        assert_eq!(&out.take(10), "!\n");
+        assert_eq!(&out.take(10), "");
+
+        assert_eq!(log.into_string(), "          0 UART: hi!\n");
+    }
+
+    #[test]
+    fn test_peek() {
+        let mut out = Output::new(Sink::default());
+
+        out.sink().push_uart_char(b'h');
+        out.sink().push_uart_char(b'i');
+        assert_eq!(out.peek(), "hi");
+        out.sink().push_uart_char(b'!');
+        assert_eq!(out.peek(), "hi!");
+    }
+
+    #[test]
+    fn test_passed() {
+        let log = Log::new();
+        let mut out = Output::new(log.clone());
+
+        out.sink().set_now(1000);
+        out.sink().push_uart_char(b'h');
+        out.sink().set_now(2000);
+        out.sink().push_uart_char(b'i');
+        out.sink().push_uart_char(b'\n');
+        assert_eq!(&out.take(10), "hi\n");
+
+        out.sink().push_uart_char(0xff);
+        assert_eq!(out.exit_status(), Some(ExitStatus::Passed));
+        assert_eq!(&out.take(10), "");
+
+        assert_eq!(
+            log.into_string(),
+            "      1,000 UART: hi\n* TESTCASE PASSED\n"
+        );
+    }
+
+    #[test]
+    fn test_failed() {
+        let log = Log::new();
+        let mut out = Output::new(log.clone());
+
+        out.sink().push_uart_char(b'h');
+        out.sink().push_uart_char(b'i');
+        out.sink().push_uart_char(b'\n');
+        out.sink().push_uart_char(0x01);
+        assert_eq!(out.exit_status(), Some(ExitStatus::Failed));
+        assert_eq!(&out.take(10), "hi\n");
+
+        assert_eq!(
+            log.into_string(),
+            "          0 UART: hi\n* TESTCASE FAILED\n"
+        );
+    }
+
+    #[test]
+    fn test_unknown_generic_load() {
+        let log = Log::new();
+        let mut out = Output::new(log.clone());
+        out.sink().push_uart_char(0xd3);
+
+        assert_eq!(&out.take(30), "");
+        assert_eq!(log.into_string(), "Unknown generic load 0xd3\n");
+    }
+
+    #[test]
+    fn test_search() {
+        let mut out = Output::new(Log::new());
+        out.set_search_term("foobar");
+        assert!(!out.search_matched);
+        for &ch in b"this is my foobar string!" {
+            out.sink.push_uart_char(ch);
+        }
+        out.process_new_data();
+        assert!(out.search_matched);
+        out.set_search_term("foobar");
+        out.process_new_data();
+        assert!(!out.search_matched);
+
+        for &ch in b"hello world strin" {
+            out.sink.push_uart_char(ch);
+        }
+        out.set_search_term("string");
+        for &ch in b"g no match" {
+            out.sink.push_uart_char(ch);
+        }
+        out.process_new_data();
+        assert!(!out.search_matched);
+
+        for &ch in b" matching string" {
+            out.sink.push_uart_char(ch);
+        }
+        out.process_new_data();
+        assert!(out.search_matched);
+        out.set_search_term("string");
+        assert!(!out.search_matched);
+    }
+}


### PR DESCRIPTION
These are pared down versions of the Caliptra hw-model: https://github.com/chipsalliance/caliptra-sw/tree/main-2.x/hw-model

I'll add more of those pieces as we add in more Caliptra functionality.

This so far will boot the ROM and runtime on the FPGA if you run:

```shell
cargo t -p mcu-hw-model --features fpga_realtime -- --test model_fpga_realtime::test::test_new_unbooted --exact --nocapture
```

Based on #200

