### PR TITLE
[test] move prod debug unlock test to its own file

### DIFF
--- a/.github/workflows/fpga.yml
+++ b/.github/workflows/fpga.yml
@@ -215,6 +215,8 @@ jobs:
               -E 'package(mcu-hw-model) - test(model_emulated::test::test_new_unbooted)'
               -E 'package(tests-integration) and test(test_jtag_taps)'
               -E 'package(tests-integration) and test(test_lc_transitions)'
+              -E 'package(tests-integration) and test(test_manuf_debug_unlock)'
+              -E 'package(tests-integration) and test(test_prod_debug_unlock)'
               -E 'package(tests-integration) and test(test_uds)' # Modify this as we onboard crates to the FPGA test suite.
           )
               # disabled for now due to flakiness of recovery boot

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,7 +271,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 [[package]]
 name = "caliptra-api"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c34e534826402b9b97df1cf19405f0532b1729f3#c34e534826402b9b97df1cf19405f0532b1729f3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5387cba9e1a895ffd1ab48ff81972b83973a5405#5387cba9e1a895ffd1ab48ff81972b83973a5405"
 dependencies = [
  "bitflags 2.10.0",
  "caliptra-api-types",
@@ -286,7 +286,7 @@ dependencies = [
 [[package]]
 name = "caliptra-api-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c34e534826402b9b97df1cf19405f0532b1729f3#c34e534826402b9b97df1cf19405f0532b1729f3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5387cba9e1a895ffd1ab48ff81972b83973a5405#5387cba9e1a895ffd1ab48ff81972b83973a5405"
 dependencies = [
  "caliptra-image-types",
 ]
@@ -294,7 +294,7 @@ dependencies = [
 [[package]]
 name = "caliptra-auth-man-gen"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c34e534826402b9b97df1cf19405f0532b1729f3#c34e534826402b9b97df1cf19405f0532b1729f3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5387cba9e1a895ffd1ab48ff81972b83973a5405#5387cba9e1a895ffd1ab48ff81972b83973a5405"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",
@@ -309,7 +309,7 @@ dependencies = [
 [[package]]
 name = "caliptra-auth-man-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c34e534826402b9b97df1cf19405f0532b1729f3#c34e534826402b9b97df1cf19405f0532b1729f3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5387cba9e1a895ffd1ab48ff81972b83973a5405#5387cba9e1a895ffd1ab48ff81972b83973a5405"
 dependencies = [
  "bitfield",
  "bitflags 2.10.0",
@@ -324,7 +324,7 @@ dependencies = [
 [[package]]
 name = "caliptra-builder"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c34e534826402b9b97df1cf19405f0532b1729f3#c34e534826402b9b97df1cf19405f0532b1729f3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5387cba9e1a895ffd1ab48ff81972b83973a5405#5387cba9e1a895ffd1ab48ff81972b83973a5405"
 dependencies = [
  "anyhow",
  "caliptra-image-crypto",
@@ -349,7 +349,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cfi-derive"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c34e534826402b9b97df1cf19405f0532b1729f3#c34e534826402b9b97df1cf19405f0532b1729f3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5387cba9e1a895ffd1ab48ff81972b83973a5405#5387cba9e1a895ffd1ab48ff81972b83973a5405"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -371,7 +371,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cfi-lib"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c34e534826402b9b97df1cf19405f0532b1729f3#c34e534826402b9b97df1cf19405f0532b1729f3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5387cba9e1a895ffd1ab48ff81972b83973a5405#5387cba9e1a895ffd1ab48ff81972b83973a5405"
 dependencies = [
  "caliptra-error",
  "caliptra-registers",
@@ -386,7 +386,7 @@ source = "git+https://github.com/chipsalliance/caliptra-cfi.git?rev=a98e499d279e
 [[package]]
 name = "caliptra-coverage"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c34e534826402b9b97df1cf19405f0532b1729f3#c34e534826402b9b97df1cf19405f0532b1729f3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5387cba9e1a895ffd1ab48ff81972b83973a5405#5387cba9e1a895ffd1ab48ff81972b83973a5405"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -404,7 +404,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cpu"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c34e534826402b9b97df1cf19405f0532b1729f3#c34e534826402b9b97df1cf19405f0532b1729f3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5387cba9e1a895ffd1ab48ff81972b83973a5405#5387cba9e1a895ffd1ab48ff81972b83973a5405"
 dependencies = [
  "caliptra-drivers",
  "caliptra-registers",
@@ -414,7 +414,7 @@ dependencies = [
 [[package]]
 name = "caliptra-drivers"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c34e534826402b9b97df1cf19405f0532b1729f3#c34e534826402b9b97df1cf19405f0532b1729f3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5387cba9e1a895ffd1ab48ff81972b83973a5405#5387cba9e1a895ffd1ab48ff81972b83973a5405"
 dependencies = [
  "arrayvec",
  "bitfield",
@@ -440,7 +440,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-bus"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c34e534826402b9b97df1cf19405f0532b1729f3#c34e534826402b9b97df1cf19405f0532b1729f3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5387cba9e1a895ffd1ab48ff81972b83973a5405#5387cba9e1a895ffd1ab48ff81972b83973a5405"
 dependencies = [
  "caliptra-emu-types",
  "tock-registers",
@@ -450,7 +450,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-cpu"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c34e534826402b9b97df1cf19405f0532b1729f3#c34e534826402b9b97df1cf19405f0532b1729f3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5387cba9e1a895ffd1ab48ff81972b83973a5405#5387cba9e1a895ffd1ab48ff81972b83973a5405"
 dependencies = [
  "bit-vec",
  "bitfield",
@@ -464,7 +464,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c34e534826402b9b97df1cf19405f0532b1729f3#c34e534826402b9b97df1cf19405f0532b1729f3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5387cba9e1a895ffd1ab48ff81972b83973a5405#5387cba9e1a895ffd1ab48ff81972b83973a5405"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -479,7 +479,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-derive"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c34e534826402b9b97df1cf19405f0532b1729f3#c34e534826402b9b97df1cf19405f0532b1729f3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5387cba9e1a895ffd1ab48ff81972b83973a5405#5387cba9e1a895ffd1ab48ff81972b83973a5405"
 dependencies = [
  "caliptra-emu-bus",
  "caliptra-emu-types",
@@ -490,7 +490,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-periph"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c34e534826402b9b97df1cf19405f0532b1729f3#c34e534826402b9b97df1cf19405f0532b1729f3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5387cba9e1a895ffd1ab48ff81972b83973a5405#5387cba9e1a895ffd1ab48ff81972b83973a5405"
 dependencies = [
  "aes",
  "arrayref",
@@ -517,17 +517,17 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c34e534826402b9b97df1cf19405f0532b1729f3#c34e534826402b9b97df1cf19405f0532b1729f3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5387cba9e1a895ffd1ab48ff81972b83973a5405#5387cba9e1a895ffd1ab48ff81972b83973a5405"
 
 [[package]]
 name = "caliptra-error"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c34e534826402b9b97df1cf19405f0532b1729f3#c34e534826402b9b97df1cf19405f0532b1729f3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5387cba9e1a895ffd1ab48ff81972b83973a5405#5387cba9e1a895ffd1ab48ff81972b83973a5405"
 
 [[package]]
 name = "caliptra-gen-linker-scripts"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c34e534826402b9b97df1cf19405f0532b1729f3#c34e534826402b9b97df1cf19405f0532b1729f3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5387cba9e1a895ffd1ab48ff81972b83973a5405#5387cba9e1a895ffd1ab48ff81972b83973a5405"
 dependencies = [
  "caliptra_common",
 ]
@@ -535,7 +535,7 @@ dependencies = [
 [[package]]
 name = "caliptra-hw-model"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c34e534826402b9b97df1cf19405f0532b1729f3#c34e534826402b9b97df1cf19405f0532b1729f3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5387cba9e1a895ffd1ab48ff81972b83973a5405#5387cba9e1a895ffd1ab48ff81972b83973a5405"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -574,7 +574,7 @@ dependencies = [
 [[package]]
 name = "caliptra-hw-model-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c34e534826402b9b97df1cf19405f0532b1729f3#c34e534826402b9b97df1cf19405f0532b1729f3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5387cba9e1a895ffd1ab48ff81972b83973a5405#5387cba9e1a895ffd1ab48ff81972b83973a5405"
 dependencies = [
  "caliptra-api-types",
  "rand",
@@ -583,7 +583,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c34e534826402b9b97df1cf19405f0532b1729f3#c34e534826402b9b97df1cf19405f0532b1729f3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5387cba9e1a895ffd1ab48ff81972b83973a5405#5387cba9e1a895ffd1ab48ff81972b83973a5405"
 dependencies = [
  "anyhow",
  "caliptra-image-gen",
@@ -603,7 +603,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-elf"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c34e534826402b9b97df1cf19405f0532b1729f3#c34e534826402b9b97df1cf19405f0532b1729f3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5387cba9e1a895ffd1ab48ff81972b83973a5405#5387cba9e1a895ffd1ab48ff81972b83973a5405"
 dependencies = [
  "anyhow",
  "caliptra-image-gen",
@@ -614,7 +614,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-fake-keys"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c34e534826402b9b97df1cf19405f0532b1729f3#c34e534826402b9b97df1cf19405f0532b1729f3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5387cba9e1a895ffd1ab48ff81972b83973a5405#5387cba9e1a895ffd1ab48ff81972b83973a5405"
 dependencies = [
  "caliptra-image-gen",
  "caliptra-image-types",
@@ -625,7 +625,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-gen"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c34e534826402b9b97df1cf19405f0532b1729f3#c34e534826402b9b97df1cf19405f0532b1729f3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5387cba9e1a895ffd1ab48ff81972b83973a5405#5387cba9e1a895ffd1ab48ff81972b83973a5405"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",
@@ -642,7 +642,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c34e534826402b9b97df1cf19405f0532b1729f3#c34e534826402b9b97df1cf19405f0532b1729f3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5387cba9e1a895ffd1ab48ff81972b83973a5405#5387cba9e1a895ffd1ab48ff81972b83973a5405"
 dependencies = [
  "caliptra-cfi-derive",
  "caliptra-cfi-lib",
@@ -658,7 +658,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-verify"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c34e534826402b9b97df1cf19405f0532b1729f3#c34e534826402b9b97df1cf19405f0532b1729f3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5387cba9e1a895ffd1ab48ff81972b83973a5405#5387cba9e1a895ffd1ab48ff81972b83973a5405"
 dependencies = [
  "bitflags 2.10.0",
  "caliptra-cfi-derive",
@@ -673,7 +673,7 @@ dependencies = [
 [[package]]
 name = "caliptra-kat"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c34e534826402b9b97df1cf19405f0532b1729f3#c34e534826402b9b97df1cf19405f0532b1729f3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5387cba9e1a895ffd1ab48ff81972b83973a5405#5387cba9e1a895ffd1ab48ff81972b83973a5405"
 dependencies = [
  "caliptra-drivers",
  "caliptra-lms-types",
@@ -685,7 +685,7 @@ dependencies = [
 [[package]]
 name = "caliptra-lms-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c34e534826402b9b97df1cf19405f0532b1729f3#c34e534826402b9b97df1cf19405f0532b1729f3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5387cba9e1a895ffd1ab48ff81972b83973a5405#5387cba9e1a895ffd1ab48ff81972b83973a5405"
 dependencies = [
  "caliptra-cfi-derive",
  "caliptra-cfi-lib",
@@ -698,7 +698,7 @@ dependencies = [
 [[package]]
 name = "caliptra-registers"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c34e534826402b9b97df1cf19405f0532b1729f3#c34e534826402b9b97df1cf19405f0532b1729f3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5387cba9e1a895ffd1ab48ff81972b83973a5405#5387cba9e1a895ffd1ab48ff81972b83973a5405"
 dependencies = [
  "caliptra-registers-latest",
 ]
@@ -706,7 +706,7 @@ dependencies = [
 [[package]]
 name = "caliptra-registers-latest"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c34e534826402b9b97df1cf19405f0532b1729f3#c34e534826402b9b97df1cf19405f0532b1729f3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5387cba9e1a895ffd1ab48ff81972b83973a5405#5387cba9e1a895ffd1ab48ff81972b83973a5405"
 dependencies = [
  "ureg",
 ]
@@ -714,7 +714,7 @@ dependencies = [
 [[package]]
 name = "caliptra-runtime"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c34e534826402b9b97df1cf19405f0532b1729f3#c34e534826402b9b97df1cf19405f0532b1729f3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5387cba9e1a895ffd1ab48ff81972b83973a5405#5387cba9e1a895ffd1ab48ff81972b83973a5405"
 dependencies = [
  "arrayvec",
  "bitfield",
@@ -749,7 +749,7 @@ dependencies = [
 [[package]]
 name = "caliptra-test"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c34e534826402b9b97df1cf19405f0532b1729f3#c34e534826402b9b97df1cf19405f0532b1729f3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5387cba9e1a895ffd1ab48ff81972b83973a5405#5387cba9e1a895ffd1ab48ff81972b83973a5405"
 dependencies = [
  "anyhow",
  "asn1",
@@ -781,12 +781,12 @@ dependencies = [
 [[package]]
 name = "caliptra-test-harness-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c34e534826402b9b97df1cf19405f0532b1729f3#c34e534826402b9b97df1cf19405f0532b1729f3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5387cba9e1a895ffd1ab48ff81972b83973a5405#5387cba9e1a895ffd1ab48ff81972b83973a5405"
 
 [[package]]
 name = "caliptra-x509"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c34e534826402b9b97df1cf19405f0532b1729f3#c34e534826402b9b97df1cf19405f0532b1729f3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5387cba9e1a895ffd1ab48ff81972b83973a5405#5387cba9e1a895ffd1ab48ff81972b83973a5405"
 dependencies = [
  "zeroize",
 ]
@@ -794,7 +794,7 @@ dependencies = [
 [[package]]
 name = "caliptra_common"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c34e534826402b9b97df1cf19405f0532b1729f3#c34e534826402b9b97df1cf19405f0532b1729f3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5387cba9e1a895ffd1ab48ff81972b83973a5405#5387cba9e1a895ffd1ab48ff81972b83973a5405"
 dependencies = [
  "bitfield",
  "bitflags 2.10.0",
@@ -1233,7 +1233,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c34e534826402b9b97df1cf19405f0532b1729f3#c34e534826402b9b97df1cf19405f0532b1729f3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5387cba9e1a895ffd1ab48ff81972b83973a5405#5387cba9e1a895ffd1ab48ff81972b83973a5405"
 dependencies = [
  "arrayvec",
  "caliptra-cfi-derive-git",
@@ -1437,7 +1437,7 @@ dependencies = [
 [[package]]
 name = "dpe"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c34e534826402b9b97df1cf19405f0532b1729f3#c34e534826402b9b97df1cf19405f0532b1729f3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5387cba9e1a895ffd1ab48ff81972b83973a5405#5387cba9e1a895ffd1ab48ff81972b83973a5405"
 dependencies = [
  "bitflags 2.10.0",
  "caliptra-cfi-derive-git",
@@ -3298,7 +3298,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 [[package]]
 name = "platform"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c34e534826402b9b97df1cf19405f0532b1729f3#c34e534826402b9b97df1cf19405f0532b1729f3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5387cba9e1a895ffd1ab48ff81972b83973a5405#5387cba9e1a895ffd1ab48ff81972b83973a5405"
 dependencies = [
  "arrayvec",
  "cfg-if",
@@ -4470,7 +4470,7 @@ dependencies = [
 [[package]]
 name = "ureg"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=c34e534826402b9b97df1cf19405f0532b1729f3#c34e534826402b9b97df1cf19405f0532b1729f3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5387cba9e1a895ffd1ab48ff81972b83973a5405#5387cba9e1a895ffd1ab48ff81972b83973a5405"
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -227,30 +227,30 @@ libtock_small_panic = { path = "runtime/userspace/libtock/panic_handlers/small_p
 libtock_unittest = { path = "runtime/userspace/libtock/unittest" }
 
 # caliptra dependencies; keep git revs in sync
-caliptra-api = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c34e534826402b9b97df1cf19405f0532b1729f3" }
-caliptra-api-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c34e534826402b9b97df1cf19405f0532b1729f3" }
-caliptra-auth-man-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c34e534826402b9b97df1cf19405f0532b1729f3" }
-caliptra-auth-man-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c34e534826402b9b97df1cf19405f0532b1729f3" }
-caliptra-builder = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c34e534826402b9b97df1cf19405f0532b1729f3" }
-caliptra-drivers = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c34e534826402b9b97df1cf19405f0532b1729f3" }
-caliptra-emu-bus = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c34e534826402b9b97df1cf19405f0532b1729f3" }
-caliptra-emu-cpu = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c34e534826402b9b97df1cf19405f0532b1729f3" }
-caliptra-emu-derive = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c34e534826402b9b97df1cf19405f0532b1729f3" }
-caliptra-emu-periph = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c34e534826402b9b97df1cf19405f0532b1729f3" }
-caliptra-emu-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c34e534826402b9b97df1cf19405f0532b1729f3" }
-caliptra-error = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c34e534826402b9b97df1cf19405f0532b1729f3", default-features = false }
-caliptra-hw-model = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c34e534826402b9b97df1cf19405f0532b1729f3" }
-caliptra-hw-model-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c34e534826402b9b97df1cf19405f0532b1729f3" }
-caliptra-image-crypto = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c34e534826402b9b97df1cf19405f0532b1729f3", default-features = false, features = ["rustcrypto"] }
-caliptra-image-fake-keys = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c34e534826402b9b97df1cf19405f0532b1729f3" }
-caliptra-image-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c34e534826402b9b97df1cf19405f0532b1729f3" }
-caliptra-image-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c34e534826402b9b97df1cf19405f0532b1729f3" }
-caliptra-registers = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c34e534826402b9b97df1cf19405f0532b1729f3" }
-caliptra-test = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c34e534826402b9b97df1cf19405f0532b1729f3" }
-caliptra-test-harness = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c34e534826402b9b97df1cf19405f0532b1729f3" }
-caliptra-test-harness-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c34e534826402b9b97df1cf19405f0532b1729f3" }
-ureg = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c34e534826402b9b97df1cf19405f0532b1729f3" }
-dpe = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "c34e534826402b9b97df1cf19405f0532b1729f3", default-features = false, features = ["dpe_profile_p384_sha384"] }
+caliptra-api = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "5387cba9e1a895ffd1ab48ff81972b83973a5405" }
+caliptra-api-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "5387cba9e1a895ffd1ab48ff81972b83973a5405" }
+caliptra-auth-man-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "5387cba9e1a895ffd1ab48ff81972b83973a5405" }
+caliptra-auth-man-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "5387cba9e1a895ffd1ab48ff81972b83973a5405" }
+caliptra-builder = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "5387cba9e1a895ffd1ab48ff81972b83973a5405" }
+caliptra-drivers = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "5387cba9e1a895ffd1ab48ff81972b83973a5405" }
+caliptra-emu-bus = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "5387cba9e1a895ffd1ab48ff81972b83973a5405" }
+caliptra-emu-cpu = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "5387cba9e1a895ffd1ab48ff81972b83973a5405" }
+caliptra-emu-derive = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "5387cba9e1a895ffd1ab48ff81972b83973a5405" }
+caliptra-emu-periph = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "5387cba9e1a895ffd1ab48ff81972b83973a5405" }
+caliptra-emu-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "5387cba9e1a895ffd1ab48ff81972b83973a5405" }
+caliptra-error = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "5387cba9e1a895ffd1ab48ff81972b83973a5405", default-features = false }
+caliptra-hw-model = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "5387cba9e1a895ffd1ab48ff81972b83973a5405" }
+caliptra-hw-model-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "5387cba9e1a895ffd1ab48ff81972b83973a5405" }
+caliptra-image-crypto = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "5387cba9e1a895ffd1ab48ff81972b83973a5405", default-features = false, features = ["rustcrypto"] }
+caliptra-image-fake-keys = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "5387cba9e1a895ffd1ab48ff81972b83973a5405" }
+caliptra-image-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "5387cba9e1a895ffd1ab48ff81972b83973a5405" }
+caliptra-image-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "5387cba9e1a895ffd1ab48ff81972b83973a5405" }
+caliptra-registers = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "5387cba9e1a895ffd1ab48ff81972b83973a5405" }
+caliptra-test = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "5387cba9e1a895ffd1ab48ff81972b83973a5405" }
+caliptra-test-harness = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "5387cba9e1a895ffd1ab48ff81972b83973a5405" }
+caliptra-test-harness-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "5387cba9e1a895ffd1ab48ff81972b83973a5405" }
+ureg = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "5387cba9e1a895ffd1ab48ff81972b83973a5405" }
+dpe = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "5387cba9e1a895ffd1ab48ff81972b83973a5405", default-features = false, features = ["dpe_profile_p384_sha384"] }
 
 # local caliptra dependency; useful when developing
 # caliptra-api = { path = "../caliptra-sw/api" }

--- a/tests/integration/src/jtag/mod.rs
+++ b/tests/integration/src/jtag/mod.rs
@@ -3,6 +3,7 @@
 mod test_jtag_taps;
 mod test_lc_transitions;
 mod test_manuf_debug_unlock;
+mod test_prod_debug_unlock;
 mod test_uds;
 
 #[cfg(test)]

--- a/tests/integration/src/jtag/test_lc_transitions.rs
+++ b/tests/integration/src/jtag/test_lc_transitions.rs
@@ -3,35 +3,14 @@
 #[cfg(test)]
 mod test {
     use std::path::PathBuf;
-    use std::thread;
-    use std::time::Duration;
 
     use crate::jtag::test::ss_setup;
 
-    use caliptra_hw_model::jtag::CaliptraCoreReg;
     use caliptra_hw_model::openocd::openocd_jtag_tap::{JtagParams, JtagTap};
     use caliptra_hw_model::HwModel;
     use caliptra_hw_model::DEFAULT_LIFECYCLE_RAW_TOKEN;
-    use caliptra_image_fake_keys::{
-        VENDOR_ECC_KEY_0_PRIVATE, VENDOR_ECC_KEY_0_PUBLIC, VENDOR_MLDSA_KEY_0_PRIVATE,
-        VENDOR_MLDSA_KEY_0_PUBLIC,
-    };
-    use caliptra_image_types::{
-        ECC384_SCALAR_BYTE_SIZE, ECC384_SCALAR_WORD_SIZE, MLDSA87_PRIV_KEY_BYTE_SIZE,
-    };
-    use mcu_hw_model::debug_unlock::{
-        prod_debug_unlock_gen_signed_token, prod_debug_unlock_get_challenge,
-        prod_debug_unlock_send_request, prod_debug_unlock_send_token,
-        prod_debug_unlock_wait_for_in_progress,
-    };
-    use mcu_hw_model::jtag::jtag_wait_for_caliptra_mailbox_resp;
     use mcu_hw_model::lcc::{lc_token_to_words, lc_transition, read_lc_state};
     use mcu_rom_common::LifecycleControllerState;
-
-    use fips204::ml_dsa_87::PrivateKey as MldsaPrivateKey;
-    use fips204::traits::SerDes;
-    use p384::SecretKey as EcdsaSecretKey;
-    use zerocopy::IntoBytes;
 
     #[test]
     fn test_raw_unlock() {
@@ -186,135 +165,5 @@ mod test {
         lc_state = read_lc_state(&mut *tap).expect("Unable to read LC state.");
         println!("LC state after reset: {}", lc_state);
         assert_eq!(lc_state, LifecycleControllerState::Rma);
-    }
-
-    #[test]
-    fn test_prod_debug_unlock() {
-        let mut model = ss_setup(
-            Some(LifecycleControllerState::Prod),
-            /*rma_or_scrap_ppd=*/ false,
-            /*debug_intent=*/ true,
-            /*bootfsm_break=*/ true,
-            /*enable_mcu_uart_log=*/ true,
-        );
-
-        // Connect to Caliptra Core JTAG TAP via OpenOCD.
-        println!("Connecting to Core TAP ...");
-        let jtag_params = JtagParams {
-            openocd: PathBuf::from("openocd"),
-            adapter_speed_khz: 1000,
-            log_stdio: true,
-        };
-        let mut tap = model
-            .jtag_tap_connect(&jtag_params, JtagTap::CaliptraCoreTap)
-            .expect("Failed to connect to the Caliptra Core JTAG TAP.");
-        println!("Connected.");
-
-        // Ensure another prod debug unlock operation is not in progress.
-        let dbg_manuf_service_rsp = tap
-            .read_reg(&CaliptraCoreReg::SsDbgManufServiceRegRsp)
-            .expect("Unable to read SsDbgManufServiceRegRes reg.");
-        assert_eq!(dbg_manuf_service_rsp & 0x20, 0);
-        let mut dbg_manuf_service_req = tap
-            .read_reg(&CaliptraCoreReg::SsDbgManufServiceRegReq)
-            .expect("Unable to read SsDbgManufServiceRegReq reg.");
-        assert_eq!(dbg_manuf_service_req, 0);
-
-        // Request prod debug unlock operation.
-        println!("Request to initiate prod debug unlock ...");
-        tap.write_reg(&CaliptraCoreReg::SsDbgManufServiceRegReq, 0x2)
-            .expect("Unable to write SsDbgManufServiceRegReq reg.");
-        dbg_manuf_service_req = tap
-            .read_reg(&CaliptraCoreReg::SsDbgManufServiceRegReq)
-            .expect("Unable to read SsDbgManufServiceRegReq reg.");
-        assert_eq!(dbg_manuf_service_req, 0x2);
-        println!("Request sent.");
-
-        // Continue Caliptra Core boot.
-        tap.write_reg(&CaliptraCoreReg::BootfsmGo, 0x1)
-            .expect("Unable to write BootfsmGo.");
-
-        // Wait for the Caliptra mailbox to become available.
-        let mut mb_available = false;
-        println!("Waiting for Caliptra mailbox TAP to become available ...");
-        while let Ok(rsp) = tap.read_reg(&CaliptraCoreReg::SsDbgManufServiceRegRsp) {
-            if rsp & 0x200 != 0 {
-                mb_available = true;
-                break;
-            }
-            println!("waiting {:x?} ...", rsp);
-            model.base.step();
-            thread::sleep(Duration::from_millis(100));
-        }
-        assert_eq!(mb_available, true);
-        println!("Mailbox available.");
-
-        // Wait for the prod debug unlock request to be "in-progress".
-        println!("Waiting for prod debug unlock in progress ...");
-        let _ = prod_debug_unlock_wait_for_in_progress(&mut model, &mut *tap, /*begin=*/ true);
-        println!("In progress.");
-
-        // Send the debug unlock request and wait for the challenge response in the mailbox.
-        println!("Sending the prod debug unlock request ...");
-        prod_debug_unlock_send_request(&mut *tap, /*debug_level=*/ 1)
-            .expect("Failed to send prod debug unlock request.");
-        model.base.step();
-        println!("Request sent.");
-        println!("Waiting for the challenge response ...");
-        let status = jtag_wait_for_caliptra_mailbox_resp(&mut *tap)
-            .expect("Never received challenge in mailbox.");
-        assert_eq!(status, 0x1);
-        model.base.step();
-        let du_challenge = prod_debug_unlock_get_challenge(&mut *tap)
-            .expect("Unable to read challenge in mailbox.");
-        println!("Challenge received.");
-
-        // Load the ECDSA private key to sign the token with.
-        let mut be_ecc_priv_key_bytes = [0u8; ECC384_SCALAR_BYTE_SIZE];
-        for (i, word) in VENDOR_ECC_KEY_0_PRIVATE.iter().enumerate() {
-            be_ecc_priv_key_bytes[i * 4..i * 4 + 4].copy_from_slice(&word.to_be_bytes());
-        }
-        let ecc_private_key = EcdsaSecretKey::from_slice(&be_ecc_priv_key_bytes)
-            .expect("Unable to load ECC P384 private key.");
-        let mut ecc_public_key = [0u32; ECC384_SCALAR_WORD_SIZE * 2];
-        ecc_public_key[..12].copy_from_slice(&VENDOR_ECC_KEY_0_PUBLIC.x);
-        ecc_public_key[12..].copy_from_slice(&VENDOR_ECC_KEY_0_PUBLIC.y);
-
-        // Load the ML-DSA private key to sign the token with.
-        let mldsa_priv_key_bytes: [u8; MLDSA87_PRIV_KEY_BYTE_SIZE] = VENDOR_MLDSA_KEY_0_PRIVATE
-            .0
-            .as_bytes()
-            .try_into()
-            .map_err(|_| anyhow::anyhow!("Invalid private key size"))
-            .expect("Unable to load ML-DSA-87 private key.");
-        let mldsa_private_key = MldsaPrivateKey::try_from_bytes(mldsa_priv_key_bytes)
-            .expect("Unable to load ML-DSA-87 private key.");
-
-        // Construct the debug unlock token.
-        println!("Constructing the signed unlock token ...");
-        let du_token = prod_debug_unlock_gen_signed_token(
-            &du_challenge,
-            /*debug_level=*/ 1,
-            &ecc_private_key,
-            &mldsa_private_key,
-            &ecc_public_key,
-            &VENDOR_MLDSA_KEY_0_PUBLIC.0,
-        )
-        .expect("Unable to generate a signed token.");
-        println!("Token constructing and signed.");
-
-        // Send the signed prod debug unlock token to the mailbox.
-        println!("Sending the signed unlock token to the mailbox ...");
-        prod_debug_unlock_send_token(&mut *tap, &du_token)
-            .expect("Unable to send the signed token to the mailbox.");
-        model.base.step();
-        println!("Token sent.");
-
-        // Wait for the prod debug unlock request to be complete.
-        println!("Waiting for prod debug unlock in progress to complete ...");
-        let response =
-            prod_debug_unlock_wait_for_in_progress(&mut model, &mut *tap, /*begin=*/ false);
-        assert_eq!(response & 0x8, 0x8);
-        println!("Unlock complete.");
     }
 }

--- a/tests/integration/src/jtag/test_prod_debug_unlock.rs
+++ b/tests/integration/src/jtag/test_prod_debug_unlock.rs
@@ -1,0 +1,163 @@
+// Licensed under the Apache-2.0 license
+
+#[cfg(test)]
+mod test {
+    use std::path::PathBuf;
+    use std::thread;
+    use std::time::Duration;
+
+    use crate::jtag::test::ss_setup;
+
+    use caliptra_hw_model::jtag::CaliptraCoreReg;
+    use caliptra_hw_model::openocd::openocd_jtag_tap::{JtagParams, JtagTap};
+    use caliptra_hw_model::HwModel;
+    use caliptra_image_fake_keys::{
+        VENDOR_ECC_KEY_0_PRIVATE, VENDOR_ECC_KEY_0_PUBLIC, VENDOR_MLDSA_KEY_0_PRIVATE,
+        VENDOR_MLDSA_KEY_0_PUBLIC,
+    };
+    use caliptra_image_types::{
+        ECC384_SCALAR_BYTE_SIZE, ECC384_SCALAR_WORD_SIZE, MLDSA87_PRIV_KEY_BYTE_SIZE,
+    };
+    use mcu_hw_model::debug_unlock::{
+        prod_debug_unlock_gen_signed_token, prod_debug_unlock_get_challenge,
+        prod_debug_unlock_send_request, prod_debug_unlock_send_token,
+        prod_debug_unlock_wait_for_in_progress,
+    };
+    use mcu_hw_model::jtag::jtag_wait_for_caliptra_mailbox_resp;
+    use mcu_rom_common::LifecycleControllerState;
+
+    use fips204::ml_dsa_87::PrivateKey as MldsaPrivateKey;
+    use fips204::traits::SerDes;
+    use p384::SecretKey as EcdsaSecretKey;
+    use zerocopy::IntoBytes;
+
+    #[test]
+    fn test_prod_debug_unlock() {
+        let mut model = ss_setup(
+            Some(LifecycleControllerState::Prod),
+            /*rma_or_scrap_ppd=*/ false,
+            /*debug_intent=*/ true,
+            /*bootfsm_break=*/ true,
+            /*enable_mcu_uart_log=*/ true,
+        );
+
+        // Connect to Caliptra Core JTAG TAP via OpenOCD.
+        println!("Connecting to Core TAP ...");
+        let jtag_params = JtagParams {
+            openocd: PathBuf::from("openocd"),
+            adapter_speed_khz: 1000,
+            log_stdio: true,
+        };
+        let mut tap = model
+            .jtag_tap_connect(&jtag_params, JtagTap::CaliptraCoreTap)
+            .expect("Failed to connect to the Caliptra Core JTAG TAP.");
+        println!("Connected.");
+
+        // Ensure another prod debug unlock operation is not in progress.
+        let dbg_manuf_service_rsp = tap
+            .read_reg(&CaliptraCoreReg::SsDbgManufServiceRegRsp)
+            .expect("Unable to read SsDbgManufServiceRegRes reg.");
+        assert_eq!(dbg_manuf_service_rsp & 0x20, 0);
+        let mut dbg_manuf_service_req = tap
+            .read_reg(&CaliptraCoreReg::SsDbgManufServiceRegReq)
+            .expect("Unable to read SsDbgManufServiceRegReq reg.");
+        assert_eq!(dbg_manuf_service_req, 0);
+
+        // Request prod debug unlock operation.
+        println!("Request to initiate prod debug unlock ...");
+        tap.write_reg(&CaliptraCoreReg::SsDbgManufServiceRegReq, 0x2)
+            .expect("Unable to write SsDbgManufServiceRegReq reg.");
+        dbg_manuf_service_req = tap
+            .read_reg(&CaliptraCoreReg::SsDbgManufServiceRegReq)
+            .expect("Unable to read SsDbgManufServiceRegReq reg.");
+        assert_eq!(dbg_manuf_service_req, 0x2);
+        println!("Request sent.");
+
+        // Continue Caliptra Core boot.
+        tap.write_reg(&CaliptraCoreReg::BootfsmGo, 0x1)
+            .expect("Unable to write BootfsmGo.");
+
+        // Wait for the Caliptra mailbox to become available.
+        let mut mb_available = false;
+        println!("Waiting for Caliptra mailbox TAP to become available ...");
+        while let Ok(rsp) = tap.read_reg(&CaliptraCoreReg::SsDbgManufServiceRegRsp) {
+            if rsp & 0x200 != 0 {
+                mb_available = true;
+                break;
+            }
+            println!("waiting {:x?} ...", rsp);
+            model.base.step();
+            thread::sleep(Duration::from_millis(100));
+        }
+        assert_eq!(mb_available, true);
+        println!("Mailbox available.");
+
+        // Wait for the prod debug unlock request to be "in-progress".
+        println!("Waiting for prod debug unlock in progress ...");
+        let _ = prod_debug_unlock_wait_for_in_progress(&mut model, &mut *tap, /*begin=*/ true);
+        println!("In progress.");
+
+        // Send the debug unlock request and wait for the challenge response in the mailbox.
+        println!("Sending the prod debug unlock request ...");
+        prod_debug_unlock_send_request(&mut *tap, /*debug_level=*/ 1)
+            .expect("Failed to send prod debug unlock request.");
+        model.base.step();
+        println!("Request sent.");
+        println!("Waiting for the challenge response ...");
+        let status = jtag_wait_for_caliptra_mailbox_resp(&mut *tap)
+            .expect("Never received challenge in mailbox.");
+        assert_eq!(status, 0x1);
+        model.base.step();
+        let du_challenge = prod_debug_unlock_get_challenge(&mut *tap)
+            .expect("Unable to read challenge in mailbox.");
+        println!("Challenge received.");
+
+        // Load the ECDSA private key to sign the token with.
+        let mut be_ecc_priv_key_bytes = [0u8; ECC384_SCALAR_BYTE_SIZE];
+        for (i, word) in VENDOR_ECC_KEY_0_PRIVATE.iter().enumerate() {
+            be_ecc_priv_key_bytes[i * 4..i * 4 + 4].copy_from_slice(&word.to_be_bytes());
+        }
+        let ecc_private_key = EcdsaSecretKey::from_slice(&be_ecc_priv_key_bytes)
+            .expect("Unable to load ECC P384 private key.");
+        let mut ecc_public_key = [0u32; ECC384_SCALAR_WORD_SIZE * 2];
+        ecc_public_key[..12].copy_from_slice(&VENDOR_ECC_KEY_0_PUBLIC.x);
+        ecc_public_key[12..].copy_from_slice(&VENDOR_ECC_KEY_0_PUBLIC.y);
+
+        // Load the ML-DSA private key to sign the token with.
+        let mldsa_priv_key_bytes: [u8; MLDSA87_PRIV_KEY_BYTE_SIZE] = VENDOR_MLDSA_KEY_0_PRIVATE
+            .0
+            .as_bytes()
+            .try_into()
+            .map_err(|_| anyhow::anyhow!("Invalid private key size"))
+            .expect("Unable to load ML-DSA-87 private key.");
+        let mldsa_private_key = MldsaPrivateKey::try_from_bytes(mldsa_priv_key_bytes)
+            .expect("Unable to load ML-DSA-87 private key.");
+
+        // Construct the debug unlock token.
+        println!("Constructing the signed unlock token ...");
+        let du_token = prod_debug_unlock_gen_signed_token(
+            &du_challenge,
+            /*debug_level=*/ 1,
+            &ecc_private_key,
+            &mldsa_private_key,
+            &ecc_public_key,
+            &VENDOR_MLDSA_KEY_0_PUBLIC.0,
+        )
+        .expect("Unable to generate a signed token.");
+        println!("Token constructing and signed.");
+
+        // Send the signed prod debug unlock token to the mailbox.
+        println!("Sending the signed unlock token to the mailbox ...");
+        prod_debug_unlock_send_token(&mut *tap, &du_token)
+            .expect("Unable to send the signed token to the mailbox.");
+        model.base.step();
+        println!("Token sent.");
+
+        // Wait for the prod debug unlock request to be complete.
+        println!("Waiting for prod debug unlock in progress to complete ...");
+        let response =
+            prod_debug_unlock_wait_for_in_progress(&mut model, &mut *tap, /*begin=*/ false);
+        assert_eq!(response & 0x8, 0x8);
+        println!("Unlock complete.");
+    }
+}


### PR DESCRIPTION
Also:
1. ensure the manuf debug unlock test runs in CI, and
2. rev the caliptra-sw repo version.