### PR TITLE
Correct VeeR timer calculation

### DIFF
--- a/runtime/kernel/veer/src/timers.rs
+++ b/runtime/kernel/veer/src/timers.rs
@@ -172,7 +172,7 @@ impl<'a> time::Alarm<'a> for InternalTimers<'a> {
         let now = self.now();
         let expire = reference.wrapping_add(dt);
         let dt = if now.within_range(reference, expire) {
-            dt
+            expire.wrapping_sub(now)
         } else {
             // expire immediately
             1u64.into()


### PR DESCRIPTION
We were setting the timer bound to be the delta from the reference time instead of the current time, so if there was a large timer set previously, then the bound would be set to some potentially very high time.

This was indeed happening due to a bug in the UART timer, which is also fixed here. (It is not clear that we need the UART timer, but I left it in now and set it to a large, fixed value.)

This fixes some weird issues in tests where SHA commands (for example) would randomly take 10+ seconds to execute.