### PR TITLE
[xtask-fpga]: Document nextest dependency & relocate bootstrap ssh check

### DIFF
--- a/docs/src/fpga.md
+++ b/docs/src/fpga.md
@@ -14,6 +14,8 @@ The machine that is used for development and cross compilation should have:
   - Make sure you pull the FPGA build image: `$ podman pull ghcr.io/chipsalliance/caliptra-build-image:latest` or `$ docker pull ghcr.io/chipsalliance/caliptra-build-image:latest` 
 - rsync
 - git
+- Cargo-nextest
+  - `$ cargo +1.93 install cargo-nextest --locked`
 
 ### FPGA System 
 

--- a/xtask/src/fpga/mod.rs
+++ b/xtask/src/fpga/mod.rs
@@ -229,6 +229,7 @@ pub(crate) fn fpga_entry(args: &Fpga) -> Result<()> {
             println!("configuration: {:?}", configuration);
 
             let target_host = target_host.as_deref();
+            check_ssh_access(target_host)?;
             check_fpga_dependencies(target_host)?;
 
             let hostname = run_command_with_output(target_host, "hostname")?;
@@ -241,7 +242,6 @@ pub(crate) fn fpga_entry(args: &Fpga) -> Result<()> {
 
             let cache_function = |config_marker| {
                 // Cache FPGA configuration in RAM. We need to re-bootstrap on power cycles.
-                check_ssh_access(target_host)?;
                 run_command(
                     target_host,
                     &format!("echo \"{config_marker}\" > /dev/shm/fpga-config"),


### PR DESCRIPTION
The SSH check happens too late, and can cause confusing errors if the host lacks SSH access.