### PR TITLE
Add OCP LOCK release flops and new message FIFO

### DIFF
--- a/hw/fpga/fpga_wrapper_regs.md
+++ b/hw/fpga/fpga_wrapper_regs.md
@@ -10,7 +10,7 @@ Don't override. Generated from: caliptra_fpga_realtime_regs
 
 - Absolute Address: 0x0
 - Base Offset: 0x0
-- Size: 0xA401101C
+- Size: 0xA4011028
 
 |  Offset  |  Identifier  |Name|
 |----------|--------------|----|
@@ -21,7 +21,7 @@ Don't override. Generated from: caliptra_fpga_realtime_regs
 
 - Absolute Address: 0xA4010000
 - Base Offset: 0xA4010000
-- Size: 0x13C
+- Size: 0x240
 
 |Offset|                  Identifier                  |Name|
 |------|----------------------------------------------|----|
@@ -99,6 +99,22 @@ Don't override. Generated from: caliptra_fpga_realtime_regs
 | 0x130|          mci_generic_input_wires[1]          |  — |
 | 0x134|          mci_generic_output_wires[0]         |  — |
 | 0x138|          mci_generic_output_wires[1]         |  — |
+| 0x200|          ocp_lock_key_release_reg[0]         |  — |
+| 0x204|          ocp_lock_key_release_reg[1]         |  — |
+| 0x208|          ocp_lock_key_release_reg[2]         |  — |
+| 0x20C|          ocp_lock_key_release_reg[3]         |  — |
+| 0x210|          ocp_lock_key_release_reg[4]         |  — |
+| 0x214|          ocp_lock_key_release_reg[5]         |  — |
+| 0x218|          ocp_lock_key_release_reg[6]         |  — |
+| 0x21C|          ocp_lock_key_release_reg[7]         |  — |
+| 0x220|          ocp_lock_key_release_reg[8]         |  — |
+| 0x224|          ocp_lock_key_release_reg[9]         |  — |
+| 0x228|         ocp_lock_key_release_reg[10]         |  — |
+| 0x22C|         ocp_lock_key_release_reg[11]         |  — |
+| 0x230|         ocp_lock_key_release_reg[12]         |  — |
+| 0x234|         ocp_lock_key_release_reg[13]         |  — |
+| 0x238|         ocp_lock_key_release_reg[14]         |  — |
+| 0x23C|         ocp_lock_key_release_reg[15]         |  — |
 
 ### fpga_magic register
 
@@ -1063,11 +1079,219 @@ Don't override. Generated from: caliptra_fpga_realtime_regs
 |----|----------|------|-----|----|
 |31:0|   value  |   r  | 0x0 |  — |
 
+### ocp_lock_key_release_reg register
+
+- Absolute Address: 0xA4010200
+- Base Offset: 0x200
+- Size: 0x4
+- Array Dimensions: [16]
+- Array Stride: 0x4
+- Total Size: 0x40
+
+|Bits|Identifier|Access|Reset|Name|
+|----|----------|------|-----|----|
+|31:0|    key   |  rw  | 0x0 |  — |
+
+### ocp_lock_key_release_reg register
+
+- Absolute Address: 0xA4010204
+- Base Offset: 0x200
+- Size: 0x4
+- Array Dimensions: [16]
+- Array Stride: 0x4
+- Total Size: 0x40
+
+|Bits|Identifier|Access|Reset|Name|
+|----|----------|------|-----|----|
+|31:0|    key   |  rw  | 0x0 |  — |
+
+### ocp_lock_key_release_reg register
+
+- Absolute Address: 0xA4010208
+- Base Offset: 0x200
+- Size: 0x4
+- Array Dimensions: [16]
+- Array Stride: 0x4
+- Total Size: 0x40
+
+|Bits|Identifier|Access|Reset|Name|
+|----|----------|------|-----|----|
+|31:0|    key   |  rw  | 0x0 |  — |
+
+### ocp_lock_key_release_reg register
+
+- Absolute Address: 0xA401020C
+- Base Offset: 0x200
+- Size: 0x4
+- Array Dimensions: [16]
+- Array Stride: 0x4
+- Total Size: 0x40
+
+|Bits|Identifier|Access|Reset|Name|
+|----|----------|------|-----|----|
+|31:0|    key   |  rw  | 0x0 |  — |
+
+### ocp_lock_key_release_reg register
+
+- Absolute Address: 0xA4010210
+- Base Offset: 0x200
+- Size: 0x4
+- Array Dimensions: [16]
+- Array Stride: 0x4
+- Total Size: 0x40
+
+|Bits|Identifier|Access|Reset|Name|
+|----|----------|------|-----|----|
+|31:0|    key   |  rw  | 0x0 |  — |
+
+### ocp_lock_key_release_reg register
+
+- Absolute Address: 0xA4010214
+- Base Offset: 0x200
+- Size: 0x4
+- Array Dimensions: [16]
+- Array Stride: 0x4
+- Total Size: 0x40
+
+|Bits|Identifier|Access|Reset|Name|
+|----|----------|------|-----|----|
+|31:0|    key   |  rw  | 0x0 |  — |
+
+### ocp_lock_key_release_reg register
+
+- Absolute Address: 0xA4010218
+- Base Offset: 0x200
+- Size: 0x4
+- Array Dimensions: [16]
+- Array Stride: 0x4
+- Total Size: 0x40
+
+|Bits|Identifier|Access|Reset|Name|
+|----|----------|------|-----|----|
+|31:0|    key   |  rw  | 0x0 |  — |
+
+### ocp_lock_key_release_reg register
+
+- Absolute Address: 0xA401021C
+- Base Offset: 0x200
+- Size: 0x4
+- Array Dimensions: [16]
+- Array Stride: 0x4
+- Total Size: 0x40
+
+|Bits|Identifier|Access|Reset|Name|
+|----|----------|------|-----|----|
+|31:0|    key   |  rw  | 0x0 |  — |
+
+### ocp_lock_key_release_reg register
+
+- Absolute Address: 0xA4010220
+- Base Offset: 0x200
+- Size: 0x4
+- Array Dimensions: [16]
+- Array Stride: 0x4
+- Total Size: 0x40
+
+|Bits|Identifier|Access|Reset|Name|
+|----|----------|------|-----|----|
+|31:0|    key   |  rw  | 0x0 |  — |
+
+### ocp_lock_key_release_reg register
+
+- Absolute Address: 0xA4010224
+- Base Offset: 0x200
+- Size: 0x4
+- Array Dimensions: [16]
+- Array Stride: 0x4
+- Total Size: 0x40
+
+|Bits|Identifier|Access|Reset|Name|
+|----|----------|------|-----|----|
+|31:0|    key   |  rw  | 0x0 |  — |
+
+### ocp_lock_key_release_reg register
+
+- Absolute Address: 0xA4010228
+- Base Offset: 0x200
+- Size: 0x4
+- Array Dimensions: [16]
+- Array Stride: 0x4
+- Total Size: 0x40
+
+|Bits|Identifier|Access|Reset|Name|
+|----|----------|------|-----|----|
+|31:0|    key   |  rw  | 0x0 |  — |
+
+### ocp_lock_key_release_reg register
+
+- Absolute Address: 0xA401022C
+- Base Offset: 0x200
+- Size: 0x4
+- Array Dimensions: [16]
+- Array Stride: 0x4
+- Total Size: 0x40
+
+|Bits|Identifier|Access|Reset|Name|
+|----|----------|------|-----|----|
+|31:0|    key   |  rw  | 0x0 |  — |
+
+### ocp_lock_key_release_reg register
+
+- Absolute Address: 0xA4010230
+- Base Offset: 0x200
+- Size: 0x4
+- Array Dimensions: [16]
+- Array Stride: 0x4
+- Total Size: 0x40
+
+|Bits|Identifier|Access|Reset|Name|
+|----|----------|------|-----|----|
+|31:0|    key   |  rw  | 0x0 |  — |
+
+### ocp_lock_key_release_reg register
+
+- Absolute Address: 0xA4010234
+- Base Offset: 0x200
+- Size: 0x4
+- Array Dimensions: [16]
+- Array Stride: 0x4
+- Total Size: 0x40
+
+|Bits|Identifier|Access|Reset|Name|
+|----|----------|------|-----|----|
+|31:0|    key   |  rw  | 0x0 |  — |
+
+### ocp_lock_key_release_reg register
+
+- Absolute Address: 0xA4010238
+- Base Offset: 0x200
+- Size: 0x4
+- Array Dimensions: [16]
+- Array Stride: 0x4
+- Total Size: 0x40
+
+|Bits|Identifier|Access|Reset|Name|
+|----|----------|------|-----|----|
+|31:0|    key   |  rw  | 0x0 |  — |
+
+### ocp_lock_key_release_reg register
+
+- Absolute Address: 0xA401023C
+- Base Offset: 0x200
+- Size: 0x4
+- Array Dimensions: [16]
+- Array Stride: 0x4
+- Total Size: 0x40
+
+|Bits|Identifier|Access|Reset|Name|
+|----|----------|------|-----|----|
+|31:0|    key   |  rw  | 0x0 |  — |
+
 ## fifo_regs register file
 
 - Absolute Address: 0xA4011000
 - Base Offset: 0xA4011000
-- Size: 0x1C
+- Size: 0x28
 
 |Offset|    Identifier   |Name|
 |------|-----------------|----|
@@ -1078,6 +1302,9 @@ Don't override. Generated from: caliptra_fpga_realtime_regs
 | 0x10 |   dbg_fifo_pop  |  — |
 | 0x14 |  dbg_fifo_push  |  — |
 | 0x18 | dbg_fifo_status |  — |
+| 0x1C |   msg_fifo_pop  |  — |
+| 0x20 |  msg_fifo_push  |  — |
+| 0x24 | msg_fifo_status |  — |
 
 ### log_fifo_data register
 
@@ -1153,3 +1380,34 @@ Don't override. Generated from: caliptra_fpga_realtime_regs
 |----|--------------|------|-----|----|
 |  0 |dbg_fifo_empty|   r  | 0x0 |  — |
 |  1 | dbg_fifo_full|   r  | 0x0 |  — |
+
+### msg_fifo_pop register
+
+- Absolute Address: 0xA401101C
+- Base Offset: 0x1C
+- Size: 0x4
+
+|Bits|Identifier|Access|Reset|Name|
+|----|----------|------|-----|----|
+|31:0| out_data |   r  | 0x0 |  — |
+
+### msg_fifo_push register
+
+- Absolute Address: 0xA4011020
+- Base Offset: 0x20
+- Size: 0x4
+
+|Bits|Identifier|Access|Reset|Name|
+|----|----------|------|-----|----|
+|31:0|  in_data |  rw  | 0x0 |  — |
+
+### msg_fifo_status register
+
+- Absolute Address: 0xA4011024
+- Base Offset: 0x24
+- Size: 0x4
+
+|Bits|  Identifier  |Access|Reset|Name|
+|----|--------------|------|-----|----|
+|  0 |msg_fifo_empty|   r  | 0x0 |  — |
+|  1 | msg_fifo_full|   r  | 0x0 |  — |

--- a/hw/fpga/src/caliptra_fpga_realtime_regs.rdl
+++ b/hw/fpga/src/caliptra_fpga_realtime_regs.rdl
@@ -206,7 +206,7 @@ regfile interface_regs {
     } mci_generic_output_wires[2];
 
     reg {
-        field { sw=rw; } key[32] = 32'h0;
+        field { sw=rw; hw=na; } key[32] = 32'h0;
     } ocp_lock_key_release_reg[16] @ 0x200;
 };
 

