### PR TITLE
emulator: MCI timer fix when large values are accidentally written

### DIFF
--- a/emulator/periph/src/mci.rs
+++ b/emulator/periph/src/mci.rs
@@ -95,7 +95,10 @@ impl Mci {
         let delay = if now >= self.mtimecmp {
             1
         } else {
-            self.mtimecmp - now
+            // Clamp to i64::MAX to avoid overflow in the timer scheduler.
+            // This can happen when software writes mtimecmp in two halves,
+            // creating a temporary very large value.
+            (self.mtimecmp - now).min(i64::MAX as u64)
         };
 
         // Directly schedule the machine timer interrupt


### PR DESCRIPTION
Occasionally integration tests will fail with:

```
...
[mcu-rom] Waiting for MCU firmware to be ready

thread '<unnamed>' panicked at /home/runner/.cargo/git/checkouts/caliptra-sw-19fafb4d49650618/787ca55/sw-emulator/lib/bus/src/clock.rs:342:9:
Cannot schedule a timer action more than 9223372036854775807 clock cycles from now.
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

The root cause is trying to write a timer with a very large value, which can happen if we follow the recommended timer programming sequence in the firmware.

The easiest fix is to clamp the value of the timer that we program so as not to exceed the emulator's limit.