### PR TITLE
fpga: Add Caliptra UDS programming test

### DIFF
--- a/.github/workflows/fpga.yml
+++ b/.github/workflows/fpga.yml
@@ -213,7 +213,7 @@ jobs:
               --target-dir-remap="${TEST_BIN}/target"
               --workspace-remap=.
               -E 'package(mcu-hw-model) - test(model_emulated::test::test_new_unbooted)'
-              -E 'package(tests-integration) and test(test_jtag_taps) and test(test_lc_transitions)' # Modify this as we onboard crates to the FPGA test suite.
+              -E 'package(tests-integration) and test(test_jtag_taps) and test(test_lc_transitions) and test(test_uds)' # Modify this as we onboard crates to the FPGA test suite.
           )
               # disabled for now due to flakiness of recovery boot
               # -E 'package(tests-integration) and test(test_mctp_capsule_loopback)'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,7 +271,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 [[package]]
 name = "caliptra-api"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=41167412550134fa7e7f1d92ea404b6e53ea4f18#41167412550134fa7e7f1d92ea404b6e53ea4f18"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8fac60b2cd922d3a634a03b07874090ddadd2fc#d8fac60b2cd922d3a634a03b07874090ddadd2fc"
 dependencies = [
  "bitflags 2.10.0",
  "caliptra-api-types",
@@ -286,7 +286,7 @@ dependencies = [
 [[package]]
 name = "caliptra-api-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=41167412550134fa7e7f1d92ea404b6e53ea4f18#41167412550134fa7e7f1d92ea404b6e53ea4f18"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8fac60b2cd922d3a634a03b07874090ddadd2fc#d8fac60b2cd922d3a634a03b07874090ddadd2fc"
 dependencies = [
  "caliptra-image-types",
 ]
@@ -294,7 +294,7 @@ dependencies = [
 [[package]]
 name = "caliptra-auth-man-gen"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=41167412550134fa7e7f1d92ea404b6e53ea4f18#41167412550134fa7e7f1d92ea404b6e53ea4f18"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8fac60b2cd922d3a634a03b07874090ddadd2fc#d8fac60b2cd922d3a634a03b07874090ddadd2fc"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",
@@ -309,7 +309,7 @@ dependencies = [
 [[package]]
 name = "caliptra-auth-man-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=41167412550134fa7e7f1d92ea404b6e53ea4f18#41167412550134fa7e7f1d92ea404b6e53ea4f18"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8fac60b2cd922d3a634a03b07874090ddadd2fc#d8fac60b2cd922d3a634a03b07874090ddadd2fc"
 dependencies = [
  "bitfield",
  "bitflags 2.10.0",
@@ -324,7 +324,7 @@ dependencies = [
 [[package]]
 name = "caliptra-builder"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=41167412550134fa7e7f1d92ea404b6e53ea4f18#41167412550134fa7e7f1d92ea404b6e53ea4f18"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8fac60b2cd922d3a634a03b07874090ddadd2fc#d8fac60b2cd922d3a634a03b07874090ddadd2fc"
 dependencies = [
  "anyhow",
  "caliptra-image-crypto",
@@ -349,7 +349,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cfi-derive"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=41167412550134fa7e7f1d92ea404b6e53ea4f18#41167412550134fa7e7f1d92ea404b6e53ea4f18"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8fac60b2cd922d3a634a03b07874090ddadd2fc#d8fac60b2cd922d3a634a03b07874090ddadd2fc"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -371,7 +371,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cfi-lib"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=41167412550134fa7e7f1d92ea404b6e53ea4f18#41167412550134fa7e7f1d92ea404b6e53ea4f18"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8fac60b2cd922d3a634a03b07874090ddadd2fc#d8fac60b2cd922d3a634a03b07874090ddadd2fc"
 dependencies = [
  "caliptra-error",
  "caliptra-registers",
@@ -386,7 +386,7 @@ source = "git+https://github.com/chipsalliance/caliptra-cfi.git?rev=a98e499d279e
 [[package]]
 name = "caliptra-coverage"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=41167412550134fa7e7f1d92ea404b6e53ea4f18#41167412550134fa7e7f1d92ea404b6e53ea4f18"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8fac60b2cd922d3a634a03b07874090ddadd2fc#d8fac60b2cd922d3a634a03b07874090ddadd2fc"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -404,7 +404,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cpu"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=41167412550134fa7e7f1d92ea404b6e53ea4f18#41167412550134fa7e7f1d92ea404b6e53ea4f18"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8fac60b2cd922d3a634a03b07874090ddadd2fc#d8fac60b2cd922d3a634a03b07874090ddadd2fc"
 dependencies = [
  "caliptra-drivers",
  "caliptra-registers",
@@ -414,7 +414,7 @@ dependencies = [
 [[package]]
 name = "caliptra-drivers"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=41167412550134fa7e7f1d92ea404b6e53ea4f18#41167412550134fa7e7f1d92ea404b6e53ea4f18"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8fac60b2cd922d3a634a03b07874090ddadd2fc#d8fac60b2cd922d3a634a03b07874090ddadd2fc"
 dependencies = [
  "arrayvec",
  "bitfield",
@@ -440,7 +440,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-bus"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=41167412550134fa7e7f1d92ea404b6e53ea4f18#41167412550134fa7e7f1d92ea404b6e53ea4f18"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8fac60b2cd922d3a634a03b07874090ddadd2fc#d8fac60b2cd922d3a634a03b07874090ddadd2fc"
 dependencies = [
  "caliptra-emu-types",
  "tock-registers",
@@ -450,7 +450,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-cpu"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=41167412550134fa7e7f1d92ea404b6e53ea4f18#41167412550134fa7e7f1d92ea404b6e53ea4f18"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8fac60b2cd922d3a634a03b07874090ddadd2fc#d8fac60b2cd922d3a634a03b07874090ddadd2fc"
 dependencies = [
  "bit-vec",
  "bitfield",
@@ -464,7 +464,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=41167412550134fa7e7f1d92ea404b6e53ea4f18#41167412550134fa7e7f1d92ea404b6e53ea4f18"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8fac60b2cd922d3a634a03b07874090ddadd2fc#d8fac60b2cd922d3a634a03b07874090ddadd2fc"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -479,7 +479,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-derive"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=41167412550134fa7e7f1d92ea404b6e53ea4f18#41167412550134fa7e7f1d92ea404b6e53ea4f18"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8fac60b2cd922d3a634a03b07874090ddadd2fc#d8fac60b2cd922d3a634a03b07874090ddadd2fc"
 dependencies = [
  "caliptra-emu-bus",
  "caliptra-emu-types",
@@ -490,7 +490,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-periph"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=41167412550134fa7e7f1d92ea404b6e53ea4f18#41167412550134fa7e7f1d92ea404b6e53ea4f18"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8fac60b2cd922d3a634a03b07874090ddadd2fc#d8fac60b2cd922d3a634a03b07874090ddadd2fc"
 dependencies = [
  "aes",
  "arrayref",
@@ -517,17 +517,17 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=41167412550134fa7e7f1d92ea404b6e53ea4f18#41167412550134fa7e7f1d92ea404b6e53ea4f18"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8fac60b2cd922d3a634a03b07874090ddadd2fc#d8fac60b2cd922d3a634a03b07874090ddadd2fc"
 
 [[package]]
 name = "caliptra-error"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=41167412550134fa7e7f1d92ea404b6e53ea4f18#41167412550134fa7e7f1d92ea404b6e53ea4f18"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8fac60b2cd922d3a634a03b07874090ddadd2fc#d8fac60b2cd922d3a634a03b07874090ddadd2fc"
 
 [[package]]
 name = "caliptra-gen-linker-scripts"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=41167412550134fa7e7f1d92ea404b6e53ea4f18#41167412550134fa7e7f1d92ea404b6e53ea4f18"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8fac60b2cd922d3a634a03b07874090ddadd2fc#d8fac60b2cd922d3a634a03b07874090ddadd2fc"
 dependencies = [
  "caliptra_common",
 ]
@@ -535,7 +535,7 @@ dependencies = [
 [[package]]
 name = "caliptra-hw-model"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=41167412550134fa7e7f1d92ea404b6e53ea4f18#41167412550134fa7e7f1d92ea404b6e53ea4f18"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8fac60b2cd922d3a634a03b07874090ddadd2fc#d8fac60b2cd922d3a634a03b07874090ddadd2fc"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -574,7 +574,7 @@ dependencies = [
 [[package]]
 name = "caliptra-hw-model-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=41167412550134fa7e7f1d92ea404b6e53ea4f18#41167412550134fa7e7f1d92ea404b6e53ea4f18"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8fac60b2cd922d3a634a03b07874090ddadd2fc#d8fac60b2cd922d3a634a03b07874090ddadd2fc"
 dependencies = [
  "caliptra-api-types",
  "rand",
@@ -583,7 +583,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=41167412550134fa7e7f1d92ea404b6e53ea4f18#41167412550134fa7e7f1d92ea404b6e53ea4f18"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8fac60b2cd922d3a634a03b07874090ddadd2fc#d8fac60b2cd922d3a634a03b07874090ddadd2fc"
 dependencies = [
  "anyhow",
  "caliptra-image-gen",
@@ -603,7 +603,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-elf"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=41167412550134fa7e7f1d92ea404b6e53ea4f18#41167412550134fa7e7f1d92ea404b6e53ea4f18"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8fac60b2cd922d3a634a03b07874090ddadd2fc#d8fac60b2cd922d3a634a03b07874090ddadd2fc"
 dependencies = [
  "anyhow",
  "caliptra-image-gen",
@@ -614,7 +614,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-fake-keys"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=41167412550134fa7e7f1d92ea404b6e53ea4f18#41167412550134fa7e7f1d92ea404b6e53ea4f18"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8fac60b2cd922d3a634a03b07874090ddadd2fc#d8fac60b2cd922d3a634a03b07874090ddadd2fc"
 dependencies = [
  "caliptra-image-gen",
  "caliptra-image-types",
@@ -625,7 +625,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-gen"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=41167412550134fa7e7f1d92ea404b6e53ea4f18#41167412550134fa7e7f1d92ea404b6e53ea4f18"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8fac60b2cd922d3a634a03b07874090ddadd2fc#d8fac60b2cd922d3a634a03b07874090ddadd2fc"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",
@@ -642,7 +642,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=41167412550134fa7e7f1d92ea404b6e53ea4f18#41167412550134fa7e7f1d92ea404b6e53ea4f18"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8fac60b2cd922d3a634a03b07874090ddadd2fc#d8fac60b2cd922d3a634a03b07874090ddadd2fc"
 dependencies = [
  "caliptra-cfi-derive",
  "caliptra-cfi-lib",
@@ -658,7 +658,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-verify"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=41167412550134fa7e7f1d92ea404b6e53ea4f18#41167412550134fa7e7f1d92ea404b6e53ea4f18"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8fac60b2cd922d3a634a03b07874090ddadd2fc#d8fac60b2cd922d3a634a03b07874090ddadd2fc"
 dependencies = [
  "bitflags 2.10.0",
  "caliptra-cfi-derive",
@@ -673,7 +673,7 @@ dependencies = [
 [[package]]
 name = "caliptra-kat"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=41167412550134fa7e7f1d92ea404b6e53ea4f18#41167412550134fa7e7f1d92ea404b6e53ea4f18"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8fac60b2cd922d3a634a03b07874090ddadd2fc#d8fac60b2cd922d3a634a03b07874090ddadd2fc"
 dependencies = [
  "caliptra-drivers",
  "caliptra-lms-types",
@@ -685,7 +685,7 @@ dependencies = [
 [[package]]
 name = "caliptra-lms-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=41167412550134fa7e7f1d92ea404b6e53ea4f18#41167412550134fa7e7f1d92ea404b6e53ea4f18"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8fac60b2cd922d3a634a03b07874090ddadd2fc#d8fac60b2cd922d3a634a03b07874090ddadd2fc"
 dependencies = [
  "caliptra-cfi-derive",
  "caliptra-cfi-lib",
@@ -698,7 +698,7 @@ dependencies = [
 [[package]]
 name = "caliptra-registers"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=41167412550134fa7e7f1d92ea404b6e53ea4f18#41167412550134fa7e7f1d92ea404b6e53ea4f18"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8fac60b2cd922d3a634a03b07874090ddadd2fc#d8fac60b2cd922d3a634a03b07874090ddadd2fc"
 dependencies = [
  "caliptra-registers-latest",
 ]
@@ -706,7 +706,7 @@ dependencies = [
 [[package]]
 name = "caliptra-registers-latest"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=41167412550134fa7e7f1d92ea404b6e53ea4f18#41167412550134fa7e7f1d92ea404b6e53ea4f18"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8fac60b2cd922d3a634a03b07874090ddadd2fc#d8fac60b2cd922d3a634a03b07874090ddadd2fc"
 dependencies = [
  "ureg",
 ]
@@ -714,7 +714,7 @@ dependencies = [
 [[package]]
 name = "caliptra-runtime"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=41167412550134fa7e7f1d92ea404b6e53ea4f18#41167412550134fa7e7f1d92ea404b6e53ea4f18"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8fac60b2cd922d3a634a03b07874090ddadd2fc#d8fac60b2cd922d3a634a03b07874090ddadd2fc"
 dependencies = [
  "arrayvec",
  "bitfield",
@@ -747,7 +747,7 @@ dependencies = [
 [[package]]
 name = "caliptra-test"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=41167412550134fa7e7f1d92ea404b6e53ea4f18#41167412550134fa7e7f1d92ea404b6e53ea4f18"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8fac60b2cd922d3a634a03b07874090ddadd2fc#d8fac60b2cd922d3a634a03b07874090ddadd2fc"
 dependencies = [
  "anyhow",
  "asn1",
@@ -779,12 +779,12 @@ dependencies = [
 [[package]]
 name = "caliptra-test-harness-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=41167412550134fa7e7f1d92ea404b6e53ea4f18#41167412550134fa7e7f1d92ea404b6e53ea4f18"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8fac60b2cd922d3a634a03b07874090ddadd2fc#d8fac60b2cd922d3a634a03b07874090ddadd2fc"
 
 [[package]]
 name = "caliptra-x509"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=41167412550134fa7e7f1d92ea404b6e53ea4f18#41167412550134fa7e7f1d92ea404b6e53ea4f18"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8fac60b2cd922d3a634a03b07874090ddadd2fc#d8fac60b2cd922d3a634a03b07874090ddadd2fc"
 dependencies = [
  "zeroize",
 ]
@@ -792,7 +792,7 @@ dependencies = [
 [[package]]
 name = "caliptra_common"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=41167412550134fa7e7f1d92ea404b6e53ea4f18#41167412550134fa7e7f1d92ea404b6e53ea4f18"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8fac60b2cd922d3a634a03b07874090ddadd2fc#d8fac60b2cd922d3a634a03b07874090ddadd2fc"
 dependencies = [
  "bitfield",
  "bitflags 2.10.0",
@@ -1231,7 +1231,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=41167412550134fa7e7f1d92ea404b6e53ea4f18#41167412550134fa7e7f1d92ea404b6e53ea4f18"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8fac60b2cd922d3a634a03b07874090ddadd2fc#d8fac60b2cd922d3a634a03b07874090ddadd2fc"
 dependencies = [
  "arrayvec",
  "caliptra-cfi-derive-git",
@@ -1435,7 +1435,7 @@ dependencies = [
 [[package]]
 name = "dpe"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=41167412550134fa7e7f1d92ea404b6e53ea4f18#41167412550134fa7e7f1d92ea404b6e53ea4f18"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8fac60b2cd922d3a634a03b07874090ddadd2fc#d8fac60b2cd922d3a634a03b07874090ddadd2fc"
 dependencies = [
  "bitflags 2.10.0",
  "caliptra-cfi-derive-git",
@@ -3292,7 +3292,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 [[package]]
 name = "platform"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=41167412550134fa7e7f1d92ea404b6e53ea4f18#41167412550134fa7e7f1d92ea404b6e53ea4f18"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8fac60b2cd922d3a634a03b07874090ddadd2fc#d8fac60b2cd922d3a634a03b07874090ddadd2fc"
 dependencies = [
  "arrayvec",
  "cfg-if",
@@ -4117,6 +4117,7 @@ dependencies = [
  "pldm-common",
  "pldm-fw-pkg",
  "pldm-ua",
+ "registers-generated",
  "sha2",
  "simple_logger",
  "tempfile",
@@ -4463,7 +4464,7 @@ dependencies = [
 [[package]]
 name = "ureg"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=41167412550134fa7e7f1d92ea404b6e53ea4f18#41167412550134fa7e7f1d92ea404b6e53ea4f18"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8fac60b2cd922d3a634a03b07874090ddadd2fc#d8fac60b2cd922d3a634a03b07874090ddadd2fc"
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -226,30 +226,30 @@ libtock_small_panic = { path = "runtime/userspace/libtock/panic_handlers/small_p
 libtock_unittest = { path = "runtime/userspace/libtock/unittest" }
 
 # caliptra dependencies; keep git revs in sync
-caliptra-api = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "41167412550134fa7e7f1d92ea404b6e53ea4f18" }
-caliptra-api-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "41167412550134fa7e7f1d92ea404b6e53ea4f18" }
-caliptra-auth-man-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "41167412550134fa7e7f1d92ea404b6e53ea4f18" }
-caliptra-auth-man-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "41167412550134fa7e7f1d92ea404b6e53ea4f18" }
-caliptra-builder = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "41167412550134fa7e7f1d92ea404b6e53ea4f18" }
-caliptra-drivers = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "41167412550134fa7e7f1d92ea404b6e53ea4f18" }
-caliptra-emu-bus = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "41167412550134fa7e7f1d92ea404b6e53ea4f18" }
-caliptra-emu-cpu = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "41167412550134fa7e7f1d92ea404b6e53ea4f18" }
-caliptra-emu-derive = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "41167412550134fa7e7f1d92ea404b6e53ea4f18" }
-caliptra-emu-periph = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "41167412550134fa7e7f1d92ea404b6e53ea4f18" }
-caliptra-emu-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "41167412550134fa7e7f1d92ea404b6e53ea4f18" }
-caliptra-error = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "41167412550134fa7e7f1d92ea404b6e53ea4f18", default-features = false }
-caliptra-hw-model = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "41167412550134fa7e7f1d92ea404b6e53ea4f18" }
-caliptra-hw-model-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "41167412550134fa7e7f1d92ea404b6e53ea4f18" }
-caliptra-image-crypto = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "41167412550134fa7e7f1d92ea404b6e53ea4f18", default-features = false, features = ["rustcrypto"] }
-caliptra-image-fake-keys = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "41167412550134fa7e7f1d92ea404b6e53ea4f18" }
-caliptra-image-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "41167412550134fa7e7f1d92ea404b6e53ea4f18" }
-caliptra-image-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "41167412550134fa7e7f1d92ea404b6e53ea4f18" }
-caliptra-registers = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "41167412550134fa7e7f1d92ea404b6e53ea4f18" }
-caliptra-test = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "41167412550134fa7e7f1d92ea404b6e53ea4f18" }
-caliptra-test-harness = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "41167412550134fa7e7f1d92ea404b6e53ea4f18" }
-caliptra-test-harness-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "41167412550134fa7e7f1d92ea404b6e53ea4f18" }
-ureg = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "41167412550134fa7e7f1d92ea404b6e53ea4f18" }
-dpe = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "41167412550134fa7e7f1d92ea404b6e53ea4f18", default-features = false, features = ["dpe_profile_p384_sha384"] }
+caliptra-api = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d8fac60b2cd922d3a634a03b07874090ddadd2fc" }
+caliptra-api-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d8fac60b2cd922d3a634a03b07874090ddadd2fc" }
+caliptra-auth-man-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d8fac60b2cd922d3a634a03b07874090ddadd2fc" }
+caliptra-auth-man-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d8fac60b2cd922d3a634a03b07874090ddadd2fc" }
+caliptra-builder = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d8fac60b2cd922d3a634a03b07874090ddadd2fc" }
+caliptra-drivers = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d8fac60b2cd922d3a634a03b07874090ddadd2fc" }
+caliptra-emu-bus = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d8fac60b2cd922d3a634a03b07874090ddadd2fc" }
+caliptra-emu-cpu = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d8fac60b2cd922d3a634a03b07874090ddadd2fc" }
+caliptra-emu-derive = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d8fac60b2cd922d3a634a03b07874090ddadd2fc" }
+caliptra-emu-periph = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d8fac60b2cd922d3a634a03b07874090ddadd2fc" }
+caliptra-emu-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d8fac60b2cd922d3a634a03b07874090ddadd2fc" }
+caliptra-error = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d8fac60b2cd922d3a634a03b07874090ddadd2fc", default-features = false }
+caliptra-hw-model = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d8fac60b2cd922d3a634a03b07874090ddadd2fc" }
+caliptra-hw-model-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d8fac60b2cd922d3a634a03b07874090ddadd2fc" }
+caliptra-image-crypto = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d8fac60b2cd922d3a634a03b07874090ddadd2fc", default-features = false, features = ["rustcrypto"] }
+caliptra-image-fake-keys = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d8fac60b2cd922d3a634a03b07874090ddadd2fc" }
+caliptra-image-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d8fac60b2cd922d3a634a03b07874090ddadd2fc" }
+caliptra-image-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d8fac60b2cd922d3a634a03b07874090ddadd2fc" }
+caliptra-registers = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d8fac60b2cd922d3a634a03b07874090ddadd2fc" }
+caliptra-test = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d8fac60b2cd922d3a634a03b07874090ddadd2fc" }
+caliptra-test-harness = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d8fac60b2cd922d3a634a03b07874090ddadd2fc" }
+caliptra-test-harness-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d8fac60b2cd922d3a634a03b07874090ddadd2fc" }
+ureg = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d8fac60b2cd922d3a634a03b07874090ddadd2fc" }
+dpe = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d8fac60b2cd922d3a634a03b07874090ddadd2fc", default-features = false, features = ["dpe_profile_p384_sha384"] }
 
 # local caliptra dependency; useful when developing
 # caliptra-api = { path = "../caliptra-sw/api" }

--- a/builder/src/caliptra.rs
+++ b/builder/src/caliptra.rs
@@ -487,8 +487,8 @@ impl CaliptraBuilder {
             });
 
         let gen_config: AuthManifestGeneratorConfig = AuthManifestGeneratorConfig {
-            vendor_fw_key_info,
-            vendor_man_key_info,
+            vendor_fw_key_info: Some(vendor_fw_key_info),
+            vendor_man_key_info: Some(vendor_man_key_info),
             owner_fw_key_info,
             owner_man_key_info,
             image_metadata_list,

--- a/hw/model/src/lib.rs
+++ b/hw/model/src/lib.rs
@@ -312,6 +312,7 @@ pub trait McuHwModel {
         Self: Sized;
 
     fn save_otp_memory(&self, path: &Path) -> Result<()>;
+    fn read_otp_memory(&self) -> Vec<u8>;
 
     /// The type name of this model
     fn type_name(&self) -> &'static str;

--- a/hw/model/src/model_emulated.rs
+++ b/hw/model/src/model_emulated.rs
@@ -530,6 +530,10 @@ impl McuHwModel for ModelEmulated {
         unimplemented!()
     }
 
+    fn read_otp_memory(&self) -> Vec<u8> {
+        unimplemented!()
+    }
+
     fn mcu_manager(&mut self) -> impl McuManager {
         self
     }

--- a/hw/model/src/model_fpga_realtime.rs
+++ b/hw/model/src/model_fpga_realtime.rs
@@ -451,6 +451,10 @@ impl McuHwModel for ModelFpgaRealtime {
         Ok(std::fs::write(path, s.as_bytes())?)
     }
 
+    fn read_otp_memory(&self) -> Vec<u8> {
+        self.base.otp_slice().to_vec()
+    }
+
     fn mcu_manager(&mut self) -> impl McuManager {
         self
     }

--- a/tests/integration/Cargo.toml
+++ b/tests/integration/Cargo.toml
@@ -40,6 +40,7 @@ p384.workspace = true
 pldm-common.workspace = true
 pldm-fw-pkg.workspace = true
 pldm-ua.workspace = true
+registers-generated.workspace = true
 sha2.workspace = true
 simple_logger.workspace = true
 tempfile.workspace = true

--- a/tests/integration/src/jtag/mod.rs
+++ b/tests/integration/src/jtag/mod.rs
@@ -3,6 +3,7 @@
 mod test_jtag_taps;
 mod test_lc_transitions;
 mod test_manuf_debug_unlock;
+mod test_uds;
 
 #[cfg(test)]
 mod test {

--- a/tests/integration/src/jtag/test_uds.rs
+++ b/tests/integration/src/jtag/test_uds.rs
@@ -1,0 +1,81 @@
+// Licensed under the Apache-2.0 license
+
+#[cfg(test)]
+mod test {
+    use std::path::PathBuf;
+    use std::thread;
+    use std::time::Duration;
+
+    use crate::jtag::test::ss_setup;
+
+    use caliptra_hw_model::jtag::CaliptraCoreReg;
+    use caliptra_hw_model::openocd::openocd_jtag_tap::{JtagParams, JtagTap};
+    use caliptra_hw_model::HwModel;
+    use mcu_hw_model::McuHwModel;
+    use mcu_rom_common::LifecycleControllerState;
+    use registers_generated::fuses::{
+        SECRET_MANUF_PARTITION_BYTE_OFFSET, SECRET_MANUF_PARTITION_BYTE_SIZE,
+    };
+
+    #[test]
+    fn test_uds() {
+        let mut model = ss_setup(
+            Some(LifecycleControllerState::Dev),
+            /*debug_intent=*/ false,
+            /*bootfsm_break=*/ true,
+            /*enable_mcu_uart_log=*/ true,
+        );
+
+        // check UDS is blank
+        let before_uds = &model.read_otp_memory()[SECRET_MANUF_PARTITION_BYTE_OFFSET
+            ..SECRET_MANUF_PARTITION_BYTE_OFFSET + SECRET_MANUF_PARTITION_BYTE_SIZE];
+        assert!(before_uds.iter().all(|&b| b == 0));
+        println!("Before UDS: {:02x?}", before_uds);
+
+        // Connect to Caliptra Core JTAG TAP via OpenOCD.
+        println!("Connecting to Core TAP ...");
+        let jtag_params = JtagParams {
+            openocd: PathBuf::from("openocd"),
+            adapter_speed_khz: 1000,
+            log_stdio: true,
+        };
+        let mut tap = model
+            .jtag_tap_connect(&jtag_params, JtagTap::CaliptraCoreTap)
+            .expect("Failed to connect to the Caliptra Core JTAG TAP.");
+        println!("Connected.");
+
+        // Request UDS programming.
+        tap.write_reg(&CaliptraCoreReg::SsDbgManufServiceRegReq, 4)
+            .expect("Unable to write SsDbgManufServiceRegReq reg.");
+        model.base.step();
+
+        // Continue Caliptra Core boot.
+        tap.write_reg(&CaliptraCoreReg::BootfsmGo, 0x1)
+            .expect("Unable to write BootfsmGo.");
+        model.base.step();
+
+        // Wait for UDS programming operation to complete.
+        while let Ok(ss_debug_manuf_response) =
+            tap.read_reg(&CaliptraCoreReg::SsDbgManufServiceRegRsp)
+        {
+            if (ss_debug_manuf_response & 0x40) != 0 {
+                println!(
+                    "UDS programming complete (response: 0x{:08x}).",
+                    ss_debug_manuf_response
+                );
+                assert_eq!(ss_debug_manuf_response, 0x40);
+                break;
+            }
+            model.base.step();
+            // UDS programming is very fast
+            thread::sleep(Duration::from_millis(1));
+        }
+        // process the logs
+        model.base.step();
+        let after_uds = &model.read_otp_memory()[SECRET_MANUF_PARTITION_BYTE_OFFSET
+            ..SECRET_MANUF_PARTITION_BYTE_OFFSET + SECRET_MANUF_PARTITION_BYTE_SIZE];
+
+        println!("After UDS: {:02x?}", after_uds);
+        assert!(!after_uds.iter().all(|&b| b == 0));
+    }
+}


### PR DESCRIPTION
This adds a JTAG UDS programming test to run on the FPGA. It uses a similar framework to how our debug unlock tests work.

I tested this locally on my FPGA with Caliptra core 2.0.2 and the latest subsystem bitstream.