### PR TITLE
Optimize PLDM firmware transfer performance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -316,6 +316,7 @@ tock-registers = { git = "https://github.com/tock/tock.git", rev = "release-2.2"
 # Always optimize the emulator during tests, as it is a major bottleneck for
 # test speed.
 [profile.test]
+inherits = "release"
 opt-level = 3
 lto = "thin"
 

--- a/emulator/periph/src/i3c.rs
+++ b/emulator/periph/src/i3c.rs
@@ -93,7 +93,7 @@ pub struct I3c {
 
 impl I3c {
     const HCI_VERSION: u32 = 0x120;
-    const HCI_TICKS: u64 = 1000;
+    const HCI_TICKS: u64 = 100; // Reduced from 1000 for faster I/O
 
     pub fn new(
         clock: &Clock,

--- a/emulator/periph/src/lib.rs
+++ b/emulator/periph/src/lib.rs
@@ -18,7 +18,7 @@ mod doe_mbox;
 mod emu_ctrl;
 mod flash_ctrl;
 mod i3c;
-pub(crate) mod i3c_protocol;
+pub mod i3c_protocol;
 mod lc_ctrl;
 mod mci;
 mod mcu_mbox0;

--- a/runtime/userspace/api/caliptra-api/src/firmware_update/pldm_fdops.rs
+++ b/runtime/userspace/api/caliptra-api/src/firmware_update/pldm_fdops.rs
@@ -18,7 +18,7 @@ use pldm_common::protocol::firmware_update::{
 use pldm_common::util::fw_component::FirmwareComponent;
 use pldm_lib::firmware_device::fd_ops::{ComponentOperation, FdOps, FdOpsError};
 
-const MAX_PLDM_TRANSFER_SIZE: usize = 196; // This should be smaller than I3C MAX_READ_WRITE_SIZE
+const MAX_PLDM_TRANSFER_SIZE: usize = 196; // Maximum firmware data bytes per packet
 const ESTIMATED_ACTIVATION_TIME_SECS: u16 = 300; // 5 minutes estimated activation time including reset
 
 pub struct UpdateFdOps {}

--- a/runtime/userspace/api/pldm-lib/src/cmd_interface.rs
+++ b/runtime/userspace/api/pldm-lib/src/cmd_interface.rs
@@ -115,6 +115,36 @@ impl<'a> CmdInterface<'a> {
         self.fd_ctx.should_stop_initiator_mode().await
     }
 
+    /// Check if the current transfer has been cancelled.
+    pub fn is_cancelled(&self) -> bool {
+        self.fd_ctx.is_cancelled()
+    }
+
+    /// Create a transfer session for optimized download.
+    pub async fn create_transfer_session(
+        &self,
+    ) -> crate::firmware_device::transfer_session::TransferSession {
+        self.fd_ctx.create_transfer_session().await
+    }
+
+    /// Sync state from a transfer session back to internal state.
+    pub async fn sync_transfer_session(
+        &self,
+        session: &crate::firmware_device::transfer_session::TransferSession,
+    ) {
+        self.fd_ctx.sync_transfer_session(session).await;
+    }
+
+    /// Get current timestamp.
+    pub fn now(&self) -> pldm_common::protocol::firmware_update::PldmFdTime {
+        self.fd_ctx.now()
+    }
+
+    /// Get the FdOps reference for download operations.
+    pub fn ops(&self) -> &dyn crate::firmware_device::fd_ops::FdOps {
+        self.fd_ctx.ops()
+    }
+
     async fn process_request(&self, msg_buf: &mut [u8]) -> Result<usize, MsgHandlerError> {
         // Check if the handler is busy processing a request
         if self.busy.load(Ordering::SeqCst) {

--- a/runtime/userspace/api/pldm-lib/src/firmware_device/mod.rs
+++ b/runtime/userspace/api/pldm-lib/src/firmware_device/mod.rs
@@ -3,3 +3,4 @@
 pub mod fd_context;
 pub mod fd_internal;
 pub mod fd_ops;
+pub mod transfer_session;

--- a/runtime/userspace/api/pldm-lib/src/firmware_device/transfer_session.rs
+++ b/runtime/userspace/api/pldm-lib/src/firmware_device/transfer_session.rs
@@ -1,0 +1,248 @@
+// Licensed under the Apache-2.0 license
+
+//! Transfer session for optimized firmware download.
+//!
+//! This module provides a local transfer context that can be used during
+//! firmware download operations to avoid repeated mutex acquisitions.
+//! The session captures state at the start of a transfer and only requires
+//! mutex access at boundaries (start, end, cancellation check).
+
+use core::sync::atomic::{AtomicBool, Ordering};
+use pldm_common::message::firmware_update::transfer_complete::TransferResult;
+use pldm_common::protocol::firmware_update::{PldmFdTime, PLDM_FWUP_MAX_PADDING_SIZE};
+use pldm_common::util::fw_component::FirmwareComponent;
+
+use super::fd_internal::FdReqState;
+
+/// Local state for an active download transfer.
+///
+/// This struct holds all the state needed during a firmware download,
+/// allowing the hot path to avoid mutex acquisitions on every chunk.
+pub struct TransferSession {
+    /// Current download offset
+    pub offset: u32,
+    /// Current chunk length being requested
+    pub length: u32,
+    /// Maximum transfer size allowed
+    pub max_xfer_size: u32,
+    /// Component image size
+    pub comp_image_size: u32,
+    /// Current instance ID for requests
+    pub instance_id: u8,
+    /// Whether the transfer is complete
+    pub complete: bool,
+    /// Transfer result (set when complete)
+    pub result: Option<TransferResult>,
+    /// Request state
+    pub req_state: FdReqState,
+    /// Timestamp when request was sent
+    pub sent_time: Option<PldmFdTime>,
+    /// FD T1 timeout value
+    pub fd_t1_timeout: PldmFdTime,
+    /// FD T2 retry time
+    pub fd_t2_retry_time: PldmFdTime,
+    /// Last T1 update timestamp
+    pub fd_t1_update_ts: PldmFdTime,
+    /// Cached component info
+    pub component: FirmwareComponent,
+    /// Initial offset from first query (for local offset computation)
+    pub initial_offset: Option<u32>,
+    /// Total bytes downloaded so far (for local offset computation)
+    pub bytes_downloaded: u32,
+}
+
+impl TransferSession {
+    /// Create a new transfer session from the given parameters.
+    pub fn new(
+        max_xfer_size: u32,
+        component: FirmwareComponent,
+        fd_t1_timeout: PldmFdTime,
+        fd_t2_retry_time: PldmFdTime,
+        initial_instance_id: u8,
+        now: PldmFdTime,
+    ) -> Self {
+        Self {
+            offset: 0,
+            length: 0,
+            max_xfer_size,
+            comp_image_size: component.comp_image_size.unwrap_or(0),
+            instance_id: initial_instance_id,
+            complete: false,
+            result: None,
+            req_state: FdReqState::Ready,
+            sent_time: None,
+            fd_t1_timeout,
+            fd_t2_retry_time,
+            fd_t1_update_ts: now,
+            component,
+            initial_offset: None,
+            bytes_downloaded: 0,
+        }
+    }
+
+    /// Allocate the next instance ID.
+    pub fn alloc_next_instance_id(&mut self) -> u8 {
+        self.instance_id = (self.instance_id + 1) % crate::config::INSTANCE_ID_COUNT;
+        self.instance_id
+    }
+
+    /// Check if we should send a request based on current state and timing.
+    pub fn should_send_request(&self, now: PldmFdTime) -> bool {
+        match self.req_state {
+            FdReqState::Unused => false,
+            FdReqState::Ready => true,
+            FdReqState::Failed => false,
+            FdReqState::Sent => {
+                if let Some(sent_time) = self.sent_time {
+                    if now < sent_time {
+                        return false;
+                    }
+                    (now - sent_time) >= self.fd_t2_retry_time
+                } else {
+                    false
+                }
+            }
+        }
+    }
+
+    /// Calculate the chunk parameters for a download request.
+    ///
+    /// Returns `Some((offset, length))` if valid, `None` if the request is invalid.
+    pub fn get_download_chunk(
+        &self,
+        requested_offset: u32,
+        requested_length: u32,
+    ) -> Option<(u32, u32)> {
+        if requested_offset > self.comp_image_size
+            || requested_offset
+                .checked_add(requested_length)
+                .is_none_or(|requested_end| {
+                    self.comp_image_size
+                        .checked_add(PLDM_FWUP_MAX_PADDING_SIZE as u32)
+                        .is_some_and(|allowed_end| requested_end > allowed_end)
+                })
+        {
+            return None;
+        }
+        let chunk_size = requested_length.min(self.max_xfer_size);
+        Some((requested_offset, chunk_size))
+    }
+
+    /// Compute the next chunk parameters locally without external calls.
+    ///
+    /// This method uses the cached initial_offset and bytes_downloaded to compute
+    /// the next chunk, avoiding async mutex acquisitions in the hot path.
+    ///
+    /// Returns `Some((offset, length))` if more data to transfer, `None` if complete.
+    pub fn compute_next_chunk_local(&self) -> Option<(u32, u32)> {
+        let initial = self.initial_offset?;
+        let current_offset = initial + self.bytes_downloaded;
+
+        if self.bytes_downloaded >= self.comp_image_size {
+            return None; // Transfer complete
+        }
+
+        let remaining = self.comp_image_size - self.bytes_downloaded;
+        let chunk_size = remaining.min(self.max_xfer_size);
+
+        Some((current_offset, chunk_size))
+    }
+
+    /// Set the initial offset from the first query_download_offset_and_length call.
+    pub fn set_initial_offset(&mut self, offset: u32) {
+        if self.initial_offset.is_none() {
+            self.initial_offset = Some(offset);
+        }
+    }
+
+    /// Record that a chunk was successfully downloaded.
+    pub fn record_chunk_downloaded(&mut self, chunk_size: u32) {
+        self.bytes_downloaded += chunk_size;
+    }
+
+    /// Check if we have the initial offset set (first query done).
+    pub fn has_initial_offset(&self) -> bool {
+        self.initial_offset.is_some()
+    }
+
+    /// Mark the request as sent.
+    pub fn mark_sent(&mut self, now: PldmFdTime, command: u8) {
+        self.req_state = FdReqState::Sent;
+        self.sent_time = Some(now);
+        self.fd_t1_update_ts = now;
+        let _ = command; // Command tracking could be added if needed
+    }
+
+    /// Mark the transfer as ready for next chunk.
+    pub fn mark_ready_for_next(&mut self) {
+        self.req_state = FdReqState::Ready;
+        self.complete = false;
+        self.result = None;
+        self.sent_time = None;
+    }
+
+    /// Mark the transfer as complete with the given result.
+    pub fn mark_complete(&mut self, result: TransferResult) {
+        self.req_state = FdReqState::Ready;
+        self.complete = true;
+        self.result = Some(result);
+    }
+
+    /// Mark the transfer as failed.
+    pub fn mark_failed(&mut self, result: TransferResult) {
+        self.req_state = FdReqState::Failed;
+        self.complete = true;
+        self.result = Some(result);
+    }
+
+    /// Check if T1 timeout has occurred.
+    pub fn is_t1_timeout(&self, now: PldmFdTime) -> bool {
+        if self.req_state != FdReqState::Sent {
+            return false;
+        }
+        let elapsed = now.saturating_sub(self.fd_t1_update_ts);
+        elapsed > self.fd_t1_timeout
+    }
+
+    /// Update T1 timestamp.
+    pub fn update_t1_timestamp(&mut self, now: PldmFdTime) {
+        self.fd_t1_update_ts = now;
+    }
+}
+
+/// Atomic flag for signaling transfer cancellation from the responder task.
+///
+/// This allows the responder to signal cancellation without requiring
+/// mutex access in the hot download path.
+pub struct CancellationFlag {
+    cancelled: AtomicBool,
+}
+
+impl CancellationFlag {
+    pub const fn new() -> Self {
+        Self {
+            cancelled: AtomicBool::new(false),
+        }
+    }
+
+    /// Signal that the transfer should be cancelled.
+    pub fn cancel(&self) {
+        self.cancelled.store(true, Ordering::Release);
+    }
+
+    /// Check if cancellation has been requested.
+    pub fn is_cancelled(&self) -> bool {
+        self.cancelled.load(Ordering::Acquire)
+    }
+
+    /// Reset the cancellation flag.
+    pub fn reset(&self) {
+        self.cancelled.store(false, Ordering::Release);
+    }
+}
+
+impl Default for CancellationFlag {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/runtime/userspace/api/pldm-lib/src/timer.rs
+++ b/runtime/userspace/api/pldm-lib/src/timer.rs
@@ -44,11 +44,19 @@ impl<S: Syscalls, C: platform::subscribe::Config> AsyncAlarm<S, C> {
     pub async fn sleep_for<T: Convert>(time: T) -> Result<(), ErrorCode> {
         let freq = Self::get_frequency()?;
         let ticks = time.to_ticks(freq).0;
+        Self::sleep_ticks(ticks).await
+    }
+
+    pub async fn sleep_ticks(ticks: u32) -> Result<(), ErrorCode> {
+        // bad things happen if multiple tasks try to use the alarm at once
+        let guard = ALARM_MUTEX.lock().await;
         let sub = TockSubscribe::subscribe::<S>(DRIVER_NUM, 0);
         S::command(DRIVER_NUM, command::SET_RELATIVE, ticks, 0)
             .to_result()
             .map(|_when: u32| ())?;
-        sub.await.map(|_| ())
+        let result = sub.await.map(|_| ());
+        drop(guard);
+        result
     }
 
     pub async fn sleep(time: Milliseconds) {

--- a/tests/integration/src/test_firmware_update.rs
+++ b/tests/integration/src/test_firmware_update.rs
@@ -17,6 +17,7 @@ mod test {
         PackageHeaderInformation, StringType,
     };
     use pldm_fw_pkg::FirmwareManifest;
+    use random_port::PortPicker;
     use std::env;
     use std::path::PathBuf;
 
@@ -511,7 +512,7 @@ mod test {
             format!("0x{:016x}", mci_base),
         );
 
-        let i3c_port = 65500;
+        let i3c_port = PortPicker::new().pick().unwrap();
         let soc_image_fw_1 = [0x55u8; 512]; // Example firmware data for SOC image 1
         let soc_image_fw_2 = [0xAAu8; 256]; // Example firmware data for SOC image 2
 
@@ -626,7 +627,7 @@ mod test {
             feature,
             rom: mcu_rom,
             runtime: test_runtime.clone(),
-            i3c_port,
+            i3c_port: i3c_port.into(),
             soc_images: soc_images.clone(),
             soc_images_paths: soc_images_paths.clone(),
             primary_flash_image_path: flash_image_path.clone(),


### PR DESCRIPTION
Performance improvements that increase emulator PLDM transfer speed from ~1.07 KB/s to ~1.65 KB/s (approximately 55% improvement):

1. Cargo.toml: Make [profile.test] inherit from release for properly optimized test binaries. This provies a medium speedup (maybe ~20%).

2. Combined MCTP syscall (command 6): Add send_request_and_receive that reduces context switches by sending a request and auto-registering to receive the response in a single syscall.

3. I3C timing optimization: Change condition variable wait from 5ms timeout to 100μs condvar wait in i3c_socket_server.rs and i3c_protocol.rs, reducing I3C communication latency.

4. PIC interrupt scanning: Add USED_CELLS const generic to limit interrupt scanning to first 32 interrupts (1 cell) instead of all 256. This provides a small speedup (maybe ~1-2%, since it is in a hot path).

5. Optimized PLDM download path: Add transfer_session.rs and run_optimized_download() that batches firmware data requests and processes responses efficiently using the combined syscall. This (combined with the combined MCTP syscall) produces the biggest speedup.