### PR TITLE
Rsync FPGA files to the local directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ layout.ld
 **/*.zip
 
 cross-target/
+
+# Test logs
+**/junit.xml

--- a/xtask/src/fpga.rs
+++ b/xtask/src/fpga.rs
@@ -95,7 +95,7 @@ fn rsync_file(target_host: &str, file: &str, from_fpga: bool) -> Result<()> {
         format!("{target_host}:.")
     };
     let args = if from_fpga {
-        ["-avxz", &copy, file]
+        ["-avxz", &copy, "."]
     } else {
         ["-avxz", file, &copy]
     };


### PR DESCRIPTION
Test logs were getting copied to `/tmp/junit.xml`.