### PR TITLE
Remove release from xtask alias

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,8 +1,8 @@
 # Licensed under the Apache-2.0 license
 
 [alias]
-xtask = "run --package xtask --release --"
-xtask-fpga = "run --package xtask --features=fpga_realtime --release --"
+xtask = "run --package xtask --"
+xtask-fpga = "run --package xtask --features=fpga_realtime --"
 
 [target.riscv32imc-unknown-none-elf]
 rustflags = [

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -91,18 +91,18 @@ jobs:
 
       - name: Run precheckin
         run: |
-          cargo --config "$EXTRA_CARGO_CONFIG" xtask precheckin
+          cargo --config "$EXTRA_CARGO_CONFIG" xtask precheckin --release
           sccache --show-stats
 
       - name: Run all tests
         run: |
           cargo clean
           # Build ROM and runtime binaries
-          cargo xtask all-build --platform emulator \
+          cargo xtask --release all-build --platform emulator \
             --runtime-features test-mctp-capsule-loopback \
             --separate-runtimes
 
           export CPTRA_FIRMWARE_BUNDLE="${PWD}/target/all-fw.zip"
           # TODO: remove this if we get larger GitHub runners
-          cargo --config "$EXTRA_CARGO_CONFIG" xtask test
+          cargo --config "$EXTRA_CARGO_CONFIG" xtask --release test
           sccache --show-stats


### PR DESCRIPTION
It makes working on xtask inconvenient due to compile times. Instead set release manually in CI.