### PR TITLE
Add Basic DOE Transport Driver skeleton. 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1312,6 +1312,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "doe-mbox-driver"
+version = "0.1.0"
+dependencies = [
+ "capsules-core",
+ "doe-transport",
+ "kernel",
+ "registers-generated",
+]
+
+[[package]]
 name = "doe-transport"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = [
     "platforms/emulator/runtime",
     "platforms/emulator/runtime/kernel/capsules",
     "platforms/emulator/runtime/kernel/drivers/dma",
+    "platforms/emulator/runtime/kernel/drivers/doe_mbox",
     "platforms/emulator/runtime/userspace/apps/example",
     "platforms/emulator/runtime/userspace/apps/user",
     "platforms/fpga/config",
@@ -136,6 +137,7 @@ zeroize = { version = "1.6.0", default-features = false, features = ["zeroize_de
 capsules-emulator = { path = "platforms/emulator/runtime/kernel/capsules" }
 capsules-runtime = { path = "runtime/kernel/capsules" }
 dma-driver = { path = "platforms/emulator/runtime/kernel/drivers/dma" }
+doe-mbox-driver = { path = "platforms/emulator/runtime/kernel/drivers/doe_mbox" }
 doe-transport = { path = "runtime/kernel/drivers/doe"}
 emulator-bmc = { path = "emulator/bmc" }
 emulator-caliptra = { "path" = "emulator/caliptra" }

--- a/docs/src/doe.md
+++ b/docs/src/doe.md
@@ -36,7 +36,7 @@ sequenceDiagram
         DOE_CAPSULE ->> DOE_CAPSULE: Copy DOE object payload <br>into app buffer
         DOE_CAPSULE -->> SPDM_APP: Invoke upcall to userspace<br> to receive() message
     end
-    DOE_CAPSULE ->> MCU_DOE_TRANSPORT_DRIVER: set_receive_buffer()<br> to set the receive buffer for the next DOE object
+    DOE_CAPSULE ->> MCU_DOE_TRANSPORT_DRIVER: set_rx_buffer()<br> to set the receive buffer for the next DOE object
     SPDM_APP ->> SPDM_APP: App processes message <br>and prepares DOE response
     SPDM_APP -->> DOE_CAPSULE: App invokes send_message <br>to send DOE response
     DOE_CAPSULE ->> MCU_DOE_TRANSPORT_DRIVER: invoke transmit()<br> to send the DOE response
@@ -138,7 +138,7 @@ pub trait DoeTransport {
 
     /// Sets the buffer used for receiving incoming DOE Objects.
     /// This function should be called by the Rx client upon receiving the `receive()` callback.
-    fn set_receive_buffer(&self, rx_buf: &'static mut [u8]);
+    fn set_rx_buffer(&self, rx_buf: &'static mut [u8]);
 
     /// Gets the maximum size of the data object that can be sent or received over DOE Transport.
     fn max_data_object_size(&self) -> usize;

--- a/docs/src/doe.md
+++ b/docs/src/doe.md
@@ -152,8 +152,8 @@ pub trait DoeTransport {
     /// Send DOE Object to be transmitted over SoC specific DOE transport.
     /// 
     /// # Arguments
-    /// * `doe_hdr` - A reference to the DOE header
+    /// * `doe_hdr` - DOE header bytes
     /// * `doe_payload` - A reference to the DOE payload
     /// * `payload_len` - The length of the payload in bytes
-    fn transmit(&self, doe_hdr: &'static [u8; 8], doe_payload: &'static mut [u8], payload_len: usize) -> Result<(), (ErrorCode, &'static mut [u8])>;
+    fn transmit(&self, doe_hdr: [u8; DOE_HDR_SIZE], doe_payload: &'static mut [u8], payload_len: usize) -> Result<(), (ErrorCode, &'static mut [u8])>;
 }

--- a/docs/src/images/doe_tock_receive.svg
+++ b/docs/src/images/doe_tock_receive.svg
@@ -209,7 +209,7 @@
 		<g id="shape50-66" v:mID="50" v:groupContext="shape" v:layerMember="0"
 				transform="translate(789.988,818.482) rotate(-58.418) scale(1,-1)">
 			<title>Line-curve connector.50</title>
-			<desc>2. set_receive_buffer()</desc>
+			<desc>2. set_rx_buffer()</desc>
 			<v:userDefs>
 				<v:ud v:nameU="Scale" v:val="VT0(1):26"/>
 				<v:ud v:nameU="AntiScale" v:val="VT0(1):26"/>
@@ -222,7 +222,7 @@
 			<rect v:rectContext="textBkgnd" x="-506.835" y="363.831" width="129.697" height="16.8" transform="rotate(-58.418)"
 					class="st3"/>
 			<text x="-506.84" y="-368.03" transform="rotate(-58.418) scale(1,-1)" class="st15" v:langID="1033"><v:paragraph
-						v:horizAlign="1"/><v:tabList/>2. set_receive_buffer()</text>		</g>
+						v:horizAlign="1"/><v:tabList/>2. set_rx_buffer()</text>		</g>
 		<g id="shape52-74" v:mID="52" v:groupContext="shape" transform="translate(179.853,-232.343) rotate(-16.1705)">
 			<title>Sheet.52</title>
 			<desc>copy payload</desc>

--- a/platforms/emulator/runtime/kernel/drivers/doe_mbox/Cargo.toml
+++ b/platforms/emulator/runtime/kernel/drivers/doe_mbox/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "doe-mbox-driver"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+
+[dependencies]
+capsules-core.workspace = true
+doe-transport.workspace = true
+registers-generated.workspace = true
+kernel.workspace = true

--- a/platforms/emulator/runtime/kernel/drivers/doe_mbox/Cargo.toml
+++ b/platforms/emulator/runtime/kernel/drivers/doe_mbox/Cargo.toml
@@ -1,3 +1,5 @@
+# Licensed under the Apache-2.0 license
+
 [package]
 name = "doe-mbox-driver"
 version.workspace = true

--- a/platforms/emulator/runtime/kernel/drivers/doe_mbox/src/lib.rs
+++ b/platforms/emulator/runtime/kernel/drivers/doe_mbox/src/lib.rs
@@ -1,0 +1,213 @@
+// Licensed under the Apache-2.0 license
+
+#![cfg_attr(target_arch = "riscv32", no_std)]
+
+use doe_transport::hil::{DoeTransport, DoeTransportRxClient, DoeTransportTxClient, DOE_HDR_SIZE};
+
+use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
+use core::cell::Cell;
+use kernel::hil::time::{Alarm, AlarmClient, Time};
+use kernel::utilities::cells::{OptionalCell, TakeCell};
+use kernel::utilities::registers::interfaces::{Readable, Writeable};
+use kernel::utilities::StaticRef;
+use kernel::{debug, ErrorCode};
+use registers_generated::doe_mbox::bits::{DoeMboxDataReady, DoeMboxStatus};
+use registers_generated::doe_mbox::regs::DoeMbox;
+
+pub const DOE_MAX_DATA_OBJECT_SIZE: usize = 256; // arbitrary, adjust as needed
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+enum DoeMboxState {
+    Off,
+    Tx,
+    Rx,
+}
+
+pub struct EmulatedDoeTransport<'a, A: Alarm<'a>> {
+    registers: StaticRef<DoeMbox>,
+    tx_client: OptionalCell<&'a dyn DoeTransportTxClient>,
+    rx_client: OptionalCell<&'a dyn DoeTransportRxClient>,
+
+    // Buffer to receive the data object.
+    rx_buffer: TakeCell<'static, [u8]>,
+
+    // Buffer to hold the transmitted data object.
+    tx_buffer: TakeCell<'static, [u8]>,
+
+    // Flag to indicate if send_done should be scheduled.
+    schedule_tx_done: Cell<bool>,
+
+    state: Cell<DoeMboxState>,
+    alarm: VirtualMuxAlarm<'a, A>,
+}
+
+impl<'a, A: Alarm<'a>> EmulatedDoeTransport<'a, A> {
+    // This is just to add a delay calling `send_done` to emulate the hardware behavior.
+    // Number of ticks to defer send_done
+    const DEFER_SEND_DONE_TICKS: u32 = 10;
+
+    // TODO: The DOE instance should generate the response within 1 second.
+    // This timeout may need to be less than 1 second and need to adjusted.
+    // Also, see if needs to be commonly defined in a shared location.
+    const RESPONSE_TIMEOUT_MS: u32 = 1000;
+
+    pub fn new(
+        base: StaticRef<DoeMbox>,
+        alarm: &'a MuxAlarm<'a, A>,
+    ) -> EmulatedDoeTransport<'a, A> {
+        EmulatedDoeTransport {
+            registers: base,
+            tx_client: OptionalCell::empty(),
+            rx_client: OptionalCell::empty(),
+            rx_buffer: TakeCell::empty(),
+            tx_buffer: TakeCell::empty(),
+            state: Cell::new(DoeMboxState::Off),
+            alarm: VirtualMuxAlarm::new(alarm),
+            schedule_tx_done: Cell::new(false),
+        }
+    }
+
+    pub fn init(&'static self) -> Result<(), ErrorCode> {
+        self.alarm.setup();
+        self.alarm.set_alarm_client(self);
+        self.state.set(DoeMboxState::Rx);
+        Ok(())
+    }
+
+    fn schedule_send_done(&self) {
+        self.schedule_tx_done.set(true);
+        let now = self.alarm.now();
+        self.alarm
+            .set_alarm(now, (Self::DEFER_SEND_DONE_TICKS).into());
+    }
+
+    pub fn handle_interrupt(&self) {
+        if self.state.get() != DoeMboxState::Rx {
+            // Ignore interrupt if not in Rx state
+            return;
+        }
+
+        let data_ready = self.registers.doe_mbox_data_ready.extract();
+        if data_ready.is_set(DoeMboxDataReady::DataReady) {
+            // Clear DataReady and Error flags
+            self.registers
+                .doe_mbox_status
+                .write(DoeMboxStatus::DataReady::CLEAR);
+            self.registers
+                .doe_mbox_status
+                .write(DoeMboxStatus::Error::CLEAR);
+
+            let data_len = self.registers.doe_mbox_dlen.get() as usize;
+            if data_len > self.max_data_object_size() {
+                self.registers
+                    .doe_mbox_status
+                    .write(DoeMboxStatus::Error::SET);
+                debug!("DOE Mbox Intr: Data length exceeds maximum size");
+                return;
+            }
+
+            match self.rx_buffer.take() {
+                Some(rx_buf) => {
+                    if let Some(client) = self.rx_client.get() {
+                        client.receive(rx_buf, data_len);
+                        // After receiving, we can set the state to Tx to allow transmission
+                        self.state.set(DoeMboxState::Tx);
+                    }
+                }
+                None => {
+                    self.registers
+                        .doe_mbox_status
+                        .write(DoeMboxStatus::Error::SET);
+                    debug!("DOE Mbox intr: No RX buffer available");
+                }
+            }
+        }
+    }
+}
+
+impl<'a, A: Alarm<'a>> AlarmClient for EmulatedDoeTransport<'a, A> {
+    fn alarm(&self) {
+        if self.schedule_tx_done.get() {
+            // If we are scheduled to send done, call the tx client
+            if let Some(client) = self.tx_client.get() {
+                // Emulate sending done
+                if let Some(tx_buf) = self.tx_buffer.take() {
+                    client.send_done(tx_buf, Ok(()));
+                }
+            }
+            self.schedule_tx_done.set(false);
+            self.state.set(DoeMboxState::Rx);
+        }
+    }
+}
+
+impl<'a, A: Alarm<'a>> DoeTransport for EmulatedDoeTransport<'a, A> {
+    fn set_tx_client(&self, client: &'a dyn DoeTransportTxClient) {
+        self.tx_client.set(client);
+    }
+
+    fn set_rx_client(&self, client: &'a dyn DoeTransportRxClient) {
+        self.rx_client.set(client);
+    }
+
+    fn set_rx_buffer(&self, rx_buf: &'static mut [u8]) {
+        self.rx_buffer.replace(rx_buf);
+    }
+
+    fn max_data_object_size(&self) -> usize {
+        todo!("Get max data size from configured mailbox sram size")
+    }
+
+    fn enable(&self) -> Result<(), ErrorCode> {
+        self.state.set(DoeMboxState::Rx);
+        Ok(())
+    }
+
+    fn disable(&self) -> Result<(), ErrorCode> {
+        self.state.set(DoeMboxState::Off);
+        Ok(())
+    }
+
+    fn transmit(
+        &self,
+        doe_hdr: &'static [u8; DOE_HDR_SIZE],
+        doe_payload: &'static mut [u8],
+        payload_len: usize,
+    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
+        // todo!("Check if the state is valid for transmission");
+        if self.state.get() != DoeMboxState::Tx {
+            debug!("DOE Mbox: Cannot transmit, not in Tx state");
+            return Err((ErrorCode::BUSY, doe_payload));
+        }
+
+        if DOE_HDR_SIZE + payload_len > self.max_data_object_size() {
+            return Err((ErrorCode::SIZE, doe_payload));
+        }
+
+        // Check if the tx buffer is available
+        if self.tx_buffer.is_none() {
+            return Err((ErrorCode::NOMEM, doe_payload));
+        }
+
+        // copy the header and payload into the tx buffer
+        let tx_buf = self.tx_buffer.take().unwrap();
+        tx_buf[..DOE_HDR_SIZE].copy_from_slice(doe_hdr);
+        tx_buf[DOE_HDR_SIZE..DOE_HDR_SIZE + payload_len].copy_from_slice(doe_payload);
+
+        // Set data len and data ready in the status register
+        self.registers
+            .doe_mbox_dlen
+            .set((DOE_HDR_SIZE + payload_len) as u32);
+        self.registers
+            .doe_mbox_status
+            .write(DoeMboxStatus::DataReady::SET);
+
+        if let Some(_client) = self.tx_client.get() {
+            // In real hardware, this would be asynchronous. Here, we defer the send_done callback
+            // to emulate hardware behavior by scheduling it via an alarm.
+            self.schedule_send_done();
+        }
+
+        Ok(())
+    }
+}

--- a/runtime/kernel/drivers/doe/src/hil.rs
+++ b/runtime/kernel/drivers/doe/src/hil.rs
@@ -3,6 +3,8 @@
 use core::result::Result;
 use kernel::ErrorCode;
 
+pub const DOE_HDR_SIZE: usize = 8; // Size of the DOE header in bytes
+
 pub trait DoeTransportTxClient {
     /// Called when the DOE data object transmission is done.
     fn send_done(&self, tx_buf: &'static mut [u8], result: Result<(), ErrorCode>);
@@ -10,7 +12,7 @@ pub trait DoeTransportTxClient {
 
 pub trait DoeTransportRxClient {
     /// Called when a DOE data object is received.
-    fn receive(&self, rx_buf: &'static mut [u8], len: usize) -> Result<(), ErrorCode>;
+    fn receive(&self, rx_buf: &'static mut [u8], len: usize);
 }
 
 pub trait DoeTransport {
@@ -20,7 +22,7 @@ pub trait DoeTransport {
 
     /// Sets the buffer used for receiving incoming DOE Objects.
     /// This function should be called by the Rx client upon receiving the `receive()` callback.
-    fn set_receive_buffer(&self, rx_buf: &'static mut [u8]);
+    fn set_rx_buffer(&self, rx_buf: &'static mut [u8]);
 
     /// Gets the maximum size of the data object that can be sent or received over DOE Transport.
     fn max_data_object_size(&self) -> usize;

--- a/runtime/kernel/drivers/doe/src/hil.rs
+++ b/runtime/kernel/drivers/doe/src/hil.rs
@@ -36,12 +36,12 @@ pub trait DoeTransport {
     /// Send DOE Object to be transmitted over SoC specific DOE transport.
     ///
     /// # Arguments
-    /// * `doe_hdr` - A reference to the DOE header
+    /// * `doe_hdr` - DOE header bytes
     /// * `doe_payload` - A reference to the DOE payload
     /// * `payload_len` - The length of the payload in bytes
     fn transmit(
         &self,
-        doe_hdr: &'static [u8; 8],
+        doe_hdr: [u8; DOE_HDR_SIZE],
         doe_payload: &'static mut [u8],
         payload_len: usize,
     ) -> Result<(), (ErrorCode, &'static mut [u8])>;


### PR DESCRIPTION
This PR adds the initial, untested skeleton for the DOE transport driver.
It establishes the basic structure, state machine, buffer management, and lays the groundwork for `response timeout` and deferred `send_done` logic.
Further development, testing, and additional features will follow in subsequent phases.
