### PR TITLE
Enable PLDM fw update e2e test in FPGA

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.11"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anstyle-parse"
@@ -113,9 +113,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.99"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "arbitrary"
@@ -553,7 +553,7 @@ dependencies = [
  "sha2",
  "sha3",
  "smlang",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tock-registers",
  "uio",
  "ureg",
@@ -804,9 +804,9 @@ dependencies = [
 
 [[package]]
 name = "camino"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1de8bc0aa9e9385ceb3bf0c152e3a9b9544f6c4a912c8ae504e80c1f0368603"
+checksum = "276a59bf2b2c967788139340c9f0c5b12d7fd6630315c15c217e559de85d2609"
 dependencies = [
  "serde_core",
 ]
@@ -909,7 +909,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -942,9 +942,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.37"
+version = "1.2.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65193589c6404eb80b450d618eaf9a2cafaaafd57ecce47370519ef674a7bd44"
+checksum = "e1354349954c6fc9cb0deab020f27f783cf0b604e8bb754dc4658ecf0d29c35f"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -973,7 +973,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link 0.2.0",
+ "windows-link",
 ]
 
 [[package]]
@@ -1003,9 +1003,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.47"
+version = "4.5.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eac00902d9d136acd712710d71823fb8ac8004ca445a89e73a41d45aa712931"
+checksum = "e2134bb3ea021b78629caa971416385309e0131b351b25e01dc16fb54e1b5fae"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1022,9 +1022,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.47"
+version = "4.5.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ad9bbf750e73b5884fb8a211a9424a1906c1e156724260fdae972f31d70e1d6"
+checksum = "c2ba64afa3c0a6df7fa517765e31314e983f51dda798ffba27b988194fb65dc9"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1085,7 +1085,7 @@ dependencies = [
  "caliptra-emu-bus",
  "caliptra-emu-cpu",
  "caliptra-emu-types",
- "clap 4.5.47",
+ "clap 4.5.48",
  "emulator-consts",
  "getrandom 0.2.16",
 ]
@@ -1266,7 +1266,7 @@ checksum = "881c5d0a13b2f1498e2306e82cbada78390e152d4b1378fb28a84f4dcd0dc4f3"
 dependencies = [
  "dispatch",
  "nix 0.30.1",
- "windows-sys 0.61.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -1329,9 +1329,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d630bccd429a5bb5a64b5e94f693bfc48c9f8566418fda4c494cc94f911f87cc"
+checksum = "a41953f86f8a05768a6cda24def994fd2f424b04ec5c719cf89989779f199071"
 dependencies = [
  "powerfmt",
 ]
@@ -1551,7 +1551,7 @@ dependencies = [
  "caliptra-image-types",
  "caliptra-test",
  "chrono",
- "clap 4.5.47",
+ "clap 4.5.48",
  "clap-num",
  "crc",
  "crossterm",
@@ -1611,7 +1611,7 @@ dependencies = [
  "caliptra-emu-periph",
  "caliptra-hw-model",
  "caliptra-registers",
- "clap 4.5.47",
+ "clap 4.5.48",
  "ctrlc",
  "elf",
  "emulator-consts",
@@ -1717,7 +1717,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -1773,9 +1773,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fd99930f64d146689264c637b5af2f0233a933bef0d8570e2526bf9e083192d"
+checksum = "1ced73b1dacfc750a6db6c0a0c3a3853c8b41997e2e2c563dc90804ae6867959"
 
 [[package]]
 name = "fips204"
@@ -2053,9 +2053,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
 
 [[package]]
 name = "heapless"
@@ -2273,12 +2273,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.11.3"
+version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92119844f513ffa41556430369ab02c295a3578af21cf945caa3e9e0c2481ac3"
+checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.0",
 ]
 
 [[package]]
@@ -2305,9 +2305,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.78"
+version = "0.3.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0b063578492ceec17683ef2f8c5e89121fbd0b172cbc280635ab7567db2738"
+checksum = "ec48937a97411dcb524a265206ccd4c90bb711fca92b2792c407f268825b9305"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -2379,9 +2379,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.175"
+version = "0.2.176"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
 
 [[package]]
 name = "libsyscall-caliptra"
@@ -2684,7 +2684,7 @@ dependencies = [
  "sha2",
  "sha3",
  "tempfile",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tock-registers",
  "uio",
  "ureg",
@@ -2881,6 +2881,7 @@ dependencies = [
  "mcu-components",
  "mcu-config",
  "mcu-config-fpga",
+ "mcu-mbox-driver",
  "mcu-platforms-common",
  "mcu-tock-veer",
  "registers-generated",
@@ -2942,9 +2943,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "memoffset"
@@ -3262,7 +3263,7 @@ name = "pldm-fw-pkg"
 version = "0.1.0"
 dependencies = [
  "chrono",
- "clap 4.5.47",
+ "clap 4.5.48",
  "crc",
  "num-derive",
  "num-traits",
@@ -3363,11 +3364,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
+checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
- "toml_edit 0.22.27",
+ "toml_edit 0.23.6",
 ]
 
 [[package]]
@@ -3387,9 +3388,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
 dependencies = [
  "proc-macro2",
 ]
@@ -3441,9 +3442,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.2"
+version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
+checksum = "8b5288124840bee7b386bc413c487869b360b2b4ec421ea56425128692f2a82c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3453,9 +3454,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
+checksum = "833eb9ce86d40ef33cb1306d8accf7bc8ec2bfea4355cbdebb3df68b40925cad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3585,7 +3586,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -3652,9 +3653,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.224"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aaeb1e94f53b16384af593c71e20b095e958dab1d26939c1b70645c5cfbcc0b"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -3697,18 +3698,18 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.224"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f39390fa6346e24defbcdd3d9544ba8a19985d0af74df8501fbfe9a64341ab"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.224"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ff78ab5e8561c9a675bfc1785cb07ae721f0ee53329a595cefd8c04c2ac4e0"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3994,15 +3995,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.22.0"
+version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84fa4d11fadde498443cca10fd3ac23c951f0dc59e080e9f4b93d4df4e4eea53"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
 dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.61.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -4076,11 +4077,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.16"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
- "thiserror-impl 2.0.16",
+ "thiserror-impl 2.0.17",
 ]
 
 [[package]]
@@ -4096,9 +4097,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.16"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4112,11 +4113,12 @@ source = "git+https://github.com/tock/tock.git?rev=b128ae817b86706c8c4e39d27fae5
 
 [[package]]
 name = "time"
-version = "0.3.43"
+version = "0.3.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83bde6f1ec10e72d583d91623c939f623002284ef622b87de38cfd546cbf2031"
+checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
 dependencies = [
  "deranged",
+ "itoa",
  "libc",
  "num-conv",
  "num_threads",
@@ -4193,7 +4195,7 @@ checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
 dependencies = [
  "serde",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 0.6.11",
  "toml_edit 0.19.15",
 ]
 
@@ -4205,7 +4207,7 @@ checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 0.6.11",
  "toml_edit 0.22.27",
 ]
 
@@ -4219,15 +4221,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32f1085dec27c2b6632b04c80b3bb1b4300d6495d1e129693bdda7d91e72eec1"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.11.3",
+ "indexmap 2.11.4",
  "serde",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 0.6.11",
  "winnow 0.5.40",
 ]
 
@@ -4237,11 +4248,32 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.11.3",
+ "indexmap 2.11.4",
  "serde",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 0.6.11",
  "toml_write",
+ "winnow 0.7.13",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.23.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3effe7c0e86fdff4f69cdd2ccc1b96f933e24811c5441d44904e8683e27184b"
+dependencies = [
+ "indexmap 2.11.4",
+ "toml_datetime 0.7.2",
+ "toml_parser",
+ "winnow 0.7.13",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf893c33be71572e0e9aa6dd15e6677937abd686b066eac3f8cd3531688a627"
+dependencies = [
  "winnow 0.7.13",
 ]
 
@@ -4483,9 +4515,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.101"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e14915cadd45b529bb8d1f343c4ed0ac1de926144b746e2710f9cd05df6603b"
+checksum = "c1da10c01ae9f1ae40cbfac0bac3b1e724b320abfcf52229f80b547c0d250e2d"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4496,9 +4528,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.101"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28d1ba982ca7923fd01448d5c30c6864d0a14109560296a162f80f305fb93bb"
+checksum = "671c9a5a66f49d8a47345ab942e2cb93c7d1d0339065d4f8139c486121b43b19"
 dependencies = [
  "bumpalo",
  "log",
@@ -4510,9 +4542,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.101"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3d463ae3eff775b0c45df9da45d68837702ac35af998361e2c84e7c5ec1b0d"
+checksum = "7ca60477e4c59f5f2986c50191cd972e3a50d8a95603bc9434501cf156a9a119"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4520,9 +4552,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.101"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bb4ce89b08211f923caf51d527662b75bdc9c9c7aab40f86dcb9fb85ac552aa"
+checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4533,9 +4565,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.101"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f143854a3b13752c6950862c906306adb27c7e839f7414cec8fea35beab624c1"
+checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
 dependencies = [
  "unicode-ident",
 ]
@@ -4562,7 +4594,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -4573,22 +4605,22 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
-version = "0.62.0"
+version = "0.62.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57fe7168f7de578d2d8a05b07fd61870d2e73b4020e9f49aa00da8471723497c"
+checksum = "6844ee5416b285084d3d3fffd743b925a6c9385455f64f6d4fa3031c4c2749a9"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link 0.2.0",
+ "windows-link",
  "windows-result",
  "windows-strings",
 ]
 
 [[package]]
 name = "windows-implement"
-version = "0.60.0"
+version = "0.60.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+checksum = "edb307e42a74fb6de9bf3a02d9712678b22399c87e6fa869d6dfcd8c1b7754e0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4597,20 +4629,14 @@ dependencies = [
 
 [[package]]
 name = "windows-interface"
-version = "0.59.1"
+version = "0.59.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+checksum = "c0abd1ddbc6964ac14db11c7213d6532ef34bd9aa042c2e5935f59d7908b46a5"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
 ]
-
-[[package]]
-name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-link"
@@ -4624,7 +4650,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7084dcc306f89883455a206237404d3eaf961e5bd7e0f312f7c91f57eb44167f"
 dependencies = [
- "windows-link 0.2.0",
+ "windows-link",
 ]
 
 [[package]]
@@ -4633,7 +4659,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7218c655a553b0bed4426cf54b20d7ba363ef543b52d515b3e48d7fd55318dda"
 dependencies = [
- "windows-link 0.2.0",
+ "windows-link",
 ]
 
 [[package]]
@@ -4660,16 +4686,16 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.3",
+ "windows-targets 0.53.4",
 ]
 
 [[package]]
 name = "windows-sys"
-version = "0.61.0"
+version = "0.61.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
+checksum = "6f109e41dd4a3c848907eb83d5a42ea98b3769495597450cf6d153507b166f0f"
 dependencies = [
- "windows-link 0.2.0",
+ "windows-link",
 ]
 
 [[package]]
@@ -4705,11 +4731,11 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.3"
+version = "0.53.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+checksum = "2d42b7b7f66d2a06854650af09cfdf8713e427a439c97ad65a6375318033ac4b"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",
@@ -4898,7 +4924,7 @@ dependencies = [
  "caliptra-image-gen",
  "caliptra-image-types",
  "cc",
- "clap 4.5.47",
+ "clap 4.5.48",
  "clap-num",
  "crc32fast",
  "elf",
@@ -4989,9 +5015,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 dependencies = [
  "zeroize_derive",
 ]
@@ -5050,7 +5076,7 @@ dependencies = [
  "chrono",
  "crc32fast",
  "flate2",
- "indexmap 2.11.3",
+ "indexmap 2.11.4",
  "memchr",
  "zopfli",
 ]

--- a/builder/src/apps.rs
+++ b/builder/src/apps.rs
@@ -7,7 +7,7 @@ use crate::{PROJECT_ROOT, TARGET};
 use anyhow::{bail, Result};
 use std::process::Command;
 
-pub const APPS: &[App] = &[
+pub const EMULATOR_APPS: &[App] = &[
     App {
         // Make sure this is the first app in the list
         name: "example-app",
@@ -18,6 +18,20 @@ pub const APPS: &[App] = &[
         name: "user-app",
         permissions: vec![],
         minimum_ram: 112 * 1024,
+    },
+];
+
+pub const FPGA_APPS: &[App] = &[
+    App {
+        // Make sure this is the first app in the list
+        name: "example-app",
+        permissions: vec![],
+        minimum_ram: 48 * 1024,
+    },
+    App {
+        name: "user-app",
+        permissions: vec![],
+        minimum_ram: 106 * 1024,
     },
 ];
 
@@ -57,7 +71,14 @@ pub fn apps_build_flat_tbf(
     let mut bin = vec![];
     let mut offset = start;
     let mut ram_start = ram_start;
-    for app in APPS.iter() {
+    let apps = match platform {
+        "emulator" => EMULATOR_APPS,
+        "fpga" => FPGA_APPS,
+        _ => {
+            bail!("Unknown platform: {}", platform);
+        }
+    };
+    for app in apps.iter() {
         if app.name == "example-app" && !example_app {
             continue;
         }

--- a/hw/model/src/model_fpga_realtime.rs
+++ b/hw/model/src/model_fpga_realtime.rs
@@ -19,7 +19,7 @@ use mcu_rom_common::{LifecycleControllerState, McuBootMilestones};
 use mcu_testing_common::i3c::{
     I3cBusCommand, I3cBusResponse, I3cTcriCommand, I3cTcriResponseXfer, ResponseDescriptor,
 };
-use mcu_testing_common::{MCU_RUNNING, MCU_RUNTIME_STARTED};
+use mcu_testing_common::{update_ticks, MCU_RUNNING, MCU_RUNTIME_STARTED};
 use std::io::Write;
 use std::marker::PhantomData;
 use std::net::{SocketAddr, TcpStream};
@@ -236,6 +236,7 @@ impl McuHwModel for ModelFpgaRealtime {
     fn step(&mut self) {
         self.base.step();
         self.handle_i3c();
+        update_ticks(self.cycle_count() / 100); // notify tests about current time, but reduce effective speed
     }
 
     fn new_unbooted(params: InitParams) -> Result<Self>

--- a/platforms/emulator/runtime/src/board.rs
+++ b/platforms/emulator/runtime/src/board.rs
@@ -153,6 +153,7 @@ struct VeeR {
         'static,
         VirtualMuxAlarm<'static, InternalTimers<'static>>,
     >,
+    system: &'static capsules_runtime::system::System<'static, EmulatorExiter>,
 }
 
 /// Mapping of integer syscalls to objects that implement syscalls.
@@ -193,6 +194,7 @@ impl SyscallDriverLookup for VeeR {
             capsules_runtime::mbox_sram::DRIVER_NUM_MCU_MBOX1_SRAM => {
                 f(Some(self.mcu_mbox1_staging_sram))
             }
+            capsules_runtime::system::DRIVER_NUM => f(Some(self.system)),
 
             _ => f(None),
         }
@@ -659,6 +661,11 @@ pub unsafe fn main() {
         mcu_mbox_driver::McuMailbox<'static, InternalTimers<'static>>
     ));
 
+    #[allow(static_mut_refs)]
+    let system = mcu_components::system::SystemComponent::new(&mut EMULATOR_EXITER).finalize(
+        kernel::static_buf!(capsules_runtime::system::System<'static, EmulatorExiter>),
+    );
+
     // Need to enable all interrupts for Tock Kernel
     chip.enable_pic_interrupts();
     chip.enable_timer_interrupts();
@@ -704,6 +711,7 @@ pub unsafe fn main() {
             mci,
             mcu_mbox0,
             mcu_mbox1_staging_sram,
+            system,
         }
     );
 

--- a/platforms/emulator/runtime/userspace/apps/example/src/main.rs
+++ b/platforms/emulator/runtime/userspace/apps/example/src/main.rs
@@ -8,6 +8,7 @@
 use core::fmt::Write;
 #[cfg(feature = "test-flash-usermode")]
 use libsyscall_caliptra::flash::{FlashCapacity, SpiFlash};
+use libsyscall_caliptra::system::System;
 use libtock::alarm::*;
 use libtock_console::Console;
 use libtock_platform::{self as platform};
@@ -96,7 +97,7 @@ pub(crate) async fn async_main<S: Syscalls>() {
                 console_writer,
                 "Alarm capsule not available, so cannot execute tests"
             );
-            romtime::test_exit(0);
+            System::exit(0);
         }
     };
 
@@ -180,7 +181,7 @@ pub(crate) async fn async_main<S: Syscalls>() {
         )
         .unwrap();
 
-        romtime::test_exit(0);
+        System::exit(0);
     }
     #[cfg(feature = "test-pldm-request-response")]
     {
@@ -192,7 +193,7 @@ pub(crate) async fn async_main<S: Syscalls>() {
         test_caliptra_mailbox::test_caliptra_mailbox_bad_command().await;
         test_caliptra_mailbox::test_caliptra_mailbox_fail().await;
         test_caliptra_mailbox::test_caliptra_evidence().await;
-        romtime::test_exit(0);
+        System::exit(0);
     }
 
     #[cfg(feature = "test-caliptra-crypto")]
@@ -203,7 +204,7 @@ pub(crate) async fn async_main<S: Syscalls>() {
         test_caliptra_crypto::test_caliptra_hmac().await;
         test_caliptra_crypto::test_caliptra_aes_gcm_cipher().await;
         test_caliptra_crypto::test_caliptra_ecdsa().await;
-        romtime::test_exit(0);
+        System::exit(0);
     }
 
     #[cfg(feature = "test-caliptra-certs")]
@@ -216,13 +217,13 @@ pub(crate) async fn async_main<S: Syscalls>() {
         test_caliptra_certs::test_get_cert_chain().await;
         test_caliptra_certs::test_certify_key().await;
         test_caliptra_certs::test_sign_with_test_key().await;
-        romtime::test_exit(0);
+        System::exit(0);
     }
     #[cfg(feature = "test-dma")]
     {
         test_dma::test_dma_xfer_local_to_local().await;
         test_dma::test_dma_xfer_local_to_external().await;
-        romtime::test_exit(0);
+        System::exit(0);
     }
 
     #[cfg(feature = "test-log-flash-usermode")]
@@ -230,12 +231,12 @@ pub(crate) async fn async_main<S: Syscalls>() {
         test_logging_flash::test_logging_flash_simple().await;
         test_logging_flash::test_logging_flash_various_entries().await;
         test_logging_flash::test_logging_flash_invalid_inputs().await;
-        romtime::test_exit(0);
+        System::exit(0);
     }
     #[cfg(feature = "test-mci")]
     {
         test_mci::test_mci_read_write().await;
-        romtime::test_exit(0);
+        System::exit(0);
     }
 
     #[cfg(feature = "test-mcu-mbox-usermode")]
@@ -246,18 +247,18 @@ pub(crate) async fn async_main<S: Syscalls>() {
     #[cfg(any(feature = "test-mcu-svn-gt-fuse", feature = "test-mcu-svn-lt-fuse"))]
     {
         writeln!(console_writer, "MCU Image SVN check passed").unwrap();
-        romtime::test_exit(0);
+        System::exit(0);
     }
     #[cfg(feature = "test-mbox-sram")]
     {
         writeln!(console_writer, "Running MEM-REG read/write test").unwrap();
         test_mbox_sram::test_mem_reg_read_write().await;
-        romtime::test_exit(0);
+        System::exit(0);
     }
     #[cfg(feature = "test-warm-reset")]
     {
         test_mci::test_mci_fw_boot_reset().await;
-        romtime::test_exit(0);
+        System::exit(0);
     }
 
     writeln!(console_writer, "app finished").unwrap();

--- a/platforms/emulator/runtime/userspace/apps/example/src/riscv.rs
+++ b/platforms/emulator/runtime/userspace/apps/example/src/riscv.rs
@@ -37,26 +37,12 @@ pub(crate) fn print_to_console(buf: &str) {
     }
 }
 
-pub(crate) struct EmulatorExiter {}
-pub(crate) static mut EMULATOR_EXITER: EmulatorExiter = EmulatorExiter {};
-impl romtime::Exit for EmulatorExiter {
-    fn exit(&mut self, code: u32) {
-        // Safety: This is a safe memory address to write to for exiting the emulator.
-        unsafe {
-            // By writing to this address we can exit the emulator.
-            core::ptr::write_volatile(0x1000_2000 as *mut u32, code);
-        }
-    }
-}
-
 fn main() {
     // TODO: remove this when the emulator-specific pieces are moved to
     // platform/emulator/runtime
     unsafe {
         #[allow(static_mut_refs)]
         romtime::set_printer(&mut EMULATOR_WRITER);
-        #[allow(static_mut_refs)]
-        romtime::set_exiter(&mut EMULATOR_EXITER);
     }
 
     // setup the global allocator for futures

--- a/platforms/emulator/runtime/userspace/apps/user/src/main.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/main.rs
@@ -24,18 +24,6 @@ mod spdm;
 #[cfg(target_arch = "riscv32")]
 mod riscv;
 
-pub(crate) struct EmulatorExiter {}
-pub(crate) static mut EMULATOR_EXITER: EmulatorExiter = EmulatorExiter {};
-impl romtime::Exit for EmulatorExiter {
-    fn exit(&mut self, code: u32) {
-        // Safety: This is a safe memory address to write to for exiting the emulator.
-        unsafe {
-            // By writing to this address we can exit the emulator.
-            core::ptr::write_volatile(0x1000_2000 as *mut u32, code);
-        }
-    }
-}
-
 struct EmulatorWriter {}
 static mut EMULATOR_WRITER: EmulatorWriter = EmulatorWriter {};
 
@@ -77,8 +65,6 @@ fn main() {
 #[embassy_executor::task]
 async fn start() {
     unsafe {
-        #[allow(static_mut_refs)]
-        romtime::set_exiter(&mut EMULATOR_EXITER);
         #[allow(static_mut_refs)]
         romtime::set_printer(&mut EMULATOR_WRITER);
     }

--- a/platforms/emulator/runtime/userspace/apps/user/src/mcu_mbox/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/mcu_mbox/mod.rs
@@ -8,6 +8,7 @@ use core::fmt::Write;
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 #[allow(unused)]
 use embassy_sync::signal::Signal;
+use libsyscall_caliptra::system::System;
 use libsyscall_caliptra::DefaultSyscalls;
 use libtock_console::Console;
 use libtock_platform::ErrorCode;
@@ -16,7 +17,7 @@ use libtock_platform::ErrorCode;
 pub async fn mcu_mbox_task() {
     match start_mcu_mbox_service().await {
         Ok(_) => {}
-        Err(_) => romtime::test_exit(1),
+        Err(_) => System::exit(1),
     }
 }
 

--- a/platforms/emulator/runtime/userspace/apps/user/src/spdm/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/spdm/mod.rs
@@ -11,10 +11,13 @@ use libsyscall_caliptra::doe;
 use libsyscall_caliptra::mctp;
 use libsyscall_caliptra::DefaultSyscalls;
 use libtock_console::Console;
+use libtock_platform::ErrorCode;
 use spdm_lib::codec::MessageBuf;
 use spdm_lib::context::{SpdmContext, MAX_SPDM_RESPONDER_BUF_SIZE};
+use spdm_lib::error::SpdmError;
 use spdm_lib::protocol::*;
 use spdm_lib::transport::common::SpdmTransport;
+use spdm_lib::transport::common::TransportError;
 use spdm_lib::transport::doe::DoeTransport;
 use spdm_lib::transport::mctp::MctpTransport;
 
@@ -174,6 +177,10 @@ async fn spdm_doe_responder() {
         match result {
             Ok(_) => {
                 writeln!(cw, "SPDM_DOE_RESPONDER: Process message successfully").unwrap();
+            }
+            Err(SpdmError::Transport(TransportError::DriverError(ErrorCode::NoDevice))) => {
+                writeln!(cw, "SPDM_DOE_RESPONDER: No DOE device, exiting task").unwrap();
+                break;
             }
             Err(e) => {
                 writeln!(cw, "SPDM_DOE_RESPONDER: Process message failed: {:?}", e).unwrap();

--- a/platforms/fpga/runtime/Cargo.toml
+++ b/platforms/fpga/runtime/Cargo.toml
@@ -21,6 +21,7 @@ kernel.workspace = true
 mcu-components.workspace = true
 mcu-config.workspace = true
 mcu-config-fpga.workspace = true
+mcu-mbox-driver.workspace = true
 mcu-platforms-common.workspace = true
 mcu-tock-veer.workspace = true
 registers-generated.workspace = true

--- a/runtime/kernel/capsules/src/lib.rs
+++ b/runtime/kernel/capsules/src/lib.rs
@@ -11,3 +11,4 @@ pub mod mbox_sram;
 pub mod mci;
 pub mod mctp;
 pub mod mcu_mbox;
+pub mod system;

--- a/runtime/kernel/capsules/src/system.rs
+++ b/runtime/kernel/capsules/src/system.rs
@@ -1,0 +1,49 @@
+// Licensed under the Apache-2.0 license
+
+//! This provides the capsule for Platform specific system utilities.
+
+use core::cell::RefCell;
+
+use kernel::syscall::{CommandReturn, SyscallDriver};
+use kernel::{ErrorCode, ProcessId};
+
+pub const DRIVER_NUM: usize = 0xC000_0000;
+
+mod cmd {
+    pub const EXIT: u32 = 1;
+}
+
+pub struct System<'a, E: romtime::Exit> {
+    exiter: RefCell<&'a mut E>,
+}
+
+impl<'a, E: romtime::Exit> System<'a, E> {
+    pub fn new(exiter: &'a mut E) -> System<'a, E> {
+        System {
+            exiter: RefCell::new(exiter),
+        }
+    }
+}
+
+/// Provide an interface for userland.
+impl<E: romtime::Exit> SyscallDriver for System<'_, E> {
+    fn command(
+        &self,
+        cmd: usize,
+        arg1: usize,
+        _arg2: usize,
+        _processid: ProcessId,
+    ) -> CommandReturn {
+        match cmd as u32 {
+            cmd::EXIT => {
+                self.exiter.borrow_mut().exit(arg1 as u32);
+                CommandReturn::success()
+            }
+            _ => CommandReturn::failure(ErrorCode::NOSUPPORT),
+        }
+    }
+
+    fn allocate_grant(&self, _processid: ProcessId) -> Result<(), kernel::process::Error> {
+        Ok(())
+    }
+}

--- a/runtime/kernel/components/src/lib.rs
+++ b/runtime/kernel/components/src/lib.rs
@@ -10,3 +10,4 @@ pub mod mctp_driver;
 pub mod mcu_mbox;
 pub mod mock_mctp;
 pub mod mux_mctp;
+pub mod system;

--- a/runtime/kernel/components/src/system.rs
+++ b/runtime/kernel/components/src/system.rs
@@ -1,0 +1,27 @@
+// Licensed under the Apache-2.0 license
+
+// Component for System driver.
+
+use core::mem::MaybeUninit;
+use kernel::component::Component;
+
+pub struct SystemComponent<E: romtime::Exit + 'static> {
+    exiter: &'static mut E,
+}
+
+impl<E: romtime::Exit> SystemComponent<E> {
+    pub fn new(exiter: &'static mut E) -> Self {
+        Self { exiter }
+    }
+}
+
+impl<E: romtime::Exit> Component for SystemComponent<E> {
+    type StaticInput = &'static mut MaybeUninit<capsules_runtime::system::System<'static, E>>;
+    type Output = &'static capsules_runtime::system::System<'static, E>;
+
+    fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
+        let system: &capsules_runtime::system::System<'static, E> =
+            static_buffer.write(capsules_runtime::system::System::new(self.exiter));
+        system
+    }
+}

--- a/runtime/userspace/syscall/src/lib.rs
+++ b/runtime/userspace/syscall/src/lib.rs
@@ -11,6 +11,7 @@ pub mod mbox_sram;
 pub mod mci;
 pub mod mctp;
 pub mod mcu_mbox;
+pub mod system;
 
 #[cfg(target_arch = "riscv32")]
 pub type DefaultSyscalls = libtock_runtime::TockSyscalls;

--- a/runtime/userspace/syscall/src/system.rs
+++ b/runtime/userspace/syscall/src/system.rs
@@ -1,0 +1,20 @@
+// Licensed under the Apache-2.0 license
+
+use crate::DefaultSyscalls;
+use libtock_platform::{ErrorCode, Syscalls};
+
+pub struct System {}
+
+impl System {
+    pub fn exit(code: u32) {
+        DefaultSyscalls::command(DRIVER_NUM, cmd::EXIT, code, 0)
+            .to_result::<(), ErrorCode>()
+            .unwrap();
+    }
+}
+
+pub const DRIVER_NUM: u32 = 0xC000_0000;
+
+mod cmd {
+    pub const EXIT: u32 = 1;
+}

--- a/tests/integration/src/test_pldm_fw_update.rs
+++ b/tests/integration/src/test_pldm_fw_update.rs
@@ -29,7 +29,6 @@ mod test {
     use std::time::Duration;
     use uuid::Uuid;
 
-    #[cfg_attr(feature = "fpga_realtime", ignore)]
     #[test]
     fn test_fw_update_e2e() {
         let feature = "test-pldm-fw-update-e2e";
@@ -134,7 +133,7 @@ mod test {
             &self,
             expected_state: update_sm::States,
         ) -> Result<(), ()> {
-            let timeout = Duration::from_secs(30);
+            let timeout = Duration::from_secs(60);
             let start_time = std::time::Instant::now();
 
             while start_time.elapsed() < timeout {


### PR DESCRIPTION
- Test PLDM FW update protocol in FPGA by enabling the pldm_fw_update_e2e test

- Add MCI and MBOX SRAM drivers in FPGA board.rs since Image Loading App depends on it.

- Fix a bug in pldm update e2e test application, where the application doesn't exit since it's waiting for a SIGNAL() that hasn't been triggered. Moved the SIGNAL() into the pldm_fdops and trigger it on the last stage of PLDM which is activation.

- Update sleep_emulator_ticks while test is stepping.