### PR TITLE
hitless-update: Add a test for the full flow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,7 +262,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 [[package]]
 name = "caliptra-api"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc#e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98da0893f3fb9371f8dda7acfb6ccf8697ab253d#98da0893f3fb9371f8dda7acfb6ccf8697ab253d"
 dependencies = [
  "bitflags 2.9.4",
  "caliptra-api-types",
@@ -277,7 +277,7 @@ dependencies = [
 [[package]]
 name = "caliptra-api-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc#e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98da0893f3fb9371f8dda7acfb6ccf8697ab253d#98da0893f3fb9371f8dda7acfb6ccf8697ab253d"
 dependencies = [
  "caliptra-image-types",
 ]
@@ -285,7 +285,7 @@ dependencies = [
 [[package]]
 name = "caliptra-auth-man-gen"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc#e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98da0893f3fb9371f8dda7acfb6ccf8697ab253d#98da0893f3fb9371f8dda7acfb6ccf8697ab253d"
 dependencies = [
  "anyhow",
  "bitflags 2.9.4",
@@ -300,7 +300,7 @@ dependencies = [
 [[package]]
 name = "caliptra-auth-man-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc#e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98da0893f3fb9371f8dda7acfb6ccf8697ab253d#98da0893f3fb9371f8dda7acfb6ccf8697ab253d"
 dependencies = [
  "bitfield",
  "bitflags 2.9.4",
@@ -315,7 +315,7 @@ dependencies = [
 [[package]]
 name = "caliptra-builder"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc#e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98da0893f3fb9371f8dda7acfb6ccf8697ab253d#98da0893f3fb9371f8dda7acfb6ccf8697ab253d"
 dependencies = [
  "anyhow",
  "caliptra-image-crypto",
@@ -340,7 +340,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cfi-derive"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc#e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98da0893f3fb9371f8dda7acfb6ccf8697ab253d#98da0893f3fb9371f8dda7acfb6ccf8697ab253d"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -362,7 +362,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cfi-lib"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc#e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98da0893f3fb9371f8dda7acfb6ccf8697ab253d#98da0893f3fb9371f8dda7acfb6ccf8697ab253d"
 dependencies = [
  "caliptra-error",
  "caliptra-registers",
@@ -377,7 +377,7 @@ source = "git+https://github.com/chipsalliance/caliptra-cfi.git?rev=a98e499d279e
 [[package]]
 name = "caliptra-coverage"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc#e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98da0893f3fb9371f8dda7acfb6ccf8697ab253d#98da0893f3fb9371f8dda7acfb6ccf8697ab253d"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -395,7 +395,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cpu"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc#e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98da0893f3fb9371f8dda7acfb6ccf8697ab253d#98da0893f3fb9371f8dda7acfb6ccf8697ab253d"
 dependencies = [
  "caliptra-drivers",
  "caliptra-registers",
@@ -405,7 +405,7 @@ dependencies = [
 [[package]]
 name = "caliptra-drivers"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc#e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98da0893f3fb9371f8dda7acfb6ccf8697ab253d#98da0893f3fb9371f8dda7acfb6ccf8697ab253d"
 dependencies = [
  "arrayvec",
  "bitfield",
@@ -431,7 +431,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-bus"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc#e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98da0893f3fb9371f8dda7acfb6ccf8697ab253d#98da0893f3fb9371f8dda7acfb6ccf8697ab253d"
 dependencies = [
  "caliptra-emu-types",
  "tock-registers",
@@ -441,7 +441,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-cpu"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc#e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98da0893f3fb9371f8dda7acfb6ccf8697ab253d#98da0893f3fb9371f8dda7acfb6ccf8697ab253d"
 dependencies = [
  "bit-vec",
  "bitfield",
@@ -455,7 +455,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc#e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98da0893f3fb9371f8dda7acfb6ccf8697ab253d#98da0893f3fb9371f8dda7acfb6ccf8697ab253d"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -470,7 +470,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-derive"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc#e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98da0893f3fb9371f8dda7acfb6ccf8697ab253d#98da0893f3fb9371f8dda7acfb6ccf8697ab253d"
 dependencies = [
  "caliptra-emu-bus",
  "caliptra-emu-types",
@@ -481,7 +481,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-periph"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc#e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98da0893f3fb9371f8dda7acfb6ccf8697ab253d#98da0893f3fb9371f8dda7acfb6ccf8697ab253d"
 dependencies = [
  "aes",
  "arrayref",
@@ -508,17 +508,17 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc#e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98da0893f3fb9371f8dda7acfb6ccf8697ab253d#98da0893f3fb9371f8dda7acfb6ccf8697ab253d"
 
 [[package]]
 name = "caliptra-error"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc#e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98da0893f3fb9371f8dda7acfb6ccf8697ab253d#98da0893f3fb9371f8dda7acfb6ccf8697ab253d"
 
 [[package]]
 name = "caliptra-gen-linker-scripts"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc#e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98da0893f3fb9371f8dda7acfb6ccf8697ab253d#98da0893f3fb9371f8dda7acfb6ccf8697ab253d"
 dependencies = [
  "caliptra_common",
 ]
@@ -526,7 +526,7 @@ dependencies = [
 [[package]]
 name = "caliptra-hw-model"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc#e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98da0893f3fb9371f8dda7acfb6ccf8697ab253d#98da0893f3fb9371f8dda7acfb6ccf8697ab253d"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -564,7 +564,7 @@ dependencies = [
 [[package]]
 name = "caliptra-hw-model-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc#e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98da0893f3fb9371f8dda7acfb6ccf8697ab253d#98da0893f3fb9371f8dda7acfb6ccf8697ab253d"
 dependencies = [
  "caliptra-api-types",
  "rand",
@@ -573,7 +573,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc#e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98da0893f3fb9371f8dda7acfb6ccf8697ab253d#98da0893f3fb9371f8dda7acfb6ccf8697ab253d"
 dependencies = [
  "anyhow",
  "caliptra-image-gen",
@@ -593,7 +593,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-elf"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc#e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98da0893f3fb9371f8dda7acfb6ccf8697ab253d#98da0893f3fb9371f8dda7acfb6ccf8697ab253d"
 dependencies = [
  "anyhow",
  "caliptra-image-gen",
@@ -604,7 +604,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-fake-keys"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc#e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98da0893f3fb9371f8dda7acfb6ccf8697ab253d#98da0893f3fb9371f8dda7acfb6ccf8697ab253d"
 dependencies = [
  "caliptra-image-gen",
  "caliptra-image-types",
@@ -615,7 +615,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-gen"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc#e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98da0893f3fb9371f8dda7acfb6ccf8697ab253d#98da0893f3fb9371f8dda7acfb6ccf8697ab253d"
 dependencies = [
  "anyhow",
  "bitflags 2.9.4",
@@ -632,7 +632,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc#e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98da0893f3fb9371f8dda7acfb6ccf8697ab253d#98da0893f3fb9371f8dda7acfb6ccf8697ab253d"
 dependencies = [
  "caliptra-cfi-derive",
  "caliptra-cfi-lib",
@@ -648,7 +648,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-verify"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc#e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98da0893f3fb9371f8dda7acfb6ccf8697ab253d#98da0893f3fb9371f8dda7acfb6ccf8697ab253d"
 dependencies = [
  "bitflags 2.9.4",
  "caliptra-cfi-derive",
@@ -663,7 +663,7 @@ dependencies = [
 [[package]]
 name = "caliptra-kat"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc#e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98da0893f3fb9371f8dda7acfb6ccf8697ab253d#98da0893f3fb9371f8dda7acfb6ccf8697ab253d"
 dependencies = [
  "caliptra-drivers",
  "caliptra-lms-types",
@@ -675,7 +675,7 @@ dependencies = [
 [[package]]
 name = "caliptra-lms-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc#e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98da0893f3fb9371f8dda7acfb6ccf8697ab253d#98da0893f3fb9371f8dda7acfb6ccf8697ab253d"
 dependencies = [
  "caliptra-cfi-derive",
  "caliptra-cfi-lib",
@@ -688,7 +688,7 @@ dependencies = [
 [[package]]
 name = "caliptra-registers"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc#e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98da0893f3fb9371f8dda7acfb6ccf8697ab253d#98da0893f3fb9371f8dda7acfb6ccf8697ab253d"
 dependencies = [
  "caliptra-registers-latest",
 ]
@@ -696,7 +696,7 @@ dependencies = [
 [[package]]
 name = "caliptra-registers-latest"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc#e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98da0893f3fb9371f8dda7acfb6ccf8697ab253d#98da0893f3fb9371f8dda7acfb6ccf8697ab253d"
 dependencies = [
  "ureg",
 ]
@@ -704,7 +704,7 @@ dependencies = [
 [[package]]
 name = "caliptra-runtime"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc#e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98da0893f3fb9371f8dda7acfb6ccf8697ab253d#98da0893f3fb9371f8dda7acfb6ccf8697ab253d"
 dependencies = [
  "arrayvec",
  "bitfield",
@@ -737,7 +737,7 @@ dependencies = [
 [[package]]
 name = "caliptra-test"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc#e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98da0893f3fb9371f8dda7acfb6ccf8697ab253d#98da0893f3fb9371f8dda7acfb6ccf8697ab253d"
 dependencies = [
  "anyhow",
  "asn1",
@@ -769,12 +769,12 @@ dependencies = [
 [[package]]
 name = "caliptra-test-harness-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc#e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98da0893f3fb9371f8dda7acfb6ccf8697ab253d#98da0893f3fb9371f8dda7acfb6ccf8697ab253d"
 
 [[package]]
 name = "caliptra-x509"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc#e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98da0893f3fb9371f8dda7acfb6ccf8697ab253d#98da0893f3fb9371f8dda7acfb6ccf8697ab253d"
 dependencies = [
  "zeroize",
 ]
@@ -782,7 +782,7 @@ dependencies = [
 [[package]]
 name = "caliptra_common"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc#e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98da0893f3fb9371f8dda7acfb6ccf8697ab253d#98da0893f3fb9371f8dda7acfb6ccf8697ab253d"
 dependencies = [
  "bitfield",
  "bitflags 2.9.4",
@@ -1219,7 +1219,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc#e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98da0893f3fb9371f8dda7acfb6ccf8697ab253d#98da0893f3fb9371f8dda7acfb6ccf8697ab253d"
 dependencies = [
  "arrayvec",
  "caliptra-cfi-derive-git",
@@ -1417,7 +1417,7 @@ dependencies = [
 [[package]]
 name = "dpe"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc#e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98da0893f3fb9371f8dda7acfb6ccf8697ab253d#98da0893f3fb9371f8dda7acfb6ccf8697ab253d"
 dependencies = [
  "bitflags 2.9.4",
  "caliptra-cfi-derive-git",
@@ -3246,7 +3246,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 [[package]]
 name = "platform"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc#e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98da0893f3fb9371f8dda7acfb6ccf8697ab253d#98da0893f3fb9371f8dda7acfb6ccf8697ab253d"
 dependencies = [
  "arrayvec",
  "cfg-if",
@@ -4036,7 +4036,9 @@ version = "0.1.0"
 name = "tests-integration"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "caliptra-api",
+ "caliptra-builder",
  "caliptra-hw-model",
  "caliptra-hw-model-types",
  "caliptra-image-types",
@@ -4402,7 +4404,7 @@ dependencies = [
 [[package]]
 name = "ureg"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc#e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=98da0893f3fb9371f8dda7acfb6ccf8697ab253d#98da0893f3fb9371f8dda7acfb6ccf8697ab253d"
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -222,29 +222,29 @@ libtock_small_panic = { path = "runtime/userspace/libtock/panic_handlers/small_p
 libtock_unittest = { path = "runtime/userspace/libtock/unittest" }
 
 # caliptra dependencies; keep git revs in sync
-caliptra-api = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc" }
-caliptra-api-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc" }
-caliptra-auth-man-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc" }
-caliptra-auth-man-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc" }
-caliptra-builder = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc" }
-caliptra-emu-bus = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc" }
-caliptra-emu-cpu = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc" }
-caliptra-emu-derive = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc" }
-caliptra-emu-periph = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc" }
-caliptra-emu-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc" }
-caliptra-error = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc", default-features = false }
-caliptra-hw-model = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc" }
-caliptra-hw-model-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc" }
-caliptra-image-crypto = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc", default-features = false, features = ["rustcrypto"] }
-caliptra-image-fake-keys = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc" }
-caliptra-image-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc" }
-caliptra-image-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc" }
-caliptra-registers = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc" }
-caliptra-test = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc" }
-caliptra-test-harness = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc" }
-caliptra-test-harness-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc" }
-ureg = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc" }
-dpe = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "e2b92934e09eac0638d0c7f9f6cb2d3f9681f5dc", default-features = false, features = ["dpe_profile_p384_sha384"] }
+caliptra-api = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "98da0893f3fb9371f8dda7acfb6ccf8697ab253d" }
+caliptra-api-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "98da0893f3fb9371f8dda7acfb6ccf8697ab253d" }
+caliptra-auth-man-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "98da0893f3fb9371f8dda7acfb6ccf8697ab253d" }
+caliptra-auth-man-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "98da0893f3fb9371f8dda7acfb6ccf8697ab253d" }
+caliptra-builder = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "98da0893f3fb9371f8dda7acfb6ccf8697ab253d" }
+caliptra-emu-bus = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "98da0893f3fb9371f8dda7acfb6ccf8697ab253d" }
+caliptra-emu-cpu = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "98da0893f3fb9371f8dda7acfb6ccf8697ab253d" }
+caliptra-emu-derive = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "98da0893f3fb9371f8dda7acfb6ccf8697ab253d" }
+caliptra-emu-periph = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "98da0893f3fb9371f8dda7acfb6ccf8697ab253d" }
+caliptra-emu-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "98da0893f3fb9371f8dda7acfb6ccf8697ab253d" }
+caliptra-error = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "98da0893f3fb9371f8dda7acfb6ccf8697ab253d", default-features = false }
+caliptra-hw-model = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "98da0893f3fb9371f8dda7acfb6ccf8697ab253d" }
+caliptra-hw-model-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "98da0893f3fb9371f8dda7acfb6ccf8697ab253d" }
+caliptra-image-crypto = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "98da0893f3fb9371f8dda7acfb6ccf8697ab253d", default-features = false, features = ["rustcrypto"] }
+caliptra-image-fake-keys = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "98da0893f3fb9371f8dda7acfb6ccf8697ab253d" }
+caliptra-image-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "98da0893f3fb9371f8dda7acfb6ccf8697ab253d" }
+caliptra-image-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "98da0893f3fb9371f8dda7acfb6ccf8697ab253d" }
+caliptra-registers = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "98da0893f3fb9371f8dda7acfb6ccf8697ab253d" }
+caliptra-test = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "98da0893f3fb9371f8dda7acfb6ccf8697ab253d" }
+caliptra-test-harness = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "98da0893f3fb9371f8dda7acfb6ccf8697ab253d" }
+caliptra-test-harness-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "98da0893f3fb9371f8dda7acfb6ccf8697ab253d" }
+ureg = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "98da0893f3fb9371f8dda7acfb6ccf8697ab253d" }
+dpe = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "98da0893f3fb9371f8dda7acfb6ccf8697ab253d", default-features = false, features = ["dpe_profile_p384_sha384"] }
 
 # local caliptra dependency; useful when developing
 # caliptra-api = { path = "../caliptra-sw/api" }

--- a/builder/src/firmware.rs
+++ b/builder/src/firmware.rs
@@ -15,8 +15,17 @@ pub mod hw_model_tests {
         bin_name: "mailbox_responder",
         ..BASE_FWID
     };
+
+    pub const HITLESS_UPDATE_FLOW: FwId = FwId {
+        bin_name: "hitless_update_flow",
+        ..BASE_FWID
+    };
 }
 
-pub const REGISTERED_FW: &[&FwId] = &[&hw_model_tests::MAILBOX_RESPONDER];
+pub const REGISTERED_FW: &[&FwId] = &[
+    &hw_model_tests::MAILBOX_RESPONDER,
+    &hw_model_tests::HITLESS_UPDATE_FLOW,
+];
 
-pub const CPTRA_REGISTERED_FW: &[&FwId] = &[];
+pub const CPTRA_REGISTERED_FW: &[&FwId] =
+    &[&caliptra_builder::firmware::hw_model_tests::MCU_HITLESS_UPDATE_FLOW];

--- a/hw/model/test-fw/Cargo.toml
+++ b/hw/model/test-fw/Cargo.toml
@@ -33,6 +33,11 @@ riscv-csr.workspace = true
 rv32i.workspace = true
 
 [[bin]]
+name = "hitless_update_flow"
+path = "hitless_update_flow.rs"
+required-features = ["riscv"]
+
+[[bin]]
 name = "mailbox_responder"
 path = "mailbox_responder.rs"
 required-features = ["riscv"]

--- a/hw/model/test-fw/hitless_update_flow.rs
+++ b/hw/model/test-fw/hitless_update_flow.rs
@@ -1,0 +1,109 @@
+// Licensed under the Apache-2.0 license
+
+//! A very simple program that follows hitless update flows. Must be used with corresponding
+//! Caliptra program.
+
+#![no_main]
+#![no_std]
+
+use mcu_rom_common::{fatal_error, McuBootMilestones, RomEnv};
+use registers_generated::mci;
+use romtime::McuResetReason;
+use tock_registers::interfaces::{ReadWriteable, Readable, Writeable};
+
+// Needed to bring in startup code
+#[allow(unused)]
+use mcu_test_harness;
+
+fn wait_for_firmware_ready(mci: &romtime::Mci, cptra: &mcu_rom_common::Soc) {
+    let notif0 = &mci.registers.intr_block_rf_notif0_internal_intr_r;
+    // Wait for a reset request from Caliptra
+    while !notif0.is_set(mci::bits::Notif0IntrT::NotifCptraMcuResetReqSts) {
+        if cptra.cptra_fw_fatal_error() {
+            romtime::println!("[mcu-rom] Caliptra reported a fatal error");
+            fatal_error(6);
+        }
+    }
+    // Clear the reset request interrupt
+    notif0.modify(mci::bits::Notif0IntrT::NotifCptraMcuResetReqSts::SET);
+}
+
+fn cold_boot(env: &mut RomEnv) -> ! {
+    let mci = &env.mci;
+    let cptra = &env.soc;
+
+    // Release Caliptra from reset because we need to use its test ROM
+    romtime::println!("[mcu-rom] Setting Caliptra boot go");
+    mci.caliptra_boot_go();
+    mci.set_flow_milestone(McuBootMilestones::CPTRA_BOOT_GO_ASSERTED.into());
+    romtime::println!(
+        "[mcu-rom] Waiting for Caliptra to be ready for fuses: {}",
+        cptra.ready_for_fuses()
+    );
+    while !cptra.ready_for_fuses() {}
+    romtime::println!("[mcu-rom] Setting Caliptra fuse write done");
+    cptra.fuse_write_done();
+
+    // Wait for "firmware" to be ready
+    wait_for_firmware_ready(mci, cptra);
+
+    // Check for known pattern from Caliptra test ROM
+    if mci.registers.mcu_sram[0].get() != u32::from_be_bytes(*b"BFOR") {
+        romtime::println!(
+            "Expected 0xBFOR, got 0x{:08x}",
+            mci.registers.mcu_sram[0].get()
+        );
+        fatal_error(1);
+    }
+
+    // Notify Caliptra to continue
+    mci.registers.mcu_sram[0].set(u32::from_be_bytes(*b"CONT"));
+
+    // Wait for "hitlesss update" to be ready
+    wait_for_firmware_ready(mci, cptra);
+
+    romtime::println!("[mcu-rom] hitless update ready");
+    mci.set_flow_milestone(McuBootMilestones::COLD_BOOT_FLOW_COMPLETE.into());
+    mci.trigger_warm_reset();
+    loop {}
+}
+
+fn hitless_update(env: &mut RomEnv) -> ! {
+    let mci = &env.mci;
+
+    // Check for updated known pattern
+    if mci.registers.mcu_sram[0].get() != u32::from_be_bytes(*b"AFTR") {
+        romtime::println!(
+            "Expected AFTR, got 0x{:08x}",
+            mci.registers.mcu_sram[0].get()
+        );
+        fatal_error(1);
+    }
+    mci.set_flow_milestone(McuBootMilestones::FIRMWARE_BOOT_FLOW_COMPLETE.into());
+    loop {}
+}
+
+fn run() -> ! {
+    let mut env = RomEnv::new();
+
+    match env.mci.reset_reason_enum() {
+        McuResetReason::ColdBoot => {
+            romtime::println!("[mcu-rom] Cold boot detected");
+            cold_boot(&mut env);
+        }
+        McuResetReason::FirmwareHitlessUpdate => {
+            romtime::println!("[mcu-rom] Starting firmware hitless update flow");
+            hitless_update(&mut env);
+        }
+        reason => {
+            romtime::println!("[mcu-rom] Invalid reset reason {reason:?}");
+            fatal_error(0x1004); // Error code for invalid reset reason
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn main() {
+    mcu_test_harness::set_printer();
+    run();
+}

--- a/platforms/test_harness/src/fpga-start.s
+++ b/platforms/test_harness/src/fpga-start.s
@@ -43,14 +43,6 @@ _start:
     li a0, 0x50000000
     li a1, 16384
     add a1, a1, a0
-clear_dccm:
-    sw zero, 0(a0)
-    addi a0, a0, 4
-    bltu a0, a1, clear_dccm
-
-    li a0, 0xa8c00000
-    li a1, 393216
-    add a1, a1, a0
 clear_sram:
     sw zero, 0(a0)
     addi a0, a0, 4

--- a/tests/integration/Cargo.toml
+++ b/tests/integration/Cargo.toml
@@ -13,7 +13,9 @@ itrng = []
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow.workspace = true
 caliptra-api.workspace = true
+caliptra-builder.workspace = true
 caliptra-hw-model-types.workspace = true
 caliptra-hw-model.workspace = true
 caliptra-image-types.workspace = true

--- a/tests/integration/src/lib.rs
+++ b/tests/integration/src/lib.rs
@@ -3,10 +3,20 @@
 mod i3c_socket;
 #[cfg(feature = "fpga_realtime")]
 mod jtag;
+#[cfg(test)]
+mod rom;
 mod test_firmware_update;
 mod test_mctp_capsule_loopback;
 mod test_pldm_fw_update;
 mod test_soc_boot;
+
+pub fn platform() -> &'static str {
+    if cfg!(feature = "fpga_realtime") {
+        "fpga"
+    } else {
+        "emulator"
+    }
+}
 
 #[cfg(test)]
 mod test {

--- a/tests/integration/src/rom/mod.rs
+++ b/tests/integration/src/rom/mod.rs
@@ -1,0 +1,3 @@
+// Licensed under the Apache-2.0 license
+
+mod test_hitless_update;

--- a/tests/integration/src/rom/test_hitless_update.rs
+++ b/tests/integration/src/rom/test_hitless_update.rs
@@ -1,0 +1,54 @@
+// Licensed under the Apache-2.0 license
+
+use crate::platform;
+use anyhow::Result;
+use caliptra_hw_model::BootParams;
+use mcu_hw_model::{new, InitParams, McuHwModel};
+use mcu_rom_common::McuBootMilestones;
+
+// TODO(zhalvorsen): Enable this test for emulator when it is supported
+#[cfg_attr(not(feature = "fpga_realtime"), ignore)]
+#[test]
+fn test_hitless_update_flow() -> Result<()> {
+    let mcu_rom_id = &mcu_builder::firmware::hw_model_tests::HITLESS_UPDATE_FLOW;
+    let cptra_rom_id = &caliptra_builder::firmware::hw_model_tests::MCU_HITLESS_UPDATE_FLOW;
+    let (caliptra_rom, mcu_rom) = if let Ok(binaries) = mcu_builder::FirmwareBinaries::from_env() {
+        (
+            binaries.caliptra_test_rom(cptra_rom_id)?,
+            binaries.test_rom(mcu_rom_id)?,
+        )
+    } else {
+        let rom_file = mcu_builder::test_rom_build(Some(platform()), mcu_rom_id)?;
+        (
+            caliptra_builder::build_firmware_rom(cptra_rom_id).unwrap(),
+            std::fs::read(&rom_file)?,
+        )
+    };
+    let mut hw = new(
+        InitParams {
+            caliptra_rom: &caliptra_rom,
+            mcu_rom: &mcu_rom,
+            enable_mcu_uart_log: true,
+            ..Default::default()
+        },
+        BootParams::default(),
+    )?;
+
+    println!("Waiting for flow to start");
+    hw.step_until(|hw| {
+        hw.mci_boot_milestones()
+            .contains(McuBootMilestones::CPTRA_BOOT_GO_ASSERTED)
+    });
+
+    println!("Waiting for flow to finish");
+    hw.step_until(|hw| {
+        hw.mci_boot_milestones()
+            .contains(McuBootMilestones::FIRMWARE_BOOT_FLOW_COMPLETE)
+    });
+
+    assert!(hw
+        .mci_boot_milestones()
+        .contains(McuBootMilestones::FIRMWARE_BOOT_FLOW_COMPLETE));
+
+    Ok(())
+}


### PR DESCRIPTION
This adds a test to make sure the expected hitless update flow works on hardware.

This is currently ignored for emulation, but compatibly will be added later and this test will also be performed there.