### PR TITLE
Add xtask for running a ROM on the FPGA without recompiling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4522,6 +4522,7 @@ dependencies = [
  "mcu-builder",
  "mcu-config-emulator",
  "mcu-config-fpga",
+ "mcu-hw-model",
  "pldm-fw-pkg",
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,6 +156,7 @@ mcu-builder = { path = "builder" }
 mcu-config = { path = "common/config" }
 mcu-config-emulator = { path = "platforms/emulator/config" }
 mcu-config-fpga = { path = "platforms/fpga/config" }
+mcu-hw-model = { path = "hw/model" }
 mcu-platforms-common = { path = "platforms/common" }
 mcu-rom-common = { path = "rom" }
 mcu-components = { path = "runtime/kernel/components" }

--- a/emulator/periph/src/doe_mbox.rs
+++ b/emulator/periph/src/doe_mbox.rs
@@ -344,7 +344,7 @@ mod tests {
     use registers_generated::doe_mbox::bits::{DoeMboxEvent, DoeMboxStatus};
     use registers_generated::doe_mbox::DOE_MBOX_ADDR;
 
-    const DOE_MBOX_BASE_ADDR: u32 = DOE_MBOX_ADDR as u32;
+    const DOE_MBOX_BASE_ADDR: u32 = DOE_MBOX_ADDR;
     const DOE_MBOX_DLEN_REG_OFFSET: u32 = 0x04;
     const DOE_MBOX_STATUS_REG_OFFSET: u32 = 0x08;
     const DOE_MBOX_EVENT_REG_OFFSET: u32 = 0x0C;
@@ -389,11 +389,7 @@ mod tests {
         let data: Vec<u32> = (0..data_word_len).collect();
         for (i, &word) in data.iter().enumerate() {
             autobus
-                .write(
-                    RvSize::Word,
-                    DOE_MBOX_SRAM_BASE_ADDR + i as u32 * 4,
-                    word as u32,
-                )
+                .write(RvSize::Word, DOE_MBOX_SRAM_BASE_ADDR + i as u32 * 4, word)
                 .unwrap();
         }
 
@@ -401,21 +397,21 @@ mod tests {
             .write(
                 RvSize::Word,
                 DOE_MBOX_BASE_ADDR + DOE_MBOX_DLEN_REG_OFFSET,
-                data_word_len as u32,
+                data_word_len,
             )
             .unwrap();
 
         let read_word_len = autobus
             .read(RvSize::Word, DOE_MBOX_BASE_ADDR + DOE_MBOX_DLEN_REG_OFFSET)
             .unwrap();
-        assert_eq!(read_word_len, data_word_len as u32);
+        assert_eq!(read_word_len, { data_word_len });
 
         // Read the DOE SRAM for read_word_len size and compare each word with the data
-        for i in 0..read_word_len as usize {
+        for (i, &data_i) in data.iter().enumerate().take(read_word_len as usize) {
             let read_word = autobus
                 .read(RvSize::Word, DOE_MBOX_SRAM_BASE_ADDR + i as u32 * 4)
                 .unwrap();
-            assert_eq!(read_word, data[i]);
+            assert_eq!(read_word, data_i);
         }
     }
 

--- a/hw/model/src/model_fpga_realtime.rs
+++ b/hw/model/src/model_fpga_realtime.rs
@@ -1,6 +1,9 @@
 // Licensed under the Apache-2.0 license
 
+#![allow(clippy::mut_from_ref)]
+
 use crate::fpga_regs::{Control, FifoData, FifoRegs, FifoStatus, ItrngFifoStatus, WrapperRegs};
+use crate::output::ExitStatus;
 use crate::{xi3c, InitParams, McuHwModel, Output, SecurityState};
 use anyhow::{anyhow, Error, Result};
 use caliptra_emu_bus::{Device, Event, EventData, RecoveryCommandCode};
@@ -9,6 +12,7 @@ use emulator_bmc::Bmc;
 use registers_generated::i3c;
 use registers_generated::i3c::bits::DeviceStatus0;
 use registers_generated::mci::bits::Go::Go;
+use std::process::exit;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{mpsc, Arc};
 use std::thread;
@@ -21,7 +25,7 @@ const FPGA_WRAPPER_MAPPING: (usize, usize) = (0, 0);
 const CALIPTRA_MAPPING: (usize, usize) = (0, 1);
 const CALIPTRA_ROM_MAPPING: (usize, usize) = (0, 2);
 const I3C_CONTROLLER_MAPPING: (usize, usize) = (0, 3);
-const MCU_SRAM_MAPPING: (usize, usize) = (0, 4);
+const OTP_RAM_MAPPING: (usize, usize) = (0, 4);
 const LC_MAPPING: (usize, usize) = (1, 0);
 const MCU_ROM_MAPPING: (usize, usize) = (1, 1);
 const I3C_TARGET_MAPPING: (usize, usize) = (1, 2);
@@ -91,7 +95,7 @@ pub struct ModelFpgaRealtime {
     caliptra_mmio: CaliptraMmio,
     caliptra_rom_backdoor: *mut u8,
     mcu_rom_backdoor: *mut u8,
-    mcu_sram_backdoor: *mut u8,
+    otp_mem_backdoor: *mut u8,
     mci: Mci,
     i3c_mmio: *mut u32,
     i3c_controller_mmio: *mut u32,
@@ -223,6 +227,15 @@ impl ModelFpgaRealtime {
                     .push_uart_char(data.read(FifoData::NextChar) as u8);
             }
         }
+        if self.output().exit_requested() {
+            println!("Exiting firmware request");
+            let code = match self.output().exit_status() {
+                Some(ExitStatus::Passed) => 0,
+                Some(ExitStatus::Failed) => 1,
+                None => 0,
+            };
+            exit(code);
+        }
     }
 
     // UIO crate doesn't provide a way to unmap memory.
@@ -329,61 +342,56 @@ impl ModelFpgaRealtime {
         self.bmc_step_counter += 1;
 
         // check if we need to fill the recovey FIFO
-        if self.bmc_step_counter % 128 == 0 {
-            if !self.recovery_fifo_blocks.is_empty() {
-                if !self.recovery_ctrl_written {
-                    let status = self
-                        .i3c_core()
-                        .sec_fw_recovery_if_device_status_0
-                        .read(DeviceStatus0::DevStatus);
+        if self.bmc_step_counter % 128 == 0 && !self.recovery_fifo_blocks.is_empty() {
+            if !self.recovery_ctrl_written {
+                let status = self
+                    .i3c_core()
+                    .sec_fw_recovery_if_device_status_0
+                    .read(DeviceStatus0::DevStatus);
 
-                    if status != 3 && self.bmc_step_counter % 65536 == 0 {
-                        println!("Waiting for device status to be 3, currently: {}", status);
-                        return;
-                    }
-
-                    let len = ((self.recovery_ctrl_len / 4) as u32).to_le_bytes();
-                    let mut ctrl = vec![0, 1];
-                    ctrl.extend_from_slice(&len);
-
-                    println!("Writing Indirect fifo ctrl: {:x?}", ctrl);
-                    self.recovery_block_write_request(RecoveryCommandCode::IndirectFifoCtrl, &ctrl);
-
-                    let reported_len = self
-                        .i3c_core()
-                        .sec_fw_recovery_if_indirect_fifo_ctrl_1
-                        .get();
-
-                    println!("I3C core reported length: {}", reported_len);
-                    if reported_len as usize != self.recovery_ctrl_len / 4 {
-                        println!(
-                            "I3C core reported length should have been {}",
-                            self.recovery_ctrl_len / 4
-                        );
-
-                        self.print_i3c_registers();
-
-                        panic!(
-                            "I3C core reported length should have been {}",
-                            self.recovery_ctrl_len / 4
-                        );
-                    }
-                    self.recovery_ctrl_written = true;
+                if status != 3 && self.bmc_step_counter % 65536 == 0 {
+                    println!("Waiting for device status to be 3, currently: {}", status);
+                    return;
                 }
-                let fifo_status = self
-                    .recovery_block_read_request(RecoveryCommandCode::IndirectFifoStatus)
-                    .expect("Device should response to indirect fifo status read request");
-                let empty = fifo_status[0] & 1 == 1;
-                // while empty send
-                if empty {
-                    // fifo is empty, send a block
-                    let chunk = self.recovery_fifo_blocks.pop().unwrap();
-                    self.blocks_sent += 1;
-                    self.recovery_block_write_request(
-                        RecoveryCommandCode::IndirectFifoData,
-                        &chunk,
+
+                let len = ((self.recovery_ctrl_len / 4) as u32).to_le_bytes();
+                let mut ctrl = vec![0, 1];
+                ctrl.extend_from_slice(&len);
+
+                println!("Writing Indirect fifo ctrl: {:x?}", ctrl);
+                self.recovery_block_write_request(RecoveryCommandCode::IndirectFifoCtrl, &ctrl);
+
+                let reported_len = self
+                    .i3c_core()
+                    .sec_fw_recovery_if_indirect_fifo_ctrl_1
+                    .get();
+
+                println!("I3C core reported length: {}", reported_len);
+                if reported_len as usize != self.recovery_ctrl_len / 4 {
+                    println!(
+                        "I3C core reported length should have been {}",
+                        self.recovery_ctrl_len / 4
+                    );
+
+                    self.print_i3c_registers();
+
+                    panic!(
+                        "I3C core reported length should have been {}",
+                        self.recovery_ctrl_len / 4
                     );
                 }
+                self.recovery_ctrl_written = true;
+            }
+            let fifo_status = self
+                .recovery_block_read_request(RecoveryCommandCode::IndirectFifoStatus)
+                .expect("Device should response to indirect fifo status read request");
+            let empty = fifo_status[0] & 1 == 1;
+            // while empty send
+            if empty {
+                // fifo is empty, send a block
+                let chunk = self.recovery_fifo_blocks.pop().unwrap();
+                self.blocks_sent += 1;
+                self.recovery_block_write_request(RecoveryCommandCode::IndirectFifoData, &chunk);
             }
         }
 
@@ -739,7 +747,7 @@ impl ModelFpgaRealtime {
                 &cmd,
                 len_range.0 + 2,
             )
-            .expect(&format!("Expected to read {}+ bytes", len_range.0 + 2));
+            .unwrap_or_else(|_| panic!("Expected to read {}+ bytes", len_range.0 + 2));
 
         if resp.len() < 2 {
             panic!("Expected to read at least 2 bytes from target for recovery block length");
@@ -788,7 +796,7 @@ impl ModelFpgaRealtime {
 
         let mut data = vec![recovery_command_code];
         data.extend_from_slice(&(payload.len() as u16).to_le_bytes());
-        data.extend_from_slice(&payload);
+        data.extend_from_slice(payload);
 
         assert!(
             self.i3c_controller
@@ -823,8 +831,8 @@ impl McuHwModel for ModelFpgaRealtime {
         let caliptra_rom_backdoor = devs[CALIPTRA_ROM_MAPPING.0]
             .map_mapping(CALIPTRA_ROM_MAPPING.1)
             .map_err(fmt_uio_error)? as *mut u8;
-        let mcu_sram_backdoor = devs[MCU_SRAM_MAPPING.0]
-            .map_mapping(MCU_SRAM_MAPPING.1)
+        let otp_mem_backdoor = devs[OTP_RAM_MAPPING.0]
+            .map_mapping(OTP_RAM_MAPPING.1)
             .map_err(fmt_uio_error)? as *mut u8;
         let mcu_rom_backdoor = devs[MCU_ROM_MAPPING.0]
             .map_mapping(MCU_ROM_MAPPING.1)
@@ -892,7 +900,7 @@ impl McuHwModel for ModelFpgaRealtime {
             caliptra_mmio: CaliptraMmio { ptr: caliptra_mmio },
             caliptra_rom_backdoor,
             mcu_rom_backdoor,
-            mcu_sram_backdoor,
+            otp_mem_backdoor,
             mci: Mci { ptr: mci_ptr },
             i3c_mmio,
             i3c_controller_mmio,
@@ -938,13 +946,13 @@ impl McuHwModel for ModelFpgaRealtime {
         }
 
         // Set the UDS Seed
-        for i in 0..16 {
-            m.wrapper.regs().cptra_obf_uds_seed[i].set(DEFAULT_UDS_SEED[i]);
+        for (i, &uds) in DEFAULT_UDS_SEED.iter().enumerate() {
+            m.wrapper.regs().cptra_obf_uds_seed[i].set(uds);
         }
 
-        // Set the FE Seed
-        for i in 0..8 {
-            m.wrapper.regs().cptra_obf_field_entropy[i].set(DEFAULT_FIELD_ENTROPY[i]);
+        // Set the FE
+        for (i, &fe) in DEFAULT_FIELD_ENTROPY.iter().enumerate() {
+            m.wrapper.regs().cptra_obf_field_entropy[i].set(fe);
         }
 
         // Currently not using strap UDS and FE
@@ -953,6 +961,10 @@ impl McuHwModel for ModelFpgaRealtime {
         println!("Putting subsystem into reset");
         m.set_subsystem_reset(true);
 
+        println!("Clearing OTP memory");
+        let otp_mem =
+            unsafe { core::slice::from_raw_parts_mut(m.otp_mem_backdoor as *mut u32, 16384 / 4) };
+        otp_mem.fill(0);
         println!("Clearing fifo");
         // Sometimes there's garbage in here; clean it out
         m.clear_logs();
@@ -1066,8 +1078,8 @@ impl McuHwModel for ModelFpgaRealtime {
     }
 
     fn set_generic_input_wires(&mut self, value: &[u32; 2]) {
-        for i in 0..2 {
-            self.wrapper.regs().generic_input_wires[i].set(value[i]);
+        for (i, &val) in value.iter().enumerate() {
+            self.wrapper.regs().generic_input_wires[i].set(val);
         }
     }
 
@@ -1096,7 +1108,7 @@ impl Drop for ModelFpgaRealtime {
         self.unmap_mapping(self.caliptra_mmio.ptr, CALIPTRA_MAPPING);
         self.unmap_mapping(self.caliptra_rom_backdoor as *mut u32, CALIPTRA_ROM_MAPPING);
         self.unmap_mapping(self.mcu_rom_backdoor as *mut u32, MCU_ROM_MAPPING);
-        self.unmap_mapping(self.mcu_sram_backdoor as *mut u32, MCU_SRAM_MAPPING);
+        self.unmap_mapping(self.otp_mem_backdoor as *mut u32, OTP_RAM_MAPPING);
         self.unmap_mapping(self.mci.ptr, MCI_MAPPING);
         self.unmap_mapping(self.i3c_mmio, I3C_TARGET_MAPPING);
         self.unmap_mapping(self.i3c_controller_mmio, I3C_CONTROLLER_MAPPING);

--- a/platforms/fpga/rom/src/io.rs
+++ b/platforms/fpga/rom/src/io.rs
@@ -3,7 +3,7 @@
 use core::fmt::Write;
 
 use mcu_rom_common::FatalErrorHandler;
-use romtime::HexWord;
+use romtime::{Exit, HexWord};
 
 pub(crate) struct FpgaWriter {}
 pub(crate) static mut FPGA_WRITER: FpgaWriter = FpgaWriter {};
@@ -24,21 +24,32 @@ pub(crate) fn print_to_console(buf: &str) {
     }
 }
 
-pub(crate) struct EmulatorFatalErrorHandler {}
-pub(crate) static mut FATAL_ERROR_HANDLER: EmulatorFatalErrorHandler = EmulatorFatalErrorHandler {};
-impl FatalErrorHandler for EmulatorFatalErrorHandler {
+pub(crate) struct FpgaFatalErrorHandler {}
+pub(crate) static mut FATAL_ERROR_HANDLER: FpgaFatalErrorHandler = FpgaFatalErrorHandler {};
+impl FatalErrorHandler for FpgaFatalErrorHandler {
     fn fatal_error(&mut self, code: u32) -> ! {
         let _ = writeln!(FpgaWriter {}, "MCU fatal error: {}", HexWord(code));
-        exit_emulator(code);
+        exit_fpga(code);
     }
 }
 
-/// Exit the emulator
-pub fn exit_emulator(exit_code: u32) -> ! {
-    // Safety: This is a safe memory address to write to for exiting the emulator.
+/// Exit the FPGA
+pub fn exit_fpga(exit_code: u32) -> ! {
+    // Safety: This is a safe memory address to write to for exiting the FPGA.
     unsafe {
-        // By writing to this address we can exit the emulator.
-        core::ptr::write_volatile(0x1000_2000 as *mut u32, exit_code);
+        // By writing to this address we can exit the FPGA.
+        let b = if exit_code == 0 { 0x01 } else { 0xff };
+        core::ptr::write_volatile(0xa401_1014 as *mut u32, b as u32 | 0x100);
     }
     loop {}
 }
+
+pub struct Exiter {}
+
+impl Exit for Exiter {
+    fn exit(&mut self, code: u32) {
+        exit_fpga(code);
+    }
+}
+
+pub(crate) static mut EXITER: Exiter = Exiter {};

--- a/platforms/fpga/rom/src/riscv.rs
+++ b/platforms/fpga/rom/src/riscv.rs
@@ -12,7 +12,7 @@ Abstract:
 
 --*/
 
-use crate::io::{print_to_console, FATAL_ERROR_HANDLER, FPGA_WRITER};
+use crate::io::{print_to_console, EXITER, FATAL_ERROR_HANDLER, FPGA_WRITER};
 use core::fmt::Write;
 
 #[cfg(target_arch = "riscv32")]
@@ -38,6 +38,10 @@ pub extern "C" fn rom_entry() -> ! {
     unsafe {
         #[allow(static_mut_refs)]
         mcu_rom_common::set_fatal_error_handler(&mut FATAL_ERROR_HANDLER);
+    }
+    unsafe {
+        #[allow(static_mut_refs)]
+        romtime::set_exiter(&mut EXITER);
     }
 
     romtime::println!("[mcu-rom] Starting FPGA MCU ROM");

--- a/rom/src/fuses.rs
+++ b/rom/src/fuses.rs
@@ -19,7 +19,8 @@ impl Otp {
     }
 
     pub fn init(&self) -> Result<(), McuError> {
-        if self.registers.otp_status.get() & ((1 << 21) - 1) != 0 {
+        romtime::println!("Initializing OTP controller...");
+        if self.registers.otp_status.get() & ((1 << 22) - 1) != 0 {
             romtime::println!("OTP error: {}", self.registers.otp_status.get());
             return Err(McuError::FusesError);
         }
@@ -34,14 +35,19 @@ impl Otp {
             return Err(McuError::FusesError);
         }
 
-        // Disable periodic background checks
-        self.registers.consistency_check_period.set(0);
-        self.registers.integrity_check_period.set(0);
-        self.registers.check_timeout.set(0);
+        // Enable periodic background checks
+        // romtime::println!("Enabling consistency check period");
+        // self.registers.consistency_check_period.set(0x3ff_ffff);
+        romtime::println!("Enabling integrity check period");
+        self.registers.integrity_check_period.set(0x3ff_ffff);
+        romtime::println!("Enabling check timeout");
+        self.registers.check_timeout.set(0x10_0000);
         // Disable modifications to the background checks
+        romtime::println!("Disabling check modifications");
         self.registers
             .check_regwen
             .write(otp_ctrl::bits::CheckRegwen::Regwen::CLEAR);
+        romtime::println!("Done init");
         Ok(())
     }
 
@@ -63,7 +69,7 @@ impl Otp {
 
     /// Reads a word from the OTP controller.
     /// word_addr is in words
-    fn read_word(&self, word_addr: usize) -> Result<u32, McuError> {
+    pub fn read_word(&self, word_addr: usize) -> Result<u32, McuError> {
         // OTP DAI status should be idle
         while !self
             .registers
@@ -91,8 +97,71 @@ impl Otp {
         Ok(self.registers.dai_rdata_rf_direct_access_rdata_0.get())
     }
 
+    /// Write a word to the OTP controller.
+    /// word_addr is in words
+    pub fn write_word(&self, word_addr: usize, data: u32) -> Result<u32, McuError> {
+        // OTP DAI status should be idle
+        while !self
+            .registers
+            .otp_status
+            .is_set(otp_ctrl::bits::OtpStatus::DaiIdle)
+        {}
+
+        // load the data
+        self.registers.dai_wdata_rf_direct_access_wdata_0.set(data);
+
+        self.registers
+            .direct_access_address
+            .set((word_addr * 4) as u32);
+        // trigger a write
+        self.registers.direct_access_cmd.set(2);
+
+        // wait for DAI to go back to idle
+        while !self
+            .registers
+            .otp_status
+            .is_set(otp_ctrl::bits::OtpStatus::DaiIdle)
+        {}
+
+        if let Some(err) = self.check_error() {
+            romtime::println!("Error writing fuses: {}", HexWord(err));
+            self.print_errors();
+            return Err(McuError::FusesError);
+        }
+        Ok(self.registers.dai_rdata_rf_direct_access_rdata_0.get())
+    }
+
+    pub fn print_errors(&self) {
+        for i in 0..18 {
+            let err_code = match i {
+                0 => self.registers.err_code_rf_err_code_0.get(),
+                1 => self.registers.err_code_rf_err_code_1.get(),
+                2 => self.registers.err_code_rf_err_code_2.get(),
+                3 => self.registers.err_code_rf_err_code_3.get(),
+                4 => self.registers.err_code_rf_err_code_4.get(),
+                5 => self.registers.err_code_rf_err_code_5.get(),
+                6 => self.registers.err_code_rf_err_code_6.get(),
+                7 => self.registers.err_code_rf_err_code_7.get(),
+                8 => self.registers.err_code_rf_err_code_8.get(),
+                9 => self.registers.err_code_rf_err_code_9.get(),
+                10 => self.registers.err_code_rf_err_code_10.get(),
+                11 => self.registers.err_code_rf_err_code_11.get(),
+                12 => self.registers.err_code_rf_err_code_12.get(),
+                13 => self.registers.err_code_rf_err_code_13.get(),
+                14 => self.registers.err_code_rf_err_code_14.get(),
+                15 => self.registers.err_code_rf_err_code_15.get(),
+                16 => self.registers.err_code_rf_err_code_16.get(),
+                17 => self.registers.err_code_rf_err_code_17.get(),
+                _ => 0,
+            };
+            if err_code != 0 {
+                romtime::println!("OTP error code {}: {}", i, err_code);
+            }
+        }
+    }
+
     pub fn check_error(&self) -> Option<u32> {
-        let status = self.registers.otp_status.get() & 0x1fff;
+        let status = self.registers.otp_status.get() & 0x3ffff;
         if status == 0 {
             None
         } else {

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -14,6 +14,7 @@ elf.workspace = true
 mcu-builder.workspace = true
 mcu-config-emulator.workspace = true
 mcu-config-fpga.workspace = true
+mcu-hw-model = { workspace = true, features = ["fpga_realtime"] }
 pldm-fw-pkg.workspace = true
 proc-macro2.workspace = true
 quote.workspace = true

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -160,6 +160,11 @@ enum Commands {
     Deps,
     /// Build and install the FPGA kernel modules for uio and the ROM backdoors
     FpgaInstallKernelModules,
+    /// Run firmware on the FPGA
+    FpgaRun {
+        #[arg(long)]
+        mcu_rom: PathBuf,
+    },
     /// Utility to create and parse PLDM firmware packages
     PldmFirmware {
         #[command(subcommand)]
@@ -295,6 +300,7 @@ fn main() {
             addrmap,
         } => registers::autogen(*check, files, addrmap),
         Commands::Deps => deps::check(),
+        Commands::FpgaRun { mcu_rom } => fpga::fpga_run(mcu_rom),
         Commands::FpgaInstallKernelModules => fpga::fpga_install_kernel_modules(),
         Commands::PldmFirmware { subcommand } => match subcommand {
             PldmFirmwareCommands::Create { manifest, file } => pldm_fw_pkg::create(manifest, file),


### PR DESCRIPTION
This makes it faster to do tests when changing the ROM, since you can compile locally, copy to the FPGA, and run without recompiling or relinking.

I also fixed some of the logic that allows the FPGA ROM to trigger the FPGA hw model to exit correctly.

This triggered some clippy warnings, which I cleaned up.