### PR TITLE
Remove on push trigger for build test job

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -3,8 +3,6 @@
 name: Build and Test
 
 on:
-  push:
-    branches: ["main"]
   pull_request:
   workflow_call:
   workflow_dispatch:


### PR DESCRIPTION
It's a
waste of resources to run this set suite on a push to main, since it
should be run on a PR as a pre-requisite.
