### PR TITLE
Set emulator exiter

### DIFF
--- a/platforms/emulator/rom/src/io.rs
+++ b/platforms/emulator/rom/src/io.rs
@@ -3,7 +3,7 @@
 use core::fmt::Write;
 
 use mcu_rom_common::FatalErrorHandler;
-use romtime::HexWord;
+use romtime::{Exit, HexWord};
 
 pub(crate) struct EmulatorWriter {}
 pub(crate) static mut EMULATOR_WRITER: EmulatorWriter = EmulatorWriter {};
@@ -29,6 +29,15 @@ pub(crate) static mut FATAL_ERROR_HANDLER: EmulatorFatalErrorHandler = EmulatorF
 impl FatalErrorHandler for EmulatorFatalErrorHandler {
     fn fatal_error(&mut self, code: u32) -> ! {
         let _ = writeln!(EmulatorWriter {}, "MCU fatal error: {}", HexWord(code));
+        exit_emulator(code);
+    }
+}
+
+pub(crate) struct EmulatorExiter {}
+pub(crate) static mut EMULATOR_EXITER: EmulatorExiter = EmulatorExiter {};
+impl Exit for EmulatorExiter {
+    fn exit(&mut self, code: u32) {
+        let _ = writeln!(EmulatorWriter {}, "MCU exit code: {}", HexWord(code));
         exit_emulator(code);
     }
 }

--- a/platforms/emulator/rom/src/riscv.rs
+++ b/platforms/emulator/rom/src/riscv.rs
@@ -14,7 +14,7 @@ Abstract:
 
 #![allow(unused_imports)]
 
-use crate::io::{EMULATOR_WRITER, FATAL_ERROR_HANDLER};
+use crate::io::{EMULATOR_EXITER, EMULATOR_WRITER, FATAL_ERROR_HANDLER};
 use core::fmt::Write;
 
 #[cfg(target_arch = "riscv32")]
@@ -52,6 +52,10 @@ pub extern "C" fn rom_entry() -> ! {
     unsafe {
         #[allow(static_mut_refs)]
         mcu_rom_common::set_fatal_error_handler(&mut FATAL_ERROR_HANDLER);
+    }
+    unsafe {
+        #[allow(static_mut_refs)]
+        romtime::set_exiter(&mut EMULATOR_EXITER);
     }
 
     #[cfg(feature = "test-flash-based-boot")]


### PR DESCRIPTION
This is used by some tests, such as the flash ROM tests, to exit.

I don't know how tests were ever working without this :)