### PR TITLE
xtask: Add optional path to `caliptra-sw`

### DIFF
--- a/xtask/src/fpga/configurations.rs
+++ b/xtask/src/fpga/configurations.rs
@@ -90,6 +90,9 @@ impl<'a> ActionHandler<'a> for CommandExecutor {
     }
 
     fn build_test(&self, args: &'a BuildTestArgs<'a>) -> Result<()> {
+        // Delete the file if it exists. Sometimes the docker build fails silently. This will force
+        // the rsync to fail in those cases.
+        let _ = std::fs::remove_file("caliptra-test-binaries.tar.zst");
         match self {
             Self::Subsystem(sub) => sub.build_test(args),
             Self::CoreOnSubsystem(core) => core.build_test(args),
@@ -154,9 +157,6 @@ impl<'a> ActionHandler<'a> for Subsystem {
     }
 
     fn build_test(&self, args: &'a BuildTestArgs<'a>) -> Result<()> {
-        // Delete the file if it exists. Sometimes the docker build fails silently. This will force
-        // the rsync to fail in those cases.
-        let _ = std::fs::remove_file("caliptra-test-binaries.tar.zst");
         let mut base_cmd = build_base_docker_command(args.caliptra_sw)?;
         base_cmd.arg(
                 "(cd /work-dir && CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc cargo nextest archive --features=fpga_realtime --target=aarch64-unknown-linux-gnu --archive-file=/work-dir/caliptra-test-binaries.tar.zst --target-dir cross-target/)"


### PR DESCRIPTION
This adds the optional path to add caliptra-sw to build_test for subsystem. This would be used when building tests with a local reference to caliptra-sw.

This will also delete the test binary archive before building, if it exists. Sometimes the docker build can fail silently, this will force the rsync to fail in those cases.