### PR TITLE
[test] refactor test_manuf_debug_unlock test

### DIFF
--- a/tests/integration/src/jtag/mod.rs
+++ b/tests/integration/src/jtag/mod.rs
@@ -2,3 +2,37 @@
 
 mod test_jtag_taps;
 mod test_lc_transitions;
+mod test_manuf_debug_unlock;
+
+#[cfg(test)]
+mod test {
+    use caliptra_hw_model::Fuses;
+    use mcu_builder::FirmwareBinaries;
+    use mcu_hw_model::{DefaultHwModel, InitParams, McuHwModel};
+    use mcu_rom_common::LifecycleControllerState;
+
+    pub fn ss_setup(
+        initial_lc_state: Option<LifecycleControllerState>,
+        debug_intent: bool,
+        bootfsm_break: bool,
+        enable_mcu_uart_log: bool,
+    ) -> DefaultHwModel {
+        let firmware_bundle = FirmwareBinaries::from_env().unwrap();
+
+        let init_params = InitParams {
+            caliptra_rom: &firmware_bundle.caliptra_rom,
+            mcu_rom: &firmware_bundle.mcu_rom,
+            lifecycle_controller_state: initial_lc_state,
+            debug_intent,
+            bootfsm_break,
+            enable_mcu_uart_log,
+            ..Default::default()
+        };
+        let mut model = DefaultHwModel::new_unbooted(init_params).unwrap();
+        model
+            .base
+            .init_otp(&Fuses::default())
+            .expect("Failed to init OTP.");
+        model
+    }
+}

