### PR TITLE
Add partial ROM warm reset flow.

### DIFF
--- a/rom/src/lib.rs
+++ b/rom/src/lib.rs
@@ -30,6 +30,8 @@ mod recovery;
 // Boot flow modules
 mod cold_boot;
 pub use cold_boot::ColdBoot;
+mod warm_boot;
+pub use warm_boot::WarmBoot;
 
 mod fw_hitless_update;
 pub use fw_hitless_update::FwHitlessUpdate;

--- a/rom/src/rom.rs
+++ b/rom/src/rom.rs
@@ -22,6 +22,7 @@ use crate::LifecycleControllerState;
 use crate::LifecycleHashedTokens;
 use crate::LifecycleToken;
 use crate::RomEnv;
+use crate::WarmBoot;
 use core::fmt::Write;
 use registers_generated::fuses::Fuses;
 use registers_generated::mci::bits::SecurityState::DeviceLifecycle;
@@ -286,9 +287,8 @@ pub fn rom_start(params: RomParameters) {
             ColdBoot::run(&mut env, params);
         }
         McuResetReason::WarmReset => {
-            // TODO: Implement warm reset flow
-            romtime::println!("[mcu-rom] TODO: Warm reset flow not implemented");
-            fatal_error(0x1001); // Error code for unimplemented warm reset
+            romtime::println!("[mcu-rom] Warm reset detected");
+            WarmBoot::run(&mut env, params);
         }
         McuResetReason::FirmwareBootUpdate => {
             // TODO: Implement firmware boot update flow

--- a/rom/src/warm_boot.rs
+++ b/rom/src/warm_boot.rs
@@ -1,0 +1,94 @@
+/*++
+
+Licensed under the Apache-2.0 license.
+
+File Name:
+
+    cold_boot.rs
+
+Abstract:
+
+    Cold Boot Flow - Handles initial boot when MCU powers on
+
+--*/
+
+#![allow(clippy::empty_loop)]
+
+use crate::boot_status::McuRomBootStatus;
+use crate::{fatal_error, BootFlow, RomEnv, RomParameters};
+use core::fmt::Write;
+use romtime::HexWord;
+use tock_registers::interfaces::Readable;
+
+pub struct WarmBoot {}
+
+impl BootFlow for WarmBoot {
+    fn run(env: &mut RomEnv, _params: RomParameters) -> ! {
+        romtime::println!("[mcu-rom] Starting warm boot flow");
+        env.mci
+            .set_flow_status(McuRomBootStatus::WarmResetFlowStarted.into());
+
+        // Create local references to minimize code changes
+        let mci = &env.mci;
+        let soc = &env.soc;
+        let lc = &env.lc;
+        let otp = &mut env.otp;
+        let i3c = &mut env.i3c;
+        let straps = &env.straps;
+
+        romtime::println!("[mcu-rom] Setting Caliptra boot go");
+        mci.caliptra_boot_go();
+        mci.set_flow_status(McuRomBootStatus::CaliptraBootGoAsserted.into());
+
+        // If testing Caliptra Core, hang here until the test signals it to continue.
+        if cfg!(feature = "core_test") {
+            while mci.registers.mci_reg_generic_input_wires[1].get() & (1 << 30) == 0 {}
+        }
+
+        lc.init().unwrap();
+        mci.set_flow_status(McuRomBootStatus::LifecycleControllerInitialized.into());
+
+        // FPGA has problems with the integrity check, so we disable it
+        if let Err(err) = otp.init() {
+            romtime::println!("[mcu-rom] Error initializing OTP: {}", HexWord(err as u32));
+            fatal_error(err as u32);
+        }
+        mci.set_flow_status(McuRomBootStatus::OtpControllerInitialized.into());
+
+        let _fuses = match otp.read_fuses() {
+            Ok(fuses) => {
+                mci.set_flow_status(McuRomBootStatus::FusesReadFromOtp.into());
+                fuses
+            }
+            Err(e) => {
+                romtime::println!("Error reading fuses: {}", HexWord(e as u32));
+                fatal_error(1);
+            }
+        };
+
+        romtime::println!("[mcu-rom] Initializing I3C");
+        i3c.configure(straps.i3c_static_addr, true);
+        mci.set_flow_status(McuRomBootStatus::I3cInitialized.into());
+
+        romtime::println!(
+            "[mcu-rom] Waiting for Caliptra to be ready for fuses: {}",
+            soc.ready_for_fuses()
+        );
+        while !soc.ready_for_fuses() {}
+        mci.set_flow_status(McuRomBootStatus::CaliptraReadyForFuses.into());
+
+        romtime::println!("[mcu-rom] Setting Caliptra fuse write done");
+        soc.fuse_write_done();
+        while soc.ready_for_fuses() {}
+        mci.set_flow_status(McuRomBootStatus::FuseWriteComplete.into());
+
+        // If testing Caliptra Core, hang here until the test signals it to continue.
+        if cfg!(feature = "core_test") {
+            while mci.registers.mci_reg_generic_input_wires[1].get() & (1 << 31) == 0 {}
+        }
+
+        // TODO: Implement full warm reset flow
+        romtime::println!("[mcu-rom] TODO: Warm reset flow not fully implemented");
+        fatal_error(0x1001); // Error code for unimplemented warm reset
+    }
+}


### PR DESCRIPTION
This can be used for initial testing of warm reset. For example, OCP LOCK warm reset flows. This does not do everything MCU ROM should do on a warm reset.

This also adds another Core test MCU ROM pause point. This will allow us to test flows that just remove the SoC from reset without booting the full system. The new flow is:

1. Come out of reset
2. Wait for signal from Core
3. Program fuses and initialize the other peripherals
4. Wait for signal from Core
5. Load mutable firmware