### PR TITLE
Update `caliptra-sw` cargo references.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,7 +268,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 [[package]]
 name = "caliptra-api"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f#ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
 dependencies = [
  "bitflags 2.9.1",
  "caliptra-api-types",
@@ -283,7 +283,7 @@ dependencies = [
 [[package]]
 name = "caliptra-api-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f#ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
 dependencies = [
  "caliptra-image-types",
 ]
@@ -291,7 +291,7 @@ dependencies = [
 [[package]]
 name = "caliptra-auth-man-gen"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f#ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
 dependencies = [
  "anyhow",
  "bitflags 2.9.1",
@@ -306,7 +306,7 @@ dependencies = [
 [[package]]
 name = "caliptra-auth-man-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f#ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
 dependencies = [
  "bitfield",
  "bitflags 2.9.1",
@@ -321,7 +321,7 @@ dependencies = [
 [[package]]
 name = "caliptra-builder"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f#ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
 dependencies = [
  "anyhow",
  "caliptra-image-crypto",
@@ -346,7 +346,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cfi-derive"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f#ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -368,7 +368,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cfi-lib"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f#ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
 dependencies = [
  "caliptra-error",
  "caliptra-registers",
@@ -383,7 +383,7 @@ source = "git+https://github.com/chipsalliance/caliptra-cfi.git?rev=a98e499d279e
 [[package]]
 name = "caliptra-coverage"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f#ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -401,7 +401,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cpu"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f#ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
 dependencies = [
  "caliptra-drivers",
  "caliptra-registers",
@@ -411,7 +411,7 @@ dependencies = [
 [[package]]
 name = "caliptra-drivers"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f#ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
 dependencies = [
  "arrayvec",
  "bitfield",
@@ -437,7 +437,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-bus"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f#ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
 dependencies = [
  "caliptra-emu-types",
  "tock-registers",
@@ -447,7 +447,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-cpu"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f#ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
 dependencies = [
  "bit-vec",
  "bitfield",
@@ -461,7 +461,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f#ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -476,7 +476,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-derive"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f#ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
 dependencies = [
  "caliptra-emu-bus",
  "caliptra-emu-types",
@@ -487,7 +487,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-periph"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f#ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
 dependencies = [
  "aes",
  "arrayref",
@@ -514,17 +514,17 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f#ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
 
 [[package]]
 name = "caliptra-error"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f#ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
 
 [[package]]
 name = "caliptra-gen-linker-scripts"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f#ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
 dependencies = [
  "caliptra_common",
 ]
@@ -532,7 +532,7 @@ dependencies = [
 [[package]]
 name = "caliptra-hw-model"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f#ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -562,7 +562,7 @@ dependencies = [
 [[package]]
 name = "caliptra-hw-model-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f#ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
 dependencies = [
  "caliptra-api-types",
  "rand",
@@ -571,7 +571,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f#ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
 dependencies = [
  "anyhow",
  "caliptra-image-gen",
@@ -591,7 +591,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-elf"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f#ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
 dependencies = [
  "anyhow",
  "caliptra-image-gen",
@@ -602,7 +602,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-fake-keys"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f#ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
 dependencies = [
  "caliptra-image-gen",
  "caliptra-image-types",
@@ -613,7 +613,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-gen"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f#ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
 dependencies = [
  "anyhow",
  "bitflags 2.9.1",
@@ -630,7 +630,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f#ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
 dependencies = [
  "caliptra-cfi-derive",
  "caliptra-cfi-lib",
@@ -646,7 +646,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-verify"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f#ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
 dependencies = [
  "bitflags 2.9.1",
  "caliptra-cfi-derive",
@@ -661,7 +661,7 @@ dependencies = [
 [[package]]
 name = "caliptra-kat"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f#ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
 dependencies = [
  "caliptra-drivers",
  "caliptra-lms-types",
@@ -673,7 +673,7 @@ dependencies = [
 [[package]]
 name = "caliptra-lms-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f#ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
 dependencies = [
  "caliptra-cfi-derive",
  "caliptra-cfi-lib",
@@ -686,7 +686,7 @@ dependencies = [
 [[package]]
 name = "caliptra-registers"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f#ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
 dependencies = [
  "caliptra-registers-latest",
 ]
@@ -694,7 +694,7 @@ dependencies = [
 [[package]]
 name = "caliptra-registers-latest"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f#ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
 dependencies = [
  "ureg",
 ]
@@ -702,7 +702,7 @@ dependencies = [
 [[package]]
 name = "caliptra-runtime"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f#ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
 dependencies = [
  "arrayvec",
  "bitfield",
@@ -735,7 +735,7 @@ dependencies = [
 [[package]]
 name = "caliptra-test"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f#ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
 dependencies = [
  "anyhow",
  "asn1",
@@ -767,12 +767,12 @@ dependencies = [
 [[package]]
 name = "caliptra-test-harness-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f#ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
 
 [[package]]
 name = "caliptra-x509"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f#ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
 dependencies = [
  "zeroize",
 ]
@@ -780,7 +780,7 @@ dependencies = [
 [[package]]
 name = "caliptra_common"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f#ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
 dependencies = [
  "bitfield",
  "bitflags 2.9.1",
@@ -1216,7 +1216,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f#ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
 dependencies = [
  "arrayvec",
  "caliptra-cfi-derive-git",
@@ -1407,7 +1407,7 @@ dependencies = [
 [[package]]
 name = "dpe"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f#ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
 dependencies = [
  "bitflags 2.9.1",
  "caliptra-cfi-derive-git",
@@ -3116,7 +3116,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 [[package]]
 name = "platform"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f#ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
 dependencies = [
  "arrayvec",
  "cfg-if",
@@ -4204,7 +4204,7 @@ dependencies = [
 [[package]]
 name = "ureg"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f#ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d#c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d"
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -203,28 +203,28 @@ libtock_small_panic = { path = "runtime/userspace/libtock/panic_handlers/small_p
 libtock_unittest = { path = "runtime/userspace/libtock/unittest" }
 
 # caliptra dependencies; keep git revs in sync
-caliptra-api = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f" }
-caliptra-api-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f" }
-caliptra-auth-man-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f" }
-caliptra-auth-man-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f" }
-caliptra-builder = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f" }
-caliptra-emu-bus = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f" }
-caliptra-emu-cpu = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f" }
-caliptra-emu-derive = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f" }
-caliptra-emu-periph = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f" }
-caliptra-emu-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f" }
-caliptra-error = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f", default-features = false }
-caliptra-hw-model = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f" }
-caliptra-hw-model-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f" }
-caliptra-image-crypto = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f", default-features = false, features = ["rustcrypto"] }
-caliptra-image-fake-keys = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f" }
-caliptra-image-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f" }
-caliptra-image-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f" }
-caliptra-registers = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f" }
-caliptra-test = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f" }
-caliptra-test-harness-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f" }
-ureg = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f" }
-dpe = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "ccce4c3a5bbf15d70eacbb5d94cf97a9476ec37f", default-features = false, features = ["dpe_profile_p384_sha384"] }
+caliptra-api = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d" }
+caliptra-api-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d" }
+caliptra-auth-man-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d" }
+caliptra-auth-man-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d" }
+caliptra-builder = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d" }
+caliptra-emu-bus = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d" }
+caliptra-emu-cpu = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d" }
+caliptra-emu-derive = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d" }
+caliptra-emu-periph = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d" }
+caliptra-emu-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d" }
+caliptra-error = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d", default-features = false }
+caliptra-hw-model = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d" }
+caliptra-hw-model-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d" }
+caliptra-image-crypto = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d", default-features = false, features = ["rustcrypto"] }
+caliptra-image-fake-keys = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d" }
+caliptra-image-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d" }
+caliptra-image-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d" }
+caliptra-registers = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d" }
+caliptra-test = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d" }
+caliptra-test-harness-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d" }
+ureg = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d" }
+dpe = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c2eadd76a6f924fb81c8f0b23d77ddb8c875cd0d", default-features = false, features = ["dpe_profile_p384_sha384"] }
 
 # local caliptra dependency; useful when developing
 # caliptra-api = { path = "../caliptra-sw/api" }


### PR DESCRIPTION
This will allow us to use the new Caliptra HW model with updated FPGA offsets