### PR TITLE
fpga: Enable JTAG tests in GHA

### DIFF
--- a/.github/workflows/fpga.yml
+++ b/.github/workflows/fpga.yml
@@ -213,7 +213,9 @@ jobs:
               --target-dir-remap="${TEST_BIN}/target"
               --workspace-remap=.
               -E 'package(mcu-hw-model) - test(model_emulated::test::test_new_unbooted)'
-              -E 'package(tests-integration) and test(test_jtag_taps) and test(test_lc_transitions) and test(test_uds)' # Modify this as we onboard crates to the FPGA test suite.
+              -E 'package(tests-integration) and test(test_jtag_taps)'
+              -E 'package(tests-integration) and test(test_lc_transitions)'
+              -E 'package(tests-integration) and test(test_uds)' # Modify this as we onboard crates to the FPGA test suite.
           )
               # disabled for now due to flakiness of recovery boot
               # -E 'package(tests-integration) and test(test_mctp_capsule_loopback)'


### PR DESCRIPTION
Fixes a syntax error that was causing tests to be skipped.