### PR TITLE
[test] add E2E FPGA manuf debug unlock test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,7 +262,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 [[package]]
 name = "caliptra-api"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3ebbd6822aad4a5a738990cf9771889269a02a1f#3ebbd6822aad4a5a738990cf9771889269a02a1f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3f5279a0d72f92f5d23a0af79443dcf70b5e047e#3f5279a0d72f92f5d23a0af79443dcf70b5e047e"
 dependencies = [
  "bitflags 2.9.4",
  "caliptra-api-types",
@@ -277,7 +277,7 @@ dependencies = [
 [[package]]
 name = "caliptra-api-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3ebbd6822aad4a5a738990cf9771889269a02a1f#3ebbd6822aad4a5a738990cf9771889269a02a1f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3f5279a0d72f92f5d23a0af79443dcf70b5e047e#3f5279a0d72f92f5d23a0af79443dcf70b5e047e"
 dependencies = [
  "caliptra-image-types",
 ]
@@ -285,7 +285,7 @@ dependencies = [
 [[package]]
 name = "caliptra-auth-man-gen"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3ebbd6822aad4a5a738990cf9771889269a02a1f#3ebbd6822aad4a5a738990cf9771889269a02a1f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3f5279a0d72f92f5d23a0af79443dcf70b5e047e#3f5279a0d72f92f5d23a0af79443dcf70b5e047e"
 dependencies = [
  "anyhow",
  "bitflags 2.9.4",
@@ -300,7 +300,7 @@ dependencies = [
 [[package]]
 name = "caliptra-auth-man-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3ebbd6822aad4a5a738990cf9771889269a02a1f#3ebbd6822aad4a5a738990cf9771889269a02a1f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3f5279a0d72f92f5d23a0af79443dcf70b5e047e#3f5279a0d72f92f5d23a0af79443dcf70b5e047e"
 dependencies = [
  "bitfield",
  "bitflags 2.9.4",
@@ -315,7 +315,7 @@ dependencies = [
 [[package]]
 name = "caliptra-builder"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3ebbd6822aad4a5a738990cf9771889269a02a1f#3ebbd6822aad4a5a738990cf9771889269a02a1f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3f5279a0d72f92f5d23a0af79443dcf70b5e047e#3f5279a0d72f92f5d23a0af79443dcf70b5e047e"
 dependencies = [
  "anyhow",
  "caliptra-image-crypto",
@@ -340,7 +340,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cfi-derive"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3ebbd6822aad4a5a738990cf9771889269a02a1f#3ebbd6822aad4a5a738990cf9771889269a02a1f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3f5279a0d72f92f5d23a0af79443dcf70b5e047e#3f5279a0d72f92f5d23a0af79443dcf70b5e047e"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -362,7 +362,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cfi-lib"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3ebbd6822aad4a5a738990cf9771889269a02a1f#3ebbd6822aad4a5a738990cf9771889269a02a1f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3f5279a0d72f92f5d23a0af79443dcf70b5e047e#3f5279a0d72f92f5d23a0af79443dcf70b5e047e"
 dependencies = [
  "caliptra-error",
  "caliptra-registers",
@@ -377,7 +377,7 @@ source = "git+https://github.com/chipsalliance/caliptra-cfi.git?rev=a98e499d279e
 [[package]]
 name = "caliptra-coverage"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3ebbd6822aad4a5a738990cf9771889269a02a1f#3ebbd6822aad4a5a738990cf9771889269a02a1f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3f5279a0d72f92f5d23a0af79443dcf70b5e047e#3f5279a0d72f92f5d23a0af79443dcf70b5e047e"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -395,7 +395,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cpu"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3ebbd6822aad4a5a738990cf9771889269a02a1f#3ebbd6822aad4a5a738990cf9771889269a02a1f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3f5279a0d72f92f5d23a0af79443dcf70b5e047e#3f5279a0d72f92f5d23a0af79443dcf70b5e047e"
 dependencies = [
  "caliptra-drivers",
  "caliptra-registers",
@@ -405,7 +405,7 @@ dependencies = [
 [[package]]
 name = "caliptra-drivers"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3ebbd6822aad4a5a738990cf9771889269a02a1f#3ebbd6822aad4a5a738990cf9771889269a02a1f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3f5279a0d72f92f5d23a0af79443dcf70b5e047e#3f5279a0d72f92f5d23a0af79443dcf70b5e047e"
 dependencies = [
  "arrayvec",
  "bitfield",
@@ -431,7 +431,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-bus"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3ebbd6822aad4a5a738990cf9771889269a02a1f#3ebbd6822aad4a5a738990cf9771889269a02a1f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3f5279a0d72f92f5d23a0af79443dcf70b5e047e#3f5279a0d72f92f5d23a0af79443dcf70b5e047e"
 dependencies = [
  "caliptra-emu-types",
  "tock-registers",
@@ -441,7 +441,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-cpu"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3ebbd6822aad4a5a738990cf9771889269a02a1f#3ebbd6822aad4a5a738990cf9771889269a02a1f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3f5279a0d72f92f5d23a0af79443dcf70b5e047e#3f5279a0d72f92f5d23a0af79443dcf70b5e047e"
 dependencies = [
  "bit-vec",
  "bitfield",
@@ -455,7 +455,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3ebbd6822aad4a5a738990cf9771889269a02a1f#3ebbd6822aad4a5a738990cf9771889269a02a1f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3f5279a0d72f92f5d23a0af79443dcf70b5e047e#3f5279a0d72f92f5d23a0af79443dcf70b5e047e"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -470,7 +470,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-derive"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3ebbd6822aad4a5a738990cf9771889269a02a1f#3ebbd6822aad4a5a738990cf9771889269a02a1f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3f5279a0d72f92f5d23a0af79443dcf70b5e047e#3f5279a0d72f92f5d23a0af79443dcf70b5e047e"
 dependencies = [
  "caliptra-emu-bus",
  "caliptra-emu-types",
@@ -481,7 +481,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-periph"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3ebbd6822aad4a5a738990cf9771889269a02a1f#3ebbd6822aad4a5a738990cf9771889269a02a1f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3f5279a0d72f92f5d23a0af79443dcf70b5e047e#3f5279a0d72f92f5d23a0af79443dcf70b5e047e"
 dependencies = [
  "aes",
  "arrayref",
@@ -508,17 +508,17 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3ebbd6822aad4a5a738990cf9771889269a02a1f#3ebbd6822aad4a5a738990cf9771889269a02a1f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3f5279a0d72f92f5d23a0af79443dcf70b5e047e#3f5279a0d72f92f5d23a0af79443dcf70b5e047e"
 
 [[package]]
 name = "caliptra-error"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3ebbd6822aad4a5a738990cf9771889269a02a1f#3ebbd6822aad4a5a738990cf9771889269a02a1f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3f5279a0d72f92f5d23a0af79443dcf70b5e047e#3f5279a0d72f92f5d23a0af79443dcf70b5e047e"
 
 [[package]]
 name = "caliptra-gen-linker-scripts"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3ebbd6822aad4a5a738990cf9771889269a02a1f#3ebbd6822aad4a5a738990cf9771889269a02a1f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3f5279a0d72f92f5d23a0af79443dcf70b5e047e#3f5279a0d72f92f5d23a0af79443dcf70b5e047e"
 dependencies = [
  "caliptra_common",
 ]
@@ -526,7 +526,7 @@ dependencies = [
 [[package]]
 name = "caliptra-hw-model"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3ebbd6822aad4a5a738990cf9771889269a02a1f#3ebbd6822aad4a5a738990cf9771889269a02a1f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3f5279a0d72f92f5d23a0af79443dcf70b5e047e#3f5279a0d72f92f5d23a0af79443dcf70b5e047e"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -542,6 +542,7 @@ dependencies = [
  "caliptra-hw-model-types",
  "caliptra-image-types",
  "caliptra-registers",
+ "caliptra_common",
  "libc",
  "nix 0.26.4",
  "once_cell",
@@ -563,7 +564,7 @@ dependencies = [
 [[package]]
 name = "caliptra-hw-model-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3ebbd6822aad4a5a738990cf9771889269a02a1f#3ebbd6822aad4a5a738990cf9771889269a02a1f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3f5279a0d72f92f5d23a0af79443dcf70b5e047e#3f5279a0d72f92f5d23a0af79443dcf70b5e047e"
 dependencies = [
  "caliptra-api-types",
  "rand",
@@ -572,7 +573,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3ebbd6822aad4a5a738990cf9771889269a02a1f#3ebbd6822aad4a5a738990cf9771889269a02a1f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3f5279a0d72f92f5d23a0af79443dcf70b5e047e#3f5279a0d72f92f5d23a0af79443dcf70b5e047e"
 dependencies = [
  "anyhow",
  "caliptra-image-gen",
@@ -592,7 +593,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-elf"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3ebbd6822aad4a5a738990cf9771889269a02a1f#3ebbd6822aad4a5a738990cf9771889269a02a1f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3f5279a0d72f92f5d23a0af79443dcf70b5e047e#3f5279a0d72f92f5d23a0af79443dcf70b5e047e"
 dependencies = [
  "anyhow",
  "caliptra-image-gen",
@@ -603,7 +604,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-fake-keys"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3ebbd6822aad4a5a738990cf9771889269a02a1f#3ebbd6822aad4a5a738990cf9771889269a02a1f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3f5279a0d72f92f5d23a0af79443dcf70b5e047e#3f5279a0d72f92f5d23a0af79443dcf70b5e047e"
 dependencies = [
  "caliptra-image-gen",
  "caliptra-image-types",
@@ -614,7 +615,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-gen"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3ebbd6822aad4a5a738990cf9771889269a02a1f#3ebbd6822aad4a5a738990cf9771889269a02a1f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3f5279a0d72f92f5d23a0af79443dcf70b5e047e#3f5279a0d72f92f5d23a0af79443dcf70b5e047e"
 dependencies = [
  "anyhow",
  "bitflags 2.9.4",
@@ -631,7 +632,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3ebbd6822aad4a5a738990cf9771889269a02a1f#3ebbd6822aad4a5a738990cf9771889269a02a1f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3f5279a0d72f92f5d23a0af79443dcf70b5e047e#3f5279a0d72f92f5d23a0af79443dcf70b5e047e"
 dependencies = [
  "caliptra-cfi-derive",
  "caliptra-cfi-lib",
@@ -647,7 +648,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-verify"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3ebbd6822aad4a5a738990cf9771889269a02a1f#3ebbd6822aad4a5a738990cf9771889269a02a1f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3f5279a0d72f92f5d23a0af79443dcf70b5e047e#3f5279a0d72f92f5d23a0af79443dcf70b5e047e"
 dependencies = [
  "bitflags 2.9.4",
  "caliptra-cfi-derive",
@@ -662,7 +663,7 @@ dependencies = [
 [[package]]
 name = "caliptra-kat"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3ebbd6822aad4a5a738990cf9771889269a02a1f#3ebbd6822aad4a5a738990cf9771889269a02a1f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3f5279a0d72f92f5d23a0af79443dcf70b5e047e#3f5279a0d72f92f5d23a0af79443dcf70b5e047e"
 dependencies = [
  "caliptra-drivers",
  "caliptra-lms-types",
@@ -674,7 +675,7 @@ dependencies = [
 [[package]]
 name = "caliptra-lms-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3ebbd6822aad4a5a738990cf9771889269a02a1f#3ebbd6822aad4a5a738990cf9771889269a02a1f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3f5279a0d72f92f5d23a0af79443dcf70b5e047e#3f5279a0d72f92f5d23a0af79443dcf70b5e047e"
 dependencies = [
  "caliptra-cfi-derive",
  "caliptra-cfi-lib",
@@ -687,7 +688,7 @@ dependencies = [
 [[package]]
 name = "caliptra-registers"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3ebbd6822aad4a5a738990cf9771889269a02a1f#3ebbd6822aad4a5a738990cf9771889269a02a1f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3f5279a0d72f92f5d23a0af79443dcf70b5e047e#3f5279a0d72f92f5d23a0af79443dcf70b5e047e"
 dependencies = [
  "caliptra-registers-latest",
 ]
@@ -695,7 +696,7 @@ dependencies = [
 [[package]]
 name = "caliptra-registers-latest"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3ebbd6822aad4a5a738990cf9771889269a02a1f#3ebbd6822aad4a5a738990cf9771889269a02a1f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3f5279a0d72f92f5d23a0af79443dcf70b5e047e#3f5279a0d72f92f5d23a0af79443dcf70b5e047e"
 dependencies = [
  "ureg",
 ]
@@ -703,7 +704,7 @@ dependencies = [
 [[package]]
 name = "caliptra-runtime"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3ebbd6822aad4a5a738990cf9771889269a02a1f#3ebbd6822aad4a5a738990cf9771889269a02a1f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3f5279a0d72f92f5d23a0af79443dcf70b5e047e#3f5279a0d72f92f5d23a0af79443dcf70b5e047e"
 dependencies = [
  "arrayvec",
  "bitfield",
@@ -736,7 +737,7 @@ dependencies = [
 [[package]]
 name = "caliptra-test"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3ebbd6822aad4a5a738990cf9771889269a02a1f#3ebbd6822aad4a5a738990cf9771889269a02a1f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3f5279a0d72f92f5d23a0af79443dcf70b5e047e#3f5279a0d72f92f5d23a0af79443dcf70b5e047e"
 dependencies = [
  "anyhow",
  "asn1",
@@ -768,12 +769,12 @@ dependencies = [
 [[package]]
 name = "caliptra-test-harness-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3ebbd6822aad4a5a738990cf9771889269a02a1f#3ebbd6822aad4a5a738990cf9771889269a02a1f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3f5279a0d72f92f5d23a0af79443dcf70b5e047e#3f5279a0d72f92f5d23a0af79443dcf70b5e047e"
 
 [[package]]
 name = "caliptra-x509"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3ebbd6822aad4a5a738990cf9771889269a02a1f#3ebbd6822aad4a5a738990cf9771889269a02a1f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3f5279a0d72f92f5d23a0af79443dcf70b5e047e#3f5279a0d72f92f5d23a0af79443dcf70b5e047e"
 dependencies = [
  "zeroize",
 ]
@@ -781,7 +782,7 @@ dependencies = [
 [[package]]
 name = "caliptra_common"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3ebbd6822aad4a5a738990cf9771889269a02a1f#3ebbd6822aad4a5a738990cf9771889269a02a1f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3f5279a0d72f92f5d23a0af79443dcf70b5e047e#3f5279a0d72f92f5d23a0af79443dcf70b5e047e"
 dependencies = [
  "bitfield",
  "bitflags 2.9.4",
@@ -1218,7 +1219,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3ebbd6822aad4a5a738990cf9771889269a02a1f#3ebbd6822aad4a5a738990cf9771889269a02a1f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3f5279a0d72f92f5d23a0af79443dcf70b5e047e#3f5279a0d72f92f5d23a0af79443dcf70b5e047e"
 dependencies = [
  "arrayvec",
  "caliptra-cfi-derive-git",
@@ -1416,7 +1417,7 @@ dependencies = [
 [[package]]
 name = "dpe"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3ebbd6822aad4a5a738990cf9771889269a02a1f#3ebbd6822aad4a5a738990cf9771889269a02a1f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3f5279a0d72f92f5d23a0af79443dcf70b5e047e#3f5279a0d72f92f5d23a0af79443dcf70b5e047e"
 dependencies = [
  "bitflags 2.9.4",
  "caliptra-cfi-derive-git",
@@ -3243,7 +3244,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 [[package]]
 name = "platform"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3ebbd6822aad4a5a738990cf9771889269a02a1f#3ebbd6822aad4a5a738990cf9771889269a02a1f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3f5279a0d72f92f5d23a0af79443dcf70b5e047e#3f5279a0d72f92f5d23a0af79443dcf70b5e047e"
 dependencies = [
  "arrayvec",
  "cfg-if",
@@ -4033,6 +4034,7 @@ version = "0.1.0"
 name = "tests-integration"
 version = "0.1.0"
 dependencies = [
+ "caliptra-api",
  "caliptra-hw-model",
  "caliptra-hw-model-types",
  "caliptra-image-types",
@@ -4398,7 +4400,7 @@ dependencies = [
 [[package]]
 name = "ureg"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3ebbd6822aad4a5a738990cf9771889269a02a1f#3ebbd6822aad4a5a738990cf9771889269a02a1f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=3f5279a0d72f92f5d23a0af79443dcf70b5e047e#3f5279a0d72f92f5d23a0af79443dcf70b5e047e"
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -222,29 +222,29 @@ libtock_small_panic = { path = "runtime/userspace/libtock/panic_handlers/small_p
 libtock_unittest = { path = "runtime/userspace/libtock/unittest" }
 
 # caliptra dependencies; keep git revs in sync
-caliptra-api = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "3ebbd6822aad4a5a738990cf9771889269a02a1f" }
-caliptra-api-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "3ebbd6822aad4a5a738990cf9771889269a02a1f" }
-caliptra-auth-man-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "3ebbd6822aad4a5a738990cf9771889269a02a1f" }
-caliptra-auth-man-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "3ebbd6822aad4a5a738990cf9771889269a02a1f" }
-caliptra-builder = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "3ebbd6822aad4a5a738990cf9771889269a02a1f" }
-caliptra-emu-bus = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "3ebbd6822aad4a5a738990cf9771889269a02a1f" }
-caliptra-emu-cpu = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "3ebbd6822aad4a5a738990cf9771889269a02a1f" }
-caliptra-emu-derive = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "3ebbd6822aad4a5a738990cf9771889269a02a1f" }
-caliptra-emu-periph = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "3ebbd6822aad4a5a738990cf9771889269a02a1f" }
-caliptra-emu-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "3ebbd6822aad4a5a738990cf9771889269a02a1f" }
-caliptra-error = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "3ebbd6822aad4a5a738990cf9771889269a02a1f", default-features = false }
-caliptra-hw-model = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "3ebbd6822aad4a5a738990cf9771889269a02a1f" }
-caliptra-hw-model-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "3ebbd6822aad4a5a738990cf9771889269a02a1f" }
-caliptra-image-crypto = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "3ebbd6822aad4a5a738990cf9771889269a02a1f", default-features = false, features = ["rustcrypto"] }
-caliptra-image-fake-keys = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "3ebbd6822aad4a5a738990cf9771889269a02a1f" }
-caliptra-image-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "3ebbd6822aad4a5a738990cf9771889269a02a1f" }
-caliptra-image-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "3ebbd6822aad4a5a738990cf9771889269a02a1f" }
-caliptra-registers = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "3ebbd6822aad4a5a738990cf9771889269a02a1f" }
-caliptra-test = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "3ebbd6822aad4a5a738990cf9771889269a02a1f" }
-caliptra-test-harness = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "3ebbd6822aad4a5a738990cf9771889269a02a1f" }
-caliptra-test-harness-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "3ebbd6822aad4a5a738990cf9771889269a02a1f" }
-ureg = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "3ebbd6822aad4a5a738990cf9771889269a02a1f" }
-dpe = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "3ebbd6822aad4a5a738990cf9771889269a02a1f", default-features = false, features = ["dpe_profile_p384_sha384"] }
+caliptra-api = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "3f5279a0d72f92f5d23a0af79443dcf70b5e047e" }
+caliptra-api-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "3f5279a0d72f92f5d23a0af79443dcf70b5e047e" }
+caliptra-auth-man-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "3f5279a0d72f92f5d23a0af79443dcf70b5e047e" }
+caliptra-auth-man-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "3f5279a0d72f92f5d23a0af79443dcf70b5e047e" }
+caliptra-builder = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "3f5279a0d72f92f5d23a0af79443dcf70b5e047e" }
+caliptra-emu-bus = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "3f5279a0d72f92f5d23a0af79443dcf70b5e047e" }
+caliptra-emu-cpu = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "3f5279a0d72f92f5d23a0af79443dcf70b5e047e" }
+caliptra-emu-derive = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "3f5279a0d72f92f5d23a0af79443dcf70b5e047e" }
+caliptra-emu-periph = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "3f5279a0d72f92f5d23a0af79443dcf70b5e047e" }
+caliptra-emu-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "3f5279a0d72f92f5d23a0af79443dcf70b5e047e" }
+caliptra-error = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "3f5279a0d72f92f5d23a0af79443dcf70b5e047e", default-features = false }
+caliptra-hw-model = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "3f5279a0d72f92f5d23a0af79443dcf70b5e047e" }
+caliptra-hw-model-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "3f5279a0d72f92f5d23a0af79443dcf70b5e047e" }
+caliptra-image-crypto = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "3f5279a0d72f92f5d23a0af79443dcf70b5e047e", default-features = false, features = ["rustcrypto"] }
+caliptra-image-fake-keys = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "3f5279a0d72f92f5d23a0af79443dcf70b5e047e" }
+caliptra-image-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "3f5279a0d72f92f5d23a0af79443dcf70b5e047e" }
+caliptra-image-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "3f5279a0d72f92f5d23a0af79443dcf70b5e047e" }
+caliptra-registers = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "3f5279a0d72f92f5d23a0af79443dcf70b5e047e" }
+caliptra-test = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "3f5279a0d72f92f5d23a0af79443dcf70b5e047e" }
+caliptra-test-harness = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "3f5279a0d72f92f5d23a0af79443dcf70b5e047e" }
+caliptra-test-harness-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "3f5279a0d72f92f5d23a0af79443dcf70b5e047e" }
+ureg = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "3f5279a0d72f92f5d23a0af79443dcf70b5e047e" }
+dpe = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "3f5279a0d72f92f5d23a0af79443dcf70b5e047e", default-features = false, features = ["dpe_profile_p384_sha384"] }
 
 # local caliptra dependency; useful when developing
 # caliptra-api = { path = "../caliptra-sw/api" }

