### PR TITLE
FPGA: Add nextest to FPGA CI

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,11 @@
+# Licensed under the Apache-2.0 license
+
+[profile.nightly]
+failure-output = "immediate-final"
+fail-fast = false
+slow-timeout = { period = "30s", terminate-after = 6 }
+
+[profile.nightly.junit]
+path = "/tmp/junit.xml"
+store-success-output = true
+store-failure-output = true

--- a/.github/workflows/fpga.yml
+++ b/.github/workflows/fpga.yml
@@ -37,6 +37,24 @@ jobs:
             target/riscv32imc-unknown-none-elf/release/runtime.bin \
             target/aarch64-unknown-linux-gnu/debug/xtask
 
+          FEATURES="fpga_realtime"
+          cargo nextest archive \
+            --features=${FEATURES} \
+            --release \
+            --target=aarch64-unknown-linux-gnu \
+            --archive-file=/tmp/caliptra-test-binaries.tar.zst
+
+          mkdir /tmp/caliptra-test-binaries/
+          tar xvf /tmp/caliptra-test-binaries.tar.zst -C /tmp/caliptra-test-binaries/
+          mksquashfs /tmp/caliptra-test-binaries /tmp/caliptra-test-binaries.sqsh -comp zstd
+
+      - name: 'Upload test binaries artifact'
+        uses: actions/upload-artifact@v4
+        with:
+          name: caliptra-test-binaries${{ inputs.artifact-suffix }}
+          path: /tmp/caliptra-test-binaries.sqsh
+          retention-days: 1
+
       - name: 'Upload test firmware artifact'
         uses: actions/upload-artifact@v4
         with:
@@ -55,6 +73,12 @@ jobs:
         with:
           submodules: 'recursive' 
 
+      - name: 'Download Test Binaries Artifact'
+        uses: actions/download-artifact@v4
+        with:
+          name: caliptra-test-binaries${{ inputs.artifact-suffix }}
+          path: /tmp/caliptra-test-binaries.sqsh
+
       - name: 'Download Test Firmware Artifact'
         uses: actions/download-artifact@v4
         with:
@@ -65,7 +89,45 @@ jobs:
         run: |
           tar -xvf /tmp/caliptra-binaries/caliptra-binaries.tar.gz
 
-      - name: Execute tests
+          sudo mkdir /tmp/caliptra-test-binaries
+          echo mount squashfs
+          sudo mount /tmp/caliptra-test-binaries.sqsh/caliptra-test-binaries.sqsh /tmp/caliptra-test-binaries -t squashfs -o loop
+          find /tmp/caliptra-test-binaries
+
+      - name: Execute FPGA Boot flow
         run: |
           export RUST_BACKTRACE=1
           sudo ./target/aarch64-unknown-linux-gnu/debug/xtask fpga-run --mcu-rom target/riscv32imc-unknown-none-elf/release/mcu-rom-fpga.bin
+
+      - name: Execute tests
+        run: |
+          export RUST_BACKTRACE=1
+          export RUST_TEST_THREADS=1
+          TEST_BIN=/tmp/caliptra-test-binaries
+
+          COMMON_ARGS=(
+              --cargo-metadata="${TEST_BIN}/target/nextest/cargo-metadata.json"
+              --binaries-metadata="${TEST_BIN}/target/nextest/binaries-metadata.json"
+              --target-dir-remap="${TEST_BIN}/target"
+              --workspace-remap=.
+              -E 'package(mcu-hw-model) - test(test_new_unbooted)' # Modify this as we onboard crates to the FPGA test suite.
+          )
+
+          cargo-nextest nextest list \
+              "${COMMON_ARGS[@]}" \
+              --message-format json > /tmp/nextest-list.json
+
+          sudo ${VARS} cargo-nextest nextest run \
+              "${COMMON_ARGS[@]}" \
+              --test-threads=${RUST_TEST_THREADS} \
+              --no-fail-fast \
+              --profile=nightly
+
+      - name: 'Upload test results'
+        uses: actions/upload-artifact@v4
+        if: success() || failure()
+        with:
+          name: caliptra-test-results${{ inputs.artifact-suffix }}
+          path: |
+            /tmp/junit.xml
+            /tmp/nextest-list.json


### PR DESCRIPTION
Adds some infrastructure for runnings tests on the FPGA.

This closes: https://github.com/chipsalliance/caliptra-mcu-sw/issues/312.