--- a/hw/fpga/src/caliptra_fpga_realtime_regs.rdl
+++ b/hw/fpga/src/caliptra_fpga_realtime_regs.rdl
@@ -207,7 +207,7 @@ regfile interface_regs {
 
     reg {
         field { sw=rw; } key[32] = 32'h0;
-    } ocp_lock_key_release_reg[16] @ 0xA4010200;
+    } ocp_lock_key_release_reg[16] @ 0x200;
 };
 
 regfile fifo_regs {

--- a/hw/fpga/src/caliptra_fpga_realtime_regs.rdl
+++ b/hw/fpga/src/caliptra_fpga_realtime_regs.rdl
@@ -204,6 +204,10 @@ regfile interface_regs {
     reg {
         field { sw=r; hw=rw; } value[32] = 32'b0;
     } mci_generic_output_wires[2];
+
+    reg {
+        field { sw=rw; } key[32] = 32'h0;
+    } ocp_lock_key_release_reg[16] @ 0xA4010200;
 };
 
 regfile fifo_regs {
@@ -239,6 +243,19 @@ regfile fifo_regs {
         field { sw=r; hw=rw; } dbg_fifo_empty = 1'b0;
         field { sw=r; hw=rw; } dbg_fifo_full = 1'b0;
     } dbg_fifo_status;
+    
+    reg {
+        field { sw=r; hw=rw; rd_swacc=true; } out_data[32] = 32'b0;
+    } msg_fifo_pop;
+
+    reg {
+        field { sw=rw; hw=r; wr_swacc=true; } in_data[32] = 32'b0;
+    } msg_fifo_push;
+
+    reg {
+        field { sw=r; hw=rw; } msg_fifo_empty = 1'b0;
+        field { sw=r; hw=rw; } msg_fifo_full = 1'b0;
+    } msg_fifo_status;
 };
 
 addrmap caliptra_fpga_realtime_regs {

--- a/hw/fpga/src/caliptra_fpga_realtime_regs.sv
+++ b/hw/fpga/src/caliptra_fpga_realtime_regs.sv
@@ -29,6 +29,15 @@ module caliptra_fpga_realtime_regs (
     logic cpuif_wr_ack;
     logic cpuif_wr_err;
 
+    `ifndef SYNTHESIS
+        initial begin
+            assert_bad_addr_width: assert($bits(s_axil.ARADDR) >= caliptra_fpga_realtime_regs_pkg::CALIPTRA_FPGA_REALTIME_REGS_MIN_ADDR_WIDTH)
+                else $error("Interface address width of %0d is too small. Shall be at least %0d bits", $bits(s_axil.ARADDR), caliptra_fpga_realtime_regs_pkg::CALIPTRA_FPGA_REALTIME_REGS_MIN_ADDR_WIDTH);
+            assert_bad_data_width: assert($bits(s_axil.WDATA) == caliptra_fpga_realtime_regs_pkg::CALIPTRA_FPGA_REALTIME_REGS_DATA_WIDTH)
+                else $error("Interface data width of %0d is incorrect. Shall be %0d bits", $bits(s_axil.WDATA), caliptra_fpga_realtime_regs_pkg::CALIPTRA_FPGA_REALTIME_REGS_DATA_WIDTH);
+        end
+    `endif
+
     // Max Outstanding Transactions: 2
     logic [1:0] axil_n_in_flight;
     logic axil_prev_was_rd;
@@ -266,22 +275,22 @@ module caliptra_fpga_realtime_regs (
         decoded_reg_strb.interface_regs.itrng_divisor = cpuif_req_masked & (cpuif_addr == 32'ha4010014);
         decoded_reg_strb.interface_regs.cycle_count = cpuif_req_masked & (cpuif_addr == 32'ha4010018);
         for(int i0=0; i0<2; i0++) begin
-            decoded_reg_strb.interface_regs.generic_input_wires[i0] = cpuif_req_masked & (cpuif_addr == 32'ha4010030 + i0*32'h4);
+            decoded_reg_strb.interface_regs.generic_input_wires[i0] = cpuif_req_masked & (cpuif_addr == 32'ha4010030 + (32)'(i0) * 32'h4);
         end
         for(int i0=0; i0<2; i0++) begin
-            decoded_reg_strb.interface_regs.generic_output_wires[i0] = cpuif_req_masked & (cpuif_addr == 32'ha4010038 + i0*32'h4);
+            decoded_reg_strb.interface_regs.generic_output_wires[i0] = cpuif_req_masked & (cpuif_addr == 32'ha4010038 + (32)'(i0) * 32'h4);
         end
         for(int i0=0; i0<8; i0++) begin
-            decoded_reg_strb.interface_regs.cptra_obf_key[i0] = cpuif_req_masked & (cpuif_addr == 32'ha4010040 + i0*32'h4);
+            decoded_reg_strb.interface_regs.cptra_obf_key[i0] = cpuif_req_masked & (cpuif_addr == 32'ha4010040 + (32)'(i0) * 32'h4);
         end
         for(int i0=0; i0<16; i0++) begin
-            decoded_reg_strb.interface_regs.cptra_csr_hmac_key[i0] = cpuif_req_masked & (cpuif_addr == 32'ha4010060 + i0*32'h4);
+            decoded_reg_strb.interface_regs.cptra_csr_hmac_key[i0] = cpuif_req_masked & (cpuif_addr == 32'ha4010060 + (32)'(i0) * 32'h4);
         end
         for(int i0=0; i0<16; i0++) begin
-            decoded_reg_strb.interface_regs.cptra_obf_uds_seed[i0] = cpuif_req_masked & (cpuif_addr == 32'ha40100a0 + i0*32'h4);
+            decoded_reg_strb.interface_regs.cptra_obf_uds_seed[i0] = cpuif_req_masked & (cpuif_addr == 32'ha40100a0 + (32)'(i0) * 32'h4);
         end
         for(int i0=0; i0<8; i0++) begin
-            decoded_reg_strb.interface_regs.cptra_obf_field_entropy[i0] = cpuif_req_masked & (cpuif_addr == 32'ha40100e0 + i0*32'h4);
+            decoded_reg_strb.interface_regs.cptra_obf_field_entropy[i0] = cpuif_req_masked & (cpuif_addr == 32'ha40100e0 + (32)'(i0) * 32'h4);
         end
         decoded_reg_strb.interface_regs.lsu_user = cpuif_req_masked & (cpuif_addr == 32'ha4010100);
         decoded_reg_strb.interface_regs.ifu_user = cpuif_req_masked & (cpuif_addr == 32'ha4010104);
@@ -295,13 +304,13 @@ module caliptra_fpga_realtime_regs (
         decoded_reg_strb.interface_regs.prod_debug_unlock_auth_pk_hash_reg_bank_offset = cpuif_req_masked & (cpuif_addr == 32'ha4010124);
         decoded_reg_strb.interface_regs.num_of_prod_debug_unlock_auth_pk_hashes = cpuif_req_masked & (cpuif_addr == 32'ha4010128);
         for(int i0=0; i0<2; i0++) begin
-            decoded_reg_strb.interface_regs.mci_generic_input_wires[i0] = cpuif_req_masked & (cpuif_addr == 32'ha401012c + i0*32'h4);
+            decoded_reg_strb.interface_regs.mci_generic_input_wires[i0] = cpuif_req_masked & (cpuif_addr == 32'ha401012c + (32)'(i0) * 32'h4);
         end
         for(int i0=0; i0<2; i0++) begin
-            decoded_reg_strb.interface_regs.mci_generic_output_wires[i0] = cpuif_req_masked & (cpuif_addr == 32'ha4010134 + i0*32'h4);
+            decoded_reg_strb.interface_regs.mci_generic_output_wires[i0] = cpuif_req_masked & (cpuif_addr == 32'ha4010134 + (32)'(i0) * 32'h4);
         end
         for(int i0=0; i0<16; i0++) begin
-            decoded_reg_strb.interface_regs.ocp_lock_key_release_reg[i0] = cpuif_req_masked & (cpuif_addr == 32'ha4010200 + i0*32'h4);
+            decoded_reg_strb.interface_regs.ocp_lock_key_release_reg[i0] = cpuif_req_masked & (cpuif_addr == 32'ha4010200 + (32)'(i0) * 32'h4);
         end
         decoded_reg_strb.fifo_regs.log_fifo_data = cpuif_req_masked & (cpuif_addr == 32'ha4011000);
         decoded_reg_strb.fifo_regs.log_fifo_status = cpuif_req_masked & (cpuif_addr == 32'ha4011004);
@@ -928,8 +937,10 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.fpga_version.fpga_version.value <= 32'h0;
-        end else if(field_combo.interface_regs.fpga_version.fpga_version.load_next) begin
-            field_storage.interface_regs.fpga_version.fpga_version.value <= field_combo.interface_regs.fpga_version.fpga_version.next;
+        end else begin
+            if(field_combo.interface_regs.fpga_version.fpga_version.load_next) begin
+                field_storage.interface_regs.fpga_version.fpga_version.value <= field_combo.interface_regs.fpga_version.fpga_version.next;
+            end
         end
     end
     assign hwif_out.interface_regs.fpga_version.fpga_version.value = field_storage.interface_regs.fpga_version.fpga_version.value;
@@ -949,8 +960,10 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.control.cptra_pwrgood.value <= 1'h0;
-        end else if(field_combo.interface_regs.control.cptra_pwrgood.load_next) begin
-            field_storage.interface_regs.control.cptra_pwrgood.value <= field_combo.interface_regs.control.cptra_pwrgood.next;
+        end else begin
+            if(field_combo.interface_regs.control.cptra_pwrgood.load_next) begin
+                field_storage.interface_regs.control.cptra_pwrgood.value <= field_combo.interface_regs.control.cptra_pwrgood.next;
+            end
         end
     end
     assign hwif_out.interface_regs.control.cptra_pwrgood.value = field_storage.interface_regs.control.cptra_pwrgood.value;
@@ -970,8 +983,10 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.control.cptra_ss_rst_b.value <= 1'h0;
-        end else if(field_combo.interface_regs.control.cptra_ss_rst_b.load_next) begin
-            field_storage.interface_regs.control.cptra_ss_rst_b.value <= field_combo.interface_regs.control.cptra_ss_rst_b.next;
+        end else begin
+            if(field_combo.interface_regs.control.cptra_ss_rst_b.load_next) begin
+                field_storage.interface_regs.control.cptra_ss_rst_b.value <= field_combo.interface_regs.control.cptra_ss_rst_b.next;
+            end
         end
     end
     assign hwif_out.interface_regs.control.cptra_ss_rst_b.value = field_storage.interface_regs.control.cptra_ss_rst_b.value;
@@ -991,8 +1006,10 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.control.cptra_obf_uds_seed_vld.value <= 1'h0;
-        end else if(field_combo.interface_regs.control.cptra_obf_uds_seed_vld.load_next) begin
-            field_storage.interface_regs.control.cptra_obf_uds_seed_vld.value <= field_combo.interface_regs.control.cptra_obf_uds_seed_vld.next;
+        end else begin
+            if(field_combo.interface_regs.control.cptra_obf_uds_seed_vld.load_next) begin
+                field_storage.interface_regs.control.cptra_obf_uds_seed_vld.value <= field_combo.interface_regs.control.cptra_obf_uds_seed_vld.next;
+            end
         end
     end
     assign hwif_out.interface_regs.control.cptra_obf_uds_seed_vld.value = field_storage.interface_regs.control.cptra_obf_uds_seed_vld.value;
@@ -1012,8 +1029,10 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.control.cptra_obf_field_entropy_vld.value <= 1'h0;
-        end else if(field_combo.interface_regs.control.cptra_obf_field_entropy_vld.load_next) begin
-            field_storage.interface_regs.control.cptra_obf_field_entropy_vld.value <= field_combo.interface_regs.control.cptra_obf_field_entropy_vld.next;
+        end else begin
+            if(field_combo.interface_regs.control.cptra_obf_field_entropy_vld.load_next) begin
+                field_storage.interface_regs.control.cptra_obf_field_entropy_vld.value <= field_combo.interface_regs.control.cptra_obf_field_entropy_vld.next;
+            end
         end
     end
     assign hwif_out.interface_regs.control.cptra_obf_field_entropy_vld.value = field_storage.interface_regs.control.cptra_obf_field_entropy_vld.value;
@@ -1033,8 +1052,10 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.control.bootfsm_brkpoint.value <= 1'h0;
-        end else if(field_combo.interface_regs.control.bootfsm_brkpoint.load_next) begin
-            field_storage.interface_regs.control.bootfsm_brkpoint.value <= field_combo.interface_regs.control.bootfsm_brkpoint.next;
+        end else begin
+            if(field_combo.interface_regs.control.bootfsm_brkpoint.load_next) begin
+                field_storage.interface_regs.control.bootfsm_brkpoint.value <= field_combo.interface_regs.control.bootfsm_brkpoint.next;
+            end
         end
     end
     assign hwif_out.interface_regs.control.bootfsm_brkpoint.value = field_storage.interface_regs.control.bootfsm_brkpoint.value;
@@ -1054,8 +1075,10 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.control.ss_debug_intent.value <= 1'h0;
-        end else if(field_combo.interface_regs.control.ss_debug_intent.load_next) begin
-            field_storage.interface_regs.control.ss_debug_intent.value <= field_combo.interface_regs.control.ss_debug_intent.next;
+        end else begin
+            if(field_combo.interface_regs.control.ss_debug_intent.load_next) begin
+                field_storage.interface_regs.control.ss_debug_intent.value <= field_combo.interface_regs.control.ss_debug_intent.next;
+            end
         end
     end
     assign hwif_out.interface_regs.control.ss_debug_intent.value = field_storage.interface_regs.control.ss_debug_intent.value;
@@ -1075,8 +1098,10 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.control.i3c_axi_user_id_filtering.value <= 1'h0;
-        end else if(field_combo.interface_regs.control.i3c_axi_user_id_filtering.load_next) begin
-            field_storage.interface_regs.control.i3c_axi_user_id_filtering.value <= field_combo.interface_regs.control.i3c_axi_user_id_filtering.next;
+        end else begin
+            if(field_combo.interface_regs.control.i3c_axi_user_id_filtering.load_next) begin
+                field_storage.interface_regs.control.i3c_axi_user_id_filtering.value <= field_combo.interface_regs.control.i3c_axi_user_id_filtering.next;
+            end
         end
     end
     assign hwif_out.interface_regs.control.i3c_axi_user_id_filtering.value = field_storage.interface_regs.control.i3c_axi_user_id_filtering.value;
@@ -1099,8 +1124,10 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.control.trigger_axi_reset.value <= 1'h0;
-        end else if(field_combo.interface_regs.control.trigger_axi_reset.load_next) begin
-            field_storage.interface_regs.control.trigger_axi_reset.value <= field_combo.interface_regs.control.trigger_axi_reset.next;
+        end else begin
+            if(field_combo.interface_regs.control.trigger_axi_reset.load_next) begin
+                field_storage.interface_regs.control.trigger_axi_reset.value <= field_combo.interface_regs.control.trigger_axi_reset.next;
+            end
         end
     end
     assign hwif_out.interface_regs.control.trigger_axi_reset.value = field_storage.interface_regs.control.trigger_axi_reset.value;
@@ -1120,8 +1147,10 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.status.cptra_error_fatal.value <= 1'h0;
-        end else if(field_combo.interface_regs.status.cptra_error_fatal.load_next) begin
-            field_storage.interface_regs.status.cptra_error_fatal.value <= field_combo.interface_regs.status.cptra_error_fatal.next;
+        end else begin
+            if(field_combo.interface_regs.status.cptra_error_fatal.load_next) begin
+                field_storage.interface_regs.status.cptra_error_fatal.value <= field_combo.interface_regs.status.cptra_error_fatal.next;
+            end
         end
     end
     assign hwif_out.interface_regs.status.cptra_error_fatal.value = field_storage.interface_regs.status.cptra_error_fatal.value;
@@ -1141,8 +1170,10 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.status.cptra_error_non_fatal.value <= 1'h0;
-        end else if(field_combo.interface_regs.status.cptra_error_non_fatal.load_next) begin
-            field_storage.interface_regs.status.cptra_error_non_fatal.value <= field_combo.interface_regs.status.cptra_error_non_fatal.next;
+        end else begin
+            if(field_combo.interface_regs.status.cptra_error_non_fatal.load_next) begin
+                field_storage.interface_regs.status.cptra_error_non_fatal.value <= field_combo.interface_regs.status.cptra_error_non_fatal.next;
+            end
         end
     end
     assign hwif_out.interface_regs.status.cptra_error_non_fatal.value = field_storage.interface_regs.status.cptra_error_non_fatal.value;
@@ -1162,8 +1193,10 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.status.ready_for_fuses.value <= 1'h0;
-        end else if(field_combo.interface_regs.status.ready_for_fuses.load_next) begin
-            field_storage.interface_regs.status.ready_for_fuses.value <= field_combo.interface_regs.status.ready_for_fuses.next;
+        end else begin
+            if(field_combo.interface_regs.status.ready_for_fuses.load_next) begin
+                field_storage.interface_regs.status.ready_for_fuses.value <= field_combo.interface_regs.status.ready_for_fuses.next;
+            end
         end
     end
     assign hwif_out.interface_regs.status.ready_for_fuses.value = field_storage.interface_regs.status.ready_for_fuses.value;
@@ -1183,8 +1216,10 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.status.ready_for_fw_push.value <= 1'h0;
-        end else if(field_combo.interface_regs.status.ready_for_fw_push.load_next) begin
-            field_storage.interface_regs.status.ready_for_fw_push.value <= field_combo.interface_regs.status.ready_for_fw_push.next;
+        end else begin
+            if(field_combo.interface_regs.status.ready_for_fw_push.load_next) begin
+                field_storage.interface_regs.status.ready_for_fw_push.value <= field_combo.interface_regs.status.ready_for_fw_push.next;
+            end
         end
     end
     assign hwif_out.interface_regs.status.ready_for_fw_push.value = field_storage.interface_regs.status.ready_for_fw_push.value;
@@ -1204,8 +1239,10 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.status.ready_for_runtime.value <= 1'h0;
-        end else if(field_combo.interface_regs.status.ready_for_runtime.load_next) begin
-            field_storage.interface_regs.status.ready_for_runtime.value <= field_combo.interface_regs.status.ready_for_runtime.next;
+        end else begin
+            if(field_combo.interface_regs.status.ready_for_runtime.load_next) begin
+                field_storage.interface_regs.status.ready_for_runtime.value <= field_combo.interface_regs.status.ready_for_runtime.next;
+            end
         end
     end
     assign hwif_out.interface_regs.status.ready_for_runtime.value = field_storage.interface_regs.status.ready_for_runtime.value;
@@ -1225,8 +1262,10 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.status.mailbox_data_avail.value <= 1'h0;
-        end else if(field_combo.interface_regs.status.mailbox_data_avail.load_next) begin
-            field_storage.interface_regs.status.mailbox_data_avail.value <= field_combo.interface_regs.status.mailbox_data_avail.next;
+        end else begin
+            if(field_combo.interface_regs.status.mailbox_data_avail.load_next) begin
+                field_storage.interface_regs.status.mailbox_data_avail.value <= field_combo.interface_regs.status.mailbox_data_avail.next;
+            end
         end
     end
     assign hwif_out.interface_regs.status.mailbox_data_avail.value = field_storage.interface_regs.status.mailbox_data_avail.value;
@@ -1246,8 +1285,10 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.status.mailbox_flow_done.value <= 1'h0;
-        end else if(field_combo.interface_regs.status.mailbox_flow_done.load_next) begin
-            field_storage.interface_regs.status.mailbox_flow_done.value <= field_combo.interface_regs.status.mailbox_flow_done.next;
+        end else begin
+            if(field_combo.interface_regs.status.mailbox_flow_done.load_next) begin
+                field_storage.interface_regs.status.mailbox_flow_done.value <= field_combo.interface_regs.status.mailbox_flow_done.next;
+            end
         end
     end
     assign hwif_out.interface_regs.status.mailbox_flow_done.value = field_storage.interface_regs.status.mailbox_flow_done.value;
@@ -1267,8 +1308,10 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.arm_user.arm_user.value <= 32'h0;
-        end else if(field_combo.interface_regs.arm_user.arm_user.load_next) begin
-            field_storage.interface_regs.arm_user.arm_user.value <= field_combo.interface_regs.arm_user.arm_user.next;
+        end else begin
+            if(field_combo.interface_regs.arm_user.arm_user.load_next) begin
+                field_storage.interface_regs.arm_user.arm_user.value <= field_combo.interface_regs.arm_user.arm_user.next;
+            end
         end
     end
     assign hwif_out.interface_regs.arm_user.arm_user.value = field_storage.interface_regs.arm_user.arm_user.value;
@@ -1288,8 +1331,10 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.itrng_divisor.itrng_divisor.value <= 32'h0;
-        end else if(field_combo.interface_regs.itrng_divisor.itrng_divisor.load_next) begin
-            field_storage.interface_regs.itrng_divisor.itrng_divisor.value <= field_combo.interface_regs.itrng_divisor.itrng_divisor.next;
+        end else begin
+            if(field_combo.interface_regs.itrng_divisor.itrng_divisor.load_next) begin
+                field_storage.interface_regs.itrng_divisor.itrng_divisor.value <= field_combo.interface_regs.itrng_divisor.itrng_divisor.next;
+            end
         end
     end
     assign hwif_out.interface_regs.itrng_divisor.itrng_divisor.value = field_storage.interface_regs.itrng_divisor.itrng_divisor.value;
@@ -1309,8 +1354,10 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.cycle_count.cycle_count.value <= 32'h0;
-        end else if(field_combo.interface_regs.cycle_count.cycle_count.load_next) begin
-            field_storage.interface_regs.cycle_count.cycle_count.value <= field_combo.interface_regs.cycle_count.cycle_count.next;
+        end else begin
+            if(field_combo.interface_regs.cycle_count.cycle_count.load_next) begin
+                field_storage.interface_regs.cycle_count.cycle_count.value <= field_combo.interface_regs.cycle_count.cycle_count.next;
+            end
         end
     end
     assign hwif_out.interface_regs.cycle_count.cycle_count.value = field_storage.interface_regs.cycle_count.cycle_count.value;
@@ -1331,8 +1378,10 @@ module caliptra_fpga_realtime_regs (
         always_ff @(posedge clk) begin
             if(rst) begin
                 field_storage.interface_regs.generic_input_wires[i0].value.value <= 32'h0;
-            end else if(field_combo.interface_regs.generic_input_wires[i0].value.load_next) begin
-                field_storage.interface_regs.generic_input_wires[i0].value.value <= field_combo.interface_regs.generic_input_wires[i0].value.next;
+            end else begin
+                if(field_combo.interface_regs.generic_input_wires[i0].value.load_next) begin
+                    field_storage.interface_regs.generic_input_wires[i0].value.value <= field_combo.interface_regs.generic_input_wires[i0].value.next;
+                end
             end
         end
         assign hwif_out.interface_regs.generic_input_wires[i0].value.value = field_storage.interface_regs.generic_input_wires[i0].value.value;
@@ -1354,8 +1403,10 @@ module caliptra_fpga_realtime_regs (
         always_ff @(posedge clk) begin
             if(rst) begin
                 field_storage.interface_regs.generic_output_wires[i0].value.value <= 32'h0;
-            end else if(field_combo.interface_regs.generic_output_wires[i0].value.load_next) begin
-                field_storage.interface_regs.generic_output_wires[i0].value.value <= field_combo.interface_regs.generic_output_wires[i0].value.next;
+            end else begin
+                if(field_combo.interface_regs.generic_output_wires[i0].value.load_next) begin
+                    field_storage.interface_regs.generic_output_wires[i0].value.value <= field_combo.interface_regs.generic_output_wires[i0].value.next;
+                end
             end
         end
         assign hwif_out.interface_regs.generic_output_wires[i0].value.value = field_storage.interface_regs.generic_output_wires[i0].value.value;
@@ -1377,8 +1428,10 @@ module caliptra_fpga_realtime_regs (
         always_ff @(posedge clk) begin
             if(rst) begin
                 field_storage.interface_regs.cptra_obf_key[i0].value.value <= 32'h0;
-            end else if(field_combo.interface_regs.cptra_obf_key[i0].value.load_next) begin
-                field_storage.interface_regs.cptra_obf_key[i0].value.value <= field_combo.interface_regs.cptra_obf_key[i0].value.next;
+            end else begin
+                if(field_combo.interface_regs.cptra_obf_key[i0].value.load_next) begin
+                    field_storage.interface_regs.cptra_obf_key[i0].value.value <= field_combo.interface_regs.cptra_obf_key[i0].value.next;
+                end
             end
         end
         assign hwif_out.interface_regs.cptra_obf_key[i0].value.value = field_storage.interface_regs.cptra_obf_key[i0].value.value;
@@ -1400,8 +1453,10 @@ module caliptra_fpga_realtime_regs (
         always_ff @(posedge clk) begin
             if(rst) begin
                 field_storage.interface_regs.cptra_csr_hmac_key[i0].value.value <= 32'h0;
-            end else if(field_combo.interface_regs.cptra_csr_hmac_key[i0].value.load_next) begin
-                field_storage.interface_regs.cptra_csr_hmac_key[i0].value.value <= field_combo.interface_regs.cptra_csr_hmac_key[i0].value.next;
+            end else begin
+                if(field_combo.interface_regs.cptra_csr_hmac_key[i0].value.load_next) begin
+                    field_storage.interface_regs.cptra_csr_hmac_key[i0].value.value <= field_combo.interface_regs.cptra_csr_hmac_key[i0].value.next;
+                end
             end
         end
         assign hwif_out.interface_regs.cptra_csr_hmac_key[i0].value.value = field_storage.interface_regs.cptra_csr_hmac_key[i0].value.value;
@@ -1423,8 +1478,10 @@ module caliptra_fpga_realtime_regs (
         always_ff @(posedge clk) begin
             if(rst) begin
                 field_storage.interface_regs.cptra_obf_uds_seed[i0].value.value <= 32'h0;
-            end else if(field_combo.interface_regs.cptra_obf_uds_seed[i0].value.load_next) begin
-                field_storage.interface_regs.cptra_obf_uds_seed[i0].value.value <= field_combo.interface_regs.cptra_obf_uds_seed[i0].value.next;
+            end else begin
+                if(field_combo.interface_regs.cptra_obf_uds_seed[i0].value.load_next) begin
+                    field_storage.interface_regs.cptra_obf_uds_seed[i0].value.value <= field_combo.interface_regs.cptra_obf_uds_seed[i0].value.next;
+                end
             end
         end
         assign hwif_out.interface_regs.cptra_obf_uds_seed[i0].value.value = field_storage.interface_regs.cptra_obf_uds_seed[i0].value.value;
@@ -1446,8 +1503,10 @@ module caliptra_fpga_realtime_regs (
         always_ff @(posedge clk) begin
             if(rst) begin
                 field_storage.interface_regs.cptra_obf_field_entropy[i0].value.value <= 32'h0;
-            end else if(field_combo.interface_regs.cptra_obf_field_entropy[i0].value.load_next) begin
-                field_storage.interface_regs.cptra_obf_field_entropy[i0].value.value <= field_combo.interface_regs.cptra_obf_field_entropy[i0].value.next;
+            end else begin
+                if(field_combo.interface_regs.cptra_obf_field_entropy[i0].value.load_next) begin
+                    field_storage.interface_regs.cptra_obf_field_entropy[i0].value.value <= field_combo.interface_regs.cptra_obf_field_entropy[i0].value.next;
+                end
             end
         end
         assign hwif_out.interface_regs.cptra_obf_field_entropy[i0].value.value = field_storage.interface_regs.cptra_obf_field_entropy[i0].value.value;
@@ -1468,8 +1527,10 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.lsu_user.lsu_user.value <= 32'h0;
-        end else if(field_combo.interface_regs.lsu_user.lsu_user.load_next) begin
-            field_storage.interface_regs.lsu_user.lsu_user.value <= field_combo.interface_regs.lsu_user.lsu_user.next;
+        end else begin
+            if(field_combo.interface_regs.lsu_user.lsu_user.load_next) begin
+                field_storage.interface_regs.lsu_user.lsu_user.value <= field_combo.interface_regs.lsu_user.lsu_user.next;
+            end
         end
     end
     assign hwif_out.interface_regs.lsu_user.lsu_user.value = field_storage.interface_regs.lsu_user.lsu_user.value;
@@ -1489,8 +1550,10 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.ifu_user.ifu_user.value <= 32'h0;
-        end else if(field_combo.interface_regs.ifu_user.ifu_user.load_next) begin
-            field_storage.interface_regs.ifu_user.ifu_user.value <= field_combo.interface_regs.ifu_user.ifu_user.next;
+        end else begin
+            if(field_combo.interface_regs.ifu_user.ifu_user.load_next) begin
+                field_storage.interface_regs.ifu_user.ifu_user.value <= field_combo.interface_regs.ifu_user.ifu_user.next;
+            end
         end
     end
     assign hwif_out.interface_regs.ifu_user.ifu_user.value = field_storage.interface_regs.ifu_user.ifu_user.value;
@@ -1510,8 +1573,10 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.dma_axi_user.dma_axi_user.value <= 32'h0;
-        end else if(field_combo.interface_regs.dma_axi_user.dma_axi_user.load_next) begin
-            field_storage.interface_regs.dma_axi_user.dma_axi_user.value <= field_combo.interface_regs.dma_axi_user.dma_axi_user.next;
+        end else begin
+            if(field_combo.interface_regs.dma_axi_user.dma_axi_user.load_next) begin
+                field_storage.interface_regs.dma_axi_user.dma_axi_user.value <= field_combo.interface_regs.dma_axi_user.dma_axi_user.next;
+            end
         end
     end
     assign hwif_out.interface_regs.dma_axi_user.dma_axi_user.value = field_storage.interface_regs.dma_axi_user.dma_axi_user.value;
@@ -1531,8 +1596,10 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.soc_config_user.soc_config_user.value <= 32'h0;
-        end else if(field_combo.interface_regs.soc_config_user.soc_config_user.load_next) begin
-            field_storage.interface_regs.soc_config_user.soc_config_user.value <= field_combo.interface_regs.soc_config_user.soc_config_user.next;
+        end else begin
+            if(field_combo.interface_regs.soc_config_user.soc_config_user.load_next) begin
+                field_storage.interface_regs.soc_config_user.soc_config_user.value <= field_combo.interface_regs.soc_config_user.soc_config_user.next;
+            end
         end
     end
     assign hwif_out.interface_regs.soc_config_user.soc_config_user.value = field_storage.interface_regs.soc_config_user.soc_config_user.value;
@@ -1552,8 +1619,10 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.sram_config_user.sram_config_user.value <= 32'h0;
-        end else if(field_combo.interface_regs.sram_config_user.sram_config_user.load_next) begin
-            field_storage.interface_regs.sram_config_user.sram_config_user.value <= field_combo.interface_regs.sram_config_user.sram_config_user.next;
+        end else begin
+            if(field_combo.interface_regs.sram_config_user.sram_config_user.load_next) begin
+                field_storage.interface_regs.sram_config_user.sram_config_user.value <= field_combo.interface_regs.sram_config_user.sram_config_user.next;
+            end
         end
     end
     assign hwif_out.interface_regs.sram_config_user.sram_config_user.value = field_storage.interface_regs.sram_config_user.sram_config_user.value;
@@ -1573,8 +1642,10 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.mcu_reset_vector.mcu_reset_vector.value <= 32'h0;
-        end else if(field_combo.interface_regs.mcu_reset_vector.mcu_reset_vector.load_next) begin
-            field_storage.interface_regs.mcu_reset_vector.mcu_reset_vector.value <= field_combo.interface_regs.mcu_reset_vector.mcu_reset_vector.next;
+        end else begin
+            if(field_combo.interface_regs.mcu_reset_vector.mcu_reset_vector.load_next) begin
+                field_storage.interface_regs.mcu_reset_vector.mcu_reset_vector.value <= field_combo.interface_regs.mcu_reset_vector.mcu_reset_vector.next;
+            end
         end
     end
     assign hwif_out.interface_regs.mcu_reset_vector.mcu_reset_vector.value = field_storage.interface_regs.mcu_reset_vector.mcu_reset_vector.value;
@@ -1594,8 +1665,10 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.mci_error.mci_error_fatal.value <= 1'h0;
-        end else if(field_combo.interface_regs.mci_error.mci_error_fatal.load_next) begin
-            field_storage.interface_regs.mci_error.mci_error_fatal.value <= field_combo.interface_regs.mci_error.mci_error_fatal.next;
+        end else begin
+            if(field_combo.interface_regs.mci_error.mci_error_fatal.load_next) begin
+                field_storage.interface_regs.mci_error.mci_error_fatal.value <= field_combo.interface_regs.mci_error.mci_error_fatal.next;
+            end
         end
     end
     assign hwif_out.interface_regs.mci_error.mci_error_fatal.value = field_storage.interface_regs.mci_error.mci_error_fatal.value;
@@ -1615,8 +1688,10 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.mci_error.mci_error_non_fatal.value <= 1'h0;
-        end else if(field_combo.interface_regs.mci_error.mci_error_non_fatal.load_next) begin
-            field_storage.interface_regs.mci_error.mci_error_non_fatal.value <= field_combo.interface_regs.mci_error.mci_error_non_fatal.next;
+        end else begin
+            if(field_combo.interface_regs.mci_error.mci_error_non_fatal.load_next) begin
+                field_storage.interface_regs.mci_error.mci_error_non_fatal.value <= field_combo.interface_regs.mci_error.mci_error_non_fatal.next;
+            end
         end
     end
     assign hwif_out.interface_regs.mci_error.mci_error_non_fatal.value = field_storage.interface_regs.mci_error.mci_error_non_fatal.value;
@@ -1636,8 +1711,10 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.mcu_config.mcu_no_rom_config.value <= 1'h0;
-        end else if(field_combo.interface_regs.mcu_config.mcu_no_rom_config.load_next) begin
-            field_storage.interface_regs.mcu_config.mcu_no_rom_config.value <= field_combo.interface_regs.mcu_config.mcu_no_rom_config.next;
+        end else begin
+            if(field_combo.interface_regs.mcu_config.mcu_no_rom_config.load_next) begin
+                field_storage.interface_regs.mcu_config.mcu_no_rom_config.value <= field_combo.interface_regs.mcu_config.mcu_no_rom_config.next;
+            end
         end
     end
     assign hwif_out.interface_regs.mcu_config.mcu_no_rom_config.value = field_storage.interface_regs.mcu_config.mcu_no_rom_config.value;
@@ -1657,8 +1734,10 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.mcu_config.cptra_ss_mci_boot_seq_brkpoint_i.value <= 1'h0;
-        end else if(field_combo.interface_regs.mcu_config.cptra_ss_mci_boot_seq_brkpoint_i.load_next) begin
-            field_storage.interface_regs.mcu_config.cptra_ss_mci_boot_seq_brkpoint_i.value <= field_combo.interface_regs.mcu_config.cptra_ss_mci_boot_seq_brkpoint_i.next;
+        end else begin
+            if(field_combo.interface_regs.mcu_config.cptra_ss_mci_boot_seq_brkpoint_i.load_next) begin
+                field_storage.interface_regs.mcu_config.cptra_ss_mci_boot_seq_brkpoint_i.value <= field_combo.interface_regs.mcu_config.cptra_ss_mci_boot_seq_brkpoint_i.next;
+            end
         end
     end
     assign hwif_out.interface_regs.mcu_config.cptra_ss_mci_boot_seq_brkpoint_i.value = field_storage.interface_regs.mcu_config.cptra_ss_mci_boot_seq_brkpoint_i.value;
@@ -1678,8 +1757,10 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.mcu_config.cptra_ss_lc_Allow_RMA_on_PPD_i.value <= 1'h0;
-        end else if(field_combo.interface_regs.mcu_config.cptra_ss_lc_Allow_RMA_on_PPD_i.load_next) begin
-            field_storage.interface_regs.mcu_config.cptra_ss_lc_Allow_RMA_on_PPD_i.value <= field_combo.interface_regs.mcu_config.cptra_ss_lc_Allow_RMA_on_PPD_i.next;
+        end else begin
+            if(field_combo.interface_regs.mcu_config.cptra_ss_lc_Allow_RMA_on_PPD_i.load_next) begin
+                field_storage.interface_regs.mcu_config.cptra_ss_lc_Allow_RMA_on_PPD_i.value <= field_combo.interface_regs.mcu_config.cptra_ss_lc_Allow_RMA_on_PPD_i.next;
+            end
         end
     end
     assign hwif_out.interface_regs.mcu_config.cptra_ss_lc_Allow_RMA_on_PPD_i.value = field_storage.interface_regs.mcu_config.cptra_ss_lc_Allow_RMA_on_PPD_i.value;
@@ -1699,8 +1780,10 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.mcu_config.cptra_ss_lc_ctrl_scan_rst_ni_i.value <= 1'h0;
-        end else if(field_combo.interface_regs.mcu_config.cptra_ss_lc_ctrl_scan_rst_ni_i.load_next) begin
-            field_storage.interface_regs.mcu_config.cptra_ss_lc_ctrl_scan_rst_ni_i.value <= field_combo.interface_regs.mcu_config.cptra_ss_lc_ctrl_scan_rst_ni_i.next;
+        end else begin
+            if(field_combo.interface_regs.mcu_config.cptra_ss_lc_ctrl_scan_rst_ni_i.load_next) begin
+                field_storage.interface_regs.mcu_config.cptra_ss_lc_ctrl_scan_rst_ni_i.value <= field_combo.interface_regs.mcu_config.cptra_ss_lc_ctrl_scan_rst_ni_i.next;
+            end
         end
     end
     assign hwif_out.interface_regs.mcu_config.cptra_ss_lc_ctrl_scan_rst_ni_i.value = field_storage.interface_regs.mcu_config.cptra_ss_lc_ctrl_scan_rst_ni_i.value;
@@ -1720,8 +1803,10 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.mcu_config.cptra_ss_lc_esclate_scrap_state0_i.value <= 1'h0;
-        end else if(field_combo.interface_regs.mcu_config.cptra_ss_lc_esclate_scrap_state0_i.load_next) begin
-            field_storage.interface_regs.mcu_config.cptra_ss_lc_esclate_scrap_state0_i.value <= field_combo.interface_regs.mcu_config.cptra_ss_lc_esclate_scrap_state0_i.next;
+        end else begin
+            if(field_combo.interface_regs.mcu_config.cptra_ss_lc_esclate_scrap_state0_i.load_next) begin
+                field_storage.interface_regs.mcu_config.cptra_ss_lc_esclate_scrap_state0_i.value <= field_combo.interface_regs.mcu_config.cptra_ss_lc_esclate_scrap_state0_i.next;
+            end
         end
     end
     assign hwif_out.interface_regs.mcu_config.cptra_ss_lc_esclate_scrap_state0_i.value = field_storage.interface_regs.mcu_config.cptra_ss_lc_esclate_scrap_state0_i.value;
@@ -1741,8 +1826,10 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.mcu_config.cptra_ss_lc_esclate_scrap_state1_i.value <= 1'h0;
-        end else if(field_combo.interface_regs.mcu_config.cptra_ss_lc_esclate_scrap_state1_i.load_next) begin
-            field_storage.interface_regs.mcu_config.cptra_ss_lc_esclate_scrap_state1_i.value <= field_combo.interface_regs.mcu_config.cptra_ss_lc_esclate_scrap_state1_i.next;
+        end else begin
+            if(field_combo.interface_regs.mcu_config.cptra_ss_lc_esclate_scrap_state1_i.load_next) begin
+                field_storage.interface_regs.mcu_config.cptra_ss_lc_esclate_scrap_state1_i.value <= field_combo.interface_regs.mcu_config.cptra_ss_lc_esclate_scrap_state1_i.next;
+            end
         end
     end
     assign hwif_out.interface_regs.mcu_config.cptra_ss_lc_esclate_scrap_state1_i.value = field_storage.interface_regs.mcu_config.cptra_ss_lc_esclate_scrap_state1_i.value;
@@ -1762,8 +1849,10 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.uds_seed_base_addr.uds_seed_base_addr.value <= 32'h0;
-        end else if(field_combo.interface_regs.uds_seed_base_addr.uds_seed_base_addr.load_next) begin
-            field_storage.interface_regs.uds_seed_base_addr.uds_seed_base_addr.value <= field_combo.interface_regs.uds_seed_base_addr.uds_seed_base_addr.next;
+        end else begin
+            if(field_combo.interface_regs.uds_seed_base_addr.uds_seed_base_addr.load_next) begin
+                field_storage.interface_regs.uds_seed_base_addr.uds_seed_base_addr.value <= field_combo.interface_regs.uds_seed_base_addr.uds_seed_base_addr.next;
+            end
         end
     end
     assign hwif_out.interface_regs.uds_seed_base_addr.uds_seed_base_addr.value = field_storage.interface_regs.uds_seed_base_addr.uds_seed_base_addr.value;
@@ -1783,8 +1872,10 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.prod_debug_unlock_auth_pk_hash_reg_bank_offset.prod_debug_unlock_auth_pk_hash_reg_bank_offset.value <= 32'h0;
-        end else if(field_combo.interface_regs.prod_debug_unlock_auth_pk_hash_reg_bank_offset.prod_debug_unlock_auth_pk_hash_reg_bank_offset.load_next) begin
-            field_storage.interface_regs.prod_debug_unlock_auth_pk_hash_reg_bank_offset.prod_debug_unlock_auth_pk_hash_reg_bank_offset.value <= field_combo.interface_regs.prod_debug_unlock_auth_pk_hash_reg_bank_offset.prod_debug_unlock_auth_pk_hash_reg_bank_offset.next;
+        end else begin
+            if(field_combo.interface_regs.prod_debug_unlock_auth_pk_hash_reg_bank_offset.prod_debug_unlock_auth_pk_hash_reg_bank_offset.load_next) begin
+                field_storage.interface_regs.prod_debug_unlock_auth_pk_hash_reg_bank_offset.prod_debug_unlock_auth_pk_hash_reg_bank_offset.value <= field_combo.interface_regs.prod_debug_unlock_auth_pk_hash_reg_bank_offset.prod_debug_unlock_auth_pk_hash_reg_bank_offset.next;
+            end
         end
     end
     assign hwif_out.interface_regs.prod_debug_unlock_auth_pk_hash_reg_bank_offset.prod_debug_unlock_auth_pk_hash_reg_bank_offset.value = field_storage.interface_regs.prod_debug_unlock_auth_pk_hash_reg_bank_offset.prod_debug_unlock_auth_pk_hash_reg_bank_offset.value;
@@ -1804,8 +1895,10 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.num_of_prod_debug_unlock_auth_pk_hashes.num_of_prod_debug_unlock_auth_pk_hashes.value <= 32'h0;
-        end else if(field_combo.interface_regs.num_of_prod_debug_unlock_auth_pk_hashes.num_of_prod_debug_unlock_auth_pk_hashes.load_next) begin
-            field_storage.interface_regs.num_of_prod_debug_unlock_auth_pk_hashes.num_of_prod_debug_unlock_auth_pk_hashes.value <= field_combo.interface_regs.num_of_prod_debug_unlock_auth_pk_hashes.num_of_prod_debug_unlock_auth_pk_hashes.next;
+        end else begin
+            if(field_combo.interface_regs.num_of_prod_debug_unlock_auth_pk_hashes.num_of_prod_debug_unlock_auth_pk_hashes.load_next) begin
+                field_storage.interface_regs.num_of_prod_debug_unlock_auth_pk_hashes.num_of_prod_debug_unlock_auth_pk_hashes.value <= field_combo.interface_regs.num_of_prod_debug_unlock_auth_pk_hashes.num_of_prod_debug_unlock_auth_pk_hashes.next;
+            end
         end
     end
     assign hwif_out.interface_regs.num_of_prod_debug_unlock_auth_pk_hashes.num_of_prod_debug_unlock_auth_pk_hashes.value = field_storage.interface_regs.num_of_prod_debug_unlock_auth_pk_hashes.num_of_prod_debug_unlock_auth_pk_hashes.value;
@@ -1826,8 +1919,10 @@ module caliptra_fpga_realtime_regs (
         always_ff @(posedge clk) begin
             if(rst) begin
                 field_storage.interface_regs.mci_generic_input_wires[i0].value.value <= 32'h0;
-            end else if(field_combo.interface_regs.mci_generic_input_wires[i0].value.load_next) begin
-                field_storage.interface_regs.mci_generic_input_wires[i0].value.value <= field_combo.interface_regs.mci_generic_input_wires[i0].value.next;
+            end else begin
+                if(field_combo.interface_regs.mci_generic_input_wires[i0].value.load_next) begin
+                    field_storage.interface_regs.mci_generic_input_wires[i0].value.value <= field_combo.interface_regs.mci_generic_input_wires[i0].value.next;
+                end
             end
         end
         assign hwif_out.interface_regs.mci_generic_input_wires[i0].value.value = field_storage.interface_regs.mci_generic_input_wires[i0].value.value;
@@ -1849,8 +1944,10 @@ module caliptra_fpga_realtime_regs (
         always_ff @(posedge clk) begin
             if(rst) begin
                 field_storage.interface_regs.mci_generic_output_wires[i0].value.value <= 32'h0;
-            end else if(field_combo.interface_regs.mci_generic_output_wires[i0].value.load_next) begin
-                field_storage.interface_regs.mci_generic_output_wires[i0].value.value <= field_combo.interface_regs.mci_generic_output_wires[i0].value.next;
+            end else begin
+                if(field_combo.interface_regs.mci_generic_output_wires[i0].value.load_next) begin
+                    field_storage.interface_regs.mci_generic_output_wires[i0].value.value <= field_combo.interface_regs.mci_generic_output_wires[i0].value.next;
+                end
             end
         end
         assign hwif_out.interface_regs.mci_generic_output_wires[i0].value.value = field_storage.interface_regs.mci_generic_output_wires[i0].value.value;
@@ -1872,8 +1969,10 @@ module caliptra_fpga_realtime_regs (
         always_ff @(posedge clk) begin
             if(rst) begin
                 field_storage.interface_regs.ocp_lock_key_release_reg[i0].key.value <= 32'h0;
-            end else if(field_combo.interface_regs.ocp_lock_key_release_reg[i0].key.load_next) begin
-                field_storage.interface_regs.ocp_lock_key_release_reg[i0].key.value <= field_combo.interface_regs.ocp_lock_key_release_reg[i0].key.next;
+            end else begin
+                if(field_combo.interface_regs.ocp_lock_key_release_reg[i0].key.load_next) begin
+                    field_storage.interface_regs.ocp_lock_key_release_reg[i0].key.value <= field_combo.interface_regs.ocp_lock_key_release_reg[i0].key.next;
+                end
             end
         end
     end
@@ -1893,8 +1992,10 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.fifo_regs.log_fifo_data.next_char.value <= 8'h0;
-        end else if(field_combo.fifo_regs.log_fifo_data.next_char.load_next) begin
-            field_storage.fifo_regs.log_fifo_data.next_char.value <= field_combo.fifo_regs.log_fifo_data.next_char.next;
+        end else begin
+            if(field_combo.fifo_regs.log_fifo_data.next_char.load_next) begin
+                field_storage.fifo_regs.log_fifo_data.next_char.value <= field_combo.fifo_regs.log_fifo_data.next_char.next;
+            end
         end
     end
     assign hwif_out.fifo_regs.log_fifo_data.next_char.value = field_storage.fifo_regs.log_fifo_data.next_char.value;
@@ -1915,8 +2016,10 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.fifo_regs.log_fifo_data.char_valid.value <= 1'h0;
-        end else if(field_combo.fifo_regs.log_fifo_data.char_valid.load_next) begin
-            field_storage.fifo_regs.log_fifo_data.char_valid.value <= field_combo.fifo_regs.log_fifo_data.char_valid.next;
+        end else begin
+            if(field_combo.fifo_regs.log_fifo_data.char_valid.load_next) begin
+                field_storage.fifo_regs.log_fifo_data.char_valid.value <= field_combo.fifo_regs.log_fifo_data.char_valid.next;
+            end
         end
     end
     assign hwif_out.fifo_regs.log_fifo_data.char_valid.value = field_storage.fifo_regs.log_fifo_data.char_valid.value;
@@ -1936,8 +2039,10 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.fifo_regs.log_fifo_status.log_fifo_empty.value <= 1'h0;
-        end else if(field_combo.fifo_regs.log_fifo_status.log_fifo_empty.load_next) begin
-            field_storage.fifo_regs.log_fifo_status.log_fifo_empty.value <= field_combo.fifo_regs.log_fifo_status.log_fifo_empty.next;
+        end else begin
+            if(field_combo.fifo_regs.log_fifo_status.log_fifo_empty.load_next) begin
+                field_storage.fifo_regs.log_fifo_status.log_fifo_empty.value <= field_combo.fifo_regs.log_fifo_status.log_fifo_empty.next;
+            end
         end
     end
     assign hwif_out.fifo_regs.log_fifo_status.log_fifo_empty.value = field_storage.fifo_regs.log_fifo_status.log_fifo_empty.value;
@@ -1957,8 +2062,10 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.fifo_regs.log_fifo_status.log_fifo_full.value <= 1'h0;
-        end else if(field_combo.fifo_regs.log_fifo_status.log_fifo_full.load_next) begin
-            field_storage.fifo_regs.log_fifo_status.log_fifo_full.value <= field_combo.fifo_regs.log_fifo_status.log_fifo_full.next;
+        end else begin
+            if(field_combo.fifo_regs.log_fifo_status.log_fifo_full.load_next) begin
+                field_storage.fifo_regs.log_fifo_status.log_fifo_full.value <= field_combo.fifo_regs.log_fifo_status.log_fifo_full.next;
+            end
         end
     end
     assign hwif_out.fifo_regs.log_fifo_status.log_fifo_full.value = field_storage.fifo_regs.log_fifo_status.log_fifo_full.value;
@@ -1978,8 +2085,10 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.fifo_regs.itrng_fifo_data.itrng_data.value <= 32'h0;
-        end else if(field_combo.fifo_regs.itrng_fifo_data.itrng_data.load_next) begin
-            field_storage.fifo_regs.itrng_fifo_data.itrng_data.value <= field_combo.fifo_regs.itrng_fifo_data.itrng_data.next;
+        end else begin
+            if(field_combo.fifo_regs.itrng_fifo_data.itrng_data.load_next) begin
+                field_storage.fifo_regs.itrng_fifo_data.itrng_data.value <= field_combo.fifo_regs.itrng_fifo_data.itrng_data.next;
+            end
         end
     end
     assign hwif_out.fifo_regs.itrng_fifo_data.itrng_data.value = field_storage.fifo_regs.itrng_fifo_data.itrng_data.value;
@@ -2000,8 +2109,10 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.fifo_regs.itrng_fifo_status.itrng_fifo_empty.value <= 1'h0;
-        end else if(field_combo.fifo_regs.itrng_fifo_status.itrng_fifo_empty.load_next) begin
-            field_storage.fifo_regs.itrng_fifo_status.itrng_fifo_empty.value <= field_combo.fifo_regs.itrng_fifo_status.itrng_fifo_empty.next;
+        end else begin
+            if(field_combo.fifo_regs.itrng_fifo_status.itrng_fifo_empty.load_next) begin
+                field_storage.fifo_regs.itrng_fifo_status.itrng_fifo_empty.value <= field_combo.fifo_regs.itrng_fifo_status.itrng_fifo_empty.next;
+            end
         end
     end
     assign hwif_out.fifo_regs.itrng_fifo_status.itrng_fifo_empty.value = field_storage.fifo_regs.itrng_fifo_status.itrng_fifo_empty.value;
@@ -2021,8 +2132,10 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.fifo_regs.itrng_fifo_status.itrng_fifo_full.value <= 1'h0;
-        end else if(field_combo.fifo_regs.itrng_fifo_status.itrng_fifo_full.load_next) begin
-            field_storage.fifo_regs.itrng_fifo_status.itrng_fifo_full.value <= field_combo.fifo_regs.itrng_fifo_status.itrng_fifo_full.next;
+        end else begin
+            if(field_combo.fifo_regs.itrng_fifo_status.itrng_fifo_full.load_next) begin
+                field_storage.fifo_regs.itrng_fifo_status.itrng_fifo_full.value <= field_combo.fifo_regs.itrng_fifo_status.itrng_fifo_full.next;
+            end
         end
     end
     assign hwif_out.fifo_regs.itrng_fifo_status.itrng_fifo_full.value = field_storage.fifo_regs.itrng_fifo_status.itrng_fifo_full.value;
@@ -2042,8 +2155,10 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.fifo_regs.itrng_fifo_status.itrng_fifo_reset.value <= 1'h0;
-        end else if(field_combo.fifo_regs.itrng_fifo_status.itrng_fifo_reset.load_next) begin
-            field_storage.fifo_regs.itrng_fifo_status.itrng_fifo_reset.value <= field_combo.fifo_regs.itrng_fifo_status.itrng_fifo_reset.next;
+        end else begin
+            if(field_combo.fifo_regs.itrng_fifo_status.itrng_fifo_reset.load_next) begin
+                field_storage.fifo_regs.itrng_fifo_status.itrng_fifo_reset.value <= field_combo.fifo_regs.itrng_fifo_status.itrng_fifo_reset.next;
+            end
         end
     end
     assign hwif_out.fifo_regs.itrng_fifo_status.itrng_fifo_reset.value = field_storage.fifo_regs.itrng_fifo_status.itrng_fifo_reset.value;
@@ -2063,8 +2178,10 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.fifo_regs.dbg_fifo_pop.out_data.value <= 32'h0;
-        end else if(field_combo.fifo_regs.dbg_fifo_pop.out_data.load_next) begin
-            field_storage.fifo_regs.dbg_fifo_pop.out_data.value <= field_combo.fifo_regs.dbg_fifo_pop.out_data.next;
+        end else begin
+            if(field_combo.fifo_regs.dbg_fifo_pop.out_data.load_next) begin
+                field_storage.fifo_regs.dbg_fifo_pop.out_data.value <= field_combo.fifo_regs.dbg_fifo_pop.out_data.next;
+            end
         end
     end
     assign hwif_out.fifo_regs.dbg_fifo_pop.out_data.value = field_storage.fifo_regs.dbg_fifo_pop.out_data.value;
@@ -2085,8 +2202,10 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.fifo_regs.dbg_fifo_push.in_data.value <= 32'h0;
-        end else if(field_combo.fifo_regs.dbg_fifo_push.in_data.load_next) begin
-            field_storage.fifo_regs.dbg_fifo_push.in_data.value <= field_combo.fifo_regs.dbg_fifo_push.in_data.next;
+        end else begin
+            if(field_combo.fifo_regs.dbg_fifo_push.in_data.load_next) begin
+                field_storage.fifo_regs.dbg_fifo_push.in_data.value <= field_combo.fifo_regs.dbg_fifo_push.in_data.next;
+            end
         end
     end
     assign hwif_out.fifo_regs.dbg_fifo_push.in_data.value = field_storage.fifo_regs.dbg_fifo_push.in_data.value;
@@ -2107,8 +2226,10 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.fifo_regs.dbg_fifo_status.dbg_fifo_empty.value <= 1'h0;
-        end else if(field_combo.fifo_regs.dbg_fifo_status.dbg_fifo_empty.load_next) begin
-            field_storage.fifo_regs.dbg_fifo_status.dbg_fifo_empty.value <= field_combo.fifo_regs.dbg_fifo_status.dbg_fifo_empty.next;
+        end else begin
+            if(field_combo.fifo_regs.dbg_fifo_status.dbg_fifo_empty.load_next) begin
+                field_storage.fifo_regs.dbg_fifo_status.dbg_fifo_empty.value <= field_combo.fifo_regs.dbg_fifo_status.dbg_fifo_empty.next;
+            end
         end
     end
     assign hwif_out.fifo_regs.dbg_fifo_status.dbg_fifo_empty.value = field_storage.fifo_regs.dbg_fifo_status.dbg_fifo_empty.value;
@@ -2128,8 +2249,10 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.fifo_regs.dbg_fifo_status.dbg_fifo_full.value <= 1'h0;
-        end else if(field_combo.fifo_regs.dbg_fifo_status.dbg_fifo_full.load_next) begin
-            field_storage.fifo_regs.dbg_fifo_status.dbg_fifo_full.value <= field_combo.fifo_regs.dbg_fifo_status.dbg_fifo_full.next;
+        end else begin
+            if(field_combo.fifo_regs.dbg_fifo_status.dbg_fifo_full.load_next) begin
+                field_storage.fifo_regs.dbg_fifo_status.dbg_fifo_full.value <= field_combo.fifo_regs.dbg_fifo_status.dbg_fifo_full.next;
+            end
         end
     end
     assign hwif_out.fifo_regs.dbg_fifo_status.dbg_fifo_full.value = field_storage.fifo_regs.dbg_fifo_status.dbg_fifo_full.value;
@@ -2149,8 +2272,10 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.fifo_regs.msg_fifo_pop.out_data.value <= 32'h0;
-        end else if(field_combo.fifo_regs.msg_fifo_pop.out_data.load_next) begin
-            field_storage.fifo_regs.msg_fifo_pop.out_data.value <= field_combo.fifo_regs.msg_fifo_pop.out_data.next;
+        end else begin
+            if(field_combo.fifo_regs.msg_fifo_pop.out_data.load_next) begin
+                field_storage.fifo_regs.msg_fifo_pop.out_data.value <= field_combo.fifo_regs.msg_fifo_pop.out_data.next;
+            end
         end
     end
     assign hwif_out.fifo_regs.msg_fifo_pop.out_data.value = field_storage.fifo_regs.msg_fifo_pop.out_data.value;
@@ -2171,8 +2296,10 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.fifo_regs.msg_fifo_push.in_data.value <= 32'h0;
-        end else if(field_combo.fifo_regs.msg_fifo_push.in_data.load_next) begin
-            field_storage.fifo_regs.msg_fifo_push.in_data.value <= field_combo.fifo_regs.msg_fifo_push.in_data.next;
+        end else begin
+            if(field_combo.fifo_regs.msg_fifo_push.in_data.load_next) begin
+                field_storage.fifo_regs.msg_fifo_push.in_data.value <= field_combo.fifo_regs.msg_fifo_push.in_data.next;
+            end
         end
     end
     assign hwif_out.fifo_regs.msg_fifo_push.in_data.value = field_storage.fifo_regs.msg_fifo_push.in_data.value;
@@ -2193,8 +2320,10 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.fifo_regs.msg_fifo_status.msg_fifo_empty.value <= 1'h0;
-        end else if(field_combo.fifo_regs.msg_fifo_status.msg_fifo_empty.load_next) begin
-            field_storage.fifo_regs.msg_fifo_status.msg_fifo_empty.value <= field_combo.fifo_regs.msg_fifo_status.msg_fifo_empty.next;
+        end else begin
+            if(field_combo.fifo_regs.msg_fifo_status.msg_fifo_empty.load_next) begin
+                field_storage.fifo_regs.msg_fifo_status.msg_fifo_empty.value <= field_combo.fifo_regs.msg_fifo_status.msg_fifo_empty.next;
+            end
         end
     end
     assign hwif_out.fifo_regs.msg_fifo_status.msg_fifo_empty.value = field_storage.fifo_regs.msg_fifo_status.msg_fifo_empty.value;
@@ -2214,8 +2343,10 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.fifo_regs.msg_fifo_status.msg_fifo_full.value <= 1'h0;
-        end else if(field_combo.fifo_regs.msg_fifo_status.msg_fifo_full.load_next) begin
-            field_storage.fifo_regs.msg_fifo_status.msg_fifo_full.value <= field_combo.fifo_regs.msg_fifo_status.msg_fifo_full.next;
+        end else begin
+            if(field_combo.fifo_regs.msg_fifo_status.msg_fifo_full.load_next) begin
+                field_storage.fifo_regs.msg_fifo_status.msg_fifo_full.value <= field_combo.fifo_regs.msg_fifo_status.msg_fifo_full.next;
+            end
         end
     end
     assign hwif_out.fifo_regs.msg_fifo_status.msg_fifo_full.value = field_storage.fifo_regs.msg_fifo_status.msg_fifo_full.value;
@@ -2261,22 +2392,22 @@ module caliptra_fpga_realtime_regs (
     assign readback_array[5][31:0] = (decoded_reg_strb.interface_regs.itrng_divisor && !decoded_req_is_wr) ? field_storage.interface_regs.itrng_divisor.itrng_divisor.value : '0;
     assign readback_array[6][31:0] = (decoded_reg_strb.interface_regs.cycle_count && !decoded_req_is_wr) ? field_storage.interface_regs.cycle_count.cycle_count.value : '0;
     for(genvar i0=0; i0<2; i0++) begin
-        assign readback_array[i0*1 + 7][31:0] = (decoded_reg_strb.interface_regs.generic_input_wires[i0] && !decoded_req_is_wr) ? field_storage.interface_regs.generic_input_wires[i0].value.value : '0;
+        assign readback_array[i0 * 1 + 7][31:0] = (decoded_reg_strb.interface_regs.generic_input_wires[i0] && !decoded_req_is_wr) ? field_storage.interface_regs.generic_input_wires[i0].value.value : '0;
     end
     for(genvar i0=0; i0<2; i0++) begin
-        assign readback_array[i0*1 + 9][31:0] = (decoded_reg_strb.interface_regs.generic_output_wires[i0] && !decoded_req_is_wr) ? field_storage.interface_regs.generic_output_wires[i0].value.value : '0;
+        assign readback_array[i0 * 1 + 9][31:0] = (decoded_reg_strb.interface_regs.generic_output_wires[i0] && !decoded_req_is_wr) ? field_storage.interface_regs.generic_output_wires[i0].value.value : '0;
     end
     for(genvar i0=0; i0<8; i0++) begin
-        assign readback_array[i0*1 + 11][31:0] = (decoded_reg_strb.interface_regs.cptra_obf_key[i0] && !decoded_req_is_wr) ? field_storage.interface_regs.cptra_obf_key[i0].value.value : '0;
+        assign readback_array[i0 * 1 + 11][31:0] = (decoded_reg_strb.interface_regs.cptra_obf_key[i0] && !decoded_req_is_wr) ? field_storage.interface_regs.cptra_obf_key[i0].value.value : '0;
     end
     for(genvar i0=0; i0<16; i0++) begin
-        assign readback_array[i0*1 + 19][31:0] = (decoded_reg_strb.interface_regs.cptra_csr_hmac_key[i0] && !decoded_req_is_wr) ? field_storage.interface_regs.cptra_csr_hmac_key[i0].value.value : '0;
+        assign readback_array[i0 * 1 + 19][31:0] = (decoded_reg_strb.interface_regs.cptra_csr_hmac_key[i0] && !decoded_req_is_wr) ? field_storage.interface_regs.cptra_csr_hmac_key[i0].value.value : '0;
     end
     for(genvar i0=0; i0<16; i0++) begin
-        assign readback_array[i0*1 + 35][31:0] = (decoded_reg_strb.interface_regs.cptra_obf_uds_seed[i0] && !decoded_req_is_wr) ? field_storage.interface_regs.cptra_obf_uds_seed[i0].value.value : '0;
+        assign readback_array[i0 * 1 + 35][31:0] = (decoded_reg_strb.interface_regs.cptra_obf_uds_seed[i0] && !decoded_req_is_wr) ? field_storage.interface_regs.cptra_obf_uds_seed[i0].value.value : '0;
     end
     for(genvar i0=0; i0<8; i0++) begin
-        assign readback_array[i0*1 + 51][31:0] = (decoded_reg_strb.interface_regs.cptra_obf_field_entropy[i0] && !decoded_req_is_wr) ? field_storage.interface_regs.cptra_obf_field_entropy[i0].value.value : '0;
+        assign readback_array[i0 * 1 + 51][31:0] = (decoded_reg_strb.interface_regs.cptra_obf_field_entropy[i0] && !decoded_req_is_wr) ? field_storage.interface_regs.cptra_obf_field_entropy[i0].value.value : '0;
     end
     assign readback_array[59][31:0] = (decoded_reg_strb.interface_regs.lsu_user && !decoded_req_is_wr) ? field_storage.interface_regs.lsu_user.lsu_user.value : '0;
     assign readback_array[60][31:0] = (decoded_reg_strb.interface_regs.ifu_user && !decoded_req_is_wr) ? field_storage.interface_regs.ifu_user.ifu_user.value : '0;
@@ -2298,13 +2429,13 @@ module caliptra_fpga_realtime_regs (
     assign readback_array[68][31:0] = (decoded_reg_strb.interface_regs.prod_debug_unlock_auth_pk_hash_reg_bank_offset && !decoded_req_is_wr) ? field_storage.interface_regs.prod_debug_unlock_auth_pk_hash_reg_bank_offset.prod_debug_unlock_auth_pk_hash_reg_bank_offset.value : '0;
     assign readback_array[69][31:0] = (decoded_reg_strb.interface_regs.num_of_prod_debug_unlock_auth_pk_hashes && !decoded_req_is_wr) ? field_storage.interface_regs.num_of_prod_debug_unlock_auth_pk_hashes.num_of_prod_debug_unlock_auth_pk_hashes.value : '0;
     for(genvar i0=0; i0<2; i0++) begin
-        assign readback_array[i0*1 + 70][31:0] = (decoded_reg_strb.interface_regs.mci_generic_input_wires[i0] && !decoded_req_is_wr) ? field_storage.interface_regs.mci_generic_input_wires[i0].value.value : '0;
+        assign readback_array[i0 * 1 + 70][31:0] = (decoded_reg_strb.interface_regs.mci_generic_input_wires[i0] && !decoded_req_is_wr) ? field_storage.interface_regs.mci_generic_input_wires[i0].value.value : '0;
     end
     for(genvar i0=0; i0<2; i0++) begin
-        assign readback_array[i0*1 + 72][31:0] = (decoded_reg_strb.interface_regs.mci_generic_output_wires[i0] && !decoded_req_is_wr) ? field_storage.interface_regs.mci_generic_output_wires[i0].value.value : '0;
+        assign readback_array[i0 * 1 + 72][31:0] = (decoded_reg_strb.interface_regs.mci_generic_output_wires[i0] && !decoded_req_is_wr) ? field_storage.interface_regs.mci_generic_output_wires[i0].value.value : '0;
     end
     for(genvar i0=0; i0<16; i0++) begin
-        assign readback_array[i0*1 + 74][31:0] = (decoded_reg_strb.interface_regs.ocp_lock_key_release_reg[i0] && !decoded_req_is_wr) ? field_storage.interface_regs.ocp_lock_key_release_reg[i0].key.value : '0;
+        assign readback_array[i0 * 1 + 74][31:0] = (decoded_reg_strb.interface_regs.ocp_lock_key_release_reg[i0] && !decoded_req_is_wr) ? field_storage.interface_regs.ocp_lock_key_release_reg[i0].key.value : '0;
     end
     assign readback_array[90][7:0] = (decoded_reg_strb.fifo_regs.log_fifo_data && !decoded_req_is_wr) ? field_storage.fifo_regs.log_fifo_data.next_char.value : '0;
     assign readback_array[90][8:8] = (decoded_reg_strb.fifo_regs.log_fifo_data && !decoded_req_is_wr) ? field_storage.fifo_regs.log_fifo_data.char_valid.value : '0;

--- a/hw/fpga/src/caliptra_fpga_realtime_regs.sv
+++ b/hw/fpga/src/caliptra_fpga_realtime_regs.sv
@@ -236,6 +236,7 @@ module caliptra_fpga_realtime_regs (
             logic num_of_prod_debug_unlock_auth_pk_hashes;
             logic mci_generic_input_wires[2];
             logic mci_generic_output_wires[2];
+            logic ocp_lock_key_release_reg[16];
         } interface_regs;
         struct {
             logic log_fifo_data;
@@ -245,6 +246,9 @@ module caliptra_fpga_realtime_regs (
             logic dbg_fifo_pop;
             logic dbg_fifo_push;
             logic dbg_fifo_status;
+            logic msg_fifo_pop;
+            logic msg_fifo_push;
+            logic msg_fifo_status;
         } fifo_regs;
     } decoded_reg_strb_t;
     decoded_reg_strb_t decoded_reg_strb;
@@ -262,22 +266,22 @@ module caliptra_fpga_realtime_regs (
         decoded_reg_strb.interface_regs.itrng_divisor = cpuif_req_masked & (cpuif_addr == 32'ha4010014);
         decoded_reg_strb.interface_regs.cycle_count = cpuif_req_masked & (cpuif_addr == 32'ha4010018);
         for(int i0=0; i0<2; i0++) begin
-            decoded_reg_strb.interface_regs.generic_input_wires[i0] = cpuif_req_masked & (cpuif_addr == 32'ha4010030 + (32)'(i0) * 32'h4);
+            decoded_reg_strb.interface_regs.generic_input_wires[i0] = cpuif_req_masked & (cpuif_addr == 32'ha4010030 + i0*32'h4);
         end
         for(int i0=0; i0<2; i0++) begin
-            decoded_reg_strb.interface_regs.generic_output_wires[i0] = cpuif_req_masked & (cpuif_addr == 32'ha4010038 + (32)'(i0) * 32'h4);
+            decoded_reg_strb.interface_regs.generic_output_wires[i0] = cpuif_req_masked & (cpuif_addr == 32'ha4010038 + i0*32'h4);
         end
         for(int i0=0; i0<8; i0++) begin
-            decoded_reg_strb.interface_regs.cptra_obf_key[i0] = cpuif_req_masked & (cpuif_addr == 32'ha4010040 + (32)'(i0) * 32'h4);
+            decoded_reg_strb.interface_regs.cptra_obf_key[i0] = cpuif_req_masked & (cpuif_addr == 32'ha4010040 + i0*32'h4);
         end
         for(int i0=0; i0<16; i0++) begin
-            decoded_reg_strb.interface_regs.cptra_csr_hmac_key[i0] = cpuif_req_masked & (cpuif_addr == 32'ha4010060 + (32)'(i0) * 32'h4);
+            decoded_reg_strb.interface_regs.cptra_csr_hmac_key[i0] = cpuif_req_masked & (cpuif_addr == 32'ha4010060 + i0*32'h4);
         end
         for(int i0=0; i0<16; i0++) begin
-            decoded_reg_strb.interface_regs.cptra_obf_uds_seed[i0] = cpuif_req_masked & (cpuif_addr == 32'ha40100a0 + (32)'(i0) * 32'h4);
+            decoded_reg_strb.interface_regs.cptra_obf_uds_seed[i0] = cpuif_req_masked & (cpuif_addr == 32'ha40100a0 + i0*32'h4);
         end
         for(int i0=0; i0<8; i0++) begin
-            decoded_reg_strb.interface_regs.cptra_obf_field_entropy[i0] = cpuif_req_masked & (cpuif_addr == 32'ha40100e0 + (32)'(i0) * 32'h4);
+            decoded_reg_strb.interface_regs.cptra_obf_field_entropy[i0] = cpuif_req_masked & (cpuif_addr == 32'ha40100e0 + i0*32'h4);
         end
         decoded_reg_strb.interface_regs.lsu_user = cpuif_req_masked & (cpuif_addr == 32'ha4010100);
         decoded_reg_strb.interface_regs.ifu_user = cpuif_req_masked & (cpuif_addr == 32'ha4010104);
@@ -291,10 +295,13 @@ module caliptra_fpga_realtime_regs (
         decoded_reg_strb.interface_regs.prod_debug_unlock_auth_pk_hash_reg_bank_offset = cpuif_req_masked & (cpuif_addr == 32'ha4010124);
         decoded_reg_strb.interface_regs.num_of_prod_debug_unlock_auth_pk_hashes = cpuif_req_masked & (cpuif_addr == 32'ha4010128);
         for(int i0=0; i0<2; i0++) begin
-            decoded_reg_strb.interface_regs.mci_generic_input_wires[i0] = cpuif_req_masked & (cpuif_addr == 32'ha401012c + (32)'(i0) * 32'h4);
+            decoded_reg_strb.interface_regs.mci_generic_input_wires[i0] = cpuif_req_masked & (cpuif_addr == 32'ha401012c + i0*32'h4);
         end
         for(int i0=0; i0<2; i0++) begin
-            decoded_reg_strb.interface_regs.mci_generic_output_wires[i0] = cpuif_req_masked & (cpuif_addr == 32'ha4010134 + (32)'(i0) * 32'h4);
+            decoded_reg_strb.interface_regs.mci_generic_output_wires[i0] = cpuif_req_masked & (cpuif_addr == 32'ha4010134 + i0*32'h4);
+        end
+        for(int i0=0; i0<16; i0++) begin
+            decoded_reg_strb.interface_regs.ocp_lock_key_release_reg[i0] = cpuif_req_masked & (cpuif_addr == 32'ha4010200 + i0*32'h4);
         end
         decoded_reg_strb.fifo_regs.log_fifo_data = cpuif_req_masked & (cpuif_addr == 32'ha4011000);
         decoded_reg_strb.fifo_regs.log_fifo_status = cpuif_req_masked & (cpuif_addr == 32'ha4011004);
@@ -303,6 +310,9 @@ module caliptra_fpga_realtime_regs (
         decoded_reg_strb.fifo_regs.dbg_fifo_pop = cpuif_req_masked & (cpuif_addr == 32'ha4011010);
         decoded_reg_strb.fifo_regs.dbg_fifo_push = cpuif_req_masked & (cpuif_addr == 32'ha4011014);
         decoded_reg_strb.fifo_regs.dbg_fifo_status = cpuif_req_masked & (cpuif_addr == 32'ha4011018);
+        decoded_reg_strb.fifo_regs.msg_fifo_pop = cpuif_req_masked & (cpuif_addr == 32'ha401101c);
+        decoded_reg_strb.fifo_regs.msg_fifo_push = cpuif_req_masked & (cpuif_addr == 32'ha4011020);
+        decoded_reg_strb.fifo_regs.msg_fifo_status = cpuif_req_masked & (cpuif_addr == 32'ha4011024);
     end
 
     // Pass down signals to next stage
@@ -542,6 +552,12 @@ module caliptra_fpga_realtime_regs (
                     logic load_next;
                 } value;
             } mci_generic_output_wires[2];
+            struct {
+                struct {
+                    logic [31:0] next;
+                    logic load_next;
+                } key;
+            } ocp_lock_key_release_reg[16];
         } interface_regs;
         struct {
             struct {
@@ -606,6 +622,28 @@ module caliptra_fpga_realtime_regs (
                     logic load_next;
                 } dbg_fifo_full;
             } dbg_fifo_status;
+            struct {
+                struct {
+                    logic [31:0] next;
+                    logic load_next;
+                } out_data;
+            } msg_fifo_pop;
+            struct {
+                struct {
+                    logic [31:0] next;
+                    logic load_next;
+                } in_data;
+            } msg_fifo_push;
+            struct {
+                struct {
+                    logic next;
+                    logic load_next;
+                } msg_fifo_empty;
+                struct {
+                    logic next;
+                    logic load_next;
+                } msg_fifo_full;
+            } msg_fifo_status;
         } fifo_regs;
     } field_combo_t;
     field_combo_t field_combo;
@@ -794,6 +832,11 @@ module caliptra_fpga_realtime_regs (
                     logic [31:0] value;
                 } value;
             } mci_generic_output_wires[2];
+            struct {
+                struct {
+                    logic [31:0] value;
+                } key;
+            } ocp_lock_key_release_reg[16];
         } interface_regs;
         struct {
             struct {
@@ -846,6 +889,24 @@ module caliptra_fpga_realtime_regs (
                     logic value;
                 } dbg_fifo_full;
             } dbg_fifo_status;
+            struct {
+                struct {
+                    logic [31:0] value;
+                } out_data;
+            } msg_fifo_pop;
+            struct {
+                struct {
+                    logic [31:0] value;
+                } in_data;
+            } msg_fifo_push;
+            struct {
+                struct {
+                    logic value;
+                } msg_fifo_empty;
+                struct {
+                    logic value;
+                } msg_fifo_full;
+            } msg_fifo_status;
         } fifo_regs;
     } field_storage_t;
     field_storage_t field_storage;
@@ -867,10 +928,8 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.fpga_version.fpga_version.value <= 32'h0;
-        end else begin
-            if(field_combo.interface_regs.fpga_version.fpga_version.load_next) begin
-                field_storage.interface_regs.fpga_version.fpga_version.value <= field_combo.interface_regs.fpga_version.fpga_version.next;
-            end
+        end else if(field_combo.interface_regs.fpga_version.fpga_version.load_next) begin
+            field_storage.interface_regs.fpga_version.fpga_version.value <= field_combo.interface_regs.fpga_version.fpga_version.next;
         end
     end
     assign hwif_out.interface_regs.fpga_version.fpga_version.value = field_storage.interface_regs.fpga_version.fpga_version.value;
@@ -890,10 +949,8 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.control.cptra_pwrgood.value <= 1'h0;
-        end else begin
-            if(field_combo.interface_regs.control.cptra_pwrgood.load_next) begin
-                field_storage.interface_regs.control.cptra_pwrgood.value <= field_combo.interface_regs.control.cptra_pwrgood.next;
-            end
+        end else if(field_combo.interface_regs.control.cptra_pwrgood.load_next) begin
+            field_storage.interface_regs.control.cptra_pwrgood.value <= field_combo.interface_regs.control.cptra_pwrgood.next;
         end
     end
     assign hwif_out.interface_regs.control.cptra_pwrgood.value = field_storage.interface_regs.control.cptra_pwrgood.value;
@@ -913,10 +970,8 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.control.cptra_ss_rst_b.value <= 1'h0;
-        end else begin
-            if(field_combo.interface_regs.control.cptra_ss_rst_b.load_next) begin
-                field_storage.interface_regs.control.cptra_ss_rst_b.value <= field_combo.interface_regs.control.cptra_ss_rst_b.next;
-            end
+        end else if(field_combo.interface_regs.control.cptra_ss_rst_b.load_next) begin
+            field_storage.interface_regs.control.cptra_ss_rst_b.value <= field_combo.interface_regs.control.cptra_ss_rst_b.next;
         end
     end
     assign hwif_out.interface_regs.control.cptra_ss_rst_b.value = field_storage.interface_regs.control.cptra_ss_rst_b.value;
@@ -936,10 +991,8 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.control.cptra_obf_uds_seed_vld.value <= 1'h0;
-        end else begin
-            if(field_combo.interface_regs.control.cptra_obf_uds_seed_vld.load_next) begin
-                field_storage.interface_regs.control.cptra_obf_uds_seed_vld.value <= field_combo.interface_regs.control.cptra_obf_uds_seed_vld.next;
-            end
+        end else if(field_combo.interface_regs.control.cptra_obf_uds_seed_vld.load_next) begin
+            field_storage.interface_regs.control.cptra_obf_uds_seed_vld.value <= field_combo.interface_regs.control.cptra_obf_uds_seed_vld.next;
         end
     end
     assign hwif_out.interface_regs.control.cptra_obf_uds_seed_vld.value = field_storage.interface_regs.control.cptra_obf_uds_seed_vld.value;
@@ -959,10 +1012,8 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.control.cptra_obf_field_entropy_vld.value <= 1'h0;
-        end else begin
-            if(field_combo.interface_regs.control.cptra_obf_field_entropy_vld.load_next) begin
-                field_storage.interface_regs.control.cptra_obf_field_entropy_vld.value <= field_combo.interface_regs.control.cptra_obf_field_entropy_vld.next;
-            end
+        end else if(field_combo.interface_regs.control.cptra_obf_field_entropy_vld.load_next) begin
+            field_storage.interface_regs.control.cptra_obf_field_entropy_vld.value <= field_combo.interface_regs.control.cptra_obf_field_entropy_vld.next;
         end
     end
     assign hwif_out.interface_regs.control.cptra_obf_field_entropy_vld.value = field_storage.interface_regs.control.cptra_obf_field_entropy_vld.value;
@@ -982,10 +1033,8 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.control.bootfsm_brkpoint.value <= 1'h0;
-        end else begin
-            if(field_combo.interface_regs.control.bootfsm_brkpoint.load_next) begin
-                field_storage.interface_regs.control.bootfsm_brkpoint.value <= field_combo.interface_regs.control.bootfsm_brkpoint.next;
-            end
+        end else if(field_combo.interface_regs.control.bootfsm_brkpoint.load_next) begin
+            field_storage.interface_regs.control.bootfsm_brkpoint.value <= field_combo.interface_regs.control.bootfsm_brkpoint.next;
         end
     end
     assign hwif_out.interface_regs.control.bootfsm_brkpoint.value = field_storage.interface_regs.control.bootfsm_brkpoint.value;
@@ -1005,10 +1054,8 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.control.ss_debug_intent.value <= 1'h0;
-        end else begin
-            if(field_combo.interface_regs.control.ss_debug_intent.load_next) begin
-                field_storage.interface_regs.control.ss_debug_intent.value <= field_combo.interface_regs.control.ss_debug_intent.next;
-            end
+        end else if(field_combo.interface_regs.control.ss_debug_intent.load_next) begin
+            field_storage.interface_regs.control.ss_debug_intent.value <= field_combo.interface_regs.control.ss_debug_intent.next;
         end
     end
     assign hwif_out.interface_regs.control.ss_debug_intent.value = field_storage.interface_regs.control.ss_debug_intent.value;
@@ -1028,10 +1075,8 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.control.i3c_axi_user_id_filtering.value <= 1'h0;
-        end else begin
-            if(field_combo.interface_regs.control.i3c_axi_user_id_filtering.load_next) begin
-                field_storage.interface_regs.control.i3c_axi_user_id_filtering.value <= field_combo.interface_regs.control.i3c_axi_user_id_filtering.next;
-            end
+        end else if(field_combo.interface_regs.control.i3c_axi_user_id_filtering.load_next) begin
+            field_storage.interface_regs.control.i3c_axi_user_id_filtering.value <= field_combo.interface_regs.control.i3c_axi_user_id_filtering.next;
         end
     end
     assign hwif_out.interface_regs.control.i3c_axi_user_id_filtering.value = field_storage.interface_regs.control.i3c_axi_user_id_filtering.value;
@@ -1054,10 +1099,8 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.control.trigger_axi_reset.value <= 1'h0;
-        end else begin
-            if(field_combo.interface_regs.control.trigger_axi_reset.load_next) begin
-                field_storage.interface_regs.control.trigger_axi_reset.value <= field_combo.interface_regs.control.trigger_axi_reset.next;
-            end
+        end else if(field_combo.interface_regs.control.trigger_axi_reset.load_next) begin
+            field_storage.interface_regs.control.trigger_axi_reset.value <= field_combo.interface_regs.control.trigger_axi_reset.next;
         end
     end
     assign hwif_out.interface_regs.control.trigger_axi_reset.value = field_storage.interface_regs.control.trigger_axi_reset.value;
@@ -1077,10 +1120,8 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.status.cptra_error_fatal.value <= 1'h0;
-        end else begin
-            if(field_combo.interface_regs.status.cptra_error_fatal.load_next) begin
-                field_storage.interface_regs.status.cptra_error_fatal.value <= field_combo.interface_regs.status.cptra_error_fatal.next;
-            end
+        end else if(field_combo.interface_regs.status.cptra_error_fatal.load_next) begin
+            field_storage.interface_regs.status.cptra_error_fatal.value <= field_combo.interface_regs.status.cptra_error_fatal.next;
         end
     end
     assign hwif_out.interface_regs.status.cptra_error_fatal.value = field_storage.interface_regs.status.cptra_error_fatal.value;
@@ -1100,10 +1141,8 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.status.cptra_error_non_fatal.value <= 1'h0;
-        end else begin
-            if(field_combo.interface_regs.status.cptra_error_non_fatal.load_next) begin
-                field_storage.interface_regs.status.cptra_error_non_fatal.value <= field_combo.interface_regs.status.cptra_error_non_fatal.next;
-            end
+        end else if(field_combo.interface_regs.status.cptra_error_non_fatal.load_next) begin
+            field_storage.interface_regs.status.cptra_error_non_fatal.value <= field_combo.interface_regs.status.cptra_error_non_fatal.next;
         end
     end
     assign hwif_out.interface_regs.status.cptra_error_non_fatal.value = field_storage.interface_regs.status.cptra_error_non_fatal.value;
@@ -1123,10 +1162,8 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.status.ready_for_fuses.value <= 1'h0;
-        end else begin
-            if(field_combo.interface_regs.status.ready_for_fuses.load_next) begin
-                field_storage.interface_regs.status.ready_for_fuses.value <= field_combo.interface_regs.status.ready_for_fuses.next;
-            end
+        end else if(field_combo.interface_regs.status.ready_for_fuses.load_next) begin
+            field_storage.interface_regs.status.ready_for_fuses.value <= field_combo.interface_regs.status.ready_for_fuses.next;
         end
     end
     assign hwif_out.interface_regs.status.ready_for_fuses.value = field_storage.interface_regs.status.ready_for_fuses.value;
@@ -1146,10 +1183,8 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.status.ready_for_fw_push.value <= 1'h0;
-        end else begin
-            if(field_combo.interface_regs.status.ready_for_fw_push.load_next) begin
-                field_storage.interface_regs.status.ready_for_fw_push.value <= field_combo.interface_regs.status.ready_for_fw_push.next;
-            end
+        end else if(field_combo.interface_regs.status.ready_for_fw_push.load_next) begin
+            field_storage.interface_regs.status.ready_for_fw_push.value <= field_combo.interface_regs.status.ready_for_fw_push.next;
         end
     end
     assign hwif_out.interface_regs.status.ready_for_fw_push.value = field_storage.interface_regs.status.ready_for_fw_push.value;
@@ -1169,10 +1204,8 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.status.ready_for_runtime.value <= 1'h0;
-        end else begin
-            if(field_combo.interface_regs.status.ready_for_runtime.load_next) begin
-                field_storage.interface_regs.status.ready_for_runtime.value <= field_combo.interface_regs.status.ready_for_runtime.next;
-            end
+        end else if(field_combo.interface_regs.status.ready_for_runtime.load_next) begin
+            field_storage.interface_regs.status.ready_for_runtime.value <= field_combo.interface_regs.status.ready_for_runtime.next;
         end
     end
     assign hwif_out.interface_regs.status.ready_for_runtime.value = field_storage.interface_regs.status.ready_for_runtime.value;
@@ -1192,10 +1225,8 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.status.mailbox_data_avail.value <= 1'h0;
-        end else begin
-            if(field_combo.interface_regs.status.mailbox_data_avail.load_next) begin
-                field_storage.interface_regs.status.mailbox_data_avail.value <= field_combo.interface_regs.status.mailbox_data_avail.next;
-            end
+        end else if(field_combo.interface_regs.status.mailbox_data_avail.load_next) begin
+            field_storage.interface_regs.status.mailbox_data_avail.value <= field_combo.interface_regs.status.mailbox_data_avail.next;
         end
     end
     assign hwif_out.interface_regs.status.mailbox_data_avail.value = field_storage.interface_regs.status.mailbox_data_avail.value;
@@ -1215,10 +1246,8 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.status.mailbox_flow_done.value <= 1'h0;
-        end else begin
-            if(field_combo.interface_regs.status.mailbox_flow_done.load_next) begin
-                field_storage.interface_regs.status.mailbox_flow_done.value <= field_combo.interface_regs.status.mailbox_flow_done.next;
-            end
+        end else if(field_combo.interface_regs.status.mailbox_flow_done.load_next) begin
+            field_storage.interface_regs.status.mailbox_flow_done.value <= field_combo.interface_regs.status.mailbox_flow_done.next;
         end
     end
     assign hwif_out.interface_regs.status.mailbox_flow_done.value = field_storage.interface_regs.status.mailbox_flow_done.value;
@@ -1238,10 +1267,8 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.arm_user.arm_user.value <= 32'h0;
-        end else begin
-            if(field_combo.interface_regs.arm_user.arm_user.load_next) begin
-                field_storage.interface_regs.arm_user.arm_user.value <= field_combo.interface_regs.arm_user.arm_user.next;
-            end
+        end else if(field_combo.interface_regs.arm_user.arm_user.load_next) begin
+            field_storage.interface_regs.arm_user.arm_user.value <= field_combo.interface_regs.arm_user.arm_user.next;
         end
     end
     assign hwif_out.interface_regs.arm_user.arm_user.value = field_storage.interface_regs.arm_user.arm_user.value;
@@ -1261,10 +1288,8 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.itrng_divisor.itrng_divisor.value <= 32'h0;
-        end else begin
-            if(field_combo.interface_regs.itrng_divisor.itrng_divisor.load_next) begin
-                field_storage.interface_regs.itrng_divisor.itrng_divisor.value <= field_combo.interface_regs.itrng_divisor.itrng_divisor.next;
-            end
+        end else if(field_combo.interface_regs.itrng_divisor.itrng_divisor.load_next) begin
+            field_storage.interface_regs.itrng_divisor.itrng_divisor.value <= field_combo.interface_regs.itrng_divisor.itrng_divisor.next;
         end
     end
     assign hwif_out.interface_regs.itrng_divisor.itrng_divisor.value = field_storage.interface_regs.itrng_divisor.itrng_divisor.value;
@@ -1284,10 +1309,8 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.cycle_count.cycle_count.value <= 32'h0;
-        end else begin
-            if(field_combo.interface_regs.cycle_count.cycle_count.load_next) begin
-                field_storage.interface_regs.cycle_count.cycle_count.value <= field_combo.interface_regs.cycle_count.cycle_count.next;
-            end
+        end else if(field_combo.interface_regs.cycle_count.cycle_count.load_next) begin
+            field_storage.interface_regs.cycle_count.cycle_count.value <= field_combo.interface_regs.cycle_count.cycle_count.next;
         end
     end
     assign hwif_out.interface_regs.cycle_count.cycle_count.value = field_storage.interface_regs.cycle_count.cycle_count.value;
@@ -1308,10 +1331,8 @@ module caliptra_fpga_realtime_regs (
         always_ff @(posedge clk) begin
             if(rst) begin
                 field_storage.interface_regs.generic_input_wires[i0].value.value <= 32'h0;
-            end else begin
-                if(field_combo.interface_regs.generic_input_wires[i0].value.load_next) begin
-                    field_storage.interface_regs.generic_input_wires[i0].value.value <= field_combo.interface_regs.generic_input_wires[i0].value.next;
-                end
+            end else if(field_combo.interface_regs.generic_input_wires[i0].value.load_next) begin
+                field_storage.interface_regs.generic_input_wires[i0].value.value <= field_combo.interface_regs.generic_input_wires[i0].value.next;
             end
         end
         assign hwif_out.interface_regs.generic_input_wires[i0].value.value = field_storage.interface_regs.generic_input_wires[i0].value.value;
@@ -1333,10 +1354,8 @@ module caliptra_fpga_realtime_regs (
         always_ff @(posedge clk) begin
             if(rst) begin
                 field_storage.interface_regs.generic_output_wires[i0].value.value <= 32'h0;
-            end else begin
-                if(field_combo.interface_regs.generic_output_wires[i0].value.load_next) begin
-                    field_storage.interface_regs.generic_output_wires[i0].value.value <= field_combo.interface_regs.generic_output_wires[i0].value.next;
-                end
+            end else if(field_combo.interface_regs.generic_output_wires[i0].value.load_next) begin
+                field_storage.interface_regs.generic_output_wires[i0].value.value <= field_combo.interface_regs.generic_output_wires[i0].value.next;
             end
         end
         assign hwif_out.interface_regs.generic_output_wires[i0].value.value = field_storage.interface_regs.generic_output_wires[i0].value.value;
@@ -1358,10 +1377,8 @@ module caliptra_fpga_realtime_regs (
         always_ff @(posedge clk) begin
             if(rst) begin
                 field_storage.interface_regs.cptra_obf_key[i0].value.value <= 32'h0;
-            end else begin
-                if(field_combo.interface_regs.cptra_obf_key[i0].value.load_next) begin
-                    field_storage.interface_regs.cptra_obf_key[i0].value.value <= field_combo.interface_regs.cptra_obf_key[i0].value.next;
-                end
+            end else if(field_combo.interface_regs.cptra_obf_key[i0].value.load_next) begin
+                field_storage.interface_regs.cptra_obf_key[i0].value.value <= field_combo.interface_regs.cptra_obf_key[i0].value.next;
             end
         end
         assign hwif_out.interface_regs.cptra_obf_key[i0].value.value = field_storage.interface_regs.cptra_obf_key[i0].value.value;
@@ -1383,10 +1400,8 @@ module caliptra_fpga_realtime_regs (
         always_ff @(posedge clk) begin
             if(rst) begin
                 field_storage.interface_regs.cptra_csr_hmac_key[i0].value.value <= 32'h0;
-            end else begin
-                if(field_combo.interface_regs.cptra_csr_hmac_key[i0].value.load_next) begin
-                    field_storage.interface_regs.cptra_csr_hmac_key[i0].value.value <= field_combo.interface_regs.cptra_csr_hmac_key[i0].value.next;
-                end
+            end else if(field_combo.interface_regs.cptra_csr_hmac_key[i0].value.load_next) begin
+                field_storage.interface_regs.cptra_csr_hmac_key[i0].value.value <= field_combo.interface_regs.cptra_csr_hmac_key[i0].value.next;
             end
         end
         assign hwif_out.interface_regs.cptra_csr_hmac_key[i0].value.value = field_storage.interface_regs.cptra_csr_hmac_key[i0].value.value;
@@ -1408,10 +1423,8 @@ module caliptra_fpga_realtime_regs (
         always_ff @(posedge clk) begin
             if(rst) begin
                 field_storage.interface_regs.cptra_obf_uds_seed[i0].value.value <= 32'h0;
-            end else begin
-                if(field_combo.interface_regs.cptra_obf_uds_seed[i0].value.load_next) begin
-                    field_storage.interface_regs.cptra_obf_uds_seed[i0].value.value <= field_combo.interface_regs.cptra_obf_uds_seed[i0].value.next;
-                end
+            end else if(field_combo.interface_regs.cptra_obf_uds_seed[i0].value.load_next) begin
+                field_storage.interface_regs.cptra_obf_uds_seed[i0].value.value <= field_combo.interface_regs.cptra_obf_uds_seed[i0].value.next;
             end
         end
         assign hwif_out.interface_regs.cptra_obf_uds_seed[i0].value.value = field_storage.interface_regs.cptra_obf_uds_seed[i0].value.value;
@@ -1433,10 +1446,8 @@ module caliptra_fpga_realtime_regs (
         always_ff @(posedge clk) begin
             if(rst) begin
                 field_storage.interface_regs.cptra_obf_field_entropy[i0].value.value <= 32'h0;
-            end else begin
-                if(field_combo.interface_regs.cptra_obf_field_entropy[i0].value.load_next) begin
-                    field_storage.interface_regs.cptra_obf_field_entropy[i0].value.value <= field_combo.interface_regs.cptra_obf_field_entropy[i0].value.next;
-                end
+            end else if(field_combo.interface_regs.cptra_obf_field_entropy[i0].value.load_next) begin
+                field_storage.interface_regs.cptra_obf_field_entropy[i0].value.value <= field_combo.interface_regs.cptra_obf_field_entropy[i0].value.next;
             end
         end
         assign hwif_out.interface_regs.cptra_obf_field_entropy[i0].value.value = field_storage.interface_regs.cptra_obf_field_entropy[i0].value.value;
@@ -1457,10 +1468,8 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.lsu_user.lsu_user.value <= 32'h0;
-        end else begin
-            if(field_combo.interface_regs.lsu_user.lsu_user.load_next) begin
-                field_storage.interface_regs.lsu_user.lsu_user.value <= field_combo.interface_regs.lsu_user.lsu_user.next;
-            end
+        end else if(field_combo.interface_regs.lsu_user.lsu_user.load_next) begin
+            field_storage.interface_regs.lsu_user.lsu_user.value <= field_combo.interface_regs.lsu_user.lsu_user.next;
         end
     end
     assign hwif_out.interface_regs.lsu_user.lsu_user.value = field_storage.interface_regs.lsu_user.lsu_user.value;
@@ -1480,10 +1489,8 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.ifu_user.ifu_user.value <= 32'h0;
-        end else begin
-            if(field_combo.interface_regs.ifu_user.ifu_user.load_next) begin
-                field_storage.interface_regs.ifu_user.ifu_user.value <= field_combo.interface_regs.ifu_user.ifu_user.next;
-            end
+        end else if(field_combo.interface_regs.ifu_user.ifu_user.load_next) begin
+            field_storage.interface_regs.ifu_user.ifu_user.value <= field_combo.interface_regs.ifu_user.ifu_user.next;
         end
     end
     assign hwif_out.interface_regs.ifu_user.ifu_user.value = field_storage.interface_regs.ifu_user.ifu_user.value;
@@ -1503,10 +1510,8 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.dma_axi_user.dma_axi_user.value <= 32'h0;
-        end else begin
-            if(field_combo.interface_regs.dma_axi_user.dma_axi_user.load_next) begin
-                field_storage.interface_regs.dma_axi_user.dma_axi_user.value <= field_combo.interface_regs.dma_axi_user.dma_axi_user.next;
-            end
+        end else if(field_combo.interface_regs.dma_axi_user.dma_axi_user.load_next) begin
+            field_storage.interface_regs.dma_axi_user.dma_axi_user.value <= field_combo.interface_regs.dma_axi_user.dma_axi_user.next;
         end
     end
     assign hwif_out.interface_regs.dma_axi_user.dma_axi_user.value = field_storage.interface_regs.dma_axi_user.dma_axi_user.value;
@@ -1526,10 +1531,8 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.soc_config_user.soc_config_user.value <= 32'h0;
-        end else begin
-            if(field_combo.interface_regs.soc_config_user.soc_config_user.load_next) begin
-                field_storage.interface_regs.soc_config_user.soc_config_user.value <= field_combo.interface_regs.soc_config_user.soc_config_user.next;
-            end
+        end else if(field_combo.interface_regs.soc_config_user.soc_config_user.load_next) begin
+            field_storage.interface_regs.soc_config_user.soc_config_user.value <= field_combo.interface_regs.soc_config_user.soc_config_user.next;
         end
     end
     assign hwif_out.interface_regs.soc_config_user.soc_config_user.value = field_storage.interface_regs.soc_config_user.soc_config_user.value;
@@ -1549,10 +1552,8 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.sram_config_user.sram_config_user.value <= 32'h0;
-        end else begin
-            if(field_combo.interface_regs.sram_config_user.sram_config_user.load_next) begin
-                field_storage.interface_regs.sram_config_user.sram_config_user.value <= field_combo.interface_regs.sram_config_user.sram_config_user.next;
-            end
+        end else if(field_combo.interface_regs.sram_config_user.sram_config_user.load_next) begin
+            field_storage.interface_regs.sram_config_user.sram_config_user.value <= field_combo.interface_regs.sram_config_user.sram_config_user.next;
         end
     end
     assign hwif_out.interface_regs.sram_config_user.sram_config_user.value = field_storage.interface_regs.sram_config_user.sram_config_user.value;
@@ -1572,10 +1573,8 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.mcu_reset_vector.mcu_reset_vector.value <= 32'h0;
-        end else begin
-            if(field_combo.interface_regs.mcu_reset_vector.mcu_reset_vector.load_next) begin
-                field_storage.interface_regs.mcu_reset_vector.mcu_reset_vector.value <= field_combo.interface_regs.mcu_reset_vector.mcu_reset_vector.next;
-            end
+        end else if(field_combo.interface_regs.mcu_reset_vector.mcu_reset_vector.load_next) begin
+            field_storage.interface_regs.mcu_reset_vector.mcu_reset_vector.value <= field_combo.interface_regs.mcu_reset_vector.mcu_reset_vector.next;
         end
     end
     assign hwif_out.interface_regs.mcu_reset_vector.mcu_reset_vector.value = field_storage.interface_regs.mcu_reset_vector.mcu_reset_vector.value;
@@ -1595,10 +1594,8 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.mci_error.mci_error_fatal.value <= 1'h0;
-        end else begin
-            if(field_combo.interface_regs.mci_error.mci_error_fatal.load_next) begin
-                field_storage.interface_regs.mci_error.mci_error_fatal.value <= field_combo.interface_regs.mci_error.mci_error_fatal.next;
-            end
+        end else if(field_combo.interface_regs.mci_error.mci_error_fatal.load_next) begin
+            field_storage.interface_regs.mci_error.mci_error_fatal.value <= field_combo.interface_regs.mci_error.mci_error_fatal.next;
         end
     end
     assign hwif_out.interface_regs.mci_error.mci_error_fatal.value = field_storage.interface_regs.mci_error.mci_error_fatal.value;
@@ -1618,10 +1615,8 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.mci_error.mci_error_non_fatal.value <= 1'h0;
-        end else begin
-            if(field_combo.interface_regs.mci_error.mci_error_non_fatal.load_next) begin
-                field_storage.interface_regs.mci_error.mci_error_non_fatal.value <= field_combo.interface_regs.mci_error.mci_error_non_fatal.next;
-            end
+        end else if(field_combo.interface_regs.mci_error.mci_error_non_fatal.load_next) begin
+            field_storage.interface_regs.mci_error.mci_error_non_fatal.value <= field_combo.interface_regs.mci_error.mci_error_non_fatal.next;
         end
     end
     assign hwif_out.interface_regs.mci_error.mci_error_non_fatal.value = field_storage.interface_regs.mci_error.mci_error_non_fatal.value;
@@ -1641,10 +1636,8 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.mcu_config.mcu_no_rom_config.value <= 1'h0;
-        end else begin
-            if(field_combo.interface_regs.mcu_config.mcu_no_rom_config.load_next) begin
-                field_storage.interface_regs.mcu_config.mcu_no_rom_config.value <= field_combo.interface_regs.mcu_config.mcu_no_rom_config.next;
-            end
+        end else if(field_combo.interface_regs.mcu_config.mcu_no_rom_config.load_next) begin
+            field_storage.interface_regs.mcu_config.mcu_no_rom_config.value <= field_combo.interface_regs.mcu_config.mcu_no_rom_config.next;
         end
     end
     assign hwif_out.interface_regs.mcu_config.mcu_no_rom_config.value = field_storage.interface_regs.mcu_config.mcu_no_rom_config.value;
@@ -1664,10 +1657,8 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.mcu_config.cptra_ss_mci_boot_seq_brkpoint_i.value <= 1'h0;
-        end else begin
-            if(field_combo.interface_regs.mcu_config.cptra_ss_mci_boot_seq_brkpoint_i.load_next) begin
-                field_storage.interface_regs.mcu_config.cptra_ss_mci_boot_seq_brkpoint_i.value <= field_combo.interface_regs.mcu_config.cptra_ss_mci_boot_seq_brkpoint_i.next;
-            end
+        end else if(field_combo.interface_regs.mcu_config.cptra_ss_mci_boot_seq_brkpoint_i.load_next) begin
+            field_storage.interface_regs.mcu_config.cptra_ss_mci_boot_seq_brkpoint_i.value <= field_combo.interface_regs.mcu_config.cptra_ss_mci_boot_seq_brkpoint_i.next;
         end
     end
     assign hwif_out.interface_regs.mcu_config.cptra_ss_mci_boot_seq_brkpoint_i.value = field_storage.interface_regs.mcu_config.cptra_ss_mci_boot_seq_brkpoint_i.value;
@@ -1687,10 +1678,8 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.mcu_config.cptra_ss_lc_Allow_RMA_on_PPD_i.value <= 1'h0;
-        end else begin
-            if(field_combo.interface_regs.mcu_config.cptra_ss_lc_Allow_RMA_on_PPD_i.load_next) begin
-                field_storage.interface_regs.mcu_config.cptra_ss_lc_Allow_RMA_on_PPD_i.value <= field_combo.interface_regs.mcu_config.cptra_ss_lc_Allow_RMA_on_PPD_i.next;
-            end
+        end else if(field_combo.interface_regs.mcu_config.cptra_ss_lc_Allow_RMA_on_PPD_i.load_next) begin
+            field_storage.interface_regs.mcu_config.cptra_ss_lc_Allow_RMA_on_PPD_i.value <= field_combo.interface_regs.mcu_config.cptra_ss_lc_Allow_RMA_on_PPD_i.next;
         end
     end
     assign hwif_out.interface_regs.mcu_config.cptra_ss_lc_Allow_RMA_on_PPD_i.value = field_storage.interface_regs.mcu_config.cptra_ss_lc_Allow_RMA_on_PPD_i.value;
@@ -1710,10 +1699,8 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.mcu_config.cptra_ss_lc_ctrl_scan_rst_ni_i.value <= 1'h0;
-        end else begin
-            if(field_combo.interface_regs.mcu_config.cptra_ss_lc_ctrl_scan_rst_ni_i.load_next) begin
-                field_storage.interface_regs.mcu_config.cptra_ss_lc_ctrl_scan_rst_ni_i.value <= field_combo.interface_regs.mcu_config.cptra_ss_lc_ctrl_scan_rst_ni_i.next;
-            end
+        end else if(field_combo.interface_regs.mcu_config.cptra_ss_lc_ctrl_scan_rst_ni_i.load_next) begin
+            field_storage.interface_regs.mcu_config.cptra_ss_lc_ctrl_scan_rst_ni_i.value <= field_combo.interface_regs.mcu_config.cptra_ss_lc_ctrl_scan_rst_ni_i.next;
         end
     end
     assign hwif_out.interface_regs.mcu_config.cptra_ss_lc_ctrl_scan_rst_ni_i.value = field_storage.interface_regs.mcu_config.cptra_ss_lc_ctrl_scan_rst_ni_i.value;
@@ -1733,10 +1720,8 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.mcu_config.cptra_ss_lc_esclate_scrap_state0_i.value <= 1'h0;
-        end else begin
-            if(field_combo.interface_regs.mcu_config.cptra_ss_lc_esclate_scrap_state0_i.load_next) begin
-                field_storage.interface_regs.mcu_config.cptra_ss_lc_esclate_scrap_state0_i.value <= field_combo.interface_regs.mcu_config.cptra_ss_lc_esclate_scrap_state0_i.next;
-            end
+        end else if(field_combo.interface_regs.mcu_config.cptra_ss_lc_esclate_scrap_state0_i.load_next) begin
+            field_storage.interface_regs.mcu_config.cptra_ss_lc_esclate_scrap_state0_i.value <= field_combo.interface_regs.mcu_config.cptra_ss_lc_esclate_scrap_state0_i.next;
         end
     end
     assign hwif_out.interface_regs.mcu_config.cptra_ss_lc_esclate_scrap_state0_i.value = field_storage.interface_regs.mcu_config.cptra_ss_lc_esclate_scrap_state0_i.value;
@@ -1756,10 +1741,8 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.mcu_config.cptra_ss_lc_esclate_scrap_state1_i.value <= 1'h0;
-        end else begin
-            if(field_combo.interface_regs.mcu_config.cptra_ss_lc_esclate_scrap_state1_i.load_next) begin
-                field_storage.interface_regs.mcu_config.cptra_ss_lc_esclate_scrap_state1_i.value <= field_combo.interface_regs.mcu_config.cptra_ss_lc_esclate_scrap_state1_i.next;
-            end
+        end else if(field_combo.interface_regs.mcu_config.cptra_ss_lc_esclate_scrap_state1_i.load_next) begin
+            field_storage.interface_regs.mcu_config.cptra_ss_lc_esclate_scrap_state1_i.value <= field_combo.interface_regs.mcu_config.cptra_ss_lc_esclate_scrap_state1_i.next;
         end
     end
     assign hwif_out.interface_regs.mcu_config.cptra_ss_lc_esclate_scrap_state1_i.value = field_storage.interface_regs.mcu_config.cptra_ss_lc_esclate_scrap_state1_i.value;
@@ -1779,10 +1762,8 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.uds_seed_base_addr.uds_seed_base_addr.value <= 32'h0;
-        end else begin
-            if(field_combo.interface_regs.uds_seed_base_addr.uds_seed_base_addr.load_next) begin
-                field_storage.interface_regs.uds_seed_base_addr.uds_seed_base_addr.value <= field_combo.interface_regs.uds_seed_base_addr.uds_seed_base_addr.next;
-            end
+        end else if(field_combo.interface_regs.uds_seed_base_addr.uds_seed_base_addr.load_next) begin
+            field_storage.interface_regs.uds_seed_base_addr.uds_seed_base_addr.value <= field_combo.interface_regs.uds_seed_base_addr.uds_seed_base_addr.next;
         end
     end
     assign hwif_out.interface_regs.uds_seed_base_addr.uds_seed_base_addr.value = field_storage.interface_regs.uds_seed_base_addr.uds_seed_base_addr.value;
@@ -1802,10 +1783,8 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.prod_debug_unlock_auth_pk_hash_reg_bank_offset.prod_debug_unlock_auth_pk_hash_reg_bank_offset.value <= 32'h0;
-        end else begin
-            if(field_combo.interface_regs.prod_debug_unlock_auth_pk_hash_reg_bank_offset.prod_debug_unlock_auth_pk_hash_reg_bank_offset.load_next) begin
-                field_storage.interface_regs.prod_debug_unlock_auth_pk_hash_reg_bank_offset.prod_debug_unlock_auth_pk_hash_reg_bank_offset.value <= field_combo.interface_regs.prod_debug_unlock_auth_pk_hash_reg_bank_offset.prod_debug_unlock_auth_pk_hash_reg_bank_offset.next;
-            end
+        end else if(field_combo.interface_regs.prod_debug_unlock_auth_pk_hash_reg_bank_offset.prod_debug_unlock_auth_pk_hash_reg_bank_offset.load_next) begin
+            field_storage.interface_regs.prod_debug_unlock_auth_pk_hash_reg_bank_offset.prod_debug_unlock_auth_pk_hash_reg_bank_offset.value <= field_combo.interface_regs.prod_debug_unlock_auth_pk_hash_reg_bank_offset.prod_debug_unlock_auth_pk_hash_reg_bank_offset.next;
         end
     end
     assign hwif_out.interface_regs.prod_debug_unlock_auth_pk_hash_reg_bank_offset.prod_debug_unlock_auth_pk_hash_reg_bank_offset.value = field_storage.interface_regs.prod_debug_unlock_auth_pk_hash_reg_bank_offset.prod_debug_unlock_auth_pk_hash_reg_bank_offset.value;
@@ -1825,10 +1804,8 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.interface_regs.num_of_prod_debug_unlock_auth_pk_hashes.num_of_prod_debug_unlock_auth_pk_hashes.value <= 32'h0;
-        end else begin
-            if(field_combo.interface_regs.num_of_prod_debug_unlock_auth_pk_hashes.num_of_prod_debug_unlock_auth_pk_hashes.load_next) begin
-                field_storage.interface_regs.num_of_prod_debug_unlock_auth_pk_hashes.num_of_prod_debug_unlock_auth_pk_hashes.value <= field_combo.interface_regs.num_of_prod_debug_unlock_auth_pk_hashes.num_of_prod_debug_unlock_auth_pk_hashes.next;
-            end
+        end else if(field_combo.interface_regs.num_of_prod_debug_unlock_auth_pk_hashes.num_of_prod_debug_unlock_auth_pk_hashes.load_next) begin
+            field_storage.interface_regs.num_of_prod_debug_unlock_auth_pk_hashes.num_of_prod_debug_unlock_auth_pk_hashes.value <= field_combo.interface_regs.num_of_prod_debug_unlock_auth_pk_hashes.num_of_prod_debug_unlock_auth_pk_hashes.next;
         end
     end
     assign hwif_out.interface_regs.num_of_prod_debug_unlock_auth_pk_hashes.num_of_prod_debug_unlock_auth_pk_hashes.value = field_storage.interface_regs.num_of_prod_debug_unlock_auth_pk_hashes.num_of_prod_debug_unlock_auth_pk_hashes.value;
@@ -1849,10 +1826,8 @@ module caliptra_fpga_realtime_regs (
         always_ff @(posedge clk) begin
             if(rst) begin
                 field_storage.interface_regs.mci_generic_input_wires[i0].value.value <= 32'h0;
-            end else begin
-                if(field_combo.interface_regs.mci_generic_input_wires[i0].value.load_next) begin
-                    field_storage.interface_regs.mci_generic_input_wires[i0].value.value <= field_combo.interface_regs.mci_generic_input_wires[i0].value.next;
-                end
+            end else if(field_combo.interface_regs.mci_generic_input_wires[i0].value.load_next) begin
+                field_storage.interface_regs.mci_generic_input_wires[i0].value.value <= field_combo.interface_regs.mci_generic_input_wires[i0].value.next;
             end
         end
         assign hwif_out.interface_regs.mci_generic_input_wires[i0].value.value = field_storage.interface_regs.mci_generic_input_wires[i0].value.value;
@@ -1874,13 +1849,33 @@ module caliptra_fpga_realtime_regs (
         always_ff @(posedge clk) begin
             if(rst) begin
                 field_storage.interface_regs.mci_generic_output_wires[i0].value.value <= 32'h0;
-            end else begin
-                if(field_combo.interface_regs.mci_generic_output_wires[i0].value.load_next) begin
-                    field_storage.interface_regs.mci_generic_output_wires[i0].value.value <= field_combo.interface_regs.mci_generic_output_wires[i0].value.next;
-                end
+            end else if(field_combo.interface_regs.mci_generic_output_wires[i0].value.load_next) begin
+                field_storage.interface_regs.mci_generic_output_wires[i0].value.value <= field_combo.interface_regs.mci_generic_output_wires[i0].value.next;
             end
         end
         assign hwif_out.interface_regs.mci_generic_output_wires[i0].value.value = field_storage.interface_regs.mci_generic_output_wires[i0].value.value;
+    end
+    for(genvar i0=0; i0<16; i0++) begin
+        // Field: caliptra_fpga_realtime_regs.interface_regs.ocp_lock_key_release_reg[].key
+        always_comb begin
+            automatic logic [31:0] next_c;
+            automatic logic load_next_c;
+            next_c = field_storage.interface_regs.ocp_lock_key_release_reg[i0].key.value;
+            load_next_c = '0;
+            if(decoded_reg_strb.interface_regs.ocp_lock_key_release_reg[i0] && decoded_req_is_wr) begin // SW write
+                next_c = (field_storage.interface_regs.ocp_lock_key_release_reg[i0].key.value & ~decoded_wr_biten[31:0]) | (decoded_wr_data[31:0] & decoded_wr_biten[31:0]);
+                load_next_c = '1;
+            end
+            field_combo.interface_regs.ocp_lock_key_release_reg[i0].key.next = next_c;
+            field_combo.interface_regs.ocp_lock_key_release_reg[i0].key.load_next = load_next_c;
+        end
+        always_ff @(posedge clk) begin
+            if(rst) begin
+                field_storage.interface_regs.ocp_lock_key_release_reg[i0].key.value <= 32'h0;
+            end else if(field_combo.interface_regs.ocp_lock_key_release_reg[i0].key.load_next) begin
+                field_storage.interface_regs.ocp_lock_key_release_reg[i0].key.value <= field_combo.interface_regs.ocp_lock_key_release_reg[i0].key.next;
+            end
+        end
     end
     // Field: caliptra_fpga_realtime_regs.fifo_regs.log_fifo_data.next_char
     always_comb begin
@@ -1898,10 +1893,8 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.fifo_regs.log_fifo_data.next_char.value <= 8'h0;
-        end else begin
-            if(field_combo.fifo_regs.log_fifo_data.next_char.load_next) begin
-                field_storage.fifo_regs.log_fifo_data.next_char.value <= field_combo.fifo_regs.log_fifo_data.next_char.next;
-            end
+        end else if(field_combo.fifo_regs.log_fifo_data.next_char.load_next) begin
+            field_storage.fifo_regs.log_fifo_data.next_char.value <= field_combo.fifo_regs.log_fifo_data.next_char.next;
         end
     end
     assign hwif_out.fifo_regs.log_fifo_data.next_char.value = field_storage.fifo_regs.log_fifo_data.next_char.value;
@@ -1922,10 +1915,8 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.fifo_regs.log_fifo_data.char_valid.value <= 1'h0;
-        end else begin
-            if(field_combo.fifo_regs.log_fifo_data.char_valid.load_next) begin
-                field_storage.fifo_regs.log_fifo_data.char_valid.value <= field_combo.fifo_regs.log_fifo_data.char_valid.next;
-            end
+        end else if(field_combo.fifo_regs.log_fifo_data.char_valid.load_next) begin
+            field_storage.fifo_regs.log_fifo_data.char_valid.value <= field_combo.fifo_regs.log_fifo_data.char_valid.next;
         end
     end
     assign hwif_out.fifo_regs.log_fifo_data.char_valid.value = field_storage.fifo_regs.log_fifo_data.char_valid.value;
@@ -1945,10 +1936,8 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.fifo_regs.log_fifo_status.log_fifo_empty.value <= 1'h0;
-        end else begin
-            if(field_combo.fifo_regs.log_fifo_status.log_fifo_empty.load_next) begin
-                field_storage.fifo_regs.log_fifo_status.log_fifo_empty.value <= field_combo.fifo_regs.log_fifo_status.log_fifo_empty.next;
-            end
+        end else if(field_combo.fifo_regs.log_fifo_status.log_fifo_empty.load_next) begin
+            field_storage.fifo_regs.log_fifo_status.log_fifo_empty.value <= field_combo.fifo_regs.log_fifo_status.log_fifo_empty.next;
         end
     end
     assign hwif_out.fifo_regs.log_fifo_status.log_fifo_empty.value = field_storage.fifo_regs.log_fifo_status.log_fifo_empty.value;
@@ -1968,10 +1957,8 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.fifo_regs.log_fifo_status.log_fifo_full.value <= 1'h0;
-        end else begin
-            if(field_combo.fifo_regs.log_fifo_status.log_fifo_full.load_next) begin
-                field_storage.fifo_regs.log_fifo_status.log_fifo_full.value <= field_combo.fifo_regs.log_fifo_status.log_fifo_full.next;
-            end
+        end else if(field_combo.fifo_regs.log_fifo_status.log_fifo_full.load_next) begin
+            field_storage.fifo_regs.log_fifo_status.log_fifo_full.value <= field_combo.fifo_regs.log_fifo_status.log_fifo_full.next;
         end
     end
     assign hwif_out.fifo_regs.log_fifo_status.log_fifo_full.value = field_storage.fifo_regs.log_fifo_status.log_fifo_full.value;
@@ -1991,10 +1978,8 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.fifo_regs.itrng_fifo_data.itrng_data.value <= 32'h0;
-        end else begin
-            if(field_combo.fifo_regs.itrng_fifo_data.itrng_data.load_next) begin
-                field_storage.fifo_regs.itrng_fifo_data.itrng_data.value <= field_combo.fifo_regs.itrng_fifo_data.itrng_data.next;
-            end
+        end else if(field_combo.fifo_regs.itrng_fifo_data.itrng_data.load_next) begin
+            field_storage.fifo_regs.itrng_fifo_data.itrng_data.value <= field_combo.fifo_regs.itrng_fifo_data.itrng_data.next;
         end
     end
     assign hwif_out.fifo_regs.itrng_fifo_data.itrng_data.value = field_storage.fifo_regs.itrng_fifo_data.itrng_data.value;
@@ -2015,10 +2000,8 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.fifo_regs.itrng_fifo_status.itrng_fifo_empty.value <= 1'h0;
-        end else begin
-            if(field_combo.fifo_regs.itrng_fifo_status.itrng_fifo_empty.load_next) begin
-                field_storage.fifo_regs.itrng_fifo_status.itrng_fifo_empty.value <= field_combo.fifo_regs.itrng_fifo_status.itrng_fifo_empty.next;
-            end
+        end else if(field_combo.fifo_regs.itrng_fifo_status.itrng_fifo_empty.load_next) begin
+            field_storage.fifo_regs.itrng_fifo_status.itrng_fifo_empty.value <= field_combo.fifo_regs.itrng_fifo_status.itrng_fifo_empty.next;
         end
     end
     assign hwif_out.fifo_regs.itrng_fifo_status.itrng_fifo_empty.value = field_storage.fifo_regs.itrng_fifo_status.itrng_fifo_empty.value;
@@ -2038,10 +2021,8 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.fifo_regs.itrng_fifo_status.itrng_fifo_full.value <= 1'h0;
-        end else begin
-            if(field_combo.fifo_regs.itrng_fifo_status.itrng_fifo_full.load_next) begin
-                field_storage.fifo_regs.itrng_fifo_status.itrng_fifo_full.value <= field_combo.fifo_regs.itrng_fifo_status.itrng_fifo_full.next;
-            end
+        end else if(field_combo.fifo_regs.itrng_fifo_status.itrng_fifo_full.load_next) begin
+            field_storage.fifo_regs.itrng_fifo_status.itrng_fifo_full.value <= field_combo.fifo_regs.itrng_fifo_status.itrng_fifo_full.next;
         end
     end
     assign hwif_out.fifo_regs.itrng_fifo_status.itrng_fifo_full.value = field_storage.fifo_regs.itrng_fifo_status.itrng_fifo_full.value;
@@ -2061,10 +2042,8 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.fifo_regs.itrng_fifo_status.itrng_fifo_reset.value <= 1'h0;
-        end else begin
-            if(field_combo.fifo_regs.itrng_fifo_status.itrng_fifo_reset.load_next) begin
-                field_storage.fifo_regs.itrng_fifo_status.itrng_fifo_reset.value <= field_combo.fifo_regs.itrng_fifo_status.itrng_fifo_reset.next;
-            end
+        end else if(field_combo.fifo_regs.itrng_fifo_status.itrng_fifo_reset.load_next) begin
+            field_storage.fifo_regs.itrng_fifo_status.itrng_fifo_reset.value <= field_combo.fifo_regs.itrng_fifo_status.itrng_fifo_reset.next;
         end
     end
     assign hwif_out.fifo_regs.itrng_fifo_status.itrng_fifo_reset.value = field_storage.fifo_regs.itrng_fifo_status.itrng_fifo_reset.value;
@@ -2084,10 +2063,8 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.fifo_regs.dbg_fifo_pop.out_data.value <= 32'h0;
-        end else begin
-            if(field_combo.fifo_regs.dbg_fifo_pop.out_data.load_next) begin
-                field_storage.fifo_regs.dbg_fifo_pop.out_data.value <= field_combo.fifo_regs.dbg_fifo_pop.out_data.next;
-            end
+        end else if(field_combo.fifo_regs.dbg_fifo_pop.out_data.load_next) begin
+            field_storage.fifo_regs.dbg_fifo_pop.out_data.value <= field_combo.fifo_regs.dbg_fifo_pop.out_data.next;
         end
     end
     assign hwif_out.fifo_regs.dbg_fifo_pop.out_data.value = field_storage.fifo_regs.dbg_fifo_pop.out_data.value;
@@ -2108,10 +2085,8 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.fifo_regs.dbg_fifo_push.in_data.value <= 32'h0;
-        end else begin
-            if(field_combo.fifo_regs.dbg_fifo_push.in_data.load_next) begin
-                field_storage.fifo_regs.dbg_fifo_push.in_data.value <= field_combo.fifo_regs.dbg_fifo_push.in_data.next;
-            end
+        end else if(field_combo.fifo_regs.dbg_fifo_push.in_data.load_next) begin
+            field_storage.fifo_regs.dbg_fifo_push.in_data.value <= field_combo.fifo_regs.dbg_fifo_push.in_data.next;
         end
     end
     assign hwif_out.fifo_regs.dbg_fifo_push.in_data.value = field_storage.fifo_regs.dbg_fifo_push.in_data.value;
@@ -2132,10 +2107,8 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.fifo_regs.dbg_fifo_status.dbg_fifo_empty.value <= 1'h0;
-        end else begin
-            if(field_combo.fifo_regs.dbg_fifo_status.dbg_fifo_empty.load_next) begin
-                field_storage.fifo_regs.dbg_fifo_status.dbg_fifo_empty.value <= field_combo.fifo_regs.dbg_fifo_status.dbg_fifo_empty.next;
-            end
+        end else if(field_combo.fifo_regs.dbg_fifo_status.dbg_fifo_empty.load_next) begin
+            field_storage.fifo_regs.dbg_fifo_status.dbg_fifo_empty.value <= field_combo.fifo_regs.dbg_fifo_status.dbg_fifo_empty.next;
         end
     end
     assign hwif_out.fifo_regs.dbg_fifo_status.dbg_fifo_empty.value = field_storage.fifo_regs.dbg_fifo_status.dbg_fifo_empty.value;
@@ -2155,13 +2128,97 @@ module caliptra_fpga_realtime_regs (
     always_ff @(posedge clk) begin
         if(rst) begin
             field_storage.fifo_regs.dbg_fifo_status.dbg_fifo_full.value <= 1'h0;
-        end else begin
-            if(field_combo.fifo_regs.dbg_fifo_status.dbg_fifo_full.load_next) begin
-                field_storage.fifo_regs.dbg_fifo_status.dbg_fifo_full.value <= field_combo.fifo_regs.dbg_fifo_status.dbg_fifo_full.next;
-            end
+        end else if(field_combo.fifo_regs.dbg_fifo_status.dbg_fifo_full.load_next) begin
+            field_storage.fifo_regs.dbg_fifo_status.dbg_fifo_full.value <= field_combo.fifo_regs.dbg_fifo_status.dbg_fifo_full.next;
         end
     end
     assign hwif_out.fifo_regs.dbg_fifo_status.dbg_fifo_full.value = field_storage.fifo_regs.dbg_fifo_status.dbg_fifo_full.value;
+    // Field: caliptra_fpga_realtime_regs.fifo_regs.msg_fifo_pop.out_data
+    always_comb begin
+        automatic logic [31:0] next_c;
+        automatic logic load_next_c;
+        next_c = field_storage.fifo_regs.msg_fifo_pop.out_data.value;
+        load_next_c = '0;
+        
+        // HW Write
+        next_c = hwif_in.fifo_regs.msg_fifo_pop.out_data.next;
+        load_next_c = '1;
+        field_combo.fifo_regs.msg_fifo_pop.out_data.next = next_c;
+        field_combo.fifo_regs.msg_fifo_pop.out_data.load_next = load_next_c;
+    end
+    always_ff @(posedge clk) begin
+        if(rst) begin
+            field_storage.fifo_regs.msg_fifo_pop.out_data.value <= 32'h0;
+        end else if(field_combo.fifo_regs.msg_fifo_pop.out_data.load_next) begin
+            field_storage.fifo_regs.msg_fifo_pop.out_data.value <= field_combo.fifo_regs.msg_fifo_pop.out_data.next;
+        end
+    end
+    assign hwif_out.fifo_regs.msg_fifo_pop.out_data.value = field_storage.fifo_regs.msg_fifo_pop.out_data.value;
+    assign hwif_out.fifo_regs.msg_fifo_pop.out_data.rd_swacc = decoded_reg_strb.fifo_regs.msg_fifo_pop && !decoded_req_is_wr;
+    // Field: caliptra_fpga_realtime_regs.fifo_regs.msg_fifo_push.in_data
+    always_comb begin
+        automatic logic [31:0] next_c;
+        automatic logic load_next_c;
+        next_c = field_storage.fifo_regs.msg_fifo_push.in_data.value;
+        load_next_c = '0;
+        if(decoded_reg_strb.fifo_regs.msg_fifo_push && decoded_req_is_wr) begin // SW write
+            next_c = (field_storage.fifo_regs.msg_fifo_push.in_data.value & ~decoded_wr_biten[31:0]) | (decoded_wr_data[31:0] & decoded_wr_biten[31:0]);
+            load_next_c = '1;
+        end
+        field_combo.fifo_regs.msg_fifo_push.in_data.next = next_c;
+        field_combo.fifo_regs.msg_fifo_push.in_data.load_next = load_next_c;
+    end
+    always_ff @(posedge clk) begin
+        if(rst) begin
+            field_storage.fifo_regs.msg_fifo_push.in_data.value <= 32'h0;
+        end else if(field_combo.fifo_regs.msg_fifo_push.in_data.load_next) begin
+            field_storage.fifo_regs.msg_fifo_push.in_data.value <= field_combo.fifo_regs.msg_fifo_push.in_data.next;
+        end
+    end
+    assign hwif_out.fifo_regs.msg_fifo_push.in_data.value = field_storage.fifo_regs.msg_fifo_push.in_data.value;
+    assign hwif_out.fifo_regs.msg_fifo_push.in_data.wr_swacc = decoded_reg_strb.fifo_regs.msg_fifo_push && decoded_req_is_wr;
+    // Field: caliptra_fpga_realtime_regs.fifo_regs.msg_fifo_status.msg_fifo_empty
+    always_comb begin
+        automatic logic [0:0] next_c;
+        automatic logic load_next_c;
+        next_c = field_storage.fifo_regs.msg_fifo_status.msg_fifo_empty.value;
+        load_next_c = '0;
+        
+        // HW Write
+        next_c = hwif_in.fifo_regs.msg_fifo_status.msg_fifo_empty.next;
+        load_next_c = '1;
+        field_combo.fifo_regs.msg_fifo_status.msg_fifo_empty.next = next_c;
+        field_combo.fifo_regs.msg_fifo_status.msg_fifo_empty.load_next = load_next_c;
+    end
+    always_ff @(posedge clk) begin
+        if(rst) begin
+            field_storage.fifo_regs.msg_fifo_status.msg_fifo_empty.value <= 1'h0;
+        end else if(field_combo.fifo_regs.msg_fifo_status.msg_fifo_empty.load_next) begin
+            field_storage.fifo_regs.msg_fifo_status.msg_fifo_empty.value <= field_combo.fifo_regs.msg_fifo_status.msg_fifo_empty.next;
+        end
+    end
+    assign hwif_out.fifo_regs.msg_fifo_status.msg_fifo_empty.value = field_storage.fifo_regs.msg_fifo_status.msg_fifo_empty.value;
+    // Field: caliptra_fpga_realtime_regs.fifo_regs.msg_fifo_status.msg_fifo_full
+    always_comb begin
+        automatic logic [0:0] next_c;
+        automatic logic load_next_c;
+        next_c = field_storage.fifo_regs.msg_fifo_status.msg_fifo_full.value;
+        load_next_c = '0;
+        
+        // HW Write
+        next_c = hwif_in.fifo_regs.msg_fifo_status.msg_fifo_full.next;
+        load_next_c = '1;
+        field_combo.fifo_regs.msg_fifo_status.msg_fifo_full.next = next_c;
+        field_combo.fifo_regs.msg_fifo_status.msg_fifo_full.load_next = load_next_c;
+    end
+    always_ff @(posedge clk) begin
+        if(rst) begin
+            field_storage.fifo_regs.msg_fifo_status.msg_fifo_full.value <= 1'h0;
+        end else if(field_combo.fifo_regs.msg_fifo_status.msg_fifo_full.load_next) begin
+            field_storage.fifo_regs.msg_fifo_status.msg_fifo_full.value <= field_combo.fifo_regs.msg_fifo_status.msg_fifo_full.next;
+        end
+    end
+    assign hwif_out.fifo_regs.msg_fifo_status.msg_fifo_full.value = field_storage.fifo_regs.msg_fifo_status.msg_fifo_full.value;
 
     //--------------------------------------------------------------------------
     // Write response
@@ -2179,7 +2236,7 @@ module caliptra_fpga_realtime_regs (
     logic [31:0] readback_data;
 
     // Assign readback values to a flattened array
-    logic [31:0] readback_array[81];
+    logic [31:0] readback_array[100];
     assign readback_array[0][31:0] = (decoded_reg_strb.interface_regs.fpga_magic && !decoded_req_is_wr) ? 32'h52545043 : '0;
     assign readback_array[1][31:0] = (decoded_reg_strb.interface_regs.fpga_version && !decoded_req_is_wr) ? field_storage.interface_regs.fpga_version.fpga_version.value : '0;
     assign readback_array[2][0:0] = (decoded_reg_strb.interface_regs.control && !decoded_req_is_wr) ? field_storage.interface_regs.control.cptra_pwrgood.value : '0;
@@ -2204,22 +2261,22 @@ module caliptra_fpga_realtime_regs (
     assign readback_array[5][31:0] = (decoded_reg_strb.interface_regs.itrng_divisor && !decoded_req_is_wr) ? field_storage.interface_regs.itrng_divisor.itrng_divisor.value : '0;
     assign readback_array[6][31:0] = (decoded_reg_strb.interface_regs.cycle_count && !decoded_req_is_wr) ? field_storage.interface_regs.cycle_count.cycle_count.value : '0;
     for(genvar i0=0; i0<2; i0++) begin
-        assign readback_array[i0 * 1 + 7][31:0] = (decoded_reg_strb.interface_regs.generic_input_wires[i0] && !decoded_req_is_wr) ? field_storage.interface_regs.generic_input_wires[i0].value.value : '0;
+        assign readback_array[i0*1 + 7][31:0] = (decoded_reg_strb.interface_regs.generic_input_wires[i0] && !decoded_req_is_wr) ? field_storage.interface_regs.generic_input_wires[i0].value.value : '0;
     end
     for(genvar i0=0; i0<2; i0++) begin
-        assign readback_array[i0 * 1 + 9][31:0] = (decoded_reg_strb.interface_regs.generic_output_wires[i0] && !decoded_req_is_wr) ? field_storage.interface_regs.generic_output_wires[i0].value.value : '0;
+        assign readback_array[i0*1 + 9][31:0] = (decoded_reg_strb.interface_regs.generic_output_wires[i0] && !decoded_req_is_wr) ? field_storage.interface_regs.generic_output_wires[i0].value.value : '0;
     end
     for(genvar i0=0; i0<8; i0++) begin
-        assign readback_array[i0 * 1 + 11][31:0] = (decoded_reg_strb.interface_regs.cptra_obf_key[i0] && !decoded_req_is_wr) ? field_storage.interface_regs.cptra_obf_key[i0].value.value : '0;
+        assign readback_array[i0*1 + 11][31:0] = (decoded_reg_strb.interface_regs.cptra_obf_key[i0] && !decoded_req_is_wr) ? field_storage.interface_regs.cptra_obf_key[i0].value.value : '0;
     end
     for(genvar i0=0; i0<16; i0++) begin
-        assign readback_array[i0 * 1 + 19][31:0] = (decoded_reg_strb.interface_regs.cptra_csr_hmac_key[i0] && !decoded_req_is_wr) ? field_storage.interface_regs.cptra_csr_hmac_key[i0].value.value : '0;
+        assign readback_array[i0*1 + 19][31:0] = (decoded_reg_strb.interface_regs.cptra_csr_hmac_key[i0] && !decoded_req_is_wr) ? field_storage.interface_regs.cptra_csr_hmac_key[i0].value.value : '0;
     end
     for(genvar i0=0; i0<16; i0++) begin
-        assign readback_array[i0 * 1 + 35][31:0] = (decoded_reg_strb.interface_regs.cptra_obf_uds_seed[i0] && !decoded_req_is_wr) ? field_storage.interface_regs.cptra_obf_uds_seed[i0].value.value : '0;
+        assign readback_array[i0*1 + 35][31:0] = (decoded_reg_strb.interface_regs.cptra_obf_uds_seed[i0] && !decoded_req_is_wr) ? field_storage.interface_regs.cptra_obf_uds_seed[i0].value.value : '0;
     end
     for(genvar i0=0; i0<8; i0++) begin
-        assign readback_array[i0 * 1 + 51][31:0] = (decoded_reg_strb.interface_regs.cptra_obf_field_entropy[i0] && !decoded_req_is_wr) ? field_storage.interface_regs.cptra_obf_field_entropy[i0].value.value : '0;
+        assign readback_array[i0*1 + 51][31:0] = (decoded_reg_strb.interface_regs.cptra_obf_field_entropy[i0] && !decoded_req_is_wr) ? field_storage.interface_regs.cptra_obf_field_entropy[i0].value.value : '0;
     end
     assign readback_array[59][31:0] = (decoded_reg_strb.interface_regs.lsu_user && !decoded_req_is_wr) ? field_storage.interface_regs.lsu_user.lsu_user.value : '0;
     assign readback_array[60][31:0] = (decoded_reg_strb.interface_regs.ifu_user && !decoded_req_is_wr) ? field_storage.interface_regs.ifu_user.ifu_user.value : '0;
@@ -2241,27 +2298,35 @@ module caliptra_fpga_realtime_regs (
     assign readback_array[68][31:0] = (decoded_reg_strb.interface_regs.prod_debug_unlock_auth_pk_hash_reg_bank_offset && !decoded_req_is_wr) ? field_storage.interface_regs.prod_debug_unlock_auth_pk_hash_reg_bank_offset.prod_debug_unlock_auth_pk_hash_reg_bank_offset.value : '0;
     assign readback_array[69][31:0] = (decoded_reg_strb.interface_regs.num_of_prod_debug_unlock_auth_pk_hashes && !decoded_req_is_wr) ? field_storage.interface_regs.num_of_prod_debug_unlock_auth_pk_hashes.num_of_prod_debug_unlock_auth_pk_hashes.value : '0;
     for(genvar i0=0; i0<2; i0++) begin
-        assign readback_array[i0 * 1 + 70][31:0] = (decoded_reg_strb.interface_regs.mci_generic_input_wires[i0] && !decoded_req_is_wr) ? field_storage.interface_regs.mci_generic_input_wires[i0].value.value : '0;
+        assign readback_array[i0*1 + 70][31:0] = (decoded_reg_strb.interface_regs.mci_generic_input_wires[i0] && !decoded_req_is_wr) ? field_storage.interface_regs.mci_generic_input_wires[i0].value.value : '0;
     end
     for(genvar i0=0; i0<2; i0++) begin
-        assign readback_array[i0 * 1 + 72][31:0] = (decoded_reg_strb.interface_regs.mci_generic_output_wires[i0] && !decoded_req_is_wr) ? field_storage.interface_regs.mci_generic_output_wires[i0].value.value : '0;
+        assign readback_array[i0*1 + 72][31:0] = (decoded_reg_strb.interface_regs.mci_generic_output_wires[i0] && !decoded_req_is_wr) ? field_storage.interface_regs.mci_generic_output_wires[i0].value.value : '0;
     end
-    assign readback_array[74][7:0] = (decoded_reg_strb.fifo_regs.log_fifo_data && !decoded_req_is_wr) ? field_storage.fifo_regs.log_fifo_data.next_char.value : '0;
-    assign readback_array[74][8:8] = (decoded_reg_strb.fifo_regs.log_fifo_data && !decoded_req_is_wr) ? field_storage.fifo_regs.log_fifo_data.char_valid.value : '0;
-    assign readback_array[74][31:9] = '0;
-    assign readback_array[75][0:0] = (decoded_reg_strb.fifo_regs.log_fifo_status && !decoded_req_is_wr) ? field_storage.fifo_regs.log_fifo_status.log_fifo_empty.value : '0;
-    assign readback_array[75][1:1] = (decoded_reg_strb.fifo_regs.log_fifo_status && !decoded_req_is_wr) ? field_storage.fifo_regs.log_fifo_status.log_fifo_full.value : '0;
-    assign readback_array[75][31:2] = '0;
-    assign readback_array[76][31:0] = (decoded_reg_strb.fifo_regs.itrng_fifo_data && !decoded_req_is_wr) ? field_storage.fifo_regs.itrng_fifo_data.itrng_data.value : '0;
-    assign readback_array[77][0:0] = (decoded_reg_strb.fifo_regs.itrng_fifo_status && !decoded_req_is_wr) ? field_storage.fifo_regs.itrng_fifo_status.itrng_fifo_empty.value : '0;
-    assign readback_array[77][1:1] = (decoded_reg_strb.fifo_regs.itrng_fifo_status && !decoded_req_is_wr) ? field_storage.fifo_regs.itrng_fifo_status.itrng_fifo_full.value : '0;
-    assign readback_array[77][2:2] = (decoded_reg_strb.fifo_regs.itrng_fifo_status && !decoded_req_is_wr) ? field_storage.fifo_regs.itrng_fifo_status.itrng_fifo_reset.value : '0;
-    assign readback_array[77][31:3] = '0;
-    assign readback_array[78][31:0] = (decoded_reg_strb.fifo_regs.dbg_fifo_pop && !decoded_req_is_wr) ? field_storage.fifo_regs.dbg_fifo_pop.out_data.value : '0;
-    assign readback_array[79][31:0] = (decoded_reg_strb.fifo_regs.dbg_fifo_push && !decoded_req_is_wr) ? field_storage.fifo_regs.dbg_fifo_push.in_data.value : '0;
-    assign readback_array[80][0:0] = (decoded_reg_strb.fifo_regs.dbg_fifo_status && !decoded_req_is_wr) ? field_storage.fifo_regs.dbg_fifo_status.dbg_fifo_empty.value : '0;
-    assign readback_array[80][1:1] = (decoded_reg_strb.fifo_regs.dbg_fifo_status && !decoded_req_is_wr) ? field_storage.fifo_regs.dbg_fifo_status.dbg_fifo_full.value : '0;
-    assign readback_array[80][31:2] = '0;
+    for(genvar i0=0; i0<16; i0++) begin
+        assign readback_array[i0*1 + 74][31:0] = (decoded_reg_strb.interface_regs.ocp_lock_key_release_reg[i0] && !decoded_req_is_wr) ? field_storage.interface_regs.ocp_lock_key_release_reg[i0].key.value : '0;
+    end
+    assign readback_array[90][7:0] = (decoded_reg_strb.fifo_regs.log_fifo_data && !decoded_req_is_wr) ? field_storage.fifo_regs.log_fifo_data.next_char.value : '0;
+    assign readback_array[90][8:8] = (decoded_reg_strb.fifo_regs.log_fifo_data && !decoded_req_is_wr) ? field_storage.fifo_regs.log_fifo_data.char_valid.value : '0;
+    assign readback_array[90][31:9] = '0;
+    assign readback_array[91][0:0] = (decoded_reg_strb.fifo_regs.log_fifo_status && !decoded_req_is_wr) ? field_storage.fifo_regs.log_fifo_status.log_fifo_empty.value : '0;
+    assign readback_array[91][1:1] = (decoded_reg_strb.fifo_regs.log_fifo_status && !decoded_req_is_wr) ? field_storage.fifo_regs.log_fifo_status.log_fifo_full.value : '0;
+    assign readback_array[91][31:2] = '0;
+    assign readback_array[92][31:0] = (decoded_reg_strb.fifo_regs.itrng_fifo_data && !decoded_req_is_wr) ? field_storage.fifo_regs.itrng_fifo_data.itrng_data.value : '0;
+    assign readback_array[93][0:0] = (decoded_reg_strb.fifo_regs.itrng_fifo_status && !decoded_req_is_wr) ? field_storage.fifo_regs.itrng_fifo_status.itrng_fifo_empty.value : '0;
+    assign readback_array[93][1:1] = (decoded_reg_strb.fifo_regs.itrng_fifo_status && !decoded_req_is_wr) ? field_storage.fifo_regs.itrng_fifo_status.itrng_fifo_full.value : '0;
+    assign readback_array[93][2:2] = (decoded_reg_strb.fifo_regs.itrng_fifo_status && !decoded_req_is_wr) ? field_storage.fifo_regs.itrng_fifo_status.itrng_fifo_reset.value : '0;
+    assign readback_array[93][31:3] = '0;
+    assign readback_array[94][31:0] = (decoded_reg_strb.fifo_regs.dbg_fifo_pop && !decoded_req_is_wr) ? field_storage.fifo_regs.dbg_fifo_pop.out_data.value : '0;
+    assign readback_array[95][31:0] = (decoded_reg_strb.fifo_regs.dbg_fifo_push && !decoded_req_is_wr) ? field_storage.fifo_regs.dbg_fifo_push.in_data.value : '0;
+    assign readback_array[96][0:0] = (decoded_reg_strb.fifo_regs.dbg_fifo_status && !decoded_req_is_wr) ? field_storage.fifo_regs.dbg_fifo_status.dbg_fifo_empty.value : '0;
+    assign readback_array[96][1:1] = (decoded_reg_strb.fifo_regs.dbg_fifo_status && !decoded_req_is_wr) ? field_storage.fifo_regs.dbg_fifo_status.dbg_fifo_full.value : '0;
+    assign readback_array[96][31:2] = '0;
+    assign readback_array[97][31:0] = (decoded_reg_strb.fifo_regs.msg_fifo_pop && !decoded_req_is_wr) ? field_storage.fifo_regs.msg_fifo_pop.out_data.value : '0;
+    assign readback_array[98][31:0] = (decoded_reg_strb.fifo_regs.msg_fifo_push && !decoded_req_is_wr) ? field_storage.fifo_regs.msg_fifo_push.in_data.value : '0;
+    assign readback_array[99][0:0] = (decoded_reg_strb.fifo_regs.msg_fifo_status && !decoded_req_is_wr) ? field_storage.fifo_regs.msg_fifo_status.msg_fifo_empty.value : '0;
+    assign readback_array[99][1:1] = (decoded_reg_strb.fifo_regs.msg_fifo_status && !decoded_req_is_wr) ? field_storage.fifo_regs.msg_fifo_status.msg_fifo_full.value : '0;
+    assign readback_array[99][31:2] = '0;
 
     // Reduce the array
     always_comb begin
@@ -2269,7 +2334,7 @@ module caliptra_fpga_realtime_regs (
         readback_done = decoded_req & ~decoded_req_is_wr;
         readback_err = '0;
         readback_data_var = '0;
-        for(int i=0; i<81; i++) readback_data_var |= readback_array[i];
+        for(int i=0; i<100; i++) readback_data_var |= readback_array[i];
         readback_data = readback_data_var;
     end
 

--- a/hw/fpga/src/caliptra_fpga_realtime_regs_pkg.sv
+++ b/hw/fpga/src/caliptra_fpga_realtime_regs_pkg.sv
@@ -5,6 +5,7 @@ package caliptra_fpga_realtime_regs_pkg;
 
     localparam CALIPTRA_FPGA_REALTIME_REGS_DATA_WIDTH = 32;
     localparam CALIPTRA_FPGA_REALTIME_REGS_MIN_ADDR_WIDTH = 32;
+    localparam CALIPTRA_FPGA_REALTIME_REGS_SIZE = 'ha4011028;
 
     typedef struct {
         logic [31:0] next;

--- a/hw/fpga/src/caliptra_fpga_realtime_regs_pkg.sv
+++ b/hw/fpga/src/caliptra_fpga_realtime_regs_pkg.sv
@@ -159,11 +159,34 @@ package caliptra_fpga_realtime_regs_pkg;
     } fifo_regs__dbg_fifo_status__in_t;
 
     typedef struct {
+        logic [31:0] next;
+    } fifo_regs__msg_fifo_pop__out_data__in_t;
+
+    typedef struct {
+        fifo_regs__msg_fifo_pop__out_data__in_t out_data;
+    } fifo_regs__msg_fifo_pop__in_t;
+
+    typedef struct {
+        logic next;
+    } fifo_regs__msg_fifo_status__msg_fifo_empty__in_t;
+
+    typedef struct {
+        logic next;
+    } fifo_regs__msg_fifo_status__msg_fifo_full__in_t;
+
+    typedef struct {
+        fifo_regs__msg_fifo_status__msg_fifo_empty__in_t msg_fifo_empty;
+        fifo_regs__msg_fifo_status__msg_fifo_full__in_t msg_fifo_full;
+    } fifo_regs__msg_fifo_status__in_t;
+
+    typedef struct {
         fifo_regs__log_fifo_data__in_t log_fifo_data;
         fifo_regs__log_fifo_status__in_t log_fifo_status;
         fifo_regs__itrng_fifo_status__in_t itrng_fifo_status;
         fifo_regs__dbg_fifo_pop__in_t dbg_fifo_pop;
         fifo_regs__dbg_fifo_status__in_t dbg_fifo_status;
+        fifo_regs__msg_fifo_pop__in_t msg_fifo_pop;
+        fifo_regs__msg_fifo_status__in_t msg_fifo_status;
     } fifo_regs__in_t;
 
     typedef struct {
@@ -589,6 +612,37 @@ package caliptra_fpga_realtime_regs_pkg;
     } fifo_regs__dbg_fifo_status__out_t;
 
     typedef struct {
+        logic [31:0] value;
+        logic rd_swacc;
+    } fifo_regs__msg_fifo_pop__out_data__out_t;
+
+    typedef struct {
+        fifo_regs__msg_fifo_pop__out_data__out_t out_data;
+    } fifo_regs__msg_fifo_pop__out_t;
+
+    typedef struct {
+        logic [31:0] value;
+        logic wr_swacc;
+    } fifo_regs__msg_fifo_push__in_data__out_t;
+
+    typedef struct {
+        fifo_regs__msg_fifo_push__in_data__out_t in_data;
+    } fifo_regs__msg_fifo_push__out_t;
+
+    typedef struct {
+        logic value;
+    } fifo_regs__msg_fifo_status__msg_fifo_empty__out_t;
+
+    typedef struct {
+        logic value;
+    } fifo_regs__msg_fifo_status__msg_fifo_full__out_t;
+
+    typedef struct {
+        fifo_regs__msg_fifo_status__msg_fifo_empty__out_t msg_fifo_empty;
+        fifo_regs__msg_fifo_status__msg_fifo_full__out_t msg_fifo_full;
+    } fifo_regs__msg_fifo_status__out_t;
+
+    typedef struct {
         fifo_regs__log_fifo_data__out_t log_fifo_data;
         fifo_regs__log_fifo_status__out_t log_fifo_status;
         fifo_regs__itrng_fifo_data__out_t itrng_fifo_data;
@@ -596,6 +650,9 @@ package caliptra_fpga_realtime_regs_pkg;
         fifo_regs__dbg_fifo_pop__out_t dbg_fifo_pop;
         fifo_regs__dbg_fifo_push__out_t dbg_fifo_push;
         fifo_regs__dbg_fifo_status__out_t dbg_fifo_status;
+        fifo_regs__msg_fifo_pop__out_t msg_fifo_pop;
+        fifo_regs__msg_fifo_push__out_t msg_fifo_push;
+        fifo_regs__msg_fifo_status__out_t msg_fifo_status;
     } fifo_regs__out_t;
 
     typedef struct {

--- a/hw/fpga/src/caliptra_wrapper_top.sv
+++ b/hw/fpga/src/caliptra_wrapper_top.sv
@@ -979,6 +979,73 @@ dbg_fifo_inst (
 // End debug FIFO
 
 
+// ========================== Message FIFO ==========================
+
+// Valid = !Empty
+logic msg_fifo_empty;
+//assign hwif_in.fifo_regs.log_fifo_data.char_valid.next = ~log_fifo_empty;
+assign hwif_in.fifo_regs.msg_fifo_status.msg_fifo_empty.next = msg_fifo_empty;
+
+// When rd_swacc is asserted, use the value of "valid" from when it was sampled.
+reg msg_fifo_valid_f;
+// wr_swacc might be asserting before the data is available. Try delaying by a clock.
+reg msg_fifo_wr_en;
+always@(posedge core_clk) begin
+    msg_fifo_valid_f <= ~msg_fifo_empty;
+    msg_fifo_wr_en <= hwif_out.fifo_regs.msg_fifo_push.in_data.wr_swacc;
+end
+
+xpm_fifo_sync #(
+    .CASCADE_HEIGHT     (0       ),         // DECIMAL
+    .DOUT_RESET_VALUE   ("0"     ),     // String
+    .ECC_MODE           ("no_ecc"),        // String
+    .FIFO_MEMORY_TYPE   ("block" ), // String
+    .FIFO_READ_LATENCY  (0       ),      // DECIMAL
+    .FIFO_WRITE_DEPTH   (8192    ),    // DECIMAL
+    .FULL_RESET_VALUE   (0       ),       // DECIMAL
+    .PROG_EMPTY_THRESH  (10      ),     // DECIMAL
+    .PROG_FULL_THRESH   (7168    ),    // DECIMAL Currently unused
+    .RD_DATA_COUNT_WIDTH(14      ),   // DECIMAL
+    .READ_DATA_WIDTH    (32      ),       // DECIMAL
+    .READ_MODE          ("fwft"  ),         // String
+    .SIM_ASSERT_CHK     (0       ),         // DECIMAL; 0=disable simulation messages, 1=enable simulation messages
+    .USE_ADV_FEATURES   ("0000"  ),  // String
+    .WAKEUP_TIME        (0       ),            // DECIMAL
+    .WRITE_DATA_WIDTH   (32      ),      // DECIMAL
+    .WR_DATA_COUNT_WIDTH(14      )    // DECIMAL
+)
+msg_fifo_inst (
+    .almost_empty (                                                                    ),
+    .almost_full  (                                                                    ),
+    .data_valid   (                                                                    ),
+    .dbiterr      (                                                                    ),
+    .dout         (hwif_in.fifo_regs.msg_fifo_pop.out_data.next                        ),
+    .empty        (msg_fifo_empty                                                      ),
+    .full         (hwif_in.fifo_regs.msg_fifo_status.msg_fifo_full.next                ),
+    .overflow     (                                                                    ),
+    .prog_empty   (                                                                    ),
+    .prog_full    (                                                                    ),
+    .rd_data_count(                                                                    ),
+    .rd_rst_busy  (                                                                    ),
+    .sbiterr      (                                                                    ),
+    .underflow    (                                                                    ),
+    .wr_ack       (                                                                    ),
+    .wr_data_count(                                                                    ),
+    .wr_rst_busy  (                                                                    ),
+    .din          (hwif_out.fifo_regs.msg_fifo_push.in_data.value                      ),
+    .injectdbiterr(0                                                                   ),
+    .injectsbiterr(0                                                                   ),
+    .rd_en        (msg_fifo_valid_f & hwif_out.fifo_regs.msg_fifo_pop.out_data.rd_swacc),
+    .rst          (~S_AXI_WRAPPER_ARESETN                                              ),
+    .sleep        (0                                                                   ),
+    .wr_clk       (core_clk                                                            ),
+    .wr_en        (msg_fifo_wr_en                                                      )
+);
+
+
+// ========================== End Message FIFO ==========================
+
+
 `ifdef CALIPTRA_INTERNAL_TRNG
 // Registers and FIFO for ITRNG entropy
 

--- a/hw/fpga/src/rdl_properties.rdl
+++ b/hw/fpga/src/rdl_properties.rdl
@@ -1,0 +1,10 @@
+
+property rd_swacc {
+    component = field;
+    type = boolean;
+};
+
+property wr_swacc {
+    component = field;
+    type = boolean;
+};


### PR DESCRIPTION
The OCP LOCK release register is just an AXI-accessible location to test releasing the OCP LOCK key.

The message FIFO is an extra FIFO for message passing between the FPGA host and the VeeR cores.