### PR TITLE
Flash Recovery Boot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,9 +63,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.18"
+version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -78,33 +78,33 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
 dependencies = [
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.8"
+version = "3.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6680de5231bd6ee4c6191b8a1325daa282b415391ec9d3a37bd34f2060dc73fa"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
@@ -161,14 +161,14 @@ checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "base16ct"
@@ -178,9 +178,9 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64ct"
-version = "1.7.3"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
+checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
 name = "bit-vec"
@@ -229,9 +229,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.17.0"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "byteorder"
@@ -242,7 +242,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 [[package]]
 name = "caliptra-api"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7fb2e579cb2a932fabf804c50e83c9ba78574836#7fb2e579cb2a932fabf804c50e83c9ba78574836"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=977a21dfbe129836fb930b00cf87803275255611#977a21dfbe129836fb930b00cf87803275255611"
 dependencies = [
  "bitflags 2.9.1",
  "caliptra-api-types",
@@ -257,7 +257,7 @@ dependencies = [
 [[package]]
 name = "caliptra-api-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7fb2e579cb2a932fabf804c50e83c9ba78574836#7fb2e579cb2a932fabf804c50e83c9ba78574836"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=977a21dfbe129836fb930b00cf87803275255611#977a21dfbe129836fb930b00cf87803275255611"
 dependencies = [
  "caliptra-image-types",
 ]
@@ -265,7 +265,7 @@ dependencies = [
 [[package]]
 name = "caliptra-auth-man-gen"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7fb2e579cb2a932fabf804c50e83c9ba78574836#7fb2e579cb2a932fabf804c50e83c9ba78574836"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=977a21dfbe129836fb930b00cf87803275255611#977a21dfbe129836fb930b00cf87803275255611"
 dependencies = [
  "anyhow",
  "bitflags 2.9.1",
@@ -280,7 +280,7 @@ dependencies = [
 [[package]]
 name = "caliptra-auth-man-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7fb2e579cb2a932fabf804c50e83c9ba78574836#7fb2e579cb2a932fabf804c50e83c9ba78574836"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=977a21dfbe129836fb930b00cf87803275255611#977a21dfbe129836fb930b00cf87803275255611"
 dependencies = [
  "bitfield",
  "bitflags 2.9.1",
@@ -295,7 +295,7 @@ dependencies = [
 [[package]]
 name = "caliptra-builder"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7fb2e579cb2a932fabf804c50e83c9ba78574836#7fb2e579cb2a932fabf804c50e83c9ba78574836"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=977a21dfbe129836fb930b00cf87803275255611#977a21dfbe129836fb930b00cf87803275255611"
 dependencies = [
  "anyhow",
  "caliptra-image-crypto",
@@ -320,7 +320,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cfi-derive"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7fb2e579cb2a932fabf804c50e83c9ba78574836#7fb2e579cb2a932fabf804c50e83c9ba78574836"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=977a21dfbe129836fb930b00cf87803275255611#977a21dfbe129836fb930b00cf87803275255611"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -342,7 +342,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cfi-lib"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7fb2e579cb2a932fabf804c50e83c9ba78574836#7fb2e579cb2a932fabf804c50e83c9ba78574836"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=977a21dfbe129836fb930b00cf87803275255611#977a21dfbe129836fb930b00cf87803275255611"
 dependencies = [
  "caliptra-error",
  "caliptra-registers",
@@ -357,7 +357,7 @@ source = "git+https://github.com/chipsalliance/caliptra-cfi.git?rev=a98e499d279e
 [[package]]
 name = "caliptra-coverage"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7fb2e579cb2a932fabf804c50e83c9ba78574836#7fb2e579cb2a932fabf804c50e83c9ba78574836"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=977a21dfbe129836fb930b00cf87803275255611#977a21dfbe129836fb930b00cf87803275255611"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -375,7 +375,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cpu"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7fb2e579cb2a932fabf804c50e83c9ba78574836#7fb2e579cb2a932fabf804c50e83c9ba78574836"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=977a21dfbe129836fb930b00cf87803275255611#977a21dfbe129836fb930b00cf87803275255611"
 dependencies = [
  "caliptra-drivers",
  "caliptra-registers",
@@ -385,7 +385,7 @@ dependencies = [
 [[package]]
 name = "caliptra-drivers"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7fb2e579cb2a932fabf804c50e83c9ba78574836#7fb2e579cb2a932fabf804c50e83c9ba78574836"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=977a21dfbe129836fb930b00cf87803275255611#977a21dfbe129836fb930b00cf87803275255611"
 dependencies = [
  "arrayvec",
  "bitfield",
@@ -411,7 +411,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-bus"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7fb2e579cb2a932fabf804c50e83c9ba78574836#7fb2e579cb2a932fabf804c50e83c9ba78574836"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=977a21dfbe129836fb930b00cf87803275255611#977a21dfbe129836fb930b00cf87803275255611"
 dependencies = [
  "caliptra-emu-types",
  "tock-registers",
@@ -421,7 +421,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-cpu"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7fb2e579cb2a932fabf804c50e83c9ba78574836#7fb2e579cb2a932fabf804c50e83c9ba78574836"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=977a21dfbe129836fb930b00cf87803275255611#977a21dfbe129836fb930b00cf87803275255611"
 dependencies = [
  "bit-vec",
  "bitfield",
@@ -435,7 +435,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7fb2e579cb2a932fabf804c50e83c9ba78574836#7fb2e579cb2a932fabf804c50e83c9ba78574836"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=977a21dfbe129836fb930b00cf87803275255611#977a21dfbe129836fb930b00cf87803275255611"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -450,7 +450,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-derive"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7fb2e579cb2a932fabf804c50e83c9ba78574836#7fb2e579cb2a932fabf804c50e83c9ba78574836"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=977a21dfbe129836fb930b00cf87803275255611#977a21dfbe129836fb930b00cf87803275255611"
 dependencies = [
  "caliptra-emu-bus",
  "caliptra-emu-types",
@@ -461,7 +461,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-periph"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7fb2e579cb2a932fabf804c50e83c9ba78574836#7fb2e579cb2a932fabf804c50e83c9ba78574836"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=977a21dfbe129836fb930b00cf87803275255611#977a21dfbe129836fb930b00cf87803275255611"
 dependencies = [
  "aes",
  "arrayref",
@@ -488,17 +488,17 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7fb2e579cb2a932fabf804c50e83c9ba78574836#7fb2e579cb2a932fabf804c50e83c9ba78574836"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=977a21dfbe129836fb930b00cf87803275255611#977a21dfbe129836fb930b00cf87803275255611"
 
 [[package]]
 name = "caliptra-error"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7fb2e579cb2a932fabf804c50e83c9ba78574836#7fb2e579cb2a932fabf804c50e83c9ba78574836"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=977a21dfbe129836fb930b00cf87803275255611#977a21dfbe129836fb930b00cf87803275255611"
 
 [[package]]
 name = "caliptra-gen-linker-scripts"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7fb2e579cb2a932fabf804c50e83c9ba78574836#7fb2e579cb2a932fabf804c50e83c9ba78574836"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=977a21dfbe129836fb930b00cf87803275255611#977a21dfbe129836fb930b00cf87803275255611"
 dependencies = [
  "caliptra_common",
 ]
@@ -506,7 +506,7 @@ dependencies = [
 [[package]]
 name = "caliptra-hw-model"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7fb2e579cb2a932fabf804c50e83c9ba78574836#7fb2e579cb2a932fabf804c50e83c9ba78574836"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=977a21dfbe129836fb930b00cf87803275255611#977a21dfbe129836fb930b00cf87803275255611"
 dependencies = [
  "bit-vec",
  "bitfield",
@@ -532,7 +532,7 @@ dependencies = [
 [[package]]
 name = "caliptra-hw-model-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7fb2e579cb2a932fabf804c50e83c9ba78574836#7fb2e579cb2a932fabf804c50e83c9ba78574836"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=977a21dfbe129836fb930b00cf87803275255611#977a21dfbe129836fb930b00cf87803275255611"
 dependencies = [
  "caliptra-api-types",
  "rand",
@@ -541,7 +541,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7fb2e579cb2a932fabf804c50e83c9ba78574836#7fb2e579cb2a932fabf804c50e83c9ba78574836"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=977a21dfbe129836fb930b00cf87803275255611#977a21dfbe129836fb930b00cf87803275255611"
 dependencies = [
  "anyhow",
  "caliptra-image-gen",
@@ -561,7 +561,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-elf"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7fb2e579cb2a932fabf804c50e83c9ba78574836#7fb2e579cb2a932fabf804c50e83c9ba78574836"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=977a21dfbe129836fb930b00cf87803275255611#977a21dfbe129836fb930b00cf87803275255611"
 dependencies = [
  "anyhow",
  "caliptra-image-gen",
@@ -572,7 +572,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-fake-keys"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7fb2e579cb2a932fabf804c50e83c9ba78574836#7fb2e579cb2a932fabf804c50e83c9ba78574836"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=977a21dfbe129836fb930b00cf87803275255611#977a21dfbe129836fb930b00cf87803275255611"
 dependencies = [
  "caliptra-image-gen",
  "caliptra-image-types",
@@ -583,7 +583,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-gen"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7fb2e579cb2a932fabf804c50e83c9ba78574836#7fb2e579cb2a932fabf804c50e83c9ba78574836"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=977a21dfbe129836fb930b00cf87803275255611#977a21dfbe129836fb930b00cf87803275255611"
 dependencies = [
  "anyhow",
  "bitflags 2.9.1",
@@ -600,7 +600,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7fb2e579cb2a932fabf804c50e83c9ba78574836#7fb2e579cb2a932fabf804c50e83c9ba78574836"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=977a21dfbe129836fb930b00cf87803275255611#977a21dfbe129836fb930b00cf87803275255611"
 dependencies = [
  "caliptra-cfi-derive",
  "caliptra-cfi-lib",
@@ -616,7 +616,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-verify"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7fb2e579cb2a932fabf804c50e83c9ba78574836#7fb2e579cb2a932fabf804c50e83c9ba78574836"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=977a21dfbe129836fb930b00cf87803275255611#977a21dfbe129836fb930b00cf87803275255611"
 dependencies = [
  "bitflags 2.9.1",
  "caliptra-cfi-derive",
@@ -631,7 +631,7 @@ dependencies = [
 [[package]]
 name = "caliptra-kat"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7fb2e579cb2a932fabf804c50e83c9ba78574836#7fb2e579cb2a932fabf804c50e83c9ba78574836"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=977a21dfbe129836fb930b00cf87803275255611#977a21dfbe129836fb930b00cf87803275255611"
 dependencies = [
  "caliptra-drivers",
  "caliptra-lms-types",
@@ -643,7 +643,7 @@ dependencies = [
 [[package]]
 name = "caliptra-lms-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7fb2e579cb2a932fabf804c50e83c9ba78574836#7fb2e579cb2a932fabf804c50e83c9ba78574836"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=977a21dfbe129836fb930b00cf87803275255611#977a21dfbe129836fb930b00cf87803275255611"
 dependencies = [
  "caliptra-cfi-derive",
  "caliptra-cfi-lib",
@@ -656,7 +656,7 @@ dependencies = [
 [[package]]
 name = "caliptra-registers"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7fb2e579cb2a932fabf804c50e83c9ba78574836#7fb2e579cb2a932fabf804c50e83c9ba78574836"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=977a21dfbe129836fb930b00cf87803275255611#977a21dfbe129836fb930b00cf87803275255611"
 dependencies = [
  "caliptra-registers-latest",
 ]
@@ -664,7 +664,7 @@ dependencies = [
 [[package]]
 name = "caliptra-registers-latest"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7fb2e579cb2a932fabf804c50e83c9ba78574836#7fb2e579cb2a932fabf804c50e83c9ba78574836"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=977a21dfbe129836fb930b00cf87803275255611#977a21dfbe129836fb930b00cf87803275255611"
 dependencies = [
  "ureg",
 ]
@@ -672,7 +672,7 @@ dependencies = [
 [[package]]
 name = "caliptra-runtime"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7fb2e579cb2a932fabf804c50e83c9ba78574836#7fb2e579cb2a932fabf804c50e83c9ba78574836"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=977a21dfbe129836fb930b00cf87803275255611#977a21dfbe129836fb930b00cf87803275255611"
 dependencies = [
  "arrayvec",
  "bitflags 2.9.1",
@@ -704,7 +704,7 @@ dependencies = [
 [[package]]
 name = "caliptra-test"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7fb2e579cb2a932fabf804c50e83c9ba78574836#7fb2e579cb2a932fabf804c50e83c9ba78574836"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=977a21dfbe129836fb930b00cf87803275255611#977a21dfbe129836fb930b00cf87803275255611"
 dependencies = [
  "anyhow",
  "asn1",
@@ -736,12 +736,12 @@ dependencies = [
 [[package]]
 name = "caliptra-test-harness-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7fb2e579cb2a932fabf804c50e83c9ba78574836#7fb2e579cb2a932fabf804c50e83c9ba78574836"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=977a21dfbe129836fb930b00cf87803275255611#977a21dfbe129836fb930b00cf87803275255611"
 
 [[package]]
 name = "caliptra-x509"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7fb2e579cb2a932fabf804c50e83c9ba78574836#7fb2e579cb2a932fabf804c50e83c9ba78574836"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=977a21dfbe129836fb930b00cf87803275255611#977a21dfbe129836fb930b00cf87803275255611"
 dependencies = [
  "zeroize",
 ]
@@ -749,7 +749,7 @@ dependencies = [
 [[package]]
 name = "caliptra_common"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7fb2e579cb2a932fabf804c50e83c9ba78574836#7fb2e579cb2a932fabf804c50e83c9ba78574836"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=977a21dfbe129836fb930b00cf87803275255611#977a21dfbe129836fb930b00cf87803275255611"
 dependencies = [
  "bitfield",
  "bitflags 2.9.1",
@@ -855,7 +855,7 @@ dependencies = [
  "serde-untagged",
  "serde-value",
  "thiserror 1.0.69",
- "toml 0.8.22",
+ "toml 0.8.23",
  "unicode-xid",
  "url",
 ]
@@ -886,18 +886,18 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.25"
+version = "1.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0fc897dc1e865cc67c0e05a836d9d3f1df3cbe442aa4a9473b18e12624a4951"
+checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
 dependencies = [
  "shlex",
 ]
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "cfg_aliases"
@@ -944,9 +944,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.39"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd60e63e9be68e5fb56422e397cf9baddded06dae1d2e523401542383bc72a9f"
+checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -963,29 +963,29 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.39"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89cc6392a1f72bbeb820d71f32108f61fdaf18bc526e1d23954168a67759ef51"
+checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
 dependencies = [
  "anstream",
  "anstyle",
- "clap_lex 0.7.4",
+ "clap_lex 0.7.5",
  "strsim",
  "terminal_size",
  "unicase",
- "unicode-width 0.2.0",
+ "unicode-width 0.2.1",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.5.32"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
+checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -999,15 +999,15 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "colored"
@@ -1026,7 +1026,7 @@ dependencies = [
  "caliptra-emu-bus",
  "caliptra-emu-cpu",
  "caliptra-emu-types",
- "clap 4.5.39",
+ "clap 4.5.40",
  "emulator-consts",
  "getrandom 0.2.16",
 ]
@@ -1146,14 +1146,14 @@ dependencies = [
 
 [[package]]
 name = "crunchy"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7fb2e579cb2a932fabf804c50e83c9ba78574836#7fb2e579cb2a932fabf804c50e83c9ba78574836"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=977a21dfbe129836fb930b00cf87803275255611#977a21dfbe129836fb930b00cf87803275255611"
 dependencies = [
  "arrayvec",
  "caliptra-cfi-derive-git",
@@ -1224,7 +1224,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1235,7 +1235,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1258,7 +1258,7 @@ checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1290,7 +1290,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1333,7 +1333,7 @@ dependencies = [
 [[package]]
 name = "dpe"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7fb2e579cb2a932fabf804c50e83c9ba78574836#7fb2e579cb2a932fabf804c50e83c9ba78574836"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=977a21dfbe129836fb930b00cf87803275255611#977a21dfbe129836fb930b00cf87803275255611"
 dependencies = [
  "bitflags 2.9.1",
  "caliptra-cfi-derive-git",
@@ -1408,7 +1408,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1468,7 +1468,7 @@ dependencies = [
  "caliptra-image-types",
  "caliptra-test",
  "chrono",
- "clap 4.5.39",
+ "clap 4.5.40",
  "clap-num",
  "crc",
  "crossterm",
@@ -1491,6 +1491,7 @@ dependencies = [
  "pldm-ua",
  "rand",
  "sec1",
+ "semver",
  "sha2",
  "simple_logger",
  "smlang 0.8.0",
@@ -1523,7 +1524,7 @@ dependencies = [
  "caliptra-emu-periph",
  "caliptra-hw-model",
  "caliptra-registers",
- "clap 4.5.39",
+ "clap 4.5.40",
  "ctrlc",
  "elf",
  "emulator-consts",
@@ -1554,6 +1555,7 @@ dependencies = [
  "lazy_static",
  "num_enum",
  "registers-generated",
+ "semver",
  "serde",
  "serde_json",
  "tempfile",
@@ -1594,12 +1596,12 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1666,6 +1668,13 @@ dependencies = [
  "registers-generated",
  "romtime",
  "tock-registers",
+]
+
+[[package]]
+name = "flash-image"
+version = "0.1.0"
+dependencies = [
+ "zerocopy",
 ]
 
 [[package]]
@@ -1764,7 +1773,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1840,7 +1849,7 @@ checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi 0.11.1+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -1893,9 +1902,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.3"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 
 [[package]]
 name = "heapless"
@@ -2103,12 +2112,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.3",
+ "hashbrown 0.15.4",
 ]
 
 [[package]]
@@ -2180,6 +2189,7 @@ dependencies = [
  "embassy-executor",
  "embassy-sync",
  "embedded-alloc",
+ "flash-image",
  "futures",
  "libsyscall-caliptra",
  "libtock_console",
@@ -2208,9 +2218,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libsyscall-caliptra"
@@ -2489,6 +2499,7 @@ dependencies = [
  "nix 0.26.4",
  "rand",
  "registers-generated",
+ "semver",
  "sha2",
  "tock-registers",
  "uio",
@@ -2512,20 +2523,24 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "same-file",
- "winnow 0.7.10",
+ "winnow 0.7.11",
 ]
 
 [[package]]
 name = "mcu-rom-common"
 version = "0.1.0"
 dependencies = [
+ "bitfield",
  "caliptra-api",
+ "flash-image",
  "mcu-config",
  "registers-generated",
  "riscv-csr",
  "romtime",
  "rv32i",
+ "smlang 0.8.0",
  "tock-registers",
+ "zerocopy",
  "zeroize",
 ]
 
@@ -2533,6 +2548,7 @@ dependencies = [
 name = "mcu-rom-emulator"
 version = "0.1.0"
 dependencies = [
+ "bitfield",
  "mcu-builder",
  "mcu-config",
  "mcu-config-emulator",
@@ -2542,6 +2558,7 @@ dependencies = [
  "romtime",
  "rv32i",
  "tock-registers",
+ "zerocopy",
  "zeroize",
 ]
 
@@ -2641,9 +2658,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "memoffset"
@@ -2671,7 +2688,7 @@ checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
 ]
 
@@ -2714,7 +2731,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2728,23 +2745,24 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
+checksum = "a973b4e44ce6cad84ce69d797acf9a044532e4184c4f267913d1b546a0727b7a"
 dependencies = [
  "num_enum_derive",
+ "rustversion",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
+checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2795,7 +2813,7 @@ source = "git+https://github.com/teythoon/rust-openssl.git?branch=justus%2Fpqc#4
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2921,7 +2939,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 [[package]]
 name = "platform"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7fb2e579cb2a932fabf804c50e83c9ba78574836#7fb2e579cb2a932fabf804c50e83c9ba78574836"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=977a21dfbe129836fb930b00cf87803275255611#977a21dfbe129836fb930b00cf87803275255611"
 dependencies = [
  "arrayvec",
  "cfg-if",
@@ -2941,13 +2959,13 @@ name = "pldm-fw-pkg"
 version = "0.1.0"
 dependencies = [
  "chrono",
- "clap 4.5.39",
+ "clap 4.5.40",
  "crc",
  "num-derive",
  "num-traits",
  "serde",
  "tempfile",
- "toml 0.8.22",
+ "toml 0.8.23",
  "uuid",
 ]
 
@@ -2995,9 +3013,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
 name = "potential_utf"
@@ -3038,7 +3056,7 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
 dependencies = [
- "toml_edit 0.22.26",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
@@ -3067,9 +3085,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
@@ -3103,9 +3121,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.12"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
+checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
 dependencies = [
  "bitflags 2.9.1",
 ]
@@ -3212,7 +3230,7 @@ checksum = "e8c4aa1ea1af6dcc83a61be12e8189f9b293c3ba5a487778a4cd89fb060fdbbc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3371,7 +3389,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3388,9 +3406,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
 ]
@@ -3476,18 +3494,15 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
+checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
 
 [[package]]
 name = "smallvec"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "smlang"
@@ -3630,9 +3645,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.101"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3647,7 +3662,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3731,7 +3746,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3742,7 +3757,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3831,21 +3846,21 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.22"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ae329d1f08c4d17a59bed7ff5b5a769d062e64a62d34a3261b219e62cd5aae"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.26",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.9"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 dependencies = [
  "serde",
 ]
@@ -3856,7 +3871,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -3865,23 +3880,23 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.26"
+version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
  "toml_write",
- "winnow 0.7.10",
+ "winnow 0.7.11",
 ]
 
 [[package]]
 name = "toml_write"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "typeid"
@@ -3975,9 +3990,9 @@ checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
 
 [[package]]
 name = "unicode-xid"
@@ -3998,7 +4013,7 @@ dependencies = [
 [[package]]
 name = "ureg"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7fb2e579cb2a932fabf804c50e83c9ba78574836#7fb2e579cb2a932fabf804c50e83c9ba78574836"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=977a21dfbe129836fb930b00cf87803275255611#977a21dfbe129836fb930b00cf87803275255611"
 
 [[package]]
 name = "url"
@@ -4087,9 +4102,9 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
@@ -4122,7 +4137,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
  "wasm-bindgen-shared",
 ]
 
@@ -4144,7 +4159,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4210,7 +4225,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4221,14 +4236,14 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "windows-link"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-result"
@@ -4267,6 +4282,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.2",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4290,11 +4314,27 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
+dependencies = [
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -4310,6 +4350,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4320,6 +4366,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4334,10 +4386,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4352,6 +4416,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4362,6 +4432,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4376,6 +4452,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4388,6 +4470,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
 name = "winnow"
 version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4398,9 +4486,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
+checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
 dependencies = [
  "memchr",
 ]
@@ -4425,7 +4513,7 @@ name = "xtask"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 4.5.39",
+ "clap 4.5.40",
  "clap-num",
  "crc32fast",
  "elf",
@@ -4442,7 +4530,7 @@ dependencies = [
  "serde-hjson",
  "sudo",
  "tempfile",
- "toml 0.8.22",
+ "toml 0.8.23",
  "walkdir",
  "zerocopy",
 ]
@@ -4467,28 +4555,28 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4508,7 +4596,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
  "synstructure",
 ]
 
@@ -4529,7 +4617,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4562,5 +4650,5 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@
 members = [
     "builder",
     "common/config",
+    "common/flash-image",
     "common/pldm",
     "emulator/app",
     "emulator/bmc/pldm-ua",
@@ -148,6 +149,7 @@ emulator-consts = { "path" = "emulator/consts" }
 emulator-periph = { path = "emulator/periph" }
 emulator-registers-generated = { path = "registers/generated-emulator" }
 flash-driver = { path = "runtime/kernel/drivers/flash" }
+flash-image = { path = "common/flash-image" }
 i3c-driver = { path = "runtime/kernel/drivers/i3c" }
 libtockasync = { path = "runtime/userspace/libtockasync" }
 mcu-builder = { path = "builder" }
@@ -187,28 +189,28 @@ libtock_small_panic = { path = "runtime/userspace/libtock/panic_handlers/small_p
 libtock_unittest = { path = "runtime/userspace/libtock/unittest" }
 
 # caliptra dependencies; keep git revs in sync
-caliptra-api = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "7fb2e579cb2a932fabf804c50e83c9ba78574836" }
-caliptra-api-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "7fb2e579cb2a932fabf804c50e83c9ba78574836" }
-caliptra-auth-man-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "7fb2e579cb2a932fabf804c50e83c9ba78574836" }
-caliptra-auth-man-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "7fb2e579cb2a932fabf804c50e83c9ba78574836" }
-caliptra-builder = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "7fb2e579cb2a932fabf804c50e83c9ba78574836" }
-caliptra-emu-bus = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "7fb2e579cb2a932fabf804c50e83c9ba78574836" }
-caliptra-emu-cpu = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "7fb2e579cb2a932fabf804c50e83c9ba78574836" }
-caliptra-emu-derive = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "7fb2e579cb2a932fabf804c50e83c9ba78574836" }
-caliptra-emu-periph = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "7fb2e579cb2a932fabf804c50e83c9ba78574836" }
-caliptra-emu-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "7fb2e579cb2a932fabf804c50e83c9ba78574836" }
-caliptra-error = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "7fb2e579cb2a932fabf804c50e83c9ba78574836", default-features = false }
-caliptra-hw-model = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "7fb2e579cb2a932fabf804c50e83c9ba78574836" }
-caliptra-hw-model-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "7fb2e579cb2a932fabf804c50e83c9ba78574836" }
-caliptra-image-crypto = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "7fb2e579cb2a932fabf804c50e83c9ba78574836", default-features = false, features = ["rustcrypto"] }
-caliptra-image-fake-keys = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "7fb2e579cb2a932fabf804c50e83c9ba78574836" }
-caliptra-image-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "7fb2e579cb2a932fabf804c50e83c9ba78574836" }
-caliptra-image-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "7fb2e579cb2a932fabf804c50e83c9ba78574836" }
-caliptra-registers = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "7fb2e579cb2a932fabf804c50e83c9ba78574836" }
-caliptra-test = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "7fb2e579cb2a932fabf804c50e83c9ba78574836" }
-caliptra-test-harness-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "7fb2e579cb2a932fabf804c50e83c9ba78574836" }
-ureg = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "7fb2e579cb2a932fabf804c50e83c9ba78574836" }
-dpe = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "7fb2e579cb2a932fabf804c50e83c9ba78574836", default-features = false, features = ["dpe_profile_p384_sha384"] }
+caliptra-api = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "977a21dfbe129836fb930b00cf87803275255611" }
+caliptra-api-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "977a21dfbe129836fb930b00cf87803275255611" }
+caliptra-auth-man-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "977a21dfbe129836fb930b00cf87803275255611" }
+caliptra-auth-man-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "977a21dfbe129836fb930b00cf87803275255611" }
+caliptra-builder = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "977a21dfbe129836fb930b00cf87803275255611" }
+caliptra-emu-bus = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "977a21dfbe129836fb930b00cf87803275255611" }
+caliptra-emu-cpu = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "977a21dfbe129836fb930b00cf87803275255611" }
+caliptra-emu-derive = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "977a21dfbe129836fb930b00cf87803275255611" }
+caliptra-emu-periph = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "977a21dfbe129836fb930b00cf87803275255611" }
+caliptra-emu-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "977a21dfbe129836fb930b00cf87803275255611" }
+caliptra-error = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "977a21dfbe129836fb930b00cf87803275255611", default-features = false }
+caliptra-hw-model = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "977a21dfbe129836fb930b00cf87803275255611" }
+caliptra-hw-model-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "977a21dfbe129836fb930b00cf87803275255611" }
+caliptra-image-crypto = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "977a21dfbe129836fb930b00cf87803275255611", default-features = false, features = ["rustcrypto"] }
+caliptra-image-fake-keys = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "977a21dfbe129836fb930b00cf87803275255611" }
+caliptra-image-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "977a21dfbe129836fb930b00cf87803275255611" }
+caliptra-image-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "977a21dfbe129836fb930b00cf87803275255611" }
+caliptra-registers = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "977a21dfbe129836fb930b00cf87803275255611" }
+caliptra-test = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "977a21dfbe129836fb930b00cf87803275255611" }
+caliptra-test-harness-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "977a21dfbe129836fb930b00cf87803275255611" }
+ureg = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "977a21dfbe129836fb930b00cf87803275255611" }
+dpe = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "977a21dfbe129836fb930b00cf87803275255611", default-features = false, features = ["dpe_profile_p384_sha384"] }
 
 # local caliptra dependency; useful when developing
 # caliptra-api = { path = "../caliptra-sw/api" }

--- a/builder/src/caliptra.rs
+++ b/builder/src/caliptra.rs
@@ -21,6 +21,7 @@ use hex::ToHex;
 use std::{num::ParseIntError, path::PathBuf, str::FromStr};
 use zerocopy::{transmute, IntoBytes};
 
+#[derive(Clone, Debug)]
 pub struct CaliptraBuilder {
     fpga: bool,
     caliptra_rom: Option<PathBuf>,
@@ -120,6 +121,18 @@ impl CaliptraBuilder {
             self.soc_manifest = Some(path);
         }
         Ok(self.soc_manifest.clone().unwrap())
+    }
+
+    pub fn replace_manifest_metadata(&mut self, metadata: Vec<SocImage>) -> Result<PathBuf> {
+        println!("Replacing SoC manifest metadata with: {:?}", metadata);
+        // Replace the current metadata
+        self.soc_images = Some(metadata);
+
+        self.soc_manifest = None; // Clear the cached manifest
+
+        // Rebuild the SoC manifest
+        println!("Rebuilding SoC manifest with new metadata");
+        self.get_soc_manifest()
     }
 
     pub fn get_vendor_pk_hash(&mut self) -> Result<&str> {

--- a/common/config/src/boot.rs
+++ b/common/config/src/boot.rs
@@ -5,7 +5,7 @@
 /// This trait abstracts the operations required to manage boot partitions,
 /// track their status and boot counts, and control rollback functionality.
 #[allow(async_fn_in_trait)]
-pub trait BootConfig {
+pub trait BootConfigAsync {
     /// Determines which partition should be booted.
     ///
     /// # Returns
@@ -79,6 +79,47 @@ pub trait BootConfig {
     /// # Returns
     /// * `Result<(), BootConfigError>` - `Ok(())` if successful, or an error on failure.
     async fn persist(&self) -> Result<(), BootConfigError> {
+        Ok(()) // Default: do nothing
+    }
+}
+
+// Synchronous version of the BootConfigAsync trait
+pub trait BootConfig {
+    /// Determines which partition should be booted.
+    fn get_active_partition(&self) -> Result<PartitionId, BootConfigError>;
+
+    /// Sets the active partition to boot from.
+    fn set_active_partition(&mut self, partition: PartitionId) -> Result<(), BootConfigError>;
+
+    /// Updates the status of a specified partition.
+    fn set_partition_status(
+        &mut self,
+        partition: PartitionId,
+        status: PartitionStatus,
+    ) -> Result<(), BootConfigError>;
+
+    /// Retrieves the current status of a specified partition.
+    fn get_partition_status(
+        &self,
+        partition: PartitionId,
+    ) -> Result<PartitionStatus, BootConfigError>;
+
+    /// Increments the boot count for a specified partition.
+    fn increment_boot_count(&self, partition: PartitionId) -> Result<u16, BootConfigError>;
+
+    /// Retrieves the boot count for a specified partition.
+    fn get_boot_count(&self, partition: PartitionId) -> Result<u16, BootConfigError>;
+
+    /// Checks if rollback functionality is enabled.
+    fn is_rollback_enabled(&self) -> Result<bool, BootConfigError>;
+
+    /// Enables or disables rollback functionality.
+    fn set_rollback_enable(&mut self, enable: bool) -> Result<(), BootConfigError>;
+
+    /// Optionally persists the updated configuration.
+    ///
+    /// This method can be overridden to persist changes to non-volatile storage.
+    fn persist(&self) -> Result<(), BootConfigError> {
         Ok(()) // Default: do nothing
     }
 }

--- a/common/flash-image/Cargo.toml
+++ b/common/flash-image/Cargo.toml
@@ -1,0 +1,10 @@
+# Licensed under the Apache-2.0 license
+
+[package]
+name = "flash-image"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+
+[dependencies]
+zerocopy.workspace = true

--- a/common/flash-image/src/lib.rs
+++ b/common/flash-image/src/lib.rs
@@ -1,4 +1,5 @@
 // Licensed under the Apache-2.0 license
+#![no_std]
 
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 

--- a/emulator/app/Cargo.toml
+++ b/emulator/app/Cargo.toml
@@ -40,6 +40,7 @@ pldm-ua.workspace = true
 rand.workspace = true
 sec1.workspace = true
 sha2.workspace = true
+semver.workspace = true
 simple_logger.workspace = true
 smlang.workspace = true
 strum_macros.workspace = true

--- a/emulator/app/src/main.rs
+++ b/emulator/app/src/main.rs
@@ -126,6 +126,10 @@ struct Emulator {
     #[arg(long)]
     secondary_flash_image: Option<PathBuf>,
 
+    /// HW revision in semver format (e.g., "2.0.0")
+    #[arg(long, value_parser = semver::Version::parse, default_value = "2.0.0")]
+    hw_revision: semver::Version,
+
     /// Override ROM offset
     #[arg(long, value_parser=maybe_hex::<u32>)]
     rom_offset: Option<u32>,
@@ -284,7 +288,7 @@ fn free_run(
     mut caliptra_cpu: CaliptraMainCpu<CaliptraMainRootBus>,
     trace_path: Option<PathBuf>,
     stdin_uart: Option<Arc<Mutex<Option<u8>>>>,
-    mut bmc: Bmc,
+    mut bmc: Option<Bmc>,
 ) {
     // read from the console in a separate thread to prevent blocking
     let running_clone = running.clone();
@@ -333,7 +337,9 @@ fn free_run(
                     println!("Caliptra CPU Halted");
                 }
             }
-            bmc.step();
+            if let Some(bmc) = bmc.as_mut() {
+                bmc.step();
+            }
         }
     } else {
         while running.load(std::sync::atomic::Ordering::Relaxed) {
@@ -352,7 +358,9 @@ fn free_run(
                     println!("Caliptra CPU Halted");
                 }
             }
-            bmc.step();
+            if let Some(bmc) = bmc.as_mut() {
+                bmc.step();
+            }
         }
     };
 }
@@ -428,10 +436,21 @@ fn run(cli: Emulator, capture_uart_output: bool) -> io::Result<Vec<u8>> {
         None
     };
 
+    let use_mcu_recovery_interface;
+    #[cfg(feature = "test-flash-based-boot")]
+    {
+        use_mcu_recovery_interface = true;
+    }
+    #[cfg(not(feature = "test-flash-based-boot"))]
+    {
+        use_mcu_recovery_interface = false;
+    }
+
     let (mut caliptra_cpu, soc_to_caliptra) = start_caliptra(&StartCaliptraArgs {
         rom: cli.caliptra_rom,
         device_lifecycle,
         req_idevid_csr,
+        use_mcu_recovery_interface,
     })
     .expect("Failed to start Caliptra CPU");
 
@@ -507,15 +526,11 @@ fn run(cli: Emulator, capture_uart_output: bool) -> io::Result<Vec<u8>> {
         mcu_root_bus_offsets.ram_size = sram_size;
     }
 
-    // Don't override default DCCM offset and size when the ROM flash driver feature is enabled.
-    #[cfg(not(feature = "test-mcu-rom-flash-access"))]
-    {
-        if let Some(dccm_offset) = cli.dccm_offset {
-            mcu_root_bus_offsets.rom_dedicated_ram_offset = dccm_offset;
-        }
-        if let Some(dccm_size) = cli.dccm_size {
-            mcu_root_bus_offsets.rom_dedicated_ram_size = dccm_size;
-        }
+    if let Some(dccm_offset) = cli.dccm_offset {
+        mcu_root_bus_offsets.rom_dedicated_ram_offset = dccm_offset;
+    }
+    if let Some(dccm_size) = cli.dccm_size {
+        mcu_root_bus_offsets.rom_dedicated_ram_size = dccm_size;
     }
 
     if let Some(i3c_offset) = cli.i3c_offset {
@@ -602,6 +617,7 @@ fn run(cli: Emulator, capture_uart_output: bool) -> io::Result<Vec<u8>> {
         &mut i3c_controller,
         i3c_error_irq,
         i3c_notif_irq,
+        cli.hw_revision.clone(),
     );
     let i3c_dynamic_address = i3c.get_dynamic_address().unwrap();
 
@@ -865,26 +881,47 @@ fn run(cli: Emulator, capture_uart_output: bool) -> io::Result<Vec<u8>> {
     cpu.write_pc(mcu_root_bus_offsets.rom_offset);
     cpu.register_events();
 
-    println!("Initializing recovery interface");
-    let (caliptra_event_sender, caliptra_event_receiver) = caliptra_cpu.register_events();
-    let (mcu_event_sender, mcu_event_reciever) = cpu.register_events();
-    // prepare the BMC recovery interface emulator
-    let mut bmc = Bmc::new(
-        caliptra_event_sender,
-        caliptra_event_receiver,
-        mcu_event_sender,
-        mcu_event_reciever,
-    );
+    let mut bmc;
+    #[cfg(feature = "test-flash-based-boot")]
+    {
+        println!("Emulator is using MCU recovery interface");
+        bmc = None;
+        let (caliptra_event_sender, caliptra_event_receiver) = caliptra_cpu.register_events();
+        let (mcu_event_sender, mcu_event_receiver) = cpu.register_events();
+        cpu.bus
+            .i3c_periph
+            .as_mut()
+            .unwrap()
+            .periph
+            .register_event_channels(
+                caliptra_event_sender,
+                caliptra_event_receiver,
+                mcu_event_sender,
+                mcu_event_receiver,
+            );
+    }
+    #[cfg(not(feature = "test-flash-based-boot"))]
+    {
+        let (caliptra_event_sender, caliptra_event_receiver) = caliptra_cpu.register_events();
+        let (mcu_event_sender, mcu_event_reciever) = cpu.register_events();
+        // prepare the BMC recovery interface emulator
+        bmc = Some(Bmc::new(
+            caliptra_event_sender,
+            caliptra_event_receiver,
+            mcu_event_sender,
+            mcu_event_reciever,
+        ));
 
-    // load the firmware images and SoC manifest into the recovery interface emulator
+        // load the firmware images and SoC manifest into the recovery interface emulator
 
-    let caliptra_firmware = read_binary(&cli.caliptra_firmware, RAM_ORG).unwrap();
-    let soc_manifest = read_binary(&cli.soc_manifest, 0).unwrap();
-    bmc.push_recovery_image(caliptra_firmware);
-    bmc.push_recovery_image(soc_manifest);
-    bmc.push_recovery_image(mcu_firmware);
-    println!("Active mode enabled with 3 recovery images");
-
+        let caliptra_firmware = read_binary(&cli.caliptra_firmware, RAM_ORG).unwrap();
+        let soc_manifest = read_binary(&cli.soc_manifest, 0).unwrap();
+        let bmc = bmc.as_mut().unwrap();
+        bmc.push_recovery_image(caliptra_firmware);
+        bmc.push_recovery_image(soc_manifest);
+        bmc.push_recovery_image(mcu_firmware);
+        println!("Active mode enabled with 3 recovery images");
+    }
     if cli.streaming_boot.is_some() {
         let _ = simple_logger::SimpleLogger::new()
             .with_level(log::LevelFilter::Debug)

--- a/emulator/caliptra/src/caliptra.rs
+++ b/emulator/caliptra/src/caliptra.rs
@@ -37,6 +37,7 @@ pub struct StartCaliptraArgs {
     pub rom: PathBuf,
     pub req_idevid_csr: Option<bool>,
     pub device_lifecycle: Option<String>,
+    pub use_mcu_recovery_interface: bool,
 }
 
 register_bitfields! [
@@ -62,6 +63,7 @@ pub fn start_caliptra(
     let args_ueid = u128::MAX;
     let unprovisioned = String::from("unprovisioned");
     let args_device_lifecycle = args.device_lifecycle.as_ref().unwrap_or(&unprovisioned);
+    let args_use_mcu_recovery_interface = args.use_mcu_recovery_interface;
     if !args.rom.exists() {
         Err(io::Error::new(
             ErrorKind::NotFound,
@@ -128,6 +130,7 @@ pub fn start_caliptra(
             },
         ),
         subsystem_mode: true,
+        use_mcu_recovery_interface: args_use_mcu_recovery_interface,
         ..Default::default()
     };
 

--- a/emulator/periph/Cargo.toml
+++ b/emulator/periph/Cargo.toml
@@ -18,6 +18,7 @@ emulator-registers-generated.workspace = true
 lazy_static.workspace = true
 num_enum.workspace = true
 registers-generated.workspace = true
+semver.workspace = true
 serde_json.workspace = true
 serde.workspace = true
 tock-registers.workspace = true

--- a/hw/model/Cargo.toml
+++ b/hw/model/Cargo.toml
@@ -34,6 +34,7 @@ mcu-config.workspace = true
 mcu-config-fpga = { workspace = true, optional = true }
 emulator-registers-generated.workspace = true
 registers-generated.workspace = true
+semver.workspace = true
 sha2.workspace = true
 tock-registers.workspace = true
 uio = { workspace = true, optional = true }

--- a/hw/model/src/model_emulated.rs
+++ b/hw/model/src/model_emulated.rs
@@ -17,6 +17,7 @@ use caliptra_hw_model_types::ErrorInjectionMode;
 use caliptra_image_types::IMAGE_MANIFEST_BYTE_SIZE;
 use emulator_periph::{I3c, I3cController, Mci, McuRootBus, McuRootBusArgs, Otp};
 use emulator_registers_generated::root_bus::AutoRootBus;
+use semver::Version;
 use std::cell::Cell;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::Hasher;
@@ -147,6 +148,7 @@ impl McuHwModel for ModelEmulated {
             &mut i3c_controller,
             i3c_error_irq,
             i3c_notif_irq,
+            Version::new(2, 0, 0),
         );
         let otp = Otp::new(&clock.clone(), None, None, None)?;
         let mci = Mci::new(&clock.clone());

--- a/platforms/emulator/rom/Cargo.toml
+++ b/platforms/emulator/rom/Cargo.toml
@@ -11,6 +11,7 @@ mcu-builder.workspace = true
 mcu-config-emulator.workspace = true
 
 [dependencies]
+bitfield.workspace = true
 mcu-config.workspace = true
 mcu-config-emulator.workspace = true
 mcu-rom-common.workspace = true
@@ -18,10 +19,14 @@ registers-generated.workspace = true
 romtime.workspace = true
 tock-registers.workspace = true
 zeroize.workspace = true
+zerocopy.workspace = true
 
 [target.'cfg(target_arch = "riscv32")'.dependencies]
 riscv-csr.workspace = true
 rv32i.workspace = true
 
 [features]
+default = []
 test-mcu-rom-flash-access = []
+test-flash-based-boot = []
+test-pldm-streaming-boot = []

--- a/platforms/emulator/rom/src/flash/flash_boot_cfg.rs
+++ b/platforms/emulator/rom/src/flash/flash_boot_cfg.rs
@@ -1,0 +1,160 @@
+// Licensed under the Apache-2.0 license
+
+use mcu_config::boot::{BootConfig, BootConfigError, PartitionId, PartitionStatus, RollbackEnable};
+use mcu_config_emulator::flash::{
+    PartitionTable, StandAloneChecksumCalculator, IMAGE_A_PARTITION, IMAGE_B_PARTITION,
+    PARTITION_TABLE,
+};
+use mcu_rom_common::flash::flash_partition::FlashPartition;
+use zerocopy::{FromBytes, IntoBytes};
+pub struct FlashBootCfg<'a> {
+    flash_driver: &'a mut FlashPartition<'a>,
+}
+
+impl<'a> FlashBootCfg<'a> {
+    pub fn new(flash_driver: &'a mut FlashPartition<'a>) -> Self {
+        Self { flash_driver }
+    }
+
+    pub fn read_partition_table(&self) -> Result<PartitionTable, ()> {
+        let mut partition_table_data: [u8; core::mem::size_of::<PartitionTable>()] =
+            [0; core::mem::size_of::<PartitionTable>()];
+        self.flash_driver
+            .read(0, &mut partition_table_data)
+            .expect("Failed to read partition table data");
+
+        let (partition_table, _) =
+            PartitionTable::read_from_prefix(&partition_table_data).map_err(|_| ())?;
+        // Verify checksum
+        let checksum_calculator = StandAloneChecksumCalculator::new();
+        if !partition_table.verify_checksum(&checksum_calculator) {
+            return Err(());
+        }
+        Ok(partition_table)
+    }
+}
+
+impl<'a> BootConfig for FlashBootCfg<'a> {
+    fn get_active_partition(&self) -> Result<PartitionId, BootConfigError> {
+        let partition_table = self
+            .read_partition_table()
+            .map_err(|_| BootConfigError::ReadFailed)?;
+
+        let (active_partition, _) = partition_table.get_active_partition();
+        Ok(active_partition)
+    }
+
+    fn set_active_partition(&mut self, partition_id: PartitionId) -> Result<(), BootConfigError> {
+        let mut partition_table = self
+            .read_partition_table()
+            .map_err(|_| BootConfigError::ReadFailed)?;
+        partition_table.set_active_partition(partition_id);
+        partition_table.populate_checksum(&StandAloneChecksumCalculator::new());
+        self.flash_driver
+            .write(0, partition_table.as_bytes())
+            .map_err(|_| BootConfigError::WriteFailed)?;
+        Ok(())
+    }
+
+    fn increment_boot_count(&self, partition_id: PartitionId) -> Result<u16, BootConfigError> {
+        let mut partition_table = self
+            .read_partition_table()
+            .map_err(|_| BootConfigError::ReadFailed)?;
+        let boot_count = match partition_id {
+            PartitionId::A => {
+                partition_table.partition_a_boot_count += 1;
+                partition_table.partition_a_boot_count
+            }
+            PartitionId::B => {
+                partition_table.partition_b_boot_count += 1;
+                partition_table.partition_b_boot_count
+            }
+            _ => return Err(BootConfigError::InvalidPartition),
+        };
+        // Write the updated partition table back to flash
+        let checksum_calculator = StandAloneChecksumCalculator::new();
+        partition_table.populate_checksum(&checksum_calculator);
+
+        self.flash_driver
+            .write(0, partition_table.as_bytes())
+            .map_err(|_| BootConfigError::WriteFailed)?;
+        Ok(boot_count)
+    }
+
+    fn get_boot_count(&self, partition_id: PartitionId) -> Result<u16, BootConfigError> {
+        let partition_table = self
+            .read_partition_table()
+            .map_err(|_| BootConfigError::ReadFailed)?;
+        match partition_id {
+            PartitionId::A => Ok(partition_table.partition_a_boot_count),
+            PartitionId::B => Ok(partition_table.partition_b_boot_count),
+            _ => Err(BootConfigError::InvalidPartition),
+        }
+    }
+
+    fn set_rollback_enable(&mut self, enable: bool) -> Result<(), BootConfigError> {
+        let mut partition_table = self
+            .read_partition_table()
+            .map_err(|_| BootConfigError::ReadFailed)?;
+        partition_table.rollback_enable = if enable {
+            RollbackEnable::Enabled as u32
+        } else {
+            RollbackEnable::Disabled as u32
+        };
+        partition_table.populate_checksum(&StandAloneChecksumCalculator::new());
+        self.flash_driver
+            .write(0, partition_table.as_bytes())
+            .map_err(|_| BootConfigError::WriteFailed)?;
+        Ok(())
+    }
+
+    fn set_partition_status(
+        &mut self,
+        partition_id: mcu_config::boot::PartitionId,
+        status: mcu_config::boot::PartitionStatus,
+    ) -> Result<(), mcu_config::boot::BootConfigError> {
+        let mut partition_table = self
+            .read_partition_table()
+            .map_err(|_| BootConfigError::ReadFailed)?;
+        match partition_id {
+            PartitionId::A => partition_table.partition_a_status = status as u16,
+            PartitionId::B => partition_table.partition_b_status = status as u16,
+            _ => return Err(BootConfigError::InvalidPartition),
+        }
+        // Write the updated partition table back to flash
+        let checksum_calculator = StandAloneChecksumCalculator::new();
+        partition_table.populate_checksum(&checksum_calculator);
+
+        self.flash_driver
+            .write(0, partition_table.as_bytes())
+            .map_err(|_| BootConfigError::WriteFailed)?;
+        Ok(())
+    }
+
+    fn get_partition_status(
+        &self,
+        partition_id: mcu_config::boot::PartitionId,
+    ) -> Result<mcu_config::boot::PartitionStatus, mcu_config::boot::BootConfigError> {
+        let partition_table = self
+            .read_partition_table()
+            .map_err(|_| BootConfigError::ReadFailed)?;
+        match partition_id {
+            PartitionId::A => Ok(partition_table
+                .partition_a_status
+                .try_into()
+                .unwrap_or(PartitionStatus::Invalid)),
+            PartitionId::B => Ok(partition_table
+                .partition_b_status
+                .try_into()
+                .unwrap_or(PartitionStatus::Invalid)),
+            _ => Err(BootConfigError::InvalidPartition),
+        }
+    }
+
+    fn is_rollback_enabled(&self) -> Result<bool, mcu_config::boot::BootConfigError> {
+        let partition_table = self
+            .read_partition_table()
+            .map_err(|_| BootConfigError::ReadFailed)?;
+        Ok(partition_table.rollback_enable == RollbackEnable::Enabled as u32)
+    }
+}

--- a/platforms/emulator/rom/src/flash/flash_test.rs
+++ b/platforms/emulator/rom/src/flash/flash_test.rs
@@ -1,6 +1,6 @@
 // Licensed under the Apache-2.0 license
 
-use crate::flash::flash_api::FlashPartition;
+use mcu_rom_common::flash::flash_partition::FlashPartition;
 use romtime::{println, test_exit};
 
 pub fn test_rom_flash_access(partition: &FlashPartition) {

--- a/platforms/emulator/rom/src/flash/mod.rs
+++ b/platforms/emulator/rom/src/flash/mod.rs
@@ -1,7 +1,9 @@
 // Licensed under the Apache-2.0 license
+pub mod flash_boot_cfg;
+pub mod flash_drv;
 
-pub mod flash_api;
-pub mod flash_ctrl;
-
-#[cfg(feature = "test-mcu-rom-flash-access")]
+#[cfg(any(
+    feature = "test-mcu-rom-flash-access",
+    feature = "test-flash-based-boot"
+))]
 pub mod flash_test;

--- a/platforms/emulator/runtime/userspace/api/caliptra-api/src/image_loading/flash_boot_cfg.rs
+++ b/platforms/emulator/runtime/userspace/api/caliptra-api/src/image_loading/flash_boot_cfg.rs
@@ -3,7 +3,9 @@
 use libsyscall_caliptra::flash::SpiFlash;
 use libsyscall_caliptra::DefaultSyscalls;
 use libtock_platform::ErrorCode;
-use mcu_config::boot::{BootConfig, BootConfigError, PartitionId, PartitionStatus, RollbackEnable};
+use mcu_config::boot::{
+    BootConfigAsync, BootConfigError, PartitionId, PartitionStatus, RollbackEnable,
+};
 use mcu_config_emulator::flash::{
     FlashPartition, PartitionTable, StandAloneChecksumCalculator, IMAGE_A_PARTITION,
     IMAGE_B_PARTITION, PARTITION_TABLE,
@@ -59,7 +61,7 @@ impl FlashBootConfig {
     }
 }
 
-impl BootConfig for FlashBootConfig {
+impl BootConfigAsync for FlashBootConfig {
     async fn get_partition_status(
         &self,
         partition_id: PartitionId,

--- a/platforms/emulator/runtime/userspace/api/caliptra-api/src/image_loading/mod.rs
+++ b/platforms/emulator/runtime/userspace/api/caliptra-api/src/image_loading/mod.rs
@@ -1,0 +1,3 @@
+// Licensed under the Apache-2.0 license
+
+pub mod flash_boot_cfg;

--- a/platforms/emulator/runtime/userspace/api/caliptra-api/src/lib.rs
+++ b/platforms/emulator/runtime/userspace/api/caliptra-api/src/lib.rs
@@ -2,4 +2,4 @@
 
 #![cfg_attr(target_arch = "riscv32", no_std)]
 
-pub mod flash_boot_cfg;
+pub mod image_loading;

--- a/platforms/emulator/runtime/userspace/apps/user/src/image_loader/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/image_loader/mod.rs
@@ -11,7 +11,7 @@ mod config;
 
 use core::fmt::Write;
 #[allow(unused)]
-use libapi_emulated_caliptra::flash_boot_cfg::FlashBootConfig;
+use libapi_emulated_caliptra::image_loading::flash_boot_cfg::FlashBootConfig;
 #[allow(unused)]
 use libsyscall_caliptra::flash::SpiFlash;
 use libtock_console::Console;
@@ -19,7 +19,7 @@ use libtock_platform::ErrorCode;
 #[allow(unused)]
 use mcu_config::boot;
 #[allow(unused)]
-use mcu_config::boot::{BootConfig, PartitionId, PartitionStatus, RollbackEnable};
+use mcu_config::boot::{BootConfigAsync, PartitionId, PartitionStatus, RollbackEnable};
 #[allow(unused)]
 use mcu_config_emulator::flash::{
     PartitionTable, StandAloneChecksumCalculator, IMAGE_A_PARTITION, IMAGE_B_PARTITION,

--- a/platforms/fpga/rom/src/riscv.rs
+++ b/platforms/fpga/rom/src/riscv.rs
@@ -42,7 +42,7 @@ pub extern "C" fn rom_entry() -> ! {
 
     romtime::println!("[mcu-rom] Starting FPGA MCU ROM");
 
-    mcu_rom_common::rom_start();
+    mcu_rom_common::rom_start(None);
 
     let addr = MCU_MEMORY_MAP.sram_offset;
     romtime::println!("[mcu-rom] Jumping to firmware at {:08x}", addr);

--- a/registers/generated-emulator/src/dma.rs
+++ b/registers/generated-emulator/src/dma.rs
@@ -7,6 +7,14 @@ use tock_registers::interfaces::{Readable, Writeable};
 pub trait DmaPeripheral {
     fn set_dma_ram(&mut self, _ram: std::rc::Rc<std::cell::RefCell<caliptra_emu_bus::Ram>>) {}
     fn set_dma_rom_sram(&mut self, _ram: std::rc::Rc<std::cell::RefCell<caliptra_emu_bus::Ram>>) {}
+    fn register_event_channels(
+        &mut self,
+        _events_to_caliptra: std::sync::mpsc::Sender<caliptra_emu_bus::Event>,
+        _events_from_caliptra: std::sync::mpsc::Receiver<caliptra_emu_bus::Event>,
+        _events_to_mcu: std::sync::mpsc::Sender<caliptra_emu_bus::Event>,
+        _events_from_mcu: std::sync::mpsc::Receiver<caliptra_emu_bus::Event>,
+    ) {
+    }
     fn poll(&mut self) {}
     fn warm_reset(&mut self) {}
     fn update_reset(&mut self) {}

--- a/registers/generated-emulator/src/doe_mbox.rs
+++ b/registers/generated-emulator/src/doe_mbox.rs
@@ -7,6 +7,14 @@ use tock_registers::interfaces::{Readable, Writeable};
 pub trait DoeMboxPeripheral {
     fn set_dma_ram(&mut self, _ram: std::rc::Rc<std::cell::RefCell<caliptra_emu_bus::Ram>>) {}
     fn set_dma_rom_sram(&mut self, _ram: std::rc::Rc<std::cell::RefCell<caliptra_emu_bus::Ram>>) {}
+    fn register_event_channels(
+        &mut self,
+        _events_to_caliptra: std::sync::mpsc::Sender<caliptra_emu_bus::Event>,
+        _events_from_caliptra: std::sync::mpsc::Receiver<caliptra_emu_bus::Event>,
+        _events_to_mcu: std::sync::mpsc::Sender<caliptra_emu_bus::Event>,
+        _events_from_mcu: std::sync::mpsc::Receiver<caliptra_emu_bus::Event>,
+    ) {
+    }
     fn poll(&mut self) {}
     fn warm_reset(&mut self) {}
     fn update_reset(&mut self) {}

--- a/registers/generated-emulator/src/el2_pic.rs
+++ b/registers/generated-emulator/src/el2_pic.rs
@@ -7,6 +7,14 @@ use tock_registers::interfaces::{Readable, Writeable};
 pub trait El2PicPeripheral {
     fn set_dma_ram(&mut self, _ram: std::rc::Rc<std::cell::RefCell<caliptra_emu_bus::Ram>>) {}
     fn set_dma_rom_sram(&mut self, _ram: std::rc::Rc<std::cell::RefCell<caliptra_emu_bus::Ram>>) {}
+    fn register_event_channels(
+        &mut self,
+        _events_to_caliptra: std::sync::mpsc::Sender<caliptra_emu_bus::Event>,
+        _events_from_caliptra: std::sync::mpsc::Receiver<caliptra_emu_bus::Event>,
+        _events_to_mcu: std::sync::mpsc::Sender<caliptra_emu_bus::Event>,
+        _events_from_mcu: std::sync::mpsc::Receiver<caliptra_emu_bus::Event>,
+    ) {
+    }
     fn poll(&mut self) {}
     fn warm_reset(&mut self) {}
     fn update_reset(&mut self) {}

--- a/registers/generated-emulator/src/i3c.rs
+++ b/registers/generated-emulator/src/i3c.rs
@@ -7,6 +7,14 @@ use tock_registers::interfaces::{Readable, Writeable};
 pub trait I3cPeripheral {
     fn set_dma_ram(&mut self, _ram: std::rc::Rc<std::cell::RefCell<caliptra_emu_bus::Ram>>) {}
     fn set_dma_rom_sram(&mut self, _ram: std::rc::Rc<std::cell::RefCell<caliptra_emu_bus::Ram>>) {}
+    fn register_event_channels(
+        &mut self,
+        _events_to_caliptra: std::sync::mpsc::Sender<caliptra_emu_bus::Event>,
+        _events_from_caliptra: std::sync::mpsc::Receiver<caliptra_emu_bus::Event>,
+        _events_to_mcu: std::sync::mpsc::Sender<caliptra_emu_bus::Event>,
+        _events_from_mcu: std::sync::mpsc::Receiver<caliptra_emu_bus::Event>,
+    ) {
+    }
     fn poll(&mut self) {}
     fn warm_reset(&mut self) {}
     fn update_reset(&mut self) {}

--- a/registers/generated-emulator/src/lc.rs
+++ b/registers/generated-emulator/src/lc.rs
@@ -7,6 +7,14 @@ use tock_registers::interfaces::{Readable, Writeable};
 pub trait LcPeripheral {
     fn set_dma_ram(&mut self, _ram: std::rc::Rc<std::cell::RefCell<caliptra_emu_bus::Ram>>) {}
     fn set_dma_rom_sram(&mut self, _ram: std::rc::Rc<std::cell::RefCell<caliptra_emu_bus::Ram>>) {}
+    fn register_event_channels(
+        &mut self,
+        _events_to_caliptra: std::sync::mpsc::Sender<caliptra_emu_bus::Event>,
+        _events_from_caliptra: std::sync::mpsc::Receiver<caliptra_emu_bus::Event>,
+        _events_to_mcu: std::sync::mpsc::Sender<caliptra_emu_bus::Event>,
+        _events_from_mcu: std::sync::mpsc::Receiver<caliptra_emu_bus::Event>,
+    ) {
+    }
     fn poll(&mut self) {}
     fn warm_reset(&mut self) {}
     fn update_reset(&mut self) {}

--- a/registers/generated-emulator/src/mbox.rs
+++ b/registers/generated-emulator/src/mbox.rs
@@ -7,6 +7,14 @@ use tock_registers::interfaces::{Readable, Writeable};
 pub trait MboxPeripheral {
     fn set_dma_ram(&mut self, _ram: std::rc::Rc<std::cell::RefCell<caliptra_emu_bus::Ram>>) {}
     fn set_dma_rom_sram(&mut self, _ram: std::rc::Rc<std::cell::RefCell<caliptra_emu_bus::Ram>>) {}
+    fn register_event_channels(
+        &mut self,
+        _events_to_caliptra: std::sync::mpsc::Sender<caliptra_emu_bus::Event>,
+        _events_from_caliptra: std::sync::mpsc::Receiver<caliptra_emu_bus::Event>,
+        _events_to_mcu: std::sync::mpsc::Sender<caliptra_emu_bus::Event>,
+        _events_from_mcu: std::sync::mpsc::Receiver<caliptra_emu_bus::Event>,
+    ) {
+    }
     fn poll(&mut self) {}
     fn warm_reset(&mut self) {}
     fn update_reset(&mut self) {}

--- a/registers/generated-emulator/src/mci.rs
+++ b/registers/generated-emulator/src/mci.rs
@@ -7,6 +7,14 @@ use tock_registers::interfaces::{Readable, Writeable};
 pub trait MciPeripheral {
     fn set_dma_ram(&mut self, _ram: std::rc::Rc<std::cell::RefCell<caliptra_emu_bus::Ram>>) {}
     fn set_dma_rom_sram(&mut self, _ram: std::rc::Rc<std::cell::RefCell<caliptra_emu_bus::Ram>>) {}
+    fn register_event_channels(
+        &mut self,
+        _events_to_caliptra: std::sync::mpsc::Sender<caliptra_emu_bus::Event>,
+        _events_from_caliptra: std::sync::mpsc::Receiver<caliptra_emu_bus::Event>,
+        _events_to_mcu: std::sync::mpsc::Sender<caliptra_emu_bus::Event>,
+        _events_from_mcu: std::sync::mpsc::Receiver<caliptra_emu_bus::Event>,
+    ) {
+    }
     fn poll(&mut self) {}
     fn warm_reset(&mut self) {}
     fn update_reset(&mut self) {}

--- a/registers/generated-emulator/src/otp.rs
+++ b/registers/generated-emulator/src/otp.rs
@@ -7,6 +7,14 @@ use tock_registers::interfaces::{Readable, Writeable};
 pub trait OtpPeripheral {
     fn set_dma_ram(&mut self, _ram: std::rc::Rc<std::cell::RefCell<caliptra_emu_bus::Ram>>) {}
     fn set_dma_rom_sram(&mut self, _ram: std::rc::Rc<std::cell::RefCell<caliptra_emu_bus::Ram>>) {}
+    fn register_event_channels(
+        &mut self,
+        _events_to_caliptra: std::sync::mpsc::Sender<caliptra_emu_bus::Event>,
+        _events_from_caliptra: std::sync::mpsc::Receiver<caliptra_emu_bus::Event>,
+        _events_to_mcu: std::sync::mpsc::Sender<caliptra_emu_bus::Event>,
+        _events_from_mcu: std::sync::mpsc::Receiver<caliptra_emu_bus::Event>,
+    ) {
+    }
     fn poll(&mut self) {}
     fn warm_reset(&mut self) {}
     fn update_reset(&mut self) {}

--- a/registers/generated-emulator/src/primary_flash.rs
+++ b/registers/generated-emulator/src/primary_flash.rs
@@ -7,6 +7,14 @@ use tock_registers::interfaces::{Readable, Writeable};
 pub trait PrimaryFlashPeripheral {
     fn set_dma_ram(&mut self, _ram: std::rc::Rc<std::cell::RefCell<caliptra_emu_bus::Ram>>) {}
     fn set_dma_rom_sram(&mut self, _ram: std::rc::Rc<std::cell::RefCell<caliptra_emu_bus::Ram>>) {}
+    fn register_event_channels(
+        &mut self,
+        _events_to_caliptra: std::sync::mpsc::Sender<caliptra_emu_bus::Event>,
+        _events_from_caliptra: std::sync::mpsc::Receiver<caliptra_emu_bus::Event>,
+        _events_to_mcu: std::sync::mpsc::Sender<caliptra_emu_bus::Event>,
+        _events_from_mcu: std::sync::mpsc::Receiver<caliptra_emu_bus::Event>,
+    ) {
+    }
     fn poll(&mut self) {}
     fn warm_reset(&mut self) {}
     fn update_reset(&mut self) {}

--- a/registers/generated-emulator/src/secondary_flash.rs
+++ b/registers/generated-emulator/src/secondary_flash.rs
@@ -7,6 +7,14 @@ use tock_registers::interfaces::{Readable, Writeable};
 pub trait SecondaryFlashPeripheral {
     fn set_dma_ram(&mut self, _ram: std::rc::Rc<std::cell::RefCell<caliptra_emu_bus::Ram>>) {}
     fn set_dma_rom_sram(&mut self, _ram: std::rc::Rc<std::cell::RefCell<caliptra_emu_bus::Ram>>) {}
+    fn register_event_channels(
+        &mut self,
+        _events_to_caliptra: std::sync::mpsc::Sender<caliptra_emu_bus::Event>,
+        _events_from_caliptra: std::sync::mpsc::Receiver<caliptra_emu_bus::Event>,
+        _events_to_mcu: std::sync::mpsc::Sender<caliptra_emu_bus::Event>,
+        _events_from_mcu: std::sync::mpsc::Receiver<caliptra_emu_bus::Event>,
+    ) {
+    }
     fn poll(&mut self) {}
     fn warm_reset(&mut self) {}
     fn update_reset(&mut self) {}

--- a/registers/generated-emulator/src/sha512_acc.rs
+++ b/registers/generated-emulator/src/sha512_acc.rs
@@ -7,6 +7,14 @@ use tock_registers::interfaces::{Readable, Writeable};
 pub trait Sha512AccPeripheral {
     fn set_dma_ram(&mut self, _ram: std::rc::Rc<std::cell::RefCell<caliptra_emu_bus::Ram>>) {}
     fn set_dma_rom_sram(&mut self, _ram: std::rc::Rc<std::cell::RefCell<caliptra_emu_bus::Ram>>) {}
+    fn register_event_channels(
+        &mut self,
+        _events_to_caliptra: std::sync::mpsc::Sender<caliptra_emu_bus::Event>,
+        _events_from_caliptra: std::sync::mpsc::Receiver<caliptra_emu_bus::Event>,
+        _events_to_mcu: std::sync::mpsc::Sender<caliptra_emu_bus::Event>,
+        _events_from_mcu: std::sync::mpsc::Receiver<caliptra_emu_bus::Event>,
+    ) {
+    }
     fn poll(&mut self) {}
     fn warm_reset(&mut self) {}
     fn update_reset(&mut self) {}

--- a/registers/generated-emulator/src/soc.rs
+++ b/registers/generated-emulator/src/soc.rs
@@ -7,6 +7,14 @@ use tock_registers::interfaces::{Readable, Writeable};
 pub trait SocPeripheral {
     fn set_dma_ram(&mut self, _ram: std::rc::Rc<std::cell::RefCell<caliptra_emu_bus::Ram>>) {}
     fn set_dma_rom_sram(&mut self, _ram: std::rc::Rc<std::cell::RefCell<caliptra_emu_bus::Ram>>) {}
+    fn register_event_channels(
+        &mut self,
+        _events_to_caliptra: std::sync::mpsc::Sender<caliptra_emu_bus::Event>,
+        _events_from_caliptra: std::sync::mpsc::Receiver<caliptra_emu_bus::Event>,
+        _events_to_mcu: std::sync::mpsc::Sender<caliptra_emu_bus::Event>,
+        _events_from_mcu: std::sync::mpsc::Receiver<caliptra_emu_bus::Event>,
+    ) {
+    }
     fn poll(&mut self) {}
     fn warm_reset(&mut self) {}
     fn update_reset(&mut self) {}

--- a/rom/Cargo.toml
+++ b/rom/Cargo.toml
@@ -7,12 +7,16 @@ authors.workspace = true
 edition.workspace = true
 
 [dependencies]
+bitfield.workspace = true
 caliptra-api.workspace = true
+flash-image.workspace = true
 mcu-config.workspace = true
 registers-generated.workspace = true
 romtime.workspace = true
+smlang.workspace = true
 tock-registers.workspace = true
 zeroize.workspace = true
+zerocopy.workspace = true
 
 [target.'cfg(target_arch = "riscv32")'.dependencies]
 riscv-csr.workspace = true

--- a/rom/src/flash/hil.rs
+++ b/rom/src/flash/hil.rs
@@ -1,0 +1,106 @@
+// Licensed under the Apache-2.0 license
+
+//! Generic interface for flash storage access.
+
+use core::result::Result;
+
+/// Simple interface for reading, writing and erasing the arbitrary length of data on flash storage. It is expected
+/// that drivers for the flash storage access would implement this trait.
+pub trait FlashStorage {
+    /// Read from the flash storage, filling the provided buffer with data
+    fn read(&self, buffer: &mut [u8], address: usize) -> Result<(), FlashDrvError>;
+
+    /// Write to the flash storage with the full contents of the buffer, starting at the specified address
+    fn write(&self, buffer: &[u8], address: usize) -> Result<(), FlashDrvError>;
+
+    /// Erase `length` bytes starting at address `address`. The address must be
+    /// in the address space of the physical storage.
+    fn erase(&self, address: usize, length: usize) -> Result<(), FlashDrvError>;
+
+    /// Returns the size of the flash storage in bytes.
+    fn capacity(&self) -> usize;
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(usize)]
+pub enum FlashDrvError {
+    // Reserved value, for when "no error" / "success" should be
+    // encoded in the same numeric representation as FlashDrvError
+    //
+    // Ok(()) = 0,
+    /// Generic failure condition
+    FAIL = 1,
+    /// Underlying system is busy; retry
+    BUSY = 2,
+    /// The state requested is already set
+    ALREADY = 3,
+    /// The component is powered down
+    OFF = 4,
+    /// Reservation required before use
+    RESERVE = 5,
+    /// An invalid parameter was passed
+    INVAL = 6,
+    /// Parameter passed was too large
+    SIZE = 7,
+    /// Operation canceled by a call
+    CANCEL = 8,
+    /// Memory required not available
+    NOMEM = 9,
+    /// Operation is not supported
+    NOSUPPORT = 10,
+    /// Device is not available
+    NODEVICE = 11,
+    /// Device is not physically installed
+    UNINSTALLED = 12,
+    /// Packet transmission not acknowledged
+    NOACK = 13,
+}
+
+impl From<FlashDrvError> for usize {
+    fn from(err: FlashDrvError) -> usize {
+        err as usize
+    }
+}
+
+impl TryFrom<Result<(), FlashDrvError>> for FlashDrvError {
+    type Error = ();
+
+    fn try_from(rc: Result<(), FlashDrvError>) -> Result<Self, Self::Error> {
+        match rc {
+            Ok(()) => Err(()),
+            Err(FlashDrvError::FAIL) => Ok(FlashDrvError::FAIL),
+            Err(FlashDrvError::BUSY) => Ok(FlashDrvError::BUSY),
+            Err(FlashDrvError::ALREADY) => Ok(FlashDrvError::ALREADY),
+            Err(FlashDrvError::OFF) => Ok(FlashDrvError::OFF),
+            Err(FlashDrvError::RESERVE) => Ok(FlashDrvError::RESERVE),
+            Err(FlashDrvError::INVAL) => Ok(FlashDrvError::INVAL),
+            Err(FlashDrvError::SIZE) => Ok(FlashDrvError::SIZE),
+            Err(FlashDrvError::CANCEL) => Ok(FlashDrvError::CANCEL),
+            Err(FlashDrvError::NOMEM) => Ok(FlashDrvError::NOMEM),
+            Err(FlashDrvError::NOSUPPORT) => Ok(FlashDrvError::NOSUPPORT),
+            Err(FlashDrvError::NODEVICE) => Ok(FlashDrvError::NODEVICE),
+            Err(FlashDrvError::UNINSTALLED) => Ok(FlashDrvError::UNINSTALLED),
+            Err(FlashDrvError::NOACK) => Ok(FlashDrvError::NOACK),
+        }
+    }
+}
+
+impl From<FlashDrvError> for Result<(), FlashDrvError> {
+    fn from(ec: FlashDrvError) -> Self {
+        match ec {
+            FlashDrvError::FAIL => Err(FlashDrvError::FAIL),
+            FlashDrvError::BUSY => Err(FlashDrvError::BUSY),
+            FlashDrvError::ALREADY => Err(FlashDrvError::ALREADY),
+            FlashDrvError::OFF => Err(FlashDrvError::OFF),
+            FlashDrvError::RESERVE => Err(FlashDrvError::RESERVE),
+            FlashDrvError::INVAL => Err(FlashDrvError::INVAL),
+            FlashDrvError::SIZE => Err(FlashDrvError::SIZE),
+            FlashDrvError::CANCEL => Err(FlashDrvError::CANCEL),
+            FlashDrvError::NOMEM => Err(FlashDrvError::NOMEM),
+            FlashDrvError::NOSUPPORT => Err(FlashDrvError::NOSUPPORT),
+            FlashDrvError::NODEVICE => Err(FlashDrvError::NODEVICE),
+            FlashDrvError::UNINSTALLED => Err(FlashDrvError::UNINSTALLED),
+            FlashDrvError::NOACK => Err(FlashDrvError::NOACK),
+        }
+    }
+}

--- a/rom/src/flash/mod.rs
+++ b/rom/src/flash/mod.rs
@@ -1,0 +1,4 @@
+// Licensed under the Apache-2.0 license
+
+pub mod flash_partition;
+pub mod hil;

--- a/rom/src/lib.rs
+++ b/rom/src/lib.rs
@@ -14,12 +14,14 @@ Abstract:
 
 #![no_std]
 
+pub mod flash;
+pub use flash::*;
 mod fuses;
 pub use fuses::*;
 mod rom;
 pub use rom::*;
 mod i3c;
-
+mod recovery;
 pub trait FatalErrorHandler {
     fn fatal_error(&mut self, code: u32) -> !;
 }

--- a/rom/src/recovery.rs
+++ b/rom/src/recovery.rs
@@ -1,0 +1,386 @@
+// Licensed under the Apache-2.0 license
+
+use crate::flash::flash_partition::FlashPartition;
+use bitfield::bitfield;
+use flash_image::{FlashChecksums, FlashHeader, ImageHeader};
+use registers_generated::i3c;
+use registers_generated::i3c::bits::{RecIntfCfg, RecoveryCtrl};
+use romtime::StaticRef;
+use smlang::statemachine;
+use tock_registers::interfaces::{ReadWriteable, Readable, Writeable};
+use zerocopy::FromBytes;
+
+const ACTIVATE_RECOVERY_IMAGE_CMD: u32 = 0xF;
+const BYPASS_CFG_USE_I3C: u32 = 0x0;
+const BYPASS_CFG_AXI_DIRECT: u32 = 0x1;
+
+statemachine! {
+    derive_states: [Clone, Copy, Debug],
+    transitions: {
+        // syntax: CurrentState Event [guard] / action = NextState
+
+        // start by reading ProtCap to see if the device supports recovery
+        *ReadProtCap + ProtCap(ProtCap2) [check_device_status_support] = ReadDeviceStatus,
+
+        // read the device status to see if it needs recovery
+        ReadDeviceStatus + DeviceStatus(DeviceStatus0) [check_device_status_healthy] = Done,
+
+        // if the device needs recovery, send the recovery control message
+        ReadDeviceStatus + DeviceStatus(DeviceStatus0) [check_device_status_recovery]
+             = WaitForRecoveryStatus,
+
+        // send the requested recovery image
+        WaitForRecoveryStatus + RecoveryStatus(RecoveryStatus) [check_recovery_status_awaiting]
+             = TransferringImage,
+
+
+        TransferringImage + TransferComplete  = WaitForRecoveryPending,
+
+        // activate the recovery image after it has been processed
+        WaitForRecoveryPending + DeviceStatus(DeviceStatus0) [check_device_status_recovery_pending]
+             = Activate,
+
+        // check if we need to send another recovery image (if awaiting image is set and running recovery)
+        Activate + CheckFwActivation = CheckFwActivation,
+
+
+        CheckFwActivation + RecoveryStatus(RecoveryStatus) [check_fw_booting_image]
+            = ActivateCheckRecoveryStatus,
+
+        ActivateCheckRecoveryStatus + RecoveryStatus(RecoveryStatus) [check_recovery_status_awaiting]
+             = ReadDeviceStatus,
+
+        ActivateCheckRecoveryStatus + RecoveryStatus(RecoveryStatus) [check_fw_recovery_success]
+             = Done,
+
+    }
+}
+
+bitfield! {
+    pub struct ProtCap2(u32);
+    impl Debug;
+    pub identification, set_identification: 0;
+    pub forced_recovery, set_forced_recovery: 1;
+    pub mgmt_reset, set_mgmt_reset: 2;
+    pub device_reset, set_device_reset: 3;
+    pub device_status, set_device_status: 4;
+    pub recovery_memory_access, set_recovery_memory_access: 5;
+    pub local_c_image_support, set_local_c_image_support: 6;
+    pub push_c_image_support, set_push_c_image_support: 7;
+    pub interface_isolation, set_interface_isolation: 8;
+    pub hardware_status, set_hardware_status: 9;
+    pub vendors_command, set_vendors_command: 10;
+    pub reserved, set_reserved: 31, 11;
+}
+
+bitfield! {
+    pub struct DeviceStatus0(u32);
+    impl Debug;
+    pub device_status, set_device_status: 7,0;
+    pub protocol_error, set_protocol_error: 15,8;
+    pub recovery_reason, set_recovery_reason: 31,16;
+
+}
+
+bitfield! {
+    pub struct RecoveryCtrl0(u32);
+    impl Debug;
+    pub cms, set_cms: 7,0;
+    pub rec_img_sel, set_rec_img_sel: 15,8;
+    pub activate_rec_image, set_activate_rec_image: 23,16;
+
+}
+
+// Device status codes (Byte 0)
+pub mod device_status_code {
+    pub const DEVICE_HEALTHY: u8 = 0x1;
+    pub const RECOVERY_MODE: u8 = 0x3;
+    pub const RECOVERY_PENDING: u8 = 0x4;
+}
+
+// RECOVERY_STATUS register (32 bits)
+bitfield! {
+    #[derive(Clone, Copy)]
+    pub struct RecoveryStatus(u32);
+    impl Debug;
+
+    // Bits 3:0 - Device recovery status
+    pub dev_rec_status, set_dev_rec_status: 3, 0;
+    // Bits 7:4 - Recovery image index
+    pub rec_img_index, set_rec_img_index: 7, 4;
+    // Bits 15:8 - Vendor specific status
+    pub vendor_specific_status, set_vendor_specific_status: 15, 8;
+    // Bits 31:16 - Reserved (not used, can be added if needed)
+}
+
+/// Device Recovery Status codes (Bits 3:0)
+pub mod dev_rec_status_code {
+    pub const AWAITING_IMAGE: u8 = 0x1;
+    pub const BOOTING_IMAGE: u8 = 0x2;
+    pub const RECOVERY_SUCCESS: u8 = 0x3;
+    // 0x4-0xB: Reserved
+}
+
+/// State machine extended variables.
+pub(crate) struct Context {
+    recovery_image_index: u8,
+    image_size: u32,
+    flash_offset: u32,
+    pub transfer_offset: u32,
+}
+
+impl Context {
+    pub(crate) fn new() -> Context {
+        Context {
+            recovery_image_index: 0,
+            image_size: 0,
+            flash_offset: 0,
+            transfer_offset: 0,
+        }
+    }
+}
+
+impl StateMachineContext for Context {
+    /// Check that the the protcap supports device status
+    fn check_device_status_support(&self, prot_cap: &ProtCap2) -> Result<bool, ()> {
+        if prot_cap.device_status() {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    /// Chjeck that the device status is healthy
+    fn check_device_status_healthy(&self, status: &DeviceStatus0) -> Result<bool, ()> {
+        if status.device_status() == device_status_code::DEVICE_HEALTHY as u32 {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    /// Check that the device status is recovery mode
+    fn check_device_status_recovery(&self, status: &DeviceStatus0) -> Result<bool, ()> {
+        if status.device_status() == device_status_code::RECOVERY_MODE as u32 {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    /// Check that the recovery status is awaiting a recovery image
+    fn check_recovery_status_awaiting(&self, status: &RecoveryStatus) -> Result<bool, ()> {
+        if status.dev_rec_status() == dev_rec_status_code::AWAITING_IMAGE as u32 {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    fn check_fw_recovery_success(&self, status: &RecoveryStatus) -> Result<bool, ()> {
+        if status.dev_rec_status() == dev_rec_status_code::RECOVERY_SUCCESS as u32 {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    /// Check that the device status is recovery pending
+    fn check_device_status_recovery_pending(&self, status: &DeviceStatus0) -> Result<bool, ()> {
+        if status.device_status() == device_status_code::RECOVERY_PENDING as u32 {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    fn check_fw_booting_image(&self, status: &RecoveryStatus) -> Result<bool, ()> {
+        if status.dev_rec_status() == dev_rec_status_code::BOOTING_IMAGE as u32 {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+}
+
+pub fn get_flash_image_info(id: u32, flash_driver: &mut FlashPartition) -> Result<(u32, u32), ()> {
+    // get the maximum size between FlashHeader, Checksums, and ImageHeader
+    let mut buf = [0u8; 12];
+
+    // Read the flash header
+    flash_driver
+        .read(0, &mut buf[..core::mem::size_of::<FlashHeader>()])
+        .map_err(|_| ())?;
+
+    let flash_header = FlashHeader::ref_from_prefix(&buf[..core::mem::size_of::<FlashHeader>()])
+        .map_err(|_| ())?
+        .0;
+
+    let image_count = flash_header.image_count;
+
+    for i in 0..image_count as usize {
+        // Read the image header
+        let offset = core::mem::size_of::<FlashHeader>()
+            + core::mem::size_of::<FlashChecksums>()
+            + i * core::mem::size_of::<ImageHeader>();
+        flash_driver
+            .read(offset, &mut buf[..core::mem::size_of::<ImageHeader>()])
+            .map_err(|_| ())?;
+        let image_header =
+            ImageHeader::ref_from_prefix(&buf[..core::mem::size_of::<ImageHeader>()])
+                .map_err(|_| ())?
+                .0;
+
+        if image_header.identifier == id {
+            return Ok((image_header.offset, image_header.size));
+        }
+    }
+
+    Err(())
+}
+
+pub fn recovery_img_index_to_image_id(recovery_image_index: u32) -> Result<u32, ()> {
+    // Convert the recovery image index to the image ID
+    match recovery_image_index {
+        0 => Ok(0x1), // Caliptra FMC+RT index 0 is image ID 1
+        1 => Ok(0x2), // SoC Manifest index 1 is image ID 2
+        2 => Ok(0x3), // MCU Runtime index 2 is image ID 3
+        _ => Err(()), // Invalid index
+    }
+}
+
+pub fn load_flash_image_to_recovery(
+    i3c_periph: StaticRef<i3c::regs::I3c>,
+    flash_driver: &mut FlashPartition,
+) -> Result<(), ()> {
+    let context = Context::new();
+    let mut state_machine = StateMachine::new(context);
+
+    let mut prev_state = States::ReadProtCap;
+    let mut last_percent = 0u32;
+
+    i3c_periph
+        .soc_mgmt_if_rec_intf_cfg
+        .modify(RecIntfCfg::RecIntfBypass.val(BYPASS_CFG_AXI_DIRECT));
+    while *state_machine.state() != States::Done {
+        if prev_state != *state_machine.state() {
+            romtime::println!(
+                "[mcu-rom] Transitioning from {:?} to {:?}",
+                prev_state,
+                state_machine.state()
+            );
+            prev_state = *state_machine.state();
+        };
+
+        match *state_machine.state() {
+            States::ReadProtCap => {
+                // Read the ProtCap2 register
+                let prot_cap = i3c_periph.sec_fw_recovery_if_prot_cap_2.get();
+                let _ = state_machine.process_event(Events::ProtCap(ProtCap2(prot_cap)));
+            }
+
+            States::ReadDeviceStatus => {
+                // Read the Device Status register
+                let device_status = i3c_periph.sec_fw_recovery_if_device_status_0.get();
+                let _ =
+                    state_machine.process_event(Events::DeviceStatus(DeviceStatus0(device_status)));
+            }
+
+            States::WaitForRecoveryStatus => {
+                // Read the Recovery Status register
+                let recovery_status =
+                    RecoveryStatus(i3c_periph.sec_fw_recovery_if_recovery_status.get());
+                let res = state_machine.process_event(Events::RecoveryStatus(recovery_status));
+                if res.is_ok() {
+                    state_machine.context_mut().recovery_image_index =
+                        recovery_status.rec_img_index() as u8;
+                    romtime::println!(
+                        "[mcu-rom] Starting recovery with image index {}",
+                        state_machine.context().recovery_image_index
+                    );
+                    let image_info = get_flash_image_info(
+                        recovery_img_index_to_image_id(
+                            state_machine.context().recovery_image_index as u32,
+                        )?,
+                        flash_driver,
+                    )?;
+                    state_machine.context_mut().flash_offset = image_info.0;
+                    state_machine.context_mut().image_size = image_info.1;
+                    state_machine.context_mut().transfer_offset = 0;
+                    i3c_periph
+                        .sec_fw_recovery_if_indirect_fifo_ctrl_1
+                        .set(state_machine.context().image_size / 4);
+                }
+            }
+
+            States::TransferringImage => {
+                if (state_machine.context().transfer_offset * 100
+                    / state_machine.context().image_size)
+                    / 10
+                    != last_percent
+                {
+                    romtime::println!(
+                        "[mcu-rom] Transferring image data at offset {} out of {}",
+                        state_machine.context().transfer_offset,
+                        state_machine.context().image_size
+                    );
+                    last_percent = (state_machine.context().transfer_offset * 100
+                        / state_machine.context().image_size)
+                        / 10;
+                }
+
+                if state_machine.context().transfer_offset >= state_machine.context().image_size {
+                    // If the transfer is complete, we can move to the next state
+                    let _ = state_machine.process_event(Events::TransferComplete);
+                } else {
+                    let mut data = [0u8; 4];
+                    flash_driver
+                        .read(
+                            (state_machine.context().flash_offset
+                                + state_machine.context().transfer_offset)
+                                as usize,
+                            &mut data,
+                        )
+                        .map_err(|_| ())?;
+                    i3c_periph.tti_tx_data_port.set(u32::from_be_bytes(data));
+                    state_machine.context_mut().transfer_offset += 4; // Simulate writing 4 bytes
+                }
+            }
+
+            States::WaitForRecoveryPending => {
+                let device_status = i3c_periph.sec_fw_recovery_if_device_status_0.get();
+                let _ =
+                    state_machine.process_event(Events::DeviceStatus(DeviceStatus0(device_status)));
+            }
+
+            States::Activate => {
+                // Activate the recovery image
+                i3c_periph
+                    .sec_fw_recovery_if_recovery_ctrl
+                    .modify(RecoveryCtrl::ActivateRecImg.val(ACTIVATE_RECOVERY_IMAGE_CMD));
+                let _ = state_machine.process_event(Events::CheckFwActivation);
+            }
+
+            States::CheckFwActivation => {
+                // Check if the device is running recovery
+                let recovery_status =
+                    RecoveryStatus(i3c_periph.sec_fw_recovery_if_recovery_status.get());
+                let _ = state_machine.process_event(Events::RecoveryStatus(recovery_status));
+            }
+
+            States::ActivateCheckRecoveryStatus => {
+                // Check the recovery status after activation
+                let recovery_status =
+                    RecoveryStatus(i3c_periph.sec_fw_recovery_if_recovery_status.get());
+                let _ = state_machine.process_event(Events::RecoveryStatus(recovery_status));
+            }
+
+            _ => {}
+        }
+    }
+    i3c_periph
+        .soc_mgmt_if_rec_intf_cfg
+        .modify(RecIntfCfg::RecIntfBypass.val(BYPASS_CFG_USE_I3C));
+
+    Ok(())
+}

--- a/runtime/userspace/api/caliptra-api/Cargo.toml
+++ b/runtime/userspace/api/caliptra-api/Cargo.toml
@@ -14,6 +14,7 @@ caliptra-error.workspace = true
 dpe.workspace = true
 embassy-executor.workspace = true
 embassy-sync.workspace = true
+flash-image.workspace = true
 libtockasync.workspace = true
 libsyscall-caliptra.workspace = true
 libtock_console.workspace = true

--- a/runtime/userspace/api/caliptra-api/src/image_loading/flash_client.rs
+++ b/runtime/userspace/api/caliptra-api/src/image_loading/flash_client.rs
@@ -4,7 +4,7 @@ use libsyscall_caliptra::dma::{AXIAddr, DMASource, DMATransaction, DMA as DMASys
 use libtock_platform::ErrorCode;
 use zerocopy::FromBytes;
 
-use crate::flash_image::{FlashChecksums, FlashHeader, ImageHeader};
+use flash_image::{FlashChecksums, FlashHeader, ImageHeader};
 
 use libsyscall_caliptra::flash::SpiFlash as FlashSyscall;
 

--- a/runtime/userspace/api/caliptra-api/src/image_loading/mod.rs
+++ b/runtime/userspace/api/caliptra-api/src/image_loading/mod.rs
@@ -6,7 +6,6 @@ mod pldm_client;
 mod pldm_context;
 mod pldm_fdops;
 
-use crate::flash_image::FlashHeader;
 use alloc::boxed::Box;
 use async_trait::async_trait;
 use caliptra_api::mailbox::{
@@ -15,6 +14,7 @@ use caliptra_api::mailbox::{
 };
 use caliptra_auth_man_types::ImageMetadataFlags;
 use embassy_executor::Spawner;
+use flash_image::FlashHeader;
 use libsyscall_caliptra::flash::SpiFlash as FlashSyscall;
 use libsyscall_caliptra::mailbox::MailboxError;
 use libsyscall_caliptra::{dma::AXIAddr, mailbox::Mailbox};

--- a/runtime/userspace/api/caliptra-api/src/image_loading/pldm_client.rs
+++ b/runtime/userspace/api/caliptra-api/src/image_loading/pldm_client.rs
@@ -1,9 +1,9 @@
 // Licensed under the Apache-2.0 license
 
 extern crate alloc;
-use crate::flash_image::{FlashChecksums, FlashHeader, ImageHeader};
 use crate::image_loading::pldm_context::State;
 use crate::image_loading::pldm_fdops::StreamingFdOps;
+use flash_image::{FlashChecksums, FlashHeader, ImageHeader};
 
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 

--- a/runtime/userspace/api/caliptra-api/src/image_loading/pldm_context.rs
+++ b/runtime/userspace/api/caliptra-api/src/image_loading/pldm_context.rs
@@ -2,7 +2,7 @@
 
 use core::cell::RefCell;
 
-use crate::flash_image::{FlashHeader, ImageHeader};
+use flash_image::{FlashHeader, ImageHeader};
 use libsyscall_caliptra::dma::AXIAddr;
 
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;

--- a/runtime/userspace/api/caliptra-api/src/image_loading/pldm_fdops.rs
+++ b/runtime/userspace/api/caliptra-api/src/image_loading/pldm_fdops.rs
@@ -4,9 +4,9 @@ extern crate alloc;
 
 use super::pldm_client::{IMAGE_LOADING_TASK_YIELD, PLDM_TASK_YIELD};
 use super::pldm_context::{State, DOWNLOAD_CTX, PLDM_STATE};
-use crate::flash_image::{FlashChecksums, FlashHeader, ImageHeader};
 use alloc::boxed::Box;
 use async_trait::async_trait;
+use flash_image::{FlashChecksums, FlashHeader, ImageHeader};
 use libsyscall_caliptra::dma::{AXIAddr, DMASource, DMATransaction, DMA as DMASyscall};
 use pldm_common::message::firmware_update::apply_complete::ApplyResult;
 use pldm_common::message::firmware_update::get_fw_params::FirmwareParameters;

--- a/runtime/userspace/api/caliptra-api/src/lib.rs
+++ b/runtime/userspace/api/caliptra-api/src/lib.rs
@@ -7,6 +7,5 @@ pub mod checksum;
 pub mod crypto;
 pub mod error;
 pub mod evidence;
-pub mod flash_image;
 pub mod image_loading;
 pub mod mailbox_api;

--- a/tests/integration/src/lib.rs
+++ b/tests/integration/src/lib.rs
@@ -78,6 +78,8 @@ mod test {
         streaming_boot_package_path: Option<PathBuf>,
         primary_flash_image_path: Option<PathBuf>,
         secondary_flash_image_path: Option<PathBuf>,
+        caliptra_builder: Option<CaliptraBuilder>,
+        hw_revision: Option<String>,
     ) -> ExitStatus {
         let mut cargo_run_args = vec![
             "run",
@@ -162,15 +164,25 @@ mod test {
         let lc_size = format!("0x{:x}", mcu_config_emulator::EMULATOR_MEMORY_MAP.lc_size);
         cargo_run_args.extend(["--lc-size", &lc_size]);
 
-        let mut caliptra_builder = CaliptraBuilder::new(
-            false,
-            None,
-            None,
-            None,
-            None,
-            Some(runtime_path.clone()),
-            soc_images,
-        );
+        let mut caliptra_builder = if let Some(caliptra_builder) = caliptra_builder {
+            caliptra_builder
+        } else {
+            CaliptraBuilder::new(
+                false,
+                None,
+                None,
+                None,
+                None,
+                Some(runtime_path.clone()),
+                soc_images,
+            )
+        };
+
+        let hw_revision_str;
+        if let Some(hw_revision) = hw_revision {
+            hw_revision_str = hw_revision;
+            cargo_run_args.extend(["--hw-revision", &hw_revision_str]);
+        }
 
         if active_mode {
             if manufacturing_mode {
@@ -245,6 +257,8 @@ mod test {
             i3c_port,
             true,  // active mode is always true
             false, //set this to true if you want to run in manufacturing mode
+            None,
+            None,
             None,
             None,
             None,
@@ -338,6 +352,8 @@ mod test {
             None,
             None,
             None,
+            None,
+            None,
         );
         assert_eq!(0, test.code().unwrap_or_default());
 
@@ -361,6 +377,8 @@ mod test {
             i3c_port,
             true,
             false,
+            None,
+            None,
             None,
             None,
             None,

--- a/tests/integration/src/test_soc_boot.rs
+++ b/tests/integration/src/test_soc_boot.rs
@@ -2,9 +2,9 @@
 
 #[cfg(test)]
 mod test {
-    use crate::test::{compile_runtime, run_runtime, ROM, TEST_LOCK};
+    use crate::test::{compile_runtime, get_rom_with_feature, run_runtime, TEST_LOCK};
     use chrono::{TimeZone, Utc};
-    use mcu_builder::SocImage;
+    use mcu_builder::{CaliptraBuilder, SocImage};
     use mcu_config::boot::{PartitionId, PartitionStatus, RollbackEnable};
     use mcu_config_emulator::flash::{
         PartitionTable, StandAloneChecksumCalculator, IMAGE_A_PARTITION, IMAGE_B_PARTITION,
@@ -22,13 +22,17 @@ mod test {
     #[derive(Clone)]
     struct TestOptions {
         feature: &'static str,
+        rom: PathBuf,
         runtime: PathBuf,
         i3c_port: u32,
         soc_images: Vec<SocImage>,
+        soc_images_paths: Vec<PathBuf>,
         primary_flash_image_path: Option<PathBuf>,
         secondary_flash_image_path: Option<PathBuf>,
         pldm_fw_pkg_path: Option<PathBuf>,
         partition_table: Option<PartitionTable>,
+        builder: Option<CaliptraBuilder>,
+        flash_offset: usize,
     }
 
     macro_rules! run_test {
@@ -38,12 +42,7 @@ mod test {
         }};
     }
 
-    // Helper function to create a flash image from the provided SOC images
-    fn create_flash_image(
-        partition_table: Option<PartitionTable>,
-        flash_offset: usize,
-        soc_images: Vec<Vec<u8>>,
-    ) -> (Vec<PathBuf>, PathBuf) {
+    fn create_soc_images(soc_images: Vec<Vec<u8>>) -> Vec<PathBuf> {
         let soc_images_paths: Vec<PathBuf> = soc_images
             .iter()
             .map(|image| {
@@ -55,16 +54,35 @@ mod test {
                 soc_image_path
             })
             .collect();
-
+        soc_images_paths
+    }
+    // Helper function to create a flash image from the provided SOC images
+    fn create_flash_image(
+        caliptra_fw_path: Option<PathBuf>,
+        soc_manifest_path: Option<PathBuf>,
+        mcu_runtime_path: Option<PathBuf>,
+        partition_table: Option<PartitionTable>,
+        flash_offset: usize,
+        soc_images_paths: Vec<PathBuf>,
+    ) -> (Vec<PathBuf>, PathBuf) {
         let flash_image_path = tempfile::NamedTempFile::new()
             .expect("Failed to create flash image file")
             .path()
             .to_path_buf();
 
+        let caliptra_fw_path_str = caliptra_fw_path
+            .as_ref()
+            .map(|p| p.to_string_lossy().to_string());
+        let soc_manifest_path_str = soc_manifest_path
+            .as_ref()
+            .map(|p| p.to_string_lossy().to_string());
+        let mcu_runtime_path_str = mcu_runtime_path
+            .as_ref()
+            .map(|p| p.to_string_lossy().to_string());
         mcu_builder::flash_image::flash_image_create(
-            &None,
-            &None,
-            &None,
+            &caliptra_fw_path_str,
+            &soc_manifest_path_str,
+            &mcu_runtime_path_str,
             &Some(
                 soc_images_paths
                     .iter()
@@ -164,10 +182,10 @@ mod test {
         ]
     }
 
-    fn run_runtime_with_options(opts: TestOptions) -> ExitStatus {
+    fn run_runtime_with_options(opts: &TestOptions) -> ExitStatus {
         run_runtime(
             opts.feature,
-            ROM.to_path_buf(),
+            opts.rom.clone(),
             opts.runtime.clone(),
             opts.i3c_port.to_string(),
             true,
@@ -176,50 +194,81 @@ mod test {
             opts.pldm_fw_pkg_path.clone(),
             opts.primary_flash_image_path.clone(),
             opts.secondary_flash_image_path.clone(),
+            opts.builder.clone(),
+            Some("2.1.0".to_string()),
         )
     }
 
     /// Test case: happy path
-    fn test_successful_boot(opts: TestOptions) {
+    fn test_successful_boot(opts: &TestOptions) {
         let test = run_runtime_with_options(opts);
         assert_eq!(0, test.code().unwrap_or_default());
     }
 
     // Test case: Image ID in the SOC manifest is different from the one being authorized in the firmware
-    fn test_boot_invalid_image_id(opts: TestOptions) {
+    fn test_boot_invalid_image_id(opts: &TestOptions) {
         let mut new_options = opts.clone();
         new_options.soc_images[0].image_id = 0xDEAD; // Change the image ID to an invalid one
+        let soc_manifest = new_options
+            .builder
+            .as_mut()
+            .unwrap()
+            .replace_manifest_metadata(new_options.soc_images.clone())
+            .unwrap();
 
-        let test = run_runtime_with_options(new_options);
+        // Update the SOC manifest in the flash image
+        let (_, flash_image_path) = create_flash_image(
+            new_options.builder.as_mut().unwrap().get_caliptra_fw().ok(),
+            Some(soc_manifest),
+            Some(new_options.runtime.clone()),
+            new_options.partition_table.clone(),
+            new_options.flash_offset,
+            new_options.soc_images_paths.clone(),
+        );
+
+        new_options.primary_flash_image_path = if opts.primary_flash_image_path.is_some() {
+            Some(flash_image_path)
+        } else {
+            None
+        };
+
+        let test = run_runtime_with_options(&new_options);
         assert_ne!(0, test.code().unwrap_or_default());
     }
 
     // Test case: The FW to be streamed has been altered making it unauthorized
-    fn test_boot_unathorized_image(opts: TestOptions) {
+    fn test_boot_unathorized_image(opts: &TestOptions) {
         let mut new_options = opts.clone();
 
         // Create another flash image with a different content
         let soc_image_fw_1 = [0xDEu8; 512];
         let soc_image_fw_2 = [0xADu8; 256];
+        let soc_images_paths =
+            create_soc_images(vec![soc_image_fw_1.to_vec(), soc_image_fw_2.to_vec()]);
         let flash_offset = opts
             .partition_table
             .as_ref()
             .and_then(|pt| pt.get_active_partition().1.as_ref().map(|p| p.offset))
             .unwrap_or(0);
         let (_, flash_image_path) = create_flash_image(
-            opts.partition_table,
+            new_options.builder.as_mut().unwrap().get_caliptra_fw().ok(),
+            new_options
+                .builder
+                .as_mut()
+                .unwrap()
+                .get_soc_manifest()
+                .ok(),
+            Some(opts.runtime.clone()),
+            opts.partition_table.clone(),
             flash_offset,
-            vec![soc_image_fw_1.to_vec(), soc_image_fw_2.to_vec()],
+            soc_images_paths.clone(),
         );
 
         // Generate the corresponding PLDM package for the altered flash image
         new_options.pldm_fw_pkg_path = if opts.pldm_fw_pkg_path.is_some() {
             let device_uuid = get_device_uuid();
-            let (_, flash_image_path) = create_flash_image(
-                None,
-                0,
-                vec![soc_image_fw_1.to_vec(), soc_image_fw_2.to_vec()],
-            );
+            let (_, flash_image_path) =
+                create_flash_image(None, None, None, None, 0, soc_images_paths.clone());
             let flash_image =
                 std::fs::read(flash_image_path.clone()).expect("Failed to read flash image");
             let pldm_manifest = get_streaming_boot_pldm_fw_manifest(&device_uuid, &flash_image);
@@ -234,17 +283,45 @@ mod test {
             None
         };
 
-        let test = run_runtime_with_options(new_options);
+        let test = run_runtime_with_options(&new_options);
         assert_ne!(0, test.code().unwrap_or_default());
     }
 
     // Test case: The load address in the SOC manifest is not a valid addressable AXI address
-    fn test_invalid_load_address(opts: TestOptions) {
+    fn test_invalid_load_address(opts: &TestOptions) {
         let mut new_options = opts.clone();
         // Change the load address in the SOC manifest to an invalid one
         new_options.soc_images[0].load_addr = 0xffff; // Invalid load address
+        new_options
+            .builder
+            .as_mut()
+            .unwrap()
+            .replace_manifest_metadata(new_options.soc_images.clone())
+            .unwrap();
 
-        let test = run_runtime_with_options(new_options);
+        let soc_manifest = new_options
+            .builder
+            .as_mut()
+            .unwrap()
+            .replace_manifest_metadata(new_options.soc_images.clone())
+            .unwrap();
+
+        // Update the SOC manifest in the flash image
+        let (_, flash_image_path) = create_flash_image(
+            new_options.builder.as_mut().unwrap().get_caliptra_fw().ok(),
+            Some(soc_manifest),
+            Some(new_options.runtime.clone()),
+            new_options.partition_table.clone(),
+            new_options.flash_offset,
+            new_options.soc_images_paths.clone(),
+        );
+        new_options.primary_flash_image_path = if opts.primary_flash_image_path.is_some() {
+            Some(flash_image_path)
+        } else {
+            None
+        };
+
+        let test = run_runtime_with_options(&new_options);
         assert_ne!(0, test.code().unwrap_or_default());
     }
 
@@ -255,6 +332,8 @@ mod test {
         // Create another flash image with a different content
         let soc_image_fw_1 = [0x55u8; 512];
         let soc_image_fw_2 = [0xAAu8; 256];
+        let soc_images_paths =
+            create_soc_images(vec![soc_image_fw_1.to_vec(), soc_image_fw_2.to_vec()]);
         let mut new_partition_table = PartitionTable {
             active_partition: PartitionId::B as u32,
             partition_a_status: PartitionStatus::Invalid as u16,
@@ -265,9 +344,17 @@ mod test {
         new_partition_table.populate_checksum(&checksum_calculator);
         let secondary_flash_image_path = if opts.secondary_flash_image_path.is_some() {
             let (_, secondary_flash_image_path) = create_flash_image(
+                new_options.builder.as_mut().unwrap().get_caliptra_fw().ok(),
+                new_options
+                    .builder
+                    .as_mut()
+                    .unwrap()
+                    .get_soc_manifest()
+                    .ok(),
+                Some(opts.runtime.clone()),
                 None,
                 0,
-                vec![soc_image_fw_1.to_vec(), soc_image_fw_2.to_vec()],
+                soc_images_paths.clone(),
             );
             Some(secondary_flash_image_path)
         } else {
@@ -277,25 +364,33 @@ mod test {
 
         // Update the partition table in the primary flash
         let primary_flash_image_path = if opts.primary_flash_image_path.is_some() {
-            let (_, primary_flash_image_path) =
-                create_flash_image(Some(new_partition_table), IMAGE_A_PARTITION.offset, vec![]);
+            let (_, primary_flash_image_path) = create_flash_image(
+                None,
+                None,
+                None,
+                Some(new_partition_table),
+                IMAGE_A_PARTITION.offset,
+                vec![],
+            );
             Some(primary_flash_image_path)
         } else {
             None
         };
         new_options.primary_flash_image_path = primary_flash_image_path.clone();
 
-        let test = run_runtime_with_options(new_options);
+        let test = run_runtime_with_options(&new_options);
         assert_eq!(0, test.code().unwrap_or_default());
     }
 
     // Test case: Partition table has invalid checksum
-    fn test_boot_partition_table_invalid_checksum(opts: TestOptions) {
+    fn test_boot_partition_table_invalid_checksum(opts: &TestOptions) {
         let mut new_options = opts.clone();
 
         // Create another flash image with a different content
         let soc_image_fw_1 = [0x55u8; 512];
         let soc_image_fw_2 = [0xAAu8; 256];
+        let soc_images_paths =
+            create_soc_images(vec![soc_image_fw_1.to_vec(), soc_image_fw_2.to_vec()]);
         let new_partition_table = PartitionTable {
             active_partition: PartitionId::B as u32,
             partition_a_status: PartitionStatus::Invalid as u16,
@@ -305,9 +400,17 @@ mod test {
         // Do not populate the checksum
         new_options.secondary_flash_image_path = if opts.secondary_flash_image_path.is_some() {
             let (_, secondary_flash_image_path) = create_flash_image(
+                new_options.builder.as_mut().unwrap().get_caliptra_fw().ok(),
+                new_options
+                    .builder
+                    .as_mut()
+                    .unwrap()
+                    .get_soc_manifest()
+                    .ok(),
+                Some(new_options.runtime.clone()),
                 None,
                 IMAGE_B_PARTITION.offset,
-                vec![soc_image_fw_1.to_vec(), soc_image_fw_2.to_vec()],
+                soc_images_paths.clone(),
             );
             Some(secondary_flash_image_path)
         } else {
@@ -317,19 +420,25 @@ mod test {
         // Update the partition table in the primary flash
 
         new_options.primary_flash_image_path = if opts.primary_flash_image_path.is_some() {
-            let (_, primary_flash_image_path) =
-                create_flash_image(Some(new_partition_table), IMAGE_A_PARTITION.offset, vec![]);
+            let (_, primary_flash_image_path) = create_flash_image(
+                None,
+                None,
+                None,
+                Some(new_partition_table),
+                IMAGE_A_PARTITION.offset,
+                vec![],
+            );
             Some(primary_flash_image_path)
         } else {
             None
         };
 
-        let test = run_runtime_with_options(new_options);
+        let test = run_runtime_with_options(&new_options);
         assert_ne!(0, test.code().unwrap_or_default());
     }
 
     // Test case: The PLDM descriptor in the PLDM package is different from the device's descriptor
-    fn test_incorrect_pldm_descriptor(opts: TestOptions) {
+    fn test_incorrect_pldm_descriptor(opts: &TestOptions) {
         let mut new_options = opts.clone();
 
         // Generate another PLDM Package with a different descriptor
@@ -338,12 +447,11 @@ mod test {
 
         let soc_image_fw_1 = [0x55u8; 512]; // Example firmware data for SOC image 1
         let soc_image_fw_2 = [0xAAu8; 256]; // Example firmware data for SOC image 2
+        let soc_images_paths =
+            create_soc_images(vec![soc_image_fw_1.to_vec(), soc_image_fw_2.to_vec()]);
         new_options.pldm_fw_pkg_path = if opts.pldm_fw_pkg_path.is_some() {
-            let (_, flash_image_path) = create_flash_image(
-                None,
-                0,
-                vec![soc_image_fw_1.to_vec(), soc_image_fw_2.to_vec()],
-            );
+            let (_, flash_image_path) =
+                create_flash_image(None, None, None, None, 0, soc_images_paths.clone());
             let flash_image = std::fs::read(flash_image_path).expect("Failed to read flash image");
             let pldm_manifest = get_streaming_boot_pldm_fw_manifest(&device_uuid, &flash_image);
             Some(create_pldm_fw_package(&pldm_manifest))
@@ -351,22 +459,21 @@ mod test {
             None
         };
 
-        let test = run_runtime_with_options(new_options);
+        let test = run_runtime_with_options(&new_options);
         assert_ne!(0, test.code().unwrap_or_default());
     }
 
     // Test case: The PLDM component ID in the PLDM package is not valid
-    fn test_incorrect_pldm_component_id(opts: TestOptions) {
+    fn test_incorrect_pldm_component_id(opts: &TestOptions) {
         let mut new_options = opts.clone();
         let device_uuid = get_device_uuid();
         let soc_image_fw_1 = [0x55u8; 512]; // Example firmware data for SOC image 1
         let soc_image_fw_2 = [0xAAu8; 256]; // Example firmware data for SOC image 2
+        let soc_images_paths =
+            create_soc_images(vec![soc_image_fw_1.to_vec(), soc_image_fw_2.to_vec()]);
         new_options.pldm_fw_pkg_path = if opts.pldm_fw_pkg_path.is_some() {
-            let (_, flash_image_path) = create_flash_image(
-                None,
-                0,
-                vec![soc_image_fw_1.to_vec(), soc_image_fw_2.to_vec()],
-            );
+            let (_, flash_image_path) =
+                create_flash_image(None, None, None, None, 0, soc_images_paths.clone());
             let flash_image = std::fs::read(flash_image_path).expect("Failed to read flash image");
             let mut pldm_manifest = get_streaming_boot_pldm_fw_manifest(&device_uuid, &flash_image);
             pldm_manifest.component_image_information[0].identifier = 0xDEAD; // Change the component ID to an invalid one
@@ -375,22 +482,21 @@ mod test {
             None
         };
 
-        let test = run_runtime_with_options(new_options);
+        let test = run_runtime_with_options(&new_options);
         assert_ne!(0, test.code().unwrap_or_default());
     }
 
     // Test case: Corrupted PLDM FW package
-    fn test_corrupted_pldm_fw_package(opts: TestOptions) {
+    fn test_corrupted_pldm_fw_package(opts: &TestOptions) {
         let mut new_options = opts.clone();
         let device_uuid = get_device_uuid();
         let soc_image_fw_1 = [0x55u8; 512]; // Example firmware data for SOC image 1
         let soc_image_fw_2 = [0xAAu8; 256]; // Example firmware data for SOC image 2
+        let soc_images_paths =
+            create_soc_images(vec![soc_image_fw_1.to_vec(), soc_image_fw_2.to_vec()]);
         new_options.pldm_fw_pkg_path = if opts.pldm_fw_pkg_path.is_some() {
-            let (_, flash_image_path) = create_flash_image(
-                None,
-                0,
-                vec![soc_image_fw_1.to_vec(), soc_image_fw_2.to_vec()],
-            );
+            let (_, flash_image_path) =
+                create_flash_image(None, None, None, None, 0, soc_images_paths.clone());
             let flash_image = std::fs::read(flash_image_path).expect("Failed to read flash image");
             let mut pldm_manifest = get_streaming_boot_pldm_fw_manifest(&device_uuid, &flash_image);
             pldm_manifest.component_image_information[0].image_data = Some(vec![0x00]); // Remove the image data to simulate corruption
@@ -399,23 +505,22 @@ mod test {
             None
         };
 
-        let test = run_runtime_with_options(new_options);
+        let test = run_runtime_with_options(&new_options);
         assert_ne!(0, test.code().unwrap_or_default());
     }
 
     // Test case: PLDM FW package has lower version than device's active image version
-    fn test_lower_version_pldm_fw_package(opts: TestOptions) {
+    fn test_lower_version_pldm_fw_package(opts: &TestOptions) {
         let mut new_options = opts.clone();
         let device_uuid = get_device_uuid();
         let soc_image_fw_1 = [0x55u8; 512]; // Example firmware data for SOC image 1
         let soc_image_fw_2 = [0xAAu8; 256]; // Example firmware data for SOC image 2
+        let soc_images_paths =
+            create_soc_images(vec![soc_image_fw_1.to_vec(), soc_image_fw_2.to_vec()]);
 
         new_options.pldm_fw_pkg_path = if opts.pldm_fw_pkg_path.is_some() {
-            let (_, flash_image_path) = create_flash_image(
-                None,
-                0,
-                vec![soc_image_fw_1.to_vec(), soc_image_fw_2.to_vec()],
-            );
+            let (_, flash_image_path) =
+                create_flash_image(None, None, None, None, 0, soc_images_paths.clone());
             let flash_image = std::fs::read(flash_image_path).expect("Failed to read flash image");
             let mut pldm_manifest = get_streaming_boot_pldm_fw_manifest(&device_uuid, &flash_image);
             pldm_manifest.component_image_information[0].options = 0x0001; // Enable comparison stamp option
@@ -425,7 +530,7 @@ mod test {
             None
         };
 
-        let test = run_runtime_with_options(new_options);
+        let test = run_runtime_with_options(&new_options);
         assert_ne!(0, test.code().unwrap_or_default());
     }
 
@@ -438,55 +543,16 @@ mod test {
             "test-pldm-streaming-boot"
         };
         let i3c_port = 65500;
+        let soc_image_fw_1 = [0x55u8; 512]; // Example firmware data for SOC image 1
+        let soc_image_fw_2 = [0xAAu8; 256]; // Example firmware data for SOC image 2
 
         // Compile the runtime once with the appropriate feature
         let test_runtime = compile_runtime(feature, false);
 
-        // Generate a valid flash image file
-        let mut partition_table = PartitionTable {
-            active_partition: PartitionId::A as u32,
-            partition_a_status: PartitionStatus::Valid as u16,
-            partition_b_status: PartitionStatus::Invalid as u16,
-            rollback_enable: RollbackEnable::Enabled as u32,
-            ..Default::default()
-        };
-        let checksum_calculator = StandAloneChecksumCalculator::new();
-        partition_table.populate_checksum(&checksum_calculator);
-        let soc_image_fw_1 = [0x55u8; 512]; // Example firmware data for SOC image 1
-        let soc_image_fw_2 = [0xAAu8; 256]; // Example firmware data for SOC image 2
-        let flash_offset = partition_table
-            .get_active_partition()
-            .1
-            .map_or(0, |p| p.offset);
-        let (soc_images_paths, flash_image_path) = create_flash_image(
-            Some(partition_table.clone()),
-            flash_offset,
-            vec![soc_image_fw_1.to_vec(), soc_image_fw_2.to_vec()],
-        );
-
-        // Generate the corresponding PLDM package from the flash image
-        let pldm_fw_pkg_path = if is_flash_based_boot {
-            None
-        } else {
-            let device_uuid = get_device_uuid();
-            let (_, flash_image_path) = create_flash_image(
-                None,
-                0,
-                vec![soc_image_fw_1.to_vec(), soc_image_fw_2.to_vec()],
-            );
-            let flash_image =
-                std::fs::read(flash_image_path.clone()).expect("Failed to read flash image");
-            let pldm_manifest = get_streaming_boot_pldm_fw_manifest(&device_uuid, &flash_image);
-            Some(create_pldm_fw_package(&pldm_manifest))
-        };
-
-        // For non flash-based boot, the flash image path is not needeed to be passed to the emulator
-        // as the firmware will be streamed from the PLDM package
-        let flash_image_path = if is_flash_based_boot {
-            Some(flash_image_path)
-        } else {
-            None
-        };
+        let soc_images_paths = create_soc_images(vec![
+            soc_image_fw_1.clone().to_vec(),
+            soc_image_fw_2.clone().to_vec(),
+        ]);
 
         // Create SOC image metadata that will be written to the SoC manifest
         let soc_images = vec![
@@ -502,38 +568,113 @@ mod test {
             },
         ];
 
+        // Build the Caliptra runtime
+        let mut builder = CaliptraBuilder::new(
+            false,
+            None,
+            None,
+            None,
+            None,
+            Some(test_runtime.clone()),
+            Some(soc_images.clone()),
+        );
+
+        // Build Caliptra firmware
+        let caliptra_fw = builder
+            .get_caliptra_fw()
+            .expect("Failed to build Caliptra firmware");
+
+        let soc_manifest = builder
+            .get_soc_manifest()
+            .expect("Failed to build SOC manifest");
+
+        // Generate a valid flash image file
+        let mut partition_table = PartitionTable {
+            active_partition: PartitionId::A as u32,
+            partition_a_status: PartitionStatus::Valid as u16,
+            partition_b_status: PartitionStatus::Invalid as u16,
+            rollback_enable: RollbackEnable::Enabled as u32,
+            ..Default::default()
+        };
+        let checksum_calculator = StandAloneChecksumCalculator::new();
+        partition_table.populate_checksum(&checksum_calculator);
+
+        let flash_offset = partition_table
+            .get_active_partition()
+            .1
+            .map_or(0, |p| p.offset);
+        let (soc_images_paths, flash_image_path) = create_flash_image(
+            Some(caliptra_fw),
+            Some(soc_manifest),
+            Some(test_runtime.clone()),
+            Some(partition_table.clone()),
+            flash_offset,
+            soc_images_paths.clone(),
+        );
+
+        // Generate the corresponding PLDM package from the flash image
+        let pldm_fw_pkg_path = if is_flash_based_boot {
+            None
+        } else {
+            let device_uuid = get_device_uuid();
+            let (_, flash_image_path) =
+                create_flash_image(None, None, None, None, 0, soc_images_paths.clone());
+            let flash_image =
+                std::fs::read(flash_image_path.clone()).expect("Failed to read flash image");
+            let pldm_manifest = get_streaming_boot_pldm_fw_manifest(&device_uuid, &flash_image);
+            Some(create_pldm_fw_package(&pldm_manifest))
+        };
+
+        // For non flash-based boot, the flash image path is not needeed to be passed to the emulator
+        // as the firmware will be streamed from the PLDM package
+        let flash_image_path = if is_flash_based_boot {
+            Some(flash_image_path)
+        } else {
+            None
+        };
+
+        let mcu_rom = get_rom_with_feature(feature);
+
         // These are the options for a successful boot
         // Each test case will override the options to simulate different scenarios
         let pass_options = TestOptions {
             feature,
+            rom: mcu_rom,
             runtime: test_runtime.clone(),
             i3c_port,
             soc_images: soc_images.clone(),
+            soc_images_paths: soc_images_paths.clone(),
             primary_flash_image_path: flash_image_path.clone(),
             secondary_flash_image_path: flash_image_path.clone(),
             pldm_fw_pkg_path: pldm_fw_pkg_path.clone(),
             partition_table: Some(partition_table.clone()),
+            builder: Some(builder.clone()),
+            flash_offset,
         };
-
-        run_test!(test_successful_boot, pass_options.clone());
-        run_test!(test_boot_invalid_image_id, pass_options.clone());
-        run_test!(test_boot_unathorized_image, pass_options.clone());
-        run_test!(test_invalid_load_address, pass_options.clone());
 
         if !is_flash_based_boot {
             // Streaming boot-only tests
-            run_test!(test_incorrect_pldm_descriptor, pass_options.clone());
-            run_test!(test_incorrect_pldm_component_id, pass_options.clone());
-            run_test!(test_corrupted_pldm_fw_package, pass_options.clone());
-            run_test!(test_lower_version_pldm_fw_package, pass_options.clone());
+            run_test!(test_successful_boot, &pass_options.clone());
+            run_test!(test_boot_invalid_image_id, &pass_options.clone());
+            run_test!(test_boot_unathorized_image, &pass_options.clone());
+            run_test!(test_invalid_load_address, &pass_options.clone());
+            run_test!(test_incorrect_pldm_descriptor, &pass_options.clone());
+            run_test!(test_incorrect_pldm_component_id, &pass_options.clone());
+            run_test!(test_corrupted_pldm_fw_package, &pass_options.clone());
+            run_test!(test_lower_version_pldm_fw_package, &pass_options.clone());
         } else {
             // Flash-based boot-only tests
+            run_test!(test_successful_boot, &pass_options.clone());
             run_test!(test_boot_secondary_flash, pass_options.clone());
+            run_test!(test_boot_invalid_image_id, &pass_options.clone());
+            run_test!(test_boot_unathorized_image, &pass_options.clone());
+            run_test!(test_invalid_load_address, &pass_options.clone());
             run_test!(
                 test_boot_partition_table_invalid_checksum,
-                pass_options.clone()
+                &pass_options.clone()
             );
         }
+
         lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     }
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -197,6 +197,10 @@ enum FlashImageCommands {
         /// Path to the flash image file
         #[arg(value_name = "FILE")]
         file: String,
+
+        /// Offset of the flash image in the file
+        #[arg(long, value_name = "OFFSET", default_value_t = 0)]
+        offset: u32,
     },
 }
 
@@ -273,8 +277,8 @@ fn main() {
                 0,
                 output,
             ),
-            FlashImageCommands::Verify { file } => {
-                mcu_builder::flash_image::flash_image_verify(file)
+            FlashImageCommands::Verify { file, offset } => {
+                mcu_builder::flash_image::flash_image_verify(file, *offset)
             }
         },
         Commands::Clippy => clippy::clippy(),

--- a/xtask/src/registers.rs
+++ b/xtask/src/registers.rs
@@ -450,6 +450,14 @@ fn emu_make_peripheral_trait(
         pub trait #periph {
             fn set_dma_ram(&mut self, _ram: std::rc::Rc<std::cell::RefCell<caliptra_emu_bus::Ram>>) {}
             fn set_dma_rom_sram(&mut self, _ram: std::rc::Rc<std::cell::RefCell<caliptra_emu_bus::Ram>>) {}
+            fn register_event_channels(
+                &mut self,
+                _events_to_caliptra: std::sync::mpsc::Sender<caliptra_emu_bus::Event>,
+                _events_from_caliptra: std::sync::mpsc::Receiver<caliptra_emu_bus::Event>,
+                _events_to_mcu: std::sync::mpsc::Sender<caliptra_emu_bus::Event>,
+                _events_from_mcu: std::sync::mpsc::Receiver<caliptra_emu_bus::Event>,
+            ) {
+            }
             fn poll(&mut self) {}
             fn warm_reset(&mut self) {}
             fn update_reset(&mut self) {}


### PR DESCRIPTION
- Load Caliptra firmware, manifest, MCU RT from the active partition of the flash and push to the recovery interface instead of the BMC pushing these images.

- Use the MCU I3C Recovery interface instead of the Caliptra Recovery Interface.

- Implement the BMC Recovery State Machine in MCU ROM

- Dependent on https://github.com/chipsalliance/caliptra-sw/pull/2269/