### PR TITLE
refactor(rom): Remove unused field_entropy parameter logic

### DIFF
--- a/rom/src/cold_boot.rs
+++ b/rom/src/cold_boot.rs
@@ -253,7 +253,7 @@ impl BootFlow for ColdBoot {
         mci.set_flow_checkpoint(McuRomBootStatus::AxiUsersConfigured.into());
 
         romtime::println!("[mcu-rom] Populating fuses");
-        soc.populate_fuses(fuses, mci, params.program_field_entropy.iter().any(|x| *x));
+        soc.populate_fuses(fuses, mci);
         mci.set_flow_checkpoint(McuRomBootStatus::FusesPopulatedToCaliptra.into());
 
         romtime::println!("[mcu-rom] Setting Caliptra fuse write done");

--- a/rom/src/rom.rs
+++ b/rom/src/rom.rs
@@ -125,15 +125,11 @@ impl Soc {
         self.registers.ss_caliptra_dma_axi_user.set(value);
     }
 
-    pub fn populate_fuses(&self, fuses: &Fuses, mci: &romtime::Mci, field_entropy: bool) {
+    pub fn populate_fuses(&self, fuses: &Fuses, mci: &romtime::Mci) {
         // secret fuses are populated by a hardware state machine, so we can skip those
 
-        // Field Entropy.
-        let offset = if field_entropy {
-            registers_generated::fuses::SECRET_PROD_PARTITION_0_BYTE_OFFSET
-        } else {
-            registers_generated::fuses::SECRET_MANUF_PARTITION_BYTE_OFFSET
-        };
+        // UDS partition base address. (FE offset is calculated automatically by Caliptra ROM.)
+        let offset = registers_generated::fuses::SECRET_MANUF_PARTITION_BYTE_OFFSET;
         romtime::println!(
             "[mcu-fuse-write] Setting UDS/FE base address to {:x}",
             offset


### PR DESCRIPTION
Remove conditional offset selection based on field_entropy parameter, using only SECRET_MANUF_PARTITION_BYTE_OFFSET for UDS/FE base address.