### PR TITLE
Update caliptra-sw reference.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,7 +268,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 [[package]]
 name = "caliptra-api"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2d5582aba8ae25027d8437dcf0c51299985198e1#2d5582aba8ae25027d8437dcf0c51299985198e1"
 dependencies = [
  "bitflags 2.9.1",
  "caliptra-api-types",
@@ -283,7 +283,7 @@ dependencies = [
 [[package]]
 name = "caliptra-api-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2d5582aba8ae25027d8437dcf0c51299985198e1#2d5582aba8ae25027d8437dcf0c51299985198e1"
 dependencies = [
  "caliptra-image-types",
 ]
@@ -291,7 +291,7 @@ dependencies = [
 [[package]]
 name = "caliptra-auth-man-gen"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2d5582aba8ae25027d8437dcf0c51299985198e1#2d5582aba8ae25027d8437dcf0c51299985198e1"
 dependencies = [
  "anyhow",
  "bitflags 2.9.1",
@@ -306,7 +306,7 @@ dependencies = [
 [[package]]
 name = "caliptra-auth-man-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2d5582aba8ae25027d8437dcf0c51299985198e1#2d5582aba8ae25027d8437dcf0c51299985198e1"
 dependencies = [
  "bitfield",
  "bitflags 2.9.1",
@@ -321,7 +321,7 @@ dependencies = [
 [[package]]
 name = "caliptra-builder"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2d5582aba8ae25027d8437dcf0c51299985198e1#2d5582aba8ae25027d8437dcf0c51299985198e1"
 dependencies = [
  "anyhow",
  "caliptra-image-crypto",
@@ -346,7 +346,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cfi-derive"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2d5582aba8ae25027d8437dcf0c51299985198e1#2d5582aba8ae25027d8437dcf0c51299985198e1"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -368,7 +368,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cfi-lib"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2d5582aba8ae25027d8437dcf0c51299985198e1#2d5582aba8ae25027d8437dcf0c51299985198e1"
 dependencies = [
  "caliptra-error",
  "caliptra-registers",
@@ -383,7 +383,7 @@ source = "git+https://github.com/chipsalliance/caliptra-cfi.git?rev=a98e499d279e
 [[package]]
 name = "caliptra-coverage"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2d5582aba8ae25027d8437dcf0c51299985198e1#2d5582aba8ae25027d8437dcf0c51299985198e1"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -401,7 +401,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cpu"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2d5582aba8ae25027d8437dcf0c51299985198e1#2d5582aba8ae25027d8437dcf0c51299985198e1"
 dependencies = [
  "caliptra-drivers",
  "caliptra-registers",
@@ -411,7 +411,7 @@ dependencies = [
 [[package]]
 name = "caliptra-drivers"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2d5582aba8ae25027d8437dcf0c51299985198e1#2d5582aba8ae25027d8437dcf0c51299985198e1"
 dependencies = [
  "arrayvec",
  "bitfield",
@@ -437,7 +437,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-bus"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2d5582aba8ae25027d8437dcf0c51299985198e1#2d5582aba8ae25027d8437dcf0c51299985198e1"
 dependencies = [
  "caliptra-emu-types",
  "tock-registers",
@@ -447,7 +447,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-cpu"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2d5582aba8ae25027d8437dcf0c51299985198e1#2d5582aba8ae25027d8437dcf0c51299985198e1"
 dependencies = [
  "bit-vec",
  "bitfield",
@@ -461,7 +461,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2d5582aba8ae25027d8437dcf0c51299985198e1#2d5582aba8ae25027d8437dcf0c51299985198e1"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -476,7 +476,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-derive"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2d5582aba8ae25027d8437dcf0c51299985198e1#2d5582aba8ae25027d8437dcf0c51299985198e1"
 dependencies = [
  "caliptra-emu-bus",
  "caliptra-emu-types",
@@ -487,7 +487,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-periph"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2d5582aba8ae25027d8437dcf0c51299985198e1#2d5582aba8ae25027d8437dcf0c51299985198e1"
 dependencies = [
  "aes",
  "arrayref",
@@ -514,17 +514,17 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2d5582aba8ae25027d8437dcf0c51299985198e1#2d5582aba8ae25027d8437dcf0c51299985198e1"
 
 [[package]]
 name = "caliptra-error"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2d5582aba8ae25027d8437dcf0c51299985198e1#2d5582aba8ae25027d8437dcf0c51299985198e1"
 
 [[package]]
 name = "caliptra-gen-linker-scripts"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2d5582aba8ae25027d8437dcf0c51299985198e1#2d5582aba8ae25027d8437dcf0c51299985198e1"
 dependencies = [
  "caliptra_common",
 ]
@@ -532,7 +532,7 @@ dependencies = [
 [[package]]
 name = "caliptra-hw-model"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2d5582aba8ae25027d8437dcf0c51299985198e1#2d5582aba8ae25027d8437dcf0c51299985198e1"
 dependencies = [
  "bit-vec",
  "bitfield",
@@ -558,7 +558,7 @@ dependencies = [
 [[package]]
 name = "caliptra-hw-model-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2d5582aba8ae25027d8437dcf0c51299985198e1#2d5582aba8ae25027d8437dcf0c51299985198e1"
 dependencies = [
  "caliptra-api-types",
  "rand",
@@ -567,7 +567,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2d5582aba8ae25027d8437dcf0c51299985198e1#2d5582aba8ae25027d8437dcf0c51299985198e1"
 dependencies = [
  "anyhow",
  "caliptra-image-gen",
@@ -587,7 +587,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-elf"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2d5582aba8ae25027d8437dcf0c51299985198e1#2d5582aba8ae25027d8437dcf0c51299985198e1"
 dependencies = [
  "anyhow",
  "caliptra-image-gen",
@@ -598,7 +598,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-fake-keys"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2d5582aba8ae25027d8437dcf0c51299985198e1#2d5582aba8ae25027d8437dcf0c51299985198e1"
 dependencies = [
  "caliptra-image-gen",
  "caliptra-image-types",
@@ -609,7 +609,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-gen"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2d5582aba8ae25027d8437dcf0c51299985198e1#2d5582aba8ae25027d8437dcf0c51299985198e1"
 dependencies = [
  "anyhow",
  "bitflags 2.9.1",
@@ -626,7 +626,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2d5582aba8ae25027d8437dcf0c51299985198e1#2d5582aba8ae25027d8437dcf0c51299985198e1"
 dependencies = [
  "caliptra-cfi-derive",
  "caliptra-cfi-lib",
@@ -642,7 +642,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-verify"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2d5582aba8ae25027d8437dcf0c51299985198e1#2d5582aba8ae25027d8437dcf0c51299985198e1"
 dependencies = [
  "bitflags 2.9.1",
  "caliptra-cfi-derive",
@@ -657,7 +657,7 @@ dependencies = [
 [[package]]
 name = "caliptra-kat"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2d5582aba8ae25027d8437dcf0c51299985198e1#2d5582aba8ae25027d8437dcf0c51299985198e1"
 dependencies = [
  "caliptra-drivers",
  "caliptra-lms-types",
@@ -669,7 +669,7 @@ dependencies = [
 [[package]]
 name = "caliptra-lms-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2d5582aba8ae25027d8437dcf0c51299985198e1#2d5582aba8ae25027d8437dcf0c51299985198e1"
 dependencies = [
  "caliptra-cfi-derive",
  "caliptra-cfi-lib",
@@ -682,7 +682,7 @@ dependencies = [
 [[package]]
 name = "caliptra-registers"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2d5582aba8ae25027d8437dcf0c51299985198e1#2d5582aba8ae25027d8437dcf0c51299985198e1"
 dependencies = [
  "caliptra-registers-latest",
 ]
@@ -690,7 +690,7 @@ dependencies = [
 [[package]]
 name = "caliptra-registers-latest"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2d5582aba8ae25027d8437dcf0c51299985198e1#2d5582aba8ae25027d8437dcf0c51299985198e1"
 dependencies = [
  "ureg",
 ]
@@ -698,7 +698,7 @@ dependencies = [
 [[package]]
 name = "caliptra-runtime"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2d5582aba8ae25027d8437dcf0c51299985198e1#2d5582aba8ae25027d8437dcf0c51299985198e1"
 dependencies = [
  "arrayvec",
  "bitfield",
@@ -731,7 +731,7 @@ dependencies = [
 [[package]]
 name = "caliptra-test"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2d5582aba8ae25027d8437dcf0c51299985198e1#2d5582aba8ae25027d8437dcf0c51299985198e1"
 dependencies = [
  "anyhow",
  "asn1",
@@ -763,12 +763,12 @@ dependencies = [
 [[package]]
 name = "caliptra-test-harness-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2d5582aba8ae25027d8437dcf0c51299985198e1#2d5582aba8ae25027d8437dcf0c51299985198e1"
 
 [[package]]
 name = "caliptra-x509"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2d5582aba8ae25027d8437dcf0c51299985198e1#2d5582aba8ae25027d8437dcf0c51299985198e1"
 dependencies = [
  "zeroize",
 ]
@@ -776,7 +776,7 @@ dependencies = [
 [[package]]
 name = "caliptra_common"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2d5582aba8ae25027d8437dcf0c51299985198e1#2d5582aba8ae25027d8437dcf0c51299985198e1"
 dependencies = [
  "bitfield",
  "bitflags 2.9.1",
@@ -1212,7 +1212,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2d5582aba8ae25027d8437dcf0c51299985198e1#2d5582aba8ae25027d8437dcf0c51299985198e1"
 dependencies = [
  "arrayvec",
  "caliptra-cfi-derive-git",
@@ -1403,7 +1403,7 @@ dependencies = [
 [[package]]
 name = "dpe"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2d5582aba8ae25027d8437dcf0c51299985198e1#2d5582aba8ae25027d8437dcf0c51299985198e1"
 dependencies = [
  "bitflags 2.9.1",
  "caliptra-cfi-derive-git",
@@ -3112,7 +3112,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 [[package]]
 name = "platform"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2d5582aba8ae25027d8437dcf0c51299985198e1#2d5582aba8ae25027d8437dcf0c51299985198e1"
 dependencies = [
  "arrayvec",
  "cfg-if",
@@ -4220,7 +4220,7 @@ dependencies = [
 [[package]]
 name = "ureg"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=63a2a36b7dd79538c3e7aae722856c5cf42359b7#63a2a36b7dd79538c3e7aae722856c5cf42359b7"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=2d5582aba8ae25027d8437dcf0c51299985198e1#2d5582aba8ae25027d8437dcf0c51299985198e1"
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -203,28 +203,28 @@ libtock_small_panic = { path = "runtime/userspace/libtock/panic_handlers/small_p
 libtock_unittest = { path = "runtime/userspace/libtock/unittest" }
 
 # caliptra dependencies; keep git revs in sync
-caliptra-api = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "63a2a36b7dd79538c3e7aae722856c5cf42359b7" }
-caliptra-api-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "63a2a36b7dd79538c3e7aae722856c5cf42359b7" }
-caliptra-auth-man-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "63a2a36b7dd79538c3e7aae722856c5cf42359b7" }
-caliptra-auth-man-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "63a2a36b7dd79538c3e7aae722856c5cf42359b7" }
-caliptra-builder = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "63a2a36b7dd79538c3e7aae722856c5cf42359b7" }
-caliptra-emu-bus = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "63a2a36b7dd79538c3e7aae722856c5cf42359b7" }
-caliptra-emu-cpu = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "63a2a36b7dd79538c3e7aae722856c5cf42359b7" }
-caliptra-emu-derive = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "63a2a36b7dd79538c3e7aae722856c5cf42359b7" }
-caliptra-emu-periph = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "63a2a36b7dd79538c3e7aae722856c5cf42359b7" }
-caliptra-emu-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "63a2a36b7dd79538c3e7aae722856c5cf42359b7" }
-caliptra-error = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "63a2a36b7dd79538c3e7aae722856c5cf42359b7", default-features = false }
-caliptra-hw-model = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "63a2a36b7dd79538c3e7aae722856c5cf42359b7" }
-caliptra-hw-model-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "63a2a36b7dd79538c3e7aae722856c5cf42359b7" }
-caliptra-image-crypto = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "63a2a36b7dd79538c3e7aae722856c5cf42359b7", default-features = false, features = ["rustcrypto"] }
-caliptra-image-fake-keys = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "63a2a36b7dd79538c3e7aae722856c5cf42359b7" }
-caliptra-image-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "63a2a36b7dd79538c3e7aae722856c5cf42359b7" }
-caliptra-image-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "63a2a36b7dd79538c3e7aae722856c5cf42359b7" }
-caliptra-registers = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "63a2a36b7dd79538c3e7aae722856c5cf42359b7" }
-caliptra-test = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "63a2a36b7dd79538c3e7aae722856c5cf42359b7" }
-caliptra-test-harness-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "63a2a36b7dd79538c3e7aae722856c5cf42359b7" }
-ureg = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "63a2a36b7dd79538c3e7aae722856c5cf42359b7" }
-dpe = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "63a2a36b7dd79538c3e7aae722856c5cf42359b7", default-features = false, features = ["dpe_profile_p384_sha384"] }
+caliptra-api = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "2d5582aba8ae25027d8437dcf0c51299985198e1" }
+caliptra-api-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "2d5582aba8ae25027d8437dcf0c51299985198e1" }
+caliptra-auth-man-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "2d5582aba8ae25027d8437dcf0c51299985198e1" }
+caliptra-auth-man-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "2d5582aba8ae25027d8437dcf0c51299985198e1" }
+caliptra-builder = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "2d5582aba8ae25027d8437dcf0c51299985198e1" }
+caliptra-emu-bus = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "2d5582aba8ae25027d8437dcf0c51299985198e1" }
+caliptra-emu-cpu = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "2d5582aba8ae25027d8437dcf0c51299985198e1" }
+caliptra-emu-derive = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "2d5582aba8ae25027d8437dcf0c51299985198e1" }
+caliptra-emu-periph = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "2d5582aba8ae25027d8437dcf0c51299985198e1" }
+caliptra-emu-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "2d5582aba8ae25027d8437dcf0c51299985198e1" }
+caliptra-error = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "2d5582aba8ae25027d8437dcf0c51299985198e1", default-features = false }
+caliptra-hw-model = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "2d5582aba8ae25027d8437dcf0c51299985198e1" }
+caliptra-hw-model-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "2d5582aba8ae25027d8437dcf0c51299985198e1" }
+caliptra-image-crypto = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "2d5582aba8ae25027d8437dcf0c51299985198e1", default-features = false, features = ["rustcrypto"] }
+caliptra-image-fake-keys = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "2d5582aba8ae25027d8437dcf0c51299985198e1" }
+caliptra-image-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "2d5582aba8ae25027d8437dcf0c51299985198e1" }
+caliptra-image-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "2d5582aba8ae25027d8437dcf0c51299985198e1" }
+caliptra-registers = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "2d5582aba8ae25027d8437dcf0c51299985198e1" }
+caliptra-test = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "2d5582aba8ae25027d8437dcf0c51299985198e1" }
+caliptra-test-harness-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "2d5582aba8ae25027d8437dcf0c51299985198e1" }
+ureg = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "2d5582aba8ae25027d8437dcf0c51299985198e1" }
+dpe = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "2d5582aba8ae25027d8437dcf0c51299985198e1", default-features = false, features = ["dpe_profile_p384_sha384"] }
 
 # local caliptra dependency; useful when developing
 # caliptra-api = { path = "../caliptra-sw/api" }


### PR DESCRIPTION
Overflows MCU SRAM when updating to p 2360 or later in caliptra-sw. Either the SRAM size is set too small or the MCU firmware image is too big. It is panicking [here](https://github.com/chipsalliance/caliptra-sw/blob/1cc9e5db651feb496f554e9e51759ccc41d1506e/sw-emulator/lib/periph/src/dma/axi_root_bus.rs#L275) because the image it is receiving from the recovery interface is 0x45000 bytes which is 20480 bytes more than the SRAM size of 0x40000.