### PR TITLE
[McuManager] Add helper functions for easier use.

### DIFF
--- a/hw/model/src/mcu_mgr.rs
+++ b/hw/model/src/mcu_mgr.rs
@@ -106,4 +106,60 @@ pub trait McuManager {
     {
         f(self)
     }
+
+    fn with_i3c<T, F>(&mut self, f: F) -> T
+    where
+        F: FnOnce(caliptra_registers::i3ccsr::RegisterBlock<Self::TMmio<'_>>) -> T,
+    {
+        f(self.i3c())
+    }
+
+    fn with_mci<T, F>(&mut self, f: F) -> T
+    where
+        F: FnOnce(caliptra_registers::mci::RegisterBlock<Self::TMmio<'_>>) -> T,
+    {
+        f(self.mci())
+    }
+
+    fn with_trace_buffer<T, F>(&mut self, f: F) -> T
+    where
+        F: FnOnce(caliptra_registers::mcu_trace_buffer::RegisterBlock<Self::TMmio<'_>>) -> T,
+    {
+        f(self.trace_buffer())
+    }
+
+    fn with_mbox0<T, F>(&mut self, f: F) -> T
+    where
+        F: FnOnce(caliptra_registers::mcu_mbox0::RegisterBlock<Self::TMmio<'_>>) -> T,
+    {
+        f(self.mbox0())
+    }
+
+    fn with_mbox1<T, F>(&mut self, f: F) -> T
+    where
+        F: FnOnce(caliptra_registers::mcu_mbox1::RegisterBlock<Self::TMmio<'_>>) -> T,
+    {
+        f(self.mbox1())
+    }
+
+    fn with_mcu_sram<T, F>(&mut self, f: F) -> T
+    where
+        F: FnOnce(caliptra_registers::mcu_sram::RegisterBlock<Self::TMmio<'_>>) -> T,
+    {
+        f(self.mcu_sram())
+    }
+
+    fn with_otp<T, F>(&mut self, f: F) -> T
+    where
+        F: FnOnce(caliptra_registers::otp_ctrl::RegisterBlock<Self::TMmio<'_>>) -> T,
+    {
+        f(self.otp_ctrl())
+    }
+
+    fn with_lc<T, F>(&mut self, f: F) -> T
+    where
+        F: FnOnce(caliptra_registers::lc_ctrl::RegisterBlock<Self::TMmio<'_>>) -> T,
+    {
+        f(self.lc_ctrl())
+    }
 }


### PR DESCRIPTION
This adds helper functions to the `McuManager` struct to allow easier access to the underlying register blocks. This also keeps use self contained to avoid using `drop`.