### PR TITLE
errors: Create a central definition for fatal errors

### DIFF
--- a/platforms/emulator/rom/src/riscv.rs
+++ b/platforms/emulator/rom/src/riscv.rs
@@ -31,7 +31,7 @@ use mcu_config_emulator::flash::{
     PARTITION_TABLE,
 };
 use mcu_rom_common::flash::flash_partition::FlashPartition;
-use mcu_rom_common::{fatal_error, RomParameters};
+use mcu_rom_common::{fatal_error_raw, RomParameters};
 use romtime::HexWord;
 use zerocopy::{FromBytes, IntoBytes};
 
@@ -71,7 +71,7 @@ pub extern "C" fn rom_entry() -> ! {
             PARTITION_TABLE.size,
         )
         .map_err(|_| {
-            fatal_error(1);
+            fatal_error_raw(1);
         })
         .ok()
         .unwrap();
@@ -80,7 +80,7 @@ pub extern "C" fn rom_entry() -> ! {
         let active_partition = boot_cfg
             .get_active_partition()
             .map_err(|_| {
-                fatal_error(1);
+                fatal_error_raw(1);
             })
             .ok()
             .unwrap();
@@ -92,7 +92,7 @@ pub extern "C" fn rom_entry() -> ! {
             IMAGE_A_PARTITION.size,
         )
         .map_err(|_| {
-            fatal_error(1);
+            fatal_error_raw(1);
         })
         .ok()
         .unwrap();
@@ -103,7 +103,7 @@ pub extern "C" fn rom_entry() -> ! {
             IMAGE_B_PARTITION.size,
         )
         .map_err(|_| {
-            fatal_error(1);
+            fatal_error_raw(1);
         })
         .ok()
         .unwrap();
@@ -117,7 +117,7 @@ pub extern "C" fn rom_entry() -> ! {
                 romtime::println!("[mcu-rom] Booting from Partition B");
                 partition_b
             }
-            _ => fatal_error(1),
+            _ => fatal_error_raw(1),
         };
 
         mcu_rom_common::rom_start(RomParameters {

--- a/rom/src/cold_boot.rs
+++ b/rom/src/cold_boot.rs
@@ -20,7 +20,7 @@ use caliptra_api::mailbox::{CommandId, FeProgReq, MailboxReqHeader};
 use caliptra_api::CaliptraApiError;
 use caliptra_api::SocManager;
 use core::fmt::Write;
-use romtime::{CaliptraSoC, HexWord};
+use romtime::{CaliptraSoC, HexWord, McuError};
 use tock_registers::interfaces::Readable;
 use zerocopy::{transmute, IntoBytes};
 
@@ -70,7 +70,7 @@ impl ColdBoot {
                         romtime::println!("[mcu-rom] Error sending mailbox command");
                     }
                 }
-                fatal_error(6);
+                fatal_error(McuError::COLD_BOOT_FIELD_ENTROPY_PROG_START);
             }
             if let Err(err) = soc_manager.finish_mailbox_resp(8, 8) {
                 match err {
@@ -84,7 +84,7 @@ impl ColdBoot {
                         romtime::println!("[mcu-rom] Error finishing mailbox command");
                     }
                 }
-                fatal_error(7);
+                fatal_error(McuError::COLD_BOOT_FIELD_ENTROPY_PROG_FINISH);
             };
 
             // Set status for each partition completion
