### PR TITLE
Eliminate recursion in flash tests

### DIFF
--- a/platforms/emulator/runtime/src/board.rs
+++ b/platforms/emulator/runtime/src/board.rs
@@ -88,34 +88,12 @@ pub static mut PROCESS_PRINTER: Option<
     &'static capsules_system::process_printer::ProcessPrinterText,
 > = None;
 
-#[cfg(any(
-    feature = "test-flash-ctrl-read-write-page",
-    feature = "test-flash-ctrl-erase-page",
-    feature = "test-flash-storage-read-write",
-    feature = "test-flash-storage-erase",
-    feature = "test-log-flash-linear",
-    feature = "test-log-flash-circular"
-))]
+// used in tests
+#[allow(unused)]
 static mut BOARD: Option<&'static kernel::Kernel> = None;
-
-#[cfg(any(
-    feature = "test-flash-ctrl-read-write-page",
-    feature = "test-flash-ctrl-erase-page",
-    feature = "test-flash-storage-read-write",
-    feature = "test-flash-storage-erase",
-    feature = "test-log-flash-linear",
-    feature = "test-log-flash-circular"
-))]
+#[allow(unused)]
 static mut PLATFORM: Option<&'static VeeR> = None;
-
-#[cfg(any(
-    feature = "test-flash-ctrl-read-write-page",
-    feature = "test-flash-ctrl-erase-page",
-    feature = "test-flash-storage-read-write",
-    feature = "test-flash-storage-erase",
-    feature = "test-log-flash-linear",
-    feature = "test-log-flash-circular"
-))]
+#[allow(unused)]
 static mut MAIN_CAP: Option<&dyn kernel::capabilities::MainLoopCapability> = None;
 
 // How should the kernel respond when a process faults.
@@ -779,14 +757,7 @@ pub unsafe fn main() {
     board_kernel.kernel_loop(veer, chip, None::<&kernel::ipc::IPC<0>>, &main_loop_cap);
 }
 
-#[cfg(any(
-    feature = "test-flash-ctrl-read-write-page",
-    feature = "test-flash-ctrl-erase-page",
-    feature = "test-flash-storage-read-write",
-    feature = "test-flash-storage-erase",
-    feature = "test-log-flash-linear",
-    feature = "test-log-flash-circular"
-))]
+#[allow(unused)]
 pub fn run_kernel_op(loops: usize) {
     unsafe {
         for _i in 0..loops {

--- a/platforms/emulator/runtime/src/interrupts.rs
+++ b/platforms/emulator/runtime/src/interrupts.rs
@@ -25,7 +25,7 @@ pub struct EmulatorPeripherals<'a> {
 impl<'a> EmulatorPeripherals<'a> {
     pub fn new(alarm: &'a MuxAlarm<'a, InternalTimers<'a>>) -> Self {
         Self {
-            uart: SemihostUart::new(alarm),
+            uart: SemihostUart::new(),
             primary_flash_ctrl: flash_driver::flash_ctrl::EmulatedFlashCtrl::new(
                 flash_driver::flash_ctrl::PRIMARY_FLASH_CTRL_BASE,
             ),


### PR DESCRIPTION
The flash tests were written with recursive calls to `run()`, which
calls `kernel_loop()`, which calls `alarm()`, which calls operations,
which in turn call `run()`, etc.

This would overflow the stack.

I'm not sure why this wouldn't happen before the prompt fix (also
included); probably something to do with how the alarms were scheduled
if there was another alarm to be processed?

Includes #323 