### PR TITLE
hw/model: FPGA now mostly boots Caliptra

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,19 +102,20 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.6"
+version = "3.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
+checksum = "6680de5231bd6ee4c6191b8a1325daa282b415391ec9d3a37bd34f2060dc73fa"
 dependencies = [
  "anstyle",
+ "once_cell_polyfill",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.97"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "arrayref"
@@ -154,13 +155,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.87"
+version = "0.1.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d556ec1359574147ec0c4fc5eb525f3f23263a592b1a9c07e0a75b427de55c97"
+checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -177,9 +178,9 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64ct"
-version = "1.6.0"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
 
 [[package]]
 name = "bit-vec"
@@ -204,9 +205,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "block-buffer"
@@ -228,9 +229,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "byteorder"
@@ -241,22 +242,22 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 [[package]]
 name = "caliptra-api"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb1bf9dcc816bddf09d02e64138b310156954781#fb1bf9dcc816bddf09d02e64138b310156954781"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2973c7df95073ef8e6d481e529ebe79ae04f4bae#2973c7df95073ef8e6d481e529ebe79ae04f4bae"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.1",
  "caliptra-api-types",
  "caliptra-emu-types",
  "caliptra-error",
  "caliptra-image-types",
  "caliptra-registers",
  "ureg",
- "zerocopy 0.8.23",
+ "zerocopy",
 ]
 
 [[package]]
 name = "caliptra-api-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb1bf9dcc816bddf09d02e64138b310156954781#fb1bf9dcc816bddf09d02e64138b310156954781"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2973c7df95073ef8e6d481e529ebe79ae04f4bae#2973c7df95073ef8e6d481e529ebe79ae04f4bae"
 dependencies = [
  "caliptra-image-types",
 ]