@@ -153,7 +153,7 @@ impl BootFlow for ColdBoot {
             mci.set_flow_checkpoint(McuRomBootStatus::LifecycleTransitionStarted.into());
             if let Err(err) = lc.transition(state, &token) {
                 romtime::println!("[mcu-rom] Error transitioning lifecycle: {:?}", err);
-                fatal_error(err.into());
+                fatal_error(err);
             }
             romtime::println!("Lifecycle transition successful; halting");
             mci.set_flow_checkpoint(McuRomBootStatus::LifecycleTransitionComplete.into());
@@ -162,8 +162,8 @@ impl BootFlow for ColdBoot {
 
         // FPGA has problems with the integrity check, so we disable it
         if let Err(err) = otp.init() {
-            romtime::println!("[mcu-rom] Error initializing OTP: {}", HexWord(err as u32));
-            fatal_error(err as u32);
+            romtime::println!("[mcu-rom] Error initializing OTP: {}", HexWord(err.into()));
+            fatal_error(err);
         }
         mci.set_flow_checkpoint(McuRomBootStatus::OtpControllerInitialized.into());
 
@@ -200,8 +200,8 @@ impl BootFlow for ColdBoot {
                 fuses
             }
             Err(e) => {
-                romtime::println!("Error reading fuses: {}", HexWord(e as u32));
-                fatal_error(1);
+                romtime::println!("Error reading fuses: {}", HexWord(e.into()));
+                fatal_error(e);
             }
         };
 
@@ -267,7 +267,7 @@ impl BootFlow for ColdBoot {
         while !soc.ready_for_mbox() {
             if soc.cptra_fw_fatal_error() {
                 romtime::println!("[mcu-rom] Caliptra reported a fatal error");
-                fatal_error(3);
+                fatal_error(McuError::COLD_BOOT_CALIPTRA_FATAL_ERROR_BEFORE_MB_READY);
             }
         }
 
@@ -287,7 +287,7 @@ impl BootFlow for ColdBoot {
                     romtime::println!("[mcu-rom] Error sending mailbox command: {:?}", err);
                 }
             }
-            fatal_error(4);
+            fatal_error(McuError::COLD_BOOT_START_RI_DOWNLOAD_ERROR);
         }
         mci.set_flow_checkpoint(McuRomBootStatus::RiDownloadFirmwareCommandSent.into());
 
@@ -309,7 +309,7 @@ impl BootFlow for ColdBoot {
                     romtime::println!("[mcu-rom] Error finishing mailbox command");
                 }
             }
-            fatal_error(5);
+            fatal_error(McuError::COLD_BOOT_FINISH_RI_DOWNLOAD_ERROR);
         };
         mci.set_flow_checkpoint(McuRomBootStatus::RiDownloadFirmwareComplete.into());
         mci.set_flow_milestone(McuBootMilestones::RI_DOWNLOAD_COMPLETED.into());
@@ -321,7 +321,7 @@ impl BootFlow for ColdBoot {
                 mci.set_flow_checkpoint(McuRomBootStatus::FlashRecoveryFlowStarted.into());
 
                 crate::recovery::load_flash_image_to_recovery(i3c_base, flash_driver)
-                    .map_err(|_| fatal_error(1))
+                    .map_err(|_| fatal_error(McuError::COLD_BOOT_LOAD_IMAGE_ERROR))
                     .unwrap();
 
                 romtime::println!("[mcu-rom] Flash Recovery flow complete");
@@ -346,7 +346,7 @@ impl BootFlow for ColdBoot {
             romtime::println!("[mcu-rom] Verifying firmware header");
             if !image_verifier.verify_header(header, &fuses) {
                 romtime::println!("Firmware header verification failed; halting");
-                fatal_error(1);
+                fatal_error(McuError::COLD_BOOT_HEADER_VERIFY_ERROR);
             }
         }
 
@@ -357,7 +357,7 @@ impl BootFlow for ColdBoot {
         // Safety: this address is valid
         if unsafe { core::ptr::read_volatile(firmware_ptr) } == 0 {
             romtime::println!("Invalid firmware detected; halting");
-            fatal_error(1);
+            fatal_error(McuError::COLD_BOOT_INVALID_FIRMWARE);
         }
         romtime::println!("[mcu-rom] Firmware load detected");
         mci.set_flow_checkpoint(McuRomBootStatus::FirmwareValidationComplete.into());
@@ -388,6 +388,6 @@ impl BootFlow for ColdBoot {
         mci.set_flow_milestone(McuBootMilestones::COLD_BOOT_FLOW_COMPLETE.into());
         mci.trigger_warm_reset();
         romtime::println!("[mcu-rom] ERROR: Still running after reset request!");
-        fatal_error(8);
+        fatal_error(McuError::COLD_BOOT_RESET_ERROR);
     }
 }

--- a/rom/src/fw_boot.rs
+++ b/rom/src/fw_boot.rs
@@ -17,6 +17,7 @@ use crate::{
     MCU_MEMORY_MAP,
 };
 use core::fmt::Write;
+use romtime::McuError;
 
 pub struct FwBoot {}
 
@@ -33,7 +34,7 @@ impl BootFlow for FwBoot {
         // Safety: this address is valid
         if unsafe { core::ptr::read_volatile(firmware_ptr) } == 0 {
             romtime::println!("Invalid firmware detected; halting");
-            fatal_error(1);
+            fatal_error(McuError::FW_BOOT_INVALID_FIRMWARE);
         }
 
         // Jump to firmware

--- a/rom/src/fw_hitless_update.rs
+++ b/rom/src/fw_hitless_update.rs
@@ -19,7 +19,7 @@ use crate::MCU_MEMORY_MAP;
 use crate::{fatal_error, BootFlow, RomEnv, RomParameters};
 use caliptra_api::{mailbox::MailboxRespHeader, CaliptraApiError};
 use core::fmt::Write;
-use romtime::HexWord;
+use romtime::{HexWord, McuError};
 
 pub struct FwHitlessUpdate {}
 
@@ -47,7 +47,7 @@ impl BootFlow for FwHitlessUpdate {
                     romtime::println!("[mcu-rom] Error finishing mailbox command");
                 }
             }
-            fatal_error(7);
+            fatal_error(McuError::FW_HITLESS_UPDATE_CLEAR_MB_ERROR);
         };
 
         while !soc.fw_ready() {}

