### PR TITLE
Fix failing FW update integ test (2.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -894,7 +894,7 @@ name = "capsules-emulator"
 version = "0.1.0"
 dependencies = [
  "bitfield",
- "dma-driver",
+ "capsules-runtime",
  "flash-driver",
  "kernel",
  "mcu-platforms-common",
@@ -1493,6 +1493,7 @@ name = "dma-driver"
 version = "0.1.0"
 dependencies = [
  "capsules-core",
+ "capsules-runtime",
  "kernel",
  "registers-generated",
  "romtime",
@@ -1788,6 +1789,7 @@ dependencies = [
  "emulator-consts",
  "emulator-registers-generated",
  "lazy_static",
+ "mcu-config-emulator",
  "mcu-testing-common",
  "num_enum",
  "registers-generated",

--- a/common/config/src/lib.rs
+++ b/common/config/src/lib.rs
@@ -49,6 +49,9 @@ pub struct McuMemoryMap {
     pub lc_offset: u32,
     pub lc_size: u32,
     pub lc_properties: MemoryRegionType,
+
+    pub staging_sram_offset: u32,
+    pub staging_sram_size: u32,
 }
 
 impl Default for McuMemoryMap {
@@ -94,6 +97,9 @@ impl Default for McuMemoryMap {
             lc_offset: 0x7000_0400,
             lc_size: 0x8c,
             lc_properties: MemoryRegionType::MMIO,
+
+            staging_sram_offset: 0xb00c_0000,
+            staging_sram_size: 1024 * 1024,
         }
     }
 }

--- a/emulator/periph/Cargo.toml
+++ b/emulator/periph/Cargo.toml
@@ -18,6 +18,7 @@ caliptra-emu-periph.workspace = true
 emulator-consts.workspace = true
 emulator-registers-generated.workspace = true
 lazy_static.workspace = true
+mcu-config-emulator.workspace = true
 mcu-testing-common.workspace = true
 num_enum.workspace = true
 registers-generated.workspace = true

--- a/platforms/emulator/config/src/lib.rs
+++ b/platforms/emulator/config/src/lib.rs
@@ -46,6 +46,9 @@ pub const EMULATOR_MEMORY_MAP: McuMemoryMap = McuMemoryMap {
     lc_offset: 0x7000_0400,
     lc_size: 0x8c,
     lc_properties: MemoryRegionType::MMIO,
+
+    staging_sram_offset: 0xb00c_0000,
+    staging_sram_size: 1024 * 1024,
 };
 
 pub const EMULATOR_MCU_STRAPS: McuStraps = McuStraps::default();

--- a/platforms/emulator/runtime/kernel/capsules/Cargo.toml
+++ b/platforms/emulator/runtime/kernel/capsules/Cargo.toml
@@ -8,7 +8,7 @@ edition.workspace = true
 
 [dependencies]
 bitfield.workspace = true
-dma-driver.workspace = true
+capsules-runtime.workspace = true
 flash-driver.workspace = true
 mcu-platforms-common.workspace = true
 kernel.workspace = true

--- a/platforms/emulator/runtime/kernel/drivers/dma/Cargo.toml
+++ b/platforms/emulator/runtime/kernel/drivers/dma/Cargo.toml
@@ -11,6 +11,7 @@ kernel.workspace = true
 
 # [target.'cfg(target_arch = "riscv32")'.dependencies]
 capsules-core.workspace = true
+capsules-runtime.workspace = true
 registers-generated.workspace = true
 romtime.workspace = true
 tock-registers.workspace = true

--- a/platforms/emulator/runtime/kernel/drivers/dma/src/lib.rs
+++ b/platforms/emulator/runtime/kernel/drivers/dma/src/lib.rs
@@ -4,5 +4,4 @@
 
 //#[cfg(target_arch = "riscv32")]
 pub mod axicdma;
-pub mod hil;
 pub mod nodma;

--- a/platforms/emulator/runtime/src/interrupts.rs
+++ b/platforms/emulator/runtime/src/interrupts.rs
@@ -35,7 +35,7 @@ impl<'a> EmulatorPeripherals<'a> {
             dma: dma_driver::axicdma::AxiCDMA::new(
                 dma_driver::axicdma::DMA_CTRL_BASE,
                 false,
-                alarm,
+                Some(alarm),
             ),
             doe_transport: doe_mbox_driver::EmulatedDoeTransport::new(
                 doe_mbox_driver::DOE_MBOX_BASE,

--- a/platforms/emulator/runtime/userspace/apps/example/src/test_dma.rs
+++ b/platforms/emulator/runtime/userspace/apps/example/src/test_dma.rs
@@ -5,11 +5,9 @@ use libsyscall_caliptra::dma::{DMASource, DMATransaction, DMA as DMASyscall};
 use libsyscall_caliptra::system::System;
 use libsyscall_caliptra::DefaultSyscalls;
 use libtock_console::Console;
-use romtime::println;
+use mcu_config_emulator::EMULATOR_MEMORY_MAP;
 
-const MCU_SRAM_HI_OFFSET: u64 = 0x0000_0000;
-const TEST_EXTERNAL_SRAM_DEST_ADDRESS: u32 = 0xB00C_0000;
-
+const TEST_EXTERNAL_SRAM_DEST_ADDRESS: u32 = EMULATOR_MEMORY_MAP.staging_sram_offset;
 fn local_ram_to_axi_address(addr: u32) -> u64 {
     // Convert a local address to an AXI address
     addr as u64

--- a/platforms/fpga/config/src/lib.rs
+++ b/platforms/fpga/config/src/lib.rs
@@ -46,6 +46,9 @@ pub const FPGA_MEMORY_MAP: McuMemoryMap = McuMemoryMap {
     lc_offset: 0xa404_0000,
     lc_size: 0x8c,
     lc_properties: MemoryRegionType::MMIO,
+
+    staging_sram_offset: 0xb00c_0000,
+    staging_sram_size: 256 * 1024,
 };
 
 pub const FPGA_MCU_STRAPS: McuStraps = McuStraps {

--- a/platforms/fpga/runtime/Cargo.toml
+++ b/platforms/fpga/runtime/Cargo.toml
@@ -38,6 +38,7 @@ rv32i.workspace = true
 [features]
 default = []
 debug = []
+hw-2-1 = []
 test-caliptra-certs = []
 test-caliptra-crypto = []
 test-caliptra-mailbox = []

--- a/runtime/kernel/capsules/src/dma/hil.rs
+++ b/runtime/kernel/capsules/src/dma/hil.rs
@@ -4,7 +4,7 @@
 use kernel::ErrorCode;
 
 /// This trait provides the interfaces for managing DMA transfers.
-pub trait DMA {
+pub trait Dma {
     /// Configure the DMA transfer with 64-bit source and destination addresses.
     ///
     /// # Arguments:
@@ -33,13 +33,13 @@ pub trait DMA {
     ) -> Result<(), ErrorCode>;
 
     /// Poll the DMA status for transfer progress or completion.
-    fn poll_status(&self) -> Result<DMAStatus, DMAError>;
+    fn poll_status(&self) -> Result<DmaStatus, DmaError>;
 
     /// Push data into the WR FIFO for AHB -> AXI WR transfers.
     ///
     /// # Arguments:
     /// - `data`: Slice of data to be written (as bytes).
-    fn write_fifo(&self, data: &[u8]) -> Result<(), DMAError>;
+    fn write_fifo(&self, data: &[u8]) -> Result<(), DmaError>;
 
     /// Pop data from the RD FIFO for AXI RD -> AHB transfers.
     ///
@@ -48,10 +48,10 @@ pub trait DMA {
     ///
     /// Returns:
     /// - `Ok(bytes_read)` indicating the number of bytes read.
-    fn read_fifo(&self, buffer: &mut [u8]) -> Result<usize, DMAError>;
+    fn read_fifo(&self, buffer: &mut [u8]) -> Result<usize, DmaError>;
 
     /// Set a client for receiving DMA transfer events asynchronously.
-    fn set_client(&self, client: &'static dyn DMAClient);
+    fn set_client(&self, client: &'static dyn DmaClient);
 }
 
 /// DMA Route configuration for Read/Write routes.
@@ -63,7 +63,7 @@ pub enum DmaRoute {
 
 /// Represents the current status of the DMA transfer.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum DMAStatus {
+pub enum DmaStatus {
     TxnDone,        // Transaction complete
     RdFifoNotEmpty, // Read FIFO has data
     RdFifoFull,     // Read FIFO is full
@@ -73,7 +73,7 @@ pub enum DMAStatus {
 
 /// Represents possible DMA errors.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum DMAError {
+pub enum DmaError {
     CommandError,     // General command error
     AxiReadError,     // AXI Read error
     AxiWriteError,    // AXI Write error
@@ -85,10 +85,10 @@ pub enum DMAError {
 }
 
 /// A client trait for handling asynchronous DMA transfer events.
-pub trait DMAClient {
+pub trait DmaClient {
     /// Called when a DMA transfer completes successfully.
-    fn transfer_complete(&self, status: DMAStatus);
+    fn transfer_complete(&self, status: DmaStatus);
 
     /// Called when a DMA transfer encounters an error.
-    fn transfer_error(&self, error: DMAError);
+    fn transfer_error(&self, error: DmaError);
 }

--- a/runtime/kernel/capsules/src/dma/mod.rs
+++ b/runtime/kernel/capsules/src/dma/mod.rs
@@ -1,0 +1,3 @@
+// Licensed under the Apache-2.0 license
+
+pub mod hil;

--- a/runtime/kernel/capsules/src/lib.rs
+++ b/runtime/kernel/capsules/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod test;
 
+pub mod dma;
 pub mod doe;
 pub mod flash_partition;
 pub mod mailbox;

--- a/runtime/kernel/components/src/dma.rs
+++ b/runtime/kernel/components/src/dma.rs
@@ -2,21 +2,21 @@
 
 // Component for DMA driver.
 
+use capsules_runtime::dma::hil::Dma as DmaHal;
 use core::mem::MaybeUninit;
-use dma_driver::hil::DMA;
 use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
 
 pub struct DmaComponent {
-    driver: &'static dyn dma_driver::hil::DMA,
+    driver: &'static dyn DmaHal,
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
 }
 
 impl DmaComponent {
     pub fn new(
-        driver: &'static dyn DMA,
+        driver: &'static dyn DmaHal,
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
     ) -> Self {

--- a/tests/integration/src/lib.rs
+++ b/tests/integration/src/lib.rs
@@ -40,6 +40,8 @@ mod test {
     };
     use zerocopy::IntoBytes;
 
+    const TEST_HW_REVISION: &str = "2.1.0";
+
     #[derive(Default)]
     pub struct TestParams<'a> {
         pub feature: Option<&'a str>,
@@ -104,6 +106,9 @@ mod test {
         let mut features = vec![];
         if let Some(feature) = feature {
             features.push(feature);
+        }
+        if TEST_HW_REVISION == "2.1.0" {
+            features.push("hw-2-1");
         }
         let feature = feature.map(|f| format!("-{f}")).unwrap_or_default();
         let output = target_binary(&format!("runtime{}-{}.bin", feature, platform()));

--- a/tests/integration/src/test_firmware_update.rs
+++ b/tests/integration/src/test_firmware_update.rs
@@ -653,12 +653,6 @@ mod test {
         lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     }
 
-    // TODO(#694): fails with
-    // 2025-12-06T00:14:42.314Z INFO  [pldm_ua::update_sm] Transfer complete success
-    // [FW Upd] Verifying Caliptra Bundle
-    // Error copying from mailbox: MailboxCmdFailed(720898)
-    // test test_firmware_update::test::test_firmware_update ... FAILED
-    #[ignore]
     #[test]
     fn test_firmware_update() {
         test_firmware_update_common(true);


### PR DESCRIPTION
- Due to the reduced mailbox size, the Caliptra FW and manifest should use an external staging area instead of mailbox fifo. To do this, the mailbox driver now wraps all mailbox commands in an ExternalMailboxReq.

- The mailbox driver will use, as much as possible, DMA to transfer data from the application buffer to the external staging area. For this, the DMA HIL is passed to the mailbox driver. DMA HIL file is now moved to the runtime code instead of emulator

- The external staging area to be used is 0xb00c_0000 mapped to the same FPGA memory address for the staging memory.

- Also fixed the unnecessary endianess swap when reading from the emulator's external test sram peripheral

- Speed up MboxSram read/write in the emulator by using block read/write instead of word read/writes. Note that fw update integ test is using MboxSram1 to stage MCU FW (this is different from Mailbox payload staging area)

- Due to upgrade in Caliptra-sw dependency, some of the crypto APIs have changed and also updated here. The example-app stack has been increased to accommodate increase certificate size.