### PR TITLE
[test] fix `test_soc_boot` tests

### DIFF
--- a/emulator/periph/src/i3c.rs
+++ b/emulator/periph/src/i3c.rs
@@ -248,7 +248,7 @@ impl I3c {
                         .read_recovery_interface(caliptra_emu_types::RvSize::Word, *start_addr)
                     {
                         Ok(data) => {
-                            response.extend_from_slice(&data.to_be_bytes());
+                            response.extend_from_slice(&data.to_le_bytes());
                         }
                         Err(err) => {
                             println!("[I3C-Emulator] Error reading recovery interface: {:?}", err);

--- a/tests/integration/src/test_soc_boot.rs
+++ b/tests/integration/src/test_soc_boot.rs
@@ -771,17 +771,15 @@ mod test {
             run_test!(test_soc_manifest_good_svn, &pass_options.clone());
         } else {
             // Flash-based boot-only tests
-            // TODO(#694): renable after debugging failing tests:
-            // failues most likely due to out-dated caliptra-sw version.
-            //run_test!(test_successful_boot, &pass_options.clone());
-            //run_test!(test_boot_secondary_flash, pass_options.clone());
-            //run_test!(test_boot_invalid_image_id, &pass_options.clone());
-            //run_test!(test_boot_unathorized_image, &pass_options.clone());
-            //run_test!(test_invalid_load_address, &pass_optins.clone());
-            //run_test!(
-            //test_boot_partition_table_invalid_checksum,
-            //&pass_options.clone()
-            //);
+            run_test!(test_successful_boot, &pass_options.clone());
+            run_test!(test_boot_secondary_flash, pass_options.clone());
+            run_test!(test_boot_invalid_image_id, &pass_options.clone());
+            run_test!(test_boot_unathorized_image, &pass_options.clone());
+            run_test!(test_invalid_load_address, &pass_options.clone());
+            run_test!(
+                test_boot_partition_table_invalid_checksum,
+                &pass_options.clone()
+            );
         }
 
         lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);


### PR DESCRIPTION
This partially addresses #694 by fixing the `test_soc_boot` tests that were disabled in #687 to unblock cherry-picks.

@swenson @mlvisaya : it is unclear why this fix is needed on the main-2.1 branch but no the main branch to enable the tests to pass. Any thoughts?