### PR TITLE
[ROM] Reserve bits in boot flow for milestones. (#424)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2832,6 +2832,7 @@ name = "mcu-rom-common"
 version = "0.1.0"
 dependencies = [
  "bitfield",
+ "bitflags 2.9.4",
  "caliptra-api",
  "flash-image",
  "mcu-config",
@@ -4137,6 +4138,8 @@ version = "0.1.0"
 name = "tests-integration"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "caliptra-api-types",
  "caliptra-hw-model",
  "caliptra-hw-model-types",
  "caliptra-image-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,7 @@ anyhow = "1.0.97"
 arrayvec = { version = "0.7.4", default-features = false }
 async-trait = "0.1.87"
 bitfield = "0.14.0"
+bitflags = "2.4.0"
 bit-vec = "0.6.3"
 cargo_metadata = "0.20.0"
 cbindgen = "0.24"

--- a/hw/model/test-fw/mailbox_responder.rs
+++ b/hw/model/test-fw/mailbox_responder.rs
@@ -5,7 +5,7 @@
 #![no_main]
 #![no_std]
 
-use mcu_rom_common::{McuRomBootStatus, RomEnv};
+use mcu_rom_common::{McuBootMilestones, McuRomBootStatus, RomEnv};
 use registers_generated::mci;
 use tock_registers::interfaces::{ReadWriteable, Readable, Writeable};
 
@@ -24,8 +24,11 @@ fn run() -> ! {
     mci.caliptra_boot_go();
 
     // This is used to tell the hardware model it is ready to start testing
-    mci.set_flow_status(McuRomBootStatus::CaliptraBootGoAsserted.into());
-    mci.set_flow_status(McuRomBootStatus::ColdBootFlowComplete.into());
+    // TODO: remove the checkpoints when the HW model supports milestones
+    mci.set_flow_checkpoint(McuRomBootStatus::CaliptraBootGoAsserted.into());
+    mci.set_flow_checkpoint(McuRomBootStatus::ColdBootFlowComplete.into());
+    mci.set_flow_milestone(McuBootMilestones::CPTRA_BOOT_GO_ASSERTED.into());
+    mci.set_flow_milestone(McuBootMilestones::COLD_BOOT_FLOW_COMPLETE.into());
 
     loop {
         let status = &mci.registers.mcu_mbox0_csr_mbox_cmd_status;

--- a/rom/Cargo.toml
+++ b/rom/Cargo.toml
@@ -8,6 +8,7 @@ edition.workspace = true
 
 [dependencies]
 bitfield.workspace = true
+bitflags.workspace = true
 caliptra-api.workspace = true
 flash-image.workspace = true
 mcu-config.workspace = true

--- a/rom/src/boot_status.rs
+++ b/rom/src/boot_status.rs
@@ -12,16 +12,18 @@ Abstract:
 
 --*/
 
-const ROM_INITIALIZATION_BASE: u32 = 1;
-const LIFECYCLE_MANAGEMENT_BASE: u32 = 65;
-const OTP_FUSE_OPERATIONS_BASE: u32 = 129;
-const CALIPTRA_SETUP_BASE: u32 = 193;
-const FIRMWARE_LOADING_BASE: u32 = 257;
-const FIELD_ENTROPY_BASE: u32 = 321;
-const BOOT_FLOW_BASE: u32 = 385;
+use bitflags::bitflags;
+
+const ROM_INITIALIZATION_BASE: u16 = 1;
+const LIFECYCLE_MANAGEMENT_BASE: u16 = 65;
+const OTP_FUSE_OPERATIONS_BASE: u16 = 129;
+const CALIPTRA_SETUP_BASE: u16 = 193;
+const FIRMWARE_LOADING_BASE: u16 = 257;
+const FIELD_ENTROPY_BASE: u16 = 321;
+const BOOT_FLOW_BASE: u16 = 385;
 
 /// Status codes used by MCU ROM to log boot progress.
-#[repr(u32)]
+#[repr(u16)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum McuRomBootStatus {
     // ROM Initialization Statuses
@@ -82,9 +84,34 @@ pub enum McuRomBootStatus {
     HitlessUpdateFlowComplete = BOOT_FLOW_BASE + 7,
 }
 
-impl From<McuRomBootStatus> for u32 {
+impl From<McuRomBootStatus> for u16 {
     /// Converts to this type from the input type.
-    fn from(status: McuRomBootStatus) -> u32 {
-        status as u32
+    fn from(status: McuRomBootStatus) -> u16 {
+        status as u16
+    }
+}
+
+pub struct McuBootMilestones(u16);
+
+bitflags! {
+    impl McuBootMilestones: u16 {
+        const ROM_STARTED                   = 0b1 << 0;
+        const CPTRA_BOOT_GO_ASSERTED        = 0b1 << 1;
+        const CPTRA_FUSES_WRITTEN           = 0b1 << 2;
+        const RI_DOWNLOAD_COMPLETED         = 0b1 << 3;
+        const FLASH_RECOVERY_FLOW_COMPLETED = 0b1 << 4;
+        const COLD_BOOT_FLOW_COMPLETE       = 0b1 << 5;
+    }
+}
+
+impl From<u16> for McuBootMilestones {
+    fn from(value: u16) -> McuBootMilestones {
+        McuBootMilestones(value)
+    }
+}
+
+impl From<McuBootMilestones> for u16 {
+    fn from(value: McuBootMilestones) -> u16 {
+        value.0
     }
 }

--- a/rom/src/rom.rs
+++ b/rom/src/rom.rs
@@ -22,6 +22,7 @@ use crate::ImageVerifier;
 use crate::LifecycleControllerState;
 use crate::LifecycleHashedTokens;
 use crate::LifecycleToken;
+use crate::McuBootMilestones;
 use crate::RomEnv;
 use crate::WarmBoot;
 use core::fmt::Write;
@@ -282,6 +283,7 @@ pub fn rom_start(params: RomParameters) {
 
     // Create local references for printing
     let mci = &env.mci;
+    mci.set_flow_milestone(McuBootMilestones::ROM_STARTED.into());
 
     romtime::println!(
         "[mcu-rom] Device lifecycle: {}",

--- a/romtime/src/mci.rs
+++ b/romtime/src/mci.rs
@@ -55,6 +55,26 @@ impl Mci {
         self.registers.mci_reg_fw_flow_status.get()
     }
 
+    /// Overwrite current checkpoint, but not the milestone
+    pub fn set_flow_checkpoint(&self, checkpoint: u16) {
+        let milestone = u32::from(self.flow_milestone()) << 16;
+        self.set_flow_status(milestone | u32::from(checkpoint));
+    }
+
+    pub fn flow_checkpoint(&self) -> u16 {
+        (self.flow_status() & 0x0000_ffff) as u16
+    }
+
+    /// Union of current milestones with incoming milestones
+    pub fn set_flow_milestone(&self, milestone: u16) {
+        let milestone = u32::from(milestone) << 16;
+        self.set_flow_status(milestone | self.flow_status());
+    }
+
+    pub fn flow_milestone(&self) -> u16 {
+        (self.flow_status() >> 16) as u16
+    }
+
     pub fn hw_flow_status(&self) -> u32 {
         self.registers.mci_reg_hw_flow_status.get()
     }


### PR DESCRIPTION
This splits the MCI FW boot flow register into two pieces:

1. 16 checkpoint status bits (same as previous behavior)
2. 16 milestones bitflags

This is intended to make it easier to wait for certain milestones in the boot flow. With the FPGA we don't have strong control over timing so it could be easy to miss a checkpoint. These bitflags are a union of all the milestones seen ensuring they can't be missed.

The checkpoints are still very helpful for more fine grained boot flow debugging.

* Split at 16:16 instead of 8:24 to give move milestone bits.

This limits to 64k checkpoint options and 16 milestones.