### PR TITLE
fpga: ci: migrate test filter to nextest profile (#719)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -19,3 +19,26 @@ slow-timeout = { period = "30m", terminate-after = 6 }
 path = "/tmp/junit.xml"
 store-success-output = true
 store-failure-output = true
+
+[profile.nightly-ci]
+inherits = "nightly"
+# Modify test(test_uds) as we onboard crates to the FPGA test suite.
+default-filter = """
+(package(mcu-hw-model)
+    - test(model_emulated::test::test_new_unbooted)) |
+(package(tests-integration) and test(test_jtag_taps)) |
+(package(tests-integration) and test(test_lc_transitions)) |
+(package(tests-integration) and test(test_manuf_debug_unlock)) |
+(package(tests-integration) and test(test_prod_debug_unlock)) |
+(package(tests-integration) and test(test_uds)) |
+(package(tests-integration) and test(test_imaginary_flash_controller)) |
+(package(tests-integration) and test(test_fw_update_e2e)) |
+(package(tests-integration) and test(test_mcu_mbox_usermode)) |
+(package(tests-integration) and test(test_mcu_mbox_cmds)) |
+(package(tests-integration) and test(test_i3c_constant_writes)) |
+(package(tests-integration) and test(test_i3c_simple))
+"""
+# disabled for now due to flakiness of recovery boot
+# (package(tests-integration) and test(test_mctp_capsule_loopback)) |
+# disabled for now due to flakiness of firmware update
+# (package(tests-integration) and test(test_firmware_update_streaming_fpga)) |

--- a/.github/workflows/fpga.yml
+++ b/.github/workflows/fpga.yml
@@ -242,26 +242,8 @@ jobs:
               --binaries-metadata="${TEST_BIN}/target/nextest/binaries-metadata.json"
               --target-dir-remap="${TEST_BIN}/target"
               --workspace-remap=.
-              -E 'package(mcu-hw-model) - test(model_emulated::test::test_new_unbooted)'
-              -E 'package(tests-integration) and test(test_jtag_taps)'
-              -E 'package(tests-integration) and test(test_lc_transitions)'
-              -E 'package(tests-integration) and test(test_manuf_debug_unlock)'
-              -E 'package(tests-integration) and test(test_prod_debug_unlock)'
-              -E 'package(tests-integration) and test(test_uds)' # Modify this as we onboard crates to the FPGA test suite.
-              -E 'package(tests-integration) and test(test_imaginary_flash_controller)'
-              -E 'package(tests-integration) and test(test_fw_update_e2e)'
-              -E 'package(tests-integration) and test(test_mcu_mbox_usermode)'
-              -E 'package(tests-integration) and test(test_mcu_mbox_cmds)'
-              -E 'package(tests-integration) and test(test_i3c_constant_writes)'
-              -E 'package(tests-integration) and test(test_i3c_simple)'
-              -E 'package(tests-integration) and test(test_mctp_vdm_cmds)'
-
+              --profile=nightly-ci
           )
-              # disabled for now due to flakiness of recovery boot
-              # -E 'package(tests-integration) and test(test_mctp_capsule_loopback)'
-              # disabled for now due to flakiness of firmware update
-              # -E 'package(tests-integration) and test(test_firmware_update_streaming_fpga)'
-
 
           cargo-nextest nextest list \
               "${COMMON_ARGS[@]}" \
@@ -270,8 +252,7 @@ jobs:
           sudo CPTRA_FIRMWARE_BUNDLE="${PWD}/target/all-fw.zip" cargo-nextest nextest run \
               "${COMMON_ARGS[@]}" \
               --test-threads=${RUST_TEST_THREADS} \
-              --no-fail-fast \
-              --profile=nightly
+              --no-fail-fast
 
       - name: 'Upload test results'
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
This commit moves the test filter for FPGA CI to the nextest profile, following the same pattern used in [caliptra-sw PR #3062](https://github.com/chipsalliance/caliptra-sw/pull/3062), in order to keep a single source of truth for CI tests.

Close #719 