### PR TITLE
errors: Remove public access to `fatal_error_raw`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2818,6 +2818,7 @@ dependencies = [
  "mcu-builder",
  "mcu-config",
  "mcu-config-emulator",
+ "mcu-error",
  "mcu-image-header",
  "mcu-rom-common",
  "registers-generated",

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -45,6 +45,11 @@ impl McuError {
         }
     }
 
+    /// Create an MCU error; intended to be used by vendors for vendor specific errors
+    pub const fn new_vendor(val: u32) -> Self {
+        Self(NonZeroU32::new(0xf000_0000 | val).unwrap())
+    }
+
     // Use the macro to define all error constants
     define_error_constants![
         (

--- a/platforms/emulator/rom/Cargo.toml
+++ b/platforms/emulator/rom/Cargo.toml
@@ -14,6 +14,7 @@ mcu-config-emulator.workspace = true
 bitfield.workspace = true
 mcu-config.workspace = true
 mcu-config-emulator.workspace = true
+mcu-error.workspace = true
 mcu-image-header.workspace = true
 mcu-rom-common.workspace = true
 registers-generated.workspace = true

--- a/rom/src/lib.rs
+++ b/rom/src/lib.rs
@@ -77,7 +77,7 @@ fn rom_panic(_: &core::panic::PanicInfo) -> ! {
 #[inline(never)]
 #[allow(dead_code)]
 #[allow(clippy::empty_loop)]
-pub fn fatal_error_raw(code: u32) -> ! {
+fn fatal_error_raw(code: u32) -> ! {
     #[allow(static_mut_refs)]
     if let Some(handler) = unsafe { FATAL_ERROR_HANDLER.as_mut() } {
         handler.fatal_error(code);


### PR DESCRIPTION
This introduces an option for vendor error codes and removes public access to `fatal_error_raw`. This makes it easier to integrate and makes it harder to have duplicate error numbers.