### PR TITLE
Fix incorrect auth and stash flag in Image Loading

### DIFF
--- a/runtime/userspace/api/caliptra-api/src/image_loading/mod.rs
+++ b/runtime/userspace/api/caliptra-api/src/image_loading/mod.rs
@@ -12,7 +12,6 @@ use caliptra_api::mailbox::{
     AuthorizeAndStashReq, AuthorizeAndStashResp, CommandId, GetImageInfoReq, GetImageInfoResp,
     ImageHashSource, MailboxReqHeader, MailboxRespHeader, Request,
 };
-use caliptra_auth_man_types::ImageMetadataFlags;
 use embassy_executor::Spawner;
 use flash_image::{FlashHeader, SOC_MANIFEST_IDENTIFIER};
 use libsyscall_caliptra::dma::DMAMapping;
@@ -232,14 +231,10 @@ async fn get_image_load_address(
 
 /// Authorizes an image based on its ID.
 async fn authorize_image(mailbox: &Mailbox, image_id: u32, size: u32) -> Result<(), ErrorCode> {
-    let mut flags = ImageMetadataFlags(0);
-    flags.set_ignore_auth_check(false);
-    flags.set_image_source(ImageHashSource::LoadAddress as u32);
-
     let mut req = AuthorizeAndStashReq {
         hdr: MailboxReqHeader::default(),
         fw_id: image_id.to_le_bytes(),
-        flags: flags.0,
+        flags: 1, // Skip Stash
         source: ImageHashSource::LoadAddress as u32,
         image_size: size,
         ..Default::default()


### PR DESCRIPTION

During image loading, MCU sends out AuthorizeAndStash but the flags set
used are values for the SoC Manifest flags not the mailbox
AuthorizeAndStash command flags.

AuthorizeAndStash only has 1 flag and that's for SKIP_STASH. We skip the
stashing for image loading.