### PR TITLE
emulator: Watchdog timer clamp fix (2.1) (#813)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,7 +298,7 @@ checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 [[package]]
 name = "caliptra-api"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1ed1a6c3aefcd27ec245e8029918c2115ccd963b#1ed1a6c3aefcd27ec245e8029918c2115ccd963b"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=84ae7a0ad5f43dea0a5e74d1c450511f226068c7#84ae7a0ad5f43dea0a5e74d1c450511f226068c7"
 dependencies = [
  "bitflags 2.10.0",
  "caliptra-api-types",
@@ -313,7 +313,7 @@ dependencies = [
 [[package]]
 name = "caliptra-api-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1ed1a6c3aefcd27ec245e8029918c2115ccd963b#1ed1a6c3aefcd27ec245e8029918c2115ccd963b"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=84ae7a0ad5f43dea0a5e74d1c450511f226068c7#84ae7a0ad5f43dea0a5e74d1c450511f226068c7"
 dependencies = [
  "caliptra-image-types",
 ]
@@ -321,7 +321,7 @@ dependencies = [
 [[package]]
 name = "caliptra-auth-man-gen"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1ed1a6c3aefcd27ec245e8029918c2115ccd963b#1ed1a6c3aefcd27ec245e8029918c2115ccd963b"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=84ae7a0ad5f43dea0a5e74d1c450511f226068c7#84ae7a0ad5f43dea0a5e74d1c450511f226068c7"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",
@@ -337,7 +337,7 @@ dependencies = [
 [[package]]
 name = "caliptra-auth-man-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1ed1a6c3aefcd27ec245e8029918c2115ccd963b#1ed1a6c3aefcd27ec245e8029918c2115ccd963b"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=84ae7a0ad5f43dea0a5e74d1c450511f226068c7#84ae7a0ad5f43dea0a5e74d1c450511f226068c7"
 dependencies = [
  "bitfield",
  "bitflags 2.10.0",
@@ -366,7 +366,7 @@ dependencies = [
 [[package]]
 name = "caliptra-builder"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1ed1a6c3aefcd27ec245e8029918c2115ccd963b#1ed1a6c3aefcd27ec245e8029918c2115ccd963b"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=84ae7a0ad5f43dea0a5e74d1c450511f226068c7#84ae7a0ad5f43dea0a5e74d1c450511f226068c7"
 dependencies = [
  "anyhow",
  "caliptra-image-crypto",
@@ -391,7 +391,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cfi-derive"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1ed1a6c3aefcd27ec245e8029918c2115ccd963b#1ed1a6c3aefcd27ec245e8029918c2115ccd963b"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=84ae7a0ad5f43dea0a5e74d1c450511f226068c7#84ae7a0ad5f43dea0a5e74d1c450511f226068c7"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -413,7 +413,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cfi-lib"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1ed1a6c3aefcd27ec245e8029918c2115ccd963b#1ed1a6c3aefcd27ec245e8029918c2115ccd963b"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=84ae7a0ad5f43dea0a5e74d1c450511f226068c7#84ae7a0ad5f43dea0a5e74d1c450511f226068c7"
 dependencies = [
  "caliptra-error",
  "caliptra-registers",
@@ -428,7 +428,7 @@ source = "git+https://github.com/chipsalliance/caliptra-cfi.git?rev=a98e499d279e
 [[package]]
 name = "caliptra-coverage"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1ed1a6c3aefcd27ec245e8029918c2115ccd963b#1ed1a6c3aefcd27ec245e8029918c2115ccd963b"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=84ae7a0ad5f43dea0a5e74d1c450511f226068c7#84ae7a0ad5f43dea0a5e74d1c450511f226068c7"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -446,7 +446,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cpu"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1ed1a6c3aefcd27ec245e8029918c2115ccd963b#1ed1a6c3aefcd27ec245e8029918c2115ccd963b"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=84ae7a0ad5f43dea0a5e74d1c450511f226068c7#84ae7a0ad5f43dea0a5e74d1c450511f226068c7"
 dependencies = [
  "caliptra-drivers",
  "caliptra-registers",
@@ -456,7 +456,7 @@ dependencies = [
 [[package]]
 name = "caliptra-drivers"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1ed1a6c3aefcd27ec245e8029918c2115ccd963b#1ed1a6c3aefcd27ec245e8029918c2115ccd963b"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=84ae7a0ad5f43dea0a5e74d1c450511f226068c7#84ae7a0ad5f43dea0a5e74d1c450511f226068c7"
 dependencies = [
  "arrayvec",
  "bitfield",
@@ -470,6 +470,7 @@ dependencies = [
  "caliptra-error",
  "caliptra-image-types",
  "caliptra-lms-types",
+ "caliptra-okref",
  "caliptra-registers",
  "cfg-if",
  "dpe",
@@ -482,7 +483,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-bus"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1ed1a6c3aefcd27ec245e8029918c2115ccd963b#1ed1a6c3aefcd27ec245e8029918c2115ccd963b"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=84ae7a0ad5f43dea0a5e74d1c450511f226068c7#84ae7a0ad5f43dea0a5e74d1c450511f226068c7"
 dependencies = [
  "caliptra-emu-types",
  "tock-registers",
@@ -492,7 +493,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-cpu"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1ed1a6c3aefcd27ec245e8029918c2115ccd963b#1ed1a6c3aefcd27ec245e8029918c2115ccd963b"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=84ae7a0ad5f43dea0a5e74d1c450511f226068c7#84ae7a0ad5f43dea0a5e74d1c450511f226068c7"
 dependencies = [
  "bit-vec",
  "bitfield",
@@ -506,7 +507,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1ed1a6c3aefcd27ec245e8029918c2115ccd963b#1ed1a6c3aefcd27ec245e8029918c2115ccd963b"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=84ae7a0ad5f43dea0a5e74d1c450511f226068c7#84ae7a0ad5f43dea0a5e74d1c450511f226068c7"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -522,7 +523,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-derive"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1ed1a6c3aefcd27ec245e8029918c2115ccd963b#1ed1a6c3aefcd27ec245e8029918c2115ccd963b"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=84ae7a0ad5f43dea0a5e74d1c450511f226068c7#84ae7a0ad5f43dea0a5e74d1c450511f226068c7"
 dependencies = [
  "caliptra-emu-bus",
  "caliptra-emu-types",
@@ -533,7 +534,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-periph"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1ed1a6c3aefcd27ec245e8029918c2115ccd963b#1ed1a6c3aefcd27ec245e8029918c2115ccd963b"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=84ae7a0ad5f43dea0a5e74d1c450511f226068c7#84ae7a0ad5f43dea0a5e74d1c450511f226068c7"
 dependencies = [
  "aes",
  "arrayref",
@@ -562,17 +563,17 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1ed1a6c3aefcd27ec245e8029918c2115ccd963b#1ed1a6c3aefcd27ec245e8029918c2115ccd963b"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=84ae7a0ad5f43dea0a5e74d1c450511f226068c7#84ae7a0ad5f43dea0a5e74d1c450511f226068c7"
 
 [[package]]
 name = "caliptra-error"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1ed1a6c3aefcd27ec245e8029918c2115ccd963b#1ed1a6c3aefcd27ec245e8029918c2115ccd963b"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=84ae7a0ad5f43dea0a5e74d1c450511f226068c7#84ae7a0ad5f43dea0a5e74d1c450511f226068c7"
 
 [[package]]
 name = "caliptra-gen-linker-scripts"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1ed1a6c3aefcd27ec245e8029918c2115ccd963b#1ed1a6c3aefcd27ec245e8029918c2115ccd963b"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=84ae7a0ad5f43dea0a5e74d1c450511f226068c7#84ae7a0ad5f43dea0a5e74d1c450511f226068c7"
 dependencies = [
  "caliptra_common",
 ]
@@ -580,7 +581,7 @@ dependencies = [
 [[package]]
 name = "caliptra-hw-model"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1ed1a6c3aefcd27ec245e8029918c2115ccd963b#1ed1a6c3aefcd27ec245e8029918c2115ccd963b"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=84ae7a0ad5f43dea0a5e74d1c450511f226068c7#84ae7a0ad5f43dea0a5e74d1c450511f226068c7"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -618,7 +619,7 @@ dependencies = [
 [[package]]
 name = "caliptra-hw-model-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1ed1a6c3aefcd27ec245e8029918c2115ccd963b#1ed1a6c3aefcd27ec245e8029918c2115ccd963b"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=84ae7a0ad5f43dea0a5e74d1c450511f226068c7#84ae7a0ad5f43dea0a5e74d1c450511f226068c7"
 dependencies = [
  "caliptra-api-types",
  "rand 0.8.5",
@@ -627,7 +628,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1ed1a6c3aefcd27ec245e8029918c2115ccd963b#1ed1a6c3aefcd27ec245e8029918c2115ccd963b"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=84ae7a0ad5f43dea0a5e74d1c450511f226068c7#84ae7a0ad5f43dea0a5e74d1c450511f226068c7"
 dependencies = [
  "anyhow",
  "caliptra-image-gen",
@@ -647,7 +648,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-elf"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1ed1a6c3aefcd27ec245e8029918c2115ccd963b#1ed1a6c3aefcd27ec245e8029918c2115ccd963b"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=84ae7a0ad5f43dea0a5e74d1c450511f226068c7#84ae7a0ad5f43dea0a5e74d1c450511f226068c7"
 dependencies = [
  "anyhow",
  "caliptra-image-gen",
@@ -658,7 +659,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-fake-keys"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1ed1a6c3aefcd27ec245e8029918c2115ccd963b#1ed1a6c3aefcd27ec245e8029918c2115ccd963b"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=84ae7a0ad5f43dea0a5e74d1c450511f226068c7#84ae7a0ad5f43dea0a5e74d1c450511f226068c7"
 dependencies = [
  "caliptra-image-gen",
  "caliptra-image-types",
@@ -669,7 +670,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-gen"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1ed1a6c3aefcd27ec245e8029918c2115ccd963b#1ed1a6c3aefcd27ec245e8029918c2115ccd963b"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=84ae7a0ad5f43dea0a5e74d1c450511f226068c7#84ae7a0ad5f43dea0a5e74d1c450511f226068c7"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",
@@ -686,7 +687,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1ed1a6c3aefcd27ec245e8029918c2115ccd963b#1ed1a6c3aefcd27ec245e8029918c2115ccd963b"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=84ae7a0ad5f43dea0a5e74d1c450511f226068c7#84ae7a0ad5f43dea0a5e74d1c450511f226068c7"
 dependencies = [
  "caliptra-cfi-derive",
  "caliptra-cfi-lib",
@@ -702,7 +703,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-verify"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1ed1a6c3aefcd27ec245e8029918c2115ccd963b#1ed1a6c3aefcd27ec245e8029918c2115ccd963b"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=84ae7a0ad5f43dea0a5e74d1c450511f226068c7#84ae7a0ad5f43dea0a5e74d1c450511f226068c7"
 dependencies = [
  "bitflags 2.10.0",
  "caliptra-cfi-derive",
@@ -717,7 +718,7 @@ dependencies = [
 [[package]]
 name = "caliptra-kat"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1ed1a6c3aefcd27ec245e8029918c2115ccd963b#1ed1a6c3aefcd27ec245e8029918c2115ccd963b"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=84ae7a0ad5f43dea0a5e74d1c450511f226068c7#84ae7a0ad5f43dea0a5e74d1c450511f226068c7"
 dependencies = [
  "caliptra-drivers",
  "caliptra-lms-types",
@@ -729,7 +730,7 @@ dependencies = [
 [[package]]
 name = "caliptra-lms-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1ed1a6c3aefcd27ec245e8029918c2115ccd963b#1ed1a6c3aefcd27ec245e8029918c2115ccd963b"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=84ae7a0ad5f43dea0a5e74d1c450511f226068c7#84ae7a0ad5f43dea0a5e74d1c450511f226068c7"
 dependencies = [
  "caliptra-cfi-derive",
  "caliptra-cfi-lib",
@@ -740,9 +741,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "caliptra-okref"
+version = "0.1.0"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=84ae7a0ad5f43dea0a5e74d1c450511f226068c7#84ae7a0ad5f43dea0a5e74d1c450511f226068c7"
+
+[[package]]
 name = "caliptra-registers"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1ed1a6c3aefcd27ec245e8029918c2115ccd963b#1ed1a6c3aefcd27ec245e8029918c2115ccd963b"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=84ae7a0ad5f43dea0a5e74d1c450511f226068c7#84ae7a0ad5f43dea0a5e74d1c450511f226068c7"
 dependencies = [
  "caliptra-registers-latest",
 ]
@@ -750,7 +756,7 @@ dependencies = [
 [[package]]
 name = "caliptra-registers-latest"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1ed1a6c3aefcd27ec245e8029918c2115ccd963b#1ed1a6c3aefcd27ec245e8029918c2115ccd963b"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=84ae7a0ad5f43dea0a5e74d1c450511f226068c7#84ae7a0ad5f43dea0a5e74d1c450511f226068c7"
 dependencies = [
  "ureg",
 ]
@@ -758,7 +764,7 @@ dependencies = [
 [[package]]
 name = "caliptra-runtime"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1ed1a6c3aefcd27ec245e8029918c2115ccd963b#1ed1a6c3aefcd27ec245e8029918c2115ccd963b"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=84ae7a0ad5f43dea0a5e74d1c450511f226068c7#84ae7a0ad5f43dea0a5e74d1c450511f226068c7"
 dependencies = [
  "arrayvec",
  "bitfield",
@@ -793,7 +799,7 @@ dependencies = [
 [[package]]
 name = "caliptra-test"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1ed1a6c3aefcd27ec245e8029918c2115ccd963b#1ed1a6c3aefcd27ec245e8029918c2115ccd963b"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=84ae7a0ad5f43dea0a5e74d1c450511f226068c7#84ae7a0ad5f43dea0a5e74d1c450511f226068c7"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -835,12 +841,12 @@ dependencies = [
 [[package]]
 name = "caliptra-test-harness-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1ed1a6c3aefcd27ec245e8029918c2115ccd963b#1ed1a6c3aefcd27ec245e8029918c2115ccd963b"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=84ae7a0ad5f43dea0a5e74d1c450511f226068c7#84ae7a0ad5f43dea0a5e74d1c450511f226068c7"
 
 [[package]]
 name = "caliptra-x509"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1ed1a6c3aefcd27ec245e8029918c2115ccd963b#1ed1a6c3aefcd27ec245e8029918c2115ccd963b"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=84ae7a0ad5f43dea0a5e74d1c450511f226068c7#84ae7a0ad5f43dea0a5e74d1c450511f226068c7"
 dependencies = [
  "zeroize",
 ]
@@ -848,7 +854,7 @@ dependencies = [
 [[package]]
 name = "caliptra_common"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1ed1a6c3aefcd27ec245e8029918c2115ccd963b#1ed1a6c3aefcd27ec245e8029918c2115ccd963b"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=84ae7a0ad5f43dea0a5e74d1c450511f226068c7#84ae7a0ad5f43dea0a5e74d1c450511f226068c7"
 dependencies = [
  "bitfield",
  "bitflags 2.10.0",
@@ -1294,7 +1300,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1ed1a6c3aefcd27ec245e8029918c2115ccd963b#1ed1a6c3aefcd27ec245e8029918c2115ccd963b"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=84ae7a0ad5f43dea0a5e74d1c450511f226068c7#84ae7a0ad5f43dea0a5e74d1c450511f226068c7"
 dependencies = [
  "arrayvec",
  "caliptra-cfi-derive-git",
@@ -1529,7 +1535,7 @@ dependencies = [
 [[package]]
 name = "dpe"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1ed1a6c3aefcd27ec245e8029918c2115ccd963b#1ed1a6c3aefcd27ec245e8029918c2115ccd963b"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=84ae7a0ad5f43dea0a5e74d1c450511f226068c7#84ae7a0ad5f43dea0a5e74d1c450511f226068c7"
 dependencies = [
  "bitflags 2.10.0",
  "caliptra-cfi-derive-git",
@@ -3667,7 +3673,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 [[package]]
 name = "platform"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1ed1a6c3aefcd27ec245e8029918c2115ccd963b#1ed1a6c3aefcd27ec245e8029918c2115ccd963b"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=84ae7a0ad5f43dea0a5e74d1c450511f226068c7#84ae7a0ad5f43dea0a5e74d1c450511f226068c7"
 dependencies = [
  "arrayvec",
  "cfg-if",
@@ -5267,7 +5273,7 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 [[package]]
 name = "ureg"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=1ed1a6c3aefcd27ec245e8029918c2115ccd963b#1ed1a6c3aefcd27ec245e8029918c2115ccd963b"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=84ae7a0ad5f43dea0a5e74d1c450511f226068c7#84ae7a0ad5f43dea0a5e74d1c450511f226068c7"
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -234,30 +234,30 @@ libtock_small_panic = { path = "runtime/userspace/libtock/panic_handlers/small_p
 libtock_unittest = { path = "runtime/userspace/libtock/unittest" }
 
 # caliptra-sw dependencies; keep git revs in sync
-caliptra-api = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "1ed1a6c3aefcd27ec245e8029918c2115ccd963b" }
-caliptra-api-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "1ed1a6c3aefcd27ec245e8029918c2115ccd963b" }
-caliptra-auth-man-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "1ed1a6c3aefcd27ec245e8029918c2115ccd963b" }
-caliptra-auth-man-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "1ed1a6c3aefcd27ec245e8029918c2115ccd963b" }
-caliptra-builder = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "1ed1a6c3aefcd27ec245e8029918c2115ccd963b" }
-caliptra-drivers = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "1ed1a6c3aefcd27ec245e8029918c2115ccd963b" }
-caliptra-emu-bus = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "1ed1a6c3aefcd27ec245e8029918c2115ccd963b" }
-caliptra-emu-cpu = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "1ed1a6c3aefcd27ec245e8029918c2115ccd963b" }
-caliptra-emu-derive = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "1ed1a6c3aefcd27ec245e8029918c2115ccd963b" }
-caliptra-emu-periph = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "1ed1a6c3aefcd27ec245e8029918c2115ccd963b" }
-caliptra-emu-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "1ed1a6c3aefcd27ec245e8029918c2115ccd963b" }
-caliptra-error = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "1ed1a6c3aefcd27ec245e8029918c2115ccd963b", default-features = false }
-caliptra-hw-model = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "1ed1a6c3aefcd27ec245e8029918c2115ccd963b" }
-caliptra-hw-model-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "1ed1a6c3aefcd27ec245e8029918c2115ccd963b" }
-caliptra-image-crypto = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "1ed1a6c3aefcd27ec245e8029918c2115ccd963b", default-features = false, features = ["rustcrypto"] }
-caliptra-image-fake-keys = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "1ed1a6c3aefcd27ec245e8029918c2115ccd963b" }
-caliptra-image-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "1ed1a6c3aefcd27ec245e8029918c2115ccd963b" }
-caliptra-image-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "1ed1a6c3aefcd27ec245e8029918c2115ccd963b" }
-caliptra-registers = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "1ed1a6c3aefcd27ec245e8029918c2115ccd963b" }
-caliptra-test = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "1ed1a6c3aefcd27ec245e8029918c2115ccd963b" }
-caliptra-test-harness = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "1ed1a6c3aefcd27ec245e8029918c2115ccd963b" }
-caliptra-test-harness-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "1ed1a6c3aefcd27ec245e8029918c2115ccd963b" }
-ureg = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "1ed1a6c3aefcd27ec245e8029918c2115ccd963b" }
-dpe = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "1ed1a6c3aefcd27ec245e8029918c2115ccd963b", default-features = false, features = ["dpe_profile_p384_sha384"] }
+caliptra-api = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "84ae7a0ad5f43dea0a5e74d1c450511f226068c7" }
+caliptra-api-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "84ae7a0ad5f43dea0a5e74d1c450511f226068c7" }
+caliptra-auth-man-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "84ae7a0ad5f43dea0a5e74d1c450511f226068c7" }
+caliptra-auth-man-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "84ae7a0ad5f43dea0a5e74d1c450511f226068c7" }
+caliptra-builder = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "84ae7a0ad5f43dea0a5e74d1c450511f226068c7" }
+caliptra-drivers = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "84ae7a0ad5f43dea0a5e74d1c450511f226068c7" }
+caliptra-emu-bus = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "84ae7a0ad5f43dea0a5e74d1c450511f226068c7" }
+caliptra-emu-cpu = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "84ae7a0ad5f43dea0a5e74d1c450511f226068c7" }
+caliptra-emu-derive = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "84ae7a0ad5f43dea0a5e74d1c450511f226068c7" }
+caliptra-emu-periph = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "84ae7a0ad5f43dea0a5e74d1c450511f226068c7" }
+caliptra-emu-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "84ae7a0ad5f43dea0a5e74d1c450511f226068c7" }
+caliptra-error = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "84ae7a0ad5f43dea0a5e74d1c450511f226068c7", default-features = false }
+caliptra-hw-model = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "84ae7a0ad5f43dea0a5e74d1c450511f226068c7" }
+caliptra-hw-model-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "84ae7a0ad5f43dea0a5e74d1c450511f226068c7" }
+caliptra-image-crypto = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "84ae7a0ad5f43dea0a5e74d1c450511f226068c7", default-features = false, features = ["rustcrypto"] }
+caliptra-image-fake-keys = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "84ae7a0ad5f43dea0a5e74d1c450511f226068c7" }
+caliptra-image-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "84ae7a0ad5f43dea0a5e74d1c450511f226068c7" }
+caliptra-image-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "84ae7a0ad5f43dea0a5e74d1c450511f226068c7" }
+caliptra-registers = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "84ae7a0ad5f43dea0a5e74d1c450511f226068c7" }
+caliptra-test = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "84ae7a0ad5f43dea0a5e74d1c450511f226068c7" }
+caliptra-test-harness = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "84ae7a0ad5f43dea0a5e74d1c450511f226068c7" }
+caliptra-test-harness-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "84ae7a0ad5f43dea0a5e74d1c450511f226068c7" }
+ureg = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "84ae7a0ad5f43dea0a5e74d1c450511f226068c7" }
+dpe = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "84ae7a0ad5f43dea0a5e74d1c450511f226068c7", default-features = false, features = ["dpe_profile_p384_sha384"] }
 
 # caliptra-infra dependencies; keep git revs in sync
 caliptra-bitstream-downloader = { git = "https://github.com/chipsalliance/caliptra-infra", rev = "46a84b2b8eea514f10994631a6823c24ebae55d6" }

