### PR TITLE
RISC-V compliance tests: pin sail to 0.19.1

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Install Sail
       run: |
         opam init -a -y && \
-        opam install -y sail && \
+        opam install -y sail.0.19.1 && \
         echo "$HOME/.opam/default/bin" >> "$GITHUB_PATH"
     - name: Build Sail RISC-V
       working-directory: sail-riscv


### PR DESCRIPTION
sail was recently updated to 0.20, which breaks the RISC-V sail module.

This pins us to use the known good sail.

Verified that this passes the compliance tests again: https://github.com/chipsalliance/caliptra-mcu-sw/actions/runs/18980302255