### PR TITLE
Don't use alarm at all in uart

### DIFF
--- a/platforms/emulator/runtime/src/interrupts.rs
+++ b/platforms/emulator/runtime/src/interrupts.rs
@@ -25,7 +25,7 @@ pub struct EmulatorPeripherals<'a> {
 impl<'a> EmulatorPeripherals<'a> {
     pub fn new(alarm: &'a MuxAlarm<'a, InternalTimers<'a>>) -> Self {
         Self {
-            uart: SemihostUart::new(alarm),
+            uart: SemihostUart::new(),
             primary_flash_ctrl: flash_driver::flash_ctrl::EmulatedFlashCtrl::new(
                 flash_driver::flash_ctrl::PRIMARY_FLASH_CTRL_BASE,
             ),


### PR DESCRIPTION
This was causing the tock$ prompt to keep being printed.

This alarm doesn't seem to be needed at all for us, so I just removed it altogether.