### PR TITLE
tests: reenable tests (#694)

### DIFF
--- a/tests/integration/src/lib.rs
+++ b/tests/integration/src/lib.rs
@@ -826,7 +826,7 @@ mod test {
     run_test!(test_log_flash_circular);
     run_test!(test_log_flash_usermode, example_app);
     run_test!(test_mctp_ctrl_cmds);
-    // run_test!(test_mctp_user_loopback, example_app);
+    run_test!(test_mctp_user_loopback, example_app);
     run_test!(test_pldm_discovery);
     run_test!(test_pldm_fw_update);
     run_test!(test_mctp_spdm_responder_conformance, nightly);


### PR DESCRIPTION
This PR re-enables tests
- `test_mctp_user_loopback`
- `test_firmware_update_flash_successful`

Issue #694