### PR TITLE
build: set app stack size in builder (#590)

### DIFF
--- a/builder/src/apps.rs
+++ b/builder/src/apps.rs
@@ -13,11 +13,13 @@ pub const EMULATOR_APPS: &[App] = &[
         name: "example-app",
         permissions: vec![],
         minimum_ram: 48 * 1024,
+        stack_size: 0x7600,
     },
     App {
         name: "user-app",
         permissions: vec![],
         minimum_ram: 116 * 1024,
+        stack_size: 0xae00,
     },
 ];
 
@@ -27,11 +29,13 @@ pub const FPGA_APPS: &[App] = &[
         name: "example-app",
         permissions: vec![],
         minimum_ram: 48 * 1024,
+        stack_size: 0x7600,
     },
     App {
         name: "user-app",
         permissions: vec![],
         minimum_ram: 116 * 1024,
+        stack_size: 0xae00,
     },
 ];
 
@@ -39,6 +43,7 @@ pub struct App {
     pub name: &'static str,
     pub permissions: Vec<(u32, u32)>, // pairs of (driver, command). All console and alarm commands are allowed by default.
     pub minimum_ram: u32,
+    pub stack_size: usize,
 }
 
 pub const BASE_PERMISSIONS: &[(u32, u32)] = &[
@@ -143,6 +148,7 @@ fn app_build_tbf(
         ram_start,
         ram_length,
         tbf_header_size,
+        app.stack_size,
         features,
     )?;
     let objcopy = objcopy()?;
@@ -182,6 +188,7 @@ fn app_build_tbf(
 }
 
 // creates an ELF of the app
+#[allow(clippy::too_many_arguments)]
 fn app_build(
     app_name: &str,
     platform: &str,
@@ -189,6 +196,7 @@ fn app_build(
     ram_start: usize,
     ram_length: usize,
     tbf_header_size: usize,
+    stack_size: usize,
     features: &[&str],
 ) -> Result<()> {
     let app_ld_filename = format!("{}-layout.ld", app_name);
@@ -221,8 +229,9 @@ FLASH_START = 0x{:x};
 FLASH_LENGTH = 0x4a500;
 RAM_START = 0x{:x};
 RAM_LENGTH = 0x{:x};
+STACK_SIZE = 0x{:x};
 INCLUDE platforms/emulator/runtime/userspace/apps/app_layout.ld",
-            tbf_header_size, offset, ram_start, ram_length,
+            tbf_header_size, offset, ram_start, ram_length, stack_size,
         ),
     )?;
 

--- a/platforms/emulator/runtime/userspace/apps/app_layout.ld
+++ b/platforms/emulator/runtime/userspace/apps/app_layout.ld
@@ -137,7 +137,7 @@ SECTIONS {
 	 * https://github.com/tock/elf2tab/blob/master/src/main.rs#L301
 	 */
         _sram_origin = .;
-        KEEP(*(.stack_buffer))
+        . = . + STACK_SIZE;
         . = ALIGN(16);
         _stack_top = .;  /* Used in rt_header */
     } > RAM

--- a/platforms/emulator/runtime/userspace/apps/example/src/riscv.rs
+++ b/platforms/emulator/runtime/userspace/apps/example/src/riscv.rs
@@ -7,13 +7,12 @@ use core::fmt::Write;
 use core::mem::MaybeUninit;
 use embedded_alloc::Heap;
 use libtock::console::Console;
-use libtock::runtime::{set_main, stack_size};
+use libtock::runtime::set_main;
 
 const HEAP_SIZE: usize = 0x40;
 #[global_allocator]
 static HEAP: Heap = Heap::empty();
 
-stack_size! {0x7600}
 set_main! {main}
 
 // TODO: remove this dependence on the emulator when the emulator-specific

--- a/platforms/emulator/runtime/userspace/apps/user/src/riscv.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/riscv.rs
@@ -7,12 +7,11 @@ use core::fmt::Write;
 use core::mem::MaybeUninit;
 use embedded_alloc::Heap;
 use libtock::console::Console;
-use libtock::runtime::{set_main, stack_size};
+use libtock::runtime::set_main;
 const HEAP_SIZE: usize = 0x4000;
 #[global_allocator]
 static HEAP: Heap = Heap::empty();
 
-stack_size! {0xae00}
 set_main! {main}
 
 fn main() {

--- a/runtime/userspace/libtock/runtime/src/startup/mod.rs
+++ b/runtime/userspace/libtock/runtime/src/startup/mod.rs
@@ -38,24 +38,6 @@ macro_rules! set_main {
     }
 }
 
-/// Executables must specify their stack size by using the `stack_size!` macro.
-/// It takes a single argument, the desired stack size in bytes. Example:
-/// ```
-/// libtock_runtime::stack_size!{0x400}
-/// ```
-// stack_size works by putting a symbol equal to the size of the stack in the
-// .stack_buffer section. The linker script uses the .stack_buffer section to
-// size the stack. flash.sh looks for the symbol by name (hence #[no_mangle]) to
-// determine the size of the stack to pass to elf2tab.
-#[macro_export]
-macro_rules! stack_size {
-    {$size:expr} => {
-        #[no_mangle]
-        #[link_section = ".stack_buffer"]
-        pub static mut STACK_MEMORY: [u8; $size] = [0; $size];
-    }
-}
-
 /// This is public for the sake of making `set_main!` usable in other crates.
 /// It doesn't have another function.
 pub fn handle_main_return<T: Termination>(result: T) -> ! {


### PR DESCRIPTION
This patch sets the app stack size in builder, along with other app-specific
constants to avoid having to modify multiple places when updates are
required. To achieve that, instead of calling `stack_size!`, it reserves
stack space of the desired size in the linker script.

Closes #590