### PR TITLE
hw model: Allow caliptra mailbox commands to be run from McuHwModel

### DIFF
--- a/emulator/app/src/emulator.rs
+++ b/emulator/app/src/emulator.rs
@@ -343,11 +343,12 @@ impl Emulator {
 
         let use_mcu_recovery_interface = is_flash_based_boot;
 
-        let (mut caliptra_cpu, soc_to_caliptra, ext_mci) = start_caliptra(&StartCaliptraArgs {
+        let (mut caliptra_cpu, soc_to_caliptra, _, ext_mci) = start_caliptra(&StartCaliptraArgs {
             rom: BytesOrPath::Path(cli.caliptra_rom),
             device_lifecycle: device_lifecycle_str,
             req_idevid_csr,
             use_mcu_recovery_interface,
+            extra_soc_bus: None,
         })
         .expect("Failed to start Caliptra CPU");
 

--- a/emulator/periph/src/root_bus.rs
+++ b/emulator/periph/src/root_bus.rs
@@ -55,7 +55,7 @@ impl Default for McuRootBusOffsets {
     fn default() -> Self {
         Self {
             rom_offset: 0,
-            rom_size: 0xc000,
+            rom_size: 64 * 1024,
             uart_offset: 0x1000_1000,
             uart_size: 0x100,
             ctrl_offset: 0x1000_2000,


### PR DESCRIPTION
And removes an extra Caliptra root bus that was being created in the emulator model that wasn't hooked up to the rest of the emulator correctly.

We need to add extra methods to access Caliptra's mailbox and set AXI users appropriately (copied from Caliptra HwModel), and pass an additional mailbox/soc accessor out of the `start_caliptra` function.