### PR TITLE
Add integration tests for Firmware Update

### DIFF
--- a/emulator/cbinding/src/simple_test.rs
+++ b/emulator/cbinding/src/simple_test.rs
@@ -47,7 +47,7 @@ fn test_emulator_args_creation() {
         i3c_port: None,
         manufacturing_mode: false,
         vendor_pk_hash: None,
-        vendor_pqc_type: FwVerificationPqcKeyType::LMS.into(),
+        vendor_pqc_type: FwVerificationPqcKeyType::LMS,
         owner_pk_hash: None,
         streaming_boot: None,
         primary_flash_image: None,


### PR DESCRIPTION
Added the following integration tests:

1. Missing Caliptra image in the PLDM FW package
2. Invalid SoC Manifest
3. Invalid MCU image
4. Invalid SOC image