### PR TITLE
Pass SoC Manifest SVN fuse values to Caliptra

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,7 +268,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 [[package]]
 name = "caliptra-api"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=bd4018def905092763143ccbda06e7973cd3b56b#bd4018def905092763143ccbda06e7973cd3b56b"
 dependencies = [
  "bitflags 2.9.1",
  "caliptra-api-types",
@@ -283,7 +283,7 @@ dependencies = [
 [[package]]
 name = "caliptra-api-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=bd4018def905092763143ccbda06e7973cd3b56b#bd4018def905092763143ccbda06e7973cd3b56b"
 dependencies = [
  "caliptra-image-types",
 ]
@@ -291,7 +291,7 @@ dependencies = [
 [[package]]
 name = "caliptra-auth-man-gen"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=bd4018def905092763143ccbda06e7973cd3b56b#bd4018def905092763143ccbda06e7973cd3b56b"
 dependencies = [
  "anyhow",
  "bitflags 2.9.1",
@@ -306,7 +306,7 @@ dependencies = [
 [[package]]
 name = "caliptra-auth-man-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=bd4018def905092763143ccbda06e7973cd3b56b#bd4018def905092763143ccbda06e7973cd3b56b"
 dependencies = [
  "bitfield",
  "bitflags 2.9.1",
@@ -321,7 +321,7 @@ dependencies = [
 [[package]]
 name = "caliptra-builder"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=bd4018def905092763143ccbda06e7973cd3b56b#bd4018def905092763143ccbda06e7973cd3b56b"
 dependencies = [
  "anyhow",
  "caliptra-image-crypto",
@@ -346,7 +346,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cfi-derive"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=bd4018def905092763143ccbda06e7973cd3b56b#bd4018def905092763143ccbda06e7973cd3b56b"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -368,7 +368,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cfi-lib"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=bd4018def905092763143ccbda06e7973cd3b56b#bd4018def905092763143ccbda06e7973cd3b56b"
 dependencies = [
  "caliptra-error",
  "caliptra-registers",
@@ -383,7 +383,7 @@ source = "git+https://github.com/chipsalliance/caliptra-cfi.git?rev=a98e499d279e
 [[package]]
 name = "caliptra-coverage"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=bd4018def905092763143ccbda06e7973cd3b56b#bd4018def905092763143ccbda06e7973cd3b56b"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -401,7 +401,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cpu"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=bd4018def905092763143ccbda06e7973cd3b56b#bd4018def905092763143ccbda06e7973cd3b56b"
 dependencies = [
  "caliptra-drivers",
  "caliptra-registers",
@@ -411,7 +411,7 @@ dependencies = [
 [[package]]
 name = "caliptra-drivers"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=bd4018def905092763143ccbda06e7973cd3b56b#bd4018def905092763143ccbda06e7973cd3b56b"
 dependencies = [
  "arrayvec",
  "bitfield",
@@ -437,7 +437,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-bus"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=bd4018def905092763143ccbda06e7973cd3b56b#bd4018def905092763143ccbda06e7973cd3b56b"
 dependencies = [
  "caliptra-emu-types",
  "tock-registers",
@@ -447,7 +447,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-cpu"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=bd4018def905092763143ccbda06e7973cd3b56b#bd4018def905092763143ccbda06e7973cd3b56b"
 dependencies = [
  "bit-vec",
  "bitfield",
@@ -461,7 +461,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=bd4018def905092763143ccbda06e7973cd3b56b#bd4018def905092763143ccbda06e7973cd3b56b"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -476,7 +476,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-derive"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=bd4018def905092763143ccbda06e7973cd3b56b#bd4018def905092763143ccbda06e7973cd3b56b"
 dependencies = [
  "caliptra-emu-bus",
  "caliptra-emu-types",
@@ -487,7 +487,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-periph"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=bd4018def905092763143ccbda06e7973cd3b56b#bd4018def905092763143ccbda06e7973cd3b56b"
 dependencies = [
  "aes",
  "arrayref",
@@ -514,17 +514,17 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=bd4018def905092763143ccbda06e7973cd3b56b#bd4018def905092763143ccbda06e7973cd3b56b"
 
 [[package]]
 name = "caliptra-error"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=bd4018def905092763143ccbda06e7973cd3b56b#bd4018def905092763143ccbda06e7973cd3b56b"
 
 [[package]]
 name = "caliptra-gen-linker-scripts"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=bd4018def905092763143ccbda06e7973cd3b56b#bd4018def905092763143ccbda06e7973cd3b56b"
 dependencies = [
  "caliptra_common",
 ]
@@ -532,7 +532,7 @@ dependencies = [
 [[package]]
 name = "caliptra-hw-model"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=bd4018def905092763143ccbda06e7973cd3b56b#bd4018def905092763143ccbda06e7973cd3b56b"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -562,7 +562,7 @@ dependencies = [
 [[package]]
 name = "caliptra-hw-model-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=bd4018def905092763143ccbda06e7973cd3b56b#bd4018def905092763143ccbda06e7973cd3b56b"
 dependencies = [
  "caliptra-api-types",
  "rand",
@@ -571,7 +571,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=bd4018def905092763143ccbda06e7973cd3b56b#bd4018def905092763143ccbda06e7973cd3b56b"
 dependencies = [
  "anyhow",
  "caliptra-image-gen",
@@ -591,7 +591,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-elf"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=bd4018def905092763143ccbda06e7973cd3b56b#bd4018def905092763143ccbda06e7973cd3b56b"
 dependencies = [
  "anyhow",
  "caliptra-image-gen",
@@ -602,7 +602,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-fake-keys"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=bd4018def905092763143ccbda06e7973cd3b56b#bd4018def905092763143ccbda06e7973cd3b56b"
 dependencies = [
  "caliptra-image-gen",
  "caliptra-image-types",
@@ -613,7 +613,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-gen"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=bd4018def905092763143ccbda06e7973cd3b56b#bd4018def905092763143ccbda06e7973cd3b56b"
 dependencies = [
  "anyhow",
  "bitflags 2.9.1",
@@ -630,7 +630,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=bd4018def905092763143ccbda06e7973cd3b56b#bd4018def905092763143ccbda06e7973cd3b56b"
 dependencies = [
  "caliptra-cfi-derive",
  "caliptra-cfi-lib",
@@ -646,7 +646,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-verify"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=bd4018def905092763143ccbda06e7973cd3b56b#bd4018def905092763143ccbda06e7973cd3b56b"
 dependencies = [
  "bitflags 2.9.1",
  "caliptra-cfi-derive",
@@ -661,7 +661,7 @@ dependencies = [
 [[package]]
 name = "caliptra-kat"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=bd4018def905092763143ccbda06e7973cd3b56b#bd4018def905092763143ccbda06e7973cd3b56b"
 dependencies = [
  "caliptra-drivers",
  "caliptra-lms-types",
@@ -673,7 +673,7 @@ dependencies = [
 [[package]]
 name = "caliptra-lms-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=bd4018def905092763143ccbda06e7973cd3b56b#bd4018def905092763143ccbda06e7973cd3b56b"
 dependencies = [
  "caliptra-cfi-derive",
  "caliptra-cfi-lib",
@@ -686,7 +686,7 @@ dependencies = [
 [[package]]
 name = "caliptra-registers"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=bd4018def905092763143ccbda06e7973cd3b56b#bd4018def905092763143ccbda06e7973cd3b56b"
 dependencies = [
  "caliptra-registers-latest",
 ]
@@ -694,7 +694,7 @@ dependencies = [
 [[package]]
 name = "caliptra-registers-latest"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=bd4018def905092763143ccbda06e7973cd3b56b#bd4018def905092763143ccbda06e7973cd3b56b"
 dependencies = [
  "ureg",
 ]
@@ -702,7 +702,7 @@ dependencies = [
 [[package]]
 name = "caliptra-runtime"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=bd4018def905092763143ccbda06e7973cd3b56b#bd4018def905092763143ccbda06e7973cd3b56b"
 dependencies = [
  "arrayvec",
  "bitfield",
@@ -735,7 +735,7 @@ dependencies = [
 [[package]]
 name = "caliptra-test"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=bd4018def905092763143ccbda06e7973cd3b56b#bd4018def905092763143ccbda06e7973cd3b56b"
 dependencies = [
  "anyhow",
  "asn1",
@@ -767,12 +767,12 @@ dependencies = [
 [[package]]
 name = "caliptra-test-harness-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=bd4018def905092763143ccbda06e7973cd3b56b#bd4018def905092763143ccbda06e7973cd3b56b"
 
 [[package]]
 name = "caliptra-x509"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=bd4018def905092763143ccbda06e7973cd3b56b#bd4018def905092763143ccbda06e7973cd3b56b"
 dependencies = [
  "zeroize",
 ]
@@ -780,7 +780,7 @@ dependencies = [
 [[package]]
 name = "caliptra_common"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=bd4018def905092763143ccbda06e7973cd3b56b#bd4018def905092763143ccbda06e7973cd3b56b"
 dependencies = [
  "bitfield",
  "bitflags 2.9.1",
@@ -1216,7 +1216,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=bd4018def905092763143ccbda06e7973cd3b56b#bd4018def905092763143ccbda06e7973cd3b56b"
 dependencies = [
  "arrayvec",
  "caliptra-cfi-derive-git",
@@ -1407,7 +1407,7 @@ dependencies = [
 [[package]]
 name = "dpe"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=bd4018def905092763143ccbda06e7973cd3b56b#bd4018def905092763143ccbda06e7973cd3b56b"
 dependencies = [
  "bitflags 2.9.1",
  "caliptra-cfi-derive-git",
@@ -3116,7 +3116,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 [[package]]
 name = "platform"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=bd4018def905092763143ccbda06e7973cd3b56b#bd4018def905092763143ccbda06e7973cd3b56b"
 dependencies = [
  "arrayvec",
  "cfg-if",
@@ -4204,7 +4204,7 @@ dependencies = [
 [[package]]
 name = "ureg"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=bd4018def905092763143ccbda06e7973cd3b56b#bd4018def905092763143ccbda06e7973cd3b56b"
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -203,28 +203,28 @@ libtock_small_panic = { path = "runtime/userspace/libtock/panic_handlers/small_p
 libtock_unittest = { path = "runtime/userspace/libtock/unittest" }
 
 # caliptra dependencies; keep git revs in sync
-caliptra-api = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d" }
-caliptra-api-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d" }
-caliptra-auth-man-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d" }
-caliptra-auth-man-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d" }
-caliptra-builder = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d" }
-caliptra-emu-bus = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d" }
-caliptra-emu-cpu = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d" }
-caliptra-emu-derive = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d" }
-caliptra-emu-periph = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d" }
-caliptra-emu-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d" }
-caliptra-error = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d", default-features = false }
-caliptra-hw-model = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d" }
-caliptra-hw-model-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d" }
-caliptra-image-crypto = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d", default-features = false, features = ["rustcrypto"] }
-caliptra-image-fake-keys = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d" }
-caliptra-image-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d" }
-caliptra-image-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d" }
-caliptra-registers = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d" }
-caliptra-test = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d" }
-caliptra-test-harness-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d" }
-ureg = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d" }
-dpe = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d", default-features = false, features = ["dpe_profile_p384_sha384"] }
+caliptra-api = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "bd4018def905092763143ccbda06e7973cd3b56b" }
+caliptra-api-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "bd4018def905092763143ccbda06e7973cd3b56b" }
+caliptra-auth-man-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "bd4018def905092763143ccbda06e7973cd3b56b" }
+caliptra-auth-man-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "bd4018def905092763143ccbda06e7973cd3b56b" }
+caliptra-builder = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "bd4018def905092763143ccbda06e7973cd3b56b" }
+caliptra-emu-bus = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "bd4018def905092763143ccbda06e7973cd3b56b" }
+caliptra-emu-cpu = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "bd4018def905092763143ccbda06e7973cd3b56b" }
+caliptra-emu-derive = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "bd4018def905092763143ccbda06e7973cd3b56b" }
+caliptra-emu-periph = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "bd4018def905092763143ccbda06e7973cd3b56b" }
+caliptra-emu-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "bd4018def905092763143ccbda06e7973cd3b56b" }
+caliptra-error = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "bd4018def905092763143ccbda06e7973cd3b56b", default-features = false }
+caliptra-hw-model = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "bd4018def905092763143ccbda06e7973cd3b56b" }
+caliptra-hw-model-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "bd4018def905092763143ccbda06e7973cd3b56b" }
+caliptra-image-crypto = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "bd4018def905092763143ccbda06e7973cd3b56b", default-features = false, features = ["rustcrypto"] }
+caliptra-image-fake-keys = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "bd4018def905092763143ccbda06e7973cd3b56b" }
+caliptra-image-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "bd4018def905092763143ccbda06e7973cd3b56b" }
+caliptra-image-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "bd4018def905092763143ccbda06e7973cd3b56b" }
+caliptra-registers = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "bd4018def905092763143ccbda06e7973cd3b56b" }
+caliptra-test = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "bd4018def905092763143ccbda06e7973cd3b56b" }
+caliptra-test-harness-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "bd4018def905092763143ccbda06e7973cd3b56b" }
+ureg = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "bd4018def905092763143ccbda06e7973cd3b56b" }
+dpe = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "bd4018def905092763143ccbda06e7973cd3b56b", default-features = false, features = ["dpe_profile_p384_sha384"] }
 
 # local caliptra dependency; useful when developing
 # caliptra-api = { path = "../caliptra-sw/api" }

--- a/builder/src/all.rs
+++ b/builder/src/all.rs
@@ -122,6 +122,7 @@ pub fn all_build(
         Some(mcu_runtime.into()),
         None,
         None,
+        None,
     );
     let caliptra_rom = caliptra_builder.get_caliptra_rom()?;
     let caliptra_fw = caliptra_builder.get_caliptra_fw()?;

--- a/emulator/cbinding/src/lib.rs
+++ b/emulator/cbinding/src/lib.rs
@@ -333,6 +333,8 @@ pub unsafe extern "C" fn emulator_init(
         otp_size: convert_optional_offset_size(config.otp_size),
         lc_offset: convert_optional_offset_size(config.lc_offset),
         lc_size: convert_optional_offset_size(config.lc_size),
+        fuse_soc_manifest_svn: None,
+        fuse_soc_manifest_max_svn: None,
     };
 
     // Convert C callbacks to Rust callbacks if provided

--- a/emulator/cbinding/src/simple_test.rs
+++ b/emulator/cbinding/src/simple_test.rs
@@ -86,6 +86,8 @@ fn test_emulator_args_creation() {
         otp_size: None,
         lc_offset: None,
         lc_size: None,
+        fuse_soc_manifest_max_svn: None,
+        fuse_soc_manifest_svn: None,
     };
 
     println!("EmulatorArgs created successfully");

--- a/emulator/periph/src/lib.rs
+++ b/emulator/periph/src/lib.rs
@@ -41,7 +41,7 @@ pub use mci::Mci;
 pub use mcu_mbox0::{
     MciMailboxRequester, McuMailbox0External, McuMailbox0Internal, MCU_MAILBOX0_SRAM_SIZE,
 };
-pub use otp::Otp;
+pub use otp::{Otp, OtpArgs};
 pub use otp_digest::{otp_digest, otp_scramble, otp_unscramble};
 pub use reset_reason::ResetReasonEmulator;
 pub use root_bus::{McuRootBus, McuRootBusArgs, McuRootBusOffsets};

--- a/hw/model/src/lib.rs
+++ b/hw/model/src/lib.rs
@@ -417,12 +417,31 @@ fn reg_access_test() {
             mcu_rom: &binaries.mcu_rom,
             vendor_pk_hash: binaries.vendor_pk_hash(),
             active_mode: true,
+            vendor_pqc_type: Some(FwVerificationPqcKeyType::LMS),
             ..Default::default()
         },
         BootParams {
             fw_image: Some(&binaries.caliptra_fw),
             soc_manifest: Some(&binaries.soc_manifest),
             mcu_fw_image: Some(&binaries.mcu_runtime),
+            fuses: Fuses {
+                fuse_pqc_key_type: FwVerificationPqcKeyType::LMS as u32,
+                vendor_pk_hash: {
+                    let mut vendor_pk_hash = [0u32; 12];
+                    binaries
+                        .vendor_pk_hash()
+                        .unwrap()
+                        .chunks(4)
+                        .enumerate()
+                        .for_each(|(i, chunk)| {
+                            let mut array = [0u8; 4];
+                            array.copy_from_slice(chunk);
+                            vendor_pk_hash[i] = u32::from_be_bytes(array);
+                        });
+                    vendor_pk_hash
+                },
+                ..Default::default()
+            },
             ..Default::default()
         },
     )

--- a/hw/model/src/model_emulated.rs
+++ b/hw/model/src/model_emulated.rs
@@ -31,7 +31,7 @@ use caliptra_image_types::FwVerificationPqcKeyType;
 use caliptra_image_types::IMAGE_MANIFEST_BYTE_SIZE;
 use emulator_periph::McuRootBusOffsets;
 use emulator_periph::{
-    I3c, I3cController, Mci, McuMailbox0Internal, McuRootBus, McuRootBusArgs, Otp,
+    I3c, I3cController, Mci, McuMailbox0Internal, McuRootBus, McuRootBusArgs, Otp, OtpArgs,
 };
 use emulator_registers_generated::root_bus::AutoRootBus;
 use mcu_config::McuMemoryMap;
@@ -216,13 +216,14 @@ impl McuHwModel for ModelEmulated {
 
         let otp = Otp::new(
             &clock.clone(),
-            None,
-            Some(otp_mem),
-            None,
-            params.vendor_pk_hash,
-            params
-                .vendor_pqc_type
-                .unwrap_or(FwVerificationPqcKeyType::LMS),
+            OtpArgs {
+                raw_memory: Some(otp_mem),
+                vendor_pk_hash: params.vendor_pk_hash,
+                vendor_pqc_type: params
+                    .vendor_pqc_type
+                    .unwrap_or(FwVerificationPqcKeyType::LMS),
+                ..Default::default()
+            },
         )?;
         let ext_mci = root_bus.mci_external_regs();
         let mci_irq = pic.register_irq(McuRootBus::MCI_IRQ);
@@ -499,6 +500,7 @@ mod test {
             None,
             None,
             Some(mcu_rom.clone().into()),
+            None,
             None,
             None,
         );

--- a/rom/src/cold_boot.rs
+++ b/rom/src/cold_boot.rs
@@ -229,7 +229,13 @@ impl BootFlow for ColdBoot {
         mci.set_flow_status(McuRomBootStatus::FuseWriteComplete.into());
 
         romtime::println!("[mcu-rom] Waiting for Caliptra to be ready for mbox",);
-        while !soc.ready_for_mbox() {}
+        while !soc.ready_for_mbox() {
+            if soc.cptra_fw_fatal_error() {
+                romtime::println!("[mcu-rom] Caliptra reported a fatal error");
+                fatal_error(3);
+            }
+        }
+
         romtime::println!("[mcu-rom] Caliptra is ready for mailbox commands",);
         mci.set_flow_status(McuRomBootStatus::CaliptraReadyForMailbox.into());
 
@@ -288,7 +294,12 @@ impl BootFlow for ColdBoot {
         }
 
         romtime::println!("[mcu-rom] Waiting for firmware to be ready");
-        while !soc.fw_ready() {}
+        while !soc.fw_ready() {
+            if soc.cptra_fw_fatal_error() {
+                romtime::println!("[mcu-rom] Caliptra reported a fatal error");
+                fatal_error(6);
+            }
+        }
         romtime::println!("[mcu-rom] Firmware is ready");
         mci.set_flow_status(McuRomBootStatus::FirmwareReadyDetected.into());
 

--- a/tests/integration/src/lib.rs
+++ b/tests/integration/src/lib.rs
@@ -82,6 +82,8 @@ mod test {
         secondary_flash_image_path: Option<PathBuf>,
         caliptra_builder: Option<CaliptraBuilder>,
         hw_revision: Option<String>,
+        fuse_soc_manifest_svn: Option<u8>,
+        fuse_soc_manifest_max_svn: Option<u8>,
     ) -> ExitStatus {
         let mut cargo_run_args = vec![
             "run",
@@ -179,6 +181,7 @@ mod test {
                 Some(runtime_path.clone()),
                 soc_images,
                 None,
+                None,
             )
         };
 
@@ -234,6 +237,20 @@ mod test {
                 cargo_run_args.push(secondary_flash_image.to_str().unwrap());
             }
 
+            let soc_manifest_svn_str;
+            if let Some(soc_manifest_svn) = fuse_soc_manifest_svn {
+                cargo_run_args.push("--fuse-soc-manifest-svn");
+                soc_manifest_svn_str = soc_manifest_svn.to_string();
+                cargo_run_args.push(soc_manifest_svn_str.as_str());
+            }
+
+            let soc_manifest_max_svn_str;
+            if let Some(soc_manifest_max_svn) = fuse_soc_manifest_max_svn {
+                cargo_run_args.push("--fuse-soc-manifest-max-svn");
+                soc_manifest_max_svn_str = soc_manifest_max_svn.to_string();
+                cargo_run_args.push(soc_manifest_max_svn_str.as_str());
+            }
+
             println!("Running test firmware {}", feature.replace("_", "-"));
             let mut cmd = Command::new("cargo");
             let cmd = cmd.args(&cargo_run_args).current_dir(&*PROJECT_ROOT);
@@ -261,6 +278,8 @@ mod test {
             i3c_port,
             true,  // active mode is always true
             false, //set this to true if you want to run in manufacturing mode
+            None,
+            None,
             None,
             None,
             None,
@@ -368,6 +387,8 @@ mod test {
             None,
             None,
             None,
+            None,
+            None,
         );
         assert_eq!(0, test.code().unwrap_or_default());
 
@@ -391,6 +412,8 @@ mod test {
             i3c_port,
             true,
             false,
+            None,
+            None,
             None,
             None,
             None,

--- a/tests/integration/src/test_firmware_update.rs
+++ b/tests/integration/src/test_firmware_update.rs
@@ -208,6 +208,8 @@ mod test {
             opts.secondary_flash_image_path.clone(),
             opts.builder.clone(),
             Some("2.1.0".to_string()),
+            None,
+            None,
         )
     }
 
@@ -253,6 +255,7 @@ mod test {
             Some(update_runtime_firmware.clone()),
             Some(update_soc_images.clone()),
             Some(mcu_cfg.clone()),
+            None,
         );
         let update_caliptra_fw = update_builder
             .get_caliptra_fw()
@@ -502,6 +505,7 @@ mod test {
             Some(test_runtime.clone()),
             Some(soc_images.clone()),
             Some(mcu_cfg.clone()),
+            None,
         );
 
         // Build Caliptra firmware

--- a/xtask/src/runtime.rs
+++ b/xtask/src/runtime.rs
@@ -56,6 +56,7 @@ pub(crate) fn runtime_run(args: Commands) -> Result<()> {
         Some(tock_binary.clone()),
         soc_images,
         None,
+        None,
     );
 
     let caliptra_rom = caliptra_builder.get_caliptra_rom()?;


### PR DESCRIPTION
- MCU ROM retrieves SoC Manifest SVN and Max SVN values and passes it to Caliptra using SoC interface.
- Add logic in MCU ROM to monitor Caliptra for Fatal Errors while waiting for FW to be ready. Caliptra will signal a fatal error if the SVN check fails. In this way, MCU will propagate the fatal error to SoC.
- Added SoC Manifest SVN to the OTP emulator peripheral
- Add arguments to the emulator runner to pass SoC Manifest SVN
- Add integration test to verify SoC Manifest Verification