### PR TITLE
CI: Do not vendor OpenSSL crate

### DIFF
--- a/.github/workflows/fpga.yml
+++ b/.github/workflows/fpga.yml
@@ -13,11 +13,20 @@ jobs:
       SCCACHE_GHA_CACHE_TO: sccache-caliptra-mcu-sw
       SCCACHE_GHA_CACHE_FROM: sccache-caliptra-mcu-sw
       SCCACHE_GHA_ENABLED: "on"
+      # Change this to a new random value if you suspect the cache is corrupted
+      CACHE_BUSTER: 9ff0ac869868
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
         with:
           submodules: 'true'
+          
+      - name: Install cross compiler
+        run: |
+          sudo apt-get update -qy && sudo apt-get install -y gcc-aarch64-linux-gnu squashfs-tools
+          rustup toolchain install 1.84-x86_64-unknown-linux-gnu
+          rustup target add riscv32imc-unknown-none-elf
+          rustup target add aarch64-unknown-linux-gnu
 
       - name: Restore sccache binary
         uses: actions/cache/restore@v3
@@ -49,30 +58,88 @@ jobs:
             core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
             core.exportVariable('ACTIONS_CACHE_SERVICE_V2', 'on');
-          
-      - name: Install cross compiler
+
+      - name: Restore openssl from cache
+        uses: actions/cache/restore@v3
+        id: restore_openssl_cache
+        with:
+          path: /tmp/openssl.tar
+          key: openssl-${{ env.CACHE_BUSTER }}
+
+      - name: Extract openssl
+        if: "steps.restore_openssl_cache.outputs.cache-hit"
         run: |
-          sudo apt-get update -qy && sudo apt-get install -y gcc-aarch64-linux-gnu squashfs-tools
-          rustup toolchain install 1.84-x86_64-unknown-linux-gnu
-          rustup target add riscv32imc-unknown-none-elf
-          rustup target add aarch64-unknown-linux-gnu
+          sudo tar -xvPf /tmp/openssl.tar
+
+      - name: Build OpenSSL
+        if: "!steps.restore_openssl_cache.outputs.cache-hit"
+        run: |
+          curl -L "https://github.com/openssl/openssl/releases/download/openssl-3.5.2/openssl-3.5.2.tar.gz" -o openssl.tar.gz
+          OPENSSL_SHA256="c53a47e5e441c930c3928cf7bf6fb00e5d129b630e0aa873b08258656e7345ec"
+          if ! (echo "${OPENSSL_SHA256} openssl.tar.gz" | sha256sum -c); then
+            echo "OpenSSL tarball was an unexpected hash."
+            exit 1
+          fi
+
+          tar -xvf openssl.tar.gz
+
+          # For some reason make clean is not fully cleaning up the previous build
+          # so create a duplicate folder
+          cp -r openssl-3.5.2 openssl-3.5.2-arm
+  
+          pushd openssl-3.5.2
+          ./config no-shared no-apps no-quic
+          make -j8 build_sw
+          popd
+
+          pushd openssl-3.5.2-arm
+          export CROSS_COMPILE="aarch64-linux-gnu-"
+          ./config linux-aarch64 no-shared no-apps no-quic --cross-compile-prefix="${CROSS_COMPILE}"
+          make -j8 build_sw
+          popd
+
+          mkdir -p /tmp/openssl/native/lib
+          mv openssl-3.5.2/include /tmp/openssl/native/include
+          mv openssl-3.5.2/libcrypto.a /tmp/openssl/native/lib
+          mv openssl-3.5.2/libssl.a /tmp/openssl/native/lib
+
+          mkdir -p /tmp/openssl/arm/lib
+          mv openssl-3.5.2-arm/include /tmp/openssl/arm/include
+          mv openssl-3.5.2-arm/libcrypto.a /tmp/openssl/arm/lib
+          mv openssl-3.5.2-arm/libssl.a /tmp/openssl/arm/lib
+
+          sudo tar cvf /tmp/openssl.tar -P /tmp/openssl
+
+      - name: Save openssl to cache
+        if: "!steps.restore_openssl_cache.outputs.cache-hit"
+        uses: actions/cache/save@v3
+        with:
+          path: /tmp/openssl.tar
+          key: openssl-${{ env.CACHE_BUSTER }}
 
       - name: Build test firmware
         run: |
-          # Build ROM and runtime binaries
-          cargo xtask all-build --platform fpga
-          sccache --show-stats
+          # In the CI we really want to avoid lengthy build steps.
+          # Vendoring OpenSSL is a huge time sink, and instead linking a prebuilt
+          # OpenSSL reduces build speeds.
+          export OPENSSL_NO_VENDOR=true
+          export OPENSSL_STATIC=true
+          export X86_64_UNKNOWN_LINUX_GNU_OPENSSL_DIR=/tmp/openssl/native
+          export AARCH64_UNKNOWN_LINUX_GNU_OPENSSL_DIR=/tmp/openssl/arm
 
-          # Cross compile xtask for the ARM core
+          # Cross compile for the ARM core
           export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER="aarch64-linux-gnu-gcc"
-          cargo build -p xtask --features fpga_realtime --target aarch64-unknown-linux-gnu
+
+          # Build ROM and runtime binaries
+          echo "Cross compiling FPGA binaries"
+          cargo xtask-fpga all-build --platform fpga
           sccache --show-stats
 
           mkdir -p /tmp/caliptra-binaries
           tar -cvz -f /tmp/caliptra-binaries/caliptra-binaries.tar.gz \
-            target/aarch64-unknown-linux-gnu/debug/xtask \
             target/all-fw.zip
 
+          echo "Cross compiling test binaries"
           FEATURES="fpga_realtime"
           cargo nextest archive \
             --features=${FEATURES} \
@@ -130,11 +197,6 @@ jobs:
           echo mount squashfs
           sudo mount /tmp/caliptra-test-binaries.sqsh/caliptra-test-binaries.sqsh /tmp/caliptra-test-binaries -t squashfs -o loop
           find /tmp/caliptra-test-binaries
-
-      # - name: Execute FPGA Boot flow
-      #   run: |
-      #     export RUST_BACKTRACE=1
-      #     sudo ./target/aarch64-unknown-linux-gnu/debug/xtask fpga-run --zip target/all-fw.zip
 
       - name: Execute tests
         run: |


### PR DESCRIPTION
Also removed the extra `xtask` build.

This reduces the wall clock time for the FPGA tests significantly. Now cross-compiling should take ~5-6 mins with a warm cache.