### PR TITLE
[test] check MCU SRAM read/writes after manuf debug unlock

### DIFF
--- a/tests/integration/src/jtag/mod.rs
+++ b/tests/integration/src/jtag/mod.rs
@@ -8,10 +8,12 @@ mod test_uds;
 
 #[cfg(test)]
 mod test {
+
     use caliptra_hw_model::jtag::DmReg;
     use caliptra_hw_model::openocd::openocd_jtag_tap::OpenOcdJtagTap;
     use caliptra_hw_model::Fuses;
     use mcu_builder::FirmwareBinaries;
+    use mcu_config_fpga::FPGA_MEMORY_MAP;
     use mcu_hw_model::{DefaultHwModel, InitParams, McuHwModel};
     use romtime::LifecycleControllerState;
 
@@ -40,7 +42,27 @@ mod test {
         DefaultHwModel::new_unbooted(init_params).unwrap()
     }
 
-    pub fn debug_is_unlocked(tap: &mut OpenOcdJtagTap) -> Result<bool> {
+    /// Write/Read words to SRAM over the system bus.
+    fn sysbus_write_read(tap: &mut OpenOcdJtagTap, sram_base_addr: u32) -> Result<bool> {
+        const NUM_WORDS: u32 = 4;
+        for i in 0..NUM_WORDS {
+            let addr = sram_base_addr + i * 4;
+            let value = 0xa5a5a5a5;
+            tap.write_memory_32(addr, value)?;
+            let read_value = tap.read_memory_32(addr)?;
+            println!(
+                "Wrote 0x{:x} to 0x{:x}; Read 0x{:x}",
+                value, addr, read_value
+            );
+            if value != read_value {
+                return Ok(false);
+            }
+        }
+        Ok(true)
+    }
+
+    /// Check if a debug module is active.
+    fn check_debug_module_active(tap: &mut OpenOcdJtagTap) -> Result<bool> {
         // Check dmstatus.allrunning and dmstatus.anyrunning bits to see if
         // debug access has been unlocked.
         let dmstatus = tap.read_reg(&DmReg::DmStatus)?;
@@ -48,6 +70,26 @@ mod test {
             println!("Debug is not unlocked: dmstatus = 0x{:08x}", dmstatus);
             return Ok(false);
         }
+        Ok(true)
+    }
+
+    pub fn debug_is_unlocked(
+        core_tap: &mut OpenOcdJtagTap,
+        mcu_tap: &mut OpenOcdJtagTap,
+    ) -> Result<bool> {
+        // Check both TAPs are active.
+        if !check_debug_module_active(core_tap)? {
+            return Ok(false);
+        }
+        if !check_debug_module_active(mcu_tap)? {
+            return Ok(false);
+        }
+
+        // Test writes to Caliptra MCU SRAM.
+        if !sysbus_write_read(mcu_tap, FPGA_MEMORY_MAP.sram_offset)? {
+            return Ok(false);
+        }
+
         Ok(true)
     }
 }

--- a/tests/integration/src/jtag/test_manuf_debug_unlock.rs
+++ b/tests/integration/src/jtag/test_manuf_debug_unlock.rs
@@ -13,7 +13,7 @@ mod test {
     use caliptra_hw_model::openocd::openocd_jtag_tap::{JtagParams, JtagTap};
     use caliptra_hw_model::HwModel;
     use caliptra_hw_model::DEFAULT_MANUF_DEBUG_UNLOCK_RAW_TOKEN;
-    use mcu_hw_model::jtag::jtag_send_caliptra_mailbox_cmd;
+    use mcu_hw_model::jtag::{jtag_get_caliptra_mailbox_resp, jtag_send_caliptra_mailbox_cmd};
     use romtime::LifecycleControllerState;
 
     use zerocopy::IntoBytes;
@@ -28,44 +28,54 @@ mod test {
             /*enable_mcu_uart_log=*/ true,
         );
 
-        // Connect to Caliptra Core JTAG TAP via OpenOCD.
-        println!("Connecting to Core TAP ...");
+        // Connect to Caliptra Core and MCU JTAG TAPs via OpenOCD.
         let jtag_params = JtagParams {
             openocd: PathBuf::from("openocd"),
             adapter_speed_khz: 1000,
             log_stdio: true,
         };
-        let mut tap = model
+        println!("Connecting to Core TAP ...");
+        let mut core_tap = model
             .jtag_tap_connect(&jtag_params, JtagTap::CaliptraCoreTap)
             .expect("Failed to connect to the Caliptra Core JTAG TAP.");
         println!("Connected.");
+        println!("Connecting to MCU TAP ...");
+        let mut mcu_tap = model
+            .jtag_tap_connect(&jtag_params, JtagTap::CaliptraMcuTap)
+            .expect("Failed to connect to the Caliptra MCU JTAG TAP.");
+        println!("Connected.");
 
         // Confirm debug is locked.
-        let is_unlocked = debug_is_unlocked(&mut *tap).unwrap_or(false);
+        let is_unlocked = debug_is_unlocked(&mut *core_tap, &mut *mcu_tap).unwrap_or(false);
         assert_eq!(is_unlocked, false);
 
         // Request manuf debug unlock operation.
-        tap.write_reg(&CaliptraCoreReg::SsDbgManufServiceRegReq, 0x1)
+        core_tap
+            .write_reg(&CaliptraCoreReg::SsDbgManufServiceRegReq, 0x1)
             .expect("Unable to write SsDbgManufServiceRegReq reg.");
         model.base.step();
 
         // Continue Caliptra Core boot.
-        tap.write_reg(&CaliptraCoreReg::BootfsmGo, 0x1)
+        core_tap
+            .write_reg(&CaliptraCoreReg::BootfsmGo, 0x1)
             .expect("Unable to write BootfsmGo.");
         model.base.step();
 
         // Send the manuf debug unlock token.
         jtag_send_caliptra_mailbox_cmd(
-            &mut *tap,
+            &mut *core_tap,
             CommandId::MANUF_DEBUG_UNLOCK_REQ_TOKEN,
             DEFAULT_MANUF_DEBUG_UNLOCK_RAW_TOKEN.0.as_bytes(),
         )
         .expect("Failed to send manuf debug unlock token.");
         model.base.step();
+        let _ = jtag_get_caliptra_mailbox_resp(&mut *core_tap)
+            .expect("Failed to get manuf debug unlock response.");
+        model.base.step();
 
         // Wait for debug unlock operation to complete.
         while let Ok(ss_debug_manuf_response) =
-            tap.read_reg(&CaliptraCoreReg::SsDbgManufServiceRegRsp)
+            core_tap.read_reg(&CaliptraCoreReg::SsDbgManufServiceRegRsp)
         {
             if (ss_debug_manuf_response & 0x3) != 0 {
                 println!(
@@ -73,6 +83,7 @@ mod test {
                     ss_debug_manuf_response
                 );
                 assert_eq!(ss_debug_manuf_response, 0x1);
+                model.base.step();
                 break;
             }
             model.base.step();
@@ -80,11 +91,19 @@ mod test {
         }
 
         // Confirm debug is unlocked.
-        tap.reexamine_cpu_target()
+        core_tap
+            .reexamine_cpu_target()
             .expect("Failed to reexamine CPU target.");
-        tap.set_sysbus_access()
+        core_tap
+            .set_sysbus_access()
             .expect("Failed to set sysbus access.");
-        let is_unlocked = debug_is_unlocked(&mut *tap).unwrap_or(false);
+        mcu_tap
+            .reexamine_cpu_target()
+            .expect("Failed to reexamine CPU target.");
+        mcu_tap
+            .set_sysbus_access()
+            .expect("Failed to set sysbus access.");
+        let is_unlocked = debug_is_unlocked(&mut *core_tap, &mut *mcu_tap).unwrap_or(false);
         assert_eq!(is_unlocked, true);
     }
 }


### PR DESCRIPTION
This updates the manuf debug unlock test case to check the MCU SRAM and writable/readable over the MCU TAP after a manuf debug unlock operation. Additionally, this checks that both the CORE and MCU debug modules are active only after a manuf debug unlock operation (but not before).