### PR TITLE
[deps] rev caliptra-sw repo version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,7 +262,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 [[package]]
 name = "caliptra-api"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1#386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8659bbf3253611e8e0c30f9bc413206babe6201a#8659bbf3253611e8e0c30f9bc413206babe6201a"
 dependencies = [
  "bitflags 2.9.4",
  "caliptra-api-types",
@@ -277,7 +277,7 @@ dependencies = [
 [[package]]
 name = "caliptra-api-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1#386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8659bbf3253611e8e0c30f9bc413206babe6201a#8659bbf3253611e8e0c30f9bc413206babe6201a"
 dependencies = [
  "caliptra-image-types",
 ]
@@ -285,7 +285,7 @@ dependencies = [
 [[package]]
 name = "caliptra-auth-man-gen"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1#386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8659bbf3253611e8e0c30f9bc413206babe6201a#8659bbf3253611e8e0c30f9bc413206babe6201a"
 dependencies = [
  "anyhow",
  "bitflags 2.9.4",
@@ -300,7 +300,7 @@ dependencies = [
 [[package]]
 name = "caliptra-auth-man-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1#386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8659bbf3253611e8e0c30f9bc413206babe6201a#8659bbf3253611e8e0c30f9bc413206babe6201a"
 dependencies = [
  "bitfield",
  "bitflags 2.9.4",
@@ -315,7 +315,7 @@ dependencies = [
 [[package]]
 name = "caliptra-builder"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1#386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8659bbf3253611e8e0c30f9bc413206babe6201a#8659bbf3253611e8e0c30f9bc413206babe6201a"
 dependencies = [
  "anyhow",
  "caliptra-image-crypto",
@@ -340,7 +340,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cfi-derive"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1#386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8659bbf3253611e8e0c30f9bc413206babe6201a#8659bbf3253611e8e0c30f9bc413206babe6201a"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -362,7 +362,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cfi-lib"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1#386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8659bbf3253611e8e0c30f9bc413206babe6201a#8659bbf3253611e8e0c30f9bc413206babe6201a"
 dependencies = [
  "caliptra-error",
  "caliptra-registers",
@@ -377,7 +377,7 @@ source = "git+https://github.com/chipsalliance/caliptra-cfi.git?rev=a98e499d279e
 [[package]]
 name = "caliptra-coverage"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1#386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8659bbf3253611e8e0c30f9bc413206babe6201a#8659bbf3253611e8e0c30f9bc413206babe6201a"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -395,7 +395,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cpu"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1#386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8659bbf3253611e8e0c30f9bc413206babe6201a#8659bbf3253611e8e0c30f9bc413206babe6201a"
 dependencies = [
  "caliptra-drivers",
  "caliptra-registers",
@@ -405,7 +405,7 @@ dependencies = [
 [[package]]
 name = "caliptra-drivers"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1#386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8659bbf3253611e8e0c30f9bc413206babe6201a#8659bbf3253611e8e0c30f9bc413206babe6201a"
 dependencies = [
  "arrayvec",
  "bitfield",
@@ -431,7 +431,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-bus"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1#386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8659bbf3253611e8e0c30f9bc413206babe6201a#8659bbf3253611e8e0c30f9bc413206babe6201a"
 dependencies = [
  "caliptra-emu-types",
  "tock-registers",
@@ -441,7 +441,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-cpu"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1#386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8659bbf3253611e8e0c30f9bc413206babe6201a#8659bbf3253611e8e0c30f9bc413206babe6201a"
 dependencies = [
  "bit-vec",
  "bitfield",
@@ -455,7 +455,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1#386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8659bbf3253611e8e0c30f9bc413206babe6201a#8659bbf3253611e8e0c30f9bc413206babe6201a"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -470,7 +470,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-derive"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1#386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8659bbf3253611e8e0c30f9bc413206babe6201a#8659bbf3253611e8e0c30f9bc413206babe6201a"
 dependencies = [
  "caliptra-emu-bus",
  "caliptra-emu-types",
@@ -481,7 +481,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-periph"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1#386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8659bbf3253611e8e0c30f9bc413206babe6201a#8659bbf3253611e8e0c30f9bc413206babe6201a"
 dependencies = [
  "aes",
  "arrayref",
@@ -508,17 +508,17 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1#386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8659bbf3253611e8e0c30f9bc413206babe6201a#8659bbf3253611e8e0c30f9bc413206babe6201a"
 
 [[package]]
 name = "caliptra-error"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1#386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8659bbf3253611e8e0c30f9bc413206babe6201a#8659bbf3253611e8e0c30f9bc413206babe6201a"
 
 [[package]]
 name = "caliptra-gen-linker-scripts"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1#386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8659bbf3253611e8e0c30f9bc413206babe6201a#8659bbf3253611e8e0c30f9bc413206babe6201a"
 dependencies = [
  "caliptra_common",
 ]
@@ -526,7 +526,7 @@ dependencies = [
 [[package]]
 name = "caliptra-hw-model"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1#386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8659bbf3253611e8e0c30f9bc413206babe6201a#8659bbf3253611e8e0c30f9bc413206babe6201a"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -563,7 +563,7 @@ dependencies = [
 [[package]]
 name = "caliptra-hw-model-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1#386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8659bbf3253611e8e0c30f9bc413206babe6201a#8659bbf3253611e8e0c30f9bc413206babe6201a"
 dependencies = [
  "caliptra-api-types",
  "rand",
@@ -572,7 +572,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1#386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8659bbf3253611e8e0c30f9bc413206babe6201a#8659bbf3253611e8e0c30f9bc413206babe6201a"
 dependencies = [
  "anyhow",
  "caliptra-image-gen",
@@ -592,7 +592,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-elf"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1#386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8659bbf3253611e8e0c30f9bc413206babe6201a#8659bbf3253611e8e0c30f9bc413206babe6201a"
 dependencies = [
  "anyhow",
  "caliptra-image-gen",
@@ -603,7 +603,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-fake-keys"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1#386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8659bbf3253611e8e0c30f9bc413206babe6201a#8659bbf3253611e8e0c30f9bc413206babe6201a"
 dependencies = [
  "caliptra-image-gen",
  "caliptra-image-types",
@@ -614,7 +614,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-gen"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1#386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8659bbf3253611e8e0c30f9bc413206babe6201a#8659bbf3253611e8e0c30f9bc413206babe6201a"
 dependencies = [
  "anyhow",
  "bitflags 2.9.4",
@@ -631,7 +631,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1#386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8659bbf3253611e8e0c30f9bc413206babe6201a#8659bbf3253611e8e0c30f9bc413206babe6201a"
 dependencies = [
  "caliptra-cfi-derive",
  "caliptra-cfi-lib",
@@ -647,7 +647,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-verify"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1#386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8659bbf3253611e8e0c30f9bc413206babe6201a#8659bbf3253611e8e0c30f9bc413206babe6201a"
 dependencies = [
  "bitflags 2.9.4",
  "caliptra-cfi-derive",
@@ -662,7 +662,7 @@ dependencies = [
 [[package]]
 name = "caliptra-kat"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1#386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8659bbf3253611e8e0c30f9bc413206babe6201a#8659bbf3253611e8e0c30f9bc413206babe6201a"
 dependencies = [
  "caliptra-drivers",
  "caliptra-lms-types",
@@ -674,7 +674,7 @@ dependencies = [
 [[package]]
 name = "caliptra-lms-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1#386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8659bbf3253611e8e0c30f9bc413206babe6201a#8659bbf3253611e8e0c30f9bc413206babe6201a"
 dependencies = [
  "caliptra-cfi-derive",
  "caliptra-cfi-lib",
@@ -687,7 +687,7 @@ dependencies = [
 [[package]]
 name = "caliptra-registers"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1#386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8659bbf3253611e8e0c30f9bc413206babe6201a#8659bbf3253611e8e0c30f9bc413206babe6201a"
 dependencies = [
  "caliptra-registers-latest",
 ]
@@ -695,7 +695,7 @@ dependencies = [
 [[package]]
 name = "caliptra-registers-latest"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1#386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8659bbf3253611e8e0c30f9bc413206babe6201a#8659bbf3253611e8e0c30f9bc413206babe6201a"
 dependencies = [
  "ureg",
 ]
@@ -703,7 +703,7 @@ dependencies = [
 [[package]]
 name = "caliptra-runtime"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1#386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8659bbf3253611e8e0c30f9bc413206babe6201a#8659bbf3253611e8e0c30f9bc413206babe6201a"
 dependencies = [
  "arrayvec",
  "bitfield",
@@ -736,7 +736,7 @@ dependencies = [
 [[package]]
 name = "caliptra-test"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1#386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8659bbf3253611e8e0c30f9bc413206babe6201a#8659bbf3253611e8e0c30f9bc413206babe6201a"
 dependencies = [
  "anyhow",
  "asn1",
@@ -768,12 +768,12 @@ dependencies = [
 [[package]]
 name = "caliptra-test-harness-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1#386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8659bbf3253611e8e0c30f9bc413206babe6201a#8659bbf3253611e8e0c30f9bc413206babe6201a"
 
 [[package]]
 name = "caliptra-x509"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1#386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8659bbf3253611e8e0c30f9bc413206babe6201a#8659bbf3253611e8e0c30f9bc413206babe6201a"
 dependencies = [
  "zeroize",
 ]
@@ -781,7 +781,7 @@ dependencies = [
 [[package]]
 name = "caliptra_common"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1#386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8659bbf3253611e8e0c30f9bc413206babe6201a#8659bbf3253611e8e0c30f9bc413206babe6201a"
 dependencies = [
  "bitfield",
  "bitflags 2.9.4",
@@ -1218,7 +1218,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1#386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8659bbf3253611e8e0c30f9bc413206babe6201a#8659bbf3253611e8e0c30f9bc413206babe6201a"
 dependencies = [
  "arrayvec",
  "caliptra-cfi-derive-git",
@@ -1416,7 +1416,7 @@ dependencies = [
 [[package]]
 name = "dpe"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1#386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8659bbf3253611e8e0c30f9bc413206babe6201a#8659bbf3253611e8e0c30f9bc413206babe6201a"
 dependencies = [
  "bitflags 2.9.4",
  "caliptra-cfi-derive-git",
@@ -3242,7 +3242,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 [[package]]
 name = "platform"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1#386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8659bbf3253611e8e0c30f9bc413206babe6201a#8659bbf3253611e8e0c30f9bc413206babe6201a"
 dependencies = [
  "arrayvec",
  "cfg-if",
@@ -4366,7 +4366,7 @@ dependencies = [
 [[package]]
 name = "ureg"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1#386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8659bbf3253611e8e0c30f9bc413206babe6201a#8659bbf3253611e8e0c30f9bc413206babe6201a"
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -222,29 +222,29 @@ libtock_small_panic = { path = "runtime/userspace/libtock/panic_handlers/small_p
 libtock_unittest = { path = "runtime/userspace/libtock/unittest" }
 
 # caliptra dependencies; keep git revs in sync
-caliptra-api = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1" }
-caliptra-api-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1" }
-caliptra-auth-man-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1" }
-caliptra-auth-man-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1" }
-caliptra-builder = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1" }
-caliptra-emu-bus = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1" }
-caliptra-emu-cpu = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1" }
-caliptra-emu-derive = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1" }
-caliptra-emu-periph = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1" }
-caliptra-emu-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1" }
-caliptra-error = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1", default-features = false }
-caliptra-hw-model = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1" }
-caliptra-hw-model-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1" }
-caliptra-image-crypto = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1", default-features = false, features = ["rustcrypto"] }
-caliptra-image-fake-keys = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1" }
-caliptra-image-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1" }
-caliptra-image-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1" }
-caliptra-registers = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1" }
-caliptra-test = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1" }
-caliptra-test-harness = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1" }
-caliptra-test-harness-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1" }
-ureg = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1" }
-dpe = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "386d3dc97853311ebd3d5a5b3944e9a1d5bfb9c1", default-features = false, features = ["dpe_profile_p384_sha384"] }
+caliptra-api = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8659bbf3253611e8e0c30f9bc413206babe6201a" }
+caliptra-api-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8659bbf3253611e8e0c30f9bc413206babe6201a" }
+caliptra-auth-man-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8659bbf3253611e8e0c30f9bc413206babe6201a" }
+caliptra-auth-man-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8659bbf3253611e8e0c30f9bc413206babe6201a" }
+caliptra-builder = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8659bbf3253611e8e0c30f9bc413206babe6201a" }
+caliptra-emu-bus = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8659bbf3253611e8e0c30f9bc413206babe6201a" }
+caliptra-emu-cpu = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8659bbf3253611e8e0c30f9bc413206babe6201a" }
+caliptra-emu-derive = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8659bbf3253611e8e0c30f9bc413206babe6201a" }
+caliptra-emu-periph = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8659bbf3253611e8e0c30f9bc413206babe6201a" }
+caliptra-emu-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8659bbf3253611e8e0c30f9bc413206babe6201a" }
+caliptra-error = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8659bbf3253611e8e0c30f9bc413206babe6201a", default-features = false }
+caliptra-hw-model = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8659bbf3253611e8e0c30f9bc413206babe6201a" }
+caliptra-hw-model-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8659bbf3253611e8e0c30f9bc413206babe6201a" }
+caliptra-image-crypto = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8659bbf3253611e8e0c30f9bc413206babe6201a", default-features = false, features = ["rustcrypto"] }
+caliptra-image-fake-keys = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8659bbf3253611e8e0c30f9bc413206babe6201a" }
+caliptra-image-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8659bbf3253611e8e0c30f9bc413206babe6201a" }
+caliptra-image-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8659bbf3253611e8e0c30f9bc413206babe6201a" }
+caliptra-registers = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8659bbf3253611e8e0c30f9bc413206babe6201a" }
+caliptra-test = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8659bbf3253611e8e0c30f9bc413206babe6201a" }
+caliptra-test-harness = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8659bbf3253611e8e0c30f9bc413206babe6201a" }
+caliptra-test-harness-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8659bbf3253611e8e0c30f9bc413206babe6201a" }
+ureg = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8659bbf3253611e8e0c30f9bc413206babe6201a" }
+dpe = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8659bbf3253611e8e0c30f9bc413206babe6201a", default-features = false, features = ["dpe_profile_p384_sha384"] }
 
 # local caliptra dependency; useful when developing
 # caliptra-api = { path = "../caliptra-sw/api" }

--- a/tests/integration/src/jtag/test_jtag_taps.rs
+++ b/tests/integration/src/jtag/test_jtag_taps.rs
@@ -39,7 +39,7 @@ mod test {
             .jtag_tap_connect(&jtag_params, JtagTap::LccTap)
             .expect("Failed to connect to the LCC JTAG TAP.");
         let lcc_status = tap
-            .read_lc_ctrl_reg(&LcCtrlReg::Status)
+            .read_reg(&LcCtrlReg::Status)
             .expect("Failed to read LCC STATUS register.");
         assert_eq!(
             LcCtrlStatus::from_bits_truncate(lcc_status),


### PR DESCRIPTION
This revs the caliptra-sw repo version to account for the changes in: https://github.com/chipsalliance/caliptra-sw/pull/2540