### PR TITLE
Add field to RomParameters struct to allow AXI users to be passed fro…

### DIFF
--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -288,6 +288,16 @@ impl McuError {
             "SOC tried to lock an Mbox user out of range"
         ),
         (
+            ROM_MCI_MBOX_USER_OUT_OF_RANGE,
+            0x5_000E,
+            "Tried to set a MCI Mbox user beyond the length of register array"
+        ),
+        (
+            ROM_MCI_MBOX_USER_LOCK_OUT_OF_RANGE,
+            0x5_000F,
+            "OC tried to lock a MCI Mbox user beyond the length of the register array"
+        ),
+        (
             GENERIC_EXCEPTION,
             0xF_0000,
             "Machine level exception was encountered during ROM execution"

--- a/platforms/emulator/config/src/lib.rs
+++ b/platforms/emulator/config/src/lib.rs
@@ -8,7 +8,7 @@ use mcu_config::{McuMemoryMap, McuStraps, MemoryRegionType};
 pub const EMULATOR_MEMORY_MAP: McuMemoryMap = McuMemoryMap {
     rom_offset: 0x8000_0000,
     rom_size: 64 * 1024,
-    rom_stack_size: 0x2e00,
+    rom_stack_size: 0x2de0,
     rom_estack_size: 0x200,
     rom_properties: MemoryRegionType::MEMORY,
 

--- a/platforms/emulator/rom/Cargo.toml
+++ b/platforms/emulator/rom/Cargo.toml
@@ -31,6 +31,7 @@ rv32i.workspace = true
 default = []
 core_test = ["mcu-rom-common/core_test"]
 hw-2-1 = ["mcu-rom-common/hw-2-1"]
+axi_user_rom_param = ["mcu-rom-common/axi_user_rom_param"]
 test-firmware-update-flash = []
 test-firmware-update-streaming = []
 test-mcu-rom-flash-access = []

--- a/platforms/emulator/rom/src/riscv.rs
+++ b/platforms/emulator/rom/src/riscv.rs
@@ -33,7 +33,7 @@ use mcu_config_emulator::flash::{
 use mcu_rom_common::flash::flash_partition::FlashPartition;
 use mcu_rom_common::hil::FlashStorage;
 use mcu_rom_common::memory::SimpleFlash;
-use mcu_rom_common::{fatal_error, RomParameters};
+use mcu_rom_common::{fatal_error, AxiUsers, MciAxiUsers, RomParameters};
 use romtime::HexWord;
 use zerocopy::{FromBytes, IntoBytes};
 
@@ -135,6 +135,52 @@ pub extern "C" fn rom_entry() -> ! {
         mcu_rom_common::rom_start(RomParameters {
             flash_partition_driver: Some(&mut flash_image_partition_driver),
             dot_flash,
+            axi_users: {
+                #[cfg(feature = "axi_user_rom_param")]
+                {
+                    Some(AxiUsers {
+                        mbox_users: [
+                            Some(0xcccc_cccc),
+                            Some(0xdddd_dddd),
+                            Some(0xeeee_eeee),
+                            Some(0xffff_ffff),
+                            Some(0x1111_1111),
+                        ],
+                        fuse_user: 0xcccc_cccc,
+                        trng_user: 0xcccc_cccc,
+                        dma_user: 0xcccc_cccc,
+                    })
+                }
+                #[cfg(not(feature = "axi_user_rom_param"))]
+                {
+                    None
+                }
+            },
+            mci_axi_users: {
+                #[cfg(feature = "axi_user_rom_param")]
+                {
+                    Some(MciAxiUsers {
+                        mci_mbox0_users: [
+                            Some(0xcccc_cccc),
+                            Some(0xdddd_dddd),
+                            Some(0xeeee_eeee),
+                            Some(0xffff_ffff),
+                            Some(0x1111_1111),
+                        ],
+                        mci_mbox1_users: [
+                            Some(0xcccc_cccc),
+                            Some(0xdddd_dddd),
+                            Some(0xeeee_eeee),
+                            Some(0xffff_ffff),
+                            Some(0x1111_1111),
+                        ],
+                    })
+                }
+                #[cfg(not(feature = "axi_user_rom_param"))]
+                {
+                    None
+                }
+            },
             ..Default::default()
         });
     } else if cfg!(any(
@@ -153,6 +199,52 @@ pub extern "C" fn rom_entry() -> ! {
     } else {
         mcu_rom_common::rom_start(RomParameters {
             dot_flash,
+            axi_users: {
+                #[cfg(feature = "axi_user_rom_param")]
+                {
+                    Some(AxiUsers {
+                        mbox_users: [
+                            Some(0xcccc_cccc),
+                            Some(0xdddd_dddd),
+                            Some(0xeeee_eeee),
+                            Some(0xffff_ffff),
+                            Some(0x1111_1111),
+                        ],
+                        fuse_user: 0xcccc_cccc,
+                        trng_user: 0xcccc_cccc,
+                        dma_user: 0xcccc_cccc,
+                    })
+                }
+                #[cfg(not(feature = "axi_user_rom_param"))]
+                {
+                    None
+                }
+            },
+            mci_axi_users: {
+                #[cfg(feature = "axi_user_rom_param")]
+                {
+                    Some(MciAxiUsers {
+                        mci_mbox0_users: [
+                            Some(0xcccc_cccc),
+                            Some(0xdddd_dddd),
+                            Some(0xeeee_eeee),
+                            Some(0xffff_ffff),
+                            Some(0x1111_1111),
+                        ],
+                        mci_mbox1_users: [
+                            Some(0xcccc_cccc),
+                            Some(0xdddd_dddd),
+                            Some(0xeeee_eeee),
+                            Some(0xffff_ffff),
+                            Some(0x1111_1111),
+                        ],
+                    })
+                }
+                #[cfg(not(feature = "axi_user_rom_param"))]
+                {
+                    None
+                }
+            },
             ..Default::default()
         });
     }

--- a/rom/Cargo.toml
+++ b/rom/Cargo.toml
@@ -30,3 +30,4 @@ rv32i.workspace = true
 default = []   # default is 2.0
 hw-2-1 = []
 core_test = []
+axi_user_rom_param = []

--- a/rom/src/cold_boot.rs
+++ b/rom/src/cold_boot.rs
@@ -218,7 +218,23 @@ impl BootFlow for ColdBoot {
 
         romtime::println!("[mcu-rom] Writing fuses to Caliptra");
 
-        soc.set_axi_users(straps.into());
+        #[cfg(feature = "axi_user_rom_param")]
+        {
+            if params.axi_users.is_some() {
+                soc.set_axi_users(params.axi_users.unwrap());
+            } else {
+                soc.set_axi_users(straps.into());
+            }
+
+            if params.mci_axi_users.is_some() {
+                soc.set_mci_axi_users(params.mci_axi_users.unwrap(), mci);
+            }
+        }
+        #[cfg(not(feature = "axi_user_rom_param"))]
+        {
+            soc.set_axi_users(straps.into());
+        }
+
         mci.set_flow_checkpoint(McuRomBootStatus::AxiUsersConfigured.into());
 
         romtime::println!("[mcu-rom] Populating fuses");

--- a/rom/src/warm_boot.rs
+++ b/rom/src/warm_boot.rs
@@ -56,7 +56,22 @@ impl BootFlow for WarmBoot {
             mci.set_flow_checkpoint(McuRomBootStatus::WatchdogConfigured.into());
         }
 
-        soc.set_axi_users(straps.into());
+        #[cfg(feature = "axi_user_rom_param")]
+        {
+            if params.axi_users.is_some() {
+                soc.set_axi_users(params.axi_users.unwrap());
+            } else {
+                soc.set_axi_users(straps.into());
+            }
+
+            if params.mci_axi_users.is_some() {
+                soc.set_mci_axi_users(params.mci_axi_users.unwrap(), mci);
+            }
+        }
+        #[cfg(not(feature = "axi_user_rom_param"))]
+        {
+            soc.set_axi_users(straps.into());
+        }
         mci.set_flow_checkpoint(McuRomBootStatus::AxiUsersConfigured.into());
 
         // According to https://github.com/chipsalliance/caliptra-rtl/blob/main/docs/CaliptraIntegrationSpecification.md#fuses

--- a/romtime/Cargo.toml
+++ b/romtime/Cargo.toml
@@ -13,6 +13,7 @@ registers-generated.workspace = true
 tock-registers.workspace = true
 ureg.workspace = true
 zerocopy.workspace = true
+mcu-error.workspace = true
 
 [target.'cfg(target_arch = "riscv32")'.dependencies]
 riscv-csr.workspace = true

--- a/romtime/src/mci.rs
+++ b/romtime/src/mci.rs
@@ -1,6 +1,7 @@
 // Licensed under the Apache-2.0 license
 
 use crate::static_ref::StaticRef;
+use mcu_error::McuError;
 use registers_generated::mci;
 use tock_registers::interfaces::{ReadWriteable, Readable, Writeable};
 
@@ -170,6 +171,42 @@ impl Mci {
     }
     pub fn write_wdt_timer1_en(&self, value: u32) {
         self.registers.mci_reg_wdt_timer1_en.set(value);
+    }
+
+    pub fn set_mci_mbox0_valid_axi_user(&self, index: usize, value: u32) -> Result<(), McuError> {
+        if index >= self.registers.mci_reg_mbox0_valid_axi_user.len() {
+            Err(McuError::ROM_MCI_MBOX_USER_OUT_OF_RANGE)
+        } else {
+            self.registers.mci_reg_mbox0_valid_axi_user[index].set(value);
+            Ok(())
+        }
+    }
+
+    pub fn set_mci_mbox0_axi_user_lock(&self, index: usize, value: u32) -> Result<(), McuError> {
+        if index >= self.registers.mci_reg_mbox0_axi_user_lock.len() {
+            Err(McuError::ROM_MCI_MBOX_USER_LOCK_OUT_OF_RANGE)
+        } else {
+            self.registers.mci_reg_mbox0_axi_user_lock[index].set(value);
+            Ok(())
+        }
+    }
+
+    pub fn set_mci_mbox1_valid_axi_user(&self, index: usize, value: u32) -> Result<(), McuError> {
+        if index >= self.registers.mci_reg_mbox1_valid_axi_user.len() {
+            Err(McuError::ROM_MCI_MBOX_USER_OUT_OF_RANGE)
+        } else {
+            self.registers.mci_reg_mbox1_valid_axi_user[index].set(value);
+            Ok(())
+        }
+    }
+
+    pub fn set_mci_mbox1_axi_user_lock(&self, index: usize, value: u32) -> Result<(), McuError> {
+        if index >= self.registers.mci_reg_mbox1_axi_user_lock.len() {
+            Err(McuError::ROM_MCI_MBOX_USER_LOCK_OUT_OF_RANGE)
+        } else {
+            self.registers.mci_reg_mbox1_axi_user_lock[index].set(value);
+            Ok(())
+        }
     }
 
     // Interrupt handler for MCI interrupts


### PR DESCRIPTION
…m platform ROM code.

This patch adds the ability for the platform code to pass the AXI user IDs for:

o Caliptra mailbox
o Fuse controller
o TRNG
o DMA controller
o MCI mailbox0
o MCI mailbox1

The patch adds a new feature called "axi_user_rom_param" which enables the code to pass the AXI users in the RomParameters structure.  If the feature is not enabled, the current behavior will apply.

Add test values to test this functionality in the emulator.