### PR TITLE
Use segmented bitstream for FPGA (#622)

### DIFF
--- a/.github/workflows/fpga.yml
+++ b/.github/workflows/fpga.yml
@@ -155,6 +155,20 @@ jobs:
           tar xvf /tmp/caliptra-test-binaries.tar.zst -C /tmp/caliptra-test-binaries/
           mksquashfs /tmp/caliptra-test-binaries /tmp/caliptra-test-binaries.sqsh -comp zstd
 
+      - name: Download bitstream
+        run: |
+          cargo install --git https://github.com/chipsalliance/caliptra-sw --branch main-2.x bitstream-downloader --root /tmp/bitstream-downloader
+          /tmp/bitstream-downloader/bin/bitstream-downloader --bitstream-manifest hw/fpga/bitstream_manifests/subsystem.toml
+          mv subsystem.pdi /tmp/caliptra-bitstream.pdi
+
+      - name: 'Upload bitstream'
+        uses: actions/upload-artifact@v4
+        with:
+          name: caliptra-bitstream${{ inputs.artifact-suffix }}
+          path: /tmp/caliptra-bitstream.pdi
+          retention-days: 1
+
+
       - name: 'Upload test binaries artifact'
         uses: actions/upload-artifact@v4
         with:
@@ -170,7 +184,7 @@ jobs:
           retention-days: 1
 
   test_artifacts:
-    runs-on: vck190-subsystem-2.0
+    runs-on: vck190-subsystem
     needs: build_test_binaries
     timeout-minutes: 120
 
@@ -191,6 +205,19 @@ jobs:
         with:
           name: caliptra-test-firmware${{ inputs.artifact-suffix }}
           path: /tmp/caliptra-binaries
+
+      - name: 'Download Bitstream'
+        uses: actions/download-artifact@v4
+        with:
+          name: caliptra-bitstream${{ inputs.artifact-suffix }}
+          path: /tmp/caliptra-bitstream
+
+      - name: Load bitstream
+        run: |
+          sudo mkdir -p /lib/firmware
+          ls /tmp/caliptra-bitstream
+          sudo cp /tmp/caliptra-bitstream/caliptra-bitstream.pdi /lib/firmware
+          sudo bash -c 'echo "caliptra-bitstream.pdi" > /sys/class/fpga_manager/fpga0/firmware'
 
       - name: Mount binaries
         run: |

--- a/hw/fpga/bitstream_manifests/subsystem.toml
+++ b/hw/fpga/bitstream_manifests/subsystem.toml
@@ -1,0 +1,9 @@
+# Licensed under the Apache-2.0 license
+
+[bitstream]
+name = "subsystem-2.0"
+url = "https://storage.googleapis.com/caliptra-github-ci-bitstreams/scratch/runtime_b9f8a767.pdi"
+hash = "8769b1dd11762c96d2734b5c83b0bdaf22f228bf6593d04c35ba4f5cf63b6657"
+caliptra_variant = "subsystem"
+caliptra_rtl_commit = "98da61f1000b32826539e9410e8c3962741ad61a"
+


### PR DESCRIPTION
This allows sharing FPGAs between 2.0 and 2.1.