### PR TITLE
[xtask-fpga]: Fix boolean logic

### DIFF
--- a/xtask/src/fpga/mod.rs
+++ b/xtask/src/fpga/mod.rs
@@ -218,8 +218,8 @@ pub(crate) fn fpga_entry(args: &Fpga) -> Result<()> {
             let hostname = run_command_with_output(target_host, "hostname")?;
 
             // skip this step for CI images. Kernel modules are already installed.
-            let caliptra_fpga = hostname.trim_end() != "caliptra-fpga";
-            if caliptra_fpga {
+            let caliptra_fpga = hostname.trim_end() == "caliptra-fpga";
+            if !caliptra_fpga {
                 fpga_install_kernel_modules(target_host)?;
             }
 


### PR DESCRIPTION
Accidentally inverted logic for determining if an FPGA is running the Caliptra CI image.