@@ -264,37 +265,38 @@ dependencies = [
 [[package]]
 name = "caliptra-auth-man-gen"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb1bf9dcc816bddf09d02e64138b310156954781#fb1bf9dcc816bddf09d02e64138b310156954781"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2973c7df95073ef8e6d481e529ebe79ae04f4bae#2973c7df95073ef8e6d481e529ebe79ae04f4bae"
 dependencies = [
  "anyhow",
- "bitflags 2.6.0",
+ "bitflags 2.9.1",
  "caliptra-auth-man-types",
  "caliptra-image-gen",
  "caliptra-image-types",
  "caliptra-lms-types",
+ "fips204",
  "memoffset 0.8.0",
- "zerocopy 0.8.23",
+ "zerocopy",
 ]
 
 [[package]]
 name = "caliptra-auth-man-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb1bf9dcc816bddf09d02e64138b310156954781#fb1bf9dcc816bddf09d02e64138b310156954781"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2973c7df95073ef8e6d481e529ebe79ae04f4bae#2973c7df95073ef8e6d481e529ebe79ae04f4bae"
 dependencies = [
  "bitfield",
- "bitflags 2.6.0",
+ "bitflags 2.9.1",
  "caliptra-error",
  "caliptra-image-types",
  "caliptra-lms-types",
  "memoffset 0.8.0",
- "zerocopy 0.8.23",
+ "zerocopy",
  "zeroize",
 ]
 
 [[package]]
 name = "caliptra-builder"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb1bf9dcc816bddf09d02e64138b310156954781#fb1bf9dcc816bddf09d02e64138b310156954781"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2973c7df95073ef8e6d481e529ebe79ae04f4bae#2973c7df95073ef8e6d481e529ebe79ae04f4bae"
 dependencies = [
  "anyhow",
  "caliptra-image-crypto",
@@ -313,13 +315,13 @@ dependencies = [
  "serde_json",
  "sha2",
  "toml 0.7.8",
- "zerocopy 0.8.23",
+ "zerocopy",
 ]
 
 [[package]]
 name = "caliptra-cfi-derive"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb1bf9dcc816bddf09d02e64138b310156954781#fb1bf9dcc816bddf09d02e64138b310156954781"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2973c7df95073ef8e6d481e529ebe79ae04f4bae#2973c7df95073ef8e6d481e529ebe79ae04f4bae"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -341,7 +343,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cfi-lib"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb1bf9dcc816bddf09d02e64138b310156954781#fb1bf9dcc816bddf09d02e64138b310156954781"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2973c7df95073ef8e6d481e529ebe79ae04f4bae#2973c7df95073ef8e6d481e529ebe79ae04f4bae"
 dependencies = [
  "caliptra-error",
  "caliptra-registers",
@@ -356,7 +358,7 @@ source = "git+https://github.com/chipsalliance/caliptra-cfi.git?rev=a98e499d279e
 [[package]]
 name = "caliptra-coverage"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb1bf9dcc816bddf09d02e64138b310156954781#fb1bf9dcc816bddf09d02e64138b310156954781"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2973c7df95073ef8e6d481e529ebe79ae04f4bae#2973c7df95073ef8e6d481e529ebe79ae04f4bae"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -374,7 +376,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cpu"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb1bf9dcc816bddf09d02e64138b310156954781#fb1bf9dcc816bddf09d02e64138b310156954781"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2973c7df95073ef8e6d481e529ebe79ae04f4bae#2973c7df95073ef8e6d481e529ebe79ae04f4bae"
 dependencies = [
  "caliptra-drivers",
  "caliptra-registers",
@@ -384,10 +386,11 @@ dependencies = [
 [[package]]
 name = "caliptra-drivers"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb1bf9dcc816bddf09d02e64138b310156954781#fb1bf9dcc816bddf09d02e64138b310156954781"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2973c7df95073ef8e6d481e529ebe79ae04f4bae#2973c7df95073ef8e6d481e529ebe79ae04f4bae"
 dependencies = [
  "bitfield",
- "bitflags 2.6.0",
+ "bitflags 2.9.1",
+ "caliptra-api",
  "caliptra-auth-man-types",
  "caliptra-cfi-derive",
  "caliptra-cfi-derive-git",
@@ -401,14 +404,14 @@ dependencies = [
  "dpe",
  "ufmt 0.2.0",
  "ureg",
- "zerocopy 0.8.23",
+ "zerocopy",
  "zeroize",
 ]
 
 [[package]]
 name = "caliptra-emu-bus"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb1bf9dcc816bddf09d02e64138b310156954781#fb1bf9dcc816bddf09d02e64138b310156954781"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2973c7df95073ef8e6d481e529ebe79ae04f4bae#2973c7df95073ef8e6d481e529ebe79ae04f4bae"
 dependencies = [
  "caliptra-emu-types",
  "tock-registers",
@@ -418,7 +421,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-cpu"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb1bf9dcc816bddf09d02e64138b310156954781#fb1bf9dcc816bddf09d02e64138b310156954781"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2973c7df95073ef8e6d481e529ebe79ae04f4bae#2973c7df95073ef8e6d481e529ebe79ae04f4bae"
 dependencies = [
  "bit-vec",
  "bitfield",
@@ -432,11 +435,13 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb1bf9dcc816bddf09d02e64138b310156954781#fb1bf9dcc816bddf09d02e64138b310156954781"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2973c7df95073ef8e6d481e529ebe79ae04f4bae#2973c7df95073ef8e6d481e529ebe79ae04f4bae"
 dependencies = [
  "aes",
  "aes-gcm",
  "cbc",
+ "cipher",
+ "ctr",
  "p384",
  "rfc6979",
  "sha2",
@@ -445,7 +450,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-derive"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb1bf9dcc816bddf09d02e64138b310156954781#fb1bf9dcc816bddf09d02e64138b310156954781"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2973c7df95073ef8e6d481e529ebe79ae04f4bae#2973c7df95073ef8e6d481e529ebe79ae04f4bae"
 dependencies = [
  "caliptra-emu-bus",
  "caliptra-emu-types",
@@ -456,7 +461,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-periph"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb1bf9dcc816bddf09d02e64138b310156954781#fb1bf9dcc816bddf09d02e64138b310156954781"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2973c7df95073ef8e6d481e529ebe79ae04f4bae#2973c7df95073ef8e6d481e529ebe79ae04f4bae"
 dependencies = [
  "aes",
  "arrayref",
@@ -477,23 +482,23 @@ dependencies = [
  "sha3",
  "smlang 0.6.0",
  "tock-registers",
- "zerocopy 0.8.23",
+ "zerocopy",
 ]
 
 [[package]]
 name = "caliptra-emu-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb1bf9dcc816bddf09d02e64138b310156954781#fb1bf9dcc816bddf09d02e64138b310156954781"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2973c7df95073ef8e6d481e529ebe79ae04f4bae#2973c7df95073ef8e6d481e529ebe79ae04f4bae"
 
 [[package]]
 name = "caliptra-error"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb1bf9dcc816bddf09d02e64138b310156954781#fb1bf9dcc816bddf09d02e64138b310156954781"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2973c7df95073ef8e6d481e529ebe79ae04f4bae#2973c7df95073ef8e6d481e529ebe79ae04f4bae"
 
 [[package]]
 name = "caliptra-gen-linker-scripts"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb1bf9dcc816bddf09d02e64138b310156954781#fb1bf9dcc816bddf09d02e64138b310156954781"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2973c7df95073ef8e6d481e529ebe79ae04f4bae#2973c7df95073ef8e6d481e529ebe79ae04f4bae"
 dependencies = [
  "caliptra_common",
 ]
@@ -501,7 +506,7 @@ dependencies = [
 [[package]]
 name = "caliptra-hw-model"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb1bf9dcc816bddf09d02e64138b310156954781#fb1bf9dcc816bddf09d02e64138b310156954781"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2973c7df95073ef8e6d481e529ebe79ae04f4bae#2973c7df95073ef8e6d481e529ebe79ae04f4bae"
 dependencies = [
  "bit-vec",
  "bitfield",
@@ -521,13 +526,13 @@ dependencies = [
  "sha2",
  "tock-registers",
  "ureg",
- "zerocopy 0.8.23",
+ "zerocopy",
 ]
 
 [[package]]
 name = "caliptra-hw-model-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb1bf9dcc816bddf09d02e64138b310156954781#fb1bf9dcc816bddf09d02e64138b310156954781"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2973c7df95073ef8e6d481e529ebe79ae04f4bae#2973c7df95073ef8e6d481e529ebe79ae04f4bae"
 dependencies = [
  "caliptra-api-types",
  "rand",
@@ -536,7 +541,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb1bf9dcc816bddf09d02e64138b310156954781#fb1bf9dcc816bddf09d02e64138b310156954781"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2973c7df95073ef8e6d481e529ebe79ae04f4bae#2973c7df95073ef8e6d481e529ebe79ae04f4bae"
 dependencies = [
  "anyhow",
  "caliptra-image-gen",
@@ -544,18 +549,19 @@ dependencies = [
  "caliptra-lms-types",
  "cfg-if",
  "ecdsa",
+ "fips204",
  "openssl",
  "p384",
  "rand",
  "sec1",
  "sha2",
- "zerocopy 0.8.23",
+ "zerocopy",
 ]
 
 [[package]]
 name = "caliptra-image-elf"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb1bf9dcc816bddf09d02e64138b310156954781#fb1bf9dcc816bddf09d02e64138b310156954781"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2973c7df95073ef8e6d481e529ebe79ae04f4bae#2973c7df95073ef8e6d481e529ebe79ae04f4bae"
 dependencies = [
  "anyhow",
  "caliptra-image-gen",
@@ -566,21 +572,21 @@ dependencies = [
 [[package]]
 name = "caliptra-image-fake-keys"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb1bf9dcc816bddf09d02e64138b310156954781#fb1bf9dcc816bddf09d02e64138b310156954781"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2973c7df95073ef8e6d481e529ebe79ae04f4bae#2973c7df95073ef8e6d481e529ebe79ae04f4bae"
 dependencies = [
  "caliptra-image-gen",
  "caliptra-image-types",
  "caliptra-lms-types",
- "zerocopy 0.8.23",
+ "zerocopy",
 ]
 
 [[package]]
 name = "caliptra-image-gen"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb1bf9dcc816bddf09d02e64138b310156954781#fb1bf9dcc816bddf09d02e64138b310156954781"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2973c7df95073ef8e6d481e529ebe79ae04f4bae#2973c7df95073ef8e6d481e529ebe79ae04f4bae"
 dependencies = [
  "anyhow",
- "bitflags 2.6.0",
+ "bitflags 2.9.1",
  "caliptra-image-types",
  "caliptra-lms-types",
  "fips204",
@@ -588,13 +594,13 @@ dependencies = [
  "rand",
  "serde",
  "serde_derive",
- "zerocopy 0.8.23",
+ "zerocopy",
 ]
 
 [[package]]
 name = "caliptra-image-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb1bf9dcc816bddf09d02e64138b310156954781#fb1bf9dcc816bddf09d02e64138b310156954781"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2973c7df95073ef8e6d481e529ebe79ae04f4bae#2973c7df95073ef8e6d481e529ebe79ae04f4bae"
 dependencies = [
  "caliptra-cfi-derive",
  "caliptra-cfi-lib",
@@ -603,54 +609,54 @@ dependencies = [
  "memoffset 0.8.0",
  "serde",
  "serde_derive",
- "zerocopy 0.8.23",
+ "zerocopy",
  "zeroize",
 ]
 
 [[package]]
 name = "caliptra-image-verify"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb1bf9dcc816bddf09d02e64138b310156954781#fb1bf9dcc816bddf09d02e64138b310156954781"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2973c7df95073ef8e6d481e529ebe79ae04f4bae#2973c7df95073ef8e6d481e529ebe79ae04f4bae"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.1",
  "caliptra-cfi-derive",
  "caliptra-cfi-lib",
  "caliptra-drivers",
  "caliptra-image-types",
  "caliptra-registers",
  "memoffset 0.8.0",
- "zerocopy 0.8.23",
+ "zerocopy",
 ]
 
 [[package]]
 name = "caliptra-kat"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb1bf9dcc816bddf09d02e64138b310156954781#fb1bf9dcc816bddf09d02e64138b310156954781"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2973c7df95073ef8e6d481e529ebe79ae04f4bae#2973c7df95073ef8e6d481e529ebe79ae04f4bae"
 dependencies = [
  "caliptra-drivers",
  "caliptra-lms-types",
  "caliptra-registers",
  "ufmt 0.2.0",
- "zerocopy 0.8.23",
+ "zerocopy",
 ]
 
 [[package]]
 name = "caliptra-lms-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb1bf9dcc816bddf09d02e64138b310156954781#fb1bf9dcc816bddf09d02e64138b310156954781"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2973c7df95073ef8e6d481e529ebe79ae04f4bae#2973c7df95073ef8e6d481e529ebe79ae04f4bae"
 dependencies = [
  "caliptra-cfi-derive",
  "caliptra-cfi-lib",
  "serde",
  "serde_derive",
- "zerocopy 0.8.23",
+ "zerocopy",
  "zeroize",
 ]
 
 [[package]]
 name = "caliptra-registers"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb1bf9dcc816bddf09d02e64138b310156954781#fb1bf9dcc816bddf09d02e64138b310156954781"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2973c7df95073ef8e6d481e529ebe79ae04f4bae#2973c7df95073ef8e6d481e529ebe79ae04f4bae"
 dependencies = [
  "caliptra-registers-latest",
 ]
@@ -658,7 +664,7 @@ dependencies = [
 [[package]]
 name = "caliptra-registers-latest"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb1bf9dcc816bddf09d02e64138b310156954781#fb1bf9dcc816bddf09d02e64138b310156954781"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2973c7df95073ef8e6d481e529ebe79ae04f4bae#2973c7df95073ef8e6d481e529ebe79ae04f4bae"
 dependencies = [
  "ureg",
 ]
@@ -666,10 +672,10 @@ dependencies = [
 [[package]]
 name = "caliptra-runtime"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb1bf9dcc816bddf09d02e64138b310156954781#fb1bf9dcc816bddf09d02e64138b310156954781"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2973c7df95073ef8e6d481e529ebe79ae04f4bae#2973c7df95073ef8e6d481e529ebe79ae04f4bae"
 dependencies = [
  "arrayvec",
- "bitflags 2.6.0",
+ "bitflags 2.9.1",
  "caliptra-auth-man-types",
  "caliptra-cfi-derive-git",
  "caliptra-cfi-lib-git",
@@ -691,14 +697,14 @@ dependencies = [
  "platform",
  "ufmt 0.2.0",
  "ureg",
- "zerocopy 0.8.23",
+ "zerocopy",
  "zeroize",
 ]
 
 [[package]]
 name = "caliptra-test"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb1bf9dcc816bddf09d02e64138b310156954781#fb1bf9dcc816bddf09d02e64138b310156954781"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2973c7df95073ef8e6d481e529ebe79ae04f4bae#2973c7df95073ef8e6d481e529ebe79ae04f4bae"
 dependencies = [
  "anyhow",
  "asn1",
@@ -717,24 +723,25 @@ dependencies = [
  "caliptra-image-verify",
  "caliptra-runtime",
  "caliptra_common",
+ "der",
  "dpe",
  "elf",
  "openssl",
  "rand",
  "regex",
  "ureg",
- "zerocopy 0.8.23",
+ "zerocopy",
 ]
 
 [[package]]
 name = "caliptra-test-harness-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb1bf9dcc816bddf09d02e64138b310156954781#fb1bf9dcc816bddf09d02e64138b310156954781"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2973c7df95073ef8e6d481e529ebe79ae04f4bae#2973c7df95073ef8e6d481e529ebe79ae04f4bae"
 
 [[package]]
 name = "caliptra-x509"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb1bf9dcc816bddf09d02e64138b310156954781#fb1bf9dcc816bddf09d02e64138b310156954781"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2973c7df95073ef8e6d481e529ebe79ae04f4bae#2973c7df95073ef8e6d481e529ebe79ae04f4bae"
 dependencies = [
  "zeroize",
 ]
@@ -742,19 +749,22 @@ dependencies = [
 [[package]]
 name = "caliptra_common"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb1bf9dcc816bddf09d02e64138b310156954781#fb1bf9dcc816bddf09d02e64138b310156954781"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2973c7df95073ef8e6d481e529ebe79ae04f4bae#2973c7df95073ef8e6d481e529ebe79ae04f4bae"
 dependencies = [
  "bitfield",
- "bitflags 2.6.0",
+ "bitflags 2.9.1",
  "caliptra-api",
+ "caliptra-cfi-lib",
  "caliptra-cpu",
  "caliptra-drivers",
+ "caliptra-error",
  "caliptra-image-types",
  "caliptra-image-verify",
  "caliptra-registers",
+ "memoffset 0.8.0",
  "riscv 0.13.0",
  "ufmt 0.2.0",
- "zerocopy 0.8.23",
+ "zerocopy",
  "zeroize",
 ]
 
@@ -803,7 +813,7 @@ dependencies = [
  "registers-generated",
  "romtime",
  "ureg",
- "zerocopy 0.8.23",
+ "zerocopy",
 ]
 
 [[package]]
@@ -826,9 +836,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.3"
+version = "1.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27f657647bcff5394bf56c7317665bbf790a137a50eaaa5c6bfbb9e27a518f2d"
+checksum = "d0fc897dc1e865cc67c0e05a836d9d3f1df3cbe442aa4a9473b18e12624a4951"
 dependencies = [
  "shlex",
 ]
@@ -847,9 +857,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.39"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -857,7 +867,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -884,9 +894,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.23"
+version = "4.5.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3135e7ec2ef7b10c6ed8950f0f792ed96ee093fa088608f1c76e569722700c84"
+checksum = "fd60e63e9be68e5fb56422e397cf9baddded06dae1d2e523401542383bc72a9f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -903,9 +913,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.23"
+version = "4.5.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30582fc632330df2bd26877bde0c1f4470d57c582bbc070376afcd04d8cb4838"
+checksum = "89cc6392a1f72bbeb820d71f32108f61fdaf18bc526e1d23954168a67759ef51"
 dependencies = [
  "anstream",
  "anstyle",
@@ -918,14 +928,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.18"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -964,10 +974,10 @@ name = "compliance-test"
 version = "0.1.0"
 dependencies = [
  "caliptra-emu-types",
- "clap 4.5.23",
+ "clap 4.5.39",
  "emulator-bus",
  "emulator-cpu",
- "getrandom",
+ "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -1002,7 +1012,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.16",
  "once_cell",
  "tiny-keccak",
 ]
@@ -1021,18 +1031,18 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "crc"
-version = "3.2.1"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636"
+checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
 dependencies = [
  "crc-catalog",
 ]
@@ -1064,11 +1074,11 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.1",
  "crossterm_winapi",
  "mio",
  "parking_lot",
- "rustix",
+ "rustix 0.38.44",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -1092,7 +1102,7 @@ checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 [[package]]
 name = "crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb1bf9dcc816bddf09d02e64138b310156954781#fb1bf9dcc816bddf09d02e64138b310156954781"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2973c7df95073ef8e6d481e529ebe79ae04f4bae#2973c7df95073ef8e6d481e529ebe79ae04f4bae"
 dependencies = [
  "arrayvec",
  "caliptra-cfi-derive-git",
@@ -1134,19 +1144,19 @@ dependencies = [
 
 [[package]]
 name = "ctrlc"
-version = "3.4.5"
+version = "3.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90eeab0aa92f3f9b4e87f258c72b139c207d251f9cbc1080a0086b86a8870dd3"
+checksum = "46f93780a459b7d656ef7f071fe699c4d3d2cb201c4b24d085b6ddc505276e73"
 dependencies = [
- "nix 0.29.0",
+ "nix 0.30.1",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "darling"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -1154,45 +1164,57 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.90",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "der"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
+ "der_derive",
  "pem-rfc7468",
  "zeroize",
 ]
 
 [[package]]
-name = "deranged"
-version = "0.3.11"
+name = "der_derive"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "deranged"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
 ]
@@ -1222,9 +1244,9 @@ dependencies = [
 
 [[package]]
 name = "document-features"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb6969eaabd2421f8a2775cfd2471a2b634372b4a25d41e3bd647b79912850a0"
+checksum = "95249b50c6c185bee49034bcb378a49dc2b5dff0be90ff6616d31d64febab05d"
 dependencies = [
  "litrs",
 ]
@@ -1232,9 +1254,9 @@ dependencies = [
 [[package]]
 name = "dpe"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb1bf9dcc816bddf09d02e64138b310156954781#fb1bf9dcc816bddf09d02e64138b310156954781"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2973c7df95073ef8e6d481e529ebe79ae04f4bae#2973c7df95073ef8e6d481e529ebe79ae04f4bae"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.1",
  "caliptra-cfi-derive-git",
  "caliptra-cfi-lib-git",
  "cfg-if",
@@ -1242,7 +1264,7 @@ dependencies = [
  "crypto",
  "platform",
  "ufmt 0.2.0",
- "zerocopy 0.8.23",
+ "zerocopy",
  "zeroize",
 ]
 
@@ -1307,7 +1329,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1367,7 +1389,7 @@ dependencies = [
  "caliptra-image-types",
  "caliptra-test",
  "chrono",
- "clap 4.5.23",
+ "clap 4.5.39",
  "clap-num",
  "crc",
  "crossterm",
@@ -1400,7 +1422,7 @@ dependencies = [
  "tempfile",
  "tock-registers",
  "uuid",
- "zerocopy 0.8.23",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1433,7 +1455,7 @@ dependencies = [
  "caliptra-emu-periph",
  "caliptra-hw-model",
  "caliptra-registers",
- "clap 4.5.23",
+ "clap 4.5.39",
  "ctrlc",
  "elf",
  "gdbstub",
@@ -1491,7 +1513,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tock-registers",
- "zerocopy 0.8.23",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1512,15 +1534,15 @@ source = "git+https://github.com/tock/tock.git?rev=b128ae817b86706c8c4e39d27fae5
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.10"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -1550,7 +1572,7 @@ dependencies = [
  "pldm-common",
  "portable-atomic",
  "romtime",
- "zerocopy 0.8.23",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1561,9 +1583,9 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ff"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
  "rand_core",
  "subtle",
@@ -1679,7 +1701,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1749,13 +1771,25 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -1796,9 +1830,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 
 [[package]]
 name = "heapless"
@@ -1859,14 +1893,15 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.61"
+version = "0.1.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
+ "log",
  "wasm-bindgen",
  "windows-core",
 ]
@@ -1923,19 +1958,19 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.3",
 ]
 
 [[package]]
 name = "inout"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "block-padding",
  "generic-array",
@@ -1949,15 +1984,15 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -2009,14 +2044,14 @@ dependencies = [
  "libtockasync",
  "pldm-common",
  "pldm-lib",
- "zerocopy 0.8.23",
+ "zerocopy",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.168"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libsyscall-caliptra"
@@ -2152,9 +2187,15 @@ checksum = "9afa463f5405ee81cdb9cc2baf37e08ec7e4c8209442b5d72c04cfb2cd6e6286"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litrs"
@@ -2164,9 +2205,9 @@ checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -2174,9 +2215,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.26"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "managed"
@@ -2206,7 +2247,7 @@ dependencies = [
  "subst",
  "tempfile",
  "walkdir",
- "zerocopy 0.8.23",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2284,7 +2325,7 @@ dependencies = [
  "tock-registers",
  "uio",
  "ureg",
- "zerocopy 0.8.23",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2293,7 +2334,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "same-file",
- "winnow 0.7.4",
+ "winnow 0.7.10",
 ]
 
 [[package]]
@@ -2440,14 +2481,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
  "log",
- "wasi",
- "windows-sys 0.52.0",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2465,11 +2506,11 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.29.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2489,7 +2530,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2519,7 +2560,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2533,9 +2574,15 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "opaque-debug"
@@ -2546,10 +2593,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 [[package]]
 name = "openssl"
 version = "0.10.72"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
+source = "git+https://github.com/teythoon/rust-openssl.git?branch=justus%2Fpqc#4ada1c1d7c264e052e7bb71ecddbd196a5c2a0c7"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.1",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2561,28 +2607,26 @@ dependencies = [
 [[package]]
 name = "openssl-macros"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+source = "git+https://github.com/teythoon/rust-openssl.git?branch=justus%2Fpqc#4ada1c1d7c264e052e7bb71ecddbd196a5c2a0c7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "openssl-src"
-version = "300.4.1+3.4.0"
+version = "300.5.0+3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faa4eac4138c62414b5622d1b31c5c304f34b406b013c079c2bbc652fdd6678c"
+checksum = "e8ce546f549326b0e6052b649198487d91320875da901e7bd11a06d1ee3f9c2f"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.107"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07"
+version = "0.9.108"
+source = "git+https://github.com/teythoon/rust-openssl.git?branch=justus%2Fpqc#4ada1c1d7c264e052e7bb71ecddbd196a5c2a0c7"
 dependencies = [
  "cc",
  "libc",
@@ -2599,9 +2643,9 @@ checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
 
 [[package]]
 name = "p384"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70786f51bcc69f6a4c0360e063a4cac5419ef7c5cd5b3c99ad70f3be5ba79209"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -2611,9 +2655,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -2621,9 +2665,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
@@ -2671,14 +2715,14 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "platform"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb1bf9dcc816bddf09d02e64138b310156954781#fb1bf9dcc816bddf09d02e64138b310156954781"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2973c7df95073ef8e6d481e529ebe79ae04f4bae#2973c7df95073ef8e6d481e529ebe79ae04f4bae"
 dependencies = [
  "arrayvec",
  "cfg-if",
@@ -2690,7 +2734,7 @@ name = "pldm-common"
 version = "0.1.0"
 dependencies = [
  "bitfield",
- "zerocopy 0.8.23",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2698,13 +2742,13 @@ name = "pldm-fw-pkg"
 version = "0.1.0"
 dependencies = [
  "chrono",
- "clap 4.5.23",
+ "clap 4.5.39",
  "crc",
  "num-derive",
  "num-traits",
  "serde",
  "tempfile",
- "toml 0.8.19",
+ "toml 0.8.22",
  "uuid",
 ]
 
@@ -2752,9 +2796,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
+checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
 
 [[package]]
 name = "powerfmt"
@@ -2764,11 +2808,11 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.7.35",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2782,11 +2826,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
+checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
 dependencies = [
- "toml_edit 0.22.22",
+ "toml_edit 0.22.26",
 ]
 
 [[package]]
@@ -2797,21 +2841,27 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.92"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "rand"
@@ -2840,16 +2890,16 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.16",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.7"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
+checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -2954,7 +3004,7 @@ checksum = "e8c4aa1ea1af6dcc83a61be12e8189f9b293c3ba5a487778a4cd89fb060fdbbc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2972,27 +3022,40 @@ dependencies = [
  "registers-generated",
  "tock-registers",
  "ureg",
- "zerocopy 0.8.23",
+ "zerocopy",
 ]
 
 [[package]]
 name = "rustix"
-version = "0.38.42"
+version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.1",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+dependencies = [
+ "bitflags 2.9.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.4",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "rustversion"
-version = "1.0.18"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
 name = "rv32i"
@@ -3007,9 +3070,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.18"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "same-file"
@@ -3042,15 +3105,15 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.23"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "serde"
-version = "1.0.215"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
@@ -3070,20 +3133,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.215"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.133"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",
@@ -3102,9 +3165,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -3129,9 +3192,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -3150,9 +3213,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.2"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
 dependencies = [
  "libc",
 ]
@@ -3190,9 +3253,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "smlang"
@@ -3267,7 +3330,7 @@ dependencies = [
  "libtock_console",
  "libtock_platform",
  "rand",
- "zerocopy 0.8.23",
+ "zerocopy",
 ]
 
 [[package]]
@@ -3356,9 +3419,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.90"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3375,24 +3438,24 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.14.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
- "cfg-if",
  "fastrand",
+ "getrandom 0.3.3",
  "once_cell",
- "rustix",
+ "rustix 1.0.7",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "terminal_size"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5352447f921fda68cf61b4101566c0bdb5104eff6804d0678e5227580ab6a4e9"
+checksum = "45c6481c4829e4cc63825e62c49186a34538b7b2750b73b266581ffb612fb5ed"
 dependencies = [
- "rustix",
+ "rustix 1.0.7",
  "windows-sys 0.59.0",
 ]
 
@@ -3414,9 +3477,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
 
 [[package]]
 name = "thiserror"
@@ -3435,7 +3498,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3445,9 +3508,9 @@ source = "git+https://github.com/tock/tock.git?rev=b128ae817b86706c8c4e39d27fae5
 
 [[package]]
 name = "time"
-version = "0.3.37"
+version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
 dependencies = [
  "deranged",
  "itoa",
@@ -3462,15 +3525,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
 
 [[package]]
 name = "time-macros"
-version = "0.2.19"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
+checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
 dependencies = [
  "num-conv",
  "time-core",
@@ -3514,21 +3577,21 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.19"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+checksum = "05ae329d1f08c4d17a59bed7ff5b5a769d062e64a62d34a3261b219e62cd5aae"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.22",
+ "toml_edit 0.22.26",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
 dependencies = [
  "serde",
 ]
@@ -3539,7 +3602,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.7.0",
+ "indexmap 2.9.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -3548,22 +3611,29 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.22"
+version = "0.22.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
 dependencies = [
- "indexmap 2.7.0",
+ "indexmap 2.9.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.20",
+ "toml_write",
+ "winnow 0.7.10",
 ]
 
 [[package]]
-name = "typenum"
-version = "1.17.0"
+name = "toml_write"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+checksum = "bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076"
+
+[[package]]
+name = "typenum"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "ufmt"
@@ -3627,15 +3697,15 @@ dependencies = [
 
 [[package]]
 name = "unicase"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e51b68083f157f853b6379db119d1c1be0e6e4dec98101079dec41f6f5cf6df"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.14"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-width"
@@ -3662,7 +3732,7 @@ dependencies = [
 [[package]]
 name = "ureg"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fb1bf9dcc816bddf09d02e64138b310156954781#fb1bf9dcc816bddf09d02e64138b310156954781"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2973c7df95073ef8e6d481e529ebe79ae04f4bae#2973c7df95073ef8e6d481e529ebe79ae04f4bae"
 
 [[package]]
 name = "utf8parse"
@@ -3672,11 +3742,13 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.11.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
+checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 dependencies = [
+ "js-sys",
  "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3708,35 +3780,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.99"
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.101",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3744,22 +3826,25 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.101",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "winapi"
@@ -3794,11 +3879,61 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
-version = "0.52.0"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -3808,15 +3943,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3960,20 +4086,20 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.20"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
+checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
-name = "winnow"
-version = "0.7.4"
+name = "wit-bindgen-rt"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "memchr",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -3981,7 +4107,7 @@ name = "xtask"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 4.5.23",
+ "clap 4.5.39",
  "crc32fast",
  "elf",
  "emulator-consts",
@@ -3998,50 +4124,29 @@ dependencies = [
  "serde-hjson",
  "sudo",
  "tempfile",
- "toml 0.8.19",
+ "toml 0.8.22",
  "walkdir",
- "zerocopy 0.8.23",
+ "zerocopy",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
 dependencies = [
- "byteorder",
- "zerocopy-derive 0.7.35",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd97444d05a4328b90e75e503a34bad781f14e28a823ad3557f0750df1ebcbc6"
-dependencies = [
- "zerocopy-derive 0.8.23",
+ "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.35"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6352c01d0edd5db859a63e2605f4ea3183ddbd15e2c4a9e7d32184df75e4f154"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.90",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4061,5 +4166,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.101",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,6 +105,7 @@ nix = "0.26.2"
 num_enum = "0.7.2"
 num-derive = "0.4.2"
 num-traits = "0.2"
+openssl = { version = "0.10", features = ["vendored"] }
 portable-atomic = "1.7.0"
 p384 = "0.13.0"
 prettyplease = "0.2.31"
@@ -182,29 +183,28 @@ libtock_runtime = { path = "runtime/userspace/libtock/runtime" }
 libtock_small_panic = { path = "runtime/userspace/libtock/panic_handlers/small_panic" }
 libtock_unittest = { path = "runtime/userspace/libtock/unittest" }
 
-
 # caliptra dependencies; keep git revs in sync
-caliptra-api = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fb1bf9dcc816bddf09d02e64138b310156954781" }
-caliptra-api-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fb1bf9dcc816bddf09d02e64138b310156954781" }
-caliptra-auth-man-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fb1bf9dcc816bddf09d02e64138b310156954781" }
-caliptra-auth-man-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fb1bf9dcc816bddf09d02e64138b310156954781" }
-caliptra-builder = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fb1bf9dcc816bddf09d02e64138b310156954781" }
-caliptra-emu-bus = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fb1bf9dcc816bddf09d02e64138b310156954781" }
-caliptra-emu-cpu = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fb1bf9dcc816bddf09d02e64138b310156954781" }
-caliptra-emu-periph = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fb1bf9dcc816bddf09d02e64138b310156954781" }
-caliptra-emu-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fb1bf9dcc816bddf09d02e64138b310156954781" }
-caliptra-error = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fb1bf9dcc816bddf09d02e64138b310156954781", default-features = false }
-caliptra-hw-model = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fb1bf9dcc816bddf09d02e64138b310156954781" }
-caliptra-hw-model-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fb1bf9dcc816bddf09d02e64138b310156954781" }
-caliptra-image-crypto = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fb1bf9dcc816bddf09d02e64138b310156954781", default-features = false, features = ["rustcrypto"] }
-caliptra-image-fake-keys = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fb1bf9dcc816bddf09d02e64138b310156954781" }
-caliptra-image-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fb1bf9dcc816bddf09d02e64138b310156954781" }
-caliptra-image-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fb1bf9dcc816bddf09d02e64138b310156954781" }
-caliptra-registers = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fb1bf9dcc816bddf09d02e64138b310156954781" }
-caliptra-test = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fb1bf9dcc816bddf09d02e64138b310156954781" }
-caliptra-test-harness-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fb1bf9dcc816bddf09d02e64138b310156954781" }
-ureg = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fb1bf9dcc816bddf09d02e64138b310156954781" }
-dpe = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fb1bf9dcc816bddf09d02e64138b310156954781", default-features = false, features = ["dpe_profile_p384_sha384"] }
+caliptra-api = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "2973c7df95073ef8e6d481e529ebe79ae04f4bae" }
+caliptra-api-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "2973c7df95073ef8e6d481e529ebe79ae04f4bae" }
+caliptra-auth-man-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "2973c7df95073ef8e6d481e529ebe79ae04f4bae" }
+caliptra-auth-man-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "2973c7df95073ef8e6d481e529ebe79ae04f4bae" }
+caliptra-builder = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "2973c7df95073ef8e6d481e529ebe79ae04f4bae" }
+caliptra-emu-bus = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "2973c7df95073ef8e6d481e529ebe79ae04f4bae" }
+caliptra-emu-cpu = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "2973c7df95073ef8e6d481e529ebe79ae04f4bae" }
+caliptra-emu-periph = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "2973c7df95073ef8e6d481e529ebe79ae04f4bae" }
+caliptra-emu-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "2973c7df95073ef8e6d481e529ebe79ae04f4bae" }
+caliptra-error = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "2973c7df95073ef8e6d481e529ebe79ae04f4bae", default-features = false }
+caliptra-hw-model = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "2973c7df95073ef8e6d481e529ebe79ae04f4bae" }
+caliptra-hw-model-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "2973c7df95073ef8e6d481e529ebe79ae04f4bae" }
+caliptra-image-crypto = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "2973c7df95073ef8e6d481e529ebe79ae04f4bae", default-features = false, features = ["rustcrypto"] }
+caliptra-image-fake-keys = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "2973c7df95073ef8e6d481e529ebe79ae04f4bae" }
+caliptra-image-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "2973c7df95073ef8e6d481e529ebe79ae04f4bae" }
+caliptra-image-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "2973c7df95073ef8e6d481e529ebe79ae04f4bae" }
+caliptra-registers = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "2973c7df95073ef8e6d481e529ebe79ae04f4bae" }
+caliptra-test = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "2973c7df95073ef8e6d481e529ebe79ae04f4bae" }
+caliptra-test-harness-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "2973c7df95073ef8e6d481e529ebe79ae04f4bae" }
+ureg = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "2973c7df95073ef8e6d481e529ebe79ae04f4bae" }
+dpe = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "2973c7df95073ef8e6d481e529ebe79ae04f4bae", default-features = false, features = ["dpe_profile_p384_sha384"] }
 
 # local caliptra dependency; useful when developing
 # caliptra-api = { path = "../caliptra-sw/api" }
@@ -218,14 +218,14 @@ dpe = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fb1bf9dcc81
 # caliptra-emu-types = { path = "../caliptra-sw/sw-emulator/lib/types" }
 # caliptra-error = { path = "../caliptra-sw/error", default-features = false }
 # caliptra-hw-model = { path = "../caliptra-sw/hw-model" }
-# caliptra-hw-model-types = { path = "../caliptra-sw/hw-model" }
+# caliptra-hw-model-types = { path = "../caliptra-sw/hw-model/types" }
 # caliptra-image-crypto = { path = "../caliptra-sw/image/crypto", default-features = false, features = ["rustcrypto"] }
 # caliptra-image-fake-keys = { path = "../caliptra-sw/image/fake-keys" }
 # caliptra-image-gen = { path = "../caliptra-sw/image/gen" }
 # caliptra-image-types = { path = "../caliptra-sw/image/types" }
 # caliptra-registers = { path = "../caliptra-sw/registers" }
 # caliptra-test = { path = "../caliptra-sw/test" }
-# caliptra-test-harness-types = { path = "../caliptra-sw/test" }
+# caliptra-test-harness-types = { path = "../caliptra-sw/test-harness/types" }
 # ureg = { path = "../caliptra-sw/ureg" }
 # dpe = { path = "../caliptra-sw/dpe/dpe", default-features = false, features = ["dpe_profile_p384_sha384"] }
 
@@ -257,3 +257,6 @@ debug = true      # Keep debug symbols in the release ELF so that we can debug m
 lto = true
 opt-level = "s"
 codegen-units = 1
+
+[patch.crates-io]
+openssl = { git = "https://github.com/teythoon/rust-openssl.git", branch = "justus/pqc" } # MLDSA

--- a/builder/src/caliptra.rs
+++ b/builder/src/caliptra.rs
@@ -9,8 +9,8 @@ use caliptra_auth_man_gen::{
     AuthManifestGenerator, AuthManifestGeneratorConfig, AuthManifestGeneratorKeyConfig,
 };
 use caliptra_auth_man_types::{
-    Addr64, AuthManifestFlags, AuthManifestImageMetadata, AuthManifestPrivKeys,
-    AuthManifestPubKeys, AuthorizationManifest, ImageMetadataFlags,
+    Addr64, AuthManifestFlags, AuthManifestImageMetadata, AuthManifestPrivKeysConfig,
+    AuthManifestPubKeysConfig, AuthorizationManifest, ImageMetadataFlags,
 };
 use caliptra_image_crypto::RustCrypto as Crypto;
 use caliptra_image_fake_keys::*;
@@ -205,48 +205,56 @@ impl CaliptraBuilder {
         image_metadata_list: Vec<AuthManifestImageMetadata>,
     ) -> AuthorizationManifest {
         let vendor_fw_key_info: AuthManifestGeneratorKeyConfig = AuthManifestGeneratorKeyConfig {
-            pub_keys: AuthManifestPubKeys {
+            pub_keys: AuthManifestPubKeysConfig {
                 ecc_pub_key: VENDOR_ECC_KEY_0_PUBLIC,
                 lms_pub_key: VENDOR_LMS_KEY_0_PUBLIC,
+                mldsa_pub_key: VENDOR_MLDSA_KEY_0_PUBLIC,
             },
-            priv_keys: Some(AuthManifestPrivKeys {
+            priv_keys: Some(AuthManifestPrivKeysConfig {
                 ecc_priv_key: VENDOR_ECC_KEY_0_PRIVATE,
                 lms_priv_key: VENDOR_LMS_KEY_0_PRIVATE,
+                mldsa_priv_key: VENDOR_MLDSA_KEY_0_PRIVATE,
             }),
         };
 
         let vendor_man_key_info: AuthManifestGeneratorKeyConfig = AuthManifestGeneratorKeyConfig {
-            pub_keys: AuthManifestPubKeys {
+            pub_keys: AuthManifestPubKeysConfig {
                 ecc_pub_key: VENDOR_ECC_KEY_1_PUBLIC,
                 lms_pub_key: VENDOR_LMS_KEY_1_PUBLIC,
+                mldsa_pub_key: VENDOR_MLDSA_KEY_0_PUBLIC,
             },
-            priv_keys: Some(AuthManifestPrivKeys {
+            priv_keys: Some(AuthManifestPrivKeysConfig {
                 ecc_priv_key: VENDOR_ECC_KEY_1_PRIVATE,
                 lms_priv_key: VENDOR_LMS_KEY_1_PRIVATE,
+                mldsa_priv_key: VENDOR_MLDSA_KEY_0_PRIVATE,
             }),
         };
 
         let owner_fw_key_info: Option<AuthManifestGeneratorKeyConfig> =
             Some(AuthManifestGeneratorKeyConfig {
-                pub_keys: AuthManifestPubKeys {
+                pub_keys: AuthManifestPubKeysConfig {
                     ecc_pub_key: OWNER_ECC_KEY_PUBLIC,
                     lms_pub_key: OWNER_LMS_KEY_PUBLIC,
+                    mldsa_pub_key: OWNER_MLDSA_KEY_PUBLIC,
                 },
-                priv_keys: Some(AuthManifestPrivKeys {
+                priv_keys: Some(AuthManifestPrivKeysConfig {
                     ecc_priv_key: OWNER_ECC_KEY_PRIVATE,
                     lms_priv_key: OWNER_LMS_KEY_PRIVATE,
+                    mldsa_priv_key: OWNER_MLDSA_KEY_PRIVATE,
                 }),
             });
 
         let owner_man_key_info: Option<AuthManifestGeneratorKeyConfig> =
             Some(AuthManifestGeneratorKeyConfig {
-                pub_keys: AuthManifestPubKeys {
+                pub_keys: AuthManifestPubKeysConfig {
                     ecc_pub_key: OWNER_ECC_KEY_PUBLIC,
                     lms_pub_key: OWNER_LMS_KEY_PUBLIC,
+                    mldsa_pub_key: OWNER_MLDSA_KEY_PUBLIC,
                 },
-                priv_keys: Some(AuthManifestPrivKeys {
+                priv_keys: Some(AuthManifestPrivKeysConfig {
                     ecc_priv_key: OWNER_ECC_KEY_PRIVATE,
                     lms_priv_key: OWNER_LMS_KEY_PRIVATE,
+                    mldsa_priv_key: OWNER_MLDSA_KEY_PRIVATE,
                 }),
             });
 
@@ -258,6 +266,7 @@ impl CaliptraBuilder {
             image_metadata_list,
             version: 1,
             flags: AuthManifestFlags::VENDOR_SIGNATURE_REQUIRED,
+            pqc_key_type: FwVerificationPqcKeyType::LMS,
         };
 
         let gen = AuthManifestGenerator::new(Crypto::default());

--- a/emulator/bmc/pldm-fw-pkg/src/manifest.rs
+++ b/emulator/bmc/pldm-fw-pkg/src/manifest.rs
@@ -841,7 +841,7 @@ impl FirmwareDeviceIdRecord {
         }
 
         // Encode applicable_components
-        let mut bitmap = vec![0u8; ((component_bitmap_length + 7) / 8) as usize];
+        let mut bitmap = vec![0u8; component_bitmap_length.div_ceil(8) as usize];
         let num_components = component_bitmap_length;
         if let Some(ref components) = self.applicable_components {
             for &component in components {
@@ -929,7 +929,7 @@ impl FirmwareDeviceIdRecord {
         }
 
         // Decode applicable_components
-        let mut bitmap = vec![0u8; ((component_bitmap_length + 7) / 8) as usize];
+        let mut bitmap = vec![0u8; component_bitmap_length.div_ceil(8) as usize];
         let num_components = component_bitmap_length;
         reader.read_exact(&mut bitmap)?;
 
@@ -1020,7 +1020,7 @@ impl FirmwareDeviceIdRecord {
         total_size += 4; // reference_manifest_length (u32)
 
         // applicable_components bitmap
-        total_size += ((component_bitmap_length + 7) / 8) as usize;
+        total_size += component_bitmap_length.div_ceil(8) as usize;
 
         // component_image_set_version_string
         if let Some(ref version_string) = self.component_image_set_version_string {
@@ -1162,7 +1162,7 @@ impl DownstreamDeviceIdRecord {
         }
 
         // Encode applicable_components
-        let mut bitmap = vec![0u8; ((component_bitmap_length + 7) / 8) as usize];
+        let mut bitmap = vec![0u8; component_bitmap_length.div_ceil(8) as usize];
         let num_components = component_bitmap_length;
         if let Some(ref components) = self.applicable_components {
             for &component in components {
@@ -1252,7 +1252,7 @@ impl DownstreamDeviceIdRecord {
 
         // Decode applicable_components
         // Read the bitmap from the reader
-        let mut bitmap = vec![0u8; ((component_bitmap_length + 7) / 8) as usize];
+        let mut bitmap = vec![0u8; component_bitmap_length.div_ceil(8) as usize];
         let num_components = component_bitmap_length;
         reader.read_exact(&mut bitmap)?;
 
@@ -1342,7 +1342,7 @@ impl DownstreamDeviceIdRecord {
         total_size += 4; // reference_manifest_length (u32)
 
         // applicable_components bitmap
-        total_size += ((component_bitmap_length + 7) / 8) as usize;
+        total_size += component_bitmap_length.div_ceil(8) as usize;
 
         // self_contained_activation_min_version_string
         if let Some(ref version_string) = self.self_contained_activation_min_version_string {

--- a/emulator/bus/src/ram.rs
+++ b/emulator/bus/src/ram.rs
@@ -64,7 +64,7 @@ impl Bus for Ram {
     /// # Error
     ///
     /// * `BusException` - Exception with cause `BusExceptionCause::LoadAccessFault`
-    ///                   or `BusExceptionCause::LoadAddrMisaligned`
+    ///   or `BusExceptionCause::LoadAddrMisaligned`
     fn read(&mut self, size: RvSize, addr: RvAddr) -> Result<RvData, BusError> {
         if 2 == self.error_injection {
             return Err(BusError::InstrAccessFault);
@@ -89,7 +89,7 @@ impl Bus for Ram {
     /// # Error
     ///
     /// * `BusException` - Exception with cause `BusExceptionCause::StoreAccessFault`
-    ///                   or `BusExceptionCause::StoreAddrMisaligned`
+    ///   or `BusExceptionCause::StoreAddrMisaligned`
     fn write(&mut self, size: RvSize, addr: RvAddr, val: RvData) -> Result<(), BusError> {
         match self.data.write(size, addr, val) {
             Ok(data) => Ok(data),

--- a/emulator/bus/src/rom.rs
+++ b/emulator/bus/src/rom.rs
@@ -64,7 +64,7 @@ impl Bus for Rom {
     /// # Error
     ///
     /// * `BusException` - Exception with cause `BusExceptionCause::LoadAccessFault`
-    ///                   or `BusExceptionCause::LoadAddrMisaligned`
+    ///   or `BusExceptionCause::LoadAddrMisaligned`
     fn read(&mut self, size: RvSize, addr: RvAddr) -> Result<RvData, BusError> {
         match self.data.read(size, addr) {
             Ok(data) => Ok(data),
@@ -83,7 +83,7 @@ impl Bus for Rom {
     /// # Error
     ///
     /// * `BusException` - Exception with cause `BusExceptionCause::StoreAccessFault`
-    ///                   or `BusExceptionCause::StoreAddrMisaligned`
+    ///   or `BusExceptionCause::StoreAddrMisaligned`
     fn write(&mut self, _size: RvSize, _addr: RvAddr, _value: RvData) -> Result<(), BusError> {
         Err(BusError::StoreAccessFault)
     }

--- a/emulator/bus/src/testing/log.rs
+++ b/emulator/bus/src/testing/log.rs
@@ -77,7 +77,7 @@ impl Default for Log {
 struct LogWriter<'a> {
     log: &'a RefCell<String>,
 }
-impl<'a> Write for LogWriter<'a> {
+impl Write for LogWriter<'_> {
     fn write_str(&mut self, s: &str) -> std::fmt::Result {
         Write::write_str(&mut *self.log.borrow_mut(), s)
     }

--- a/emulator/cpu/src/cpu.rs
+++ b/emulator/cpu/src/cpu.rs
@@ -483,7 +483,7 @@ impl<TBus: Bus> Cpu<TBus> {
     /// # Error
     ///
     /// * `RvException` - Exception with cause `RvExceptionCause::LoadAccessFault`
-    ///                   or `RvExceptionCause::LoadAddrMisaligned`
+    ///   or `RvExceptionCause::LoadAddrMisaligned`
     pub fn read_bus(&mut self, size: RvSize, addr: RvAddr) -> Result<RvData, RvException> {
         // Check if we are in step mode
         if self.is_execute_instr {
@@ -521,7 +521,7 @@ impl<TBus: Bus> Cpu<TBus> {
     /// # Error
     ///
     /// * `RvException` - Exception with cause `RvExceptionCause::StoreAccessFault`
-    ///                   or `RvExceptionCause::StoreAddrMisaligned`
+    ///   or `RvExceptionCause::StoreAddrMisaligned`
     pub fn write_bus(
         &mut self,
         size: RvSize,
@@ -563,7 +563,7 @@ impl<TBus: Bus> Cpu<TBus> {
     /// # Error
     ///
     /// * `RvException` - Exception with cause `RvExceptionCause::LoadAccessFault`
-    ///                   or `RvExceptionCause::LoadAddrMisaligned`
+    ///   or `RvExceptionCause::LoadAddrMisaligned`
     pub fn read_instr(&mut self, size: RvSize, addr: RvAddr) -> Result<RvData, RvException> {
         self.check_mem_priv(addr, size, RvMemAccessType::Execute)?;
 
@@ -900,8 +900,7 @@ mod tests {
         let mut bus = DynamicBus::new();
 
         let ram = Ram::new(
-            std::iter::repeat(fill_val)
-                .take(128)
+            std::iter::repeat_n(fill_val, 128)
                 .flat_map(u32::to_le_bytes)
                 .collect(),
         );
@@ -1744,8 +1743,7 @@ mod tests {
         let mut bus = DynamicBus::new();
 
         let rom = Rom::new(
-            std::iter::repeat(RV32_NO_OP)
-                .take(256)
+            std::iter::repeat_n(RV32_NO_OP, 256)
                 .flat_map(u32::to_le_bytes)
                 .collect(),
         );
@@ -1812,8 +1810,7 @@ mod tests {
         let mut bus = DynamicBus::new();
 
         let rom = Rom::new(
-            std::iter::repeat(RV32_NO_OP)
-                .take(256)
+            std::iter::repeat_n(RV32_NO_OP, 256)
                 .flat_map(u32::to_le_bytes)
                 .collect(),
         );

--- a/emulator/cpu/src/instr/mod.rs
+++ b/emulator/cpu/src/instr/mod.rs
@@ -89,7 +89,7 @@ impl<TBus: Bus> Cpu<TBus> {
     /// # Error
     ///
     /// * `RvException` - Exception with cause `RvExceptionCause::InstrAccessFault`
-    ///                   or `RvExceptionCause::InstrAddrMisaligned`
+    ///   or `RvExceptionCause::InstrAddrMisaligned`
     fn fetch(&mut self) -> Result<Instr, RvException> {
         let instr = self.read_instr(RvSize::HalfWord, self.read_pc())?;
         match instr & 0b11 {

--- a/emulator/derive/src/util/token_iter.rs
+++ b/emulator/derive/src/util/token_iter.rs
@@ -29,7 +29,7 @@ pub struct FieldWithAttributes {
 }
 
 pub struct DisplayToken<'a>(pub &'a Option<TokenTree>);
-impl<'a> Display for DisplayToken<'a> {
+impl Display for DisplayToken<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self.0 {
             Some(TokenTree::Ident(i)) => write!(f, "identifier {}", i),

--- a/emulator/periph/src/emu_ctrl.rs
+++ b/emulator/periph/src/emu_ctrl.rs
@@ -53,7 +53,7 @@ impl Bus for EmuCtrl {
     /// # Error
     ///
     /// * `RvException` - Exception with cause `RvExceptionCause::LoadAccessFault`
-    ///                   or `RvExceptionCause::LoadAddrMisaligned`
+    ///   or `RvExceptionCause::LoadAddrMisaligned`
     fn read(&mut self, size: RvSize, addr: RvAddr) -> Result<RvData, BusError> {
         match (size, addr) {
             (RvSize::Word, EmuCtrl::ADDR_EXIT) => Ok(0),
@@ -72,7 +72,7 @@ impl Bus for EmuCtrl {
     /// # Error
     ///
     /// * `RvException` - Exception with cause `RvExceptionCause::StoreAccessFault`
-    ///                   or `RvExceptionCause::StoreAddrMisaligned`
+    ///   or `RvExceptionCause::StoreAddrMisaligned`
     fn write(&mut self, _size: RvSize, addr: RvAddr, val: RvData) -> Result<(), BusError> {
         match addr {
             EmuCtrl::ADDR_EXIT => {

--- a/emulator/periph/src/spi_flash.rs
+++ b/emulator/periph/src/spi_flash.rs
@@ -176,8 +176,8 @@ pub struct SpiFlashImpl {
     state: FlashState,
 }
 
-impl<'a> SpiFlashImpl {
-    const SUPPORTED_FLASH: &'a [FlashPartInfo] = &[FlashPartInfo {
+impl SpiFlashImpl {
+    const SUPPORTED_FLASH: &[FlashPartInfo] = &[FlashPartInfo {
         part_name: "w25q01jv",
         id: &[0xef, 0x40, 0x21],
         chip_size: 256 * 1024 * 1024,

--- a/emulator/periph/src/uart.rs
+++ b/emulator/periph/src/uart.rs
@@ -100,7 +100,7 @@ impl Bus for Uart {
     /// # Error
     ///
     /// * `RvException` - Exception with cause `RvExceptionCause::LoadAccessFault`
-    ///                   or `RvExceptionCause::LoadAddrMisaligned`
+    ///   or `RvExceptionCause::LoadAddrMisaligned`
     fn read(&mut self, size: RvSize, addr: RvAddr) -> Result<RvData, BusError> {
         match (size, addr) {
             (RvSize::Byte, Uart::ADDR_BIT_RATE) => Ok(self.bit_rate as RvData),
@@ -135,7 +135,7 @@ impl Bus for Uart {
     /// # Error
     ///
     /// * `RvException` - Exception with cause `RvExceptionCause::StoreAccessFault`
-    ///                   or `RvExceptionCause::StoreAddrMisaligned`
+    ///   or `RvExceptionCause::StoreAddrMisaligned`
     fn write(&mut self, size: RvSize, addr: RvAddr, value: RvData) -> Result<(), BusError> {
         match (size, addr) {
             (RvSize::Byte, Uart::ADDR_BIT_RATE) => self.bit_rate = value as u8,

--- a/hw/fpga/kernel-modules/io_module.c
+++ b/hw/fpga/kernel-modules/io_module.c
@@ -84,10 +84,10 @@ int init_module(void)
     uio_info1.name = caliptra_dev_name1;
     uio_info1.version = "1.0.0";
 
-    // SS Wrapper
-    uio_info1.mem[0].name = "ss_wrapper";
-    uio_info1.mem[0].addr = 0xA4010000;
-    uio_info1.mem[0].size = 0x00010000;
+    // LC
+    uio_info1.mem[0].name = "lc";
+    uio_info1.mem[0].addr = 0xA4040000;
+    uio_info1.mem[0].size = 0x00002000;
     uio_info1.mem[0].memtype = UIO_MEM_PHYS;
 
     // MCU ROM Backdoor
@@ -108,10 +108,10 @@ int init_module(void)
     uio_info1.mem[3].size = 0x01000000;
     uio_info1.mem[3].memtype = UIO_MEM_PHYS;
 
-    // MCU ROM Frontdoor
-    uio_info1.mem[4].name = "mcu_frontdoor_rom";
-    uio_info1.mem[4].addr = 0xB0040000;
-    uio_info1.mem[4].size = 0x00020000;
+    // OTP
+    uio_info1.mem[4].name = "otp";
+    uio_info1.mem[4].addr = 0xA4060000;
+    uio_info1.mem[4].size = 0x00002000;
     uio_info1.mem[4].memtype = UIO_MEM_PHYS;
 
 

--- a/hw/model/src/fpga_regs.rs
+++ b/hw/model/src/fpga_regs.rs
@@ -1,0 +1,95 @@
+// Licensed under the Apache-2.0 license.
+
+#![allow(dead_code)]
+
+use tock_registers::registers::{ReadOnly, ReadWrite, WriteOnly};
+use tock_registers::{register_bitfields, register_structs};
+
+register_bitfields! {
+    u32,
+    pub Control [
+        CptraPwrgood OFFSET(0) NUMBITS(1) [],
+        CptraSsRstB OFFSET(1) NUMBITS(1) [],
+        CptraObfUdsSeedVld OFFSET(2) NUMBITS(1) [],
+        CptraObfFieldEntropyVld OFFSET(3) NUMBITS(1) [],
+        ForceMcuDmiCoreEnable OFFSET(4) NUMBITS(1) [],
+        ForceMcuDmiUncoreEnable OFFSET(5) NUMBITS(1) [],
+        BootfsmBrkpoint OFFSET(6) NUMBITS(1) [],
+        SsDebugIntent OFFSET(7) NUMBITS(1) [],
+        I3cAxiUserIdFiltering OFFSET(8) NUMBITS(1) [],
+    ],
+    pub MciError [
+        MciErrorFatal OFFSET(0) NUMBITS(1) [],
+        MciErrorNonFatal OFFSET(1) NUMBITS(1) [],
+    ],
+    pub McuConfig [
+        McuNoRomConfig OFFSET(0) NUMBITS(1) [],
+        CptraSsMciBootSeqBrkpointI OFFSET(1) NUMBITS(1) [],
+        CptraSsLcAllowRmaOnPpdI OFFSET(2) NUMBITS(1) [],
+        CptraSsLcCtrlScanRstNiI OFFSET(3) NUMBITS(1) [],
+        CptraSsLcEsclateScrapState0I OFFSET(4) NUMBITS(1) [],
+        CptraSsLcEsclateScrapState1I OFFSET(5) NUMBITS(1) [],
+    ],
+    pub Status [
+        CptraErrorFatal OFFSET(0) NUMBITS(1) [],
+        CptraErrorNonFatal OFFSET(1) NUMBITS(1) [],
+        ReadyForFuses OFFSET(2) NUMBITS(1) [],
+        ReadyForFwPush OFFSET(3) NUMBITS(1) [],
+        ReadyForRuntime OFFSET(4) NUMBITS(1) [],
+        MailboxDataAvail OFFSET(5) NUMBITS(1) [],
+        MailboxFlowDone OFFSET(6) NUMBITS(1) [],
+    ],
+    pub FifoStatus [
+        Empty OFFSET(0) NUMBITS(1) [],
+        Full OFFSET(1) NUMBITS(1) [],
+    ],
+    pub ItrngFifoStatus [
+        Empty OFFSET(0) NUMBITS(1) [],
+        Full OFFSET(1) NUMBITS(1) [],
+        Reset OFFSET(2) NUMBITS(1) [],
+    ],
+    pub FifoData [
+        NextChar OFFSET(0) NUMBITS(8) [],
+        CharValid OFFSET(8) NUMBITS(1) [],
+    ],
+}
+
+register_structs! {
+    pub FifoRegs {
+        (0x0 => pub log_fifo_data: ReadOnly<u32, FifoData::Register>),
+        (0x4 => pub log_fifo_status: ReadOnly<u32, FifoStatus::Register>),
+        (0x8 => pub itrng_fifo_data: ReadWrite<u32>),
+        (0xc => pub itrng_fifo_status: ReadWrite<u32, ItrngFifoStatus::Register>),
+        (0x10 => pub dbg_fifo_data_pop: ReadOnly<u32, FifoData::Register>),
+        (0x14 => pub dbg_fifo_data_push: WriteOnly<u32, FifoData::Register>),
+        (0x18 => pub dbg_fifo_status: ReadOnly<u32, FifoStatus::Register>),
+        (0x1c => @END),
+    },
+    pub WrapperRegs {
+        (0x0 => pub fpga_magic: ReadOnly<u32>),
+        (0x4 => pub fpga_version: ReadOnly<u32>),
+        (0x8 => pub control: ReadWrite<u32, Control::Register>),
+        (0xc => pub status: ReadOnly<u32, Status::Register>),
+        (0x10 => pub pauser: ReadWrite<u32>),
+        (0x14 => pub itrng_divisor: ReadWrite<u32>),
+        (0x18 => pub cycle_count: ReadOnly<u32>),
+        (0x1c => _reserved0),
+        (0x30 => pub generic_input_wires: [ReadWrite<u32>; 2]),
+        (0x38 => pub generic_output_wires: [ReadOnly<u32>; 2]),
+        (0x40 => pub cptra_obf_key: [ReadWrite<u32>; 8]),
+        (0x60 => pub cptra_csr_hmac_key: [ReadWrite<u32>; 16]),
+        (0xa0 => pub cptra_obf_uds_seed: [ReadWrite<u32>; 16]),
+        (0xe0 => pub cptra_obf_field_entropy: [ReadWrite<u32>; 8]),
+        (0x100 => pub lsu_user: ReadWrite<u32>),
+        (0x104 => pub ifu_user: ReadWrite<u32>),
+        (0x108 => pub clp_user: ReadWrite<u32>),
+        (0x10c => pub soc_config_user: ReadWrite<u32>),
+        (0x110 => pub sram_config_user: ReadWrite<u32>),
+        (0x114 => pub mcu_reset_vector: ReadWrite<u32>),
+        (0x118 => pub mci_error: ReadOnly<u32, MciError::Register>),
+        (0x11c => pub mcu_config: ReadWrite<u32, McuConfig::Register>),
+        (0x120 => pub mci_generic_input_wires: [ReadWrite<u32>; 2]),
+        (0x128 => pub mci_generic_output_wires: [ReadOnly<u32>; 2]),
+        (0x130 => @END),
+    }
+}

--- a/hw/model/src/lib.rs
+++ b/hw/model/src/lib.rs
@@ -3,7 +3,7 @@
 use anyhow::{bail, Result};
 pub use api::mailbox::mbox_write_fifo;
 pub use api_types::{DbgManufServiceRegReq, DeviceLifecycle, Fuses, SecurityState, U4};
-use caliptra_api as api;
+use caliptra_api::{self as api};
 use caliptra_api_types as api_types;
 use caliptra_emu_bus::Event;
 pub use caliptra_emu_cpu::{CodeRange, ImageInfo, StackInfo, StackRange};
@@ -25,6 +25,7 @@ use std::sync::mpsc;
 
 mod bus_logger;
 mod bus_logger_mcu;
+mod fpga_regs;
 mod model_emulated;
 #[cfg(feature = "fpga_realtime")]
 mod model_fpga_realtime;
@@ -89,6 +90,10 @@ pub struct InitParams<'a> {
     // The silicon obfuscation key passed to caliptra_top.
     pub cptra_obf_key: [u32; 8],
 
+    pub csr_hmac_key: [u32; 16],
+
+    pub uds_granularity_64: bool,
+
     // 4-bit nibbles of raw entropy to feed into the internal TRNG (ENTROPY_SRC
     // peripheral).
     pub itrng_nibbles: Box<dyn Iterator<Item = u8> + Send>,
@@ -110,7 +115,7 @@ pub struct InitParams<'a> {
     // overflows.
     pub stack_info: Option<StackInfo>,
 }
-impl<'a> Default for InitParams<'a> {
+impl Default for InitParams<'_> {
     fn default() -> Self {
         let seed = std::env::var("CPTRA_TRNG_SEED")
             .ok()
@@ -137,6 +142,7 @@ impl<'a> Default for InitParams<'a> {
             security_state: *SecurityState::default()
                 .set_device_lifecycle(DeviceLifecycle::Unprovisioned),
             dbg_manuf_service: Default::default(),
+            uds_granularity_64: true,
             active_mode: false,
             prod_dbg_unlock_keypairs: Default::default(),
             debug_intent: false,
@@ -146,6 +152,7 @@ impl<'a> Default for InitParams<'a> {
             random_sram_puf: true,
             trace_path: None,
             stack_info: None,
+            csr_hmac_key: [1; 16],
         }
     }
 }
@@ -186,7 +193,7 @@ pub struct BootParams<'a> {
     pub mcu_fw_image: Option<&'a [u8]>,
 }
 
-impl<'a> Default for BootParams<'a> {
+impl Default for BootParams<'_> {
     fn default() -> Self {
         Self {
             fuses: Default::default(),
@@ -312,6 +319,14 @@ pub trait McuHwModel {
     fn ecc_error_injection(&mut self, _mode: ErrorInjectionMode) {}
 
     fn set_axi_user(&mut self, axi_user: u32);
+
+    fn set_itrng_divider(&mut self, _divider: u32) {}
+
+    fn set_security_state(&mut self, _value: SecurityState) {}
+
+    fn set_generic_input_wires(&mut self, _value: &[u32; 2]) {}
+
+    fn set_caliptra_boot_go(&mut self, _value: bool) {}
 
     fn events_from_caliptra(&mut self) -> Vec<Event>;
 

--- a/hw/model/src/model_emulated.rs
+++ b/hw/model/src/model_emulated.rs
@@ -10,6 +10,7 @@ use crate::Output;
 use anyhow::Result;
 use caliptra_emu_bus::Clock;
 use caliptra_emu_bus::Event;
+use caliptra_emu_cpu::CpuArgs;
 use caliptra_emu_cpu::{Cpu as CaliptraCpu, InstrTracer as CaliptraInstrTracer};
 use caliptra_emu_periph::ActionCb;
 use caliptra_emu_periph::MailboxRequester;
@@ -20,7 +21,7 @@ use caliptra_hw_model_types::ErrorInjectionMode;
 use caliptra_image_types::IMAGE_MANIFEST_BYTE_SIZE;
 use emulator_bus::BusConverter;
 use emulator_bus::Clock as McuClock;
-use emulator_cpu::{Cpu as McuCpu, InstrTracer as McuInstrTracer, Pic};
+use emulator_cpu::{Cpu as McuCpu, InstrTracer as McuInstrTracer};
 use emulator_periph::{I3c, I3cController, Mci, McuRootBus, McuRootBusArgs, Otp};
 use emulator_registers_generated::root_bus::AutoRootBus;
 use std::cell::Cell;
@@ -65,7 +66,8 @@ impl McuHwModel for ModelEmulated {
     where
         Self: Sized,
     {
-        let clock = Clock::new();
+        let clock = Rc::new(Clock::new());
+        let pic = Rc::new(caliptra_emu_cpu::Pic::new());
         let timer = clock.timer();
 
         let ready_for_fw = Rc::new(Cell::new(false));
@@ -99,9 +101,10 @@ impl McuHwModel for ModelEmulated {
 
             itrng_nibbles: Some(params.itrng_nibbles),
             etrng_responses: params.etrng_responses,
+            clock: clock.clone(),
             ..CaliptraRootBusArgs::default()
         };
-        let mut root_bus = CaliptraRootBus::new(&clock, bus_args);
+        let mut root_bus = CaliptraRootBus::new(bus_args);
 
         root_bus
             .soc_reg
@@ -128,7 +131,12 @@ impl McuHwModel for ModelEmulated {
         let soc_to_caliptra_bus2 =
             root_bus.soc_to_caliptra_bus(MailboxRequester::SocUser(DEFAULT_AXI_PAUSER));
         let (events_to_caliptra, events_from_caliptra, caliptra_cpu) = {
-            let mut cpu = CaliptraCpu::new(BusLogger::new(root_bus), clock);
+            let mut cpu = CaliptraCpu::new(
+                BusLogger::new(root_bus),
+                clock.clone(),
+                pic.clone(),
+                CpuArgs::default(),
+            );
             if let Some(stack_info) = params.stack_info {
                 cpu.with_stack_info(stack_info);
             }
@@ -140,11 +148,8 @@ impl McuHwModel for ModelEmulated {
         std::hash::Hash::hash_slice(params.caliptra_rom, &mut hasher);
         let image_tag = hasher.finish();
 
-        // this just immediately exits
-        let _mcu_firmware = [0xb7, 0xf6, 0x00, 0x20, 0x94, 0xc2];
-
         let clock = Rc::new(McuClock::new());
-        let pic = Rc::new(Pic::new());
+        let pic = Rc::new(emulator_cpu::Pic::new());
         let bus_args = McuRootBusArgs {
             rom: params.mcu_rom.into(),
             pic: pic.clone(),

--- a/hw/model/src/model_fpga_realtime.rs
+++ b/hw/model/src/model_fpga_realtime.rs
@@ -1,12 +1,16 @@
 // Licensed under the Apache-2.0 license
 
-use crate::InitParams;
-use crate::McuHwModel;
-use crate::Output;
+use crate::fpga_regs::{Control, FifoData, FifoRegs, FifoStatus, ItrngFifoStatus, WrapperRegs};
+use crate::{InitParams, McuHwModel, Output, SecurityState};
 use anyhow::{anyhow, Error, Result};
-use bitfield::bitfield;
 use caliptra_emu_bus::Event;
-use std::sync::mpsc;
+use caliptra_hw_model_types::{DEFAULT_FIELD_ENTROPY, DEFAULT_UDS_SEED};
+use registers_generated::mci::bits::Go::Go;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{mpsc, Arc};
+use std::thread;
+use std::time::{Duration, Instant};
+use tock_registers::interfaces::{ReadWriteable, Readable, Writeable};
 use uio::{UioDevice, UioError};
 
 // UIO mapping indices
@@ -15,216 +19,193 @@ const CALIPTRA_MAPPING: (usize, usize) = (0, 1);
 const CALIPTRA_ROM_MAPPING: (usize, usize) = (0, 2);
 const I3C_CONTROLLER_MAPPING: (usize, usize) = (0, 3);
 const MCU_SRAM_MAPPING: (usize, usize) = (0, 4);
-const _SS_MAPPING: (usize, usize) = (1, 0);
+const LC_MAPPING: (usize, usize) = (1, 0);
 const MCU_ROM_MAPPING: (usize, usize) = (1, 1);
 const I3C_TARGET_MAPPING: (usize, usize) = (1, 2);
 const MCI_MAPPING: (usize, usize) = (1, 3);
+const OTP_MAPPING: (usize, usize) = (1, 4);
 
+// Set to core_clk cycles per ITRNG sample.
+const ITRNG_DIVISOR: u32 = 400;
 const DEFAULT_AXI_PAUSER: u32 = 0x1;
+
+// ITRNG FIFO stores 1024 DW and outputs 4 bits at a time to Caliptra.
+const FPGA_ITRNG_FIFO_SIZE: usize = 1024;
 
 fn fmt_uio_error(err: UioError) -> Error {
     anyhow!("{err:?}")
 }
 
-// FPGA wrapper register offsets
-const _FPGA_WRAPPER_MAGIC_OFFSET: isize = 0x0000 / 4;
-const _FPGA_WRAPPER_VERSION_OFFSET: isize = 0x0004 / 4;
-const FPGA_WRAPPER_CONTROL_OFFSET: isize = 0x0008 / 4;
-const _FPGA_WRAPPER_STATUS_OFFSET: isize = 0x000C / 4;
-const FPGA_WRAPPER_PAUSER_OFFSET: isize = 0x0010 / 4;
-const _FPGA_WRAPPER_ITRNG_DIV_OFFSET: isize = 0x0014 / 4;
-const FPGA_WRAPPER_CYCLE_COUNT_OFFSET: isize = 0x0018 / 4;
-const _FPGA_WRAPPER_GENERIC_INPUT_OFFSET: isize = 0x0030 / 4;
-const _FPGA_WRAPPER_GENERIC_OUTPUT_OFFSET: isize = 0x0038 / 4;
-const _FPGA_WRAPPER_DEOBF_KEY_OFFSET: isize = 0x0040 / 4;
-const _FPGA_WRAPPER_CSR_HMAC_KEY_OFFSET: isize = 0x0060 / 4;
-
-const _FPGA_WRAPPER_LSU_USER_OFFSET: isize = 0x0100 / 4;
-const _FPGA_WRAPPER_IFU_USER_OFFSET: isize = 0x0104 / 4;
-const _FPGA_WRAPPER_CLP_USER_OFFSET: isize = 0x0108 / 4;
-const _FPGA_WRAPPER_SOC_CFG_USER_OFFSET: isize = 0x010C / 4;
-const _FPGA_WRAPPER_SRAM_CFG_USER_OFFSET: isize = 0x0110 / 4;
-const FPGA_WRAPPER_MCU_RESET_VECTOR_OFFSET: isize = 0x0114 / 4;
-const _FPGA_WRAPPER_MCI_ERROR: isize = 0x0118 / 4;
-const _FPGA_WRAPPER_MCU_CONFIG: isize = 0x011C / 4;
-const _FPGA_WRAPPER_MCI_GENERIC_INPUT_WIRES_0_OFFSET: isize = 0x0120 / 4;
-const _FPGA_WRAPPER_MCI_GENERIC_INPUT_WIRES_1_OFFSET: isize = 0x0124 / 4;
-const _FPGA_WRAPPER_MCI_GENERIC_OUTPUT_WIRES_0_OFFSET: isize = 0x0128 / 4;
-const _FPGA_WRAPPER_MCI_GENERIC_OUTPUT_WIRES_1_OFFSET: isize = 0x012C / 4;
-const _FPGA_WRAPPER_LOG_FIFO_DATA_OFFSET: isize = 0x1000 / 4;
-const _FPGA_WRAPPER_LOG_FIFO_STATUS_OFFSET: isize = 0x1004 / 4;
-const _FPGA_WRAPPER_ITRNG_FIFO_DATA_OFFSET: isize = 0x1008 / 4;
-const _FPGA_WRAPPER_ITRNG_FIFO_STATUS_OFFSET: isize = 0x100C / 4;
-const FPGA_WRAPPER_MCU_LOG_FIFO_DATA_OFFSET: isize = 0x1010 / 4;
-const FPGA_WRAPPER_MCU_LOG_FIFO_STATUS_OFFSET: isize = 0x1018 / 4;
-
-bitfield! {
-    #[derive(Debug, PartialEq, Eq, Clone, Copy)]
-    /// Wrapper wires -> Caliptra
-    pub struct GpioOutput(u32);
-    cptra_pwrgood, set_cptra_pwrgood: 0, 0;
-    cptra_rst_b, set_cptra_rst_b: 1, 1;
-    debug_locked, set_debug_locked: 2, 2;
-    device_lifecycle, set_device_lifecycle: 4, 3;
+struct Wrapper {
+    ptr: *mut u32,
 }
 
-bitfield! {
-    #[derive(Debug, PartialEq, Eq, Clone, Copy)]
-    /// Wrapper wires <- Caliptra
-    pub struct GpioInput(u32);
-    cptra_error_fatal, _: 0, 0;
-    cptra_error_non_fatal, _: 1, 1;
-    ready_for_fuses, _: 2, 2;
-    ready_for_fw, _: 3, 3;
-    ready_for_runtime, _: 4, 4;
+impl Wrapper {
+    fn regs(&self) -> &mut WrapperRegs {
+        unsafe { &mut *(self.ptr as *mut WrapperRegs) }
+    }
+    fn fifo_regs(&self) -> &mut FifoRegs {
+        unsafe { &mut *(self.ptr.offset(0x1000 / 4) as *mut FifoRegs) }
+    }
+}
+unsafe impl Send for Wrapper {}
+unsafe impl Sync for Wrapper {}
+
+struct Mci {
+    ptr: *mut u32,
 }
 
-bitfield! {
-    #[derive(Debug, PartialEq, Eq, Clone, Copy)]
-    /// Log FIFO data
-    pub struct FifoData(u32);
-    log_fifo_char, _: 7, 0;
-    log_fifo_valid, _: 8, 8;
+impl Mci {
+    fn regs(&self) -> &mut registers_generated::mci::regs::Mci {
+        unsafe { &mut *(self.ptr as *mut registers_generated::mci::regs::Mci) }
+    }
 }
 
-bitfield! {
-    #[derive(Debug, PartialEq, Eq, Clone, Copy)]
-    /// Log FIFO status
-    pub struct FifoStatus(u32);
-    log_fifo_empty, _: 0, 0;
-    log_fifo_full, _: 1, 1;
+struct CaliptraMmio {
+    ptr: *mut u32,
 }
 
-bitfield! {
-    #[derive(Debug, PartialEq, Eq, Clone, Copy)]
-    /// ITRNG FIFO status
-    pub struct TrngFifoStatus(u32);
-    trng_fifo_empty, _: 0, 0;
-    trng_fifo_full, _: 1, 1;
-    trng_fifo_reset, set_trng_fifo_reset: 2, 2;
+impl CaliptraMmio {
+    #[allow(unused)]
+    fn mbox(&self) -> &mut registers_generated::mbox::regs::Mbox {
+        unsafe {
+            &mut *(self.ptr.offset(0x2_0000 / 4) as *mut registers_generated::mbox::regs::Mbox)
+        }
+    }
+    #[allow(unused)]
+    fn soc(&self) -> &mut registers_generated::soc::regs::Soc {
+        unsafe { &mut *(self.ptr.offset(0x3_0000 / 4) as *mut registers_generated::soc::regs::Soc) }
+    }
 }
 
 pub struct ModelFpgaRealtime {
     devs: [UioDevice; 2],
     // mmio uio pointers
-    wrapper: *mut u32,
-    caliptra_mmio: *mut u32,
+    wrapper: Arc<Wrapper>,
+    caliptra_mmio: CaliptraMmio,
     caliptra_rom_backdoor: *mut u8,
     mcu_rom_backdoor: *mut u8,
     mcu_sram_backdoor: *mut u8,
-    mci: *mut u32,
+    mci: Mci,
     i3c_mmio: *mut u32,
     i3c_controller_mmio: *mut u32,
+
+    realtime_thread: Option<thread::JoinHandle<()>>,
+    realtime_thread_exit_flag: Arc<AtomicBool>,
 
     output: Output,
 }
 
 impl ModelFpgaRealtime {
     fn set_subsystem_reset(&mut self, reset: bool) {
-        let value = if reset { 0 } else { 3 };
-        unsafe {
-            core::ptr::write_volatile(self.wrapper.offset(FPGA_WRAPPER_CONTROL_OFFSET), value);
-        }
+        self.wrapper.regs().control.modify(
+            Control::CptraSsRstB.val(!(reset) as u32)
+                + Control::CptraPwrgood.val((!reset) as u32)
+                + Control::SsDebugIntent::SET,
+        );
     }
 
-    fn clear_log_fifo(&mut self) {
-        // clear Caliptra log FIFO
-        // loop {
-        //     let fifodata = unsafe {
-        //         FifoData(
-        //             self.wrapper
-        //                 .offset(FPGA_WRAPPER_LOG_FIFO_DATA_OFFSET)
-        //                 .read_volatile(),
-        //         )
-        //     };
-        //     if fifodata.log_fifo_valid() == 0 {
-        //         break;
-        //     }
-        // }
-        // clear MCU log FIFO
+    fn set_secrets_valid(&mut self, value: bool) {
+        self.wrapper.regs().control.modify(
+            Control::CptraObfUdsSeedVld.val(value as u32)
+                + Control::CptraObfFieldEntropyVld.val(value as u32),
+        )
+    }
+
+    fn clear_logs(&mut self) {
+        println!("Clearing Caliptra logs");
         loop {
-            let fifosts = unsafe {
-                FifoStatus(
-                    self.wrapper
-                        .offset(FPGA_WRAPPER_MCU_LOG_FIFO_STATUS_OFFSET)
-                        .read_volatile(),
-                )
-            };
-            if fifosts.log_fifo_empty() == 1 {
+            if self
+                .wrapper
+                .fifo_regs()
+                .log_fifo_status
+                .is_set(FifoStatus::Empty)
+            {
                 break;
             }
-            let fifodata = unsafe {
-                FifoData(
-                    self.wrapper
-                        .offset(FPGA_WRAPPER_MCU_LOG_FIFO_DATA_OFFSET)
-                        .read_volatile(),
-                )
-            };
-            if fifodata.log_fifo_valid() == 0 {
-                return;
+            if !self
+                .wrapper
+                .fifo_regs()
+                .log_fifo_data
+                .is_set(FifoData::CharValid)
+            {
+                break;
+            }
+        }
+
+        println!("Clearing MCU logs");
+        loop {
+            if self
+                .wrapper
+                .fifo_regs()
+                .dbg_fifo_status
+                .is_set(FifoStatus::Empty)
+            {
+                break;
+            }
+            if !self
+                .wrapper
+                .fifo_regs()
+                .dbg_fifo_data_pop
+                .is_set(FifoData::CharValid)
+            {
+                break;
             }
         }
     }
 
     fn handle_log(&mut self) {
-        // Check if the FIFO is full (which probably means there was an overrun)
-        // let fifosts = unsafe {
-        //     FifoStatus(
-        //         self.wrapper
-        //             .offset(FPGA_WRAPPER_LOG_FIFO_STATUS_OFFSET)
-        //             .read_volatile(),
-        //     )
-        // };
-        // if fifosts.log_fifo_full() != 0 {
-        //     panic!("FPGA log Caliptra FIFO overran");
-        // }
-        // // Check and empty log Caliptra FIFO
-        // loop {
-        //     let fifodata = unsafe {
-        //         FifoData(
-        //             self.wrapper
-        //                 .offset(FPGA_WRAPPER_LOG_FIFO_DATA_OFFSET)
-        //                 .read_volatile(),
-        //         )
-        //     };
-        //     // Add byte to log if it is valid
-        //     if fifodata.log_fifo_valid() != 0 {
-        //         self.output()
-        //             .sink()
-        //             .push_uart_char(fifodata.log_fifo_char().try_into().unwrap());
-        //     } else {
-        //         break;
-        //     }
-        // }
-        // Check if the FIFO is full (which probably means there was an overrun)
         loop {
-            let fifosts = unsafe {
-                FifoStatus(
-                    self.wrapper
-                        .offset(FPGA_WRAPPER_MCU_LOG_FIFO_STATUS_OFFSET)
-                        .read_volatile(),
-                )
-            };
-            if fifosts.log_fifo_full() != 0 {
-                panic!("FPGA log MCU FIFO overran");
+            // Check if the FIFO is full (which probably means there was an overrun)
+            if self
+                .wrapper
+                .fifo_regs()
+                .log_fifo_status
+                .is_set(FifoStatus::Full)
+            {
+                panic!("FPGA log FIFO overran");
             }
-            if fifosts.log_fifo_empty() == 1 {
+            if self
+                .wrapper
+                .fifo_regs()
+                .log_fifo_status
+                .is_set(FifoStatus::Empty)
+            {
                 break;
             }
-            let fifodata = unsafe {
-                FifoData(
-                    self.wrapper
-                        .offset(FPGA_WRAPPER_MCU_LOG_FIFO_DATA_OFFSET)
-                        .read_volatile(),
-                )
-            };
+            let data = self.wrapper.fifo_regs().log_fifo_data.extract();
             // Add byte to log if it is valid
-            if fifodata.log_fifo_valid() != 0 {
+            if data.is_set(FifoData::CharValid) {
                 self.output()
                     .sink()
-                    .push_uart_char(fifodata.log_fifo_char().try_into().unwrap());
-            } else {
+                    .push_uart_char(data.read(FifoData::NextChar) as u8);
+            }
+        }
+
+        loop {
+            // Check if the FIFO is full (which probably means there was an overrun)
+            if self
+                .wrapper
+                .fifo_regs()
+                .dbg_fifo_status
+                .is_set(FifoStatus::Full)
+            {
+                panic!("FPGA log FIFO overran");
+            }
+            if self
+                .wrapper
+                .fifo_regs()
+                .dbg_fifo_status
+                .is_set(FifoStatus::Empty)
+            {
                 break;
+            }
+            let data = self.wrapper.fifo_regs().dbg_fifo_data_pop.extract();
+            // Add byte to log if it is valid
+            if data.is_set(FifoData::CharValid) {
+                self.output()
+                    .sink()
+                    .push_uart_char(data.read(FifoData::NextChar) as u8);
             }
         }
     }
@@ -235,6 +216,54 @@ impl ModelFpgaRealtime {
 
         unsafe {
             nix::sys::mman::munmap(addr as *mut libc::c_void, map_size).unwrap();
+        }
+    }
+
+    fn realtime_thread_itrng_fn(
+        wrapper: Arc<Wrapper>,
+        exit: Arc<AtomicBool>,
+        mut itrng_nibbles: Box<dyn Iterator<Item = u8> + Send>,
+    ) {
+        // Reset ITRNG FIFO to clear out old data
+
+        wrapper
+            .fifo_regs()
+            .itrng_fifo_status
+            .write(ItrngFifoStatus::Reset::SET);
+        wrapper
+            .fifo_regs()
+            .itrng_fifo_status
+            .write(ItrngFifoStatus::Reset::CLEAR);
+
+        // Small delay to allow reset to complete
+        thread::sleep(Duration::from_millis(1));
+
+        while !exit.load(Ordering::Relaxed) {
+            // Once TRNG data is requested the FIFO will continously empty. Load at max one FIFO load at a time.
+            // FPGA ITRNG FIFO is 1024 DW deep.
+            for _ in 0..FPGA_ITRNG_FIFO_SIZE {
+                if !wrapper
+                    .fifo_regs()
+                    .itrng_fifo_status
+                    .is_set(ItrngFifoStatus::Full)
+                {
+                    let mut itrng_dw = 0;
+                    for i in 0..8 {
+                        match itrng_nibbles.next() {
+                            Some(nibble) => itrng_dw += u32::from(nibble) << (4 * i),
+                            None => return,
+                        }
+                    }
+                    wrapper.fifo_regs().itrng_fifo_data.set(itrng_dw);
+                } else {
+                    break;
+                }
+            }
+            // 1 second * (20 MHz / (2^13 throttling counter)) / 8 nibbles per DW: 305 DW of data consumed in 1 second.
+            let end_time = Instant::now() + Duration::from_millis(1000);
+            while !exit.load(Ordering::Relaxed) && Instant::now() < end_time {
+                thread::sleep(Duration::from_millis(1));
+            }
         }
     }
 }
@@ -253,9 +282,11 @@ impl McuHwModel for ModelFpgaRealtime {
         let dev1 = UioDevice::blocking_new(1)?;
         let devs = [dev0, dev1];
 
-        let wrapper = devs[FPGA_WRAPPER_MAPPING.0]
-            .map_mapping(FPGA_WRAPPER_MAPPING.1)
-            .map_err(fmt_uio_error)? as *mut u32;
+        let wrapper = Arc::new(Wrapper {
+            ptr: devs[FPGA_WRAPPER_MAPPING.0]
+                .map_mapping(FPGA_WRAPPER_MAPPING.1)
+                .map_err(fmt_uio_error)? as *mut u32,
+        });
         let caliptra_rom_backdoor = devs[CALIPTRA_ROM_MAPPING.0]
             .map_mapping(CALIPTRA_ROM_MAPPING.1)
             .map_err(fmt_uio_error)? as *mut u8;
@@ -265,7 +296,7 @@ impl McuHwModel for ModelFpgaRealtime {
         let mcu_rom_backdoor = devs[MCU_ROM_MAPPING.0]
             .map_mapping(MCU_ROM_MAPPING.1)
             .map_err(fmt_uio_error)? as *mut u8;
-        let mci = devs[MCI_MAPPING.0]
+        let mci_ptr = devs[MCI_MAPPING.0]
             .map_mapping(MCI_MAPPING.1)
             .map_err(fmt_uio_error)? as *mut u32;
         let caliptra_mmio = devs[CALIPTRA_MAPPING.0]
@@ -277,6 +308,24 @@ impl McuHwModel for ModelFpgaRealtime {
         let i3c_controller_mmio = devs[I3C_CONTROLLER_MAPPING.0]
             .map_mapping(I3C_CONTROLLER_MAPPING.1)
             .map_err(fmt_uio_error)? as *mut u32;
+        let _lc_mmio = devs[LC_MAPPING.0]
+            .map_mapping(LC_MAPPING.1)
+            .map_err(fmt_uio_error)? as *mut u32;
+        let _otp_mmio = devs[OTP_MAPPING.0]
+            .map_mapping(OTP_MAPPING.1)
+            .map_err(fmt_uio_error)? as *mut u32;
+
+        let realtime_thread_exit_flag = Arc::new(AtomicBool::new(false));
+        let realtime_thread_exit_flag2 = realtime_thread_exit_flag.clone();
+        let realtime_wrapper = wrapper.clone();
+
+        let realtime_thread = Some(std::thread::spawn(move || {
+            Self::realtime_thread_itrng_fn(
+                realtime_wrapper,
+                realtime_thread_exit_flag2,
+                params.itrng_nibbles,
+            )
+        }));
 
         // TODO: initialize this after the I3C target is configured.
         // let i3c_controller = xi3c::Controller::new(i3c_controller_mmio);
@@ -284,20 +333,59 @@ impl McuHwModel for ModelFpgaRealtime {
         let mut m = Self {
             devs,
             wrapper,
-            caliptra_mmio,
+            caliptra_mmio: CaliptraMmio { ptr: caliptra_mmio },
             caliptra_rom_backdoor,
             mcu_rom_backdoor,
             mcu_sram_backdoor,
-            mci,
+            mci: Mci { ptr: mci_ptr },
             i3c_mmio,
             i3c_controller_mmio,
+
+            realtime_thread,
+            realtime_thread_exit_flag,
 
             output,
         };
 
+        // Set generic input wires.
+        let input_wires = [(!params.uds_granularity_64 as u32) << 31, 0];
+        m.set_generic_input_wires(&input_wires);
+
+        // Set Security State signal wires
+        println!("Set security state");
+        m.set_security_state(params.security_state);
+
+        println!("Set itrng divider");
+        // Set divisor for ITRNG throttling
+        m.set_itrng_divider(ITRNG_DIVISOR);
+
+        println!("Set deobf key");
+        // Set deobfuscation key
+        for i in 0..8 {
+            m.wrapper.regs().cptra_obf_key[i].set(params.cptra_obf_key[i]);
+        }
+
+        // Set the CSR HMAC key
+        for i in 0..16 {
+            m.wrapper.regs().cptra_csr_hmac_key[i].set(params.csr_hmac_key[i]);
+        }
+
+        // Set the UDS Seed
+        for i in 0..16 {
+            m.wrapper.regs().cptra_obf_uds_seed[i].set(DEFAULT_UDS_SEED[i]);
+        }
+
+        // Set the FE Seed
+        for i in 0..8 {
+            m.wrapper.regs().cptra_obf_field_entropy[i].set(DEFAULT_FIELD_ENTROPY[i]);
+        }
+
+        // Currently not using strap UDS and FE
+        m.set_secrets_valid(false);
+
         println!("Clearing fifo");
         // Sometimes there's garbage in here; clean it out
-        m.clear_log_fifo();
+        m.clear_logs();
 
         println!("Putting subsystem into reset");
         m.set_subsystem_reset(true);
@@ -311,22 +399,21 @@ impl McuHwModel for ModelFpgaRealtime {
 
         // Write ROM images over backdoors
         // ensure that they are 8-byte aligned to write to AXI
-        // let mut caliptra_rom_data = params.caliptra_rom.to_vec();
-        // while caliptra_rom_data.len() % 8 != 0 {
-        //     caliptra_rom_data.push(0);
-        // }
+        let mut caliptra_rom_data = params.caliptra_rom.to_vec();
+        while caliptra_rom_data.len() % 8 != 0 {
+            caliptra_rom_data.push(0);
+        }
         let mut mcu_rom_data = params.mcu_rom.to_vec();
         while mcu_rom_data.len() % 8 != 0 {
             mcu_rom_data.push(0);
         }
 
         // copy the ROM data
-        // let caliptra_rom_slice = unsafe {
-        //     core::slice::from_raw_parts_mut(m.caliptra_rom_backdoor, caliptra_rom_data.len())
-        // };
-        // println!("Writing Caliptra ROM");
-        // TODO: this crashes the FPGA
-        // caliptra_rom_slice.copy_from_slice(&caliptra_rom_data);
+        let caliptra_rom_slice = unsafe {
+            core::slice::from_raw_parts_mut(m.caliptra_rom_backdoor, caliptra_rom_data.len())
+        };
+        println!("Writing Caliptra ROM ({} bytes)", caliptra_rom_data.len());
+        caliptra_rom_slice.copy_from_slice(&caliptra_rom_data);
         println!("Writing MCU ROM");
         let mcu_rom_slice =
             unsafe { core::slice::from_raw_parts_mut(m.mcu_rom_backdoor, mcu_rom_data.len()) };
@@ -334,17 +421,15 @@ impl McuHwModel for ModelFpgaRealtime {
 
         // set the reset vector to point to the ROM backdoor
         println!("Writing MCU reset vector");
-        unsafe {
-            core::ptr::write_volatile(
-                m.wrapper.offset(FPGA_WRAPPER_MCU_RESET_VECTOR_OFFSET),
-                mcu_config_fpga::FPGA_MEMORY_MAP.rom_offset,
-            )
-        };
+        m.wrapper
+            .regs()
+            .mcu_reset_vector
+            .set(mcu_config_fpga::FPGA_MEMORY_MAP.rom_offset);
 
         println!("Taking subsystem out of reset");
         m.set_subsystem_reset(false);
 
-        // TODO: finish testing active mode
+        // TODO: remove this when we can finish subsystem/active mode
         println!("Writing MCU firmware to SRAM");
         // For now, we copy the runtime directly into the SRAM
         let mut fw_data = params.mcu_firmware.to_vec();
@@ -352,13 +437,13 @@ impl McuHwModel for ModelFpgaRealtime {
             fw_data.push(0);
         }
         // TODO: remove this offset 0x80 and add 128 bytes of padding to the beginning of the firmware
+        // as this is going to fail when we use the DMA controller
         let sram_slice = unsafe {
             core::slice::from_raw_parts_mut(m.mcu_sram_backdoor.offset(0x80), fw_data.len())
         };
         sram_slice.copy_from_slice(&fw_data);
 
         println!("Done starting MCU");
-
         Ok(m)
     }
 
@@ -367,11 +452,7 @@ impl McuHwModel for ModelFpgaRealtime {
     }
 
     fn output(&mut self) -> &mut crate::Output {
-        let cycle = unsafe {
-            self.wrapper
-                .offset(FPGA_WRAPPER_CYCLE_COUNT_OFFSET)
-                .read_volatile()
-        };
+        let cycle = self.wrapper.regs().cycle_count.get();
         self.output.sink().set_now(u64::from(cycle));
         &mut self.output
     }
@@ -385,10 +466,27 @@ impl McuHwModel for ModelFpgaRealtime {
     }
 
     fn set_axi_user(&mut self, pauser: u32) {
-        unsafe {
-            self.wrapper
-                .offset(FPGA_WRAPPER_PAUSER_OFFSET)
-                .write_volatile(pauser);
+        self.wrapper.regs().pauser.set(pauser);
+    }
+
+    fn set_caliptra_boot_go(&mut self, go: bool) {
+        self.mci
+            .regs()
+            .mci_reg_cptra_boot_go
+            .write(Go.val(go as u32));
+    }
+
+    fn set_itrng_divider(&mut self, divider: u32) {
+        self.wrapper.regs().itrng_divisor.set(divider - 1);
+    }
+
+    fn set_security_state(&mut self, _value: SecurityState) {
+        // todo!() // this is no yet supported in FPGA
+    }
+
+    fn set_generic_input_wires(&mut self, value: &[u32; 2]) {
+        for i in 0..2 {
+            self.wrapper.regs().generic_input_wires[i].set(value[i]);
         }
     }
 
@@ -403,13 +501,17 @@ impl McuHwModel for ModelFpgaRealtime {
 
 impl Drop for ModelFpgaRealtime {
     fn drop(&mut self) {
+        self.realtime_thread_exit_flag
+            .store(true, Ordering::Relaxed);
+        self.realtime_thread.take().unwrap().join().unwrap();
+
         // Unmap UIO memory space so that the file lock is released
-        self.unmap_mapping(self.wrapper, FPGA_WRAPPER_MAPPING);
-        self.unmap_mapping(self.caliptra_mmio, CALIPTRA_MAPPING);
+        self.unmap_mapping(self.wrapper.ptr, FPGA_WRAPPER_MAPPING);
+        self.unmap_mapping(self.caliptra_mmio.ptr, CALIPTRA_MAPPING);
         self.unmap_mapping(self.caliptra_rom_backdoor as *mut u32, CALIPTRA_ROM_MAPPING);
         self.unmap_mapping(self.mcu_rom_backdoor as *mut u32, MCU_ROM_MAPPING);
         self.unmap_mapping(self.mcu_sram_backdoor as *mut u32, MCU_SRAM_MAPPING);
-        self.unmap_mapping(self.mci, MCI_MAPPING);
+        self.unmap_mapping(self.mci.ptr, MCI_MAPPING);
         self.unmap_mapping(self.i3c_mmio, I3C_TARGET_MAPPING);
         self.unmap_mapping(self.i3c_controller_mmio, I3C_CONTROLLER_MAPPING);
     }
@@ -452,10 +554,11 @@ mod test {
             caliptra_firmware: &caliptra_fw,
             mcu_rom: &mcu_rom,
             mcu_firmware: &mcu_runtime,
+            active_mode: true,
             ..Default::default()
         })
         .unwrap();
-        for _ in 0..1_000_000 {
+        for _ in 0..5_000_000 {
             model.step();
         }
     }

--- a/platforms/emulator/runtime/src/board.rs
+++ b/platforms/emulator/runtime/src/board.rs
@@ -339,7 +339,12 @@ pub unsafe fn main() {
         capsules_runtime::mailbox::DRIVER_NUM,
         mux_alarm,
     )
-    .finalize(mailbox_component_static!(InternalTimers<'static>));
+    .finalize(mailbox_component_static!(
+        InternalTimers<'static>,
+        Some(MCU_MEMORY_MAP.soc_offset),
+        Some(MCU_MEMORY_MAP.soc_offset),
+        Some(MCU_MEMORY_MAP.mbox_offset)
+    ));
     mailbox.alarm.set_alarm_client(mailbox);
 
     let emulator_peripherals =

--- a/platforms/emulator/runtime/userspace/apps/example/src/test_caliptra_crypto.rs
+++ b/platforms/emulator/runtime/userspace/apps/example/src/test_caliptra_crypto.rs
@@ -7,14 +7,14 @@ use libapi_caliptra::mailbox_api::{MAX_RANDOM_NUM_SIZE, MAX_RANDOM_STIR_SIZE};
 use core::fmt::write;
 use romtime::{println, test_exit};
 
-const expected_hashes_384: [[u8; 48]; 1] = [[
+const EXPECTED_HASHES_384: [[u8; 48]; 1] = [[
     // data 1
     0x95, 0x07, 0x7f, 0x78, 0x7b, 0x9a, 0xe1, 0x93, 0x72, 0x24, 0x54, 0xbe, 0x37, 0xf5, 0x01, 0x2a,
     0x0e, 0xbf, 0x81, 0xd0, 0xe3, 0x99, 0xdc, 0x3f, 0x14, 0x7d, 0x41, 0x31, 0xc3, 0x76, 0x42, 0x7b,
     0xa4, 0x8d, 0xd1, 0xc4, 0xae, 0x71, 0xde, 0x9a, 0x88, 0x54, 0x71, 0x30, 0xf2, 0xc5, 0x04, 0x28,
 ]];
 
-const expected_hashes_512: [[u8; 64]; 1] = [[
+const EXPECTED_HASHES_512: [[u8; 64]; 1] = [[
     // data 1
     0xd7, 0x71, 0xd8, 0x3e, 0x23, 0xfa, 0xfc, 0x4b, 0x92, 0x67, 0xe1, 0xd5, 0xd8, 0x62, 0x10, 0x6d,
     0x3e, 0xc1, 0x23, 0x26, 0x51, 0x96, 0x45, 0xc8, 0xab, 0x7a, 0xba, 0x26, 0xa5, 0xdf, 0x2e, 0xfd,
@@ -26,8 +26,8 @@ pub async fn test_caliptra_sha() {
     println!("Starting Caliptra mailbox SHA test");
 
     let data1 = b"Hello from Caliptra! This is a test of the SHA algorithm.";
-    let expected_sha_384 = expected_hashes_384[0];
-    let expected_sha_512 = expected_hashes_512[0];
+    let expected_sha_384 = EXPECTED_HASHES_384[0];
+    let expected_sha_512 = EXPECTED_HASHES_512[0];
 
     test_sha(data1, HashAlgoType::SHA384, &expected_sha_384).await;
     test_sha(data1, HashAlgoType::SHA512, &expected_sha_512).await;
@@ -43,17 +43,17 @@ async fn test_sha(data: &[u8], algo: HashAlgoType, expected_hash: &[u8]) {
 
     let mut hash = [0u8; 64];
 
-    hash_context.init(algo, None).await.map_err(|e| {
+    let _ = hash_context.init(algo, None).await.map_err(|e| {
         println!("Failed to initialize hash context with error: {:?}", e);
         test_exit(1);
     });
 
-    hash_context.update(&data).await.map_err(|e| {
+    let _ = hash_context.update(&data).await.map_err(|e| {
         println!("Failed to update hash context with error: {:?}", e);
         test_exit(1);
     });
 
-    hash_context.finalize(&mut hash).await.map_err(|e| {
+    let _ = hash_context.finalize(&mut hash).await.map_err(|e| {
         println!("Failed to finalize hash context with error: {:?}", e);
         test_exit(1);
     });

--- a/platforms/emulator/runtime/userspace/apps/image-loader/src/pldm_fdops_mock.rs
+++ b/platforms/emulator/runtime/userspace/apps/image-loader/src/pldm_fdops_mock.rs
@@ -6,7 +6,6 @@ use alloc::boxed::Box;
 use async_trait::async_trait;
 use core::cell::RefCell;
 use embassy_sync::lazy_lock::LazyLock;
-use libsyscall_caliptra::DefaultSyscalls;
 use pldm_common::message::firmware_update::apply_complete::ApplyResult;
 use pldm_common::message::firmware_update::get_fw_params::FirmwareParameters;
 use pldm_common::message::firmware_update::get_status::ProgressPercent;
@@ -14,13 +13,12 @@ use pldm_common::message::firmware_update::transfer_complete::TransferResult;
 use pldm_common::message::firmware_update::verify_complete::VerifyResult;
 use pldm_common::protocol::firmware_update::{
     ComponentActivationMethods, ComponentClassification, ComponentParameterEntry,
-    ComponentResponseCode, Descriptor, DescriptorType, FirmwareDeviceCapability, PldmFdTime,
+    ComponentResponseCode, Descriptor, DescriptorType, FirmwareDeviceCapability,
     PldmFirmwareString, PldmFirmwareVersion, PLDM_FWUP_BASELINE_TRANSFER_SIZE,
     PLDM_FWUP_MAX_PADDING_SIZE,
 };
 use pldm_common::util::fw_component::FirmwareComponent;
 use pldm_lib::firmware_device::fd_ops::{ComponentOperation, FdOps, FdOpsError};
-use pldm_lib::timer::AsyncAlarm;
 
 const FD_DESCRIPTORS_COUNT: usize = 1;
 const FD_FW_COMPONENTS_COUNT: usize = 1;

--- a/platforms/emulator/runtime/userspace/apps/spdm/src/dev_cert_store.rs
+++ b/platforms/emulator/runtime/userspace/apps/spdm/src/dev_cert_store.rs
@@ -58,7 +58,7 @@ pub struct DeviceCertChain<'b> {
     device_cert_chain_len: Option<usize>,
 }
 
-impl<'b> DeviceCertChain<'b> {
+impl DeviceCertChain<'_> {
     pub async fn new(slot_id: u8) -> DevCertStoreResult<Self> {
         if slot_id >= MAX_CERT_SLOTS_SUPPORTED {
             Err(DevCertStoreError::InvalidSlotId)?;
@@ -211,7 +211,7 @@ impl<'b> DeviceCertChain<'b> {
 }
 
 #[async_trait]
-impl<'b> SpdmCertStore for DeviceCertStore<'b> {
+impl SpdmCertStore for DeviceCertStore<'_> {
     fn slot_count(&self) -> u8 {
         MAX_CERT_SLOTS_SUPPORTED
     }

--- a/platforms/fpga/runtime/src/board.rs
+++ b/platforms/fpga/runtime/src/board.rs
@@ -342,7 +342,10 @@ pub unsafe fn main() {
         mux_alarm,
     )
     .finalize(mcu_components::mailbox_component_static!(
-        InternalTimers<'static>
+        InternalTimers<'static>,
+        Some(MCU_MEMORY_MAP.soc_offset),
+        Some(MCU_MEMORY_MAP.soc_offset),
+        Some(MCU_MEMORY_MAP.mbox_offset)
     ));
     mailbox.alarm.set_alarm_client(mailbox);
     romtime::println!("[mcu-runtime] Mailbox initialized");

--- a/registers/generator/src/schema.rs
+++ b/registers/generator/src/schema.rs
@@ -1037,7 +1037,7 @@ impl RegisterBlock {
             let reg_names: Vec<&str> = regs.iter().map(|r| r.name.as_str()).collect();
             let pre_name = new_type.name.clone();
             if new_type.name.is_none() {
-                new_type.name = compute_common_name(&reg_names).map(Into::into);
+                new_type.name = compute_common_name(&reg_names);
             }
             if new_type.name.is_none() {
                 new_type.name = Some(format!("Field{:016x}", hash_u64(&new_type)));

--- a/rom/src/fuses.rs
+++ b/rom/src/fuses.rs
@@ -45,6 +45,10 @@ impl Otp {
         Ok(())
     }
 
+    pub fn status(&self) -> u32 {
+        self.registers.otp_status.get()
+    }
+
     fn read_data(&self, addr: usize, len: usize, data: &mut [u8]) -> Result<(), McuError> {
         if data.len() < len || len % 4 != 0 {
             return Err(McuError::InvalidDataError);

--- a/romtime/src/lib.rs
+++ b/romtime/src/lib.rs
@@ -40,10 +40,8 @@ macro_rules! print {
 #[macro_export]
 macro_rules! println {
     ($($arg:tt)*) => {
-        unsafe {
-            if let Some(writer) = $crate::WRITER.as_mut() {
-                let _ = writeln!(writer, $($arg)*);
-            }
+        if let Some(writer) = unsafe { $crate::WRITER.as_mut() } {
+            let _ = writeln!(writer, $($arg)*);
         }
     };
 }

--- a/romtime/src/mci.rs
+++ b/romtime/src/mci.rs
@@ -20,4 +20,8 @@ impl Mci {
     pub fn flow_status(&self) -> u32 {
         self.registers.mci_reg_fw_flow_status.get()
     }
+
+    pub fn hw_flow_status(&self) -> u32 {
+        self.registers.mci_reg_hw_flow_status.get()
+    }
 }

--- a/runtime/kernel/capsules/src/mctp/driver.rs
+++ b/runtime/kernel/capsules/src/mctp/driver.rs
@@ -181,7 +181,7 @@ impl<'a> MCTPDriver<'a> {
     /// * `msg_type` - Message type
     /// * `dest_eid` - Destination EID to send the message to
     /// * `msg_tag` - Message tag of the message. It is MCTP_TAG_OWNER if the message is a request message or
-    ///               a value between 0 and 7 if it is a response message.
+    ///   a value between 0 and 7 if it is a response message.
     ///
     /// # Returns
     /// Returns Ok(()) if the message is successfully submitted to be sent to the peer EID.
@@ -295,19 +295,19 @@ impl SyscallDriver for MCTPDriver<'_> {
     ///
     /// - `1`: Receive Request Message.
     /// - `2`: Receive Response Message.
-    ///         Returns INVAL if the command arguments are invalid.
-    ///         Otherwise, replaces the pending rx operation context with the new one.
-    ///         When a new message is received from peer EID, the metadata is compared with the pending rx operation context.
-    ///         If the metadata matches, the message is copied to the process buffer and the upcall is scheduled.
+    ///   Returns INVAL if the command arguments are invalid.
+    ///   Otherwise, replaces the pending rx operation context with the new one.
+    ///   When a new message is received from peer EID, the metadata is compared with the pending rx operation context.
+    ///   If the metadata matches, the message is copied to the process buffer and the upcall is scheduled.
     ///
     ///
     /// - `3`: Send Request Message.
     /// - `4`: Send Response Message.
-    ///         Sends the message payload to the peer EID.
-    ///         Returns INVAL if the command arguments are invalid.
-    ///         Returns EBUSY if there is already a pending tx operation.
-    ///         Otherwise, returns the result of send_msg_payload(). A successful send_msg_payload() call
-    ///         will return Ok(()) and the pending tx operation context is updated. Otherwise, the result is returned immediately.
+    ///   Sends the message payload to the peer EID.
+    ///   Returns INVAL if the command arguments are invalid.
+    ///   Returns EBUSY if there is already a pending tx operation.
+    ///   Otherwise, returns the result of send_msg_payload(). A successful send_msg_payload() call
+    ///   will return Ok(()) and the pending tx operation context is updated. Otherwise, the result is returned immediately.
     ///
     /// - `5`: Get the maximum message size supported by the MCTP driver.
     fn command(

--- a/runtime/kernel/capsules/src/mctp/transport_binding.rs
+++ b/runtime/kernel/capsules/src/mctp/transport_binding.rs
@@ -197,7 +197,7 @@ impl<'a> MCTPTransportBinding<'a> for MCTPI3CBinding<'a> {
     }
 }
 
-impl<'a> TxClient for MCTPI3CBinding<'a> {
+impl TxClient for MCTPI3CBinding<'_> {
     fn send_done(&self, tx_buffer: &'static mut [u8], result: Result<(), ErrorCode>) {
         self.tx_client.map(|client| {
             client.send_done(tx_buffer, result);
@@ -205,7 +205,7 @@ impl<'a> TxClient for MCTPI3CBinding<'a> {
     }
 }
 
-impl<'a> RxClient for MCTPI3CBinding<'a> {
+impl RxClient for MCTPI3CBinding<'_> {
     fn receive_write(&self, rx_buffer: &'static mut [u8], len: usize) {
         // check if len is > 0 and <= max_write_len
         // if yes, compute PEC and check if it matches with the last byte of the buffer

--- a/runtime/kernel/capsules/src/test/mctp.rs
+++ b/runtime/kernel/capsules/src/test/mctp.rs
@@ -73,7 +73,7 @@ impl<'a> MockMctp<'a> {
     }
 }
 
-impl<'a> MCTPRxClient for MockMctp<'a> {
+impl MCTPRxClient for MockMctp<'_> {
     fn receive(
         &self,
         src_eid: u8,
@@ -129,7 +129,7 @@ impl<'a> MCTPRxClient for MockMctp<'a> {
     }
 }
 
-impl<'a> MCTPTxClient for MockMctp<'a> {
+impl MCTPTxClient for MockMctp<'_> {
     fn send_done(
         &self,
         dest_eid: u8,

--- a/runtime/userspace/api/caliptra-api/src/certificate.rs
+++ b/runtime/userspace/api/caliptra-api/src/certificate.rs
@@ -80,7 +80,7 @@ impl CertContext {
         if cert.len() > PopulateIdevEcc384CertReq::MAX_CERT_SIZE {
             return Err(CaliptraApiError::InvalidArgument("Invalid cert size"));
         }
-        let cmd = CommandId::POPULATE_IDEV_CERT.into();
+        let cmd = CommandId::POPULATE_IDEV_ECC384_CERT.into();
         let mut req = PopulateIdevEcc384CertReq {
             cert_size: cert.len() as u32,
             ..Default::default()
@@ -277,9 +277,9 @@ impl CertContext {
         Ok(resp)
     }
 
-    async fn execute_dpe_cmd<'a>(
+    async fn execute_dpe_cmd(
         &mut self,
-        dpe_cmd: &mut Command<'a>,
+        dpe_cmd: &mut Command<'_>,
     ) -> CaliptraApiResult<DpeResponse> {
         let mut cmd_data: [u8; InvokeDpeReq::DATA_MAX_SIZE] = [0; InvokeDpeReq::DATA_MAX_SIZE];
         let dpe_cmd_id: u32 = Self::dpe_cmd_id(dpe_cmd);

--- a/runtime/userspace/api/pldm-lib/src/control_context.rs
+++ b/runtime/userspace/api/pldm-lib/src/control_context.rs
@@ -139,7 +139,7 @@ impl<'a> ControlContext<'a> {
         self.capabilities
             .iter()
             .find(|cap| cap.pldm_type == pldm_type)
-            .map_or(false, |cap| cap.supported_commands.contains(&cmd))
+            .is_some_and(|cap| cap.supported_commands.contains(&cmd))
     }
 }
 
@@ -165,7 +165,7 @@ pub trait CtrlCmdResponder {
     fn get_pldm_version_rsp(&self, payload: &mut [u8]) -> Result<usize, MsgHandlerError>;
 }
 
-impl<'a> CtrlCmdResponder for ControlContext<'a> {
+impl CtrlCmdResponder for ControlContext<'_> {
     fn get_tid_rsp(&self, payload: &mut [u8]) -> Result<usize, MsgHandlerError> {
         let req = GetTidRequest::decode(payload).map_err(MsgHandlerError::Codec)?;
         let resp = GetTidResponse::new(

--- a/runtime/userspace/api/pldm-lib/src/transport.rs
+++ b/runtime/userspace/api/pldm-lib/src/transport.rs
@@ -35,11 +35,7 @@ impl MctpTransport {
         }
     }
 
-    pub async fn send_request<'a>(
-        &mut self,
-        dest_eid: u8,
-        req: &'a [u8],
-    ) -> Result<(), TransportError> {
+    pub async fn send_request(&mut self, dest_eid: u8, req: &[u8]) -> Result<(), TransportError> {
         let mctp_hdr = MctpCommonHeader(req[MCTP_COMMON_HEADER_OFFSET]);
         if mctp_hdr.ic() != 0 || mctp_hdr.msg_type() != MCTP_PLDM_MSG_TYPE {
             Err(TransportError::UnexpectedMessageType)?;
@@ -56,7 +52,7 @@ impl MctpTransport {
         Ok(())
     }
 
-    pub async fn receive_response<'a>(&mut self, rsp: &'a mut [u8]) -> Result<(), TransportError> {
+    pub async fn receive_response(&mut self, rsp: &mut [u8]) -> Result<(), TransportError> {
         // Reset msg buffer
         rsp.fill(0);
         let (rsp_len, _msg_info) = if let Some(msg_info) = &self.cur_req_ctx {
@@ -82,7 +78,7 @@ impl MctpTransport {
         Ok(())
     }
 
-    pub async fn receive_request<'a>(&mut self, req: &'a mut [u8]) -> Result<(), TransportError> {
+    pub async fn receive_request(&mut self, req: &mut [u8]) -> Result<(), TransportError> {
         // Reset msg buffer
         req.fill(0);
         let (req_len, msg_info) = self
@@ -106,7 +102,7 @@ impl MctpTransport {
         Ok(())
     }
 
-    pub async fn send_response<'a>(&mut self, resp: &'a [u8]) -> Result<(), TransportError> {
+    pub async fn send_response(&mut self, resp: &[u8]) -> Result<(), TransportError> {
         let mctp_hdr = MctpCommonHeader(resp[MCTP_COMMON_HEADER_OFFSET]);
         if mctp_hdr.ic() != 0 || mctp_hdr.msg_type() != MCTP_PLDM_MSG_TYPE {
             Err(TransportError::UnexpectedMessageType)?;

--- a/runtime/userspace/api/spdm-lib/src/commands/algorithms_rsp.rs
+++ b/runtime/userspace/api/spdm-lib/src/commands/algorithms_rsp.rs
@@ -17,7 +17,7 @@ const MAX_SPDM_EXT_ALG_COUNT_V10: u8 = 8;
 const MAX_SPDM_EXT_ALG_COUNT_V11: u8 = 20;
 
 #[derive(IntoBytes, FromBytes, Immutable, Default, Debug)]
-#[repr(packed)]
+#[repr(C, packed)]
 struct NegotiateAlgorithmsReq {
     num_alg_struct_tables: u8,
     param2: u8,
@@ -70,7 +70,7 @@ impl NegotiateAlgorithmsReq {
 impl CommonCodec for NegotiateAlgorithmsReq {}
 
 #[derive(IntoBytes, FromBytes, Immutable, Default)]
-#[repr(packed)]
+#[repr(C, packed)]
 #[allow(dead_code)]
 struct AlgorithmsResp {
     num_alg_struct_tables: u8,

--- a/runtime/userspace/api/spdm-lib/src/commands/capabilities_rsp.rs
+++ b/runtime/userspace/api/spdm-lib/src/commands/capabilities_rsp.rs
@@ -18,7 +18,7 @@ pub(crate) struct GetCapabilitiesBase {
 impl CommonCodec for GetCapabilitiesBase {}
 
 #[derive(IntoBytes, FromBytes, Immutable, Default)]
-#[repr(packed)]
+#[repr(C, packed)]
 #[allow(dead_code)]
 pub(crate) struct GetCapabilitiesV11 {
     reserved: u8,
@@ -43,7 +43,7 @@ impl GetCapabilitiesV11 {
 impl CommonCodec for GetCapabilitiesV11 {}
 
 #[derive(IntoBytes, FromBytes, Immutable)]
-#[repr(packed)]
+#[repr(C, packed)]
 pub(crate) struct GetCapabilitiesV12 {
     data_transfer_size: u32,
     max_spdm_msg_size: u32,

--- a/runtime/userspace/api/spdm-lib/src/commands/certificate_rsp.rs
+++ b/runtime/userspace/api/spdm-lib/src/commands/certificate_rsp.rs
@@ -43,7 +43,7 @@ bitfield! {
 impl CommonCodec for GetCertificateReq {}
 
 #[derive(IntoBytes, FromBytes, Immutable)]
-#[repr(packed)]
+#[repr(C, packed)]
 pub struct CertificateRespCommon {
     pub slot_id: SlotId,
     pub param2: CertificateRespAttributes,
@@ -79,14 +79,14 @@ bitfield! {
     reserved, _: 7,3;
 }
 
-async fn encode_certchain_metadata<'a>(
+async fn encode_certchain_metadata(
     cert_store: &mut dyn SpdmCertStore,
     total_certchain_len: u16,
     slot_id: u8,
     asym_algo: AsymAlgo,
     offset: usize,
     length: usize,
-    rsp: &mut MessageBuf<'a>,
+    rsp: &mut MessageBuf<'_>,
 ) -> CommandResult<usize> {
     let mut certchain_metadata = [0u8; SPDM_CERT_CHAIN_METADATA_LEN as usize];
 

--- a/runtime/userspace/api/spdm-lib/src/commands/digests_rsp.rs
+++ b/runtime/userspace/api/spdm-lib/src/commands/digests_rsp.rs
@@ -30,7 +30,7 @@ pub struct GetDigestsRespCommon {
 
 impl CommonCodec for GetDigestsRespCommon {}
 
-pub(crate) async fn compute_cert_chain_hash<'a>(
+pub(crate) async fn compute_cert_chain_hash(
     slot_id: u8,
     cert_store: &mut dyn SpdmCertStore,
     asym_algo: AsymAlgo,
@@ -99,11 +99,11 @@ pub(crate) async fn compute_cert_chain_hash<'a>(
         .map_err(|e| (false, CommandError::CaliptraApi(e)))
 }
 
-async fn encode_cert_chain_digest<'a>(
+async fn encode_cert_chain_digest(
     slot_id: u8,
     cert_store: &mut dyn SpdmCertStore,
     asym_algo: AsymAlgo,
-    rsp: &mut MessageBuf<'a>,
+    rsp: &mut MessageBuf<'_>,
 ) -> CommandResult<usize> {
     // Fill the response buffer with the certificate chain digest
     rsp.put_data(SHA384_HASH_SIZE)

--- a/runtime/userspace/libtock/platform/src/allow_ro.rs
+++ b/runtime/userspace/libtock/platform/src/allow_ro.rs
@@ -35,8 +35,8 @@ pub struct AllowRo<'share, S: Syscalls, const DRIVER_NUM: u32, const BUFFER_NUM:
 // We can't derive(Default) because S is not Default, and derive(Default)
 // generates a Default implementation that requires S to be Default. Instead, we
 // manually implement Default.
-impl<'share, S: Syscalls, const DRIVER_NUM: u32, const BUFFER_NUM: u32> Default
-    for AllowRo<'share, S, DRIVER_NUM, BUFFER_NUM>
+impl<S: Syscalls, const DRIVER_NUM: u32, const BUFFER_NUM: u32> Default
+    for AllowRo<'_, S, DRIVER_NUM, BUFFER_NUM>
 {
     fn default() -> Self {
         Self {
@@ -46,16 +46,16 @@ impl<'share, S: Syscalls, const DRIVER_NUM: u32, const BUFFER_NUM: u32> Default
     }
 }
 
-impl<'share, S: Syscalls, const DRIVER_NUM: u32, const BUFFER_NUM: u32> Drop
-    for AllowRo<'share, S, DRIVER_NUM, BUFFER_NUM>
+impl<S: Syscalls, const DRIVER_NUM: u32, const BUFFER_NUM: u32> Drop
+    for AllowRo<'_, S, DRIVER_NUM, BUFFER_NUM>
 {
     fn drop(&mut self) {
         S::unallow_ro(DRIVER_NUM, BUFFER_NUM);
     }
 }
 
-impl<'share, S: Syscalls, const DRIVER_NUM: u32, const BUFFER_NUM: u32> List
-    for AllowRo<'share, S, DRIVER_NUM, BUFFER_NUM>
+impl<S: Syscalls, const DRIVER_NUM: u32, const BUFFER_NUM: u32> List
+    for AllowRo<'_, S, DRIVER_NUM, BUFFER_NUM>
 {
 }
 

--- a/runtime/userspace/libtock/platform/src/allow_rw.rs
+++ b/runtime/userspace/libtock/platform/src/allow_rw.rs
@@ -35,8 +35,8 @@ pub struct AllowRw<'share, S: Syscalls, const DRIVER_NUM: u32, const BUFFER_NUM:
 // We can't derive(Default) because S is not Default, and derive(Default)
 // generates a Default implementation that requires S to be Default. Instead, we
 // manually implement Default.
-impl<'share, S: Syscalls, const DRIVER_NUM: u32, const BUFFER_NUM: u32> Default
-    for AllowRw<'share, S, DRIVER_NUM, BUFFER_NUM>
+impl<S: Syscalls, const DRIVER_NUM: u32, const BUFFER_NUM: u32> Default
+    for AllowRw<'_, S, DRIVER_NUM, BUFFER_NUM>
 {
     fn default() -> Self {
         Self {
@@ -46,16 +46,16 @@ impl<'share, S: Syscalls, const DRIVER_NUM: u32, const BUFFER_NUM: u32> Default
     }
 }
 
-impl<'share, S: Syscalls, const DRIVER_NUM: u32, const BUFFER_NUM: u32> Drop
-    for AllowRw<'share, S, DRIVER_NUM, BUFFER_NUM>
+impl<S: Syscalls, const DRIVER_NUM: u32, const BUFFER_NUM: u32> Drop
+    for AllowRw<'_, S, DRIVER_NUM, BUFFER_NUM>
 {
     fn drop(&mut self) {
         S::unallow_rw(DRIVER_NUM, BUFFER_NUM);
     }
 }
 
-impl<'share, S: Syscalls, const DRIVER_NUM: u32, const BUFFER_NUM: u32> List
-    for AllowRw<'share, S, DRIVER_NUM, BUFFER_NUM>
+impl<S: Syscalls, const DRIVER_NUM: u32, const BUFFER_NUM: u32> List
+    for AllowRw<'_, S, DRIVER_NUM, BUFFER_NUM>
 {
 }
 

--- a/runtime/userspace/libtock/platform/src/share/handle.rs
+++ b/runtime/userspace/libtock/platform/src/share/handle.rs
@@ -22,13 +22,13 @@ pub struct Handle<'handle, L: List> {
 // We can't #[derive(Clone, Copy)] because derive's implementations of Clone and
 // Copy have `L: Clone` and `L: Copy` constraints, respectively. We don't want
 // those constraints, so we manually implement Clone and Copy.
-impl<'handle, L: List> Clone for Handle<'handle, L> {
+impl<L: List> Clone for Handle<'_, L> {
     fn clone(&self) -> Self {
         *self
     }
 }
 
-impl<'handle, L: List> Copy for Handle<'handle, L> {}
+impl<L: List> Copy for Handle<'_, L> {}
 
 impl<'handle, L: List> Handle<'handle, L> {
     /// Constructs a new `Handle`, typing its lifetime to the provided list.

--- a/runtime/userspace/libtock/platform/src/subscribe.rs
+++ b/runtime/userspace/libtock/platform/src/subscribe.rs
@@ -31,8 +31,8 @@ pub struct Subscribe<'share, S: Syscalls, const DRIVER_NUM: u32, const SUBSCRIBE
 // We can't derive(Default) because S is not Default, and derive(Default)
 // generates a Default implementation that requires S to be Default. Instead, we
 // manually implement Default.
-impl<'share, S: Syscalls, const DRIVER_NUM: u32, const SUBSCRIBE_NUM: u32> Default
-    for Subscribe<'share, S, DRIVER_NUM, SUBSCRIBE_NUM>
+impl<S: Syscalls, const DRIVER_NUM: u32, const SUBSCRIBE_NUM: u32> Default
+    for Subscribe<'_, S, DRIVER_NUM, SUBSCRIBE_NUM>
 {
     fn default() -> Self {
         Self {
@@ -42,16 +42,16 @@ impl<'share, S: Syscalls, const DRIVER_NUM: u32, const SUBSCRIBE_NUM: u32> Defau
     }
 }
 
-impl<'share, S: Syscalls, const DRIVER_NUM: u32, const SUBSCRIBE_NUM: u32> Drop
-    for Subscribe<'share, S, DRIVER_NUM, SUBSCRIBE_NUM>
+impl<S: Syscalls, const DRIVER_NUM: u32, const SUBSCRIBE_NUM: u32> Drop
+    for Subscribe<'_, S, DRIVER_NUM, SUBSCRIBE_NUM>
 {
     fn drop(&mut self) {
         S::unsubscribe(DRIVER_NUM, SUBSCRIBE_NUM);
     }
 }
 
-impl<'share, S: Syscalls, const DRIVER_NUM: u32, const SUBSCRIBE_NUM: u32> List
-    for Subscribe<'share, S, DRIVER_NUM, SUBSCRIBE_NUM>
+impl<S: Syscalls, const DRIVER_NUM: u32, const SUBSCRIBE_NUM: u32> List
+    for Subscribe<'_, S, DRIVER_NUM, SUBSCRIBE_NUM>
 {
 }
 

--- a/runtime/userspace/libtock/unittest/src/fake/kernel.rs
+++ b/runtime/userspace/libtock/unittest/src/fake/kernel.rs
@@ -115,14 +115,14 @@ impl Kernel {
     /// Returns true if the specified driver installed.
     pub fn is_driver_present(driver_num: u32) -> bool {
         with_kernel_data(|kernel_data| {
-            kernel_data.map_or(false, |kernel| kernel.drivers.contains_key(&driver_num))
+            kernel_data.is_some_and(|kernel| kernel.drivers.contains_key(&driver_num))
         })
     }
 
     /// Returns true if there are any pending upcalls.
     pub fn is_upcall_pending() -> bool {
         with_kernel_data(|kernel_data| {
-            kernel_data.map_or(false, |kernel| !kernel.upcall_queue.is_empty())
+            kernel_data.is_some_and(|kernel| !kernel.upcall_queue.is_empty())
         })
     }
 }

--- a/runtime/userspace/libtock/unittest/src/fake/mailbox/mod.rs
+++ b/runtime/userspace/libtock/unittest/src/fake/mailbox/mod.rs
@@ -122,7 +122,7 @@ impl SyscallDriver for FakeMailboxDriver {
         buffer: RoAllowBuffer,
     ) -> Result<RoAllowBuffer, (RoAllowBuffer, ErrorCode)> {
         if allow_num == mailbox_ro_buffer::INPUT {
-            if buffer.len() != 0 {
+            if !buffer.is_empty() {
                 // Buffer len of 0 means unallow, we don't want to replace the buffer in that case
                 self.last_ro_input.replace(buffer.to_vec());
             }

--- a/runtime/userspace/libtock/unittest/src/share_data.rs
+++ b/runtime/userspace/libtock/unittest/src/share_data.rs
@@ -114,6 +114,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(unpredictable_function_pointer_comparisons)]
     fn schedule_success() {
         let mock_driver = Rc::new(MockDriver::default());
         let kernel = crate::fake::Kernel::new();
@@ -174,6 +175,7 @@ mod tests {
                     subscribe_num: 2
                 }
             );
+
             assert!(upcall_queue_entry.upcall.fn_pointer == Some(upcall_ptr));
             let data: usize = upcall_queue_entry.upcall.data.into();
             assert_eq!(data, 1111);

--- a/runtime/userspace/syscall/src/dma.rs
+++ b/runtime/userspace/syscall/src/dma.rs
@@ -62,7 +62,7 @@ impl<S: Syscalls> DMA<S> {
     /// # Returns
     /// * `Ok(())` if the transfer starts successfully.
     /// * `Err(ErrorCode)` if the transfer fails.
-    pub async fn xfer<'a>(&self, transaction: &DMATransaction<'a>) -> Result<(), ErrorCode> {
+    pub async fn xfer(&self, transaction: &DMATransaction<'_>) -> Result<(), ErrorCode> {
         self.setup(transaction)?;
 
         match transaction.source {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,7 +1,7 @@
 # Licensed under the Apache-2.0 license
 
 [toolchain]
-channel = "nightly-2024-10-01"
+channel = "nightly-2025-02-15"
 components = ["clippy", "rust-src", "llvm-tools", "rustfmt", "rustc-dev"]
 targets = [
   "x86_64-unknown-linux-gnu",


### PR DESCRIPTION
There's a problem with the MCU -> Caliptra mailbox interface that we are debugging, but this gets through most of the boot process.

I updated `caliptra-sw` to point to the latest commit and did some related cleanup (new Rust version so some clippy fixes were necessary).

I also did some more cleanup of the FPGA model to use Tock registers that were automatically generated from RDL and then did some manual tuning.