--- a/rom/src/i3c.rs
+++ b/rom/src/i3c.rs
@@ -5,7 +5,7 @@ use registers_generated::i3c::bits::{
     DeviceStatus0, HcControl, IndirectFifoCtrl0, QueueThldCtrl, RingHeadersSectionOffset,
     StbyCrCapabilities, StbyCrControl, StbyCrDeviceAddr, StbyCrVirtDeviceAddr, TtiQueueThldCtrl,
 };
-use romtime::{HexWord, StaticRef};
+use romtime::{HexWord, McuError, StaticRef};
 use tock_registers::interfaces::{ReadWriteable, Readable, Writeable};
 
 use crate::fatal_error;
@@ -40,7 +40,7 @@ impl I3c {
             .read(RingHeadersSectionOffset::SectionOffset);
         if rhso != 0 {
             romtime::println!("[mcu-rom-i3c] RING_HEADERS_SECTION_OFFSET is not 0");
-            fatal_error(0x101);
+            fatal_error(McuError::I3C_CONFIG_RING_HEADER_ERROR);
         }
 
         // initialize timing registers
@@ -116,7 +116,7 @@ impl I3c {
             .is_set(StbyCrCapabilities::TargetXactSupport)
         {
             romtime::println!("[mcu-rom-i3c] I3C target transaction support is not enabled");
-            fatal_error(0x102)
+            fatal_error(McuError::I3C_CONFIG_STDBY_CTRL_MODE_ERROR)
         }
 
         // program a static address

--- a/rom/src/lib.rs
+++ b/rom/src/lib.rs
@@ -71,13 +71,13 @@ fn panic_is_possible() {
 #[cfg(target_arch = "riscv32")]
 fn rom_panic(_: &core::panic::PanicInfo) -> ! {
     panic_is_possible();
-    fatal_error(0);
+    fatal_error_raw(0);
 }
 
 #[inline(never)]
 #[allow(dead_code)]
 #[allow(clippy::empty_loop)]
-pub fn fatal_error(code: u32) -> ! {
+pub fn fatal_error_raw(code: u32) -> ! {
     #[allow(static_mut_refs)]
     if let Some(handler) = unsafe { FATAL_ERROR_HANDLER.as_mut() } {
         handler.fatal_error(code);
@@ -85,4 +85,10 @@ pub fn fatal_error(code: u32) -> ! {
         // If no handler is set, just loop forever
         loop {}
     }
+}
+
+#[inline(never)]
+#[allow(dead_code)]
+pub fn fatal_error(error: romtime::McuError) -> ! {
+    fatal_error_raw(error.into())
 }

--- a/rom/src/rom.rs
+++ b/rom/src/rom.rs
@@ -31,6 +31,7 @@ use registers_generated::fuses::Fuses;
 use registers_generated::mci;
 use registers_generated::mci::bits::SecurityState::DeviceLifecycle;
 use registers_generated::soc;
+use romtime::McuError;
 use romtime::{HexWord, StaticRef};
 use tock_registers::interfaces::ReadWriteable;
 use tock_registers::interfaces::{Readable, Writeable};
@@ -158,7 +159,7 @@ impl Soc {
         if fuses.cptra_core_vendor_pk_hash_0().len() != self.registers.fuse_vendor_pk_hash.len() * 4
         {
             romtime::println!("[mcu-fuse-write] Key manifest PK hash length mismatch");
-            fatal_error(1);
+            fatal_error(McuError::SOC_KEY_MANIFEST_PK_HASH_LEN_MISMATCH);
         }
         for i in 0..fuses.cptra_core_vendor_pk_hash_0().len() / 4 {
             let word = u32::from_le_bytes(
@@ -180,7 +181,7 @@ impl Soc {
         //romtime::println!("");
         if fuses.cptra_core_runtime_svn().len() != self.registers.fuse_runtime_svn.len() * 4 {
             romtime::println!("[mcu-fuse-write] Runtime SVN length mismatch");
-            fatal_error(1);
+            fatal_error(McuError::SOC_RT_SVN_LEN_MISMATCH);
         }
         for i in 0..fuses.cptra_core_runtime_svn().len() / 4 {
             let word = u32::from_le_bytes(
@@ -196,7 +197,7 @@ impl Soc {
             != self.registers.fuse_soc_manifest_svn.len() * 4
         {
             romtime::println!("[mcu-fuse-write] SoC Manifest SVN length mismatch");
-            fatal_error(1);
+            fatal_error(McuError::SOC_MANIFEST_SVN_LEN_MISMATCH);
         }
         for i in 0..fuses.cptra_core_soc_manifest_svn().len() / 4 {
             let word = u32::from_le_bytes(
@@ -241,7 +242,7 @@ impl Soc {
             != size_of_val(&self.registers.fuse_manuf_dbg_unlock_token)
         {
             romtime::println!("[mcu-fuse-write] SS manuf debug unlock token length mismatch");
-            fatal_error(1);
+            fatal_error(McuError::SOC_MANUF_DEBUG_UNLOCK_TOKEN_LEN_MISMATCH);
         }
         for i in 0..fuses.cptra_ss_manuf_debug_unlock_token().len() / 4 {
             let word = u32::from_le_bytes(
@@ -266,7 +267,7 @@ impl Soc {
         while !self.fw_ready() {
             if self.cptra_fw_fatal_error() {
                 romtime::println!("[mcu-rom] Caliptra reported a fatal error");
-                fatal_error(6);
+                fatal_error(McuError::SOC_CALIPTRA_FATAL_ERROR_BEFORE_FW_READY);
             }
         }
         // Clear the reset request interrupt
@@ -338,7 +339,7 @@ pub fn rom_start(params: RomParameters) {
         }
         McuResetReason::Invalid => {
             romtime::println!("[mcu-rom] Invalid reset reason: multiple bits set");
-            fatal_error(0x1004); // Error code for invalid reset reason
+            fatal_error(McuError::ROM_INVALID_RESET_REASON);
         }
     }
 }

--- a/rom/src/warm_boot.rs
+++ b/rom/src/warm_boot.rs
@@ -14,6 +14,8 @@ Abstract:
 
 #![allow(clippy::empty_loop)]
 
+use romtime::McuError;
+
 use crate::{
     fatal_error, BootFlow, McuBootMilestones, McuRomBootStatus, RomEnv, RomParameters,
     MCU_MEMORY_MAP,
@@ -65,7 +67,7 @@ impl BootFlow for WarmBoot {
         // Safety: this address is valid
         if unsafe { core::ptr::read_volatile(firmware_ptr) } == 0 {
             romtime::println!("Invalid firmware detected; halting");
-            fatal_error(1);
+            fatal_error(McuError::WARM_BOOT_INVALID_FIRMWARE);
         }
 
         // Reset so FirmwareBootReset can jump to firmware
@@ -74,6 +76,6 @@ impl BootFlow for WarmBoot {
         mci.set_flow_milestone(McuBootMilestones::WARM_RESET_FLOW_COMPLETE.into());
         mci.trigger_warm_reset();
         romtime::println!("[mcu-rom] ERROR: Still running after reset request!");
-        fatal_error(8);
+        fatal_error(McuError::WARM_BOOT_RESET_ERROR);
     }
 }

--- a/romtime/src/error.rs
+++ b/romtime/src/error.rs
@@ -1,15 +1,256 @@
 // Licensed under the Apache-2.0 license
+use core::convert::From;
+use core::num::{NonZeroU32, TryFromIntError};
 
-#[allow(dead_code)]
-#[repr(u32)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum McuError {
-    InvalidDataError = 0xf000_0001,
-    FusesError = 0xf000_0002,
+/// MCU Error Type
+/// Derives debug, copy, clone, eq, and partial eq
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct McuError(pub NonZeroU32);
+
+/// Macro to define error constants ensuring uniqueness
+///
+/// This macro takes a list of (name, value, doc) tuples and generates
+/// constant definitions for each error code.
+#[macro_export]
+macro_rules! define_error_constants {
+    ($(($name:ident, $value:expr, $doc:expr)),* $(,)?) => {
+        $(
+            #[doc = $doc]
+            pub const $name: McuError = McuError::new_const($value);
+        )*
+
+        #[cfg(test)]
+        /// Returns a vector of all defined error constants for testing uniqueness
+        pub fn all_constants() -> Vec<(& 'static str, u32)> {
+            vec![
+                $(
+                    (stringify!($name), $value),
+                )*
+            ]
+        }
+    };
+}
+
+impl McuError {
+    /// Create a MCU error; intended to only be used from const contexts, as we don't want
+    /// runtime panics if val is zero. The preferred way to get a McuError from a u32 is to
+    /// use `McuError::try_from()` from the `TryFrom` trait impl.
+    const fn new_const(val: u32) -> Self {
+        match NonZeroU32::new(val) {
+            Some(val) => Self(val),
+            None => panic!("McuError cannot be 0"),
+        }
+    }
+
+    // Use the macro to define all error constants
+    define_error_constants![
+        (
+            COLD_BOOT_CALIPTRA_FATAL_ERROR_BEFORE_MB_READY,
+            0x1_0000,
+            "Cold boot Caliptra fatal error before mailbox was ready"
+        ),
+        (
+            COLD_BOOT_START_RI_DOWNLOAD_ERROR,
+            0x1_0001,
+            "Cold boot failed to start recovery interface download"
+        ),
+        (
+            COLD_BOOT_FINISH_RI_DOWNLOAD_ERROR,
+            0x1_0002,
+            "Cold boot failed to finish recovery interface download"
+        ),
+        (
+            COLD_BOOT_LOAD_IMAGE_ERROR,
+            0x1_0003,
+            "Cold boot failed to load firmware image"
+        ),
+        (
+            COLD_BOOT_HEADER_VERIFY_ERROR,
+            0x1_0004,
+            "Cold boot failed to verify firmware image header"
+        ),
+        (
+            COLD_BOOT_INVALID_FIRMWARE,
+            0x1_0005,
+            "Cold boot firmware is invalid"
+        ),
+        (
+            COLD_BOOT_RESET_ERROR,
+            0x1_0006,
+            "Cold boot reset to firmware boot error"
+        ),
+        (
+            COLD_BOOT_FIELD_ENTROPY_PROG_START,
+            0x1_0007,
+            "Cold boot failed to start field entropy program"
+        ),
+        (
+            COLD_BOOT_FIELD_ENTROPY_PROG_FINISH,
+            0x1_0008,
+            "Cold boot failed to finish field entropy program"
+        ),
+        (
+            FW_BOOT_INVALID_FIRMWARE,
+            0x1_0009,
+            "Firmware boot reset invalid firmware"
+        ),
+        (
+            FW_HITLESS_UPDATE_CLEAR_MB_ERROR,
+            0x1_000a,
+            "Hitless update failed to clear the Caliptra mailbox"
+        ),
+        (
+            WARM_BOOT_INVALID_FIRMWARE,
+            0x1_000b,
+            "Warm boot invalid firmware"
+        ),
+        (WARM_BOOT_RESET_ERROR, 0x1000c, "Warm boot reset error"),
+        (ROM_INVALID_RESET_REASON, 0x1_000d, "Invalid reset reason"),
+        (LC_TRANSITION_ERROR, 0x2_0000, "Lifecycle transition error"),
+        (LC_TOKEN_ERROR, 0x2_0001, "Lifecycle token error"),
+        (LC_OTP_ERROR, 0x2_0002, "Lifecycle OTP error"),
+        (LC_FLASH_RMA_ERROR, 0x2_0003, "Lifecycle flash RMA error"),
+        (
+            LC_TRANSITION_COUNT_ERROR,
+            0x2_0004,
+            "Lifecycle transition count error"
+        ),
+        (LC_STATE_ERROR, 0x2_0005, "Lifecycle state error"),
+        (
+            LC_BUS_INTEG_ERROR,
+            0x2_0006,
+            "Lifecycle bus integrity error"
+        ),
+        (
+            LC_OTP_PARTITION_ERROR,
+            0x2_0007,
+            "Lifecycle OTP partition error"
+        ),
+        (
+            OTP_INIT_STATUS_ERROR,
+            0x3_0000,
+            "OTP controller status error during initialization"
+        ),
+        (
+            OTP_INIT_NOT_IDLE,
+            0x3_0001,
+            "OTP controller not idle during initialization"
+        ),
+        (OTP_INVALID_DATA_ERROR, 0x3_0002, "OTP invalid data error"),
+        (OTP_READ_ERROR, 0x3_0003, "Failed to read from OTP"),
+        (
+            OTP_WRITE_DWORD_ERROR,
+            0x3_0004,
+            "Failed to write dword to OTP"
+        ),
+        (
+            OTP_WRITE_WORD_ERROR,
+            0x3_0005,
+            "Failed to write word to OTP"
+        ),
+        (
+            OTP_FINALIZE_DIGEST_ERROR,
+            0x3_0006,
+            "Failed to finalize digest"
+        ),
+        (
+            I3C_CONFIG_RING_HEADER_ERROR,
+            0x4_0000,
+            "I3C config ring header error"
+        ),
+        (
+            I3C_CONFIG_STDBY_CTRL_MODE_ERROR,
+            0x4_0001,
+            "I3C config standby controller mode error"
+        ),
+        (
+            SOC_KEY_MANIFEST_PK_HASH_LEN_MISMATCH,
+            0x5_0000,
+            "SOC key manifest PK hash length mismatch"
+        ),
+        (
+            SOC_RT_SVN_LEN_MISMATCH,
+            0x5_0001,
+            "Runtime SVN length mismatch"
+        ),
+        (
+            SOC_MANIFEST_SVN_LEN_MISMATCH,
+            0x5_0002,
+            "SOC Manifest SVN length mismatch"
+        ),
+        (
+            SOC_MANUF_DEBUG_UNLOCK_TOKEN_LEN_MISMATCH,
+            0x5_0003,
+            "SOC manuf debug unlock token length mismatch"
+        ),
+        (
+            SOC_CALIPTRA_FATAL_ERROR_BEFORE_FW_READY,
+            0x5_0004,
+            "SOC Caliptra fatal error before firmware ready"
+        ),
+    ];
+}
+
+impl From<core::num::NonZeroU32> for crate::McuError {
+    fn from(val: core::num::NonZeroU32) -> Self {
+        crate::McuError(val)
+    }
+}
+
+impl From<McuError> for core::num::NonZeroU32 {
+    fn from(val: McuError) -> Self {
+        val.0
+    }
 }
 
 impl From<McuError> for u32 {
-    fn from(error: McuError) -> Self {
-        error as u32
+    fn from(val: McuError) -> Self {
+        core::num::NonZeroU32::from(val).get()
+    }
+}
+
+impl TryFrom<u32> for McuError {
+    type Error = TryFromIntError;
+    fn try_from(val: u32) -> Result<Self, TryFromIntError> {
+        match NonZeroU32::try_from(val) {
+            Ok(val) => Ok(McuError(val)),
+            Err(err) => Err(err),
+        }
+    }
+}
+
+pub type McuResult<T> = Result<T, McuError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn test_try_from() {
+        assert!(McuError::try_from(0).is_err());
+        assert_eq!(
+            Ok(McuError::COLD_BOOT_CALIPTRA_FATAL_ERROR_BEFORE_MB_READY),
+            McuError::try_from(0x1_0000)
+        );
+    }
+
+    #[test]
+    fn test_error_constants_uniqueness() {
+        let constants = McuError::all_constants();
+        let mut error_values = HashSet::new();
+        let mut duplicates = Vec::new();
+
+        for (name, value) in constants {
+            if !error_values.insert(value) {
+                duplicates.push((name, value));
+            }
+        }
+
+        assert!(
+            duplicates.is_empty(),
+            "Found duplicate error codes: {:?}",
+            duplicates
+        );
     }
 }


### PR DESCRIPTION
Fixes #502

Creates unique error codes with the same strategy as Caliptra to define ROM fatal errors.