### PR TITLE
fpga: Disable firmware update test for FPGA as it is also flaky

### DIFF
--- a/.github/workflows/fpga.yml
+++ b/.github/workflows/fpga.yml
@@ -252,13 +252,13 @@ jobs:
               -E 'package(tests-integration) and test(test_fw_update_e2e)'
               -E 'package(tests-integration) and test(test_mcu_mbox_usermode)'
               -E 'package(tests-integration) and test(test_mcu_mbox_cmds)'
-              -E 'package(tests-integration) and test(test_firmware_update_streaming_fpga)'
               -E 'package(tests-integration) and test(test_i3c_constant_writes)'
               -E 'package(tests-integration) and test(test_i3c_simple)'
-
           )
               # disabled for now due to flakiness of recovery boot
               # -E 'package(tests-integration) and test(test_mctp_capsule_loopback)'
+              # disabled for now due to flakiness of firmware update
+              # -E 'package(tests-integration) and test(test_firmware_update_streaming_fpga)'
 
 
           cargo-nextest nextest list \


### PR DESCRIPTION
Been seeing a lot of failures in CI like:

```
2026-01-30T19:45:08.222Z INFO  [pldm_ua::update_sm] Transferred 234612 bytes so far out of 359284 bytes
2026-01-30T19:45:11.834Z INFO  [pldm_ua::update_sm] Retrying request, attempt: 1
2026-01-30T19:45:14.838Z INFO  [pldm_ua::update_sm] Retrying request, attempt: 2
2026-01-30T19:45:17.838Z INFO  [pldm_ua::update_sm] Retrying request, attempt: 3
2026-01-30T19:45:20.838Z ERROR [pldm_ua::update_sm] Max retry count reached, giving up on request
```

So disabling for now. Likely a timing issue.