### PR TITLE
RFC: Isolation and abstraction of platform-specific features in spdm-lib.

### DIFF
--- a/platforms/emulator/runtime/userspace/apps/user/src/spdm/crypto_provider.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/spdm/crypto_provider.rs
@@ -1,0 +1,99 @@
+// Licensed under the Apache-2.0 license
+
+extern crate alloc;
+
+use alloc::boxed::Box;
+use async_trait::async_trait;
+
+use spdm_lib::platform::crypto::hash::{SpdmHash, SpdmHashAlgoType, SpdmHashError};
+use spdm_lib::platform::crypto::provider::SpdmCryptoProvider;
+
+use libapi_caliptra::crypto::hash::{HashAlgoType as CalAlgo, HashContext as CalHash};
+
+/// Adapter that wraps Caliptra HashContext to implement SpdmHash.
+pub struct CaliptraSpdmHash {
+    inner: CalHash,
+    algo: Option<SpdmHashAlgoType>,
+}
+
+impl CaliptraSpdmHash {
+    pub fn new() -> Self {
+        Self {
+            inner: CalHash::new(),
+            algo: None,
+        }
+    }
+
+    fn to_cal_algo(algo: SpdmHashAlgoType) -> CalAlgo {
+        match algo {
+            SpdmHashAlgoType::SHA384 => CalAlgo::SHA384,
+            SpdmHashAlgoType::SHA512 => CalAlgo::SHA512,
+        }
+    }
+}
+
+#[async_trait]
+impl SpdmHash for CaliptraSpdmHash {
+    async fn hash(
+        &mut self,
+        hash_algo: SpdmHashAlgoType,
+        data: &[u8],
+        hash: &mut [u8],
+    ) -> Result<(), SpdmHashError> {
+        // One-shot: init, update, finalize
+        self.reset();
+        self.init(hash_algo, None).await?;
+        self.update(data).await?;
+        self.finalize(hash).await
+    }
+
+    async fn init(
+        &mut self,
+        hash_algo: SpdmHashAlgoType,
+        data: Option<&[u8]>,
+    ) -> Result<(), SpdmHashError> {
+        self.algo = Some(hash_algo);
+        self.inner
+            .init(Self::to_cal_algo(hash_algo), data)
+            .await
+            .map_err(|_| SpdmHashError::PlatformError)
+    }
+
+    async fn update(&mut self, data: &[u8]) -> Result<(), SpdmHashError> {
+        self.inner
+            .update(data)
+            .await
+            .map_err(|_| SpdmHashError::PlatformError)
+    }
+
+    async fn finalize(&mut self, hash: &mut [u8]) -> Result<(), SpdmHashError> {
+        self.inner
+            .finalize(hash)
+            .await
+            .map_err(|_| SpdmHashError::PlatformError)
+    }
+
+    fn reset(&mut self) {
+        self.inner = CalHash::new();
+        self.algo = None;
+    }
+
+    fn algo(&self) -> SpdmHashAlgoType {
+        self.algo.unwrap_or(SpdmHashAlgoType::SHA384)
+    }
+}
+
+/// Crypto provider that creates Caliptra-backed SPDM hashers.
+pub struct CaliptraCryptoProvider;
+
+impl CaliptraCryptoProvider {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl SpdmCryptoProvider for CaliptraCryptoProvider {
+    fn create_hasher(&mut self) -> Box<dyn SpdmHash> {
+        Box::new(CaliptraSpdmHash::new())
+    }
+}

--- a/platforms/emulator/runtime/userspace/apps/user/src/spdm/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/spdm/mod.rs
@@ -1,12 +1,14 @@
 // Licensed under the Apache-2.0 license
 
 mod cert_store;
+mod crypto_provider;
 mod device_cert_store;
 mod device_measurements;
 mod endorsement_certs;
 #[cfg(feature = "test-doe-spdm-tdisp-ide-validator")]
 mod integration_example;
 
+use crate::spdm::crypto_provider::CaliptraCryptoProvider;
 #[cfg(feature = "test-mctp-spdm-responder-conformance")]
 use crate::spdm::device_measurements::ocp_eat::init_target_env_claims;
 use core::fmt::Write;
@@ -90,6 +92,8 @@ async fn spdm_mctp_responder() {
     };
 
     let local_algorithms = LocalDeviceAlgorithms::default();
+    // Out-of-tree SPDM crypto provider backed by Caliptra
+    let mut crypto_provider = CaliptraCryptoProvider::new();
 
     // Create a wrapper for the global certificate store
     let shared_cert_store = SharedCertStore::new();
@@ -116,6 +120,7 @@ async fn spdm_mctp_responder() {
         &shared_cert_store,
         device_measurements,
         None, // VDM handlers are not supported for MCTP transport in this configuration
+        &mut crypto_provider,
     ) {
         Ok(ctx) => ctx,
         Err(e) => {
@@ -171,6 +176,8 @@ async fn spdm_doe_responder() {
     device_doe_algorithms.set_other_param_support();
 
     let local_algorithms = LocalDeviceAlgorithms::new(device_doe_algorithms);
+    // Out-of-tree SPDM crypto provider backed by Caliptra
+    let mut crypto_provider = CaliptraCryptoProvider::new();
 
     // Create a wrapper for the global certificate store
     let shared_cert_store = SharedCertStore::new();
@@ -230,6 +237,7 @@ async fn spdm_doe_responder() {
         &shared_cert_store,
         device_measurements,
         vdm_handlers,
+        &mut crypto_provider,
     ) {
         Ok(ctx) => ctx,
         Err(e) => {

--- a/runtime/userspace/api/spdm-lib/src/commands/certificate_rsp.rs
+++ b/runtime/userspace/api/spdm-lib/src/commands/certificate_rsp.rs
@@ -9,6 +9,7 @@ use crate::codec::{Codec, CommonCodec, MessageBuf};
 use crate::commands::error_rsp::ErrorCode;
 use crate::context::SpdmContext;
 use crate::error::{CommandError, CommandResult};
+use crate::platform::crypto::provider::SpdmCryptoProvider;
 use crate::protocol::*;
 use crate::state::ConnectionState;
 use crate::transcript::{Transcript, TranscriptContext};
@@ -127,6 +128,7 @@ impl CertificateResponse {
         cert_store: &dyn SpdmCertStore,
         cert_rsp_offset: usize,
         chunk: &mut [u8],
+        crypto: &mut dyn SpdmCryptoProvider,
     ) -> CommandResult<usize> {
         let certchain_offset: usize;
         let mut chunk_data_len = 0;
@@ -164,7 +166,12 @@ impl CertificateResponse {
         }
 
         shared_transcript
-            .append(TranscriptContext::M1, None, &chunk[..chunk_data_len])
+            .append(
+                TranscriptContext::M1,
+                None,
+                &chunk[..chunk_data_len],
+                crypto,
+            )
             .await
             .map_err(|e| (false, CommandError::Transcript(e)))?;
         Ok(chunk_data_len)

--- a/runtime/userspace/api/spdm-lib/src/commands/chunk_get_rsp.rs
+++ b/runtime/userspace/api/spdm-lib/src/commands/chunk_get_rsp.rs
@@ -167,6 +167,7 @@ async fn encode_chunk_data(
                         ctx.device_certs_store,
                         offset,
                         chunk_buf,
+                        ctx.crypto_provider,
                     )
                     .await?;
                 rsp.pull_data(chunk_size)
@@ -181,6 +182,7 @@ async fn encode_chunk_data(
                         ctx.device_certs_store,
                         offset,
                         chunk_buf,
+                        ctx.crypto_provider,
                         None,
                     )
                     .await?;

--- a/runtime/userspace/api/spdm-lib/src/lib.rs
+++ b/runtime/userspace/api/spdm-lib/src/lib.rs
@@ -41,3 +41,6 @@ pub mod vdm_handler;
 
 // Opaque Element
 pub mod opaque_element;
+
+// Platform specific implementations
+pub mod platform;

--- a/runtime/userspace/api/spdm-lib/src/platform/crypto/asym.rs
+++ b/runtime/userspace/api/spdm-lib/src/platform/crypto/asym.rs
@@ -1,0 +1,1 @@
+//Licensed under the Apache-2.0 license

--- a/runtime/userspace/api/spdm-lib/src/platform/crypto/hash.rs
+++ b/runtime/userspace/api/spdm-lib/src/platform/crypto/hash.rs
@@ -1,0 +1,60 @@
+//Licensed under the Apache-2.0 license
+extern crate alloc;
+use alloc::boxed::Box;
+use async_trait::async_trait;
+
+pub type SpdmHashResult<T> = Result<T, SpdmHashError>;
+
+#[async_trait]
+pub trait SpdmHash {
+    async fn hash(
+        &mut self,
+        hash_algo: SpdmHashAlgoType,
+        data: &[u8],
+        hash: &mut [u8],
+    ) -> SpdmHashResult<()>;
+    async fn init(
+        &mut self,
+        hash_algo: SpdmHashAlgoType,
+        data: Option<&[u8]>,
+    ) -> SpdmHashResult<()>;
+    async fn update(&mut self, data: &[u8]) -> SpdmHashResult<()>;
+    async fn finalize(&mut self, hash: &mut [u8]) -> SpdmHashResult<()>;
+
+    fn reset(&mut self);
+    fn algo(&self) -> SpdmHashAlgoType;
+}
+
+#[derive(Debug, PartialEq)]
+pub enum SpdmHashError {
+    PlatformError,
+    BufferTooSmall,
+    InvalidAlgorithm,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum SpdmHashAlgoType {
+    SHA384,
+    SHA512,
+}
+
+pub const SHA384_HASH_SIZE: usize = 48;
+pub const SHA512_HASH_SIZE: usize = 64;
+
+impl From<SpdmHashAlgoType> for u32 {
+    fn from(algo: SpdmHashAlgoType) -> Self {
+        match algo {
+            SpdmHashAlgoType::SHA384 => 2u32,
+            SpdmHashAlgoType::SHA512 => 4u32,
+        }
+    }
+}
+
+impl SpdmHashAlgoType {
+    pub fn hash_size(&self) -> usize {
+        match self {
+            SpdmHashAlgoType::SHA384 => SHA384_HASH_SIZE,
+            SpdmHashAlgoType::SHA512 => SHA512_HASH_SIZE,
+        }
+    }
+}

--- a/runtime/userspace/api/spdm-lib/src/platform/crypto/mod.rs
+++ b/runtime/userspace/api/spdm-lib/src/platform/crypto/mod.rs
@@ -1,0 +1,4 @@
+//Licensed under the Apache-2.0 license
+// Hashing interfaces
+pub mod hash;
+pub mod provider;

--- a/runtime/userspace/api/spdm-lib/src/platform/crypto/provider.rs
+++ b/runtime/userspace/api/spdm-lib/src/platform/crypto/provider.rs
@@ -1,0 +1,12 @@
+// Licensed under the Apache-2.0 license
+
+extern crate alloc;
+
+use crate::platform::crypto::hash::SpdmHash;
+use alloc::boxed::Box;
+
+/// Factory interface for creating SPDM hashers.
+/// Platform crates will implement this out-of-tree and provide a concrete hasher.
+pub trait SpdmCryptoProvider {
+    fn create_hasher(&mut self) -> Box<dyn SpdmHash>;
+}

--- a/runtime/userspace/api/spdm-lib/src/platform/mod.rs
+++ b/runtime/userspace/api/spdm-lib/src/platform/mod.rs
@@ -1,0 +1,2 @@
+//Licensed under the Apache-2.0 license
+pub mod crypto;


### PR DESCRIPTION
This is a proof-of-concept of changes required to separate spdm-lib from Caliptra MCU, shifting platform-specific interfaces for cryptographic operations into a platform-provided implementation. This follows along with Transport and Certificate handling, both of which are defined by spdm-lib but implemented by the consumer.

* Defined an SpdmHash trait object that abstracts out platform hash capability.
* Defined an SpdmCryptoProvider that defines a set of factory APIs, preserving current
  behavior of the HashContext API behind a trait object.
  * The provider wraps SpdmHash in a Box<> to ensure that spdm-lib can work with dyn traits, rather than generic traits. This is mostly a space-saving decision.
  * Created a Caliptra-level impl of SpdmHash and SpdmCryptoProvider.
  * Added SpdmCryptoProvider to spdm-lib crate APIs that require access.

This also includes a fix for chunking that caused a failure in Challenge.

Note: This changeset includes code written via LLM.