### PR TITLE
Run unit tests in CI directly.

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -88,13 +88,18 @@ jobs:
             exit 1
           )
 
-      - name: Run precheckin
+      - name: Run xtest precheckin tests
         run: |
           cargo --config "$EXTRA_CARGO_CONFIG" xtask precheckin
           sccache --show-stats
 
-      - name: Run all tests
+      - name: Run xtest tests
         run: |
           export SPDM_VALIDATOR_DIR=$GITHUB_WORKSPACE/spdm-emu/build/bin
           cargo --config "$EXTRA_CARGO_CONFIG" xtask test
+          sccache --show-stats
+
+      - name: Run unit tests
+        run: |
+          cargo --config "$EXTRA_CARGO_CONFIG" test --locked --workspace
           sccache --show-stats

--- a/emulator/cbinding/src/simple_test.rs
+++ b/emulator/cbinding/src/simple_test.rs
@@ -31,7 +31,7 @@ fn test_emulator_args_creation() {
     // Test that we can create EmulatorArgs
     use std::path::PathBuf;
 
-    let args = EmulatorArgs {
+    let _ = EmulatorArgs {
         rom: PathBuf::from("test_rom.bin"),
         firmware: PathBuf::from("test_firmware.bin"),
         caliptra_rom: PathBuf::from("test_caliptra_rom.bin"),

--- a/xtask/src/test.rs
+++ b/xtask/src/test.rs
@@ -8,21 +8,7 @@ use crate::emulator_cbinding;
 
 pub(crate) fn test() -> Result<()> {
     test_panic_missing()?;
-    e2e_tests()?;
-    cargo_test()
-}
-
-fn cargo_test() -> Result<()> {
-    println!("Running: cargo test");
-    let status = Command::new("cargo")
-        .current_dir(&*PROJECT_ROOT)
-        .args(["test", "--workspace"])
-        .status()?;
-
-    if !status.success() {
-        bail!("cargo test failed");
-    }
-    Ok(())
+    e2e_tests()
 }
 
 fn e2e_tests() -> Result<()> {


### PR DESCRIPTION
Pull running the unit tests out of `xtask`. This was causing an issue while writing emulator unit tests that were accidentally also enabling the FPGA build.