### PR TITLE
[rom] update MCU ROM to provision SW_MANUF fuse fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,7 +262,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 [[package]]
 name = "caliptra-api"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e86b933225d2d9ab2446b02dbb0f44d3d2c49117#e86b933225d2d9ab2446b02dbb0f44d3d2c49117"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=691aed1c23e8e413ab867de75867ca9165eb1afe#691aed1c23e8e413ab867de75867ca9165eb1afe"
 dependencies = [
  "bitflags 2.9.4",
  "caliptra-api-types",
@@ -277,7 +277,7 @@ dependencies = [
 [[package]]
 name = "caliptra-api-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e86b933225d2d9ab2446b02dbb0f44d3d2c49117#e86b933225d2d9ab2446b02dbb0f44d3d2c49117"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=691aed1c23e8e413ab867de75867ca9165eb1afe#691aed1c23e8e413ab867de75867ca9165eb1afe"
 dependencies = [
  "caliptra-image-types",
 ]
@@ -285,7 +285,7 @@ dependencies = [
 [[package]]
 name = "caliptra-auth-man-gen"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e86b933225d2d9ab2446b02dbb0f44d3d2c49117#e86b933225d2d9ab2446b02dbb0f44d3d2c49117"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=691aed1c23e8e413ab867de75867ca9165eb1afe#691aed1c23e8e413ab867de75867ca9165eb1afe"
 dependencies = [
  "anyhow",
  "bitflags 2.9.4",
@@ -300,7 +300,7 @@ dependencies = [
 [[package]]
 name = "caliptra-auth-man-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e86b933225d2d9ab2446b02dbb0f44d3d2c49117#e86b933225d2d9ab2446b02dbb0f44d3d2c49117"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=691aed1c23e8e413ab867de75867ca9165eb1afe#691aed1c23e8e413ab867de75867ca9165eb1afe"
 dependencies = [
  "bitfield",
  "bitflags 2.9.4",
@@ -315,7 +315,7 @@ dependencies = [
 [[package]]
 name = "caliptra-builder"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e86b933225d2d9ab2446b02dbb0f44d3d2c49117#e86b933225d2d9ab2446b02dbb0f44d3d2c49117"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=691aed1c23e8e413ab867de75867ca9165eb1afe#691aed1c23e8e413ab867de75867ca9165eb1afe"
 dependencies = [
  "anyhow",
  "caliptra-image-crypto",
@@ -340,7 +340,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cfi-derive"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e86b933225d2d9ab2446b02dbb0f44d3d2c49117#e86b933225d2d9ab2446b02dbb0f44d3d2c49117"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=691aed1c23e8e413ab867de75867ca9165eb1afe#691aed1c23e8e413ab867de75867ca9165eb1afe"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -362,7 +362,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cfi-lib"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e86b933225d2d9ab2446b02dbb0f44d3d2c49117#e86b933225d2d9ab2446b02dbb0f44d3d2c49117"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=691aed1c23e8e413ab867de75867ca9165eb1afe#691aed1c23e8e413ab867de75867ca9165eb1afe"
 dependencies = [
  "caliptra-error",
  "caliptra-registers",
@@ -377,7 +377,7 @@ source = "git+https://github.com/chipsalliance/caliptra-cfi.git?rev=a98e499d279e
 [[package]]
 name = "caliptra-coverage"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e86b933225d2d9ab2446b02dbb0f44d3d2c49117#e86b933225d2d9ab2446b02dbb0f44d3d2c49117"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=691aed1c23e8e413ab867de75867ca9165eb1afe#691aed1c23e8e413ab867de75867ca9165eb1afe"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -395,7 +395,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cpu"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e86b933225d2d9ab2446b02dbb0f44d3d2c49117#e86b933225d2d9ab2446b02dbb0f44d3d2c49117"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=691aed1c23e8e413ab867de75867ca9165eb1afe#691aed1c23e8e413ab867de75867ca9165eb1afe"
 dependencies = [
  "caliptra-drivers",
  "caliptra-registers",
@@ -405,7 +405,7 @@ dependencies = [
 [[package]]
 name = "caliptra-drivers"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e86b933225d2d9ab2446b02dbb0f44d3d2c49117#e86b933225d2d9ab2446b02dbb0f44d3d2c49117"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=691aed1c23e8e413ab867de75867ca9165eb1afe#691aed1c23e8e413ab867de75867ca9165eb1afe"
 dependencies = [
  "arrayvec",
  "bitfield",
@@ -431,7 +431,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-bus"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e86b933225d2d9ab2446b02dbb0f44d3d2c49117#e86b933225d2d9ab2446b02dbb0f44d3d2c49117"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=691aed1c23e8e413ab867de75867ca9165eb1afe#691aed1c23e8e413ab867de75867ca9165eb1afe"
 dependencies = [
  "caliptra-emu-types",
  "tock-registers",
@@ -441,7 +441,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-cpu"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e86b933225d2d9ab2446b02dbb0f44d3d2c49117#e86b933225d2d9ab2446b02dbb0f44d3d2c49117"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=691aed1c23e8e413ab867de75867ca9165eb1afe#691aed1c23e8e413ab867de75867ca9165eb1afe"
 dependencies = [
  "bit-vec",
  "bitfield",
@@ -455,7 +455,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e86b933225d2d9ab2446b02dbb0f44d3d2c49117#e86b933225d2d9ab2446b02dbb0f44d3d2c49117"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=691aed1c23e8e413ab867de75867ca9165eb1afe#691aed1c23e8e413ab867de75867ca9165eb1afe"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -470,7 +470,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-derive"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e86b933225d2d9ab2446b02dbb0f44d3d2c49117#e86b933225d2d9ab2446b02dbb0f44d3d2c49117"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=691aed1c23e8e413ab867de75867ca9165eb1afe#691aed1c23e8e413ab867de75867ca9165eb1afe"
 dependencies = [
  "caliptra-emu-bus",
  "caliptra-emu-types",
@@ -481,7 +481,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-periph"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e86b933225d2d9ab2446b02dbb0f44d3d2c49117#e86b933225d2d9ab2446b02dbb0f44d3d2c49117"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=691aed1c23e8e413ab867de75867ca9165eb1afe#691aed1c23e8e413ab867de75867ca9165eb1afe"
 dependencies = [
  "aes",
  "arrayref",
@@ -508,17 +508,17 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e86b933225d2d9ab2446b02dbb0f44d3d2c49117#e86b933225d2d9ab2446b02dbb0f44d3d2c49117"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=691aed1c23e8e413ab867de75867ca9165eb1afe#691aed1c23e8e413ab867de75867ca9165eb1afe"
 
 [[package]]
 name = "caliptra-error"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e86b933225d2d9ab2446b02dbb0f44d3d2c49117#e86b933225d2d9ab2446b02dbb0f44d3d2c49117"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=691aed1c23e8e413ab867de75867ca9165eb1afe#691aed1c23e8e413ab867de75867ca9165eb1afe"
 
 [[package]]
 name = "caliptra-gen-linker-scripts"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e86b933225d2d9ab2446b02dbb0f44d3d2c49117#e86b933225d2d9ab2446b02dbb0f44d3d2c49117"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=691aed1c23e8e413ab867de75867ca9165eb1afe#691aed1c23e8e413ab867de75867ca9165eb1afe"
 dependencies = [
  "caliptra_common",
 ]
@@ -526,7 +526,7 @@ dependencies = [
 [[package]]
 name = "caliptra-hw-model"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e86b933225d2d9ab2446b02dbb0f44d3d2c49117#e86b933225d2d9ab2446b02dbb0f44d3d2c49117"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=691aed1c23e8e413ab867de75867ca9165eb1afe#691aed1c23e8e413ab867de75867ca9165eb1afe"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -564,7 +564,7 @@ dependencies = [
 [[package]]
 name = "caliptra-hw-model-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e86b933225d2d9ab2446b02dbb0f44d3d2c49117#e86b933225d2d9ab2446b02dbb0f44d3d2c49117"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=691aed1c23e8e413ab867de75867ca9165eb1afe#691aed1c23e8e413ab867de75867ca9165eb1afe"
 dependencies = [
  "caliptra-api-types",
  "rand",
@@ -573,7 +573,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e86b933225d2d9ab2446b02dbb0f44d3d2c49117#e86b933225d2d9ab2446b02dbb0f44d3d2c49117"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=691aed1c23e8e413ab867de75867ca9165eb1afe#691aed1c23e8e413ab867de75867ca9165eb1afe"
 dependencies = [
  "anyhow",
  "caliptra-image-gen",
@@ -593,7 +593,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-elf"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e86b933225d2d9ab2446b02dbb0f44d3d2c49117#e86b933225d2d9ab2446b02dbb0f44d3d2c49117"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=691aed1c23e8e413ab867de75867ca9165eb1afe#691aed1c23e8e413ab867de75867ca9165eb1afe"
 dependencies = [
  "anyhow",
  "caliptra-image-gen",
@@ -604,7 +604,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-fake-keys"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e86b933225d2d9ab2446b02dbb0f44d3d2c49117#e86b933225d2d9ab2446b02dbb0f44d3d2c49117"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=691aed1c23e8e413ab867de75867ca9165eb1afe#691aed1c23e8e413ab867de75867ca9165eb1afe"
 dependencies = [
  "caliptra-image-gen",
  "caliptra-image-types",
@@ -615,7 +615,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-gen"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e86b933225d2d9ab2446b02dbb0f44d3d2c49117#e86b933225d2d9ab2446b02dbb0f44d3d2c49117"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=691aed1c23e8e413ab867de75867ca9165eb1afe#691aed1c23e8e413ab867de75867ca9165eb1afe"
 dependencies = [
  "anyhow",
  "bitflags 2.9.4",
@@ -632,7 +632,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e86b933225d2d9ab2446b02dbb0f44d3d2c49117#e86b933225d2d9ab2446b02dbb0f44d3d2c49117"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=691aed1c23e8e413ab867de75867ca9165eb1afe#691aed1c23e8e413ab867de75867ca9165eb1afe"
 dependencies = [
  "caliptra-cfi-derive",
  "caliptra-cfi-lib",
@@ -648,7 +648,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-verify"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e86b933225d2d9ab2446b02dbb0f44d3d2c49117#e86b933225d2d9ab2446b02dbb0f44d3d2c49117"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=691aed1c23e8e413ab867de75867ca9165eb1afe#691aed1c23e8e413ab867de75867ca9165eb1afe"
 dependencies = [
  "bitflags 2.9.4",
  "caliptra-cfi-derive",
@@ -663,7 +663,7 @@ dependencies = [
 [[package]]
 name = "caliptra-kat"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e86b933225d2d9ab2446b02dbb0f44d3d2c49117#e86b933225d2d9ab2446b02dbb0f44d3d2c49117"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=691aed1c23e8e413ab867de75867ca9165eb1afe#691aed1c23e8e413ab867de75867ca9165eb1afe"
 dependencies = [
  "caliptra-drivers",
  "caliptra-lms-types",
@@ -675,7 +675,7 @@ dependencies = [
 [[package]]
 name = "caliptra-lms-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e86b933225d2d9ab2446b02dbb0f44d3d2c49117#e86b933225d2d9ab2446b02dbb0f44d3d2c49117"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=691aed1c23e8e413ab867de75867ca9165eb1afe#691aed1c23e8e413ab867de75867ca9165eb1afe"
 dependencies = [
  "caliptra-cfi-derive",
  "caliptra-cfi-lib",
@@ -688,7 +688,7 @@ dependencies = [
 [[package]]
 name = "caliptra-registers"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e86b933225d2d9ab2446b02dbb0f44d3d2c49117#e86b933225d2d9ab2446b02dbb0f44d3d2c49117"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=691aed1c23e8e413ab867de75867ca9165eb1afe#691aed1c23e8e413ab867de75867ca9165eb1afe"
 dependencies = [
  "caliptra-registers-latest",
 ]
@@ -696,7 +696,7 @@ dependencies = [
 [[package]]
 name = "caliptra-registers-latest"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e86b933225d2d9ab2446b02dbb0f44d3d2c49117#e86b933225d2d9ab2446b02dbb0f44d3d2c49117"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=691aed1c23e8e413ab867de75867ca9165eb1afe#691aed1c23e8e413ab867de75867ca9165eb1afe"
 dependencies = [
  "ureg",
 ]
@@ -704,7 +704,7 @@ dependencies = [
 [[package]]
 name = "caliptra-runtime"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e86b933225d2d9ab2446b02dbb0f44d3d2c49117#e86b933225d2d9ab2446b02dbb0f44d3d2c49117"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=691aed1c23e8e413ab867de75867ca9165eb1afe#691aed1c23e8e413ab867de75867ca9165eb1afe"
 dependencies = [
  "arrayvec",
  "bitfield",
@@ -737,7 +737,7 @@ dependencies = [
 [[package]]
 name = "caliptra-test"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e86b933225d2d9ab2446b02dbb0f44d3d2c49117#e86b933225d2d9ab2446b02dbb0f44d3d2c49117"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=691aed1c23e8e413ab867de75867ca9165eb1afe#691aed1c23e8e413ab867de75867ca9165eb1afe"
 dependencies = [
  "anyhow",
  "asn1",
@@ -769,12 +769,12 @@ dependencies = [
 [[package]]
 name = "caliptra-test-harness-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e86b933225d2d9ab2446b02dbb0f44d3d2c49117#e86b933225d2d9ab2446b02dbb0f44d3d2c49117"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=691aed1c23e8e413ab867de75867ca9165eb1afe#691aed1c23e8e413ab867de75867ca9165eb1afe"
 
 [[package]]
 name = "caliptra-x509"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e86b933225d2d9ab2446b02dbb0f44d3d2c49117#e86b933225d2d9ab2446b02dbb0f44d3d2c49117"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=691aed1c23e8e413ab867de75867ca9165eb1afe#691aed1c23e8e413ab867de75867ca9165eb1afe"
 dependencies = [
  "zeroize",
 ]
@@ -782,7 +782,7 @@ dependencies = [
 [[package]]
 name = "caliptra_common"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e86b933225d2d9ab2446b02dbb0f44d3d2c49117#e86b933225d2d9ab2446b02dbb0f44d3d2c49117"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=691aed1c23e8e413ab867de75867ca9165eb1afe#691aed1c23e8e413ab867de75867ca9165eb1afe"
 dependencies = [
  "bitfield",
  "bitflags 2.9.4",
@@ -1219,7 +1219,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e86b933225d2d9ab2446b02dbb0f44d3d2c49117#e86b933225d2d9ab2446b02dbb0f44d3d2c49117"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=691aed1c23e8e413ab867de75867ca9165eb1afe#691aed1c23e8e413ab867de75867ca9165eb1afe"
 dependencies = [
  "arrayvec",
  "caliptra-cfi-derive-git",
@@ -1417,7 +1417,7 @@ dependencies = [
 [[package]]
 name = "dpe"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e86b933225d2d9ab2446b02dbb0f44d3d2c49117#e86b933225d2d9ab2446b02dbb0f44d3d2c49117"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=691aed1c23e8e413ab867de75867ca9165eb1afe#691aed1c23e8e413ab867de75867ca9165eb1afe"
 dependencies = [
  "bitflags 2.9.4",
  "caliptra-cfi-derive-git",
@@ -3247,7 +3247,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 [[package]]
 name = "platform"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e86b933225d2d9ab2446b02dbb0f44d3d2c49117#e86b933225d2d9ab2446b02dbb0f44d3d2c49117"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=691aed1c23e8e413ab867de75867ca9165eb1afe#691aed1c23e8e413ab867de75867ca9165eb1afe"
 dependencies = [
  "arrayvec",
  "cfg-if",
@@ -4406,7 +4406,7 @@ dependencies = [
 [[package]]
 name = "ureg"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=e86b933225d2d9ab2446b02dbb0f44d3d2c49117#e86b933225d2d9ab2446b02dbb0f44d3d2c49117"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=691aed1c23e8e413ab867de75867ca9165eb1afe#691aed1c23e8e413ab867de75867ca9165eb1afe"
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -222,29 +222,29 @@ libtock_small_panic = { path = "runtime/userspace/libtock/panic_handlers/small_p
 libtock_unittest = { path = "runtime/userspace/libtock/unittest" }
 
 # caliptra dependencies; keep git revs in sync
-caliptra-api = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "e86b933225d2d9ab2446b02dbb0f44d3d2c49117" }
-caliptra-api-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "e86b933225d2d9ab2446b02dbb0f44d3d2c49117" }
-caliptra-auth-man-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "e86b933225d2d9ab2446b02dbb0f44d3d2c49117" }
-caliptra-auth-man-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "e86b933225d2d9ab2446b02dbb0f44d3d2c49117" }
-caliptra-builder = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "e86b933225d2d9ab2446b02dbb0f44d3d2c49117" }
-caliptra-emu-bus = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "e86b933225d2d9ab2446b02dbb0f44d3d2c49117" }
-caliptra-emu-cpu = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "e86b933225d2d9ab2446b02dbb0f44d3d2c49117" }
-caliptra-emu-derive = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "e86b933225d2d9ab2446b02dbb0f44d3d2c49117" }
-caliptra-emu-periph = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "e86b933225d2d9ab2446b02dbb0f44d3d2c49117" }
-caliptra-emu-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "e86b933225d2d9ab2446b02dbb0f44d3d2c49117" }
-caliptra-error = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "e86b933225d2d9ab2446b02dbb0f44d3d2c49117", default-features = false }
-caliptra-hw-model = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "e86b933225d2d9ab2446b02dbb0f44d3d2c49117" }
-caliptra-hw-model-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "e86b933225d2d9ab2446b02dbb0f44d3d2c49117" }
-caliptra-image-crypto = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "e86b933225d2d9ab2446b02dbb0f44d3d2c49117", default-features = false, features = ["rustcrypto"] }
-caliptra-image-fake-keys = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "e86b933225d2d9ab2446b02dbb0f44d3d2c49117" }
-caliptra-image-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "e86b933225d2d9ab2446b02dbb0f44d3d2c49117" }
-caliptra-image-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "e86b933225d2d9ab2446b02dbb0f44d3d2c49117" }
-caliptra-registers = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "e86b933225d2d9ab2446b02dbb0f44d3d2c49117" }
-caliptra-test = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "e86b933225d2d9ab2446b02dbb0f44d3d2c49117" }
-caliptra-test-harness = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "e86b933225d2d9ab2446b02dbb0f44d3d2c49117" }
-caliptra-test-harness-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "e86b933225d2d9ab2446b02dbb0f44d3d2c49117" }
-ureg = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "e86b933225d2d9ab2446b02dbb0f44d3d2c49117" }
-dpe = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "e86b933225d2d9ab2446b02dbb0f44d3d2c49117", default-features = false, features = ["dpe_profile_p384_sha384"] }
+caliptra-api = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "691aed1c23e8e413ab867de75867ca9165eb1afe" }
+caliptra-api-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "691aed1c23e8e413ab867de75867ca9165eb1afe" }
+caliptra-auth-man-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "691aed1c23e8e413ab867de75867ca9165eb1afe" }
+caliptra-auth-man-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "691aed1c23e8e413ab867de75867ca9165eb1afe" }
+caliptra-builder = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "691aed1c23e8e413ab867de75867ca9165eb1afe" }
+caliptra-emu-bus = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "691aed1c23e8e413ab867de75867ca9165eb1afe" }
+caliptra-emu-cpu = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "691aed1c23e8e413ab867de75867ca9165eb1afe" }
+caliptra-emu-derive = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "691aed1c23e8e413ab867de75867ca9165eb1afe" }
+caliptra-emu-periph = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "691aed1c23e8e413ab867de75867ca9165eb1afe" }
+caliptra-emu-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "691aed1c23e8e413ab867de75867ca9165eb1afe" }
+caliptra-error = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "691aed1c23e8e413ab867de75867ca9165eb1afe", default-features = false }
+caliptra-hw-model = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "691aed1c23e8e413ab867de75867ca9165eb1afe" }
+caliptra-hw-model-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "691aed1c23e8e413ab867de75867ca9165eb1afe" }
+caliptra-image-crypto = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "691aed1c23e8e413ab867de75867ca9165eb1afe", default-features = false, features = ["rustcrypto"] }
+caliptra-image-fake-keys = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "691aed1c23e8e413ab867de75867ca9165eb1afe" }
+caliptra-image-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "691aed1c23e8e413ab867de75867ca9165eb1afe" }
+caliptra-image-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "691aed1c23e8e413ab867de75867ca9165eb1afe" }
+caliptra-registers = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "691aed1c23e8e413ab867de75867ca9165eb1afe" }
+caliptra-test = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "691aed1c23e8e413ab867de75867ca9165eb1afe" }
+caliptra-test-harness = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "691aed1c23e8e413ab867de75867ca9165eb1afe" }
+caliptra-test-harness-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "691aed1c23e8e413ab867de75867ca9165eb1afe" }
+ureg = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "691aed1c23e8e413ab867de75867ca9165eb1afe" }
+dpe = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "691aed1c23e8e413ab867de75867ca9165eb1afe", default-features = false, features = ["dpe_profile_p384_sha384"] }
 
 # local caliptra dependency; useful when developing
 # caliptra-api = { path = "../caliptra-sw/api" }

