### PR TITLE
Enable SOC BOOT Integration Tests

### DIFF
--- a/builder/src/runtime.rs
+++ b/builder/src/runtime.rs
@@ -20,7 +20,7 @@ const DEFAULT_PLATFORM: &str = "emulator";
 const DEFAULT_RUNTIME_NAME: &str = "runtime.bin";
 const INTERRUPT_TABLE_SIZE: usize = 128;
 // amount to reserve for data RAM at the end of RAM
-const DATA_RAM_SIZE: usize = 128 * 1024;
+const DATA_RAM_SIZE: usize = 120 * 1024;
 
 fn get_apps_memory_offset(elf_file: PathBuf) -> Result<usize> {
     let elf_bytes = std::fs::read(&elf_file)?;

--- a/runtime/userspace/syscall/src/mailbox.rs
+++ b/runtime/userspace/syscall/src/mailbox.rs
@@ -95,9 +95,6 @@ impl<S: Syscalls> Mailbox<S> {
         })?
         .await;
 
-        S::unallow_ro(self.driver_num, mailbox_ro_buffer::INPUT);
-        S::unallow_rw(self.driver_num, mailbox_rw_buffer::RESPONSE);
-
         match result {
             Ok((bytes, error_code, _)) => {
                 if error_code != 0 {

--- a/tests/integration/src/test_soc_boot.rs
+++ b/tests/integration/src/test_soc_boot.rs
@@ -384,13 +384,11 @@ mod test {
     }
 
     #[test]
-    #[ignore]
     fn test_flash_soc_boot() {
         test_soc_boot(true);
     }
 
     #[test]
-    #[ignore]
     fn test_streaming_soc_boot() {
         test_soc_boot(false);
     }


### PR DESCRIPTION
The SOC boot integration tests were previously disabled since the compiled user app with the soc boot features enabled will not fit RAM.

To be able to fit the App, the DATA_RAM_SIZE is decreased by 8KB.

With the Image loading task running the integ tests with the SPDM task, an issue with the mailbox syscall was encountered:

Error copying from mailbox: MailboxRespTypeTooSmall

It was found that there is a race condition between the Image Loading task and the SPDM Task.

Image Loading Task executes a mailbox command. After mailbox driver calls the upcall for the response of this command, the SPDM task immediately enqueues a command to the mailbox. However, the Image Loading Task will call:

        S::unallow_ro(self.driver_num, mailbox_ro_buffer::INPUT);
        S::unallow_rw(self.driver_num, mailbox_rw_buffer::RESPONSE);

before it exits the syscall. This will ungrant the kernel access to the rw_buffer. When the mailbox driver receives the response for the SPDM command, it will try to read an invalid rw_buffer with a length of 0. The driver will then throw the MailboxRespTypeTooSmall error since it can't copy the response to the buffer.

To fix this issue, an mutex is added to make sure only 1 task can execute a mailbox command at a time.