### PR TITLE
FPGA Xtask changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ layout.ld
 
 # Zstandard Archives (e.g. cargo nextest test archive)
 **/*.tar.zst
+**/*.zip
+
+cross-target/

--- a/docs/src/fpga.md
+++ b/docs/src/fpga.md
@@ -17,6 +17,8 @@ The FPGA should have the following installed:
 
 - rsync
 - git
+- make
+- gcc
 
 **Suggestion**: Download the latest FPGA Image from the Caliptra-SW main-2.x branch's FPGA Image build [job](https://github.com/chipsalliance/caliptra-sw/actions/workflows/fpga-image.yml?query=branch%3Amain-2.x). This ensures you are testing with the same system used in the FPGA CI.
 

--- a/docs/src/fpga.md
+++ b/docs/src/fpga.md
@@ -1,28 +1,74 @@
-# Running with an FPGA
+# Testing with an FPGA
+
+## Pre Requisites
+
+### Host System 
+
+The machine that is used for development and cross compilation should have:
+
+- Rust
+- Docker
+- rsync
+- git
+
+### FPGA System 
+
+The FPGA should have the following installed:
+
+- rsync
+- git
+
+**Suggestion**: Download the latest FPGA Image from the Caliptra-SW main-2.x branch's FPGA Image build [job](https://github.com/chipsalliance/caliptra-sw/actions/workflows/fpga-image.yml?query=branch%3Amain-2.x). This ensures you are testing with the same system used in the FPGA CI.
+
+## Suggested Development Flow
+
+Prefer to develop on your main machine and use xtask to test your changes on the FPGA via ssh.
+
+### Setup SSH config
+
+xtask will access the FPGA over SSH. You will need an SSH config to define how to do this.
+
+This config should be added to `~/.ssh/config`.
+
+```
+Host <FPGA-NAME> # Update me!
+  Hostname <FPGA-IP-ADDRESS> # Update me!
+  User ubuntu # Use "root" on CI image.
+
+```
 
 ## Cross compiling
 
-### Linux binaries
+### Firmware
 
