### PR TITLE
Set FW_EXEC_CTRL bit of SoC after loading image

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5104,6 +5104,7 @@ version = "0.1.0"
 dependencies = [
  "arrayvec",
  "async-trait",
+ "caliptra-api",
  "critical-section",
  "embassy-executor",
  "embassy-sync",

--- a/platforms/emulator/runtime/userspace/apps/user/Cargo.toml
+++ b/platforms/emulator/runtime/userspace/apps/user/Cargo.toml
@@ -7,7 +7,9 @@ authors.workspace = true
 edition.workspace = true
 
 [dependencies]
+arrayvec.workspace = true
 async-trait.workspace = true
+caliptra-api.workspace = true
 critical-section.workspace = true
 embassy-executor.workspace = true
 embassy-sync.workspace = true
@@ -25,14 +27,13 @@ mcu-config.workspace = true
 mcu-config-emulator.workspace = true
 mcu-mbox-lib.workspace = true
 mcu-mbox-common.workspace = true
+ocp-eat.workspace = true
 portable-atomic.workspace = true
 pldm-common.workspace = true
 pldm-lib.workspace = true
 romtime.workspace = true
 spdm-lib.workspace = true
 zerocopy.workspace = true
-arrayvec.workspace = true
-ocp-eat.workspace = true
 
 [target.'cfg(not(target_arch = "riscv32"))'.dependencies]
 libtock_unittest.workspace = true

--- a/tests/integration/src/test_soc_boot.rs
+++ b/tests/integration/src/test_soc_boot.rs
@@ -649,6 +649,7 @@ mod test {
                 path: soc_images_paths[0].clone(),
                 load_addr: MCI_BASE_AXI_ADDRESS + MCU_MBOX_SRAM1_OFFSET,
                 image_id: 4096,
+                exec_bit: 5,
                 ..Default::default()
             },
             ImageCfg {
@@ -657,6 +658,7 @@ mod test {
                     + MCU_MBOX_SRAM1_OFFSET
                     + soc_image_fw_1.len() as u64,
                 image_id: 4097,
+                exec_bit: 6,
                 ..Default::default()
             },
         ];


### PR DESCRIPTION
Fixes: https://github.com/chipsalliance/caliptra-mcu-sw/issues/508

Set the FW_EXEC_CTRL of the the SoC after loading its image. This is done by sending the ACTIVATE_FIRMWARE mailbox command to Caliptra. Since the SoC architecture is platform dependent, there could be additional integrator steps to activate the SoC. Therefore, this is just an example of how the SoC can be activated.