--- a/rom/src/cold_boot.rs
+++ b/rom/src/cold_boot.rs
@@ -249,7 +249,7 @@ impl BootFlow for ColdBoot {
         mci.set_flow_checkpoint(McuRomBootStatus::AxiUsersConfigured.into());
 
         romtime::println!("[mcu-rom] Populating fuses");
-        soc.populate_fuses(&fuses, params.program_field_entropy.iter().any(|x| *x));
+        soc.populate_fuses(&fuses, mci, params.program_field_entropy.iter().any(|x| *x));
         mci.set_flow_checkpoint(McuRomBootStatus::FusesPopulatedToCaliptra.into());
 
         romtime::println!("[mcu-rom] Setting Caliptra fuse write done");

--- a/romtime/src/error.rs
+++ b/romtime/src/error.rs
@@ -164,28 +164,63 @@ impl McuError {
             "I3C config standby controller mode error"
         ),
         (
-            SOC_KEY_MANIFEST_PK_HASH_LEN_MISMATCH,
+            SOC_FMC_KEY_MANIFEST_SVN_LEN_MISMATCH,
             0x5_0000,
+            "SOC FMC key manifest SVN length mismatch"
+        ),
+        (
+            SOC_KEY_MANIFEST_PK_HASH_LEN_MISMATCH,
+            0x5_0001,
             "SOC key manifest PK hash length mismatch"
         ),
         (
             SOC_RT_SVN_LEN_MISMATCH,
-            0x5_0001,
+            0x5_0002,
             "Runtime SVN length mismatch"
         ),
         (
             SOC_MANIFEST_SVN_LEN_MISMATCH,
-            0x5_0002,
+            0x5_0003,
             "SOC Manifest SVN length mismatch"
         ),
         (
+            SOC_MANIFEST_MAX_SVN_LEN_MISMATCH,
+            0x5_0004,
+            "SOC Manifest Max SVN length mismatch"
+        ),
+        (
             SOC_MANUF_DEBUG_UNLOCK_TOKEN_LEN_MISMATCH,
-            0x5_0003,
+            0x5_0005,
             "SOC manuf debug unlock token length mismatch"
         ),
         (
+            SOC_STEPPING_ID_LEN_MISMATCH,
+            0x5_0006,
+            "SOC stepping ID length mismatch"
+        ),
+        (
+            SOC_ANTI_ROLLBACK_DISABLE_LEN_MISMATCH,
+            0x5_0007,
+            "SOC stepping ID length mismatch"
+        ),
+        (
+            SOC_IDEVID_CERT_ATTR_LEN_MISMATCH,
+            0x5_0008,
+            "SOC IDevID Cert Attr length mismatch"
+        ),
+        (
+            SOC_IDEVID_MANUF_HSM_ID_LEN_MISMATCH,
+            0x5_0009,
+            "SOC IDevID Manuf HSM ID length mismatch"
+        ),
+        (
+            SOC_PROD_DEBUG_UNLOCK_PKS_HASH_LEN_MISMATCH,
+            0x5_000A,
+            "SOC Prod Debug Unlock PKS Hash length mismatch"
+        ),
+        (
             SOC_CALIPTRA_FATAL_ERROR_BEFORE_FW_READY,
-            0x5_0004,
+            0x5_000B,
             "SOC Caliptra fatal error before firmware ready"
         ),
     ];

