### PR TITLE
rom: Remove MRAC hardcoded value

### DIFF
--- a/platforms/fpga/rom/src/start.s
+++ b/platforms/fpga/rom/src/start.s
@@ -34,19 +34,7 @@ _start:
     lui     t0, %hi(MRAC_VALUE)
     addi    t0, t0, %lo(MRAC_VALUE)
     csrw    0x7c0, t0
-    li t0, 0xaaaaaaaa
-    csrrw t0, 0x7c0, t0
     fence.i
-
-    # the FPGA does not clear RAM on reset, so we do it here
-    # TODO: get addresses from ld script
-    li a0, 0x50000000
-    li a1, 16384
-    add a1, a1, a0
-clear_sram:
-    sw zero, 0(a0)
-    addi a0, a0, 4
-    bltu a0, a1, clear_sram
 
     # Copy BSS
     la t0, BSS_START

--- a/platforms/test_harness/src/fpga-start.s
+++ b/platforms/test_harness/src/fpga-start.s
@@ -34,19 +34,7 @@ _start:
     lui     t0, %hi(MRAC_VALUE)
     addi    t0, t0, %lo(MRAC_VALUE)
     csrw    0x7c0, t0
-    li t0, 0xaaaaaaaa
-    csrrw t0, 0x7c0, t0
     fence.i
-
-    # the FPGA does not clear RAM on reset, so we do it here
-    # TODO: get addresses from ld script
-    li a0, 0x50000000
-    li a1, 16384
-    add a1, a1, a0
-clear_sram:
-    sw zero, 0(a0)
-    addi a0, a0, 4
-    bltu a0, a1, clear_sram
 
     # Copy BSS
     la t0, BSS_START


### PR DESCRIPTION
And clearing of memory on start.

We set the MRAC correctly right above, but we accidentally left in the AAAA_AAAA value below it.

These were leftovers from testing at one point.