### PR TITLE
rom: Endianness incorrect for PROT_CAP2 and indirect fifo data

### DIFF
--- a/emulator/periph/src/i3c.rs
+++ b/emulator/periph/src/i3c.rs
@@ -686,10 +686,9 @@ impl I3cPeripheral for I3c {
             registers_generated::i3c::bits::ProtCap2::Register,
         >,
     ) {
-        // convert the value in the other endianess
-        let x = u32::from_be_bytes(val.reg.get().to_le_bytes());
-
-        self.i3c_ec_sec_fw_recovery_if_prot_cap_2.reg.set(x);
+        self.i3c_ec_sec_fw_recovery_if_prot_cap_2
+            .reg
+            .set(val.reg.get());
     }
 
     fn read_i3c_ec_sec_fw_recovery_if_prot_cap_2(
@@ -845,7 +844,7 @@ impl I3cPeripheral for I3c {
             .reg
             .set(read_index + 1);
 
-        u32::from_be_bytes(data.try_into().unwrap())
+        u32::from_le_bytes(data.try_into().unwrap())
     }
 
     fn read_i3c_ec_sec_fw_recovery_if_indirect_fifo_status_0(

--- a/rom/src/recovery.rs
+++ b/rom/src/recovery.rs
@@ -62,18 +62,17 @@ statemachine! {
 bitfield! {
     pub struct ProtCap2(u32);
     impl Debug;
-    pub identification, set_identification: 0;
-    pub forced_recovery, set_forced_recovery: 1;
-    pub mgmt_reset, set_mgmt_reset: 2;
-    pub device_reset, set_device_reset: 3;
-    pub device_status, set_device_status: 4;
-    pub recovery_memory_access, set_recovery_memory_access: 5;
-    pub local_c_image_support, set_local_c_image_support: 6;
-    pub push_c_image_support, set_push_c_image_support: 7;
-    pub interface_isolation, set_interface_isolation: 8;
-    pub hardware_status, set_hardware_status: 9;
-    pub vendors_command, set_vendors_command: 10;
-    pub reserved, set_reserved: 31, 11;
+    pub identification, set_identification: 16;
+    pub forced_recovery, set_forced_recovery: 17;
+    pub mgmt_reset, set_mgmt_reset: 18;
+    pub device_reset, set_device_reset: 19;
+    pub device_status, set_device_status: 20;
+    pub recovery_memory_access, set_recovery_memory_access: 21;
+    pub local_c_image_support, set_local_c_image_support: 22;
+    pub push_c_image_support, set_push_c_image_support: 23;
+    pub interface_isolation, set_interface_isolation: 24;
+    pub hardware_status, set_hardware_status: 25;
+    pub vendors_command, set_vendors_command: 26;
 }
 
 bitfield! {
@@ -353,7 +352,7 @@ pub fn load_flash_image_to_recovery(
                             &mut data,
                         )
                         .map_err(|_| ())?;
-                    i3c_periph.tti_tx_data_port.set(u32::from_be_bytes(data));
+                    i3c_periph.tti_tx_data_port.set(u32::from_le_bytes(data));
                     state_machine.context_mut().transfer_offset += 4; // Simulate writing 4 bytes
                 }
             }


### PR DESCRIPTION
I validated that this makes the PROT_CAP2 register emulator behavior match the FPGA behavior (there should be no endian swapping when reading or writing the register).

This requires a change in the AXI recovery bypass mode of the ROM so that the correct bit of the PROT_CAP2 register is read for the device_status field. It's a little bit confusing as the PROT_CAP2 register corresponds to bytes 8, 9, 10, and 11 of the PROT_CAP recovery block. Bytes 10 to 11 are the agent capabilities, of which bit 4 is the device status. The OCP recovery spec states that bytes 10 and 11 should be considered to be a little endian 16-bit word, so byte 10, bit 4 should be device status. When translated to a 32-bit little endian dword, this means bit 20 of our u32, not bit 4.

I'm still working on validating the indirect fifo data register behavior on FPGA, but I don't see any reason why it should be big endian when everything else is little endian in i3c-core.