### PR TITLE
rom: Speed up flash boot scenario

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4010,6 +4010,8 @@ dependencies = [
  "caliptra-api",
  "caliptra-registers",
  "registers-generated",
+ "riscv-csr",
+ "rv32i",
  "tock-registers",
  "ureg",
  "zerocopy",

--- a/common/config/src/lib.rs
+++ b/common/config/src/lib.rs
@@ -56,8 +56,8 @@ impl Default for McuMemoryMap {
         McuMemoryMap {
             rom_offset: 0x8000_0000,
             rom_size: 32 * 1024,
-            rom_stack_size: 0x3000,
-            rom_estack_size: 0x800,
+            rom_stack_size: 0x2f00,
+            rom_estack_size: 0x200,
             rom_properties: MemoryRegionType::MEMORY,
 
             dccm_offset: 0x5000_0000,

--- a/emulator/periph/src/i3c.rs
+++ b/emulator/periph/src/i3c.rs
@@ -125,7 +125,9 @@ impl I3c {
             i3c_ec_sec_fw_recovery_if_recovery_status: ReadWriteRegister::new(0),
             i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_0: ReadWriteRegister::new(0),
             i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_1: ReadWriteRegister::new(0),
-            i3c_ec_sec_fw_recovery_if_indirect_fifo_status_0: ReadWriteRegister::new(0),
+            i3c_ec_sec_fw_recovery_if_indirect_fifo_status_0: ReadWriteRegister::new(
+                1 << IndirectFifoStatus0::Empty.shift,
+            ),
             i3c_ec_sec_fw_recovery_if_indirect_fifo_status_1: ReadWriteRegister::new(0),
             i3c_ec_sec_fw_recovery_if_indirect_fifo_status_2: ReadWriteRegister::new(0),
             i3c_ec_sec_fw_recovery_if_recovery_ctrl: ReadWriteRegister::new(0),
@@ -720,7 +722,7 @@ impl I3cPeripheral for I3c {
                 .set(0);
             self.i3c_ec_sec_fw_recovery_if_indirect_fifo_status_0
                 .reg
-                .set(0);
+                .write(IndirectFifoStatus0::Empty::SET);
             self.i3c_ec_sec_fw_recovery_if_indirect_fifo_status_1
                 .reg
                 .set(0);
@@ -796,7 +798,7 @@ impl I3cPeripheral for I3c {
         self.indirect_fifo_data.clear();
         self.i3c_ec_sec_fw_recovery_if_indirect_fifo_status_0
             .reg
-            .set(0);
+            .write(IndirectFifoStatus0::Empty::SET);
         self.i3c_ec_sec_fw_recovery_if_indirect_fifo_status_1
             .reg
             .set(0);
@@ -834,7 +836,7 @@ impl I3cPeripheral for I3c {
         if address >= image_len - 4 {
             self.i3c_ec_sec_fw_recovery_if_indirect_fifo_status_0
                 .reg
-                .modify(IndirectFifoStatus0::Full::SET);
+                .modify(IndirectFifoStatus0::Full::SET + IndirectFifoStatus0::Empty::CLEAR);
         }
 
         let address: usize = address.try_into().unwrap();

--- a/platforms/emulator/config/src/lib.rs
+++ b/platforms/emulator/config/src/lib.rs
@@ -8,7 +8,7 @@ use mcu_config::{McuMemoryMap, McuStraps, MemoryRegionType};
 pub const EMULATOR_MEMORY_MAP: McuMemoryMap = McuMemoryMap {
     rom_offset: 0x8000_0000,
     rom_size: 64 * 1024,
-    rom_stack_size: 0x3000,
+    rom_stack_size: 0x2f00,
     rom_estack_size: 0x200,
     rom_properties: MemoryRegionType::MEMORY,
 

--- a/platforms/fpga/config/src/lib.rs
+++ b/platforms/fpga/config/src/lib.rs
@@ -8,7 +8,7 @@ use mcu_config::{McuMemoryMap, McuStraps, MemoryRegionType};
 pub const FPGA_MEMORY_MAP: McuMemoryMap = McuMemoryMap {
     rom_offset: 0xb004_0000,
     rom_size: 128 * 1024,
-    rom_stack_size: 0x3000,
+    rom_stack_size: 0x2f00,
     rom_estack_size: 0x200,
     rom_properties: MemoryRegionType::MEMORY,
 

--- a/rom/src/cold_boot.rs
+++ b/rom/src/cold_boot.rs
@@ -108,27 +108,10 @@ impl ColdBoot {
 
 impl BootFlow for ColdBoot {
     fn run(env: &mut RomEnv, params: RomParameters) -> ! {
-        #[cfg(target_arch = "riscv32")]
-        {
-            use tock_registers::register_bitfields;
-            register_bitfields![usize,
-                value [
-                    value OFFSET(0) NUMBITS(32) [],
-                ],
-            ];
-            let mcycle: riscv_csr::csr::ReadWriteRiscvCsr<
-                usize,
-                value::Register,
-                { riscv_csr::csr::MCYCLE },
-            > = riscv_csr::csr::ReadWriteRiscvCsr::new();
-            let mcycleh: riscv_csr::csr::ReadWriteRiscvCsr<
-                usize,
-                value::Register,
-                { riscv_csr::csr::MCYCLEH },
-            > = riscv_csr::csr::ReadWriteRiscvCsr::new();
-            let cycle = (mcycleh.get() as u64) << 32 | (mcycle.get() as u64);
-            romtime::println!("[mcu-rom] Starting cold boot flow at time {}", cycle);
-        }
+        romtime::println!(
+            "[mcu-rom] Starting cold boot flow at time {}",
+            romtime::mcycle()
+        );
         env.mci
             .set_flow_checkpoint(McuRomBootStatus::ColdBootFlowStarted.into());
 

--- a/romtime/Cargo.toml
+++ b/romtime/Cargo.toml
@@ -15,3 +15,5 @@ ureg.workspace = true
 zerocopy.workspace = true
 
 [target.'cfg(target_arch = "riscv32")'.dependencies]
+riscv-csr.workspace = true
+rv32i.workspace = true


### PR DESCRIPTION
Rather than dword-at-a-time loading, try to load 256 bytes at a time from flash and write it in a tighter loop.

We also measure and print the number of cycles it takes to load the image and print the loading speed (bytes per 1,000 cycles).

Before: 32,178,550 cycles to load 197968 bytes
After: 1,597,018 cycles

This is a speedup of 20×, which greatly improves test speed.

There are some misc fixes as well:

* Move the `mcycle` code to `romtime`
* The emulated I3C peripheral was not setting the empty bit
* The `recovery.rs` was using the wrong bit to check for FIFO full.
* Simplify the instruction sequence for printing percentages in `recovery.rs` (small performance benefit of a few thousand cycles and probably a code size improvement).