--- a/emulator/periph/src/mci.rs
+++ b/emulator/periph/src/mci.rs
@@ -18,6 +18,13 @@ use tock_registers::interfaces::{ReadWriteable, Readable};
 const RESET_STATUS_MCU_RESET_MASK: u32 = 0x2;
 const RESET_REQUEST_MCU_REQ_MASK: u32 = 0x1; // McuReq bit (bit 0)
 
+/// Clamp a timer period to i64::MAX to avoid overflow in the timer scheduler.
+/// This can happen when software writes timer registers in two halves,
+/// creating a temporary very large value.
+fn clamp_timer_period(period: u64) -> u64 {
+    period.min(i64::MAX as u64)
+}
+
 pub struct Mci {
     ext_mci_regs: caliptra_emu_periph::mci::Mci,
     generated: MciGenerated,
@@ -222,7 +229,10 @@ impl MciPeripheral for Mci {
                 ((self.ext_mci_regs.regs.borrow().wdt_timer1_timeout_period[1] as u64) << 32)
                     | self.ext_mci_regs.regs.borrow().wdt_timer1_timeout_period[0] as u64;
 
-            self.op_wdt_timer1_expired_action = Some(self.timer.schedule_poll_in(timer_period));
+            self.op_wdt_timer1_expired_action = Some(
+                self.timer
+                    .schedule_poll_in(clamp_timer_period(timer_period)),
+            );
         } else {
             self.op_wdt_timer1_expired_action = None;
         }
@@ -250,7 +260,10 @@ impl MciPeripheral for Mci {
                 ((self.ext_mci_regs.regs.borrow().wdt_timer1_timeout_period[1] as u64) << 32)
                     | self.ext_mci_regs.regs.borrow().wdt_timer1_timeout_period[0] as u64;
 
-            self.op_wdt_timer1_expired_action = Some(self.timer.schedule_poll_in(timer_period));
+            self.op_wdt_timer1_expired_action = Some(
+                self.timer
+                    .schedule_poll_in(clamp_timer_period(timer_period)),
+            );
         }
     }
 
