### PR TITLE
[Infra] Windows Build Fixes for Emulator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1610,7 +1610,6 @@ dependencies = [
  "caliptra-emu-bus",
  "caliptra-emu-cpu",
  "caliptra-emu-periph",
- "caliptra-hw-model",
  "caliptra-registers",
  "clap 4.5.48",
  "ctrlc",

--- a/emulator/app/Cargo.toml
+++ b/emulator/app/Cargo.toml
@@ -14,7 +14,6 @@ caliptra-emu-cpu.workspace = true
 caliptra-emu-periph.workspace = true
 caliptra-emu-types.workspace = true
 caliptra-image-types.workspace = true
-caliptra-test.workspace = true
 chrono.workspace = true
 clap.workspace = true
 clap-num.workspace = true
@@ -53,6 +52,9 @@ tempfile.workspace = true
 tock-registers.workspace = true
 uuid.workspace = true
 zerocopy.workspace = true
+
+[dev-dependencies]
+caliptra-test.workspace = true
 
 [[bin]]
 name = "emulator"

--- a/emulator/caliptra/Cargo.toml
+++ b/emulator/caliptra/Cargo.toml
@@ -12,7 +12,6 @@ caliptra-api-types.workspace = true
 caliptra-emu-bus.workspace = true
 caliptra-emu-cpu.workspace = true
 caliptra-emu-periph.workspace = true
-caliptra-hw-model.workspace = true
 caliptra-registers.workspace = true
 clap.workspace = true
 ctrlc.workspace = true

--- a/emulator/caliptra/src/caliptra.rs
+++ b/emulator/caliptra/src/caliptra.rs
@@ -13,14 +13,13 @@ Abstract:
 --*/
 
 use caliptra_api_types::{DeviceLifecycle, SecurityState};
-use caliptra_emu_bus::Clock;
+use caliptra_emu_bus::{BusMmio, Clock};
 use caliptra_emu_cpu::{Cpu, CpuArgs, Pic};
 use caliptra_emu_periph::soc_reg::DebugManufService;
 use caliptra_emu_periph::{
     CaliptraRootBus, CaliptraRootBusArgs, DownloadIdevidCsrCb, MailboxInternal, MailboxRequester,
     Mci, ReadyForFwCb, SocToCaliptraBus, TbServicesCb, UploadUpdateFwCb,
 };
-use caliptra_hw_model::BusMmio;
 use std::io::{self, ErrorKind, Write};
 use std::path::PathBuf;
 use std::process::exit;

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -6,7 +6,11 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-fpga_realtime = ["mcu-hw-model/fpga_realtime"]
+fpga_realtime = [
+	"mcu-hw-model/fpga_realtime",
+	"dep:caliptra-hw-model",
+	"dep:mcu-hw-model",
+]
 
 [dependencies]
 caliptra-api-types.workspace = true
@@ -15,7 +19,7 @@ cargo_metadata.workspace = true
 cc.workspace = true
 caliptra-image-gen.workspace = true
 caliptra-image-types.workspace = true
-caliptra-hw-model.workspace = true
+caliptra-hw-model = { workspace = true, optional = true }
 clap.workspace = true
 clap-num.workspace = true
 crc32fast.workspace = true
@@ -24,7 +28,7 @@ mcu-builder.workspace = true
 mcu-config-emulator.workspace = true
 mcu-config-fpga.workspace = true
 mcu-rom-common.workspace = true
-mcu-hw-model.workspace = true
+mcu-hw-model = { workspace = true, optional = true }
 pldm-fw-pkg.workspace = true
 proc-macro2.workspace = true
 quote.workspace = true


### PR DESCRIPTION
*-hw-model has dependence on unix only crates.