--- a/hw/model/src/model_fpga_realtime.rs
+++ b/hw/model/src/model_fpga_realtime.rs
@@ -284,6 +284,7 @@ impl McuHwModel for ModelFpgaRealtime {
             uds_granularity_64: !params.uds_granularity_32,
             prod_dbg_unlock_keypairs: params.prod_dbg_unlock_keypairs,
             debug_intent: params.debug_intent,
+            bootfsm_break: params.bootfsm_break,
             cptra_obf_key: params.cptra_obf_key,
             csr_hmac_key: params.csr_hmac_key,
             itrng_nibbles: params.itrng_nibbles,

--- a/rom/src/fuses.rs
+++ b/rom/src/fuses.rs
@@ -636,6 +636,12 @@ impl Otp {
 
     pub fn read_fuses(&self) -> Result<Fuses, McuError> {
         let mut fuses = Fuses::default();
+        romtime::println!("[mcu-rom-otp] Reading SW tests unlock partition");
+        self.read_data(
+            fuses::SW_TEST_UNLOCK_PARTITION_BYTE_OFFSET,
+            fuses::SW_TEST_UNLOCK_PARTITION_BYTE_SIZE,
+            &mut fuses.sw_test_unlock_partition,
+        )?;
         romtime::println!("[mcu-rom-otp] Reading SW manufacturer partition");
         self.read_data(
             fuses::SW_MANUF_PARTITION_BYTE_OFFSET,

--- a/rom/src/rom.rs
+++ b/rom/src/rom.rs
@@ -236,7 +236,21 @@ impl Soc {
         self.registers
             .fuse_soc_stepping_id
             .write(soc::bits::FuseSocSteppingId::SocSteppingId.val(soc_stepping_id));
-        // TODO: debug unlock / rma token?
+
+        if fuses.cptra_ss_manuf_debug_unlock_token().len()
+            != self.registers.fuse_manuf_dbg_unlock_token.len() * 4
+        {
+            romtime::println!("[mcu-fuse-write] SS manuf debug unlock token length mismatch");
+            fatal_error(1);
+        }
+        for i in 0..fuses.cptra_ss_manuf_debug_unlock_token().len() / 4 {
+            let word = u32::from_le_bytes(
+                fuses.cptra_ss_manuf_debug_unlock_token()[i * 4..i * 4 + 4]
+                    .try_into()
+                    .unwrap(),
+            );
+            self.registers.fuse_manuf_dbg_unlock_token[i].set(word);
+        }
     }
 
     pub fn fuse_write_done(&self) {

--- a/tests/integration/Cargo.toml
+++ b/tests/integration/Cargo.toml
@@ -13,6 +13,7 @@ itrng = []
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+caliptra-api.workspace = true
 caliptra-hw-model-types.workspace = true
 caliptra-hw-model.workspace = true
 caliptra-image-types.workspace = true

--- a/tests/integration/src/jtag/test_lc_transitions.rs
+++ b/tests/integration/src/jtag/test_lc_transitions.rs
@@ -3,33 +3,52 @@
 #[cfg(test)]
 mod test {
     use std::path::PathBuf;
+    use std::thread;
+    use std::time::Duration;
 
+    use caliptra_api::soc_mgr::SocManager;
+    use caliptra_hw_model::jtag::CaliptraCoreReg;
     use caliptra_hw_model::lcc::LcCtrlStatus;
     use caliptra_hw_model::openocd::openocd_jtag_tap::{JtagParams, JtagTap};
-    use caliptra_hw_model::{Fuses, DEFAULT_LIFECYCLE_RAW_TOKEN};
+    use caliptra_hw_model::HwModel;
+    use caliptra_hw_model::{
+        Fuses, DEFAULT_LIFECYCLE_RAW_TOKEN, DEFAULT_MANUF_DEBUG_UNLOCK_RAW_TOKEN,
+    };
     use mcu_builder::FirmwareBinaries;
     use mcu_hw_model::lcc::{lc_token_to_words, lc_transition, read_lc_state, LccUtilError};
     use mcu_hw_model::{DefaultHwModel, InitParams, McuHwModel};
     use mcu_rom_common::LifecycleControllerState;
 
-    fn ss_setup(initial_lc_state: Option<LifecycleControllerState>) -> DefaultHwModel {
+    fn ss_setup(
+        initial_lc_state: Option<LifecycleControllerState>,
+        debug_intent: bool,
+        bootfsm_break: bool,
+        enable_mcu_uart_log: bool,
+    ) -> DefaultHwModel {
         let firmware_bundle = FirmwareBinaries::from_env().unwrap();
 
         let init_params = InitParams {
             caliptra_rom: &firmware_bundle.caliptra_rom,
             mcu_rom: &firmware_bundle.mcu_rom,
             lifecycle_controller_state: initial_lc_state,
+            debug_intent,
+            bootfsm_break,
+            enable_mcu_uart_log,
             ..Default::default()
         };
         let mut model = DefaultHwModel::new_unbooted(init_params).unwrap();
         model.init_fuses(&Fuses::default());
-        model.set_subsystem_reset(false);
         model
     }
 
     #[test]
     fn test_raw_unlock() {
-        let mut model = ss_setup(Some(LifecycleControllerState::Raw));
+        let mut model = ss_setup(
+            Some(LifecycleControllerState::Raw),
+            /*debug_intent=*/ false,
+            /*bootfsm_break=*/ false,
+            /*enable_mcu_uart_log=*/ false,
+        );
 
         // Connect to LCC JTAG TAP via OpenOCD.
         let jtag_params = JtagParams {
@@ -87,7 +106,12 @@ mod test {
         ];
 
         // Initialize Caliptra SS in first LC state.
-        let mut model = ss_setup(Some(lc_states[0]));
+        let mut model = ss_setup(
+            Some(lc_states[0]),
+            /*debug_intent=*/ false,
+            /*bootfsm_break=*/ false,
+            /*enable_mcu_uart_log=*/ false,
+        );
 
         // Connect to LCC JTAG TAP via OpenOCD.
         let jtag_params = JtagParams {
@@ -133,7 +157,12 @@ mod test {
 
     #[test]
     fn test_prod_rma_unlock() {
-        let mut model = ss_setup(Some(LifecycleControllerState::Prod));
+        let mut model = ss_setup(
+            Some(LifecycleControllerState::Prod),
+            /*debug_intent=*/ false,
+            /*bootfsm_break=*/ false,
+            /*enable_mcu_uart_log=*/ false,
+        );
 
         // Connect to LCC JTAG TAP via OpenOCD.
         let jtag_params = JtagParams {
@@ -169,5 +198,135 @@ mod test {
             *status,
             LcCtrlStatus::FLASH_RMA_ERROR | LcCtrlStatus::INITIALIZED
         );
+    }
+
+    #[test]
+    fn test_manuf_debug_unlock() {
+        let mut model = ss_setup(
+            Some(LifecycleControllerState::Dev),
+            /*debug_intent=*/ true,
+            /*bootfsm_break=*/ true,
+            /*enable_mcu_uart_log=*/ true,
+        );
+
+        println!("Give the FPGA time to boot...");
+        let mut flow_status = model.base.soc_ifc().cptra_flow_status().read();
+        println!("Flow status: 0x{:08x?}", u32::from(flow_status));
+        for _ in 0..5_000 {
+            model.base.step();
+            flow_status = model.base.soc_ifc().cptra_flow_status().read();
+            if flow_status.ready_for_mb_processing() {
+                break;
+            }
+        }
+        println!("Flow status: 0x{:08x?}", u32::from(flow_status));
+
+        // Connect to Caliptra Core JTAG TAP via OpenOCD.
+        println!("Connecting to Core TAP ...");
+        let jtag_params = JtagParams {
+            openocd: PathBuf::from("openocd"),
+            adapter_speed_khz: 1000,
+            log_stdio: true,
+        };
+        let mut tap = model
+            .jtag_tap_connect(&jtag_params, JtagTap::CaliptraCoreTap)
+            .expect("Failed to connect to the Caliptra Core JTAG TAP.");
+        println!("Connected.");
+
+        // Check SS Debug Intent is active.
+        let debug_intent = tap
+            .read_reg(&CaliptraCoreReg::SsDebugIntent)
+            .expect("Unable to read SS Debug Inteng.");
+        println!("SS Debug Intent: {}", debug_intent);
+        assert_eq!(debug_intent, 0x1);
+
+        // Ensure another manuf debug unlock is not in progress.
+        let ss_debug_manuf_response = tap
+            .read_reg(&CaliptraCoreReg::SsDbgManufServiceRegRsp)
+            .expect("Unable to read SsDbgManufServiceRegRes reg.");
+        assert_eq!(ss_debug_manuf_response, 0);
+        let mut ss_debug_manuf_request = tap
+            .read_reg(&CaliptraCoreReg::SsDbgManufServiceRegReq)
+            .expect("Unable to read SsDbgManufServiceRegReq reg.");
+        assert_eq!(ss_debug_manuf_request, 0);
+
+        // Request manuf debug unlock operation.
+        println!("Request to initiate manuf debug unlock ...");
+        tap.write_reg(&CaliptraCoreReg::SsDbgManufServiceRegReq, 0x1)
+            .expect("Unable to write SsDbgManufServiceRegReq reg.");
+        println!(
+            "Manuf debug unlock request (before): 0x{:08x})",
+            ss_debug_manuf_request
+        );
+        ss_debug_manuf_request = tap
+            .read_reg(&CaliptraCoreReg::SsDbgManufServiceRegReq)
+            .expect("Unable to read SsDbgManufServiceRegReq reg.");
+        println!(
+            "Manuf debug unlock request (after): 0x{:08x})",
+            ss_debug_manuf_request
+        );
+        assert_eq!(ss_debug_manuf_request, 1);
+        println!("Request sent.");
+
+        // Continue Caliptra Core boot.
+        tap.write_reg(&CaliptraCoreReg::BootfsmGo, 0x1)
+            .expect("Unable to write BootfsmGo.");
+
+        // Acquire the Caliptra Core mailbox lock.
+        println!("Attempting to acquire Caliptra Core mailbox lock ...");
+        while let Ok(mbox_lock) = tap.read_reg(&CaliptraCoreReg::MboxLock) {
+            if (mbox_lock & 0x1) == 0 {
+                break;
+            }
+            thread::sleep(Duration::from_millis(100));
+        }
+        println!("Lock acquired.");
+
+        // Program the manuf debug unlock token via the Caliptra Core mailbox.
+        println!("Programming the manuf debug unlock token ...");
+        tap.write_reg(&CaliptraCoreReg::MboxCmd, 0x4d445554)
+            .expect("Unable to write MboxCmd reg.");
+        tap.write_reg(
+            &CaliptraCoreReg::MboxDlen,
+            ((DEFAULT_MANUF_DEBUG_UNLOCK_RAW_TOKEN.0.len() + 1) * 4)
+                .try_into()
+                .unwrap(),
+        )
+        .expect("Unable to write MboxDlen reg.");
+        tap.write_reg(&CaliptraCoreReg::MboxDin, 0xFFFFF8E2)
+            .expect("Unable to write to MboxDin register.");
+        for token_word in DEFAULT_MANUF_DEBUG_UNLOCK_RAW_TOKEN.0 {
+            println!("Writing token word: 0x{:08x}.", token_word);
+            tap.write_reg(&CaliptraCoreReg::MboxDin, token_word)
+                .expect("Unable to write to MboxDin register.");
+        }
+        println!("Token programming complete.");
+
+        // Executing the manuf debug unlock operation and wait for completion.
+        println!("Executing the manuf debug unlock operation ...");
+        tap.write_reg(&CaliptraCoreReg::MboxExecute, 0x1)
+            .expect("Unable to write to MboxExecute register.");
+
+        // Wait for debug unlock operation to complete.
+        while let Ok(ss_debug_manuf_response) =
+            tap.read_reg(&CaliptraCoreReg::SsDbgManufServiceRegRsp)
+        {
+            if (ss_debug_manuf_response & 0x4) != 0 {
+                println!(
+                    "Manuf debug unlock operation in progress (response: 0x{:08x}) ...",
+                    ss_debug_manuf_response
+                );
+            }
+            if (ss_debug_manuf_response & 0x3) != 0 {
+                println!(
+                    "Manuf debug unlock operation complete (response: 0x{:08x}).",
+                    ss_debug_manuf_response
+                );
+                assert_eq!(ss_debug_manuf_response, 0x1);
+                break;
+            }
+            model.base.step();
+            thread::sleep(Duration::from_millis(100));
+        }
     }
 }


### PR DESCRIPTION
This partially addresses #233 by adding an E2E FPGA test case that perfoms a manuf debug unlock flow via the Caliptra Core TAP.