### PR TITLE
[SPDM] Add support for certificate response chunking

### DIFF
--- a/runtime/userspace/api/spdm-lib/src/chunk_ctx.rs
+++ b/runtime/userspace/api/spdm-lib/src/chunk_ctx.rs
@@ -1,5 +1,6 @@
 // Licensed under the Apache-2.0 license
 
+use crate::commands::certificate_rsp::CertificateResponse;
 use crate::commands::measurements_rsp::MeasurementsResponse;
 use crate::commands::vendor_defined_rsp::VendorLargeResponse;
 
@@ -48,6 +49,7 @@ pub type ChunkResult<T> = Result<T, ChunkError>;
 
 /// Represents a large message response type that can be split into chunks
 pub(crate) enum LargeResponse {
+    Certificate(CertificateResponse),
     Measurements(MeasurementsResponse),
     Vdm(VendorLargeResponse),
 }

--- a/runtime/userspace/api/spdm-lib/src/commands/challenge_auth_rsp.rs
+++ b/runtime/userspace/api/spdm-lib/src/commands/challenge_auth_rsp.rs
@@ -1,5 +1,5 @@
 // Licensed under the Apache-2.0 license
-use crate::cert_store::{compute_cert_chain_hash, MAX_CERT_SLOTS_SUPPORTED};
+use crate::cert_store::{spdm_cert_chain_hash, MAX_CERT_SLOTS_SUPPORTED};
 use crate::codec::{Codec, CommonCodec, MessageBuf};
 use crate::commands::algorithms_rsp::selected_measurement_specification;
 use crate::commands::error_rsp::ErrorCode;
@@ -193,7 +193,7 @@ async fn encode_challenge_auth_rsp_base<'a>(
     let mut challenge_auth_rsp = ChallengeAuthRspBase::new(slot_id);
 
     // Get the certificate chain hash
-    compute_cert_chain_hash(
+    spdm_cert_chain_hash(
         ctx.device_certs_store,
         slot_id,
         asym_algo,

--- a/runtime/userspace/api/spdm-lib/src/commands/chunk_get_rsp.rs
+++ b/runtime/userspace/api/spdm-lib/src/commands/chunk_get_rsp.rs
@@ -159,6 +159,19 @@ async fn encode_chunk_data(
 
     if let Some(response) = ctx.large_resp_context.response() {
         match response {
+            LargeResponse::Certificate(cert_rsp) => {
+                // Get the chunk data from the certificate response
+                cert_rsp
+                    .get_chunk(
+                        &mut ctx.shared_transcript,
+                        ctx.device_certs_store,
+                        offset,
+                        chunk_buf,
+                    )
+                    .await?;
+                rsp.pull_data(chunk_size)
+                    .map_err(|e| (false, CommandError::Codec(e)))?;
+            }
             LargeResponse::Measurements(meas_rsp) => {
                 // Get the chunk data from the measurements response
                 meas_rsp

--- a/runtime/userspace/api/spdm-lib/src/commands/digests_rsp.rs
+++ b/runtime/userspace/api/spdm-lib/src/commands/digests_rsp.rs
@@ -1,6 +1,6 @@
 // Licensed under the Apache-2.0 license
 
-use crate::cert_store::{cert_slot_mask, compute_cert_chain_hash, SpdmCertStore};
+use crate::cert_store::{cert_slot_mask, spdm_cert_chain_hash, SpdmCertStore};
 use crate::codec::{Codec, CommonCodec, MessageBuf};
 use crate::commands::error_rsp::ErrorCode;
 use crate::context::SpdmContext;
@@ -44,7 +44,7 @@ async fn encode_cert_chain_digest(
         .data_mut(SHA384_HASH_SIZE)
         .map_err(|_| (false, CommandError::BufferTooSmall))?;
 
-    compute_cert_chain_hash(cert_store, slot_id, asym_algo, cert_chain_digest_buf)
+    spdm_cert_chain_hash(cert_store, slot_id, asym_algo, cert_chain_digest_buf)
         .await
         .map_err(|e| (false, CommandError::CertStore(e)))?;
 

--- a/runtime/userspace/api/spdm-lib/src/commands/key_exchange_rsp.rs
+++ b/runtime/userspace/api/spdm-lib/src/commands/key_exchange_rsp.rs
@@ -2,7 +2,7 @@
 
 #![allow(dead_code)]
 
-use crate::cert_store::{compute_cert_chain_hash, MAX_CERT_SLOTS_SUPPORTED};
+use crate::cert_store::{spdm_cert_chain_hash, MAX_CERT_SLOTS_SUPPORTED};
 use crate::codec::{encode_u8_slice, Codec, CommonCodec, MessageBuf};
 use crate::commands::algorithms_rsp::selected_measurement_specification;
 use crate::commands::challenge_auth_rsp::encode_measurement_summary_hash;
@@ -219,7 +219,7 @@ async fn process_key_exchange<'a>(
 
     let mut cert_chain_hash = [0u8; SHA384_HASH_SIZE];
 
-    compute_cert_chain_hash(
+    spdm_cert_chain_hash(
         ctx.device_certs_store,
         exch_req.slot_id,
         asym_algo,

--- a/runtime/userspace/api/spdm-lib/src/protocol/certs.rs
+++ b/runtime/userspace/api/spdm-lib/src/protocol/certs.rs
@@ -4,19 +4,29 @@ use libapi_caliptra::crypto::hash::SHA384_HASH_SIZE;
 use zerocopy::{FromBytes, Immutable, IntoBytes};
 
 pub(crate) const SPDM_MAX_CERT_CHAIN_PORTION_LEN: u16 = 512;
-pub(crate) const SPDM_CERT_CHAIN_METADATA_LEN: u16 =
-    size_of::<SpdmCertChainHeader>() as u16 + SHA384_HASH_SIZE as u16;
+pub(crate) const SPDM_CERT_CHAIN_METADATA_LEN: usize = size_of::<SpdmCertChainHeader>();
 
-#[derive(IntoBytes, FromBytes, Immutable, Debug, Default)]
+#[derive(IntoBytes, FromBytes, Immutable, Debug)]
 #[repr(C, packed)]
 pub(crate) struct SpdmCertChainHeader {
     pub length: u16,
     pub reserved: u16,
+    pub root_hash: [u8; SHA384_HASH_SIZE],
+}
+
+impl Default for SpdmCertChainHeader {
+    fn default() -> Self {
+        Self {
+            length: 0,
+            reserved: 0,
+            root_hash: [0u8; SHA384_HASH_SIZE],
+        }
+    }
 }
 
 // SPDM CertificateInfo fields
 bitfield! {
-#[derive(FromBytes, IntoBytes, Immutable, Default)]
+#[derive(FromBytes, IntoBytes, Immutable, Default, Clone, Copy)]
 #[repr(C, packed)]
 pub struct CertificateInfo(u8);
 impl Debug;
@@ -27,7 +37,7 @@ reserved, _: 3,7;
 
 // SPDM KeyUsageMask fields
 bitfield! {
-#[derive(FromBytes, IntoBytes, Immutable, Default)]
+#[derive(FromBytes, IntoBytes, Immutable, Default, Clone, Copy)]
 #[repr(C)]
 pub struct KeyUsageMask(u16);
 impl Debug;


### PR DESCRIPTION
This PR refactors the GET_CERTIFICATE response path to support transferring large certificate payloads using SPDM chunking. The Certificate chunking flow has been validated with the CCC requester tool.