### PR TITLE
[tooling] add shell scripting for deploying FPGA tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ test_certs
 
 # ld scripts
 layout.ld
+
+# Zstandard Archives (e.g. cargo nextest test archive)
+**/*.tar.zst

--- a/hw/fpga/util/README.md
+++ b/hw/fpga/util/README.md
@@ -1,0 +1,40 @@
+# Overview
+
+This subdir provides tools for building, deploying, and running caliptra-mcu-sw tests on the Versal FPGA board.
+
+# Prerequsites
+
+To use this tool flow, we assume you have the following pre-configured.
+
+### Hardware and SSH Setup
+1. a Versal FPGA board setup with ssh access,
+2. an SSH configuration file with `mcu-host` as the hostname for the FPGA board, and
+3. docker installed.
+
+### Docker Image Build
+
+We use a Docker container to perform cross-compilations of FPGA (Rust) test harness since the FPGA board is running Ubuntu22.04 and may have different system dependency (e.g., glibc) versions than your host workstation.
+
+To build the Docker image run:
+```sh
+docker build -t caliptra-fpga-builder:latest hw/fpga/util/cross-compiling
+```
+
+# Test Build and Deployment Flow
+
+The CaliptraSS FPGA tests can be cross-compiled for the FPGA board and copied to the board by running the following:
+
+1. Cross-compile FPGA tests for FPGA's ARM core and copy them to the FPGA board:
+`./hw/fpga/util/build-and-deploy-tests-to-fpga.sh`
+
+2. SSH to FPGA board: `ssh mcu-host`
+
+3. Navigate to user destination dir that files were copied to: `cd ${HOME}/<dst>`
+
+4. Run the FPGA tests.
+   a. Run all tests:
+   `./run-fpga-tests.sh -d <dst dir in ${HOME}/>`
+   a. Run a specific test (`-t` option):
+   `./run-fpga-tests.sh -d <dst dir in ${HOME}/> -t model_fpga_realtime::test::test_new_unbooted`
+   b. List all available tests (`-l` option):
+   `./run-fpga-tests.sh -d <dst dir in ${HOME}/> -l`

--- a/hw/fpga/util/build-and-deploy-tests-to-fpga.sh
+++ b/hw/fpga/util/build-and-deploy-tests-to-fpga.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Licensed under the Apache-2.0 license
+
+# Cross compile the tests for the FPGA environment.
+docker run --rm -t \
+  -v "${HOME}/.cargo/registry/cache:/root/.cargo/registry/cache" \
+  -v "${HOME}/.cargo/git:/root/.cargo/git"  \
+  -v "${PWD}":/work-dir \
+  -w "/work-dir" \
+  caliptra-fpga:latest \
+  /bin/bash \
+  -c "./hw/fpga/util/cross-compiling/build-fpga-tests.sh"
+
+# Copy the tests to the FPGA board.
+./hw/fpga/util/fpga/copy-fpga-tests-to-board.sh

--- a/hw/fpga/util/copy-fpga-tests-to-board.sh
+++ b/hw/fpga/util/copy-fpga-tests-to-board.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Licensed under the Apache-2.0 license
+
+rsync -avzP \
+  target/all-fw.zip \
+  target/aarch64-unknown-linux-gnu/debug/xtask \
+  caliptra-test-bins.tar.zst \
+  "hw/fpga/util/run-fpga-tests.sh" \
+  mcu-host:"$USER"

--- a/hw/fpga/util/cross-compiling/Dockerfile
+++ b/hw/fpga/util/cross-compiling/Dockerfile
@@ -1,0 +1,12 @@
+# Licensed under the Apache-2.0 license
+FROM ubuntu:22.04
+
+# Install build tools.
+RUN apt update && apt install gcc git curl make gcc-aarch64-linux-gnu  -y
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+RUN rustup target add riscv32imc-unknown-none-elf && rustup target add aarch64-unknown-linux-gnu
+RUN cargo install cargo-nextest
+
+# Always trust the working directory where the git repo will be mounted.
+RUN git config --global --add safe.directory /work-dir

--- a/hw/fpga/util/cross-compiling/build-fpga-tests.sh
+++ b/hw/fpga/util/cross-compiling/build-fpga-tests.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Licensed under the Apache-2.0 license
+
+# Build all Caliptra[SS] ROM and Runtime firmware for the FPGA platform.
+cargo xtask-fpga all-build --platform fpga
+
+# Build build xtask binary for the FPGA's ARM core.
+export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER="aarch64-linux-gnu-gcc"
+cargo build -p xtask --features fpga_realtime --target aarch64-unknown-linux-gnu
+
+# Build all test binaries and archive them into a file.
+cargo nextest archive \
+  --features="fpga_realtime" \
+  --release \
+  --target=aarch64-unknown-linux-gnu \
+  --archive-file=caliptra-test-bins.tar.zst

--- a/hw/fpga/util/run-fpga-tests.sh
+++ b/hw/fpga/util/run-fpga-tests.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Licensed under the Apache-2.0 license
+
+export RUST_BACKTRACE=1
+export RUST_TEST_THREADS=1
+
+# Parse command line args.
+DEST_DIR=""
+LIST_TESTS=false
+RUN_SPECIFIC_TEST=""
+while getopts "d:l:t:" opt; do
+  case ${opt} in
+    d )
+      DEST_DIR="$OPTARG"
+      ;;
+    l )
+      LIST_TESTS=true
+      ;;
+    t )
+      RUN_SPECIFIC_TEST="$OPTARG"
+      ;;
+    \? )
+      echo "Invalid option: -$OPTARG" 1>&2
+      exit 1
+      ;;
+  esac
+done
+
+# Check destination dir provided.
+if [ -z "$DEST_DIR" ]; then
+  echo "Usage: ./run-fpga-tests.sh -d <destination dir> -t <test>"
+  exit 1
+fi
+
+# List / execute tests.
+COMMON_ARGS=(
+    --archive-file="${HOME}/${DEST_DIR}/caliptra-test-bins.tar.zst"
+    --workspace-remap=.
+    -E 'package(mcu-hw-model) - test(model_emulated::test::test_new_unbooted)'
+    -E 'package(tests-integration)'
+)
+cd "${HOME}/caliptra-mcu-sw"
+if [ "$LIST_TESTS" = true ]; then
+  # Only list tests if requested.
+  sudo cargo-nextest nextest list "${COMMON_ARGS[@]}"
+else
+  # Run the tests.
+  sudo CPTRA_FIRMWARE_BUNDLE="${HOME}/${DEST_DIR}/all-fw.zip" \
+    cargo-nextest nextest run \
+      "${COMMON_ARGS[@]}" \
+      --test-threads=${RUST_TEST_THREADS} \
+      --status-level=all \
+      --no-fail-fast \
+      --profile=nightly \
+      --success-output=immediate \
+      "$RUN_SPECIFIC_TEST"
+fi


### PR DESCRIPTION
This add tooling for building, deploying, and running FPGA tests on the Versal FPGA board. This demonstrates how to cross compile tests (on a more power host machine) before copying them to the FPGA to be dispatched.