--- a/tests/integration/src/jtag/test_lc_transitions.rs
+++ b/tests/integration/src/jtag/test_lc_transitions.rs
@@ -6,12 +6,13 @@ mod test {
     use std::thread;
     use std::time::Duration;
 
+    use crate::jtag::test::ss_setup;
+
     use caliptra_hw_model::jtag::CaliptraCoreReg;
     use caliptra_hw_model::lcc::LcCtrlStatus;
     use caliptra_hw_model::openocd::openocd_jtag_tap::{JtagParams, JtagTap};
-    use caliptra_hw_model::Fuses;
     use caliptra_hw_model::HwModel;
-    use caliptra_hw_model::{DEFAULT_LIFECYCLE_RAW_TOKEN, DEFAULT_MANUF_DEBUG_UNLOCK_RAW_TOKEN};
+    use caliptra_hw_model::DEFAULT_LIFECYCLE_RAW_TOKEN;
     use caliptra_image_fake_keys::{
         VENDOR_ECC_KEY_0_PRIVATE, VENDOR_ECC_KEY_0_PUBLIC, VENDOR_MLDSA_KEY_0_PRIVATE,
         VENDOR_MLDSA_KEY_0_PUBLIC,
@@ -19,7 +20,6 @@ mod test {
     use caliptra_image_types::{
         ECC384_SCALAR_BYTE_SIZE, ECC384_SCALAR_WORD_SIZE, MLDSA87_PRIV_KEY_BYTE_SIZE,
     };
-    use mcu_builder::FirmwareBinaries;
     use mcu_hw_model::debug_unlock::{
         prod_debug_unlock_gen_signed_token, prod_debug_unlock_get_challenge,
         prod_debug_unlock_send_request, prod_debug_unlock_send_token,
@@ -27,38 +27,12 @@ mod test {
     };
     use mcu_hw_model::jtag::jtag_wait_for_caliptra_mailbox_resp;
     use mcu_hw_model::lcc::{lc_token_to_words, lc_transition, read_lc_state, LccUtilError};
-    use mcu_hw_model::{DefaultHwModel, InitParams, McuHwModel};
     use mcu_rom_common::LifecycleControllerState;
 
     use fips204::ml_dsa_87::PrivateKey as MldsaPrivateKey;
     use fips204::traits::SerDes;
     use p384::SecretKey as EcdsaSecretKey;
     use zerocopy::IntoBytes;
-
-    fn ss_setup(
-        initial_lc_state: Option<LifecycleControllerState>,
-        debug_intent: bool,
-        bootfsm_break: bool,
-        enable_mcu_uart_log: bool,
-    ) -> DefaultHwModel {
-        let firmware_bundle = FirmwareBinaries::from_env().unwrap();
-
-        let init_params = InitParams {
-            caliptra_rom: &firmware_bundle.caliptra_rom,
-            mcu_rom: &firmware_bundle.mcu_rom,
-            lifecycle_controller_state: initial_lc_state,
-            debug_intent,
-            bootfsm_break,
-            enable_mcu_uart_log,
-            ..Default::default()
-        };
-        let mut model = DefaultHwModel::new_unbooted(init_params).unwrap();
-        model
-            .base
-            .init_otp(&Fuses::default())
-            .expect("Failed to init OTP.");
-        model
-    }
 
     #[test]
     fn test_raw_unlock() {
@@ -217,130 +191,6 @@ mod test {
             *status,
             LcCtrlStatus::FLASH_RMA_ERROR | LcCtrlStatus::INITIALIZED
         );
-    }
-
-    #[test]
-    fn test_manuf_debug_unlock() {
-        let mut model = ss_setup(
-            Some(LifecycleControllerState::Dev),
-            /*debug_intent=*/ true,
-            /*bootfsm_break=*/ true,
-            /*enable_mcu_uart_log=*/ true,
-        );
-
-        // Connect to Caliptra Core JTAG TAP via OpenOCD.
-        println!("Connecting to Core TAP ...");
-        let jtag_params = JtagParams {
-            openocd: PathBuf::from("openocd"),
-            adapter_speed_khz: 1000,
-            log_stdio: true,
-        };
-        let mut tap = model
-            .jtag_tap_connect(&jtag_params, JtagTap::CaliptraCoreTap)
-            .expect("Failed to connect to the Caliptra Core JTAG TAP.");
-        println!("Connected.");
-
-        // Check SS Debug Intent is active.
-        let debug_intent = tap
-            .read_reg(&CaliptraCoreReg::SsDebugIntent)
-            .expect("Unable to read SS Debug Intent.");
-        println!("SS Debug Intent: {}", debug_intent);
-        assert_eq!(debug_intent, 0x1);
-
-        // Ensure another manuf debug unlock is not in progress.
-        let ss_debug_manuf_response = tap
-            .read_reg(&CaliptraCoreReg::SsDbgManufServiceRegRsp)
-            .expect("Unable to read SsDbgManufServiceRegRes reg.");
-        assert_eq!(ss_debug_manuf_response & 0x4, 0);
-        let mut ss_debug_manuf_request = tap
-            .read_reg(&CaliptraCoreReg::SsDbgManufServiceRegReq)
-            .expect("Unable to read SsDbgManufServiceRegReq reg.");
-        assert_eq!(ss_debug_manuf_request, 0);
-
-        // Request manuf debug unlock operation.
-        println!("Request to initiate manuf debug unlock ...");
-        tap.write_reg(&CaliptraCoreReg::SsDbgManufServiceRegReq, 0x1)
-            .expect("Unable to write SsDbgManufServiceRegReq reg.");
-        println!(
-            "Manuf debug unlock request (before): 0x{:08x})",
-            ss_debug_manuf_request
-        );
-        ss_debug_manuf_request = tap
-            .read_reg(&CaliptraCoreReg::SsDbgManufServiceRegReq)
-            .expect("Unable to read SsDbgManufServiceRegReq reg.");
-        println!(
-            "Manuf debug unlock request (after): 0x{:08x})",
-            ss_debug_manuf_request
-        );
-        assert_eq!(ss_debug_manuf_request, 1);
-        println!("Request sent.");
-
-        // Continue Caliptra Core boot.
-        tap.write_reg(&CaliptraCoreReg::BootfsmGo, 0x1)
-            .expect("Unable to write BootfsmGo.");
-
-        // Acquire the Caliptra Core mailbox lock.
-        println!("Attempting to acquire Caliptra Core mailbox lock ...");
-        let mut lock_acquired = false;
-        while let Ok(mbox_lock) = tap.read_reg(&CaliptraCoreReg::MboxLock) {
-            if (mbox_lock & 0x1) == 0 {
-                lock_acquired = true;
-                break;
-            }
-            thread::sleep(Duration::from_millis(100));
-        }
-        assert_eq!(lock_acquired, true);
-        println!("Lock acquired.");
-
-        // Program the manuf debug unlock token via the Caliptra Core mailbox.
-        println!("Programming the manuf debug unlock token ...");
-        tap.write_reg(&CaliptraCoreReg::MboxCmd, 0x4d445554)
-            .expect("Unable to write MboxCmd reg.");
-        tap.write_reg(
-            &CaliptraCoreReg::MboxDlen,
-            ((DEFAULT_MANUF_DEBUG_UNLOCK_RAW_TOKEN.0.len() + 1) * 4)
-                .try_into()
-                .unwrap(),
-        )
-        .expect("Unable to write MboxDlen reg.");
-        tap.write_reg(&CaliptraCoreReg::MboxDin, 0xFFFFF8E2)
-            .expect("Unable to write to MboxDin register.");
-        for token_word in DEFAULT_MANUF_DEBUG_UNLOCK_RAW_TOKEN.0 {
-            println!("Writing token word: 0x{:08x}.", token_word);
-            tap.write_reg(&CaliptraCoreReg::MboxDin, token_word)
-                .expect("Unable to write to MboxDin register.");
-        }
-        println!("Token programming complete.");
-
-        // Executing the manuf debug unlock operation and wait for completion.
-        println!("Executing the manuf debug unlock operation ...");
-        tap.write_reg(&CaliptraCoreReg::MboxExecute, 0x1)
-            .expect("Unable to write to MboxExecute register.");
-
-        // Wait for debug unlock operation to complete.
-        let mut ss_debug_manuf_success = false;
-        while let Ok(ss_debug_manuf_response) =
-            tap.read_reg(&CaliptraCoreReg::SsDbgManufServiceRegRsp)
-        {
-            if (ss_debug_manuf_response & 0x4) != 0 {
-                println!(
-                    "Manuf debug unlock operation in progress (response: 0x{:08x}) ...",
-                    ss_debug_manuf_response
-                );
-            }
-            if (ss_debug_manuf_response & 0x3) != 0 {
-                println!(
-                    "Manuf debug unlock operation complete (response: 0x{:08x}).",
-                    ss_debug_manuf_response
-                );
-                assert_eq!(ss_debug_manuf_response, 0x1);
-                ss_debug_manuf_success = true;
-                break;
-            }
-            model.base.step();
-            thread::sleep(Duration::from_millis(100));
-        }
-        assert_eq!(ss_debug_manuf_success, true);
     }
 
     #[test]

--- a/tests/integration/src/jtag/test_manuf_debug_unlock.rs
+++ b/tests/integration/src/jtag/test_manuf_debug_unlock.rs
@@ -1,0 +1,77 @@
+// Licensed under the Apache-2.0 license
+
+#[cfg(test)]
+mod test {
+    use std::path::PathBuf;
+    use std::thread;
+    use std::time::Duration;
+
+    use crate::jtag::test::ss_setup;
+
+    use caliptra_api::mailbox::CommandId;
+    use caliptra_hw_model::jtag::CaliptraCoreReg;
+    use caliptra_hw_model::openocd::openocd_jtag_tap::{JtagParams, JtagTap};
+    use caliptra_hw_model::HwModel;
+    use caliptra_hw_model::DEFAULT_MANUF_DEBUG_UNLOCK_RAW_TOKEN;
+    use mcu_hw_model::jtag::jtag_send_caliptra_mailbox_cmd;
+    use mcu_rom_common::LifecycleControllerState;
+
+    use zerocopy::IntoBytes;
+
+    #[test]
+    fn test_manuf_debug_unlock() {
+        let mut model = ss_setup(
+            Some(LifecycleControllerState::Dev),
+            /*debug_intent=*/ true,
+            /*bootfsm_break=*/ true,
+            /*enable_mcu_uart_log=*/ true,
+        );
+
+        // Connect to Caliptra Core JTAG TAP via OpenOCD.
+        println!("Connecting to Core TAP ...");
+        let jtag_params = JtagParams {
+            openocd: PathBuf::from("openocd"),
+            adapter_speed_khz: 1000,
+            log_stdio: true,
+        };
+        let mut tap = model
+            .jtag_tap_connect(&jtag_params, JtagTap::CaliptraCoreTap)
+            .expect("Failed to connect to the Caliptra Core JTAG TAP.");
+        println!("Connected.");
+
+        // Request manuf debug unlock operation.
+        tap.write_reg(&CaliptraCoreReg::SsDbgManufServiceRegReq, 0x1)
+            .expect("Unable to write SsDbgManufServiceRegReq reg.");
+        model.base.step();
+
+        // Continue Caliptra Core boot.
+        tap.write_reg(&CaliptraCoreReg::BootfsmGo, 0x1)
+            .expect("Unable to write BootfsmGo.");
+        model.base.step();
+
+        // Send the manuf debug unlock token.
+        jtag_send_caliptra_mailbox_cmd(
+            &mut *tap,
+            CommandId::MANUF_DEBUG_UNLOCK_REQ_TOKEN,
+            DEFAULT_MANUF_DEBUG_UNLOCK_RAW_TOKEN.0.as_bytes(),
+        )
+        .expect("Failed to send manuf debug unlock token.");
+        model.base.step();
+
+        // Wait for debug unlock operation to complete.
+        while let Ok(ss_debug_manuf_response) =
+            tap.read_reg(&CaliptraCoreReg::SsDbgManufServiceRegRsp)
+        {
+            if (ss_debug_manuf_response & 0x3) != 0 {
+                println!(
+                    "Manuf debug unlock operation complete (response: 0x{:08x}).",
+                    ss_debug_manuf_response
+                );
+                assert_eq!(ss_debug_manuf_response, 0x1);
+                break;
+            }
+            model.base.step();
+            thread::sleep(Duration::from_millis(100));
+        }
+    }
+}


### PR DESCRIPTION
This refactors the manuf debug unlock FPGA test into its own file. Additionally, it updates the test to make use of the JTAG mailbox utility functions.