### PR TITLE
Onboard mctp-capsule-loopback test to FPGA CI

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -96,7 +96,9 @@ jobs:
       - name: Run all tests
         run: |
           # Build ROM and runtime binaries
-          cargo xtask all-build --platform emulator
+          cargo xtask all-build --platform emulator \
+            --runtime-features test-mctp-capsule-loopback \
+            --separate-runtimes
 
           export SPDM_VALIDATOR_DIR=$GITHUB_WORKSPACE/spdm-emu/build/bin
           export CPTRA_FIRMWARE_BUNDLE="${PWD}/target/all-fw.zip"

--- a/.github/workflows/fpga.yml
+++ b/.github/workflows/fpga.yml
@@ -134,7 +134,7 @@ jobs:
           # Build ROM and runtime binaries
           echo "Cross compiling FPGA binaries"
           cargo xtask-fpga all-build --platform fpga \
-            --features test-mctp-capsule-loopback,test-pldm-fw-update-e2e \
+            --runtime-features test-mctp-capsule-loopback,test-pldm-fw-update-e2e \
             --separate-runtimes
           sccache --show-stats
 

--- a/.github/workflows/fpga.yml
+++ b/.github/workflows/fpga.yml
@@ -134,7 +134,7 @@ jobs:
           # Build ROM and runtime binaries
           echo "Cross compiling FPGA binaries"
           cargo xtask-fpga all-build --platform fpga \
-            --runtime-features test-mctp-capsule-loopback,test-pldm-fw-update-e2e \
+            --runtime-features test-mctp-capsule-loopback \
             --separate-runtimes
           sccache --show-stats
 
@@ -213,7 +213,8 @@ jobs:
               --target-dir-remap="${TEST_BIN}/target"
               --workspace-remap=.
               -E 'package(mcu-hw-model) - test(model_emulated::test::test_new_unbooted)'
-              -E 'package(tests-integration) and (test(test_jtag_taps) | test(test_mctp_capsule_loopback))' # Modify this as we onboard crates to the FPGA test suite.
+              -E 'package(tests-integration) and test(test_jtag_taps)'
+              -E 'package(tests-integration) and test(test_mctp_capsule_loopback)' # Modify these as we onboard crates to the FPGA test suite.
           )
 
           cargo-nextest nextest list \

--- a/.github/workflows/fpga.yml
+++ b/.github/workflows/fpga.yml
@@ -213,9 +213,11 @@ jobs:
               --target-dir-remap="${TEST_BIN}/target"
               --workspace-remap=.
               -E 'package(mcu-hw-model) - test(model_emulated::test::test_new_unbooted)'
-              -E 'package(tests-integration) and test(test_jtag_taps)'
-              -E 'package(tests-integration) and test(test_mctp_capsule_loopback)' # Modify these as we onboard crates to the FPGA test suite.
+              -E 'package(tests-integration) and test(test_jtag_taps)' # Modify these as we onboard crates to the FPGA test suite.
           )
+              # disabled for now due to flakiness of recovery boot
+              # -E 'package(tests-integration) and test(test_mctp_capsule_loopback)'
+
 
           cargo-nextest nextest list \
               "${COMMON_ARGS[@]}" \

--- a/.github/workflows/fpga.yml
+++ b/.github/workflows/fpga.yml
@@ -213,7 +213,7 @@ jobs:
               --target-dir-remap="${TEST_BIN}/target"
               --workspace-remap=.
               -E 'package(mcu-hw-model) - test(model_emulated::test::test_new_unbooted)'
-              -E 'package(tests-integration) and (test(test_jtag_taps) | test(mctp_capsule_loopback))' # Modify this as we onboard crates to the FPGA test suite.
+              -E 'package(tests-integration) and (test(test_jtag_taps) | test(test_mctp_capsule_loopback))' # Modify this as we onboard crates to the FPGA test suite.
           )
 
           cargo-nextest nextest list \

--- a/.github/workflows/fpga.yml
+++ b/.github/workflows/fpga.yml
@@ -133,7 +133,9 @@ jobs:
 
           # Build ROM and runtime binaries
           echo "Cross compiling FPGA binaries"
