### PR TITLE
Add In-Field Fuse Programming (IFP) mailbox message types

### DIFF
--- a/docs/src/external_mailbox_cmds.md
+++ b/docs/src/external_mailbox_cmds.md
@@ -69,8 +69,8 @@ These commands support a wide range of functionalities, including querying devic
 | MC_PRODUCTION_DEBUG_UNLOCK_REQ    | 0x4D44_5552 ("MDUR") | Requests debug unlock in a production environment.                                                 |
 | MC_PRODUCTION_DEBUG_UNLOCK_TOKEN  | 0x4D44_5554 ("MDUT") | Sends the debug unlock token.                                                                      |
 | MC_FUSE_READ                      | 0x4946_5052 ("IFPR") | See [fuses spec](fuses.md) for details |
-| MC_FUSE_WRITE                      | 0x4946_5057 ("IFPW") | See [fuses spec](fuses.md) for details |
-| MC_FUSE_LOCK_PARTITION             | 0x4946_504B ("IFPK") | See [fuses spec](fuses.md) for details |
+| MC_FUSE_WRITE                     | 0x4946_5057 ("IFPW") | See [fuses spec](fuses.md) for details |
+| MC_FUSE_LOCK_PARTITION            | 0x4946_504B ("IFPK") | See [fuses spec](fuses.md) for details |
 
 ## Command Format
 

--- a/docs/src/fuse_api_cmd.md
+++ b/docs/src/fuse_api_cmd.md
@@ -50,20 +50,20 @@ Caveats:
 * Will fail if any of the existing data is 1 but is set to 0 in the input data. Existing data that is 0 but set to 1 will be burned to a 1.
 * Writes to buffered partitions will not take effect until the next reset.
 
-### MC_FUSE_LOCK_PARTITON
+### MC_FUSE_LOCK_PARTITION
 
 Lock a partition.
 
 Command Code: `0x4946_504B` ("IFPK")
 
-*Table: `MC_FUSE_WRITE` input arguments*
+*Table: `MC_FUSE_LOCK_PARTITION` input arguments*
 | **Name**   | **Type**       | **Description**               |
 | ---------- | -------------- | ----------------------------- |
 | chksum     |  u32           |                               |
 | partition  |  u32           | Partition number to lock      |
 
 
-*Table: `MC_FUSE_WRITE` output arguments*
+*Table: `MC_FUSE_LOCK_PARTITION` output arguments*
 | **Name**      | **Type**       | **Description**                         |
 | ------------- | -------------- | --------------------------------------- |
 | chksum        |  u32           |                                         |


### PR DESCRIPTION
Implement mailbox request/response structs for the three IFP commands:
- MC_FUSE_READ (IFPR): Read fuse values from a partition entry
- MC_FUSE_WRITE (IFPW): Write fuse values to a partition entry
- MC_FUSE_LOCK_PARTITION (IFPK): Lock a partition to prevent further writes

Add FuseReadReq/Resp, FuseWriteReq/Resp, and FuseLockPartitionReq/Resp with proper serialization support including variable-size handling for FuseWriteReq and FuseReadResp.

Also fix documentation typos in fuse_api_cmd.md (MC_FUSE_LOCK_PARTITON -> MC_FUSE_LOCK_PARTITION) and correct table headers.