### PR TITLE
tests: Use random port rather than hard-coded for all I3C tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5616,7 +5616,6 @@ dependencies = [
  "clap-num",
  "crc32fast",
  "elf",
- "firmware-bundler",
  "mcu-builder",
  "mcu-config-emulator",
  "mcu-config-fpga",

--- a/tests/integration/src/test_firmware_update.rs
+++ b/tests/integration/src/test_firmware_update.rs
@@ -17,6 +17,7 @@ mod test {
         PackageHeaderInformation, StringType,
     };
     use pldm_fw_pkg::FirmwareManifest;
+    use random_port::PortPicker;
     use std::env;
     use std::path::PathBuf;
 
@@ -511,7 +512,7 @@ mod test {
             format!("0x{:016x}", mci_base),
         );
 
-        let i3c_port = 65500;
+        let i3c_port = PortPicker::new().pick().unwrap();
         let soc_image_fw_1 = [0x55u8; 512]; // Example firmware data for SOC image 1
         let soc_image_fw_2 = [0xAAu8; 256]; // Example firmware data for SOC image 2
 
@@ -626,7 +627,7 @@ mod test {
             feature,
             rom: mcu_rom,
             runtime: test_runtime.clone(),
-            i3c_port,
+            i3c_port: i3c_port.into(),
             soc_images: soc_images.clone(),
             soc_images_paths: soc_images_paths.clone(),
             primary_flash_image_path: flash_image_path.clone(),

--- a/tests/integration/src/test_soc_boot.rs
+++ b/tests/integration/src/test_soc_boot.rs
@@ -15,6 +15,7 @@ mod test {
         PackageHeaderInformation, StringType,
     };
     use pldm_fw_pkg::FirmwareManifest;
+    use random_port::PortPicker;
     use std::env;
     use std::path::PathBuf;
 
@@ -633,7 +634,7 @@ mod test {
         } else {
             "test-pldm-streaming-boot"
         };
-        let i3c_port = 65500;
+        let i3c_port = PortPicker::new().pick().unwrap();
         let soc_image_fw_1 = [0x55u8; 512]; // Example firmware data for SOC image 1
         let soc_image_fw_2 = [0xAAu8; 256]; // Example firmware data for SOC image 2
 
@@ -742,7 +743,7 @@ mod test {
             feature,
             rom: mcu_rom,
             runtime: test_runtime.clone(),
-            i3c_port,
+            i3c_port: i3c_port.into(),
             soc_images: soc_images.clone(),
             soc_images_paths: soc_images_paths.clone(),
             primary_flash_image_path: flash_image_path.clone(),


### PR DESCRIPTION
There's no need to hard-code these ports, which can cause port conflicts if running two sets of tests at the same time.