### PR TITLE
Fix FPGA HW Model being unable to run recovery flow.

### DIFF
--- a/hw/model/src/lib.rs
+++ b/hw/model/src/lib.rs
@@ -447,6 +447,14 @@ fn reg_access_test() {
     )
     .unwrap();
 
+    assert_eq!(
+        hw.caliptra_soc_manager()
+            .soc_ifc()
+            .cptra_fw_error_fatal()
+            .read(),
+        0
+    );
+
     // Check Caliptra reports 2.x
     assert_eq!(
         u32::from(hw.caliptra_soc_manager().soc_ifc().cptra_hw_rev_id().read()),

--- a/hw/model/src/model_fpga_realtime.rs
+++ b/hw/model/src/model_fpga_realtime.rs
@@ -131,9 +131,9 @@ impl McuHwModel for ModelFpgaRealtime {
             .lifecycle_controller_state
             .unwrap_or(LifecycleControllerState::Raw)
         {
-            LifecycleControllerState::Raw
-            | LifecycleControllerState::Prod
-            | LifecycleControllerState::ProdEnd => security_state_prod,
+            LifecycleControllerState::Prod | LifecycleControllerState::ProdEnd => {
+                security_state_prod
+            }
             LifecycleControllerState::Dev => security_state_manufacturing,
             _ => security_state_unprovisioned,
         };


### PR DESCRIPTION
The default lifecycle state was being set to prod which later would later cause it to fail the Caliptra firmware integrity checks because the built image uses ML-DSA by default, but the hardware model uses LMS by default.