### PR TITLE
Firmware Update Image Verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,7 +268,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 [[package]]
 name = "caliptra-api"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
 dependencies = [
  "bitflags 2.9.1",
  "caliptra-api-types",
@@ -283,7 +283,7 @@ dependencies = [
 [[package]]
 name = "caliptra-api-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
 dependencies = [
  "caliptra-image-types",
 ]
@@ -291,7 +291,7 @@ dependencies = [
 [[package]]
 name = "caliptra-auth-man-gen"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
 dependencies = [
  "anyhow",
  "bitflags 2.9.1",
@@ -306,7 +306,7 @@ dependencies = [
 [[package]]
 name = "caliptra-auth-man-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
 dependencies = [
  "bitfield",
  "bitflags 2.9.1",
@@ -321,7 +321,7 @@ dependencies = [
 [[package]]
 name = "caliptra-builder"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
 dependencies = [
  "anyhow",
  "caliptra-image-crypto",
@@ -346,7 +346,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cfi-derive"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -368,7 +368,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cfi-lib"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
 dependencies = [
  "caliptra-error",
  "caliptra-registers",
@@ -383,7 +383,7 @@ source = "git+https://github.com/chipsalliance/caliptra-cfi.git?rev=a98e499d279e
 [[package]]
 name = "caliptra-coverage"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -401,7 +401,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cpu"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
 dependencies = [
  "caliptra-drivers",
  "caliptra-registers",
@@ -411,7 +411,7 @@ dependencies = [
 [[package]]
 name = "caliptra-drivers"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
 dependencies = [
  "arrayvec",
  "bitfield",
@@ -437,7 +437,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-bus"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
 dependencies = [
  "caliptra-emu-types",
  "tock-registers",
@@ -447,7 +447,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-cpu"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
 dependencies = [
  "bit-vec",
  "bitfield",
@@ -461,7 +461,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -476,7 +476,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-derive"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
 dependencies = [
  "caliptra-emu-bus",
  "caliptra-emu-types",
@@ -487,7 +487,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-periph"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
 dependencies = [
  "aes",
  "arrayref",
@@ -514,17 +514,17 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
 
 [[package]]
 name = "caliptra-error"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
 
 [[package]]
 name = "caliptra-gen-linker-scripts"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
 dependencies = [
  "caliptra_common",
 ]
@@ -532,7 +532,7 @@ dependencies = [
 [[package]]
 name = "caliptra-hw-model"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
 dependencies = [
  "bit-vec",
  "bitfield",
@@ -558,7 +558,7 @@ dependencies = [
 [[package]]
 name = "caliptra-hw-model-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
 dependencies = [
  "caliptra-api-types",
  "rand",
@@ -567,7 +567,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
 dependencies = [
  "anyhow",
  "caliptra-image-gen",
@@ -587,7 +587,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-elf"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
 dependencies = [
  "anyhow",
  "caliptra-image-gen",
@@ -598,7 +598,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-fake-keys"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
 dependencies = [
  "caliptra-image-gen",
  "caliptra-image-types",
@@ -609,7 +609,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-gen"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
 dependencies = [
  "anyhow",
  "bitflags 2.9.1",
@@ -626,7 +626,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
 dependencies = [
  "caliptra-cfi-derive",
  "caliptra-cfi-lib",
@@ -642,7 +642,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-verify"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
 dependencies = [
  "bitflags 2.9.1",
  "caliptra-cfi-derive",
@@ -657,7 +657,7 @@ dependencies = [
 [[package]]
 name = "caliptra-kat"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
 dependencies = [
  "caliptra-drivers",
  "caliptra-lms-types",
@@ -669,7 +669,7 @@ dependencies = [
 [[package]]
 name = "caliptra-lms-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
 dependencies = [
  "caliptra-cfi-derive",
  "caliptra-cfi-lib",
@@ -682,7 +682,7 @@ dependencies = [
 [[package]]
 name = "caliptra-registers"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
 dependencies = [
  "caliptra-registers-latest",
 ]
@@ -690,7 +690,7 @@ dependencies = [
 [[package]]
 name = "caliptra-registers-latest"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
 dependencies = [
  "ureg",
 ]
@@ -698,7 +698,7 @@ dependencies = [
 [[package]]
 name = "caliptra-runtime"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
 dependencies = [
  "arrayvec",
  "bitfield",
@@ -731,7 +731,7 @@ dependencies = [
 [[package]]
 name = "caliptra-test"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
 dependencies = [
  "anyhow",
  "asn1",
@@ -763,12 +763,12 @@ dependencies = [
 [[package]]
 name = "caliptra-test-harness-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
 
 [[package]]
 name = "caliptra-x509"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
 dependencies = [
  "zeroize",
 ]
@@ -776,7 +776,7 @@ dependencies = [
 [[package]]
 name = "caliptra_common"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
 dependencies = [
  "bitfield",
  "bitflags 2.9.1",
@@ -1211,7 +1211,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
 dependencies = [
  "arrayvec",
  "caliptra-cfi-derive-git",
@@ -1402,7 +1402,7 @@ dependencies = [
 [[package]]
 name = "dpe"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
 dependencies = [
  "bitflags 2.9.1",
  "caliptra-cfi-derive-git",
@@ -3078,7 +3078,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 [[package]]
 name = "platform"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
 dependencies = [
  "arrayvec",
  "cfg-if",
@@ -4186,7 +4186,7 @@ dependencies = [
 [[package]]
 name = "ureg"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
 
 [[package]]
 name = "url"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,7 +268,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 [[package]]
 name = "caliptra-api"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7af98ba805fd7cd59a747accd80625f87b639966#7af98ba805fd7cd59a747accd80625f87b639966"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
 dependencies = [
  "bitflags 2.9.1",
  "caliptra-api-types",
@@ -283,7 +283,7 @@ dependencies = [
 [[package]]
 name = "caliptra-api-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7af98ba805fd7cd59a747accd80625f87b639966#7af98ba805fd7cd59a747accd80625f87b639966"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
 dependencies = [
  "caliptra-image-types",
 ]
@@ -291,7 +291,7 @@ dependencies = [
 [[package]]
 name = "caliptra-auth-man-gen"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7af98ba805fd7cd59a747accd80625f87b639966#7af98ba805fd7cd59a747accd80625f87b639966"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
 dependencies = [
  "anyhow",
  "bitflags 2.9.1",
@@ -306,7 +306,7 @@ dependencies = [
 [[package]]
 name = "caliptra-auth-man-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7af98ba805fd7cd59a747accd80625f87b639966#7af98ba805fd7cd59a747accd80625f87b639966"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
 dependencies = [
  "bitfield",
  "bitflags 2.9.1",
@@ -321,7 +321,7 @@ dependencies = [
 [[package]]
 name = "caliptra-builder"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7af98ba805fd7cd59a747accd80625f87b639966#7af98ba805fd7cd59a747accd80625f87b639966"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
 dependencies = [
  "anyhow",
  "caliptra-image-crypto",
@@ -346,7 +346,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cfi-derive"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7af98ba805fd7cd59a747accd80625f87b639966#7af98ba805fd7cd59a747accd80625f87b639966"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -368,7 +368,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cfi-lib"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7af98ba805fd7cd59a747accd80625f87b639966#7af98ba805fd7cd59a747accd80625f87b639966"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
 dependencies = [
  "caliptra-error",
  "caliptra-registers",
@@ -383,7 +383,7 @@ source = "git+https://github.com/chipsalliance/caliptra-cfi.git?rev=a98e499d279e
 [[package]]
 name = "caliptra-coverage"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7af98ba805fd7cd59a747accd80625f87b639966#7af98ba805fd7cd59a747accd80625f87b639966"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -401,7 +401,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cpu"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7af98ba805fd7cd59a747accd80625f87b639966#7af98ba805fd7cd59a747accd80625f87b639966"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
 dependencies = [
  "caliptra-drivers",
  "caliptra-registers",
@@ -411,7 +411,7 @@ dependencies = [
 [[package]]
 name = "caliptra-drivers"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7af98ba805fd7cd59a747accd80625f87b639966#7af98ba805fd7cd59a747accd80625f87b639966"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
 dependencies = [
  "arrayvec",
  "bitfield",
@@ -437,7 +437,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-bus"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7af98ba805fd7cd59a747accd80625f87b639966#7af98ba805fd7cd59a747accd80625f87b639966"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
 dependencies = [
  "caliptra-emu-types",
  "tock-registers",
@@ -447,7 +447,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-cpu"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7af98ba805fd7cd59a747accd80625f87b639966#7af98ba805fd7cd59a747accd80625f87b639966"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
 dependencies = [
  "bit-vec",
  "bitfield",
@@ -461,7 +461,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7af98ba805fd7cd59a747accd80625f87b639966#7af98ba805fd7cd59a747accd80625f87b639966"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -476,7 +476,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-derive"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7af98ba805fd7cd59a747accd80625f87b639966#7af98ba805fd7cd59a747accd80625f87b639966"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
 dependencies = [
  "caliptra-emu-bus",
  "caliptra-emu-types",
@@ -487,7 +487,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-periph"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7af98ba805fd7cd59a747accd80625f87b639966#7af98ba805fd7cd59a747accd80625f87b639966"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
 dependencies = [
  "aes",
  "arrayref",
@@ -514,17 +514,17 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7af98ba805fd7cd59a747accd80625f87b639966#7af98ba805fd7cd59a747accd80625f87b639966"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
 
 [[package]]
 name = "caliptra-error"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7af98ba805fd7cd59a747accd80625f87b639966#7af98ba805fd7cd59a747accd80625f87b639966"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
 
 [[package]]
 name = "caliptra-gen-linker-scripts"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7af98ba805fd7cd59a747accd80625f87b639966#7af98ba805fd7cd59a747accd80625f87b639966"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
 dependencies = [
  "caliptra_common",
 ]
@@ -532,7 +532,7 @@ dependencies = [
 [[package]]
 name = "caliptra-hw-model"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7af98ba805fd7cd59a747accd80625f87b639966#7af98ba805fd7cd59a747accd80625f87b639966"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
 dependencies = [
  "bit-vec",
  "bitfield",
@@ -558,7 +558,7 @@ dependencies = [
 [[package]]
 name = "caliptra-hw-model-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7af98ba805fd7cd59a747accd80625f87b639966#7af98ba805fd7cd59a747accd80625f87b639966"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
 dependencies = [
  "caliptra-api-types",
  "rand",
@@ -567,7 +567,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7af98ba805fd7cd59a747accd80625f87b639966#7af98ba805fd7cd59a747accd80625f87b639966"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
 dependencies = [
  "anyhow",
  "caliptra-image-gen",
@@ -587,7 +587,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-elf"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7af98ba805fd7cd59a747accd80625f87b639966#7af98ba805fd7cd59a747accd80625f87b639966"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
 dependencies = [
  "anyhow",
  "caliptra-image-gen",
@@ -598,7 +598,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-fake-keys"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7af98ba805fd7cd59a747accd80625f87b639966#7af98ba805fd7cd59a747accd80625f87b639966"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
 dependencies = [
  "caliptra-image-gen",
  "caliptra-image-types",
@@ -609,7 +609,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-gen"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7af98ba805fd7cd59a747accd80625f87b639966#7af98ba805fd7cd59a747accd80625f87b639966"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
 dependencies = [
  "anyhow",
  "bitflags 2.9.1",
@@ -626,7 +626,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7af98ba805fd7cd59a747accd80625f87b639966#7af98ba805fd7cd59a747accd80625f87b639966"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
 dependencies = [
  "caliptra-cfi-derive",
  "caliptra-cfi-lib",
@@ -642,7 +642,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-verify"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7af98ba805fd7cd59a747accd80625f87b639966#7af98ba805fd7cd59a747accd80625f87b639966"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
 dependencies = [
  "bitflags 2.9.1",
  "caliptra-cfi-derive",
@@ -657,7 +657,7 @@ dependencies = [
 [[package]]
 name = "caliptra-kat"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7af98ba805fd7cd59a747accd80625f87b639966#7af98ba805fd7cd59a747accd80625f87b639966"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
 dependencies = [
  "caliptra-drivers",
  "caliptra-lms-types",
@@ -669,7 +669,7 @@ dependencies = [
 [[package]]
 name = "caliptra-lms-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7af98ba805fd7cd59a747accd80625f87b639966#7af98ba805fd7cd59a747accd80625f87b639966"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
 dependencies = [
  "caliptra-cfi-derive",
  "caliptra-cfi-lib",
@@ -682,7 +682,7 @@ dependencies = [
 [[package]]
 name = "caliptra-registers"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7af98ba805fd7cd59a747accd80625f87b639966#7af98ba805fd7cd59a747accd80625f87b639966"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
 dependencies = [
  "caliptra-registers-latest",
 ]
@@ -690,7 +690,7 @@ dependencies = [
 [[package]]
 name = "caliptra-registers-latest"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7af98ba805fd7cd59a747accd80625f87b639966#7af98ba805fd7cd59a747accd80625f87b639966"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
 dependencies = [
  "ureg",
 ]
@@ -698,7 +698,7 @@ dependencies = [
 [[package]]
 name = "caliptra-runtime"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7af98ba805fd7cd59a747accd80625f87b639966#7af98ba805fd7cd59a747accd80625f87b639966"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
 dependencies = [
  "arrayvec",
  "bitfield",
@@ -731,7 +731,7 @@ dependencies = [
 [[package]]
 name = "caliptra-test"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7af98ba805fd7cd59a747accd80625f87b639966#7af98ba805fd7cd59a747accd80625f87b639966"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
 dependencies = [
  "anyhow",
  "asn1",
@@ -763,12 +763,12 @@ dependencies = [
 [[package]]
 name = "caliptra-test-harness-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7af98ba805fd7cd59a747accd80625f87b639966#7af98ba805fd7cd59a747accd80625f87b639966"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
 
 [[package]]
 name = "caliptra-x509"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7af98ba805fd7cd59a747accd80625f87b639966#7af98ba805fd7cd59a747accd80625f87b639966"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
 dependencies = [
  "zeroize",
 ]
@@ -776,7 +776,7 @@ dependencies = [
 [[package]]
 name = "caliptra_common"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7af98ba805fd7cd59a747accd80625f87b639966#7af98ba805fd7cd59a747accd80625f87b639966"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
 dependencies = [
  "bitfield",
  "bitflags 2.9.1",
@@ -1211,7 +1211,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7af98ba805fd7cd59a747accd80625f87b639966#7af98ba805fd7cd59a747accd80625f87b639966"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
 dependencies = [
  "arrayvec",
  "caliptra-cfi-derive-git",
@@ -1402,7 +1402,7 @@ dependencies = [
 [[package]]
 name = "dpe"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7af98ba805fd7cd59a747accd80625f87b639966#7af98ba805fd7cd59a747accd80625f87b639966"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
 dependencies = [
  "bitflags 2.9.1",
  "caliptra-cfi-derive-git",
@@ -3078,7 +3078,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 [[package]]
 name = "platform"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7af98ba805fd7cd59a747accd80625f87b639966#7af98ba805fd7cd59a747accd80625f87b639966"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
 dependencies = [
  "arrayvec",
  "cfg-if",
@@ -4186,7 +4186,7 @@ dependencies = [
 [[package]]
 name = "ureg"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=7af98ba805fd7cd59a747accd80625f87b639966#7af98ba805fd7cd59a747accd80625f87b639966"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ffac6e51131cf0b96651a72c3be205702ac55210#ffac6e51131cf0b96651a72c3be205702ac55210"
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -196,28 +196,28 @@ libtock_small_panic = { path = "runtime/userspace/libtock/panic_handlers/small_p
 libtock_unittest = { path = "runtime/userspace/libtock/unittest" }
 
 # caliptra dependencies; keep git revs in sync
-caliptra-api = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ffac6e51131cf0b96651a72c3be205702ac55210" }
-caliptra-api-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ffac6e51131cf0b96651a72c3be205702ac55210" }
-caliptra-auth-man-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ffac6e51131cf0b96651a72c3be205702ac55210" }
-caliptra-auth-man-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ffac6e51131cf0b96651a72c3be205702ac55210" }
-caliptra-builder = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ffac6e51131cf0b96651a72c3be205702ac55210" }
-caliptra-emu-bus = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ffac6e51131cf0b96651a72c3be205702ac55210" }
-caliptra-emu-cpu = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ffac6e51131cf0b96651a72c3be205702ac55210" }
-caliptra-emu-derive = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ffac6e51131cf0b96651a72c3be205702ac55210" }
-caliptra-emu-periph = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ffac6e51131cf0b96651a72c3be205702ac55210" }
-caliptra-emu-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ffac6e51131cf0b96651a72c3be205702ac55210" }
-caliptra-error = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ffac6e51131cf0b96651a72c3be205702ac55210", default-features = false }
-caliptra-hw-model = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ffac6e51131cf0b96651a72c3be205702ac55210" }
-caliptra-hw-model-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ffac6e51131cf0b96651a72c3be205702ac55210" }
-caliptra-image-crypto = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ffac6e51131cf0b96651a72c3be205702ac55210", default-features = false, features = ["rustcrypto"] }
-caliptra-image-fake-keys = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ffac6e51131cf0b96651a72c3be205702ac55210" }
-caliptra-image-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ffac6e51131cf0b96651a72c3be205702ac55210" }
-caliptra-image-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ffac6e51131cf0b96651a72c3be205702ac55210" }
-caliptra-registers = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ffac6e51131cf0b96651a72c3be205702ac55210" }
-caliptra-test = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ffac6e51131cf0b96651a72c3be205702ac55210" }
-caliptra-test-harness-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ffac6e51131cf0b96651a72c3be205702ac55210" }
-ureg = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ffac6e51131cf0b96651a72c3be205702ac55210" }
-dpe = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ffac6e51131cf0b96651a72c3be205702ac55210", default-features = false, features = ["dpe_profile_p384_sha384"] }
+caliptra-api = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "63a2a36b7dd79538c3e7aae722856c5cf42359b7" }
+caliptra-api-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "63a2a36b7dd79538c3e7aae722856c5cf42359b7" }
+caliptra-auth-man-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "63a2a36b7dd79538c3e7aae722856c5cf42359b7" }
+caliptra-auth-man-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "63a2a36b7dd79538c3e7aae722856c5cf42359b7" }
+caliptra-builder = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "63a2a36b7dd79538c3e7aae722856c5cf42359b7" }
+caliptra-emu-bus = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "63a2a36b7dd79538c3e7aae722856c5cf42359b7" }
+caliptra-emu-cpu = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "63a2a36b7dd79538c3e7aae722856c5cf42359b7" }
+caliptra-emu-derive = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "63a2a36b7dd79538c3e7aae722856c5cf42359b7" }
+caliptra-emu-periph = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "63a2a36b7dd79538c3e7aae722856c5cf42359b7" }
+caliptra-emu-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "63a2a36b7dd79538c3e7aae722856c5cf42359b7" }
+caliptra-error = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "63a2a36b7dd79538c3e7aae722856c5cf42359b7", default-features = false }
+caliptra-hw-model = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "63a2a36b7dd79538c3e7aae722856c5cf42359b7" }
+caliptra-hw-model-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "63a2a36b7dd79538c3e7aae722856c5cf42359b7" }
+caliptra-image-crypto = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "63a2a36b7dd79538c3e7aae722856c5cf42359b7", default-features = false, features = ["rustcrypto"] }
+caliptra-image-fake-keys = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "63a2a36b7dd79538c3e7aae722856c5cf42359b7" }
+caliptra-image-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "63a2a36b7dd79538c3e7aae722856c5cf42359b7" }
+caliptra-image-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "63a2a36b7dd79538c3e7aae722856c5cf42359b7" }
+caliptra-registers = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "63a2a36b7dd79538c3e7aae722856c5cf42359b7" }
+caliptra-test = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "63a2a36b7dd79538c3e7aae722856c5cf42359b7" }
+caliptra-test-harness-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "63a2a36b7dd79538c3e7aae722856c5cf42359b7" }
+ureg = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "63a2a36b7dd79538c3e7aae722856c5cf42359b7" }
+dpe = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "63a2a36b7dd79538c3e7aae722856c5cf42359b7", default-features = false, features = ["dpe_profile_p384_sha384"] }
 
 # local caliptra dependency; useful when developing
 # caliptra-api = { path = "../caliptra-sw/api" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -196,28 +196,28 @@ libtock_small_panic = { path = "runtime/userspace/libtock/panic_handlers/small_p
 libtock_unittest = { path = "runtime/userspace/libtock/unittest" }
 
 # caliptra dependencies; keep git revs in sync
-caliptra-api = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "7af98ba805fd7cd59a747accd80625f87b639966" }
-caliptra-api-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "7af98ba805fd7cd59a747accd80625f87b639966" }
-caliptra-auth-man-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "7af98ba805fd7cd59a747accd80625f87b639966" }
-caliptra-auth-man-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "7af98ba805fd7cd59a747accd80625f87b639966" }
-caliptra-builder = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "7af98ba805fd7cd59a747accd80625f87b639966" }
-caliptra-emu-bus = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "7af98ba805fd7cd59a747accd80625f87b639966" }
-caliptra-emu-cpu = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "7af98ba805fd7cd59a747accd80625f87b639966" }
-caliptra-emu-derive = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "7af98ba805fd7cd59a747accd80625f87b639966" }
-caliptra-emu-periph = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "7af98ba805fd7cd59a747accd80625f87b639966" }
-caliptra-emu-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "7af98ba805fd7cd59a747accd80625f87b639966" }
-caliptra-error = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "7af98ba805fd7cd59a747accd80625f87b639966", default-features = false }
-caliptra-hw-model = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "7af98ba805fd7cd59a747accd80625f87b639966" }
-caliptra-hw-model-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "7af98ba805fd7cd59a747accd80625f87b639966" }
-caliptra-image-crypto = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "7af98ba805fd7cd59a747accd80625f87b639966", default-features = false, features = ["rustcrypto"] }
-caliptra-image-fake-keys = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "7af98ba805fd7cd59a747accd80625f87b639966" }
-caliptra-image-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "7af98ba805fd7cd59a747accd80625f87b639966" }
-caliptra-image-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "7af98ba805fd7cd59a747accd80625f87b639966" }
-caliptra-registers = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "7af98ba805fd7cd59a747accd80625f87b639966" }
-caliptra-test = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "7af98ba805fd7cd59a747accd80625f87b639966" }
-caliptra-test-harness-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "7af98ba805fd7cd59a747accd80625f87b639966" }
-ureg = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "7af98ba805fd7cd59a747accd80625f87b639966" }
-dpe = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "7af98ba805fd7cd59a747accd80625f87b639966", default-features = false, features = ["dpe_profile_p384_sha384"] }
+caliptra-api = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ffac6e51131cf0b96651a72c3be205702ac55210" }
+caliptra-api-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ffac6e51131cf0b96651a72c3be205702ac55210" }
+caliptra-auth-man-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ffac6e51131cf0b96651a72c3be205702ac55210" }
+caliptra-auth-man-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ffac6e51131cf0b96651a72c3be205702ac55210" }
+caliptra-builder = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ffac6e51131cf0b96651a72c3be205702ac55210" }
+caliptra-emu-bus = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ffac6e51131cf0b96651a72c3be205702ac55210" }
+caliptra-emu-cpu = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ffac6e51131cf0b96651a72c3be205702ac55210" }
+caliptra-emu-derive = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ffac6e51131cf0b96651a72c3be205702ac55210" }
+caliptra-emu-periph = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ffac6e51131cf0b96651a72c3be205702ac55210" }
+caliptra-emu-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ffac6e51131cf0b96651a72c3be205702ac55210" }
+caliptra-error = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ffac6e51131cf0b96651a72c3be205702ac55210", default-features = false }
+caliptra-hw-model = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ffac6e51131cf0b96651a72c3be205702ac55210" }
+caliptra-hw-model-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ffac6e51131cf0b96651a72c3be205702ac55210" }
+caliptra-image-crypto = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ffac6e51131cf0b96651a72c3be205702ac55210", default-features = false, features = ["rustcrypto"] }
+caliptra-image-fake-keys = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ffac6e51131cf0b96651a72c3be205702ac55210" }
+caliptra-image-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ffac6e51131cf0b96651a72c3be205702ac55210" }
+caliptra-image-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ffac6e51131cf0b96651a72c3be205702ac55210" }
+caliptra-registers = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ffac6e51131cf0b96651a72c3be205702ac55210" }
+caliptra-test = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ffac6e51131cf0b96651a72c3be205702ac55210" }
+caliptra-test-harness-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ffac6e51131cf0b96651a72c3be205702ac55210" }
+ureg = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ffac6e51131cf0b96651a72c3be205702ac55210" }
+dpe = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ffac6e51131cf0b96651a72c3be205702ac55210", default-features = false, features = ["dpe_profile_p384_sha384"] }
 
 # local caliptra dependency; useful when developing
 # caliptra-api = { path = "../caliptra-sw/api" }

--- a/platforms/emulator/config/src/flash.rs
+++ b/platforms/emulator/config/src/flash.rs
@@ -52,7 +52,7 @@ pub struct FlashDeviceConfig {
     pub partitions: &'static [&'static FlashPartition], // partitions on the flash device
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub struct FlashPartition {
     pub name: &'static str, // name of the partition
     pub offset: usize,      // flash partition offset in bytes

--- a/rom/src/fw_hitless_update.rs
+++ b/rom/src/fw_hitless_update.rs
@@ -28,9 +28,12 @@ impl BootFlow for FwHitlessUpdate {
 
         // Create local references to minimize code changes
         let soc_manager = &mut env.soc_manager;
+        let soc = &env.soc;
 
         // Release mailbox from activate command before device reboot
         soc_manager.soc_mbox().execute().write(|w| w.execute(false));
+
+        while !soc.fw_ready() {}
 
         // Jump to firmware
         romtime::println!("[mcu-rom] Jumping to firmware");

--- a/runtime/userspace/api/caliptra-api/src/firmware_update/pldm_context.rs
+++ b/runtime/userspace/api/caliptra-api/src/firmware_update/pldm_context.rs
@@ -4,6 +4,7 @@ use core::cell::RefCell;
 
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_sync::blocking_mutex::Mutex;
+use pldm_common::message::firmware_update::apply_complete::ApplyResult;
 use pldm_common::message::firmware_update::get_fw_params::FirmwareParameters;
 use pldm_common::message::firmware_update::verify_complete::VerifyResult;
 use pldm_common::protocol::firmware_update::Descriptor;
@@ -16,6 +17,9 @@ pub enum State {
     Initialized,
     DownloadingImage,
     ImageDownloadComplete,
+    Verifying,
+    Apply,
+    Activate,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -26,6 +30,7 @@ pub struct DownloadCtx<'a> {
     pub total_downloaded: usize,
     pub last_requested_length: usize,
     pub verify_result: VerifyResult,
+    pub apply_result: ApplyResult,
     pub descriptors: Option<&'a [Descriptor]>,
     pub fw_params: Option<&'a FirmwareParameters>,
     pub staging_memory: Option<&'a dyn StagingMemory>,
@@ -38,6 +43,7 @@ pub static DOWNLOAD_CTX: Mutex<CriticalSectionRawMutex, RefCell<DownloadCtx>> =
         initial_offset: 0,
         total_downloaded: 0,
         verify_result: VerifyResult::VerifySuccess,
+        apply_result: ApplyResult::ApplySuccess,
         last_requested_length: 0,
         descriptors: None,
         fw_params: None,


### PR DESCRIPTION
Verify the firmware package after downloading the firmware update package from the PLDM update agent and before activating the images.

Steps:

1. Download the firmware package to MCU
2. Parse the components of the package
3. Verify the SOC manifest through mailbox command (without setting it in Caliptra)
4. Verify the downloaded MCU image by getting sha384 of image and comparing it with downloaded Manifest's SHA.
4. Verify the downloaded SOC images by getting sha384 of images and comparing it with downloaded Manifest's SHAs.
5. Verify and Activate Caliptra fw using FIRMWARE_LOAD mbox command.
6. Activate MCU FW using Hitless Update Reset
7. After boot, set the downloaded manifest to Caliptra using SET_AUTH_MANIFEST mbox command
8. Use image loading to load the rest of the SOC images from the staging partition.

This change relies on the new VERIFY_MANIFEST mailbox command that allows verifying the SOC manifest without activating it in Caliptra.

Also fixed a bug in the ROM for FW Hitless Update flow, the flow didn't wait for Caliptra to set the EXEC_CTRL[2] before jumping to MCU RT.