### PR TITLE
Make SPDM DOE tests deterministic

### DIFF
--- a/emulator/app/src/doe_mbox_fsm.rs
+++ b/emulator/app/src/doe_mbox_fsm.rs
@@ -1,6 +1,6 @@
 // Licensed under the Apache-2.0 license
 
-use crate::{wait_for_runtime_start, EMULATOR_RUNNING};
+use crate::{sleep_emulator_ticks, wait_for_runtime_start, EMULATOR_RUNNING};
 use emulator_periph::DoeMboxPeriph;
 use std::process::exit;
 use std::sync::atomic::Ordering;
@@ -44,7 +44,7 @@ impl DoeMboxFsm {
                 fsm.on_event();
 
                 // Small delay to prevent busy waiting
-                thread::sleep(Duration::from_millis(10));
+                sleep_emulator_ticks(1000);
             }
         });
         (fsm_to_test_rx, test_to_fsm_tx)

--- a/emulator/app/src/emulator.rs
+++ b/emulator/app/src/emulator.rs
@@ -19,6 +19,8 @@ use crate::i3c_socket;
 use crate::i3c_socket::start_i3c_socket;
 use crate::mctp_transport::MctpTransport;
 use crate::tests;
+use crate::EMULATOR_TICKS;
+use crate::TICK_COND;
 use crate::{EMULATOR_RUNNING, MCU_RUNTIME_STARTED};
 use caliptra_emu_bus::{Bus, Clock, Timer};
 use caliptra_emu_cpu::{Cpu, Pic, RvInstr, StepAction};
@@ -896,6 +898,12 @@ impl Emulator {
     pub fn step(&mut self) -> StepAction {
         if !EMULATOR_RUNNING.load(Ordering::Relaxed) {
             return StepAction::Break;
+        }
+
+        let now = self.mcu_cpu.clock.now();
+        EMULATOR_TICKS.store(now, Ordering::Relaxed);
+        if now % 1000 == 0 {
+            TICK_COND.notify_all();
         }
 
         if let Some(ref stdin_uart) = self.stdin_uart {

--- a/emulator/app/src/main.rs
+++ b/emulator/app/src/main.rs
@@ -29,15 +29,37 @@ use std::cell::RefCell;
 use std::io;
 use std::io::IsTerminal;
 use std::rc::Rc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Condvar, Mutex};
 use std::time::Duration;
 
 pub static MCU_RUNTIME_STARTED: AtomicBool = AtomicBool::new(false);
 pub static EMULATOR_RUNNING: AtomicBool = AtomicBool::new(true);
+pub static EMULATOR_TICKS: AtomicU64 = AtomicU64::new(0);
+pub static TICK_NOTIFY_TICKS: u64 = 1000; // wake up every 1000 ticks to check
+pub static TICK_LOCK: Mutex<()> = Mutex::new(());
+pub static TICK_COND: Condvar = Condvar::new();
 
 pub fn wait_for_runtime_start() {
     while EMULATOR_RUNNING.load(Ordering::Relaxed) && !MCU_RUNTIME_STARTED.load(Ordering::Relaxed) {
         std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
+/// Sleep for the specified number of emulator ticks.
+/// This is deterministic and exact if ticks is a multiple of 1,000, unless
+/// the emulator is very slow (<1,000 ticks per second), in which case it
+/// the exact number of ticks slept may vary by up to 1,000.
+pub fn sleep_emulator_ticks(ticks: u32) {
+    let wait = ticks as u64;
+    let start = EMULATOR_TICKS.load(Ordering::Relaxed);
+    while EMULATOR_RUNNING.load(Ordering::Relaxed) {
+        let now = EMULATOR_TICKS.load(Ordering::Relaxed);
+        if now - start >= wait {
+            break;
+        }
+        let lock = TICK_LOCK.lock().unwrap();
+        let _ = TICK_COND.wait_timeout(lock, Duration::from_secs(1));
     }
 }
 

--- a/emulator/app/src/tests/doe_discovery.rs
+++ b/emulator/app/src/tests/doe_discovery.rs
@@ -3,7 +3,7 @@
 use crate::doe_mbox_fsm::{DoeTestState, DoeTransportTest};
 use crate::tests::doe_util::common::DoeUtil;
 use crate::tests::doe_util::protocol::*;
-use crate::EMULATOR_RUNNING;
+use crate::{sleep_emulator_ticks, EMULATOR_RUNNING};
 use std::sync::atomic::Ordering;
 use std::sync::mpsc::{Receiver, Sender};
 use strum::IntoEnumIterator;
@@ -103,7 +103,7 @@ impl DoeTransportTest for Test {
             match self.test_state {
                 DoeTestState::Start => {
                     if wait_for_responder {
-                        std::thread::sleep(std::time::Duration::from_secs(5));
+                        sleep_emulator_ticks(10_000_000);
                     }
                     self.test_state = DoeTestState::SendData;
                 }
@@ -112,7 +112,7 @@ impl DoeTransportTest for Test {
                         .is_ok()
                     {
                         self.test_state = DoeTestState::ReceiveData;
-                        std::thread::sleep(std::time::Duration::from_millis(100));
+                        sleep_emulator_ticks(100_000);
                     } else {
                         println!("DOE_DISCOVERY_TEST: Failed to send request");
                         self.passed = false;
@@ -138,7 +138,7 @@ impl DoeTransportTest for Test {
                     }
                     Ok(_) => {
                         // Stay in ReceiveData state and yield for a bit
-                        std::thread::sleep(std::time::Duration::from_millis(300));
+                        sleep_emulator_ticks(100_000);
                     }
                     Err(e) => {
                         println!("DOE_DISCOVERY_TEST: Failed to receive response: {:?}", e);

--- a/emulator/app/src/tests/doe_user_loopback.rs
+++ b/emulator/app/src/tests/doe_user_loopback.rs
@@ -1,7 +1,7 @@
 // Licensed under the Apache-2.0 license
 
 use crate::doe_mbox_fsm::{DoeTestState, DoeTransportTest};
-use crate::EMULATOR_RUNNING;
+use crate::{sleep_emulator_ticks, EMULATOR_RUNNING};
 use rand::Rng;
 const NUM_TEST_VECTORS: usize = 10;
 const MIN_TEST_DATA_DWORDS: usize = 1; // minimum size of test vectors
@@ -54,7 +54,7 @@ impl DoeTransportTest for Test {
             match self.test_state {
                 DoeTestState::Start => {
                     if wait_for_responder {
-                        std::thread::sleep(std::time::Duration::from_secs(20));
+                        sleep_emulator_ticks(1_000_000);
                     }
                     self.test_state = DoeTestState::SendData;
                 }
@@ -63,7 +63,7 @@ impl DoeTransportTest for Test {
                         .is_ok()
                     {
                         self.test_state = DoeTestState::ReceiveData;
-                        std::thread::sleep(std::time::Duration::from_secs(2));
+                        sleep_emulator_ticks(100_000);
                     } else {
                         println!("DOE_USER_LOOPBACK: Failed to send request");
                         self.passed = false;


### PR DESCRIPTION
These now sleep a deterministic amount of time (measured by CPU cycles), so won't be dependent on the speed of the host computer.

This also means we can trim down the sleep times, which reduces how long this test takes by 50% (down from 2.5 hours to 1.2 hours or so).

Next we should do the same for all of the emulator tests that use `sleep`.