### PR TITLE
[fpga] fix JTAG pin orderings

### DIFF
--- a/hw/fpga/openocd_ss.txt
+++ b/hw/fpga/openocd_ss.txt
@@ -29,8 +29,8 @@ proc connect {target} {
 
     # Define pin numbers for sysfsgpio
     sysfsgpio tck_num [expr {$gpionum + 0}]
-    sysfsgpio tdi_num [expr {$gpionum + 1}]
-    sysfsgpio tms_num [expr {$gpionum + 2}]
+    sysfsgpio tms_num [expr {$gpionum + 1}]
+    sysfsgpio tdi_num [expr {$gpionum + 2}]
     sysfsgpio trst_num [expr {$gpionum + 3}]
     sysfsgpio tdo_num [expr {$gpionum + 4}]
 

--- a/hw/fpga/src/caliptra_package_top.v
+++ b/hw/fpga/src/caliptra_package_top.v
@@ -966,8 +966,8 @@ caliptra_wrapper_top cptra_wrapper (
 
     // EL2 JTAG interface
     .jtag_tck(jtag_in[0]),
-    .jtag_tdi(jtag_in[1]),
-    .jtag_tms(jtag_in[2]),
+    .jtag_tms(jtag_in[1]),
+    .jtag_tdi(jtag_in[2]),
     .jtag_trst_n(jtag_in[3]),
     .jtag_tdo(jtag_out[4]),
 


### PR DESCRIPTION
This aligns the JTAG pin orderings across all TAPs (core, lcc, and mcu) as:
1. tck
2. tms
3. tdi
4. trst
5. tdo

Additionally, this fixes the openocd configuration script to use the same JTAG pin orderings. This partially addresses #363 by enabling connecting to the LCC TAP (along with the other TAPs).

With this fix, I am able to successfully connect to the LCC TAP with OpenOCD.