### PR TITLE
emulator: Watchdog timer clamp fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,7 +289,7 @@ checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 [[package]]
 name = "caliptra-api"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fbb6bfadf2534a379f1666627a2021dd006a5d5f#fbb6bfadf2534a379f1666627a2021dd006a5d5f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5cff948de1a5da013c8edcc7efbf4a959387ec87#5cff948de1a5da013c8edcc7efbf4a959387ec87"
 dependencies = [
  "bitflags 2.10.0",
  "caliptra-api-types",
@@ -304,7 +304,7 @@ dependencies = [
 [[package]]
 name = "caliptra-api-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fbb6bfadf2534a379f1666627a2021dd006a5d5f#fbb6bfadf2534a379f1666627a2021dd006a5d5f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5cff948de1a5da013c8edcc7efbf4a959387ec87#5cff948de1a5da013c8edcc7efbf4a959387ec87"
 dependencies = [
  "caliptra-image-types",
 ]
@@ -312,7 +312,7 @@ dependencies = [
 [[package]]
 name = "caliptra-auth-man-gen"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fbb6bfadf2534a379f1666627a2021dd006a5d5f#fbb6bfadf2534a379f1666627a2021dd006a5d5f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5cff948de1a5da013c8edcc7efbf4a959387ec87#5cff948de1a5da013c8edcc7efbf4a959387ec87"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",
@@ -327,7 +327,7 @@ dependencies = [
 [[package]]
 name = "caliptra-auth-man-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fbb6bfadf2534a379f1666627a2021dd006a5d5f#fbb6bfadf2534a379f1666627a2021dd006a5d5f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5cff948de1a5da013c8edcc7efbf4a959387ec87#5cff948de1a5da013c8edcc7efbf4a959387ec87"
 dependencies = [
  "bitfield",
  "bitflags 2.10.0",
@@ -342,7 +342,7 @@ dependencies = [
 [[package]]
 name = "caliptra-bitstream-downloader"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fbb6bfadf2534a379f1666627a2021dd006a5d5f#fbb6bfadf2534a379f1666627a2021dd006a5d5f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5cff948de1a5da013c8edcc7efbf4a959387ec87#5cff948de1a5da013c8edcc7efbf4a959387ec87"
 dependencies = [
  "anyhow",
  "clap 4.5.51",
@@ -356,7 +356,7 @@ dependencies = [
 [[package]]
 name = "caliptra-builder"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fbb6bfadf2534a379f1666627a2021dd006a5d5f#fbb6bfadf2534a379f1666627a2021dd006a5d5f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5cff948de1a5da013c8edcc7efbf4a959387ec87#5cff948de1a5da013c8edcc7efbf4a959387ec87"
 dependencies = [
  "anyhow",
  "caliptra-image-crypto",
@@ -381,7 +381,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cfi-derive"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fbb6bfadf2534a379f1666627a2021dd006a5d5f#fbb6bfadf2534a379f1666627a2021dd006a5d5f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5cff948de1a5da013c8edcc7efbf4a959387ec87#5cff948de1a5da013c8edcc7efbf4a959387ec87"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -403,7 +403,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cfi-lib"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fbb6bfadf2534a379f1666627a2021dd006a5d5f#fbb6bfadf2534a379f1666627a2021dd006a5d5f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5cff948de1a5da013c8edcc7efbf4a959387ec87#5cff948de1a5da013c8edcc7efbf4a959387ec87"
 dependencies = [
  "caliptra-error",
  "caliptra-registers",
@@ -418,7 +418,7 @@ source = "git+https://github.com/chipsalliance/caliptra-cfi.git?rev=a98e499d279e
 [[package]]
 name = "caliptra-coverage"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fbb6bfadf2534a379f1666627a2021dd006a5d5f#fbb6bfadf2534a379f1666627a2021dd006a5d5f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5cff948de1a5da013c8edcc7efbf4a959387ec87#5cff948de1a5da013c8edcc7efbf4a959387ec87"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cpu"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fbb6bfadf2534a379f1666627a2021dd006a5d5f#fbb6bfadf2534a379f1666627a2021dd006a5d5f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5cff948de1a5da013c8edcc7efbf4a959387ec87#5cff948de1a5da013c8edcc7efbf4a959387ec87"
 dependencies = [
  "caliptra-drivers",
  "caliptra-registers",
@@ -446,7 +446,7 @@ dependencies = [
 [[package]]
 name = "caliptra-drivers"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fbb6bfadf2534a379f1666627a2021dd006a5d5f#fbb6bfadf2534a379f1666627a2021dd006a5d5f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5cff948de1a5da013c8edcc7efbf4a959387ec87#5cff948de1a5da013c8edcc7efbf4a959387ec87"
 dependencies = [
  "arrayvec",
  "bitfield",
@@ -472,7 +472,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-bus"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fbb6bfadf2534a379f1666627a2021dd006a5d5f#fbb6bfadf2534a379f1666627a2021dd006a5d5f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5cff948de1a5da013c8edcc7efbf4a959387ec87#5cff948de1a5da013c8edcc7efbf4a959387ec87"
 dependencies = [
  "caliptra-emu-types",
  "tock-registers",
@@ -482,7 +482,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-cpu"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fbb6bfadf2534a379f1666627a2021dd006a5d5f#fbb6bfadf2534a379f1666627a2021dd006a5d5f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5cff948de1a5da013c8edcc7efbf4a959387ec87#5cff948de1a5da013c8edcc7efbf4a959387ec87"
 dependencies = [
  "bit-vec",
  "bitfield",
@@ -496,7 +496,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fbb6bfadf2534a379f1666627a2021dd006a5d5f#fbb6bfadf2534a379f1666627a2021dd006a5d5f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5cff948de1a5da013c8edcc7efbf4a959387ec87#5cff948de1a5da013c8edcc7efbf4a959387ec87"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -511,7 +511,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-derive"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fbb6bfadf2534a379f1666627a2021dd006a5d5f#fbb6bfadf2534a379f1666627a2021dd006a5d5f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5cff948de1a5da013c8edcc7efbf4a959387ec87#5cff948de1a5da013c8edcc7efbf4a959387ec87"
 dependencies = [
  "caliptra-emu-bus",
  "caliptra-emu-types",
@@ -522,7 +522,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-periph"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fbb6bfadf2534a379f1666627a2021dd006a5d5f#fbb6bfadf2534a379f1666627a2021dd006a5d5f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5cff948de1a5da013c8edcc7efbf4a959387ec87#5cff948de1a5da013c8edcc7efbf4a959387ec87"
 dependencies = [
  "aes",
  "arrayref",
@@ -549,17 +549,17 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fbb6bfadf2534a379f1666627a2021dd006a5d5f#fbb6bfadf2534a379f1666627a2021dd006a5d5f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5cff948de1a5da013c8edcc7efbf4a959387ec87#5cff948de1a5da013c8edcc7efbf4a959387ec87"
 
 [[package]]
 name = "caliptra-error"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fbb6bfadf2534a379f1666627a2021dd006a5d5f#fbb6bfadf2534a379f1666627a2021dd006a5d5f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5cff948de1a5da013c8edcc7efbf4a959387ec87#5cff948de1a5da013c8edcc7efbf4a959387ec87"
 
 [[package]]
 name = "caliptra-gen-linker-scripts"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fbb6bfadf2534a379f1666627a2021dd006a5d5f#fbb6bfadf2534a379f1666627a2021dd006a5d5f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5cff948de1a5da013c8edcc7efbf4a959387ec87#5cff948de1a5da013c8edcc7efbf4a959387ec87"
 dependencies = [
  "caliptra_common",
 ]
@@ -567,7 +567,7 @@ dependencies = [
 [[package]]
 name = "caliptra-hw-model"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fbb6bfadf2534a379f1666627a2021dd006a5d5f#fbb6bfadf2534a379f1666627a2021dd006a5d5f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5cff948de1a5da013c8edcc7efbf4a959387ec87#5cff948de1a5da013c8edcc7efbf4a959387ec87"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -606,7 +606,7 @@ dependencies = [
 [[package]]
 name = "caliptra-hw-model-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fbb6bfadf2534a379f1666627a2021dd006a5d5f#fbb6bfadf2534a379f1666627a2021dd006a5d5f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5cff948de1a5da013c8edcc7efbf4a959387ec87#5cff948de1a5da013c8edcc7efbf4a959387ec87"
 dependencies = [
  "caliptra-api-types",
  "rand 0.8.5",
@@ -615,7 +615,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fbb6bfadf2534a379f1666627a2021dd006a5d5f#fbb6bfadf2534a379f1666627a2021dd006a5d5f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5cff948de1a5da013c8edcc7efbf4a959387ec87#5cff948de1a5da013c8edcc7efbf4a959387ec87"
 dependencies = [
  "anyhow",
  "caliptra-image-gen",
@@ -635,7 +635,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-elf"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fbb6bfadf2534a379f1666627a2021dd006a5d5f#fbb6bfadf2534a379f1666627a2021dd006a5d5f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5cff948de1a5da013c8edcc7efbf4a959387ec87#5cff948de1a5da013c8edcc7efbf4a959387ec87"
 dependencies = [
  "anyhow",
  "caliptra-image-gen",
@@ -646,7 +646,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-fake-keys"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fbb6bfadf2534a379f1666627a2021dd006a5d5f#fbb6bfadf2534a379f1666627a2021dd006a5d5f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5cff948de1a5da013c8edcc7efbf4a959387ec87#5cff948de1a5da013c8edcc7efbf4a959387ec87"
 dependencies = [
  "caliptra-image-gen",
  "caliptra-image-types",
@@ -657,7 +657,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-gen"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fbb6bfadf2534a379f1666627a2021dd006a5d5f#fbb6bfadf2534a379f1666627a2021dd006a5d5f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5cff948de1a5da013c8edcc7efbf4a959387ec87#5cff948de1a5da013c8edcc7efbf4a959387ec87"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",
@@ -674,7 +674,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fbb6bfadf2534a379f1666627a2021dd006a5d5f#fbb6bfadf2534a379f1666627a2021dd006a5d5f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5cff948de1a5da013c8edcc7efbf4a959387ec87#5cff948de1a5da013c8edcc7efbf4a959387ec87"
 dependencies = [
  "caliptra-cfi-derive",
  "caliptra-cfi-lib",
@@ -690,7 +690,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-verify"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fbb6bfadf2534a379f1666627a2021dd006a5d5f#fbb6bfadf2534a379f1666627a2021dd006a5d5f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5cff948de1a5da013c8edcc7efbf4a959387ec87#5cff948de1a5da013c8edcc7efbf4a959387ec87"
 dependencies = [
  "bitflags 2.10.0",
  "caliptra-cfi-derive",
@@ -705,7 +705,7 @@ dependencies = [
 [[package]]
 name = "caliptra-kat"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fbb6bfadf2534a379f1666627a2021dd006a5d5f#fbb6bfadf2534a379f1666627a2021dd006a5d5f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5cff948de1a5da013c8edcc7efbf4a959387ec87#5cff948de1a5da013c8edcc7efbf4a959387ec87"
 dependencies = [
  "caliptra-drivers",
  "caliptra-lms-types",
@@ -717,7 +717,7 @@ dependencies = [
 [[package]]
 name = "caliptra-lms-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fbb6bfadf2534a379f1666627a2021dd006a5d5f#fbb6bfadf2534a379f1666627a2021dd006a5d5f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5cff948de1a5da013c8edcc7efbf4a959387ec87#5cff948de1a5da013c8edcc7efbf4a959387ec87"
 dependencies = [
  "caliptra-cfi-derive",
  "caliptra-cfi-lib",
@@ -740,7 +740,7 @@ dependencies = [
 [[package]]
 name = "caliptra-registers"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fbb6bfadf2534a379f1666627a2021dd006a5d5f#fbb6bfadf2534a379f1666627a2021dd006a5d5f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5cff948de1a5da013c8edcc7efbf4a959387ec87#5cff948de1a5da013c8edcc7efbf4a959387ec87"
 dependencies = [
  "caliptra-registers-latest",
 ]
@@ -748,7 +748,7 @@ dependencies = [
 [[package]]
 name = "caliptra-registers-latest"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fbb6bfadf2534a379f1666627a2021dd006a5d5f#fbb6bfadf2534a379f1666627a2021dd006a5d5f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5cff948de1a5da013c8edcc7efbf4a959387ec87#5cff948de1a5da013c8edcc7efbf4a959387ec87"
 dependencies = [
  "ureg",
 ]
@@ -756,7 +756,7 @@ dependencies = [
 [[package]]
 name = "caliptra-runtime"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fbb6bfadf2534a379f1666627a2021dd006a5d5f#fbb6bfadf2534a379f1666627a2021dd006a5d5f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5cff948de1a5da013c8edcc7efbf4a959387ec87#5cff948de1a5da013c8edcc7efbf4a959387ec87"
 dependencies = [
  "arrayvec",
  "bitfield",
@@ -791,7 +791,7 @@ dependencies = [
 [[package]]
 name = "caliptra-test"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fbb6bfadf2534a379f1666627a2021dd006a5d5f#fbb6bfadf2534a379f1666627a2021dd006a5d5f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5cff948de1a5da013c8edcc7efbf4a959387ec87#5cff948de1a5da013c8edcc7efbf4a959387ec87"
 dependencies = [
  "anyhow",
  "asn1",
@@ -823,7 +823,7 @@ dependencies = [
 [[package]]
 name = "caliptra-test-harness-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fbb6bfadf2534a379f1666627a2021dd006a5d5f#fbb6bfadf2534a379f1666627a2021dd006a5d5f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5cff948de1a5da013c8edcc7efbf4a959387ec87#5cff948de1a5da013c8edcc7efbf4a959387ec87"
 
 [[package]]
 name = "caliptra-util-host-mailbox-test-config"
@@ -837,7 +837,7 @@ dependencies = [
 [[package]]
 name = "caliptra-x509"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fbb6bfadf2534a379f1666627a2021dd006a5d5f#fbb6bfadf2534a379f1666627a2021dd006a5d5f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5cff948de1a5da013c8edcc7efbf4a959387ec87#5cff948de1a5da013c8edcc7efbf4a959387ec87"
 dependencies = [
  "zeroize",
 ]
@@ -845,7 +845,7 @@ dependencies = [
 [[package]]
 name = "caliptra_common"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fbb6bfadf2534a379f1666627a2021dd006a5d5f#fbb6bfadf2534a379f1666627a2021dd006a5d5f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5cff948de1a5da013c8edcc7efbf4a959387ec87#5cff948de1a5da013c8edcc7efbf4a959387ec87"
 dependencies = [
  "bitfield",
  "bitflags 2.10.0",
@@ -1285,7 +1285,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fbb6bfadf2534a379f1666627a2021dd006a5d5f#fbb6bfadf2534a379f1666627a2021dd006a5d5f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5cff948de1a5da013c8edcc7efbf4a959387ec87#5cff948de1a5da013c8edcc7efbf4a959387ec87"
 dependencies = [
  "arrayvec",
  "caliptra-cfi-derive-git",
@@ -1489,7 +1489,7 @@ dependencies = [
 [[package]]
 name = "dpe"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fbb6bfadf2534a379f1666627a2021dd006a5d5f#fbb6bfadf2534a379f1666627a2021dd006a5d5f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5cff948de1a5da013c8edcc7efbf4a959387ec87#5cff948de1a5da013c8edcc7efbf4a959387ec87"
 dependencies = [
  "bitflags 2.10.0",
  "caliptra-cfi-derive-git",
@@ -3557,7 +3557,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 [[package]]
 name = "platform"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fbb6bfadf2534a379f1666627a2021dd006a5d5f#fbb6bfadf2534a379f1666627a2021dd006a5d5f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5cff948de1a5da013c8edcc7efbf4a959387ec87#5cff948de1a5da013c8edcc7efbf4a959387ec87"
 dependencies = [
  "arrayvec",
  "cfg-if",
@@ -5113,7 +5113,7 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 [[package]]
 name = "ureg"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fbb6bfadf2534a379f1666627a2021dd006a5d5f#fbb6bfadf2534a379f1666627a2021dd006a5d5f"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=5cff948de1a5da013c8edcc7efbf4a959387ec87#5cff948de1a5da013c8edcc7efbf4a959387ec87"
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -238,31 +238,31 @@ libtock_small_panic = { path = "runtime/userspace/libtock/panic_handlers/small_p
 libtock_unittest = { path = "runtime/userspace/libtock/unittest" }
 
 # caliptra dependencies; keep git revs in sync
-caliptra-api = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fbb6bfadf2534a379f1666627a2021dd006a5d5f" }
-caliptra-api-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fbb6bfadf2534a379f1666627a2021dd006a5d5f" }
-caliptra-auth-man-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fbb6bfadf2534a379f1666627a2021dd006a5d5f" }
-caliptra-auth-man-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fbb6bfadf2534a379f1666627a2021dd006a5d5f" }
-caliptra-bitstream-downloader = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fbb6bfadf2534a379f1666627a2021dd006a5d5f" }
-caliptra-builder = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fbb6bfadf2534a379f1666627a2021dd006a5d5f" }
-caliptra-drivers = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fbb6bfadf2534a379f1666627a2021dd006a5d5f" }
-caliptra-emu-bus = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fbb6bfadf2534a379f1666627a2021dd006a5d5f" }
-caliptra-emu-cpu = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fbb6bfadf2534a379f1666627a2021dd006a5d5f" }
-caliptra-emu-derive = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fbb6bfadf2534a379f1666627a2021dd006a5d5f" }
-caliptra-emu-periph = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fbb6bfadf2534a379f1666627a2021dd006a5d5f" }
-caliptra-emu-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fbb6bfadf2534a379f1666627a2021dd006a5d5f" }
-caliptra-error = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fbb6bfadf2534a379f1666627a2021dd006a5d5f", default-features = false }
-caliptra-hw-model = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fbb6bfadf2534a379f1666627a2021dd006a5d5f" }
-caliptra-hw-model-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fbb6bfadf2534a379f1666627a2021dd006a5d5f" }
-caliptra-image-crypto = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fbb6bfadf2534a379f1666627a2021dd006a5d5f", default-features = false, features = ["rustcrypto"] }
-caliptra-image-fake-keys = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fbb6bfadf2534a379f1666627a2021dd006a5d5f" }
-caliptra-image-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fbb6bfadf2534a379f1666627a2021dd006a5d5f" }
-caliptra-image-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fbb6bfadf2534a379f1666627a2021dd006a5d5f" }
-caliptra-registers = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fbb6bfadf2534a379f1666627a2021dd006a5d5f" }
-caliptra-test = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fbb6bfadf2534a379f1666627a2021dd006a5d5f" }
-caliptra-test-harness = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fbb6bfadf2534a379f1666627a2021dd006a5d5f" }
-caliptra-test-harness-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fbb6bfadf2534a379f1666627a2021dd006a5d5f" }
-ureg = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fbb6bfadf2534a379f1666627a2021dd006a5d5f" }
-dpe = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fbb6bfadf2534a379f1666627a2021dd006a5d5f", default-features = false, features = ["dpe_profile_p384_sha384"] }
+caliptra-api = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "5cff948de1a5da013c8edcc7efbf4a959387ec87" }
+caliptra-api-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "5cff948de1a5da013c8edcc7efbf4a959387ec87" }
+caliptra-auth-man-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "5cff948de1a5da013c8edcc7efbf4a959387ec87" }
+caliptra-auth-man-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "5cff948de1a5da013c8edcc7efbf4a959387ec87" }
+caliptra-bitstream-downloader = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "5cff948de1a5da013c8edcc7efbf4a959387ec87" }
+caliptra-builder = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "5cff948de1a5da013c8edcc7efbf4a959387ec87" }
+caliptra-drivers = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "5cff948de1a5da013c8edcc7efbf4a959387ec87" }
+caliptra-emu-bus = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "5cff948de1a5da013c8edcc7efbf4a959387ec87" }
+caliptra-emu-cpu = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "5cff948de1a5da013c8edcc7efbf4a959387ec87" }
+caliptra-emu-derive = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "5cff948de1a5da013c8edcc7efbf4a959387ec87" }
+caliptra-emu-periph = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "5cff948de1a5da013c8edcc7efbf4a959387ec87" }
+caliptra-emu-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "5cff948de1a5da013c8edcc7efbf4a959387ec87" }
+caliptra-error = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "5cff948de1a5da013c8edcc7efbf4a959387ec87", default-features = false }
+caliptra-hw-model = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "5cff948de1a5da013c8edcc7efbf4a959387ec87" }
+caliptra-hw-model-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "5cff948de1a5da013c8edcc7efbf4a959387ec87" }
+caliptra-image-crypto = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "5cff948de1a5da013c8edcc7efbf4a959387ec87", default-features = false, features = ["rustcrypto"] }
+caliptra-image-fake-keys = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "5cff948de1a5da013c8edcc7efbf4a959387ec87" }
+caliptra-image-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "5cff948de1a5da013c8edcc7efbf4a959387ec87" }
+caliptra-image-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "5cff948de1a5da013c8edcc7efbf4a959387ec87" }
+caliptra-registers = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "5cff948de1a5da013c8edcc7efbf4a959387ec87" }
+caliptra-test = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "5cff948de1a5da013c8edcc7efbf4a959387ec87" }
+caliptra-test-harness = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "5cff948de1a5da013c8edcc7efbf4a959387ec87" }
+caliptra-test-harness-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "5cff948de1a5da013c8edcc7efbf4a959387ec87" }
+ureg = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "5cff948de1a5da013c8edcc7efbf4a959387ec87" }
+dpe = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "5cff948de1a5da013c8edcc7efbf4a959387ec87", default-features = false, features = ["dpe_profile_p384_sha384"] }
 
 # local caliptra dependency; useful when developing
 # caliptra-api = { path = "../caliptra-sw/api" }

--- a/emulator/periph/src/mci.rs
+++ b/emulator/periph/src/mci.rs
@@ -18,6 +18,13 @@ use tock_registers::interfaces::{ReadWriteable, Readable};
 const RESET_STATUS_MCU_RESET_MASK: u32 = 0x2;
 const RESET_REQUEST_MCU_REQ_MASK: u32 = 0x1; // McuReq bit (bit 0)
 
+/// Clamp a timer period to i64::MAX to avoid overflow in the timer scheduler.
+/// This can happen when software writes timer registers in two halves,
+/// creating a temporary very large value.
+fn clamp_timer_period(period: u64) -> u64 {
+    period.min(i64::MAX as u64)
+}
+
 pub struct Mci {
     ext_mci_regs: caliptra_emu_periph::mci::Mci,
     generated: MciGenerated,
@@ -225,7 +232,10 @@ impl MciPeripheral for Mci {
                 ((self.ext_mci_regs.regs.borrow().wdt_timer1_timeout_period[1] as u64) << 32)
                     | self.ext_mci_regs.regs.borrow().wdt_timer1_timeout_period[0] as u64;
 
-            self.op_wdt_timer1_expired_action = Some(self.timer.schedule_poll_in(timer_period));
+            self.op_wdt_timer1_expired_action = Some(
+                self.timer
+                    .schedule_poll_in(clamp_timer_period(timer_period)),
+            );
         } else {
             self.op_wdt_timer1_expired_action = None;
         }
@@ -253,7 +263,10 @@ impl MciPeripheral for Mci {
                 ((self.ext_mci_regs.regs.borrow().wdt_timer1_timeout_period[1] as u64) << 32)
                     | self.ext_mci_regs.regs.borrow().wdt_timer1_timeout_period[0] as u64;
 
-            self.op_wdt_timer1_expired_action = Some(self.timer.schedule_poll_in(timer_period));
+            self.op_wdt_timer1_expired_action = Some(
+                self.timer
+                    .schedule_poll_in(clamp_timer_period(timer_period)),
+            );
         }
     }
 
@@ -282,7 +295,10 @@ impl MciPeripheral for Mci {
                 ((self.ext_mci_regs.regs.borrow().wdt_timer2_timeout_period[1] as u64) << 32)
                     | self.ext_mci_regs.regs.borrow().wdt_timer2_timeout_period[0] as u64;
 
-            self.op_wdt_timer2_expired_action = Some(self.timer.schedule_poll_in(timer_period));
+            self.op_wdt_timer2_expired_action = Some(
+                self.timer
+                    .schedule_poll_in(clamp_timer_period(timer_period)),
+            );
         } else {
             self.op_wdt_timer2_expired_action = None;
         }
@@ -308,7 +324,10 @@ impl MciPeripheral for Mci {
                 ((self.ext_mci_regs.regs.borrow().wdt_timer2_timeout_period[1] as u64) << 32)
                     | self.ext_mci_regs.regs.borrow().wdt_timer2_timeout_period[0] as u64;
 
-            self.op_wdt_timer2_expired_action = Some(self.timer.schedule_poll_in(timer_period));
+            self.op_wdt_timer2_expired_action = Some(
+                self.timer
+                    .schedule_poll_in(clamp_timer_period(timer_period)),
+            );
         }
     }
 
@@ -986,7 +1005,10 @@ impl MciPeripheral for Mci {
                     ((self.ext_mci_regs.regs.borrow().wdt_timer2_timeout_period[1] as u64) << 32)
                         | self.ext_mci_regs.regs.borrow().wdt_timer2_timeout_period[0] as u64;
 
-                self.op_wdt_timer2_expired_action = Some(self.timer.schedule_poll_in(timer_period));
+                self.op_wdt_timer2_expired_action = Some(
+                    self.timer
+                        .schedule_poll_in(clamp_timer_period(timer_period)),
+                );
             }
         }
 


### PR DESCRIPTION
This clamps additional timers so that they cannot overflow the underlying emulated CPU timers.