### PR TITLE
PLDM transfer speedup by reducing async locking

### DIFF
--- a/runtime/userspace/api/pldm-lib/src/cmd_interface.rs
+++ b/runtime/userspace/api/pldm-lib/src/cmd_interface.rs
@@ -115,6 +115,36 @@ impl<'a> CmdInterface<'a> {
         self.fd_ctx.should_stop_initiator_mode().await
     }
 
+    /// Check if the current transfer has been cancelled.
+    pub fn is_cancelled(&self) -> bool {
+        self.fd_ctx.is_cancelled()
+    }
+
+    /// Create a transfer session for optimized download.
+    pub async fn create_transfer_session(
+        &self,
+    ) -> crate::firmware_device::transfer_session::TransferSession {
+        self.fd_ctx.create_transfer_session().await
+    }
+
+    /// Sync state from a transfer session back to internal state.
+    pub async fn sync_transfer_session(
+        &self,
+        session: &crate::firmware_device::transfer_session::TransferSession,
+    ) {
+        self.fd_ctx.sync_transfer_session(session).await;
+    }
+
+    /// Get current timestamp.
+    pub fn now(&self) -> pldm_common::protocol::firmware_update::PldmFdTime {
+        self.fd_ctx.now()
+    }
+
+    /// Get the FdOps reference for download operations.
+    pub fn ops(&self) -> &dyn crate::firmware_device::fd_ops::FdOps {
+        self.fd_ctx.ops()
+    }
+
     async fn process_request(&self, msg_buf: &mut [u8]) -> Result<usize, MsgHandlerError> {
         // Check if the handler is busy processing a request
         if self.busy.load(Ordering::SeqCst) {

--- a/runtime/userspace/api/pldm-lib/src/daemon.rs
+++ b/runtime/userspace/api/pldm-lib/src/daemon.rs
@@ -4,6 +4,7 @@ use crate::cmd_interface::CmdInterface;
 use crate::config;
 use crate::firmware_device::fd_context::FirmwareDeviceContext;
 use crate::firmware_device::fd_ops::FdOps;
+use crate::firmware_device::transfer_session::TransferSession;
 use crate::timer::AsyncAlarm;
 use crate::transport::MctpTransport;
 use core::fmt::Write;
@@ -13,10 +14,20 @@ use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_sync::signal::Signal;
 use libsyscall_caliptra::mctp::driver_num;
 use libsyscall_caliptra::DefaultSyscalls;
-use libtock_alarm::Milliseconds;
 use libtock_console::Console;
+use pldm_common::codec::PldmCodec;
+use pldm_common::message::firmware_update::request_fw_data::{
+    RequestFirmwareDataRequest, RequestFirmwareDataResponseFixed,
+};
+use pldm_common::message::firmware_update::transfer_complete::TransferResult;
+use pldm_common::protocol::base::{PldmBaseCompletionCode, PldmMsgType};
+use pldm_common::protocol::firmware_update::{FwUpdateCmd, FwUpdateCompletionCode};
+use pldm_common::util::mctp_transport::{
+    construct_mctp_pldm_msg, extract_pldm_msg, PLDM_MSG_OFFSET,
+};
 
 pub const MAX_MCTP_PLDM_MSG_SIZE: usize = 1024;
+const YIELD_EVERY_ITERATIONS: u32 = 32;
 
 #[derive(Debug)]
 pub enum PldmServiceError {
@@ -134,29 +145,77 @@ pub async fn pldm_initiator(
 
         let mut msg_buffer = [0; MAX_MCTP_PLDM_MSG_SIZE];
         let mut transport = MctpTransport::new(driver_num::MCTP_PLDM);
+
+        // Transfer session for optimized download - created lazily when entering download phase
+        let mut session: Option<TransferSession> = None;
+        let mut counter: u32 = 0;
+
         while running.load(Ordering::SeqCst) {
             if cmd_interface.should_stop_initiator_mode().await {
                 break;
             }
 
-            // Handle initiator messages
-            match cmd_interface
-                .handle_initiator_msg(&mut transport, &mut msg_buffer)
-                .await
-            {
-                Ok(_) => {}
-                Err(e) => {
-                    writeln!(
-                        console_writer,
-                        "PLDM_APP: Error handling initiator msg: {:?}",
-                        e
-                    )
-                    .unwrap();
+            // Use optimized download path when we have an active session
+            if let Some(ref mut sess) = session {
+                match run_optimized_download(cmd_interface, &mut transport, &mut msg_buffer, sess)
+                    .await
+                {
+                    Ok(download_complete) => {
+                        if download_complete {
+                            // Sync session state back to internal state
+                            cmd_interface.sync_transfer_session(sess).await;
+                            session = None;
+                            // Fall through to regular handling for TransferComplete/Verify/Apply
+                        }
+                    }
+                    Err(e) => {
+                        writeln!(
+                            console_writer,
+                            "PLDM_APP: Error in optimized download: {:?}",
+                            e
+                        )
+                        .unwrap();
+                        // Sync and fall back to regular path
+                        cmd_interface.sync_transfer_session(sess).await;
+                        session = None;
+                    }
                 }
             }
 
-            // Sleep to yield control to other tasks.
-            AsyncAlarm::<DefaultSyscalls>::sleep(Milliseconds(1)).await;
+            if session.is_some() {
+                // yield every so often still so that we handle cancelations
+                counter = counter.wrapping_add(1);
+                if counter % YIELD_EVERY_ITERATIONS == 0 {
+                    let _ = AsyncAlarm::<DefaultSyscalls>::sleep_ticks(1).await;
+                }
+            } else {
+                // Handle phases via regular path, which will properly wait for Download state
+                match cmd_interface
+                    .handle_initiator_msg(&mut transport, &mut msg_buffer)
+                    .await
+                {
+                    Ok(_) => {
+                        // After successful handling, check if we should switch to optimized download
+                        // The regular handler will have processed the first chunk; now create session
+                        // for subsequent chunks if we're still in download phase
+                        if cmd_interface.should_start_initiator_mode().await {
+                            session = Some(cmd_interface.create_transfer_session().await);
+                            counter = 0;
+                        }
+                    }
+                    Err(e) => {
+                        writeln!(
+                            console_writer,
+                            "PLDM_APP: Error handling initiator msg: {:?}",
+                            e
+                        )
+                        .unwrap();
+                    }
+                }
+
+                // Sleep to yield control to other tasks (only in non-optimized path)
+                let _ = AsyncAlarm::<DefaultSyscalls>::sleep_ticks(1).await;
+            }
         }
     }
 }
@@ -192,4 +251,138 @@ pub async fn pldm_responder(
             initiator_signal.signal(());
         }
     }
+}
+
+/// Optimized download loop that uses a local TransferSession to minimize mutex acquisitions.
+///
+/// This function runs the download phase with the session state kept outside the async mutex,
+/// only syncing back periodically or when the transfer completes/is cancelled.
+async fn run_optimized_download(
+    cmd_interface: &'static CmdInterface<'static>,
+    transport: &mut MctpTransport,
+    msg_buffer: &mut [u8],
+    session: &mut TransferSession,
+) -> Result<bool, crate::error::MsgHandlerError> {
+    let ua_eid: u8 = crate::config::UA_EID;
+    let ops = cmd_interface.ops();
+
+    // Check for cancellation (atomic, no mutex)
+    if cmd_interface.is_cancelled() {
+        session.mark_complete(TransferResult::FdAbortedTransfer);
+        return Ok(true); // Signal that download phase is done
+    }
+
+    let now = cmd_interface.now();
+
+    // Check T1 timeout
+    if session.is_t1_timeout(now) {
+        session.mark_failed(TransferResult::FdAbortedTransfer);
+        return Ok(true);
+    }
+
+    // Check if we should send a request
+    if !session.should_send_request(now) {
+        return Ok(false);
+    }
+
+    // If transfer is complete, signal done (TransferComplete will be handled by fallback path)
+    if session.complete {
+        return Ok(true);
+    }
+
+    // Query offset and length from ops (this is an async call but necessary)
+    let (requested_offset, requested_length) = ops
+        .query_download_offset_and_length(&session.component)
+        .await
+        .map_err(crate::error::MsgHandlerError::FdOps)?;
+
+    // Calculate chunk parameters using local session state
+    let (chunk_offset, chunk_length) =
+        match session.get_download_chunk(requested_offset as u32, requested_length as u32) {
+            Some(chunk) => chunk,
+            None => {
+                session.mark_failed(TransferResult::FdAbortedTransfer);
+                return Ok(true);
+            }
+        };
+
+    // Update session state
+    session.offset = chunk_offset;
+    session.length = chunk_length;
+
+    // Build request message
+    let instance_id = session.alloc_next_instance_id();
+    let payload =
+        construct_mctp_pldm_msg(msg_buffer).map_err(crate::error::MsgHandlerError::Util)?;
+
+    let msg_len = RequestFirmwareDataRequest::new(
+        instance_id,
+        PldmMsgType::Request,
+        chunk_offset,
+        chunk_length,
+    )
+    .encode(payload)
+    .map_err(crate::error::MsgHandlerError::Codec)?;
+
+    // Mark as sent
+    session.mark_sent(cmd_interface.now(), FwUpdateCmd::RequestFirmwareData as u8);
+
+    // Send request
+    transport
+        .send_request(ua_eid, &msg_buffer[..msg_len + PLDM_MSG_OFFSET])
+        .await
+        .map_err(crate::error::MsgHandlerError::Transport)?;
+
+    // Receive response
+    transport
+        .receive_response(msg_buffer)
+        .await
+        .map_err(crate::error::MsgHandlerError::Transport)?;
+
+    // Process response
+    let resp_payload = extract_pldm_msg(msg_buffer).map_err(crate::error::MsgHandlerError::Util)?;
+
+    let rsp_fixed = RequestFirmwareDataResponseFixed::decode(resp_payload)
+        .map_err(crate::error::MsgHandlerError::Codec)?;
+
+    // Update T1 timestamp on response
+    session.update_t1_timestamp(cmd_interface.now());
+
+    match rsp_fixed.completion_code {
+        code if code == PldmBaseCompletionCode::Success as u8 => {
+            // Extract firmware data and pass to ops
+            let fw_data = &resp_payload[core::mem::size_of::<RequestFirmwareDataResponseFixed>()..]
+                .get(..chunk_length as usize)
+                .ok_or(crate::error::MsgHandlerError::Codec(
+                    pldm_common::codec::PldmCodecError::BufferTooShort,
+                ))?;
+
+            let result = ops
+                .download_fw_data(chunk_offset as usize, fw_data, &session.component)
+                .await
+                .map_err(crate::error::MsgHandlerError::FdOps)?;
+
+            if result == TransferResult::TransferSuccess {
+                if ops.is_download_complete(&session.component) {
+                    session.mark_complete(TransferResult::TransferSuccess);
+                    return Ok(true);
+                } else {
+                    session.mark_ready_for_next();
+                }
+            } else {
+                session.mark_complete(result);
+                return Ok(true);
+            }
+        }
+        code if code == FwUpdateCompletionCode::RetryRequestFwData as u8 => {
+            // Retry - keep state as ready
+            session.mark_ready_for_next();
+        }
+        _ => {
+            session.mark_complete(TransferResult::FdAbortedTransfer);
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
 }

--- a/runtime/userspace/api/pldm-lib/src/firmware_device/mod.rs
+++ b/runtime/userspace/api/pldm-lib/src/firmware_device/mod.rs
@@ -3,3 +3,4 @@
 pub mod fd_context;
 pub mod fd_internal;
 pub mod fd_ops;
+pub mod transfer_session;

--- a/runtime/userspace/api/pldm-lib/src/firmware_device/transfer_session.rs
+++ b/runtime/userspace/api/pldm-lib/src/firmware_device/transfer_session.rs
@@ -1,0 +1,205 @@
+// Licensed under the Apache-2.0 license
+
+//! Transfer session for optimized firmware download.
+//!
+//! This module provides a local transfer context that can be used during
+//! firmware download operations to avoid repeated mutex acquisitions.
+//! The session captures state at the start of a transfer and only requires
+//! mutex access at boundaries (start, end, cancellation check).
+
+use core::sync::atomic::{AtomicBool, Ordering};
+use pldm_common::message::firmware_update::transfer_complete::TransferResult;
+use pldm_common::protocol::firmware_update::{PldmFdTime, PLDM_FWUP_MAX_PADDING_SIZE};
+use pldm_common::util::fw_component::FirmwareComponent;
+
+use super::fd_internal::FdReqState;
+
+/// Local state for an active download transfer.
+///
+/// This struct holds all the state needed during a firmware download,
+/// allowing the hot path to avoid mutex acquisitions on every chunk.
+pub struct TransferSession {
+    /// Current download offset
+    pub offset: u32,
+    /// Current chunk length being requested
+    pub length: u32,
+    /// Maximum transfer size allowed
+    pub max_xfer_size: u32,
+    /// Component image size
+    pub comp_image_size: u32,
+    /// Current instance ID for requests
+    pub instance_id: u8,
+    /// Whether the transfer is complete
+    pub complete: bool,
+    /// Transfer result (set when complete)
+    pub result: Option<TransferResult>,
+    /// Request state
+    pub req_state: FdReqState,
+    /// Timestamp when request was sent
+    pub sent_time: Option<PldmFdTime>,
+    /// FD T1 timeout value
+    pub fd_t1_timeout: PldmFdTime,
+    /// FD T2 retry time
+    pub fd_t2_retry_time: PldmFdTime,
+    /// Last T1 update timestamp
+    pub fd_t1_update_ts: PldmFdTime,
+    /// Cached component info
+    pub component: FirmwareComponent,
+}
+
+impl TransferSession {
+    /// Create a new transfer session from the given parameters.
+    pub fn new(
+        max_xfer_size: u32,
+        component: FirmwareComponent,
+        fd_t1_timeout: PldmFdTime,
+        fd_t2_retry_time: PldmFdTime,
+        initial_instance_id: u8,
+        now: PldmFdTime,
+    ) -> Self {
+        Self {
+            offset: 0,
+            length: 0,
+            max_xfer_size,
+            comp_image_size: component.comp_image_size.unwrap_or(0),
+            instance_id: initial_instance_id,
+            complete: false,
+            result: None,
+            req_state: FdReqState::Ready,
+            sent_time: None,
+            fd_t1_timeout,
+            fd_t2_retry_time,
+            fd_t1_update_ts: now,
+            component,
+        }
+    }
+
+    /// Allocate the next instance ID.
+    pub fn alloc_next_instance_id(&mut self) -> u8 {
+        self.instance_id = (self.instance_id + 1) % crate::config::INSTANCE_ID_COUNT;
+        self.instance_id
+    }
+
+    /// Check if we should send a request based on current state and timing.
+    pub fn should_send_request(&self, now: PldmFdTime) -> bool {
+        match self.req_state {
+            FdReqState::Unused => false,
+            FdReqState::Ready => true,
+            FdReqState::Failed => false,
+            FdReqState::Sent => {
+                if let Some(sent_time) = self.sent_time {
+                    if now < sent_time {
+                        return false;
+                    }
+                    (now - sent_time) >= self.fd_t2_retry_time
+                } else {
+                    false
+                }
+            }
+        }
+    }
+
+    /// Calculate the chunk parameters for a download request.
+    ///
+    /// Returns `Some((offset, length))` if valid, `None` if the request is invalid.
+    pub fn get_download_chunk(
+        &self,
+        requested_offset: u32,
+        requested_length: u32,
+    ) -> Option<(u32, u32)> {
+        if requested_offset > self.comp_image_size
+            || requested_offset
+                .checked_add(requested_length)
+                .is_none_or(|requested_end| {
+                    self.comp_image_size
+                        .checked_add(PLDM_FWUP_MAX_PADDING_SIZE as u32)
+                        .is_some_and(|allowed_end| requested_end > allowed_end)
+                })
+        {
+            return None;
+        }
+        let chunk_size = requested_length.min(self.max_xfer_size);
+        Some((requested_offset, chunk_size))
+    }
+
+    /// Mark the request as sent.
+    pub fn mark_sent(&mut self, now: PldmFdTime, command: u8) {
+        self.req_state = FdReqState::Sent;
+        self.sent_time = Some(now);
+        self.fd_t1_update_ts = now;
+        let _ = command; // Command tracking could be added if needed
+    }
+
+    /// Mark the transfer as ready for next chunk.
+    pub fn mark_ready_for_next(&mut self) {
+        self.req_state = FdReqState::Ready;
+        self.complete = false;
+        self.result = None;
+        self.sent_time = None;
+    }
+
+    /// Mark the transfer as complete with the given result.
+    pub fn mark_complete(&mut self, result: TransferResult) {
+        self.req_state = FdReqState::Ready;
+        self.complete = true;
+        self.result = Some(result);
+    }
+
+    /// Mark the transfer as failed.
+    pub fn mark_failed(&mut self, result: TransferResult) {
+        self.req_state = FdReqState::Failed;
+        self.complete = true;
+        self.result = Some(result);
+    }
+
+    /// Check if T1 timeout has occurred.
+    pub fn is_t1_timeout(&self, now: PldmFdTime) -> bool {
+        if self.req_state != FdReqState::Sent {
+            return false;
+        }
+        let elapsed = now.saturating_sub(self.fd_t1_update_ts);
+        elapsed > self.fd_t1_timeout
+    }
+
+    /// Update T1 timestamp.
+    pub fn update_t1_timestamp(&mut self, now: PldmFdTime) {
+        self.fd_t1_update_ts = now;
+    }
+}
+
+/// Atomic flag for signaling transfer cancellation from the responder task.
+///
+/// This allows the responder to signal cancellation without requiring
+/// mutex access in the hot download path.
+pub struct CancellationFlag {
+    cancelled: AtomicBool,
+}
+
+impl CancellationFlag {
+    pub const fn new() -> Self {
+        Self {
+            cancelled: AtomicBool::new(false),
+        }
+    }
+
+    /// Signal that the transfer should be cancelled.
+    pub fn cancel(&self) {
+        self.cancelled.store(true, Ordering::Release);
+    }
+
+    /// Check if cancellation has been requested.
+    pub fn is_cancelled(&self) -> bool {
+        self.cancelled.load(Ordering::Acquire)
+    }
+
+    /// Reset the cancellation flag.
+    pub fn reset(&self) {
+        self.cancelled.store(false, Ordering::Release);
+    }
+}
+
+impl Default for CancellationFlag {
+    fn default() -> Self {
+        Self::new()
+    }
+}


### PR DESCRIPTION
The biggest change is moving some of the state out from `FdInternal` into a separate context struct that is extracted once, rather than using locks to access each `FdInternal` field every time (except for checking if the update was canceled).

Then, after the transfer is completed, we update the `FdInternal` with any changes.

This allows us to significantly reduce the `async` overhead of transfers.

In addition:
* We add time tracking in the PLDM emulator side to keep track of how long PLDM updates are taking
* We reduce the AsyncAlarm sleep after a PLDM operation from 1 millisecond to 1 tick, which gives another small performance boost.

For the initial PLDM transfer, this increases the speed in the emulator from 1100 bytes/s to 1300 bytes/s for me locally, about an 18% increase.