### PR TITLE
xtask-fpga: migrate default test filter to nextest profile (#720)

### DIFF
--- a/xtask/src/fpga/mod.rs
+++ b/xtask/src/fpga/mod.rs
@@ -31,6 +31,7 @@ struct BuildTestArgs<'a> {
 struct TestArgs<'a> {
     test_filter: &'a Option<String>,
     test_output: &'a bool,
+    default_test_profile: &'a str,
 }
 trait ActionHandler<'a> {
     fn bootstrap(&self) -> Result<()>;
@@ -272,6 +273,7 @@ pub(crate) fn fpga_entry(args: &Fpga) -> Result<()> {
                 .test(&TestArgs {
                     test_filter,
                     test_output,
+                    default_test_profile: config.default_test_profile(),
                 })?;
         }
         _ => todo!("implement this command"),

--- a/xtask/src/fpga/utils.rs
+++ b/xtask/src/fpga/utils.rs
@@ -328,19 +328,25 @@ pub fn build_base_container_command() -> Result<Container> {
 pub fn run_test_suite(
     test_dir: &str,
     prelude: &str,
-    test_filters: Vec<&str>,
+    test_filters: Option<Vec<&str>>,
     test_output: &str,
     target_host: Option<&str>,
+    default_test_profile: &str,
 ) -> Result<()> {
     let mut test_command = format!(
         "(cd {test_dir} && \
                 sudo {prelude} \
                 cargo-nextest nextest run \
                 --workspace-remap=. --archive-file $HOME/caliptra-test-binaries.tar.zst \
-                {test_output} --no-fail-fast --profile=nightly "
+                {test_output} --no-fail-fast "
     );
-    for filter in test_filters {
-        test_command += format!("-E \"{filter}\" ").as_str();
+    if let Some(filters) = test_filters {
+        test_command += "--profile=nightly ";
+        for filter in filters {
+            test_command += format!("-E \"{filter}\" ").as_str();
+        }
+    } else {
+        test_command += format!("--profile={default_test_profile} ").as_str();
     }
     test_command += ")";
     // Run test suite.


### PR DESCRIPTION
This commit moves the default test filter for FPGA tests to nextest profile, so that we only maintain a single source of truth.

Please note that I don't have access to FPGA yet so I only tested by verifying the test command.

Close #720 