### PR TITLE
docs: Fix Identifier field values to match u32 fmt

### DIFF
--- a/docs/src/flash_layout.md
+++ b/docs/src/flash_layout.md
@@ -56,9 +56,9 @@ The Image Information section is repeated for each image and provides detailed m
 | Field               | Size (bytes) | Descr                                                                                  |
 | ------------------- | ------------ | -------------------------------------------------------------------------------------- |
 | Identifier          | 4            | Vendor selected unique value to distinguish between images.                            |
-|                     |              | `0x0001`: Caliptra FMC+RT                                                              |
-|                     |              | `0x0002`: SoC Manifest:                                                                |
-|                     |              | `0x0003`: MCU RT<br />`0x1000`-`0xFFFF` - Reserved for other Vendor-defined SoC images |
+|                     |              | `0x00000001`: Caliptra FMC+RT                                                              |
+|                     |              | `0x00000002`: SoC Manifest                                                                |
+|                     |              | `0x00000003`: MCU RT<br />`0x00001000`-`0xFFFFFFFF` - Reserved for other Vendor-defined SoC images |
 | ImageLocationOffset | 4            | Offset in bytes from byte 0 of the header to where the image content begins.           |
 | Size                | 4            | Size in bytes of the image. This is the actual size of the image without padding.      |
 |                     |              | The image itself as written to the flash should be 4-byte aligned and additional       |


### PR DESCRIPTION
The Image Information table incorrectly showed Identifier field example values as 16-bit hex (0x0001, 0x0002, 0x0003) and the reserved range as 0x1000-0xFFFF, despite the field being defined as u32 (4 bytes).

Changed:
- 0x0001 → 0x00000001 (Caliptra FMC+RT)
- 0x0002 → 0x00000002 (SoC Manifest)
- 0x0003 → 0x00000003 (MCU RT)
- 0x1000-0xFFFF → 0x00001000-0xFFFFFFFF (Vendor-defined SoC images)

Evidence from code:

1. Identifier field is u32 (common/flash-image/src/lib.rs): pub struct ImageHeader { pub identifier: u32,  // 4 bytes, not 2 bytes ... }

2. Reserved identifiers use full 32-bit values (common/flash-image/src/lib.rs): pub const CALIPTRA_FMC_RT_IDENTIFIER: u32 = 0x00000000; pub const SOC_MANIFEST_IDENTIFIER: u32 = 0x00000001; pub const MCU_RT_IDENTIFIER: u32 = 0x00000002; pub const SOC_IMAGES_BASE_IDENTIFIER: u32 = 0x00001000;

3. Builder increments from base without upper bound (builder/src/flash_image.rs): let mut soc_image_identifer = SOC_IMAGES_BASE_IDENTIFIER; for soc_img in soc_img_buffers.iter() { images.push(FirmwareImage::new(soc_image_identifer, soc_img)?); soc_image_identifer += 1;  // Allows increment to 0xFFFFFFFF }

4. Tests use SOC_IMAGES_BASE_IDENTIFIER + offsets (tests/integration/src/test_firmware_update.rs):
   image_id: SOC_IMAGES_BASE_IDENTIFIER,      // 0x00001000
   image_id: SOC_IMAGES_BASE_IDENTIFIER + 1,  // 0x00001001

No maximum identifier constant exists in the codebase, confirming the full u32 range (0x00000000 to 0xFFFFFFFF) is valid, with vendor-defined images starting at 0x00001000