### PR TITLE
xtask and build: consolidate platform parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4915,6 +4915,7 @@ dependencies = [
  "crc32fast",
  "elf",
  "mcu-builder",
+ "mcu-config",
  "mcu-config-emulator",
  "mcu-config-fpga",
  "mcu-hw-model",

--- a/builder/src/lib.rs
+++ b/builder/src/lib.rs
@@ -11,6 +11,7 @@ mod tbf;
 
 pub use all::{all_build, AllBuildArgs, FirmwareBinaries};
 pub use caliptra::{CaliptraBuilder, ImageCfg};
+pub use mcu_config::McuMemoryMap;
 pub use rom::{rom_build, rom_ld_script, test_rom_build};
 pub use runtime::{
     runtime_build_no_apps_uncached, runtime_build_with_apps_cached, runtime_ld_script,
@@ -113,4 +114,24 @@ pub(crate) fn target_binary(name: &str) -> PathBuf {
         .join(TARGET)
         .join("release")
         .join(name)
+}
+
+/// Selects and returns the memory map based on the platform name.
+pub fn select_memory_map(platform_name: &str) -> McuMemoryMap {
+    match platform_name {
+        "emulator" => mcu_config_emulator::EMULATOR_MEMORY_MAP,
+        "fpga" => mcu_config_fpga::FPGA_MEMORY_MAP,
+        _ => mcu_config_emulator::EMULATOR_MEMORY_MAP, /* default to emulator */
+    }
+}
+
+/// Selects and returns the logging flash configuration based on the platform name.
+pub fn select_logging_flash_config(
+    platform_name: &str,
+) -> Option<&mcu_config_emulator::flash::LoggingFlashConfig> {
+    match platform_name {
+        "emulator" => Some(&mcu_config_emulator::flash::LOGGING_FLASH_CONFIG),
+        "fpga" => None,
+        _ => panic!("Unsupported platform"),
+    }
 }

--- a/builder/src/runtime.rs
+++ b/builder/src/runtime.rs
@@ -46,10 +46,11 @@ fn get_apps_memory_offset(elf_file: PathBuf) -> Result<usize> {
 }
 
 pub(crate) fn bit_flags(platform: &str) -> &str {
-    match platform {
-        // TODO: remove this hack when the FPGA has another apeture for MCU SRAM
-        "fpga" => "-C target-feature=+relax", // no-op since this is already included
-        _ => "-C target-feature=+unaligned-scalar-mem",
+    // TODO: remove this hack when the FPGA has another apeture for MCU SRAM
+    if platform.contains("fpga") {
+        "-C target-feature=+relax" // no-op since this is already included
+    } else {
+        "-C target-feature=+unaligned-scalar-mem"
     }
 }
 

--- a/common/config/src/lib.rs
+++ b/common/config/src/lib.rs
@@ -7,6 +7,7 @@ pub mod boot;
 /// Configures the memory map for the MCU.
 /// These are the defaults that can be overridden and provided to the ROM and runtime builds.
 #[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct McuMemoryMap {
     pub rom_offset: u32,
     pub rom_size: u32,

--- a/tests/integration/src/lib.rs
+++ b/tests/integration/src/lib.rs
@@ -10,14 +10,6 @@ mod test_mctp_capsule_loopback;
 mod test_pldm_fw_update;
 mod test_soc_boot;
 
-pub fn platform() -> &'static str {
-    if cfg!(feature = "fpga_realtime") {
-        "fpga"
-    } else {
-        "emulator"
-    }
-}
-
 #[cfg(test)]
 mod test {
     use caliptra_hw_model::BootParams;

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -25,6 +25,7 @@ clap-num.workspace = true
 crc32fast.workspace = true
 elf.workspace = true
 mcu-builder.workspace = true
+mcu-config.workspace = true
 mcu-config-emulator.workspace = true
 mcu-config-fpga.workspace = true
 mcu-rom-common.workspace = true


### PR DESCRIPTION
xtask and builder: 
* Add hex output for ROMs (needed by all HW standard tools).
* Consolidate platform parsing.
* Add support for any fpga platform (use "contains" to detect such platforms).
* Remove double function.

Signed-off-by: Tali Perry <tali.perry@nuvoton.com>