@@ -279,7 +292,10 @@ impl MciPeripheral for Mci {
                 ((self.ext_mci_regs.regs.borrow().wdt_timer2_timeout_period[1] as u64) << 32)
                     | self.ext_mci_regs.regs.borrow().wdt_timer2_timeout_period[0] as u64;
 
-            self.op_wdt_timer2_expired_action = Some(self.timer.schedule_poll_in(timer_period));
+            self.op_wdt_timer2_expired_action = Some(
+                self.timer
+                    .schedule_poll_in(clamp_timer_period(timer_period)),
+            );
         } else {
             self.op_wdt_timer2_expired_action = None;
         }
@@ -305,7 +321,10 @@ impl MciPeripheral for Mci {
                 ((self.ext_mci_regs.regs.borrow().wdt_timer2_timeout_period[1] as u64) << 32)
                     | self.ext_mci_regs.regs.borrow().wdt_timer2_timeout_period[0] as u64;
 
-            self.op_wdt_timer2_expired_action = Some(self.timer.schedule_poll_in(timer_period));
+            self.op_wdt_timer2_expired_action = Some(
+                self.timer
+                    .schedule_poll_in(clamp_timer_period(timer_period)),
+            );
         }
     }
 
@@ -983,7 +1002,10 @@ impl MciPeripheral for Mci {
                     ((self.ext_mci_regs.regs.borrow().wdt_timer2_timeout_period[1] as u64) << 32)
                         | self.ext_mci_regs.regs.borrow().wdt_timer2_timeout_period[0] as u64;
 
-                self.op_wdt_timer2_expired_action = Some(self.timer.schedule_poll_in(timer_period));
+                self.op_wdt_timer2_expired_action = Some(
+                    self.timer
+                        .schedule_poll_in(clamp_timer_period(timer_period)),
+                );
             }
         }
 


### PR DESCRIPTION
This clamps additional timers so that they cannot overflow the underlying emulated CPU timers.

(cherry picked from commit e30d702011e8adb566cb8083f16a6b77230922de)