### PR TITLE
[xtask-fpga]: Parse xtask Cargo.toml for caliptra_sw path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4925,6 +4925,7 @@ dependencies = [
  "caliptra-hw-model",
  "caliptra-image-gen",
  "caliptra-image-types",
+ "cargo_metadata",
  "cc",
  "clap 4.5.48",
  "clap-num",

--- a/docs/src/fpga.md
+++ b/docs/src/fpga.md
@@ -105,8 +105,8 @@ The xtask workflow also supports running caliptra-sw tests on a subsystem FPGA.
 
 ```
 $ cargo xtask-fpga fpga bootstrap --target-host $SSH-FPGA-NAME --configuration core-on-subsystem # Run this only once per boot. Re-run bootstrap to change configurations
-$ cargo xtask-fpga fpga build --target-host $SSH-FPGA-NAME --caliptra-sw $CALIPTRA_SW_DIR # Build firmware. Re-run every time firmware changes. Must pass path to caliptra-sw repo. Cargo.toml must set the caliptra-sw dependencies to "../caliptra-sw".
-$ cargo xtask-fpga fpga build-test --target-host $SSH-FPGA-NAME --caliptra-sw $CALIPTRA_SW_DIR # Build test binaries. Re-run every time tests change. Must pass path to caliptra-sw repo. Cargo.toml must set the caliptra-sw dependencies to "../caliptra-sw".
+$ cargo xtask-fpga fpga build --target-host $SSH-FPGA-NAME  # Build firmware. Re-run every time firmware changes.
+$ cargo xtask-fpga fpga build-test --target-host $SSH-FPGA-NAME # Build test binaries. Re-run every time tests change.
 ```
 
 # Running on FPGA

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -11,6 +11,7 @@ fpga_realtime = ["mcu-hw-model/fpga_realtime"]
 [dependencies]
 caliptra-api-types.workspace = true
 anyhow.workspace = true
+cargo_metadata.workspace = true
 cc.workspace = true
 caliptra-image-gen.workspace = true
 caliptra-image-types.workspace = true

--- a/xtask/src/fpga/configurations.rs
+++ b/xtask/src/fpga/configurations.rs
@@ -6,7 +6,7 @@ use mcu_builder::AllBuildArgs;
 
 use super::{
     run_command, run_command_with_output,
-    utils::{build_base_docker_command, rsync_file, run_test_suite},
+    utils::{build_base_docker_command, caliptra_sw_workspace_root, rsync_file, run_test_suite},
     ActionHandler, BuildArgs, BuildTestArgs, TestArgs,
 };
 
@@ -156,8 +156,8 @@ impl<'a> ActionHandler<'a> for Subsystem {
         Ok(())
     }
 
-    fn build_test(&self, args: &'a BuildTestArgs<'a>) -> Result<()> {
-        let mut base_cmd = build_base_docker_command(args.caliptra_sw)?;
+    fn build_test(&self, _args: &'a BuildTestArgs<'a>) -> Result<()> {
+        let mut base_cmd = build_base_docker_command()?;
         base_cmd.arg(
                 "(cd /work-dir && CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc cargo nextest archive --features=fpga_realtime --target=aarch64-unknown-linux-gnu --archive-file=/work-dir/caliptra-test-binaries.tar.zst --target-dir cross-target/)"
             );
@@ -212,14 +212,13 @@ impl<'a> ActionHandler<'a> for CoreOnSubsystem {
         run_command(target_host, bootstrap_cmd).context("failed to clone caliptra-sw repo")?;
         Ok(())
     }
-    fn build(&self, args: &'a BuildArgs<'a>) -> Result<()> {
+    fn build(&self, _args: &'a BuildArgs<'a>) -> Result<()> {
         run_command(
             None,
             "mkdir -p /tmp/caliptra-test-firmware/caliptra-test-firmware",
         )?;
-        let caliptra_sw = args
-            .caliptra_sw
-            .expect("need to set `caliptra-sw` when in core-on-subsystem mode");
+        let caliptra_sw = caliptra_sw_workspace_root()
+            .expect("core-on-subsystem only supported when using a local copy of caliptra-sw");
         run_command(
                         None,
                         &format!("(cd {} && cargo run --release -p caliptra-builder -- --all_elfs /tmp/caliptra-test-firmware)", caliptra_sw.display()),
@@ -237,13 +236,11 @@ impl<'a> ActionHandler<'a> for CoreOnSubsystem {
         Ok(())
     }
 
-    fn build_test(&self, args: &'a BuildTestArgs<'a>) -> Result<()> {
-        let caliptra_sw = args
-            .caliptra_sw
-            .expect("caliptra-sw path is required for Core On Subsystem mode");
+    fn build_test(&self, _args: &'a BuildTestArgs<'a>) -> Result<()> {
+        let caliptra_sw = caliptra_sw_workspace_root()
+            .expect("core-on-subsystem only supported when using a local copy of caliptra-sw");
         let base_name = caliptra_sw.file_name().unwrap().to_str().unwrap();
-
-        let mut base_cmd = build_base_docker_command(Some(caliptra_sw))?;
+        let mut base_cmd = build_base_docker_command()?;
         base_cmd.arg(
                 format!("(cd /{} && CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc cargo nextest archive --features=fpga_subsystem,itrng --target=aarch64-unknown-linux-gnu --archive-file=/work-dir/caliptra-test-binaries.tar.zst --target-dir cross-target/)"
             , base_name));
@@ -296,14 +293,13 @@ impl<'a> ActionHandler<'a> for Core {
         run_command(target_host, bootstrap_cmd).context("failed to clone caliptra-sw repo")?;
         Ok(())
     }
-    fn build(&self, args: &'a BuildArgs<'a>) -> Result<()> {
+    fn build(&self, _args: &'a BuildArgs<'a>) -> Result<()> {
         run_command(
             None,
             "mkdir -p /tmp/caliptra-test-firmware/caliptra-test-firmware",
         )?;
-        let caliptra_sw = args
-            .caliptra_sw
-            .expect("need to set `caliptra-sw` when in core mode");
+        let caliptra_sw = caliptra_sw_workspace_root()
+            .expect("core-on-subsystem only supported when using a local copy of caliptra-sw");
         run_command(
                         None,
                         &format!("(cd {} && cargo run --release -p caliptra-builder -- --all_elfs /tmp/caliptra-test-firmware)", caliptra_sw.display()),
@@ -319,13 +315,12 @@ impl<'a> ActionHandler<'a> for Core {
         Ok(())
     }
 
-    fn build_test(&self, args: &'a BuildTestArgs<'a>) -> Result<()> {
-        let caliptra_sw = args
-            .caliptra_sw
-            .expect("caliptra-sw path is required for Core On Subsystem mode");
+    fn build_test(&self, _args: &'a BuildTestArgs<'a>) -> Result<()> {
+        let caliptra_sw = caliptra_sw_workspace_root()
+            .expect("core only supported when using a local copy of caliptra-sw");
         let base_name = caliptra_sw.file_name().unwrap().to_str().unwrap();
 
-        let mut base_cmd = build_base_docker_command(Some(caliptra_sw))?;
+        let mut base_cmd = build_base_docker_command()?;
         base_cmd.arg(
                 format!("(cd /{} && CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc cargo nextest archive --features=fpga_realtime,itrng --target=aarch64-unknown-linux-gnu --archive-file=/work-dir/caliptra-test-binaries.tar.zst --target-dir cross-target/)"
             , base_name));

--- a/xtask/src/fpga/configurations.rs
+++ b/xtask/src/fpga/configurations.rs
@@ -299,7 +299,7 @@ impl<'a> ActionHandler<'a> for Core {
             "mkdir -p /tmp/caliptra-test-firmware/caliptra-test-firmware",
         )?;
         let caliptra_sw = caliptra_sw_workspace_root()
-            .expect("core-on-subsystem only supported when using a local copy of caliptra-sw");
+            .expect("core only supported when using a local copy of caliptra-sw");
         run_command(
                         None,
                         &format!("(cd {} && cargo run --release -p caliptra-builder -- --all_elfs /tmp/caliptra-test-firmware)", caliptra_sw.display()),


### PR DESCRIPTION
This removes the need for specifying `caliptra-sw` as a flag.