### PR TITLE
emulator: Support UTF8 characters in output

### DIFF
--- a/emulator/periph/src/lib.rs
+++ b/emulator/periph/src/lib.rs
@@ -11,6 +11,9 @@ Abstract:
     File contains exports for for Caliptra Emulator Peripheral library.
 
 --*/
+
+#![feature(cell_update)]
+
 mod axicdma;
 mod caliptra_to_ext_bus;
 mod doe_mbox;


### PR DESCRIPTION
So that the Tock panic prints correctly finally:

```
╔═══════════╤══════════════════════════════════════════╗
║  Address  │ Region Name    Used | Allocated (bytes)  ║
╚0x4007F4B0═╪══════════════════════════════════════════╝
            │ Grant Ptrs      120
            │ Upcalls         320
            │ Process         756
 0x4007F004 ┼───────────────────────────────────────────
```

I'll also port this to `caliptra-sw` for the HwModel output.