### PR TITLE
Fix incorrect File Name in assembly file headers

### DIFF
--- a/platforms/emulator/rom/src/start.s
+++ b/platforms/emulator/rom/src/start.s
@@ -4,7 +4,7 @@ Licensed under the Apache-2.0 license.
 
 File Name:
 
-    main.rs
+    start.s
 
 Abstract:
 

--- a/platforms/fpga/rom/src/start.s
+++ b/platforms/fpga/rom/src/start.s
@@ -4,7 +4,7 @@ Licensed under the Apache-2.0 license.
 
 File Name:
 
-    main.rs
+    start.s
 
 Abstract:
 

--- a/platforms/test_harness/src/emulator-start.s
+++ b/platforms/test_harness/src/emulator-start.s
@@ -4,7 +4,7 @@ Licensed under the Apache-2.0 license.
 
 File Name:
 
-    main.rs
+    emulator-start.s
 
 Abstract:
 

--- a/platforms/test_harness/src/fpga-start.s
+++ b/platforms/test_harness/src/fpga-start.s
@@ -4,7 +4,7 @@ Licensed under the Apache-2.0 license.
 
 File Name:
 
-    main.rs
+    fpga-start.s
 
 Abstract:
 

--- a/tests/hello/src/start.S
+++ b/tests/hello/src/start.S
@@ -4,7 +4,7 @@ Licensed under the Apache-2.0 license.
 
 File Name:
 
-    main.rs
+    start.S
 
 Abstract:
 


### PR DESCRIPTION
Corrected the "File Name:" field in assembly file headers that incorrectly listed "main.rs" instead of their actual filenames.

Files updated:
- platforms/emulator/rom/src/start.s
- platforms/fpga/rom/src/start.s
- platforms/test_harness/src/emulator-start.s
- platforms/test_harness/src/fpga-start.s
- tests/hello/src/start.S