### PR TITLE
build: remove build cache for runtime (#645)

### DIFF
--- a/builder/src/all.rs
+++ b/builder/src/all.rs
@@ -256,7 +256,7 @@ pub fn all_build(args: AllBuildArgs) -> Result<()> {
     let base_runtime_file = tempfile::NamedTempFile::new().unwrap();
     let base_runtime_path = base_runtime_file.path().to_str().unwrap();
 
-    let mcu_runtime = &crate::runtime_build_with_apps_cached(
+    let mcu_runtime = &crate::runtime_build_with_apps(
         &base_runtime_features,
         Some(base_runtime_path.to_string()),
         false,
@@ -327,7 +327,7 @@ pub fn all_build(args: AllBuildArgs) -> Result<()> {
         let feature_runtime_file = tempfile::NamedTempFile::new().unwrap();
         let feature_runtime_path = feature_runtime_file.path().to_str().unwrap().to_string();
 
-        crate::runtime_build_with_apps_cached(
+        crate::runtime_build_with_apps(
             &[feature],
             Some(feature_runtime_path),
             false,

--- a/builder/src/lib.rs
+++ b/builder/src/lib.rs
@@ -12,9 +12,7 @@ mod tbf;
 pub use all::{all_build, AllBuildArgs, FirmwareBinaries};
 pub use caliptra::{CaliptraBuilder, ImageCfg};
 pub use rom::{rom_build, rom_ld_script, test_rom_build};
-pub use runtime::{
-    runtime_build_no_apps_uncached, runtime_build_with_apps_cached, runtime_ld_script,
-};
+pub use runtime::{runtime_build_no_apps, runtime_build_with_apps, runtime_ld_script};
 
 use anyhow::{anyhow, Result};
 use std::{

--- a/hw/model/src/model_emulated.rs
+++ b/hw/model/src/model_emulated.rs
@@ -677,7 +677,7 @@ mod test {
     #[test]
     fn test_new_unbooted() {
         let mcu_rom = mcu_builder::rom_build(None, "").expect("Could not build MCU ROM");
-        let mcu_runtime = &mcu_builder::runtime_build_with_apps_cached(
+        let mcu_runtime = &mcu_builder::runtime_build_with_apps(
             &[],
             None,
             false,

--- a/tests/integration/src/lib.rs
+++ b/tests/integration/src/lib.rs
@@ -106,7 +106,7 @@ mod test {
         let feature = feature.map(|f| format!("-{f}")).unwrap_or_default();
         let output = target_binary(&format!("runtime{}-{}.bin", feature, platform()));
         let output_name = format!("{}", output.display());
-        mcu_builder::runtime_build_with_apps_cached(
+        mcu_builder::runtime_build_with_apps(
             &features,
             Some(output_name),
             example_app,
@@ -667,7 +667,7 @@ mod test {
 
         let test_runtime = target_binary(&format!("runtime-{}.bin", feature));
         let output_name = format!("{}", test_runtime.display());
-        mcu_builder::runtime_build_with_apps_cached(
+        mcu_builder::runtime_build_with_apps(
             &[feature],
             Some(output_name),
             true,

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -417,7 +417,7 @@ fn main() {
             dccm_size,
         } => {
             let features: Vec<&str> = features.iter().map(|x| x.as_str()).collect();
-            mcu_builder::runtime_build_with_apps_cached(
+            mcu_builder::runtime_build_with_apps(
                 &features,
                 output.clone(),
                 false,

--- a/xtask/src/precheckin.rs
+++ b/xtask/src/precheckin.rs
@@ -9,7 +9,7 @@ pub(crate) fn precheckin() -> Result<()> {
     crate::header::check()?;
     crate::deps::check()?;
     crate::registers::autogen(true, &[], &[], None, None)?;
-    mcu_builder::runtime_build_with_apps_cached(
+    mcu_builder::runtime_build_with_apps(
         &[],
         None,
         false,
@@ -21,7 +21,7 @@ pub(crate) fn precheckin() -> Result<()> {
         None,
         None,
     )?;
-    mcu_builder::runtime_build_with_apps_cached(
+    mcu_builder::runtime_build_with_apps(
         &[],
         None,
         false,

--- a/xtask/src/runtime.rs
+++ b/xtask/src/runtime.rs
@@ -2,7 +2,7 @@
 
 use crate::Commands;
 use anyhow::Result;
-use mcu_builder::{rom_build, runtime_build_with_apps_cached, CaliptraBuilder, PROJECT_ROOT};
+use mcu_builder::{rom_build, runtime_build_with_apps, CaliptraBuilder, PROJECT_ROOT};
 use std::{path::PathBuf, process::Command};
 
 /// Run the Runtime Tock kernel image for RISC-V in the emulator.
@@ -36,7 +36,7 @@ pub(crate) fn runtime_run(args: Commands) -> Result<()> {
     // include debug features since this is interactive
     features.push("debug");
     let rom_binary: PathBuf = rom_build(None, "")?.into();
-    let tock_binary: PathBuf = runtime_build_with_apps_cached(
+    let tock_binary: PathBuf = runtime_build_with_apps(
         &features,
         None,
         false,


### PR DESCRIPTION
This patch removes the build cache of runtime and always uses platform default values in builds.

Closes #645 