### PR TITLE
apps: Ensure exclusive access to the mailbox within an application

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2216,6 +2216,7 @@ name = "libsyscall-caliptra"
 version = "0.1.0"
 dependencies = [
  "caliptra-api",
+ "embassy-sync",
  "libtock_console",
  "libtock_platform",
  "libtock_runtime",

--- a/builder/src/runtime.rs
+++ b/builder/src/runtime.rs
@@ -24,7 +24,7 @@ const DEFAULT_PLATFORM: &str = "emulator";
 const DEFAULT_RUNTIME_NAME: &str = "runtime.bin";
 const INTERRUPT_TABLE_SIZE: usize = 128;
 // amount to reserve for data RAM at the end of RAM
-const DATA_RAM_SIZE: usize = 116 * 1024;
+const DATA_RAM_SIZE: usize = 112 * 1024;
 
 fn get_apps_memory_offset(elf_file: PathBuf) -> Result<usize> {
     let elf_bytes = std::fs::read(&elf_file)?;

--- a/runtime/userspace/syscall/Cargo.toml
+++ b/runtime/userspace/syscall/Cargo.toml
@@ -8,6 +8,7 @@ edition.workspace = true
 
 [dependencies]
 caliptra-api.workspace = true
+embassy-sync.workspace = true
 libtock_console.workspace = true
 libtock_platform.workspace = true
 libtockasync.workspace = true


### PR DESCRIPTION
Some tests were failing within our app (like SoC streaming boot), which would appear to hang when they started.

This was due to the simultaneous access to the mailbox capsule. Each app had several `Mailbox` structs, each of which might be simultaneously trying to use the mailbox.

Within the kernel, this is okay, as these syscalls are serialized.

However, the Tock locking is only per-application.

If two tasks within a single app try to use the mailbox, then the second one can overwrite the upcall pointer of the first, so the first upcall never happens.

This PR resolves the overwriting the upcall pointers by adding a global mutex around mailbox execution within an app.