### PR TITLE
Add a feature flag for firmware for 2.1 HW.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,20 @@ cargo xtask runtime
 
 This uses the full [active, or subsystem, mode boot flow](https://chipsalliance.github.io/caliptra-mcu-sw/rom.html#cold-boot-flow).
 
+## Hardware revisions
+
+Currently, two hardware revisions are supported: 2.0 and 2.1.
+
+The features added to the 2.1 hardware are, briefly:
+
+* Caliptra ML-KEM support
+* I3C AXI recovery bypass
+
+By default, the emulator and firmware use the 2.0 hardware features.
+
+For the emulator, there is a `--hw-revision 2.1.0` flag that can be used to select the 2.1 hardware when running (`cargo xtask runtime` also supports this flag).
+
+For firmware, 2.1 features can be enabled using the `hw-2-1` feature flag when specifying dependencies.
 
 ## Documentation
 

--- a/platforms/emulator/rom/Cargo.toml
+++ b/platforms/emulator/rom/Cargo.toml
@@ -27,7 +27,8 @@ rv32i.workspace = true
 
 [features]
 default = []
+hw-2-1 = ["mcu-rom-common/hw-2-1"]
 test-firmware-update = []
 test-mcu-rom-flash-access = []
-test-flash-based-boot = []
+test-flash-based-boot = ["hw-2-1"]
 test-pldm-streaming-boot = []

--- a/platforms/emulator/runtime/Cargo.toml
+++ b/platforms/emulator/runtime/Cargo.toml
@@ -36,6 +36,7 @@ rv32i.workspace = true
 
 [features]
 default = []
+hw-2-1 = []
 test-caliptra-certs = []
 test-caliptra-crypto = []
 test-caliptra-mailbox = []

--- a/platforms/emulator/runtime/userspace/apps/example/Cargo.toml
+++ b/platforms/emulator/runtime/userspace/apps/example/Cargo.toml
@@ -36,6 +36,7 @@ embedded-alloc.workspace = true
 
 [features]
 default = []
+hw-2-1 = []
 test-caliptra-certs = []
 test-caliptra-crypto = []
 test-caliptra-mailbox = []

--- a/platforms/emulator/runtime/userspace/apps/user/Cargo.toml
+++ b/platforms/emulator/runtime/userspace/apps/user/Cargo.toml
@@ -38,6 +38,7 @@ embedded-alloc.workspace = true
 
 [features]
 default = []
+hw-2-1 = []
 test-caliptra-certs = []
 test-caliptra-crypto = []
 test-caliptra-mailbox = []

--- a/rom/Cargo.toml
+++ b/rom/Cargo.toml
@@ -21,3 +21,7 @@ zerocopy.workspace = true
 [target.'cfg(target_arch = "riscv32")'.dependencies]
 riscv-csr.workspace = true
 rv32i.workspace = true
+
+[features]
+default = [] # default is 2.0
+hw-2-1 = []

--- a/rom/src/rom.rs
+++ b/rom/src/rom.rs
@@ -302,14 +302,17 @@ pub fn rom_start(flash_partition_driver: Option<&mut FlashPartition>) {
         fatal_error(5);
     };
 
-    if let Some(flash_driver) = flash_partition_driver {
-        romtime::println!("[mcu-rom] Starting Flash recovery flow");
+    // Loading flash into the recovery flow is only possible in 2.1+.
+    if cfg!(feature = "hw-2-1") {
+        if let Some(flash_driver) = flash_partition_driver {
+            romtime::println!("[mcu-rom] Starting Flash recovery flow");
 
-        crate::recovery::load_flash_image_to_recovery(i3c_base, flash_driver)
-            .map_err(|_| fatal_error(1))
-            .unwrap();
+            crate::recovery::load_flash_image_to_recovery(i3c_base, flash_driver)
+                .map_err(|_| fatal_error(1))
+                .unwrap();
 
-        romtime::println!("[mcu-rom] Flash Recovery flow complete");
+            romtime::println!("[mcu-rom] Flash Recovery flow complete");
+        }
     }
 
     romtime::println!("[mcu-rom] Waiting for firmware to be ready");

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -31,6 +31,10 @@ struct Xtask {
 enum Commands {
     /// Build and Run Runtime image
     Runtime {
+        /// HW revision in semver format (e.g., "2.0.0")
+        #[arg(long, value_parser = semver::Version::parse, default_value = "2.0.0")]
+        hw_revision: semver::Version,
+
         /// Run with tracing options
         #[arg(short, long, default_value_t = false)]
         trace: bool,


### PR DESCRIPTION
This is an additive flag to turn on 2.1 features, particularly for ROM (I3C AXI recovery bypass) and eventually for SPDM (ML-KEM, external mu support for ML-DSA).

This adds support for switching versions when using `cargo xtask runtime`, which will ensure that the firmware is built with the `hw-2-1` flag if running the emulator for 2.1.