### PR TITLE
rom: Read from OTP directly rather than reading all fuses

### DIFF
--- a/platforms/emulator/rom/src/mcu_image_verifier.rs
+++ b/platforms/emulator/rom/src/mcu_image_verifier.rs
@@ -1,38 +1,43 @@
 // Licensed under the Apache-2.0 license
 
 use mcu_rom_common::ImageVerifier;
+use mcu_rom_common::Otp;
 
-use registers_generated::fuses::Fuses;
-
-#[cfg(any(feature = "test-mcu-svn-gt-fuse", feature = "test-mcu-svn-lt-fuse"))]
-use mcu_image_header::McuImageHeader;
-#[cfg(any(feature = "test-mcu-svn-gt-fuse", feature = "test-mcu-svn-lt-fuse"))]
-use zerocopy::FromBytes;
 pub struct McuImageVerifier;
 
 impl ImageVerifier for McuImageVerifier {
-    fn verify_header(&self, _header: &[u8], _fuses: &Fuses) -> bool {
+    fn verify_header(&self, _header: &[u8], _otp: &Otp) -> bool {
         // TODO: make this unconditional and use proper fuses for it instead of test fuses
         #[cfg(any(feature = "test-mcu-svn-gt-fuse", feature = "test-mcu-svn-lt-fuse"))]
         {
+            use mcu_image_header::McuImageHeader;
+            use zerocopy::FromBytes;
             let Ok((header, _)) = McuImageHeader::ref_from_prefix(_header) else {
                 romtime::println!("[mcu-rom] Invalid MCU image header");
                 return false;
             };
 
+            // Read vendor test partition first 16 bytes word by word
             let mut fuse_vendor_svn: u16 = 0;
-            // Use the first 128 bits of vendor test partition as SVN
-            for byte in _fuses.vendor_test_partition[..16].iter() {
-                // Count contiguous 1's in the byte
-                let mut count = 0;
-                for bit in 0..8 {
-                    if byte & (1 << bit) != 0 {
-                        count += 1;
-                    } else {
-                        break;
+            for word_idx in 0..4 {
+                let Ok(word) = _otp.read_vendor_test_word(word_idx) else {
+                    romtime::println!("[mcu-rom] Error reading vendor test fuse");
+                    return false;
+                };
+                // Process each byte in the word
+                for byte_idx in 0..4 {
+                    let byte = ((word >> (byte_idx * 8)) & 0xFF) as u8;
+                    // Count contiguous 1's in the byte
+                    let mut count = 0;
+                    for bit in 0..8 {
+                        if byte & (1 << bit) != 0 {
+                            count += 1;
+                        } else {
+                            break;
+                        }
                     }
+                    fuse_vendor_svn += count;
                 }
-                fuse_vendor_svn += count;
             }
 
             if header.svn < fuse_vendor_svn {

--- a/registers/generated-firmware/src/fuses.rs
+++ b/registers/generated-firmware/src/fuses.rs
@@ -42,18 +42,6 @@ pub struct Fuses {
     /// Vendor non-secret production partition.
     #[zeroize(skip)]
     pub vendor_non_secret_prod_partition: [u8; 520],
-
-    /// Lifecycle partition.
-    /// This contains lifecycle transition count and state. This partition
-    /// cannot be locked since the life cycle state needs to advance to RMA
-    /// in-field. Note that while this partition is not marked secret, it
-    /// is not readable nor writeable via the DAI. Only the LC controller
-    /// can access this partition, and even via the LC controller it is not
-    /// possible to read the raw manufacturing life cycle state in encoded
-    /// form, since that encoding is considered a netlist secret. The LC
-    /// controller only exposes a decoded version of this state.
-    #[zeroize(skip)]
-    pub life_cycle: [u8; 88],
 }
 impl Fuses {
     pub fn cptra_ss_manuf_debug_unlock_token(&self) -> &[u8] {
@@ -503,12 +491,6 @@ impl Fuses {
     pub fn cptra_ss_vendor_specific_non_secret_fuse_15(&self) -> &[u8] {
         &self.vendor_non_secret_prod_partition[480..512]
     }
-    pub fn lc_transition_cnt(&self) -> &[u8] {
-        &self.life_cycle[0..48]
-    }
-    pub fn lc_state(&self) -> &[u8] {
-        &self.life_cycle[48..88]
-    }
 }
 impl Default for Fuses {
     fn default() -> Self {
@@ -523,7 +505,6 @@ impl Default for Fuses {
             vendor_revocations_prod_partition: [0; 216],
             vendor_secret_prod_partition: [0; 520],
             vendor_non_secret_prod_partition: [0; 520],
-            life_cycle: [0; 88],
         }
     }
 }

--- a/rom/src/boot_status.rs
+++ b/rom/src/boot_status.rs
@@ -44,8 +44,7 @@ pub enum McuRomBootStatus {
 
     // OTP and Fuse Operations
     OtpControllerInitialized = OTP_FUSE_OPERATIONS_BASE,
-    FusesReadFromOtp = OTP_FUSE_OPERATIONS_BASE + 1,
-    WatchdogConfigured = OTP_FUSE_OPERATIONS_BASE + 2,
+    WatchdogConfigured = OTP_FUSE_OPERATIONS_BASE + 1,
 
     // Caliptra Setup Statuses
     CaliptraBootGoAsserted = CALIPTRA_SETUP_BASE,

--- a/rom/src/cold_boot.rs
+++ b/rom/src/cold_boot.rs
@@ -24,7 +24,6 @@ use caliptra_api::mailbox::{CmStableKeyType, CommandId, FeProgReq, MailboxReqHea
 use caliptra_api::CaliptraApiError;
 use caliptra_api::SocManager;
 use caliptra_api_types::{DeviceLifecycle, SecurityState};
-use caliptra_drivers::okref;
 use core::fmt::Write;
 use core::ops::Deref;
 use mcu_error::McuError;
@@ -187,19 +186,7 @@ impl BootFlow for ColdBoot {
             loop {}
         }
 
-        romtime::println!("[mcu-rom] Reading fuses");
-        let fuses_result = otp.read_fuses();
-        let fuses_result = okref(&fuses_result);
-        let fuses = match fuses_result {
-            Ok(fuses) => {
-                mci.set_flow_checkpoint(McuRomBootStatus::FusesReadFromOtp.into());
-                fuses
-            }
-            Err(e) => {
-                romtime::println!("Error reading fuses: {}", HexWord(e.into()));
-                fatal_error(e);
-            }
-        };
+        romtime::println!("[mcu-rom] OTP initialized");
 
         // TODO: Handle flash image loading with the watchdog enabled
         if params.flash_partition_driver.is_none() {
@@ -245,7 +232,7 @@ impl BootFlow for ColdBoot {
         mci.set_flow_checkpoint(McuRomBootStatus::AxiUsersConfigured.into());
 
         romtime::println!("[mcu-rom] Populating fuses");
-        soc.populate_fuses(fuses, mci);
+        soc.populate_fuses(otp, mci);
         mci.set_flow_checkpoint(McuRomBootStatus::FusesPopulatedToCaliptra.into());
 
         // Configure MCU mailbox AXI users before locking
@@ -271,7 +258,7 @@ impl BootFlow for ColdBoot {
 
         // Verify PK hashes haven't been tampered with after locking
         romtime::println!("[mcu-rom] Verifying production debug unlock PK hashes");
-        if let Err(err) = verify_prod_debug_unlock_pk_hash(mci, fuses) {
+        if let Err(err) = verify_prod_debug_unlock_pk_hash(mci, otp) {
             romtime::println!("[mcu-rom] PK hash verification failed");
             fatal_error(err);
         }
@@ -328,7 +315,6 @@ impl BootFlow for ColdBoot {
                 let dot_blob: DotBlob = transmute!(dot_blob);
                 if let Err(err) = device_ownership_transfer::dot_flow(
                     env,
-                    fuses,
                     &dot_fuses,
                     &dot_blob,
                     params
@@ -419,7 +405,7 @@ impl BootFlow for ColdBoot {
             };
 
             romtime::println!("[mcu-rom] Verifying firmware header");
-            if !image_verifier.verify_header(header, fuses) {
+            if !image_verifier.verify_header(header, &env.otp) {
                 romtime::println!("Firmware header verification failed; halting");
                 fatal_error(McuError::ROM_COLD_BOOT_HEADER_VERIFY_ERROR);
             }

--- a/rom/src/image_verifier.rs
+++ b/rom/src/image_verifier.rs
@@ -1,6 +1,6 @@
 // Licensed under the Apache-2.0 license
 
-use registers_generated::fuses::Fuses;
+use crate::otp::Otp;
 
 /// Verifies the authenticity and integrity of the provided image header
 /// against the device's fuse state.
@@ -10,11 +10,11 @@ use registers_generated::fuses::Fuses;
 ///
 /// Parameters:
 ///   header:  Raw bytes of the image header
-///   fuses:  Immutable view of device/programmed fuse values
+///   otp:  Reference to the OTP driver for reading fuse values on demand
 ///
 /// Returns:
 ///   true if every required check passes.
 ///   false on any structural, policy, or cryptographic failure.
 pub trait ImageVerifier {
-    fn verify_header(&self, header: &[u8], fuses: &Fuses) -> bool;
+    fn verify_header(&self, header: &[u8], otp: &Otp) -> bool;
 }

--- a/xtask/src/fuses.rs
+++ b/xtask/src/fuses.rs
@@ -12,11 +12,15 @@ const OTP_CTRL_DEFAULT_PATH: &str = "hw/caliptra-ss/src/fuse_ctrl/data/otp_ctrl_
 const SPECIFIC_FUSES_DEFAULT_PATH: &str = "hw/fuses.hjson";
 
 const SKIP_PARTITIONS: &[&str] = &[
+    "SW_TEST_UNLOCK_PARTITON",
     "SECRET_MANUF_PARTITION",
     "SECRET_PROD_PARTITION_0",
     "SECRET_PROD_PARTITION_1",
     "SECRET_PROD_PARTITION_2",
     "SECRET_PROD_PARTITION_3",
+    "VENDOR_TEST_PARTITON",
+    "SECRET_LC_TRANSITION_PARTITON",
+    "LIFE_CYCLE",
 ];
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
Rather than reading the entire `Fuses` structure at once and then passing it around, we instead pass the `&Otp` around to read fuses as needed.

This saves over 6 KB in stack space in the ROM (!), which is great, because we were basically out of ROM stack (limited to 16 KB right now).

This also skips even generating code for unnecessary fuse partitions.