### PR TITLE
Update Flash Format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2417,6 +2417,7 @@ dependencies = [
  "crc32fast",
  "elf",
  "emulator-consts",
+ "flash-image",
  "hex",
  "mcu-config",
  "mcu-config-emulator",

--- a/builder/Cargo.toml
+++ b/builder/Cargo.toml
@@ -17,6 +17,7 @@ cargo_metadata.workspace = true
 crc32fast.workspace = true
 elf.workspace = true
 emulator-consts.workspace = true
+flash-image.workspace = true
 hex.workspace = true
 mcu-config.workspace = true
 mcu-config-emulator.workspace = true

--- a/common/flash-image/src/lib.rs
+++ b/common/flash-image/src/lib.rs
@@ -1,21 +1,19 @@
 // Licensed under the Apache-2.0 license
 #![no_std]
 
-use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
+use zerocopy::{byteorder::U32, FromBytes, Immutable, IntoBytes, KnownLayout};
+
+pub const FLASH_IMAGE_MAGIC_NUMBER: u32 = u32::from_be_bytes(*b"FLSH");
+pub const HEADER_VERSION: u16 = 0x0001;
 
 #[repr(C)]
 #[derive(Debug, FromBytes, IntoBytes, Immutable, KnownLayout)]
 pub struct FlashHeader {
-    pub magic: u32,
+    pub magic: U32<zerocopy::byteorder::BigEndian>,
     pub version: u16,
     pub image_count: u16,
-}
-
-#[repr(C)]
-#[derive(Debug, FromBytes, IntoBytes, Immutable, KnownLayout)]
-pub struct FlashChecksums {
+    pub image_headers_offset: u32,
     pub header_crc32: u32,
-    pub payload_crc32: u32,
 }
 
 #[repr(C)]
@@ -24,4 +22,6 @@ pub struct ImageHeader {
     pub identifier: u32,
     pub offset: u32,
     pub size: u32,
+    pub image_checksum: u32,
+    pub image_header_checksum: u32,
 }

--- a/docs/src/flash_layout.md
+++ b/docs/src/flash_layout.md
@@ -13,7 +13,6 @@ A typical overall flash layout is:
 | Flash Layout |
 | ------------ |
 | Header       |
-| Checksum     |
 | Payload      |
 
 The Payload contains the following fields:
@@ -47,21 +46,8 @@ The Header section contains the metadata for the images stored in the flash.
 | Magic Number   | 4            | A unique identifier to mark the start of the header.<br />The value must be `0x464C5348` (`"FLSH"` in ASCII)                               |
 | Header Version | 2            | The header version format, allowing for backward compatibility if the package format changes over time.<br />(Current version is `0x0001`) |
 | Image Count    | 2            | The number of image stored in the flash.<br />Each image will have its own image information section.                                      |
-
-## Checksum
-
-The checksum section contains integrity checksums for the header and the payload sections.
-
-| Field            | Size (bytes) | Description                                                                                                       |
-| ---------------- | ------------ | ----------------------------------------------------------------------------------------------------------------- |
-| Header Checksum  | 4            | The integrity checksum of the Header section.                                                                     |
-|                  |              | It is calculated starting at the first byte of the Header until the last byte of the Image Count field.           |
-|                  |              | For this specification, The CRC-32 algorithm with polynomial 0x04C11DB7 (as used by IEEE 802.3)                   |
-|                  |              | is used for checksum computation, processing one byte at a time with the least significant bit first.             |
-| Payload Checksum | 4            | The integrity checksum of the payload section.                                                                    |
-|                  |              | It is calculated starting at the first byte of the first image information until the last byte of the last image. |
-|                  |              | For this specification, The CRC-32 algorithm with polynomial `0x04C11DB7` (as used by IEEE 802.3)                 |
-|                  |              | is used for checksum computation, processing one byte at a time with the least significant bit first.             |
+| Payload Offset | 4            | Offset in bytes of the header to where the first byte of the Payload is located.  |
+| Header Checksum | 4            | CRC-32 checksum calculated for the header excluding this field  |
 
 ## Image Information
 
@@ -77,6 +63,8 @@ The Image Information section is repeated for each image and provides detailed m
 | Size                | 4            | Size in bytes of the image. This is the actual size of the image without padding.      |
 |                     |              | The image itself as written to the flash should be 4-byte aligned and additional       |
 |                     |              | padding will be required to guarantee alignment.                                       |
+| Image Checksum      | 4            | CRC-32 checksum calculated for the binary image located at `ImageLocationOffset` |
+| Image Info Checksum | 4            | CRC-32 checksum calculated for the header excluding this field  |
 
 ## Image
 

--- a/runtime/userspace/api/caliptra-api/src/image_loading/flash_client.rs
+++ b/runtime/userspace/api/caliptra-api/src/image_loading/flash_client.rs
@@ -4,7 +4,7 @@ use libsyscall_caliptra::dma::{AXIAddr, DMASource, DMATransaction, DMA as DMASys
 use libtock_platform::ErrorCode;
 use zerocopy::FromBytes;
 
-use flash_image::{FlashChecksums, FlashHeader, ImageHeader};
+use flash_image::{FlashHeader, ImageHeader};
 
 use libsyscall_caliptra::flash::SpiFlash as FlashSyscall;
 
@@ -34,9 +34,8 @@ pub async fn flash_read_toc(
 ) -> Result<(u32, u32), ErrorCode> {
     let (header, _) = FlashHeader::ref_from_prefix(header).map_err(|_| ErrorCode::Fail)?;
     for index in 0..header.image_count as usize {
-        let flash_offset = core::mem::size_of::<FlashHeader>()
-            + core::mem::size_of::<FlashChecksums>()
-            + index * core::mem::size_of::<ImageHeader>();
+        let flash_offset =
+            core::mem::size_of::<FlashHeader>() + index * core::mem::size_of::<ImageHeader>();
         let buffer = &mut [0u8; core::mem::size_of::<ImageHeader>()];
         flash
             .read(flash_offset, core::mem::size_of::<ImageHeader>(), buffer)

--- a/runtime/userspace/api/caliptra-api/src/image_loading/pldm_client.rs
+++ b/runtime/userspace/api/caliptra-api/src/image_loading/pldm_client.rs
@@ -3,7 +3,7 @@
 extern crate alloc;
 use crate::image_loading::pldm_context::State;
 use crate::image_loading::pldm_fdops::StreamingFdOps;
-use flash_image::{FlashChecksums, FlashHeader, ImageHeader};
+use flash_image::{FlashHeader, ImageHeader};
 
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 
@@ -88,9 +88,8 @@ pub async fn pldm_download_toc(image_id: u32) -> Result<(u32, u32), ErrorCode> {
         DOWNLOAD_CTX.lock(|ctx| {
             let mut ctx = ctx.borrow_mut();
             ctx.total_length = core::mem::size_of::<ImageHeader>(); // image info length
-            ctx.initial_offset = core::mem::size_of::<FlashHeader>()
-                + core::mem::size_of::<FlashChecksums>()
-                + index * core::mem::size_of::<ImageHeader>();
+            ctx.initial_offset =
+                core::mem::size_of::<FlashHeader>() + index * core::mem::size_of::<ImageHeader>();
             ctx.current_offset = ctx.initial_offset;
             ctx.total_downloaded = 0;
         });

--- a/runtime/userspace/api/caliptra-api/src/image_loading/pldm_fdops.rs
+++ b/runtime/userspace/api/caliptra-api/src/image_loading/pldm_fdops.rs
@@ -6,7 +6,7 @@ use super::pldm_client::{IMAGE_LOADING_TASK_YIELD, PLDM_TASK_YIELD};
 use super::pldm_context::{State, DOWNLOAD_CTX, PLDM_STATE};
 use alloc::boxed::Box;
 use async_trait::async_trait;
-use flash_image::{FlashChecksums, FlashHeader, ImageHeader};
+use flash_image::{FlashHeader, ImageHeader};
 use libsyscall_caliptra::dma::{AXIAddr, DMASource, DMATransaction, DMA as DMASyscall};
 use pldm_common::message::firmware_update::apply_complete::ApplyResult;
 use pldm_common::message::firmware_update::get_fw_params::FirmwareParameters;
@@ -122,9 +122,7 @@ impl FdOps for StreamingFdOps<'_> {
     ) -> Result<ComponentResponseCode, FdOpsError> {
         if let Some(size) = component.comp_image_size {
             if size
-                < (core::mem::size_of::<ImageHeader>()
-                    + core::mem::size_of::<FlashChecksums>()
-                    + core::mem::size_of::<FlashHeader>()) as u32
+                < (core::mem::size_of::<ImageHeader>() + core::mem::size_of::<FlashHeader>()) as u32
             {
                 // Image size is too small
                 // Return Ok with response code here to allow PLDM lib to pass it to UA


### PR DESCRIPTION
- Use the common flash-image format defined in the common library used for builder, instead of redefining it in the builder.

- Make the flash header format more extensible by adding a pointer to where the payload begins. This allows the header to be extended in the future

- Instead of the payload checksum, have a checksum per image to be added in the TOC. This allows per image update without needing to update the payload checksum.

- Update doc