### PR TITLE
FPGA: Add new_unbooted test case

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,6 +2,7 @@
 
 [alias]
 xtask = "run --package xtask --"
+xtask-fpga = "run --package xtask --features=fpga_realtime --"
 
 [target.riscv32imc-unknown-none-elf]
 rustflags = [

--- a/.github/workflows/fpga.yml
+++ b/.github/workflows/fpga.yml
@@ -28,7 +28,7 @@ jobs:
 
           # Cross compile xtask for the ARM core
           export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER="aarch64-linux-gnu-gcc"
-          cargo build -p xtask --target aarch64-unknown-linux-gnu
+          cargo build -p xtask --features fpga_realtime --target aarch64-unknown-linux-gnu
 
           mkdir -p /tmp/caliptra-binaries
           tar -cvz -f /tmp/caliptra-binaries/caliptra-binaries.tar.gz \
@@ -92,10 +92,10 @@ jobs:
           sudo mount /tmp/caliptra-test-binaries.sqsh/caliptra-test-binaries.sqsh /tmp/caliptra-test-binaries -t squashfs -o loop
           find /tmp/caliptra-test-binaries
 
-      - name: Execute FPGA Boot flow
-        run: |
-          export RUST_BACKTRACE=1
-          sudo ./target/aarch64-unknown-linux-gnu/debug/xtask fpga-run --zip target/all-fw.zip
+      # - name: Execute FPGA Boot flow
+      #   run: |
+      #     export RUST_BACKTRACE=1
+      #     sudo ./target/aarch64-unknown-linux-gnu/debug/xtask fpga-run --zip target/all-fw.zip
 
       - name: Execute tests
         run: |
@@ -108,14 +108,14 @@ jobs:
               --binaries-metadata="${TEST_BIN}/target/nextest/binaries-metadata.json"
               --target-dir-remap="${TEST_BIN}/target"
               --workspace-remap=.
-              -E 'package(mcu-hw-model) - test(test_new_unbooted)' # Modify this as we onboard crates to the FPGA test suite.
+              -E 'package(mcu-hw-model) - test(model_emulated::test::test_new_unbooted)' # Modify this as we onboard crates to the FPGA test suite.
           )
 
           cargo-nextest nextest list \
               "${COMMON_ARGS[@]}" \
               --message-format json > /tmp/nextest-list.json
 
-          sudo ${VARS} cargo-nextest nextest run \
+          sudo CPTRA_FIRMWARE_BUNDLE="${PWD}/target/all-fw.zip" cargo-nextest nextest run \
               "${COMMON_ARGS[@]}" \
               --test-threads=${RUST_TEST_THREADS} \
               --no-fail-fast \

--- a/README.md
+++ b/README.md
@@ -176,5 +176,5 @@ When implementing a new emulator peripheral and firmware driver, the workflow wi
 To build install the `uio` device and the ROM backdoors for FPGA development, run
 
 ```shell
-cargo xtask fpga-install-kernel-modules
+cargo xtask-fpga fpga-install-kernel-modules
 ```

--- a/builder/src/all.rs
+++ b/builder/src/all.rs
@@ -30,6 +30,15 @@ impl FirmwareBinaries {
     const MCU_RUNTIME_NAME: &'static str = "mcu_runtime.bin";
     const SOC_MANIFEST_NAME: &'static str = "soc_manifest.bin";
 
+    /// Reads the environment variable `CPTRA_FIRMWARE_BUNDLE` and returns `FirmwareBinaries` if
+    /// it is set and it points to a valid zip file.
+    pub fn from_env() -> Result<Self> {
+        // TODO: Consider falling back to building the firmware if CPTRA_FIRMWARE_BUNDLE is unset.
+        let bundle_path = std::env::var("CPTRA_FIRMWARE_BUNDLE")
+            .expect("Set the environment variable CPTRA_FIRMWARE_BUNDLE ");
+        Self::read_from_zip(&bundle_path.into())
+    }
+
     pub fn read_from_zip(path: &PathBuf) -> Result<Self> {
         let file = std::fs::File::open(path)?;
         let mut zip = zip::ZipArchive::new(file)?;

--- a/docs/src/fpga.md
+++ b/docs/src/fpga.md
@@ -9,7 +9,7 @@ You can use [`cross-rs`](https://github.com/cross-rs/cross) to make it easier to
 For example,
 
 ```shell
-CARGO_BUILD_TARGET=aarch64-unknown-linux-gnu CARGO_TARGET_DIR=target/build/aarch64-unknown-linux-gnu cross build -p xtask --bin xtask --target=aarch64-unknown-linux-gnu
+CARGO_BUILD_TARGET=aarch64-unknown-linux-gnu CARGO_TARGET_DIR=target/build/aarch64-unknown-linux-gnu cross build -p xtask --features fpga_realtime --bin xtask --target=aarch64-unknown-linux-gnu
 ```
 
 will build the a binary that runs `xtask` that can be used on the FPGA, which can then be used to install the FPGA kernel modules (assuming the `caliptra-mcu-sw` repository is checked out and the `xtask` binary is renamed to `xtask-bin`):

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -5,6 +5,9 @@ name = "xtask"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+fpga_realtime = ["mcu-hw-model/fpga_realtime"]
+
 [dependencies]
 anyhow.workspace = true
 clap.workspace = true
@@ -15,7 +18,7 @@ mcu-builder.workspace = true
 mcu-config-emulator.workspace = true
 mcu-config-fpga.workspace = true
 mcu-rom-common.workspace = true
-mcu-hw-model = { workspace = true, features = ["fpga_realtime"] }
+mcu-hw-model.workspace = true
 pldm-fw-pkg.workspace = true
 proc-macro2.workspace = true
 quote.workspace = true

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -12,6 +12,7 @@ mod deps;
 mod docs;
 mod emulator_cbinding;
 mod format;
+#[cfg(feature = "fpga_realtime")]
 mod fpga;
 mod header;
 mod pldm_fw_pkg;
@@ -183,8 +184,10 @@ enum Commands {
     /// Check dependencies
     Deps,
     /// Build and install the FPGA kernel modules for uio and the ROM backdoors
+    #[cfg(feature = "fpga_realtime")]
     FpgaInstallKernelModules,
     /// Run firmware on the FPGA
+    #[cfg(feature = "fpga_realtime")]
     FpgaRun {
         /// ZIP with all images.
         #[arg(long)]
@@ -410,7 +413,9 @@ fn main() {
             addrmap,
         } => registers::autogen(*check, files, addrmap),
         Commands::Deps => deps::check(),
+        #[cfg(feature = "fpga_realtime")]
         Commands::FpgaRun { .. } => fpga::fpga_run(cli.xtask),
+        #[cfg(feature = "fpga_realtime")]
         Commands::FpgaInstallKernelModules => fpga::fpga_install_kernel_modules(),
         Commands::PldmFirmware { subcommand } => match subcommand {
             PldmFirmwareCommands::Create { manifest, file } => pldm_fw_pkg::create(manifest, file),


### PR DESCRIPTION
This is a basic test case that boots the FPGA and checks the MCI boot
status.

This change also removes "fpga_realtime" as an enabled dependency in the xtask crate.

Since the dependency features of a workspace are resolved via a union,
this enabled "fpga_realtime" for the rest of the workspace.