### PR TITLE
increase the app binary boundary for streaming boot test

### DIFF
--- a/builder/src/runtime.rs
+++ b/builder/src/runtime.rs
@@ -20,7 +20,7 @@ const DEFAULT_PLATFORM: &str = "emulator";
 const DEFAULT_RUNTIME_NAME: &str = "runtime.bin";
 const INTERRUPT_TABLE_SIZE: usize = 128;
 // amount to reserve for data RAM at the end of RAM
-const DATA_RAM_SIZE: usize = 120 * 1024;
+const DATA_RAM_SIZE: usize = 116 * 1024;
 
 fn get_apps_memory_offset(elf_file: PathBuf) -> Result<usize> {
     let elf_bytes = std::fs::read(&elf_file)?;

--- a/emulator/app/src/tests/mctp_util/common.rs
+++ b/emulator/app/src/tests/mctp_util/common.rs
@@ -140,6 +140,9 @@ impl MctpUtil {
         while running.load(Ordering::Relaxed) && retry > 0 {
             match i3c_state {
                 I3cControllerState::Start => {
+                    // Add some delay before sending the first packet.
+                    // The MCU might need some time to boot up and be ready to receive the request.
+                    std::thread::sleep(std::time::Duration::from_secs(5));
                     i3c_state = I3cControllerState::SendPrivateWrite;
                 }
 


### PR DESCRIPTION
Increase the app binary limit for the streaming boot test.
Add additional delay to the wait for responder test case to ensure the MCU has fully booted up.