### PR TITLE
[xtask-fpga]: Filter caliptra fw binaries and allow specifying the FW…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5687,6 +5687,7 @@ dependencies = [
  "anyhow",
  "caliptra-api-types",
  "caliptra-bitstream-downloader",
+ "caliptra-builder",
  "caliptra-hw-model",
  "caliptra-image-gen",
  "caliptra-image-types",

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -14,6 +14,7 @@ fpga_realtime = [
 
 [dependencies]
 caliptra-api-types.workspace = true
+caliptra-builder.workspace = true
 anyhow.workspace = true
 cargo_metadata.workspace = true
 cc.workspace = true

--- a/xtask/src/fpga/utils.rs
+++ b/xtask/src/fpga/utils.rs
@@ -299,3 +299,27 @@ pub fn download_bitstream_pdi<P: AsRef<Path>>(
     )?;
     Ok(())
 }
+
+pub fn build_caliptra_firmware(caliptra_workspace: &PathBuf, fw_id: Option<&str>) -> Result<()> {
+    let fw_dir = PathBuf::from("/tmp/caliptra-test-firmware");
+    run_command(
+        None,
+        "mkdir -p /tmp/caliptra-test-firmware/caliptra-test-firmware",
+    )?;
+    let binaries = match fw_id {
+        None => caliptra_builder::firmware::REGISTERED_FW.to_vec(),
+        Some(fw_id) => caliptra_builder::firmware::REGISTERED_FW
+            .iter()
+            .cloned()
+            .filter(|&fw| fw.bin_name == fw_id)
+            .collect(),
+    };
+
+    for (fwid, elf_bytes) in
+        caliptra_builder::build_firmware_elfs_uncached(Some(caliptra_workspace), &binaries).unwrap()
+    {
+        let elf_filename = fwid.elf_filename();
+        std::fs::write(fw_dir.join(elf_filename), elf_bytes).unwrap();
+    }
+    Ok(())
+}


### PR DESCRIPTION
…ID as a flag

The binaries take a long time to compile and filtering the list down speeds up the `build` command.