### PR TITLE
Add an MCU manager to the HW model.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,7 +268,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 [[package]]
 name = "caliptra-api"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d39e2916b8b26cb663e99461a1bfbaff6e5283b1#d39e2916b8b26cb663e99461a1bfbaff6e5283b1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ad9be75165c297bfefc66e06c8ceb246936dac29#ad9be75165c297bfefc66e06c8ceb246936dac29"
 dependencies = [
  "bitflags 2.9.1",
  "caliptra-api-types",
@@ -283,7 +283,7 @@ dependencies = [
 [[package]]
 name = "caliptra-api-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d39e2916b8b26cb663e99461a1bfbaff6e5283b1#d39e2916b8b26cb663e99461a1bfbaff6e5283b1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ad9be75165c297bfefc66e06c8ceb246936dac29#ad9be75165c297bfefc66e06c8ceb246936dac29"
 dependencies = [
  "caliptra-image-types",
 ]
@@ -291,7 +291,7 @@ dependencies = [
 [[package]]
 name = "caliptra-auth-man-gen"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d39e2916b8b26cb663e99461a1bfbaff6e5283b1#d39e2916b8b26cb663e99461a1bfbaff6e5283b1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ad9be75165c297bfefc66e06c8ceb246936dac29#ad9be75165c297bfefc66e06c8ceb246936dac29"
 dependencies = [
  "anyhow",
  "bitflags 2.9.1",
@@ -306,7 +306,7 @@ dependencies = [
 [[package]]
 name = "caliptra-auth-man-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d39e2916b8b26cb663e99461a1bfbaff6e5283b1#d39e2916b8b26cb663e99461a1bfbaff6e5283b1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ad9be75165c297bfefc66e06c8ceb246936dac29#ad9be75165c297bfefc66e06c8ceb246936dac29"
 dependencies = [
  "bitfield",
  "bitflags 2.9.1",
@@ -321,7 +321,7 @@ dependencies = [
 [[package]]
 name = "caliptra-builder"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d39e2916b8b26cb663e99461a1bfbaff6e5283b1#d39e2916b8b26cb663e99461a1bfbaff6e5283b1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ad9be75165c297bfefc66e06c8ceb246936dac29#ad9be75165c297bfefc66e06c8ceb246936dac29"
 dependencies = [
  "anyhow",
  "caliptra-image-crypto",
@@ -346,7 +346,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cfi-derive"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d39e2916b8b26cb663e99461a1bfbaff6e5283b1#d39e2916b8b26cb663e99461a1bfbaff6e5283b1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ad9be75165c297bfefc66e06c8ceb246936dac29#ad9be75165c297bfefc66e06c8ceb246936dac29"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -368,7 +368,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cfi-lib"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d39e2916b8b26cb663e99461a1bfbaff6e5283b1#d39e2916b8b26cb663e99461a1bfbaff6e5283b1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ad9be75165c297bfefc66e06c8ceb246936dac29#ad9be75165c297bfefc66e06c8ceb246936dac29"
 dependencies = [
  "caliptra-error",
  "caliptra-registers",
@@ -383,7 +383,7 @@ source = "git+https://github.com/chipsalliance/caliptra-cfi.git?rev=a98e499d279e
 [[package]]
 name = "caliptra-coverage"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d39e2916b8b26cb663e99461a1bfbaff6e5283b1#d39e2916b8b26cb663e99461a1bfbaff6e5283b1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ad9be75165c297bfefc66e06c8ceb246936dac29#ad9be75165c297bfefc66e06c8ceb246936dac29"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -401,7 +401,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cpu"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d39e2916b8b26cb663e99461a1bfbaff6e5283b1#d39e2916b8b26cb663e99461a1bfbaff6e5283b1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ad9be75165c297bfefc66e06c8ceb246936dac29#ad9be75165c297bfefc66e06c8ceb246936dac29"
 dependencies = [
  "caliptra-drivers",
  "caliptra-registers",
@@ -411,7 +411,7 @@ dependencies = [
 [[package]]
 name = "caliptra-drivers"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d39e2916b8b26cb663e99461a1bfbaff6e5283b1#d39e2916b8b26cb663e99461a1bfbaff6e5283b1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ad9be75165c297bfefc66e06c8ceb246936dac29#ad9be75165c297bfefc66e06c8ceb246936dac29"
 dependencies = [
  "arrayvec",
  "bitfield",
@@ -437,7 +437,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-bus"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d39e2916b8b26cb663e99461a1bfbaff6e5283b1#d39e2916b8b26cb663e99461a1bfbaff6e5283b1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ad9be75165c297bfefc66e06c8ceb246936dac29#ad9be75165c297bfefc66e06c8ceb246936dac29"
 dependencies = [
  "caliptra-emu-types",
  "tock-registers",
@@ -447,7 +447,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-cpu"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d39e2916b8b26cb663e99461a1bfbaff6e5283b1#d39e2916b8b26cb663e99461a1bfbaff6e5283b1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ad9be75165c297bfefc66e06c8ceb246936dac29#ad9be75165c297bfefc66e06c8ceb246936dac29"
 dependencies = [
  "bit-vec",
  "bitfield",
@@ -461,7 +461,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d39e2916b8b26cb663e99461a1bfbaff6e5283b1#d39e2916b8b26cb663e99461a1bfbaff6e5283b1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ad9be75165c297bfefc66e06c8ceb246936dac29#ad9be75165c297bfefc66e06c8ceb246936dac29"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -476,7 +476,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-derive"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d39e2916b8b26cb663e99461a1bfbaff6e5283b1#d39e2916b8b26cb663e99461a1bfbaff6e5283b1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ad9be75165c297bfefc66e06c8ceb246936dac29#ad9be75165c297bfefc66e06c8ceb246936dac29"
 dependencies = [
  "caliptra-emu-bus",
  "caliptra-emu-types",
@@ -487,7 +487,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-periph"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d39e2916b8b26cb663e99461a1bfbaff6e5283b1#d39e2916b8b26cb663e99461a1bfbaff6e5283b1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ad9be75165c297bfefc66e06c8ceb246936dac29#ad9be75165c297bfefc66e06c8ceb246936dac29"
 dependencies = [
  "aes",
  "arrayref",
@@ -514,17 +514,17 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d39e2916b8b26cb663e99461a1bfbaff6e5283b1#d39e2916b8b26cb663e99461a1bfbaff6e5283b1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ad9be75165c297bfefc66e06c8ceb246936dac29#ad9be75165c297bfefc66e06c8ceb246936dac29"
 
 [[package]]
 name = "caliptra-error"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d39e2916b8b26cb663e99461a1bfbaff6e5283b1#d39e2916b8b26cb663e99461a1bfbaff6e5283b1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ad9be75165c297bfefc66e06c8ceb246936dac29#ad9be75165c297bfefc66e06c8ceb246936dac29"
 
 [[package]]
 name = "caliptra-gen-linker-scripts"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d39e2916b8b26cb663e99461a1bfbaff6e5283b1#d39e2916b8b26cb663e99461a1bfbaff6e5283b1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ad9be75165c297bfefc66e06c8ceb246936dac29#ad9be75165c297bfefc66e06c8ceb246936dac29"
 dependencies = [
  "caliptra_common",
 ]
@@ -532,7 +532,7 @@ dependencies = [
 [[package]]
 name = "caliptra-hw-model"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d39e2916b8b26cb663e99461a1bfbaff6e5283b1#d39e2916b8b26cb663e99461a1bfbaff6e5283b1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ad9be75165c297bfefc66e06c8ceb246936dac29#ad9be75165c297bfefc66e06c8ceb246936dac29"
 dependencies = [
  "bit-vec",
  "bitfield",
@@ -558,7 +558,7 @@ dependencies = [
 [[package]]
 name = "caliptra-hw-model-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d39e2916b8b26cb663e99461a1bfbaff6e5283b1#d39e2916b8b26cb663e99461a1bfbaff6e5283b1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ad9be75165c297bfefc66e06c8ceb246936dac29#ad9be75165c297bfefc66e06c8ceb246936dac29"
 dependencies = [
  "caliptra-api-types",
  "rand",
@@ -567,7 +567,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d39e2916b8b26cb663e99461a1bfbaff6e5283b1#d39e2916b8b26cb663e99461a1bfbaff6e5283b1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ad9be75165c297bfefc66e06c8ceb246936dac29#ad9be75165c297bfefc66e06c8ceb246936dac29"
 dependencies = [
  "anyhow",
  "caliptra-image-gen",
@@ -587,7 +587,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-elf"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d39e2916b8b26cb663e99461a1bfbaff6e5283b1#d39e2916b8b26cb663e99461a1bfbaff6e5283b1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ad9be75165c297bfefc66e06c8ceb246936dac29#ad9be75165c297bfefc66e06c8ceb246936dac29"
 dependencies = [
  "anyhow",
  "caliptra-image-gen",
@@ -598,7 +598,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-fake-keys"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d39e2916b8b26cb663e99461a1bfbaff6e5283b1#d39e2916b8b26cb663e99461a1bfbaff6e5283b1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ad9be75165c297bfefc66e06c8ceb246936dac29#ad9be75165c297bfefc66e06c8ceb246936dac29"
 dependencies = [
  "caliptra-image-gen",
  "caliptra-image-types",
@@ -609,7 +609,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-gen"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d39e2916b8b26cb663e99461a1bfbaff6e5283b1#d39e2916b8b26cb663e99461a1bfbaff6e5283b1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ad9be75165c297bfefc66e06c8ceb246936dac29#ad9be75165c297bfefc66e06c8ceb246936dac29"
 dependencies = [
  "anyhow",
  "bitflags 2.9.1",
@@ -626,7 +626,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d39e2916b8b26cb663e99461a1bfbaff6e5283b1#d39e2916b8b26cb663e99461a1bfbaff6e5283b1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ad9be75165c297bfefc66e06c8ceb246936dac29#ad9be75165c297bfefc66e06c8ceb246936dac29"
 dependencies = [
  "caliptra-cfi-derive",
  "caliptra-cfi-lib",
@@ -642,7 +642,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-verify"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d39e2916b8b26cb663e99461a1bfbaff6e5283b1#d39e2916b8b26cb663e99461a1bfbaff6e5283b1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ad9be75165c297bfefc66e06c8ceb246936dac29#ad9be75165c297bfefc66e06c8ceb246936dac29"
 dependencies = [
  "bitflags 2.9.1",
  "caliptra-cfi-derive",
@@ -657,7 +657,7 @@ dependencies = [
 [[package]]
 name = "caliptra-kat"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d39e2916b8b26cb663e99461a1bfbaff6e5283b1#d39e2916b8b26cb663e99461a1bfbaff6e5283b1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ad9be75165c297bfefc66e06c8ceb246936dac29#ad9be75165c297bfefc66e06c8ceb246936dac29"
 dependencies = [
  "caliptra-drivers",
  "caliptra-lms-types",
@@ -669,7 +669,7 @@ dependencies = [
 [[package]]
 name = "caliptra-lms-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d39e2916b8b26cb663e99461a1bfbaff6e5283b1#d39e2916b8b26cb663e99461a1bfbaff6e5283b1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ad9be75165c297bfefc66e06c8ceb246936dac29#ad9be75165c297bfefc66e06c8ceb246936dac29"
 dependencies = [
  "caliptra-cfi-derive",
  "caliptra-cfi-lib",
@@ -682,7 +682,7 @@ dependencies = [
 [[package]]
 name = "caliptra-registers"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d39e2916b8b26cb663e99461a1bfbaff6e5283b1#d39e2916b8b26cb663e99461a1bfbaff6e5283b1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ad9be75165c297bfefc66e06c8ceb246936dac29#ad9be75165c297bfefc66e06c8ceb246936dac29"
 dependencies = [
  "caliptra-registers-latest",
 ]
@@ -690,7 +690,7 @@ dependencies = [
 [[package]]
 name = "caliptra-registers-latest"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d39e2916b8b26cb663e99461a1bfbaff6e5283b1#d39e2916b8b26cb663e99461a1bfbaff6e5283b1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ad9be75165c297bfefc66e06c8ceb246936dac29#ad9be75165c297bfefc66e06c8ceb246936dac29"
 dependencies = [
  "ureg",
 ]
@@ -698,7 +698,7 @@ dependencies = [
 [[package]]
 name = "caliptra-runtime"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d39e2916b8b26cb663e99461a1bfbaff6e5283b1#d39e2916b8b26cb663e99461a1bfbaff6e5283b1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ad9be75165c297bfefc66e06c8ceb246936dac29#ad9be75165c297bfefc66e06c8ceb246936dac29"
 dependencies = [
  "arrayvec",
  "bitflags 2.9.1",
@@ -730,7 +730,7 @@ dependencies = [
 [[package]]
 name = "caliptra-test"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d39e2916b8b26cb663e99461a1bfbaff6e5283b1#d39e2916b8b26cb663e99461a1bfbaff6e5283b1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ad9be75165c297bfefc66e06c8ceb246936dac29#ad9be75165c297bfefc66e06c8ceb246936dac29"
 dependencies = [
  "anyhow",
  "asn1",
@@ -762,12 +762,12 @@ dependencies = [
 [[package]]
 name = "caliptra-test-harness-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d39e2916b8b26cb663e99461a1bfbaff6e5283b1#d39e2916b8b26cb663e99461a1bfbaff6e5283b1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ad9be75165c297bfefc66e06c8ceb246936dac29#ad9be75165c297bfefc66e06c8ceb246936dac29"
 
 [[package]]
 name = "caliptra-x509"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d39e2916b8b26cb663e99461a1bfbaff6e5283b1#d39e2916b8b26cb663e99461a1bfbaff6e5283b1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ad9be75165c297bfefc66e06c8ceb246936dac29#ad9be75165c297bfefc66e06c8ceb246936dac29"
 dependencies = [
  "zeroize",
 ]
@@ -775,7 +775,7 @@ dependencies = [
 [[package]]
 name = "caliptra_common"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d39e2916b8b26cb663e99461a1bfbaff6e5283b1#d39e2916b8b26cb663e99461a1bfbaff6e5283b1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ad9be75165c297bfefc66e06c8ceb246936dac29#ad9be75165c297bfefc66e06c8ceb246936dac29"
 dependencies = [
  "bitfield",
  "bitflags 2.9.1",
@@ -1210,7 +1210,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d39e2916b8b26cb663e99461a1bfbaff6e5283b1#d39e2916b8b26cb663e99461a1bfbaff6e5283b1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ad9be75165c297bfefc66e06c8ceb246936dac29#ad9be75165c297bfefc66e06c8ceb246936dac29"
 dependencies = [
  "arrayvec",
  "caliptra-cfi-derive-git",
@@ -1401,7 +1401,7 @@ dependencies = [
 [[package]]
 name = "dpe"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d39e2916b8b26cb663e99461a1bfbaff6e5283b1#d39e2916b8b26cb663e99461a1bfbaff6e5283b1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ad9be75165c297bfefc66e06c8ceb246936dac29#ad9be75165c297bfefc66e06c8ceb246936dac29"
 dependencies = [
  "bitflags 2.9.1",
  "caliptra-cfi-derive-git",
@@ -3077,7 +3077,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 [[package]]
 name = "platform"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d39e2916b8b26cb663e99461a1bfbaff6e5283b1#d39e2916b8b26cb663e99461a1bfbaff6e5283b1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ad9be75165c297bfefc66e06c8ceb246936dac29#ad9be75165c297bfefc66e06c8ceb246936dac29"
 dependencies = [
  "arrayvec",
  "cfg-if",
@@ -4185,7 +4185,7 @@ dependencies = [
 [[package]]
 name = "ureg"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d39e2916b8b26cb663e99461a1bfbaff6e5283b1#d39e2916b8b26cb663e99461a1bfbaff6e5283b1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ad9be75165c297bfefc66e06c8ceb246936dac29#ad9be75165c297bfefc66e06c8ceb246936dac29"
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -196,28 +196,28 @@ libtock_small_panic = { path = "runtime/userspace/libtock/panic_handlers/small_p
 libtock_unittest = { path = "runtime/userspace/libtock/unittest" }
 
 # caliptra dependencies; keep git revs in sync
-caliptra-api = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d39e2916b8b26cb663e99461a1bfbaff6e5283b1" }
-caliptra-api-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d39e2916b8b26cb663e99461a1bfbaff6e5283b1" }
-caliptra-auth-man-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d39e2916b8b26cb663e99461a1bfbaff6e5283b1" }
-caliptra-auth-man-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d39e2916b8b26cb663e99461a1bfbaff6e5283b1" }
-caliptra-builder = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d39e2916b8b26cb663e99461a1bfbaff6e5283b1" }
-caliptra-emu-bus = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d39e2916b8b26cb663e99461a1bfbaff6e5283b1" }
-caliptra-emu-cpu = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d39e2916b8b26cb663e99461a1bfbaff6e5283b1" }
-caliptra-emu-derive = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d39e2916b8b26cb663e99461a1bfbaff6e5283b1" }
-caliptra-emu-periph = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d39e2916b8b26cb663e99461a1bfbaff6e5283b1" }
-caliptra-emu-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d39e2916b8b26cb663e99461a1bfbaff6e5283b1" }
-caliptra-error = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d39e2916b8b26cb663e99461a1bfbaff6e5283b1", default-features = false }
-caliptra-hw-model = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d39e2916b8b26cb663e99461a1bfbaff6e5283b1" }
-caliptra-hw-model-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d39e2916b8b26cb663e99461a1bfbaff6e5283b1" }
-caliptra-image-crypto = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d39e2916b8b26cb663e99461a1bfbaff6e5283b1", default-features = false, features = ["rustcrypto"] }
-caliptra-image-fake-keys = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d39e2916b8b26cb663e99461a1bfbaff6e5283b1" }
-caliptra-image-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d39e2916b8b26cb663e99461a1bfbaff6e5283b1" }
-caliptra-image-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d39e2916b8b26cb663e99461a1bfbaff6e5283b1" }
-caliptra-registers = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d39e2916b8b26cb663e99461a1bfbaff6e5283b1" }
-caliptra-test = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d39e2916b8b26cb663e99461a1bfbaff6e5283b1" }
-caliptra-test-harness-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d39e2916b8b26cb663e99461a1bfbaff6e5283b1" }
-ureg = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d39e2916b8b26cb663e99461a1bfbaff6e5283b1" }
-dpe = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d39e2916b8b26cb663e99461a1bfbaff6e5283b1", default-features = false, features = ["dpe_profile_p384_sha384"] }
+caliptra-api = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ad9be75165c297bfefc66e06c8ceb246936dac29" }
+caliptra-api-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ad9be75165c297bfefc66e06c8ceb246936dac29" }
+caliptra-auth-man-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ad9be75165c297bfefc66e06c8ceb246936dac29" }
+caliptra-auth-man-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ad9be75165c297bfefc66e06c8ceb246936dac29" }
+caliptra-builder = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ad9be75165c297bfefc66e06c8ceb246936dac29" }
+caliptra-emu-bus = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ad9be75165c297bfefc66e06c8ceb246936dac29" }
+caliptra-emu-cpu = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ad9be75165c297bfefc66e06c8ceb246936dac29" }
+caliptra-emu-derive = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ad9be75165c297bfefc66e06c8ceb246936dac29" }
+caliptra-emu-periph = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ad9be75165c297bfefc66e06c8ceb246936dac29" }
+caliptra-emu-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ad9be75165c297bfefc66e06c8ceb246936dac29" }
+caliptra-error = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ad9be75165c297bfefc66e06c8ceb246936dac29", default-features = false }
+caliptra-hw-model = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ad9be75165c297bfefc66e06c8ceb246936dac29" }
+caliptra-hw-model-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ad9be75165c297bfefc66e06c8ceb246936dac29" }
+caliptra-image-crypto = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ad9be75165c297bfefc66e06c8ceb246936dac29", default-features = false, features = ["rustcrypto"] }
+caliptra-image-fake-keys = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ad9be75165c297bfefc66e06c8ceb246936dac29" }
+caliptra-image-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ad9be75165c297bfefc66e06c8ceb246936dac29" }
+caliptra-image-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ad9be75165c297bfefc66e06c8ceb246936dac29" }
+caliptra-registers = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ad9be75165c297bfefc66e06c8ceb246936dac29" }
+caliptra-test = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ad9be75165c297bfefc66e06c8ceb246936dac29" }
+caliptra-test-harness-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ad9be75165c297bfefc66e06c8ceb246936dac29" }
+ureg = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ad9be75165c297bfefc66e06c8ceb246936dac29" }
+dpe = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ad9be75165c297bfefc66e06c8ceb246936dac29", default-features = false, features = ["dpe_profile_p384_sha384"] }
 
 # local caliptra dependency; useful when developing
 # caliptra-api = { path = "../caliptra-sw/api" }

--- a/hw/model/src/mcu_mgr.rs
+++ b/hw/model/src/mcu_mgr.rs
@@ -1,0 +1,102 @@
+// Licensed under the Apache-2.0 license
+
+use ureg::MmioMut;
+
+pub trait McuManager {
+    const I3C_ADDR: u32;
+    const MCI_ADDR: u32;
+    const TRACE_BUFFER_ADDR: u32;
+    const MBOX_0_ADDR: u32;
+    const MBOX_1_ADDR: u32;
+    const MCU_SRAM_ADDR: u32;
+    const OTP_CTRL_ADDR: u32;
+    const LC_CTRL_ADDR: u32;
+
+    type TMmio<'a>: MmioMut
+    where
+        Self: 'a;
+
+    fn mmio_mut(&mut self) -> Self::TMmio<'_>;
+
+    /// A register block that can be used to manipulate the i3c peripheral
+    fn i3c(&mut self) -> caliptra_registers::i3ccsr::RegisterBlock<Self::TMmio<'_>> {
+        unsafe {
+            caliptra_registers::i3ccsr::RegisterBlock::new_with_mmio(
+                Self::I3C_ADDR as *mut u32,
+                self.mmio_mut(),
+            )
+        }
+    }
+
+    /// A register block that can be used to manipulate the mci peripheral
+    fn mci(&mut self) -> caliptra_registers::mci::RegisterBlock<Self::TMmio<'_>> {
+        unsafe {
+            caliptra_registers::mci::RegisterBlock::new_with_mmio(
+                Self::MCI_ADDR as *mut u32,
+                self.mmio_mut(),
+            )
+        }
+    }
+
+    /// A register block that can be used to manipulate the mcu_trace_buffer peripheral
+    fn trace_buffer(
+        &mut self,
+    ) -> caliptra_registers::mcu_trace_buffer::RegisterBlock<Self::TMmio<'_>> {
+        unsafe {
+            caliptra_registers::mcu_trace_buffer::RegisterBlock::new_with_mmio(
+                Self::TRACE_BUFFER_ADDR as *mut u32,
+                self.mmio_mut(),
+            )
+        }
+    }
+
+    /// A register block that can be used to manipulate the mcu_mbox0 peripheral
+    fn mbox0(&mut self) -> caliptra_registers::mcu_mbox0::RegisterBlock<Self::TMmio<'_>> {
+        unsafe {
+            caliptra_registers::mcu_mbox0::RegisterBlock::new_with_mmio(
+                Self::MBOX_0_ADDR as *mut u32,
+                self.mmio_mut(),
+            )
+        }
+    }
+
+    /// A register block that can be used to manipulate the mcu_mbox1 peripheral
+    fn mbox1(&mut self) -> caliptra_registers::mcu_mbox1::RegisterBlock<Self::TMmio<'_>> {
+        unsafe {
+            caliptra_registers::mcu_mbox1::RegisterBlock::new_with_mmio(
+                Self::MBOX_1_ADDR as *mut u32,
+                self.mmio_mut(),
+            )
+        }
+    }
+
+    /// A register block that can be used to manipulate the mcu_sram peripheral
+    fn mcu_sram(&mut self) -> caliptra_registers::mcu_sram::RegisterBlock<Self::TMmio<'_>> {
+        unsafe {
+            caliptra_registers::mcu_sram::RegisterBlock::new_with_mmio(
+                Self::MCU_SRAM_ADDR as *mut u32,
+                self.mmio_mut(),
+            )
+        }
+    }
+
+    /// A register block that can be used to manipulate the otp_ctrl peripheral
+    fn otp_ctrl(&mut self) -> caliptra_registers::otp_ctrl::RegisterBlock<Self::TMmio<'_>> {
+        unsafe {
+            caliptra_registers::otp_ctrl::RegisterBlock::new_with_mmio(
+                Self::OTP_CTRL_ADDR as *mut u32,
+                self.mmio_mut(),
+            )
+        }
+    }
+
+    /// A register block that can be used to manipulate the lc_ctrl peripheral
+    fn lc_ctrl(&mut self) -> caliptra_registers::lc_ctrl::RegisterBlock<Self::TMmio<'_>> {
+        unsafe {
+            caliptra_registers::lc_ctrl::RegisterBlock::new_with_mmio(
+                Self::LC_CTRL_ADDR as *mut u32,
+                self.mmio_mut(),
+            )
+        }
+    }
+}


### PR DESCRIPTION
This will be used by integration tests to support accessing registers as if from the external SoC. This also makes it easy to make tests that work with both the emulator and the FPGA.

This can been tested locally and on the FPGA, tests will be added in a follow on PR.