### PR TITLE
hw/model: rom_build now requires the feature argument

### DIFF
--- a/hw/model/src/model_emulated.rs
+++ b/hw/model/src/model_emulated.rs
@@ -310,7 +310,7 @@ mod test {
 
     #[test]
     fn test_new_unbooted() {
-        let mcu_rom = mcu_builder::rom_build(None).expect("Could not build MCU ROM");
+        let mcu_rom = mcu_builder::rom_build(None, "").expect("Could not build MCU ROM");
         let mcu_runtime = &mcu_builder::runtime_build_with_apps(&[], None, false, None, None)
             .expect("Could not build MCU runtime");
         let mut caliptra_builder =

--- a/hw/model/src/model_fpga_realtime.rs
+++ b/hw/model/src/model_fpga_realtime.rs
@@ -421,7 +421,7 @@ mod test {
 
     #[test]
     fn test_new_unbooted() {
-        let mcu_rom = mcu_builder::rom_build(Some("fpga")).expect("Could not build MCU ROM");
+        let mcu_rom = mcu_builder::rom_build(Some("fpga"), "").expect("Could not build MCU ROM");
         let mcu_runtime = &mcu_builder::runtime_build_with_apps(
             &[],
             Some("fpga-runtime.bin"),


### PR DESCRIPTION
I merged #202 without rebasing after #208, which added a feature argument to the rom_build.