### PR TITLE
[hw-model] adjust mailbox command send interface

### DIFF
--- a/hw/model/src/debug_unlock.rs
+++ b/hw/model/src/debug_unlock.rs
@@ -31,7 +31,7 @@ pub fn prod_debug_unlock_send_request(tap: &mut OpenOcdJtagTap, debug_level: u32
     jtag_send_caliptra_mailbox_cmd(
         tap,
         CommandId::PRODUCTION_AUTH_DEBUG_UNLOCK_REQ,
-        &request_payload,
+        &request_payload.as_bytes(),
     )?;
     Ok(())
 }
@@ -61,7 +61,7 @@ pub fn prod_debug_unlock_send_token(
     jtag_send_caliptra_mailbox_cmd(
         tap,
         CommandId::PRODUCTION_AUTH_DEBUG_UNLOCK_TOKEN,
-        &token_payload,
+        &token_payload.as_bytes(),
     )?;
 
     Ok(())


### PR DESCRIPTION
This adjusts the mailbox command send function interface to accept an array of bytes instead of words to address this review feedback: https://github.com/chipsalliance/caliptra-mcu-sw/pull/522#discussion_r2473609683