### PR TITLE
[Workflow] Add missing steps to spdm conformance test workflow

### DIFF
--- a/.github/workflows/spdm-validator.yml
+++ b/.github/workflows/spdm-validator.yml
@@ -94,30 +94,40 @@ jobs:
           popd
           popd
 
-      - name: Run SPDM validator test tests on MCTP transport
+      - name: Run SPDM validator tests on MCTP transport
         run: |
           export SPDM_VALIDATOR_DIR=$GITHUB_WORKSPACE/spdm-emu/build/bin
           cargo t -p tests-integration -- --test test_mctp_spdm_responder_conformance --nocapture  --include-ignored
           sccache --show-stats
+
+      - name: Upload logs and traces for MCTP transport
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: spdm-mctp-validator-test-results
+          path: |
+            test.log
+            caliptra_spdm_validator.pcap
+            spdm_device_validator_output.txt
     
       - name: Display SPDM Validator test results on MCTP transport
         run: |
           cat $GITHUB_WORKSPACE/test.log
-      
-      - name: Check for test failures
+
+      - name: Check for test failures on MCTP transport
         run: |
           if grep -E 'test suite \(.*\) - pass: [0-9]+, fail: [1-9][0-9]*' $GITHUB_WORKSPACE/test.log; then
             echo "Test suite had failures."
             exit 1
           fi
 
-      - name: Run SPDM validator test tests on DOE transport
+      - name: Run SPDM validator tests on DOE transport
         run: |
           export SPDM_VALIDATOR_DIR=$GITHUB_WORKSPACE/spdm-emu/build/bin
           cargo t -p tests-integration -- --test test_doe_spdm_responder_conformance --nocapture  --include-ignored
           sccache --show-stats
 
-      - name: Upload logs and traces
+      - name: Upload logs and traces for DOE transport
         if: always()
         uses: actions/upload-artifact@v4
         with:
@@ -127,7 +137,7 @@ jobs:
             caliptra_spdm_validator.pcap
             spdm_device_validator_output.txt
 
-      - name: Display SPDM Validator test results on DOE transport
+      - name: Display SPDM Validator test results for DOE transport
         run: |
           cat $GITHUB_WORKSPACE/test.log
 


### PR DESCRIPTION
Add missing steps to SPDM validator workflow and make the names of the steps consistent. 

The workflow is intended to run this order
MCTP transport test
Upload MCTP artifacts
Display MCTP results
Check MCTP failures
DOE transport test
Upload DOE artifacts
Display DOE results
Check DOE failures