### PR TITLE
Adding second axi user to McuStraps

### DIFF
--- a/common/config/src/lib.rs
+++ b/common/config/src/lib.rs
@@ -100,7 +100,8 @@ impl Default for McuMemoryMap {
 #[repr(C)]
 pub struct McuStraps {
     pub i3c_static_addr: u8,
-    pub axi_user: u32,
+    pub axi_user0: u32,
+    pub axi_user1: u32,
     pub cptra_wdt_cfg0: u32,
     pub cptra_wdt_cfg1: u32,
     pub mcu_wdt_cfg0: u32,
@@ -111,7 +112,8 @@ impl McuStraps {
     pub const fn default() -> Self {
         McuStraps {
             i3c_static_addr: 0x3a,
-            axi_user: 0xcccc_cccc,
+            axi_user0: 0xcccc_cccc,
+            axi_user1: 0xdddd_dddd,
             cptra_wdt_cfg0: 100_000_000,
             cptra_wdt_cfg1: 100_000_000,
             mcu_wdt_cfg0: 20_000_000,

--- a/platforms/fpga/config/src/lib.rs
+++ b/platforms/fpga/config/src/lib.rs
@@ -48,7 +48,8 @@ pub const FPGA_MEMORY_MAP: McuMemoryMap = McuMemoryMap {
 
 pub const FPGA_MCU_STRAPS: McuStraps = McuStraps {
     i3c_static_addr: 0x3a,
-    axi_user: 0x1,
+    axi_user0: 0x1,
+    axi_user1: 0x2,
     cptra_wdt_cfg0: 200_000_000,
     cptra_wdt_cfg1: 200_000_000,
     mcu_wdt_cfg0: 800_000_000, // the FPGA is slower to boot

--- a/rom/src/cold_boot.rs
+++ b/rom/src/cold_boot.rs
@@ -231,25 +231,33 @@ impl BootFlow for ColdBoot {
         mci.set_flow_checkpoint(McuRomBootStatus::CaliptraReadyForFuses.into());
 
         romtime::println!("[mcu-rom] Writing fuses to Caliptra");
+
         romtime::println!(
             "[mcu-rom] Setting Caliptra mailbox user 0 to {}",
-            HexWord(straps.axi_user)
+            HexWord(straps.axi_user0)
         );
-
-        soc.set_cptra_mbox_valid_axi_user(0, straps.axi_user);
+        soc.set_cptra_mbox_valid_axi_user(0, straps.axi_user0);
         romtime::println!("[mcu-rom] Locking Caliptra mailbox user 0");
         soc.set_cptra_mbox_axi_user_lock(0, 1);
 
+        romtime::println!(
+            "[mcu-rom] Setting Caliptra mailbox user 1 to {}",
+            HexWord(straps.axi_user1)
+        );
+        soc.set_cptra_mbox_valid_axi_user(1, straps.axi_user1);
+        romtime::println!("[mcu-rom] Locking Caliptra mailbox user 1");
+        soc.set_cptra_mbox_axi_user_lock(1, 1);
+
         romtime::println!("[mcu-rom] Setting fuse user");
-        soc.set_cptra_fuse_valid_axi_user(straps.axi_user);
+        soc.set_cptra_fuse_valid_axi_user(straps.axi_user0);
         romtime::println!("[mcu-rom] Locking fuse user");
         soc.set_cptra_fuse_axi_user_lock(1);
         romtime::println!("[mcu-rom] Setting TRNG user");
-        soc.set_cptra_trng_valid_axi_user(straps.axi_user);
+        soc.set_cptra_trng_valid_axi_user(straps.axi_user0);
         romtime::println!("[mcu-rom] Locking TRNG user");
         soc.set_cptra_trng_axi_user_lock(1);
         romtime::println!("[mcu-rom] Setting DMA user");
-        soc.set_ss_caliptra_dma_axi_user(straps.axi_user);
+        soc.set_ss_caliptra_dma_axi_user(straps.axi_user0);
         mci.set_flow_checkpoint(McuRomBootStatus::AxiUsersConfigured.into());
 
         romtime::println!("[mcu-rom] Populating fuses");


### PR DESCRIPTION
Resolves subsystem FPGA failures in test_reallocate_dpe_context_limits.

Note: A more robust solution could include using the array of AXI users in the boot_params