-          cargo xtask-fpga all-build --platform fpga
+          cargo xtask-fpga all-build --platform fpga \
+            --features test-mctp-capsule-loopback,test-pldm-fw-update-e2e \
+            --separate-runtimes
           sccache --show-stats
 
           mkdir -p /tmp/caliptra-binaries
@@ -211,7 +213,7 @@ jobs:
               --target-dir-remap="${TEST_BIN}/target"
               --workspace-remap=.
               -E 'package(mcu-hw-model) - test(model_emulated::test::test_new_unbooted)'
-              -E 'package(tests-integration) and test(test_jtag_taps)' # Modify this as we onboard crates to the FPGA test suite.
+              -E 'package(tests-integration) and (test(test_jtag_taps) | test(mctp_capsule_loopback))' # Modify this as we onboard crates to the FPGA test suite.
           )
 
           cargo-nextest nextest list \

--- a/builder/src/all.rs
+++ b/builder/src/all.rs
@@ -26,6 +26,8 @@ pub struct FirmwareBinaries {
     pub mcu_runtime: Vec<u8>,
     pub soc_manifest: Vec<u8>,
     pub test_roms: Vec<(String, Vec<u8>)>,
+    pub test_soc_manifests: Vec<(String, Vec<u8>)>,
+    pub test_runtimes: Vec<(String, Vec<u8>)>,
 }
 
 impl FirmwareBinaries {
@@ -44,7 +46,7 @@ impl FirmwareBinaries {
     pub fn from_env() -> Result<&'static Self> {
         // TODO: Consider falling back to building the firmware if CPTRA_FIRMWARE_BUNDLE is unset.
         let bundle_path = var("CPTRA_FIRMWARE_BUNDLE")
-            .expect("Set the environment variable CPTRA_FIRMWARE_BUNDLE ");
+            .map_err(|_| anyhow::anyhow!("Set the environment variable CPTRA_FIRMWARE_BUNDLE"))?;
 
         static BINARIES: OnceLock<FirmwareBinaries> = OnceLock::new();
         let binaries = BINARIES.get_or_init(|| {
@@ -71,6 +73,12 @@ impl FirmwareBinaries {
                 Self::MCU_ROM_NAME => binaries.mcu_rom = data,
                 Self::MCU_RUNTIME_NAME => binaries.mcu_runtime = data,
                 Self::SOC_MANIFEST_NAME => binaries.soc_manifest = data,
+                name if name.contains("mcu-test-soc-manifest") => {
+                    binaries.test_soc_manifests.push((name.to_string(), data));
+                }
+                name if name.contains("mcu-test-runtime") => {
+                    binaries.test_runtimes.push((name.to_string(), data));
+                }
                 name if name.contains("mcu-test-rom") => {
                     binaries.test_roms.push((name.to_string(), data));
                 }
@@ -101,6 +109,30 @@ impl FirmwareBinaries {
             fwid
         ))
     }
+
+    pub fn test_soc_manifest(&self, feature: &str) -> Result<Vec<u8>> {
+        let expected_name = format!("mcu-test-soc-manifest-{}.bin", feature);
+        for (name, data) in self.test_soc_manifests.iter() {
+            if &expected_name == name {
+                return Ok(data.clone());
+            }
+        }
+        Err(anyhow::anyhow!(
+            "SoC Manifest not found. File name: {expected_name}, feature: {feature}"
+        ))
+    }
+
+    pub fn test_runtime(&self, feature: &str) -> Result<Vec<u8>> {
+        let expected_name = format!("mcu-test-runtime-{}.bin", feature);
+        for (name, data) in self.test_runtimes.iter() {
+            if &expected_name == name {
+                return Ok(data.clone());
+            }
+        }
+        Err(anyhow::anyhow!(
+            "Runtime not found. File name: {expected_name}, feature: {feature}"
+        ))
+    }
 }
 
 #[derive(Default)]
@@ -112,6 +144,7 @@ pub struct AllBuildArgs<'a> {
     pub platform: Option<&'a str>,
     pub rom_features: Option<&'a str>,
     pub runtime_features: Option<&'a str>,
+    pub separate_runtimes: bool,
 }
 
 /// Build Caliptra ROM and firmware bundle, MCU ROM and runtime, and SoC manifest, and package them all together in a ZIP file.
@@ -124,6 +157,7 @@ pub fn all_build(args: AllBuildArgs) -> Result<()> {
         platform,
         rom_features,
         runtime_features,
+        separate_runtimes,
     } = args;
 
     // TODO: use temp files
@@ -148,15 +182,31 @@ pub fn all_build(args: AllBuildArgs) -> Result<()> {
         test_roms.push((bin_path, filename));
     }
 
-    let runtime_features: Vec<&str> = if let Some(runtime_features) = runtime_features {
-        runtime_features.split(",").collect()
-    } else {
-        Vec::new()
-    };
+    let (base_runtime_features, separate_runtimes) =
+        if separate_runtimes && runtime_features.is_some() {
+            // build a separate runtime for each feature flag, since they are used as tests
+            if runtime_features.is_none() || runtime_features.unwrap().is_empty() {
+                bail!("Must specify runtime features when building separate runtimes");
+            }
+            (
+                Vec::new(),
+                runtime_features.unwrap().split(",").collect::<Vec<&str>>(),
+            )
+        } else {
+            // build one runtime with all feature flags
+            if let Some(runtime_features) = runtime_features {
+                (runtime_features.split(",").collect(), Vec::new())
+            } else {
+                (Vec::new(), Vec::new())
+            }
+        };
+
+    let base_runtime_file = tempfile::NamedTempFile::new().unwrap();
+    let base_runtime_path = base_runtime_file.path().to_str().unwrap();
 
     let mcu_runtime = &crate::runtime_build_with_apps_cached(
-        &runtime_features,
-        None,
+        &base_runtime_features,
+        Some(base_runtime_path),
         false,
         Some(platform),
         Some(memory_map),
@@ -181,9 +231,47 @@ pub fn all_build(args: AllBuildArgs) -> Result<()> {
     );
     let caliptra_rom = caliptra_builder.get_caliptra_rom()?;
     let caliptra_fw = caliptra_builder.get_caliptra_fw()?;
-    let vendor_pk_hash = caliptra_builder.get_vendor_pk_hash()?;
+    let vendor_pk_hash = caliptra_builder.get_vendor_pk_hash()?.to_string();
     println!("Vendor PK hash: {:x?}", vendor_pk_hash);
-    let soc_manifest = caliptra_builder.get_soc_manifest()?;
+    let soc_manifest = caliptra_builder.get_soc_manifest(None)?;
+
+    let mut test_runtimes = vec![];
+    for feature in separate_runtimes.iter() {
+        let feature_runtime_file = tempfile::NamedTempFile::new().unwrap();
+        let feature_runtime_path = feature_runtime_file.path().to_str().unwrap().to_string();
+
+        crate::runtime_build_with_apps_cached(
+            &[feature],
+            Some(&feature_runtime_path),
+            false,
+            Some(platform),
+            Some(memory_map),
+            use_dccm_for_stack,
+            dccm_offset,
+            dccm_size,
+            None,
+            None,
+        )?;
+
+        let mut caliptra_builder = crate::CaliptraBuilder::new(
+            fpga,
+            Some(caliptra_rom.clone()),
+            Some(caliptra_fw.clone()),
+            None,
+            Some(vendor_pk_hash.clone()),
+            Some(feature_runtime_file.path().to_path_buf()),
+            None,
+            None,
+            None,
+        );
+        let feature_soc_manifest_file = tempfile::NamedTempFile::new().unwrap();
+        caliptra_builder.get_soc_manifest(feature_soc_manifest_file.path().to_str())?;
+        test_runtimes.push((
+            feature.to_string(),
+            feature_runtime_file,
+            feature_soc_manifest_file,
+        ));
+    }
 
     let default_path = crate::target_dir().join("all-fw.zip");
     let path = output.map(Path::new).unwrap_or(&default_path);
@@ -227,6 +315,30 @@ pub fn all_build(args: AllBuildArgs) -> Result<()> {
     )?;
     for (test_rom, name) in test_roms {
         add_to_zip(&test_rom, &name, &mut zip, options)?;
+    }
+
+    for (feature, runtime, soc_manifest) in test_runtimes {
+        let runtime_name = format!("mcu-test-runtime-{}.bin", feature);
+        println!("Adding {} -> {}", runtime.path().display(), runtime_name);
+        add_to_zip(
+            &runtime.path().to_path_buf(),
+            &runtime_name,
+            &mut zip,
+            options,
+        )?;
+
+        let soc_manifest_name = format!("mcu-test-soc-manifest-{}.bin", feature);
+        println!(
+            "Adding {} -> {}",
+            soc_manifest.path().display(),
+            soc_manifest_name
+        );
+        add_to_zip(
+            &soc_manifest.path().to_path_buf(),
+            &soc_manifest_name,
+            &mut zip,
+            options,
+        )?;
     }
 
     zip.finish()?;

--- a/hw/model/src/lib.rs
+++ b/hw/model/src/lib.rs
@@ -631,12 +631,28 @@ mod tests {
     use super::*;
     use mcu_builder::firmware;
 
+    fn platform() -> &'static str {
+        if cfg!(feature = "fpga_realtime") {
+            "fpga"
+        } else {
+            "emulator"
+        }
+    }
+
     #[test]
     pub fn test_mailbox_execute() {
-        let binaries = mcu_builder::FirmwareBinaries::from_env().unwrap();
-        let mcu_rom = binaries
-            .test_rom(&firmware::hw_model_tests::MAILBOX_RESPONDER)
+        let mcu_rom = if let Ok(binaries) = mcu_builder::FirmwareBinaries::from_env() {
+            binaries
+                .test_rom(&firmware::hw_model_tests::MAILBOX_RESPONDER)
+                .unwrap()
+        } else {
+            let rom_file = mcu_builder::test_rom_build(
+                Some(platform()),
+                &firmware::hw_model_tests::MAILBOX_RESPONDER,
+            )
             .unwrap();
+            std::fs::read(&rom_file).unwrap()
+        };
 
         let mut model = new(
             InitParams {

--- a/hw/model/src/model_emulated.rs
+++ b/hw/model/src/model_emulated.rs
@@ -680,7 +680,7 @@ mod test {
             .expect("Could not get vendor PK hash");
         println!("Vendor PK hash: {:x?}", vendor_pk_hash);
         let vendor_pk_hash = hex::decode(vendor_pk_hash).unwrap().try_into().unwrap();
-        let soc_manifest = caliptra_builder.get_soc_manifest().unwrap();
+        let soc_manifest = caliptra_builder.get_soc_manifest(None).unwrap();
 
         let mcu_rom = std::fs::read(mcu_rom).unwrap();
         let mcu_runtime = std::fs::read(mcu_runtime).unwrap();

--- a/tests/integration/src/lib.rs
+++ b/tests/integration/src/lib.rs
@@ -12,7 +12,7 @@ mod test_soc_boot;
 mod test {
     use caliptra_hw_model::BootParams;
     use caliptra_image_types::FwVerificationPqcKeyType;
-    use mcu_builder::{CaliptraBuilder, ImageCfg, TARGET};
+    use mcu_builder::{CaliptraBuilder, FirmwareBinaries, ImageCfg, TARGET};
     use mcu_config::McuMemoryMap;
     use mcu_hw_model::{DefaultHwModel, Fuses, InitParams, McuHwModel};
     use mcu_image_header::McuImageHeader;
@@ -78,12 +78,16 @@ mod test {
         output
     }
 
-    pub fn compile_runtime(feature: &str, example_app: bool) -> PathBuf {
-        // TODO: use environment firmware binaries
-        let output = target_binary(&format!("runtime-{}-{}.bin", feature, platform()));
+    pub fn compile_runtime(feature: Option<&str>, example_app: bool) -> PathBuf {
+        let mut features = vec![];
+        if let Some(feature) = feature {
+            features.push(feature);
+        }
+        let feature = feature.map(|f| format!("-{f}")).unwrap_or_default();
+        let output = target_binary(&format!("runtime{}-{}.bin", feature, platform()));
         let output_name = format!("{}", output.display());
         mcu_builder::runtime_build_with_apps_cached(
-            &[feature],
+            &features,
             Some(&output_name),
             example_app,
             Some(platform()),
@@ -99,32 +103,108 @@ mod test {
         output
     }
 
-    pub fn start_runtime_hw_model(
-        rom_path: PathBuf,
-        runtime_path: PathBuf,
-        i3c_port: Option<u16>,
-    ) -> DefaultHwModel {
-        // TODO: use FirmwareBinaries for all binaries to make FPGA easier
-        let mut caliptra_builder = CaliptraBuilder::new(
+    struct TestBinaries {
+        vendor_pk_hash_u8: Vec<u8>,
+        caliptra_rom: Vec<u8>,
+        caliptra_fw: Vec<u8>,
+        mcu_rom: Vec<u8>,
+        soc_manifest: Vec<u8>,
+        mcu_runtime: Vec<u8>,
+    }
+
+    fn prebuilt_binaries(
+        feature: Option<&str>,
+        binaries: &'static FirmwareBinaries,
+    ) -> TestBinaries {
+        let mut test_binaries = TestBinaries {
+            vendor_pk_hash_u8: binaries
+                .vendor_pk_hash()
+                .expect("Failed to get Vendor PK hash")
+                .to_vec(),
+            caliptra_rom: binaries.caliptra_rom.clone(),
+            caliptra_fw: binaries.caliptra_fw.clone(),
+            mcu_rom: binaries.mcu_rom.clone(),
+            soc_manifest: binaries.soc_manifest.clone(),
+            mcu_runtime: binaries.mcu_runtime.clone(),
+        };
+
+        // check for prebuilt binaries for our test feature
+        if let Some(feature) = feature {
+            let err = format!(
+                "Failed to get MCU firmware and manifest for feature {}",
+                feature
+            );
+            test_binaries.soc_manifest = binaries.test_soc_manifest(feature).expect(&err).clone();
+            test_binaries.mcu_runtime = binaries.test_runtime(feature).expect(&err).clone();
+        }
+
+        test_binaries
+    }
+
+    fn build_test_binaries(feature: Option<&str>) -> TestBinaries {
+        let mcu_runtime = compile_runtime(feature, false);
+        let mut builder = CaliptraBuilder::new(
             cfg!(feature = "fpga_realtime"),
             None,
             None,
             None,
             None,
-            Some(runtime_path.clone()),
+            Some(mcu_runtime.clone()),
             None,
             None,
             None,
         );
+        let caliptra_rom = std::fs::read(
+            builder
+                .get_caliptra_rom()
+                .expect("Failed to build Caliptra ROM"),
+        )
+        .unwrap();
 
-        // let binaries = mcu_builder::FirmwareBinaries::from_env().unwrap();
-        let caliptra_rom = std::fs::read(caliptra_builder.get_caliptra_rom().unwrap()).unwrap();
-        let mcu_rom = std::fs::read(rom_path).unwrap();
-        let caliptra_fw = std::fs::read(caliptra_builder.get_caliptra_fw().unwrap()).unwrap();
-        let soc_manifest = std::fs::read(caliptra_builder.get_soc_manifest().unwrap()).unwrap();
-        let mcu_runtime = std::fs::read(runtime_path).unwrap();
-        let vendor_pk_hash_u8 = hex::decode(caliptra_builder.get_vendor_pk_hash().unwrap())
+        let caliptra_fw = std::fs::read(
+            builder
+                .get_caliptra_fw()
+                .expect("Failed to build Caliptra ROM"),
+        )
+        .unwrap();
+
+        let mcu_rom = std::fs::read(&*ROM).unwrap();
+        let soc_manifest = std::fs::read(
+            builder
+                .get_soc_manifest(None)
+                .expect("Failed to build SoC manifest"),
+        )
+        .unwrap();
+        let vendor_pk_hash_u8 = hex::decode(builder.get_vendor_pk_hash().unwrap())
             .expect("Invalid hex string for vendor_pk_hash");
+        let mcu_runtime = std::fs::read(mcu_runtime).unwrap();
+
+        TestBinaries {
+            vendor_pk_hash_u8,
+            caliptra_rom,
+            caliptra_fw,
+            mcu_rom,
+            soc_manifest,
+            mcu_runtime,
+        }
+    }
+
+    pub fn start_runtime_hw_model(feature: Option<&str>, i3c_port: Option<u16>) -> DefaultHwModel {
+        let TestBinaries {
+            vendor_pk_hash_u8,
+            caliptra_rom,
+            caliptra_fw,
+            mcu_rom,
+            soc_manifest,
+            mcu_runtime,
+        } = match FirmwareBinaries::from_env() {
+            Ok(binaries) => prebuilt_binaries(feature, binaries),
+            _ => {
+                println!("Could not find prebuilt firmware binaries, building firmware...");
+                build_test_binaries(feature)
+            }
+        };
+
         let vendor_pk_hash: Vec<u32> = vendor_pk_hash_u8
             .chunks(4)
             .map(|chunk| {
@@ -135,6 +215,7 @@ mod test {
             .collect();
         let vendor_pk_hash: [u32; 12] = vendor_pk_hash.as_slice().try_into().unwrap();
 
+        // TODO: read the PQC type
         mcu_hw_model::new(
             InitParams {
                 caliptra_rom: &caliptra_rom,
@@ -310,7 +391,7 @@ mod test {
             cargo_run_args.push("--caliptra-firmware");
             cargo_run_args.push(caliptra_fw.to_str().unwrap());
             let soc_manifest = caliptra_builder
-                .get_soc_manifest()
+                .get_soc_manifest(None)
                 .expect("Failed to build SoC manifest");
             cargo_run_args.push("--soc-manifest");
             cargo_run_args.push(soc_manifest.to_str().unwrap());
@@ -384,7 +465,7 @@ mod test {
 
         println!("Compiling test firmware {}", feature);
         let feature = feature.replace("_", "-");
-        let test_runtime = compile_runtime(&feature, example_app);
+        let test_runtime = compile_runtime(Some(&feature), example_app);
         let i3c_port = "65534".to_string();
         let test = run_runtime(
             &feature,
@@ -487,7 +568,7 @@ mod test {
 
         let feature = "test-exit-immediately".to_string();
         println!("Compiling test firmware {}", &feature);
-        let test_runtime = compile_runtime(&feature, false);
+        let test_runtime = compile_runtime(Some(&feature), false);
         let i3c_port = "65534".to_string();
         let test = run_runtime(
             &feature,
@@ -519,7 +600,7 @@ mod test {
 
         let feature = "test-mcu-rom-flash-access".to_string();
         println!("Compiling test firmware {}", &feature);
-        let test_runtime = compile_runtime(&feature, false);
+        let test_runtime = compile_runtime(Some(&feature), false);
         let i3c_port = "65534".to_string();
         let test = run_runtime(
             &feature,

--- a/tests/integration/src/lib.rs
+++ b/tests/integration/src/lib.rs
@@ -70,7 +70,6 @@ mod test {
     }
 
     fn compile_rom(feature: &str) -> PathBuf {
-        // TODO: use environment firmware binaries
         let output: PathBuf = mcu_builder::rom_build(Some(platform()), feature)
             .expect("ROM build failed")
             .into();

--- a/tests/integration/src/test_firmware_update.rs
+++ b/tests/integration/src/test_firmware_update.rs
@@ -240,7 +240,7 @@ mod test {
                 ..Default::default()
             },
         ];
-        let update_runtime_firmware = compile_runtime("test-flash-based-boot", false);
+        let update_runtime_firmware = compile_runtime(Some("test-flash-based-boot"), false);
         let mcu_cfg = ImageCfg {
             path: update_runtime_firmware.clone(),
             load_addr: (EMULATOR_MEMORY_MAP.mci_offset as u64) + MCU_SRAM_OFFSET,
@@ -264,7 +264,7 @@ mod test {
             .get_caliptra_fw()
             .expect("Failed to build Caliptra firmware for update");
         let update_soc_manifest = update_builder
-            .get_soc_manifest()
+            .get_soc_manifest(None)
             .expect("Failed to build SOC manifest for update");
 
         let temp_soc_manifest = tempfile::NamedTempFile::new()
@@ -472,7 +472,7 @@ mod test {
         ) = create_update_package();
 
         // Compile the runtime once with the appropriate feature
-        let test_runtime = compile_runtime(feature, false);
+        let test_runtime = compile_runtime(Some(feature), false);
 
         let soc_images_paths = create_soc_images(vec![
             soc_image_fw_1.clone().to_vec(),
@@ -526,7 +526,7 @@ mod test {
             .expect("Failed to build Caliptra firmware");
 
         let soc_manifest = builder
-            .get_soc_manifest()
+            .get_soc_manifest(None)
             .expect("Failed to build SOC manifest");
 
         // Generate a flash image file to write to the primary flash

--- a/tests/integration/src/test_mctp_capsule_loopback.rs
+++ b/tests/integration/src/test_mctp_capsule_loopback.rs
@@ -4,9 +4,7 @@
 
 #[cfg(test)]
 mod test {
-    use crate::test::{
-        compile_runtime, finish_runtime_hw_model, start_runtime_hw_model, ROM, TEST_LOCK,
-    };
+    use crate::test::{finish_runtime_hw_model, start_runtime_hw_model, TEST_LOCK};
     use mcu_hw_model::McuHwModel;
     use mcu_testing_common::i3c_socket::{self, BufferedStream, MctpTestState, MctpTransportTest};
     use mcu_testing_common::mctp_util::common::MctpUtil;
@@ -17,14 +15,11 @@ mod test {
     #[test]
     fn test_mctp_capsule_loopback() {
         let feature = "test-mctp-capsule-loopback";
-        let example_app = false;
         let lock = TEST_LOCK.lock().unwrap();
         lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 
-        println!("Compiling test firmware {}", feature);
         let feature = feature.replace("_", "-");
-        let test_runtime = compile_runtime(&feature, example_app);
-        let mut hw = start_runtime_hw_model(ROM.to_path_buf(), test_runtime, Some(65534));
+        let mut hw = start_runtime_hw_model(Some(&feature), Some(65534));
 
         hw.start_i3c_controller();
 

--- a/tests/integration/src/test_mctp_capsule_loopback.rs
+++ b/tests/integration/src/test_mctp_capsule_loopback.rs
@@ -11,7 +11,6 @@ mod test {
     use mcu_testing_common::MCU_RUNNING;
     use std::sync::atomic::Ordering;
 
-    #[cfg_attr(feature = "fpga_realtime", ignore)]
     #[test]
     fn test_mctp_capsule_loopback() {
         let feature = "test-mctp-capsule-loopback";

--- a/tests/integration/src/test_pldm_fw_update.rs
+++ b/tests/integration/src/test_pldm_fw_update.rs
@@ -4,9 +4,7 @@
 
 #[cfg(test)]
 mod test {
-    use crate::test::{
-        compile_runtime, finish_runtime_hw_model, start_runtime_hw_model, ROM, TEST_LOCK,
-    };
+    use crate::test::{finish_runtime_hw_model, start_runtime_hw_model, TEST_LOCK};
     use chrono::{TimeZone, Utc};
     use lazy_static::lazy_static;
     use log::{error, LevelFilter};
@@ -35,14 +33,11 @@ mod test {
     #[test]
     fn test_fw_update_e2e() {
         let feature = "test-pldm-fw-update-e2e";
-        let example_app = false;
         let lock = TEST_LOCK.lock().unwrap();
         lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 
-        println!("Compiling test firmware {}", feature);
         let feature = feature.replace("_", "-");
-        let test_runtime = compile_runtime(&feature, example_app);
-        let mut hw = start_runtime_hw_model(ROM.to_path_buf(), test_runtime, Some(65534));
+        let mut hw = start_runtime_hw_model(Some(&feature), Some(65534));
 
         hw.start_i3c_controller();
 

--- a/tests/integration/src/test_soc_boot.rs
+++ b/tests/integration/src/test_soc_boot.rs
@@ -268,7 +268,7 @@ mod test {
                 .builder
                 .as_mut()
                 .unwrap()
-                .get_soc_manifest()
+                .get_soc_manifest(None)
                 .ok(),
             Some(opts.runtime.clone()),
             opts.partition_table.clone(),
@@ -340,7 +340,7 @@ mod test {
                 .builder
                 .as_mut()
                 .unwrap()
-                .get_soc_manifest()
+                .get_soc_manifest(None)
                 .ok(),
             Some(opts.runtime.clone()),
             opts.partition_table.clone(),
@@ -433,7 +433,7 @@ mod test {
                     .builder
                     .as_mut()
                     .unwrap()
-                    .get_soc_manifest()
+                    .get_soc_manifest(None)
                     .ok(),
                 Some(opts.runtime.clone()),
                 None,
@@ -489,7 +489,7 @@ mod test {
                     .builder
                     .as_mut()
                     .unwrap()
-                    .get_soc_manifest()
+                    .get_soc_manifest(None)
                     .ok(),
                 Some(new_options.runtime.clone()),
                 None,
@@ -636,7 +636,7 @@ mod test {
         let soc_image_fw_2 = [0xAAu8; 256]; // Example firmware data for SOC image 2
 
         // Compile the runtime once with the appropriate feature
-        let test_runtime = compile_runtime(feature, false);
+        let test_runtime = compile_runtime(Some(feature), false);
 
         let soc_images_paths = create_soc_images(vec![
             soc_image_fw_1.clone().to_vec(),
@@ -680,7 +680,7 @@ mod test {
             .expect("Failed to build Caliptra firmware");
 
         let soc_manifest = builder
-            .get_soc_manifest()
+            .get_soc_manifest(None)
             .expect("Failed to build SOC manifest");
 
         // Generate a valid flash image file

--- a/xtask/src/fpga.rs
+++ b/xtask/src/fpga.rs
@@ -513,6 +513,8 @@ pub(crate) fn fpga_run(args: crate::Commands) -> Result<()> {
             caliptra_fw: blank.to_vec(),
             soc_manifest: blank.to_vec(),
             test_roms: vec![],
+            test_runtimes: vec![],
+            test_soc_manifests: vec![],
         }
     };
     let otp_memory = if otp_file.is_some() && otp_file.unwrap().exists() {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -153,6 +153,9 @@ enum Commands {
 
         #[arg(long)]
         runtime_features: Option<String>,
+
+        #[arg(long, default_value_t = false)]
+        separate_runtimes: bool,
     },
     /// Commands related to flash images
     FlashImage {
@@ -350,6 +353,7 @@ fn main() {
             dccm_size,
             rom_features,
             runtime_features,
+            separate_runtimes,
         } => mcu_builder::all_build(mcu_builder::AllBuildArgs {
             output: output.as_deref(),
             platform: platform.as_deref(),
@@ -358,6 +362,7 @@ fn main() {
             dccm_size: *dccm_size,
             rom_features: rom_features.as_deref(),
             runtime_features: runtime_features.as_deref(),
+            separate_runtimes: *separate_runtimes,
         }),
         Commands::Runtime { .. } => runtime::runtime_run(cli.xtask),
         Commands::RuntimeBuild {

--- a/xtask/src/runtime.rs
+++ b/xtask/src/runtime.rs
@@ -62,7 +62,7 @@ pub(crate) fn runtime_run(args: Commands) -> Result<()> {
 
     let caliptra_rom = caliptra_builder.get_caliptra_rom()?;
     let caliptra_firmware = caliptra_builder.get_caliptra_fw()?;
-    let soc_manifest = caliptra_builder.get_soc_manifest()?;
+    let soc_manifest = caliptra_builder.get_soc_manifest(None)?;
     let vendor_pk_hash = caliptra_builder.get_vendor_pk_hash()?;
     let hw_revision = hw_revision.to_string();
     let mut cargo_run_args = vec![

--- a/xtask/src/test.rs
+++ b/xtask/src/test.rs
@@ -16,13 +16,7 @@ fn cargo_test() -> Result<()> {
     println!("Running: cargo test");
     let status = Command::new("cargo")
         .current_dir(&*PROJECT_ROOT)
-        .args([
-            "test",
-            "--workspace",
-            "--",
-            "--skip",
-            "test_mailbox_execute",
-        ])
+        .args(["test", "--workspace"])
         .status()?;
 
     if !status.success() {


### PR DESCRIPTION
The `FwId` and `REGISTERED_FW` abstraction doesn't quite work for specifying the different runtime binaries since they are in a different crate for FPGA. There's additional complexity in that a different runtime would also require a different SoC manifest to authorize it. So I added a slightly different mechanism for building and packaging them in the the `all-fw.zip` bundle.

The downside is that the FPGA test is flaky due to it halting when going through the full recovery flow to load MCU runtime.