-You can use [`cross-rs`](https://github.com/cross-rs/cross) to make it easier to cross compile binaries for the FPGA host.
+Run `cargo xtask-fpga fpga build --target-host $SSH-FPGA-NAME` to create a firmware bundle. Using the `--target-host` flag will automatically copy the firmware to the FPGA host.
 
-For example,
+This command should be re-run after making any firmware changes.
 
-```shell
-CARGO_BUILD_TARGET=aarch64-unknown-linux-gnu CARGO_TARGET_DIR=target/build/aarch64-unknown-linux-gnu cross build -p xtask --features fpga_realtime --bin xtask --target=aarch64-unknown-linux-gnu
+### Test Binaries
+
+Run `cargo xtask-fpga fpga build-test --target-host $SSH-FPGA-NAME` to create a test archive. Using the `--target-host` flag will automatically copy the test binaries to the FPGA host.
+
+This command should be re-run after making any test changes.
+
+## FPGA bootstrap
+
+The FPGA needs to be bootstrapped each time it is booted. This ensures that the kernel modules we use in this repo are present.
+
+Run `cargo xtask-fpga fpga bootstrap --target-host $SSH-FPGA-NAME` to bootstrap the FPGA.
+
+# Test Workflow
+
+A developer verifying changes against an FPGA should use the following sequence.
+
+```
+$ cargo xtask-fpga fpga bootstrap --target-host $SSH-FPGA-NAME # Run this only once per boot.
+$ cargo xtask-fpga fpga build --target-host $SSH-FPGA-NAME # Build firmware. Re-run every time firmware changes.
+$ cargo xtask-fpga fpga build-test --target-host $SSH-FPGA-NAME # Build test binaries. Re-run every time tests change.
+$ cargo xtask-fpga fpga test --target-host $SSH-FPGA-NAME # Run test suite on FPGA.
 ```
 
-will build the a binary that runs `xtask` that can be used on the FPGA, which can then be used to install the FPGA kernel modules (assuming the `caliptra-mcu-sw` repository is checked out and the `xtask` binary is renamed to `xtask-bin`):
-
-```shell
-./xtask-bin fpga-install-kernel-modules
-```
-
-or to run a set of ROMs and firmware:
-
-```shell
-./xtask-bin fpga-run --zip all-fw.zip
-```
+# Running on FPGA
 
 ### Firmware files
 

--- a/xtask/src/fpga.rs
+++ b/xtask/src/fpga.rs
@@ -1,71 +1,176 @@
 // Licensed under the Apache-2.0 license
 
 use anyhow::{anyhow, bail, Result};
+use clap::Subcommand;
 use mcu_builder::{FirmwareBinaries, PROJECT_ROOT};
 use mcu_hw_model::{InitParams, McuHwModel, ModelFpgaRealtime};
 use mcu_rom_common::LifecycleControllerState;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::str::FromStr;
 
-pub fn fpga_install_kernel_modules() -> Result<()> {
-    let dir = &PROJECT_ROOT.join("hw").join("fpga").join("kernel-modules");
+#[derive(Subcommand)]
+pub(crate) enum Fpga {
+    /// Bootstraps an FPGA. This command should be run after each boot
+    // TODO(clundin): Refactor this command to run over ssh.
+    Bootstrap {
+        #[arg(long)]
+        target_host: Option<String>,
+    },
+    /// Run firmware on Fpga
+    /// NOTE: THIS COMMAND HAS NOT YET BEEN TESTED
+    // TODO(clundin): Refactor this command to run over ssh.
+    Run {
+        /// ZIP with all images.
+        #[arg(long)]
+        zip: Option<PathBuf>,
 
-    disable_all_cpus_idle()?;
+        /// Where to load the MCU ROM from.
+        #[arg(long)]
+        mcu_rom: Option<PathBuf>,
 
-    // need to wrap it in bash so that the current_dir is propagated to make correctly
-    if !Command::new("bash")
-        .args(["-c", "make"])
-        .current_dir(dir)
-        .status()
-        .expect("Failed to build modules")
-        .success()
-    {
-        bail!("Failed to build modules");
+        /// Where to load the Caliptra ROM from.
+        #[arg(long)]
+        caliptra_rom: Option<PathBuf>,
+
+        /// Where to load and save OTP memory.
+        #[arg(long)]
+        otp: Option<PathBuf>,
+
+        /// Save OTP memory to a file after running.
+        #[arg(long, default_value_t = false)]
+        save_otp: bool,
+
+        /// Run UDS provisioning flow
+        #[arg(long, default_value_t = false)]
+        uds: bool,
+
+        /// Number of "steps" to run the FPGA before stopping
+        #[arg(long, default_value_t = 1_000_000)]
+        steps: u64,
+
+        /// Whether to disable the recovery interface and I3C
+        #[arg(long, default_value_t = false)]
+        no_recovery: bool,
+
+        /// Lifecycle controller state to set (raw, test_unlocked0, manufacturing, prod, etc.).
+        #[arg(long)]
+        lifecycle: Option<String>,
+    },
+    /// Build FPGA firmware
+    Build {
+        /// When set copy firmware to `target_host`
+        #[arg(long)]
+        target_host: Option<String>,
+    },
+    /// Build FPGA test binaries
+    BuildTest {
+        /// When copy test binaries to `target_host`
+        #[arg(long)]
+        target_host: Option<String>,
+    },
+    /// Run FPGA tests
+    Test {
+        /// When set run commands over ssh to `target_host`
+        #[arg(long)]
+        target_host: Option<String>,
+        // TODO(clundin): Add support for passing in test filter
+    },
+}
+
+// Copies a file to FPGA over rsync to the FPGA home folder.
+fn rsync_file(target_host: &str, file: &str, from_fpga: bool) -> Result<()> {
+    // TODO(clundin): We assume are files are dropped in the root / home folder. May want to find a
+    // put things in their own directory.
+    let copy = if from_fpga {
+        format!("{target_host}:{file}")
+    } else {
+        format!("{target_host}:.")
+    };
+    let args = if from_fpga {
+        ["-avxz", &copy, file]
+    } else {
+        ["-avxz", file, &copy]
+    };
+    let status = Command::new("rsync")
+        .current_dir(&*PROJECT_ROOT)
+        .args(args)
+        .status()?;
+    if !status.success() {
+        bail!("failed rsync file: {file} to {target_host}");
     }
+    Ok(())
+}
 
-    if !is_module_loaded("uio")? {
-        sudo::escalate_if_needed().map_err(|e| anyhow!("{}", e))?;
-        if !Command::new("modprobe")
-            .arg("uio")
-            .status()
-            .expect("Could not load uio kernel module")
-            .success()
-        {
-            bail!("Could not load uio kernel module");
+/// Runs a command over SSH if `target_host` is `Some`. Otherwise runs command on current machine.
+fn run_command_with_output(
+    target_host: Option<&str>,
+    command: &str,
+) -> Result<std::process::Output> {
+    // TODO(clundin): Refactor to share code with `run_command`
+    if let Some(target_host) = target_host {
+        Ok(Command::new("ssh")
+            .current_dir(&*PROJECT_ROOT)
+            .args([target_host, "-t", command])
+            .output()?)
+    } else {
+        let mut command = command.split_whitespace();
+        Ok(Command::new(command.next().expect("Expected a command"))
+            .current_dir(&*PROJECT_ROOT)
+            .args(command)
+            .output()?)
+    }
+}
+
+/// Runs a command over SSH if `target_host` is `Some`. Otherwise runs command on current machine.
+fn run_command(target_host: Option<&str>, command: &str) -> Result<()> {
+    if let Some(target_host) = target_host {
+        println!("[FPGA HOST] Running command: {command}");
+        let status = Command::new("ssh")
+            .current_dir(&*PROJECT_ROOT)
+            .args([target_host, "-t", command])
+            .status()?;
+        if !status.success() {
+            bail!("\"{command}\" failed to run on FPGA over ssh");
+        }
+    } else {
+        println!("Running command: {command}");
+        let mut command = command.split_whitespace();
+        let status = Command::new(command.next().expect("Expected a command"))
+            .current_dir(&*PROJECT_ROOT)
+            .args(command)
+            .status()?;
+        if !status.success() {
+            bail!("Failed to run command");
         }
     }
-
-    for module in [
-        "io_module",
-        "rom_backdoor_class",
-        "caliptra_rom_backdoor",
-        "mcu_rom_backdoor",
-    ] {
-        let module_path = dir.join(format!("{}.ko", module));
-        if !module_path.exists() {
-            bail!("Module {} not found", module_path.display());
-        }
-        if is_module_loaded(module)? {
-            println!("Module {} already loaded", module);
-            continue;
-        }
-
-        sudo::escalate_if_needed().map_err(|e| anyhow!("{}", e))?;
-        if !Command::new("insmod")
-            .arg(module_path.to_str().unwrap())
-            .status()?
-            .success()
-        {
-            bail!("Failed to insert module {}", module_path.display());
-        }
-    }
-
-    fix_permissions()?;
 
     Ok(())
 }
 
+pub fn fpga_install_kernel_modules(target_host: Option<&str>) -> Result<()> {
+    // TODO(clundin): Port this over SSH and then re-enable.
+    // disable_all_cpus_idle()?;
+
+    // Make file assumes we are in the same directory.
+    // TODO(clundin): Need to test this, the Ubuntu FPGA is in a bad state and seems to not be able
+    // to build kernel modules.
+    run_command(
+        target_host,
+        "(cd caliptra-mcu-sw/hw/fpga/kernel-modules && make)",
+    )?;
+    run_command(
+        target_host,
+        "sudo insmod caliptra-mcu-sw/hw/fpga/kernel-modules/io_module.ko",
+    )?;
+
+    // TODO(clundin): Port this over SSH and then re-enable.
+    // fix_permissions()?;
+
+    Ok(())
+}
+
+#[allow(dead_code)]
 fn disable_all_cpus_idle() -> Result<()> {
     println!("Disabling idle on CPUs");
     let mut cpu = 0;
@@ -75,6 +180,7 @@ fn disable_all_cpus_idle() -> Result<()> {
     Ok(())
 }
 
+#[allow(dead_code)]
 fn disable_cpu_idle(cpu: usize) -> Result<()> {
     sudo::escalate_if_needed().map_err(|e| anyhow!("{}", e))?;
     let cpu_sysfs = format!("/sys/devices/system/cpu/cpu{}/cpuidle/state1/disable", cpu);
@@ -93,6 +199,7 @@ fn disable_cpu_idle(cpu: usize) -> Result<()> {
     Ok(())
 }
 
+#[allow(dead_code)]
 fn fix_permissions() -> Result<()> {
     let uio_path = Path::new("/dev/uio0");
     if uio_path.exists() {
@@ -121,6 +228,7 @@ fn fix_permissions() -> Result<()> {
     Ok(())
 }
 
+#[allow(dead_code)]
 fn is_module_loaded(module: &str) -> Result<bool> {
     let output = Command::new("lsmod").output()?;
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -129,6 +237,75 @@ fn is_module_loaded(module: &str) -> Result<bool> {
         .any(|line| line.split_whitespace().next() == Some(module)))
 }
 
+pub(crate) fn fpga_entry(args: &Fpga) -> Result<()> {
+    match args {
+        Fpga::Build { target_host } => {
+            println!("Building FPGA firmware");
+            // TODO(clundin): Modify `mcu_builder::all_build` to return the zip instead of writing it?
+            // TODO(clundin): Place FPGA xtask artifacts in a specific folder?
+            mcu_builder::all_build(Some("all-fw.zip"), Some("fpga"), false, None, None)?;
+
+            // We want to copy the zip to the FPGA if `target_host` is specified.
+            if let Some(target_host) = target_host {
+                rsync_file(&target_host, "all-fw.zip", false)?;
+            }
+        }
+        Fpga::BuildTest { target_host } => {
+            println!("Building FPGA test");
+            // Build test binaries in a docker container
+            let home = std::env::var("HOME").unwrap();
+            let project_root = PROJECT_ROOT.clone();
+            let project_root = project_root.display();
+
+            // TODO(clundin): Clean this docker command up.
+            Command::new("docker")
+                .current_dir(&*PROJECT_ROOT)
+                .args(["run", "--rm", &format!("-v{project_root}:/work-dir"), "-w/work-dir", &format!("-v{home}/.cargo/registry:/root/.cargo/registry"), &format!("-v{home}/.cargo/git:/root/.cargo/git"), "ghcr.io/chipsalliance/caliptra-build-image:latest", "/bin/bash", "-c", "(cd /work-dir && echo 'Cross compiling tests' && CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc cargo nextest archive --features=fpga_realtime --target=aarch64-unknown-linux-gnu --archive-file=caliptra-test-binaries.tar.zst --target-dir cross-target/ )"])
+                .status()?;
+
+            if let Some(target_host) = target_host {
+                rsync_file(target_host, "caliptra-test-binaries.tar.zst", false)?;
+            }
+        }
+        Fpga::Bootstrap { target_host } => {
+            println!("Bootstrapping FPGA");
+            let hostname = run_command_with_output(target_host.as_deref(), "hostname")?;
+            let hostname = String::from_utf8(hostname.stdout).expect("Failed to parse hostname");
+
+            // skip this step for CI images. Kernel modules are already installed.
+            if hostname.trim_end() != "caliptra-fpga" {
+                fpga_install_kernel_modules(target_host.as_deref())?;
+            }
+
+            // Need to clone caliptra-mcu-sw to run tests.
+            // TODO(clundin): Maybe we can skip recurse-submodules. Also should check if the repo
+            // exists to make errors easier.
+            run_command(target_host.as_deref(), "git clone https://github.com/chipsalliance/caliptra-mcu-sw --branch=main --recurse-submodules").expect("failed to clone caliptra-mcu-sw repo");
+        }
+        Fpga::Test { target_host } => {
+            println!("Running test suite on FPGA");
+            // Clear old test logs
+            run_command(target_host.as_deref(), "(sudo rm /tmp/junit.xml || true)")?;
+            // Run caliptra-mcu-sw test suite.
+            // Ignore error so we still copy the logs.
+            let _ = run_command(target_host.as_deref(), "(cd caliptra-mcu-sw && \
+                sudo CPTRA_FIRMWARE_BUNDLE=\"${HOME}/all-fw.zip\" \
+                cargo-nextest nextest run \
+                --workspace-remap=. --archive-file $HOME/caliptra-test-binaries.tar.zst \
+                -E \"package(mcu-hw-model) - test(model_emulated::test::test_new_unbooted)\" --test-threads=1 --no-fail-fast --profile=nightly)");
+
+            if let Some(target_host) = target_host {
+                println!("Copying test log from FPGA to junit.xml");
+                rsync_file(target_host, "/tmp/junit.xml", true)?;
+            }
+        }
+        _ => todo!("implement this command"),
+    }
+
+    Ok(())
+}
+
+// TODO(clundin): Refactor to match rest of module
 pub(crate) fn fpga_run(args: crate::Commands) -> Result<()> {
     let crate::Commands::FpgaRun {
         zip,
@@ -148,7 +325,7 @@ pub(crate) fn fpga_run(args: crate::Commands) -> Result<()> {
     let recovery = !no_recovery;
 
     if !Path::new("/dev/uio0").exists() {
-        fpga_install_kernel_modules()?;
+        fpga_install_kernel_modules(None)?;
     }
     if mcu_rom.is_none() && zip.is_none() {
         bail!("Must specify either --mcu-rom or --zip");


### PR DESCRIPTION
This change adds:

* Add subcommand to manage FPGA life cycle.
* Add command to run tests on an FPGA over SSH.
* Add command to build and copy firmware to FPGA.
* Add command to build and copy test binaries to FPGA.
* Add command to bootstrap FPGA.

I plan to do more clean up / feature work, but this should help folks quickly iterate on FPGA tests.