### PR TITLE
[xtask] enable dispatching a single FPGA test

### DIFF
--- a/docs/src/fpga.md
+++ b/docs/src/fpga.md
@@ -61,13 +61,40 @@ Run `cargo xtask-fpga fpga bootstrap --target-host $SSH-FPGA-NAME` to bootstrap 
 
 # Test Workflow
 
-A developer verifying changes against an FPGA should use the following sequence.
+## FPGA Bootstrapping and FW/Test Building
+
+A developer verifying changes against an FPGA should use the following sequence of commands to bootstrap their FPGA board by:
+1. downloading the caliptra-mcu-sw repo on their board,
+2. building all Caliptra Core and MCU firmware collateral, and
+3. building all FPGA tests for the FPGA environment.
 
 ```
 $ cargo xtask-fpga fpga bootstrap --target-host $SSH-FPGA-NAME # Run this only once per boot.
 $ cargo xtask-fpga fpga build --target-host $SSH-FPGA-NAME # Build firmware. Re-run every time firmware changes.
 $ cargo xtask-fpga fpga build-test --target-host $SSH-FPGA-NAME # Build test binaries. Re-run every time tests change.
-$ cargo xtask-fpga fpga test --target-host $SSH-FPGA-NAME # Run test suite on FPGA.
+```
+
+## Dispatching all FPGA Tests
+
+A developer verifying changes against an FPGA can dispatch the entire FPGA test in a single shot by running:
+
+```
+$ cargo xtask-fpga fpga test --target-host $SSH-FPGA-NAME
+```
+
+## Dispatching a Single FPGA Test
+
+A developer that only wishes to run a single test on the FPGA can replace the last command with the following:
+
+```
+# Run a single FPGA test.
+$ cargo xtask-fpga fpga test --target-host $SSH-FPGA-NAME \
+    --test-package <test package> \
+    --test <test>
+
+# For example:
+$ cargo xtask-fpga fpga test --target-host $SSH-FPGA-NAME \
+    --test-filter="package(mcu-hw-model) and test(test_hash_token)"
 ```
 
 # Running on FPGA

--- a/xtask/src/fpga.rs
+++ b/xtask/src/fpga.rs
@@ -73,7 +73,9 @@ pub(crate) enum Fpga {
         /// When set run commands over ssh to `target_host`
         #[arg(long)]
         target_host: Option<String>,
-        // TODO(clundin): Add support for passing in test filter
+        /// A specific test filter to apply.
+        #[arg(long)]
+        test_filter: Option<String>,
     },
 }
 
@@ -253,18 +255,33 @@ pub(crate) fn fpga_entry(args: &Fpga) -> Result<()> {
             // Need to clone caliptra-mcu-sw to run tests.
             run_command(target_host.as_deref(), "[ -d caliptra-mcu-sw ] || git clone https://github.com/chipsalliance/caliptra-mcu-sw --branch=main --depth=1").expect("failed to clone caliptra-mcu-sw repo");
         }
-        Fpga::Test { target_host } => {
+        Fpga::Test {
+            target_host,
+            test_filter,
+        } => {
             println!("Running test suite on FPGA");
             is_module_loaded("io_module", target_host.as_deref())?;
             // Clear old test logs
             run_command(target_host.as_deref(), "(sudo rm /tmp/junit.xml || true)")?;
             // Run caliptra-mcu-sw test suite.
             // Ignore error so we still copy the logs.
-            let _ = run_command(target_host.as_deref(), "(cd caliptra-mcu-sw && \
-                sudo CPTRA_FIRMWARE_BUNDLE=\"${HOME}/all-fw.zip\" \
+            let tf = if let Some(tf) = test_filter {
+                // Specific test filter to apply.
+                tf
+            } else {
+                // Default test suite to run.
+                "package(mcu-hw-model) - test(model_emulated::test::test_new_unbooted)"
+            };
+            let test_command = format!(
+                "(cd caliptra-mcu-sw && \
+                sudo CPTRA_FIRMWARE_BUNDLE=$HOME/all-fw.zip \
                 cargo-nextest nextest run \
                 --workspace-remap=. --archive-file $HOME/caliptra-test-binaries.tar.zst \
-                -E \"package(mcu-hw-model) - test(model_emulated::test::test_new_unbooted)\" --test-threads=1 --no-fail-fast --profile=nightly)");
+                --test-threads=1 --no-fail-fast --profile=nightly \
+                -E \"{}\")",
+                tf
+            );
+            let _ = run_command(target_host.as_deref(), test_command.as_str());
 
             if let Some(target_host) = target_host {
                 println!("Copying test log from FPGA to junit.xml");


### PR DESCRIPTION
This updates the xtask flow for executing FPGA tests by enabling running a single specified task instead of the entire test suite.