### PR TITLE
[CI]: Disable incremental compilation in CI to save disk space

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -105,8 +105,9 @@ jobs:
           # The rustc incremental compilation is optimized for a dev loop w/ code edits.
           # The CI uses sccache to speed up compilation (which already does not work with incremental compilation).
           # Disable incremental testing to reduce disk usage
-          export CARGO_PROFILE_TEST_INCREMENTAL=false
+          # export CARGO_PROFILE_TEST_INCREMENTAL=false
           export CPTRA_FIRMWARE_BUNDLE="${PWD}/target/all-fw.zip"
           # TODO: remove this if we get larger GitHub runners
           cargo --config "$EXTRA_CARGO_CONFIG" xtask test
           sccache --show-stats
+          echo "Target folder size: $(du -hs target/)"


### PR DESCRIPTION
This feature is not useful in CI and disabling it helps reduce disk usage of the CI tests.