### PR TITLE
Fix Misaligned exception on noDMA driver

### DIFF
--- a/platforms/emulator/runtime/kernel/drivers/dma/src/nodma.rs
+++ b/platforms/emulator/runtime/kernel/drivers/dma/src/nodma.rs
@@ -125,9 +125,11 @@ impl<'a, A: Alarm<'a>> AlarmClient for NoDMA<'a, A> {
         if !*self.busy.borrow() {
             return;
         }
-        for offset in 0..(*self.btt.borrow() / 4) {
-            let src_ptr = self.src_addr.borrow().wrapping_add(offset * 4) as *const u32;
-            let dst_ptr = self.dest_addr.borrow().wrapping_add(offset * 4) as *mut u32;
+
+        // Transfer in bytes since src or dest may not be word aligned
+        for offset in 0..(*self.btt.borrow()) {
+            let src_ptr = self.src_addr.borrow().wrapping_add(offset) as *const u8;
+            let dst_ptr = self.dest_addr.borrow().wrapping_add(offset) as *mut u8;
             unsafe {
                 let value = core::ptr::read_volatile(src_ptr);
                 core::ptr::write_volatile(dst_ptr, value);


### PR DESCRIPTION
The fake DMA driver that does manual SW copy of data from source to destination address can throw Misaligned load Exception if the source or destination is not 4-byte aligned. This is because the driver transfers in 4-byte chunks.

Transfer in bytes instead of words since is not assured that application will pass 4-byte aligned source or destination address.