--- a/tests/integration/src/jtag/test_jtag_taps.rs
+++ b/tests/integration/src/jtag/test_jtag_taps.rs
@@ -6,7 +6,6 @@ mod test {
 
     use caliptra_hw_model::lcc::{LcCtrlReg, LcCtrlStatus};
     use caliptra_hw_model::openocd::openocd_jtag_tap::{JtagParams, JtagTap};
-    use caliptra_hw_model::Fuses;
     use mcu_builder::FirmwareBinaries;
     use mcu_hw_model::{DefaultHwModel, InitParams, McuHwModel};
     use mcu_rom_common::LifecycleControllerState;
@@ -26,7 +25,6 @@ mod test {
         let mut model = DefaultHwModel::new_unbooted(init_params).unwrap();
 
         // Initialize fuses and bring subsystem out of reset.
-        model.init_fuses(&Fuses::default());
         model.set_subsystem_reset(false);
 
         // Connect to LCC JTAG TAP via OpenOCD.

--- a/tests/integration/src/jtag/test_lc_transitions.rs
+++ b/tests/integration/src/jtag/test_lc_transitions.rs
@@ -10,9 +10,7 @@ mod test {
     use caliptra_hw_model::lcc::LcCtrlStatus;
     use caliptra_hw_model::openocd::openocd_jtag_tap::{JtagParams, JtagTap};
     use caliptra_hw_model::HwModel;
-    use caliptra_hw_model::{
-        Fuses, DEFAULT_LIFECYCLE_RAW_TOKEN, DEFAULT_MANUF_DEBUG_UNLOCK_RAW_TOKEN,
-    };
+    use caliptra_hw_model::{DEFAULT_LIFECYCLE_RAW_TOKEN, DEFAULT_MANUF_DEBUG_UNLOCK_RAW_TOKEN};
     use mcu_builder::FirmwareBinaries;
     use mcu_hw_model::lcc::{lc_token_to_words, lc_transition, read_lc_state, LccUtilError};
     use mcu_hw_model::{DefaultHwModel, InitParams, McuHwModel};
@@ -35,8 +33,7 @@ mod test {
             enable_mcu_uart_log,
             ..Default::default()
         };
-        let mut model = DefaultHwModel::new_unbooted(init_params).unwrap();
-        model.init_fuses(&Fuses::default());
+        let model = DefaultHwModel::new_unbooted(init_params).unwrap();
         model
     }
 
@@ -223,7 +220,7 @@ mod test {
         // Check SS Debug Intent is active.
         let debug_intent = tap
             .read_reg(&CaliptraCoreReg::SsDebugIntent)
-            .expect("Unable to read SS Debug Inteng.");
+            .expect("Unable to read SS Debug Intent.");
         println!("SS Debug Intent: {}", debug_intent);
         assert_eq!(debug_intent, 0x1);
 
@@ -231,7 +228,7 @@ mod test {
         let ss_debug_manuf_response = tap
             .read_reg(&CaliptraCoreReg::SsDbgManufServiceRegRsp)
             .expect("Unable to read SsDbgManufServiceRegRes reg.");
-        assert_eq!(ss_debug_manuf_response, 0);
+        assert_eq!(ss_debug_manuf_response & 0x4, 0);
         let mut ss_debug_manuf_request = tap
             .read_reg(&CaliptraCoreReg::SsDbgManufServiceRegReq)
             .expect("Unable to read SsDbgManufServiceRegReq reg.");


### PR DESCRIPTION
This updates the MCU ROM to provision the OTP SW_MANUF partition's fields into the corresponding Caliptra Core and Subsystem CSRs. This includes the prod debug unlock public key hash CSRs that must be configured in order to test the prod debug unlock flow on the FPGA.