### PR TITLE
fpga: Route interrupts from flash controllers to VeeR PIC

### DIFF
--- a/hw/fpga/src/caliptra_fpga_realtime_regs.rdl
+++ b/hw/fpga/src/caliptra_fpga_realtime_regs.rdl
@@ -252,12 +252,12 @@ regfile flash_ctrl_regs {
     reg {
         field {
             sw = rw;
-            hw = na;
+            hw = r;
             desc = "Error-related interrupts";
         } ERROR[0:0] = 1'b0;
         field {
             sw = rw;
-            hw = na;
+            hw = r;
             desc = "Event-related interrupts";
         } EVENT[1:1] = 1'b0;
     } FL_INTERRUPT_STATE @ 0x00;
@@ -265,12 +265,12 @@ regfile flash_ctrl_regs {
     reg {
         field {
             sw = rw;
-            hw = na;
+            hw = r;
             desc = "Enable error interrupt";
         } ERROR[0:0] = 1'b0;
         field {
             sw = rw;
-            hw = na;
+            hw = r;
             desc = "Enable event interrupt";
         } EVENT[1:1] = 1'b0;
     } FL_INTERRUPT_ENABLE @ 0x04;

--- a/hw/fpga/src/caliptra_fpga_realtime_regs.sv
+++ b/hw/fpga/src/caliptra_fpga_realtime_regs.sv
@@ -291,24 +291,29 @@ module caliptra_fpga_realtime_regs (
         } secondary_flash_ctrl_regs;
     } decoded_reg_strb_t;
     decoded_reg_strb_t decoded_reg_strb;
+    logic decoded_err;
     logic decoded_req;
     logic decoded_req_is_wr;
     logic [31:0] decoded_wr_data;
     logic [31:0] decoded_wr_biten;
 
     always_comb begin
-        decoded_reg_strb.interface_regs.fpga_magic = cpuif_req_masked & (cpuif_addr == 32'ha4010000);
-        decoded_reg_strb.interface_regs.fpga_version = cpuif_req_masked & (cpuif_addr == 32'ha4010004);
+        automatic logic is_valid_addr;
+        automatic logic is_invalid_rw;
+        is_valid_addr = '1; // No error checking on valid address access
+        is_invalid_rw = '0;
+        decoded_reg_strb.interface_regs.fpga_magic = cpuif_req_masked & (cpuif_addr == 32'ha4010000) & !cpuif_req_is_wr;
+        decoded_reg_strb.interface_regs.fpga_version = cpuif_req_masked & (cpuif_addr == 32'ha4010004) & !cpuif_req_is_wr;
         decoded_reg_strb.interface_regs.control = cpuif_req_masked & (cpuif_addr == 32'ha4010008);
-        decoded_reg_strb.interface_regs.status = cpuif_req_masked & (cpuif_addr == 32'ha401000c);
+        decoded_reg_strb.interface_regs.status = cpuif_req_masked & (cpuif_addr == 32'ha401000c) & !cpuif_req_is_wr;
         decoded_reg_strb.interface_regs.arm_user = cpuif_req_masked & (cpuif_addr == 32'ha4010010);
         decoded_reg_strb.interface_regs.itrng_divisor = cpuif_req_masked & (cpuif_addr == 32'ha4010014);
-        decoded_reg_strb.interface_regs.cycle_count = cpuif_req_masked & (cpuif_addr == 32'ha4010018);
+        decoded_reg_strb.interface_regs.cycle_count = cpuif_req_masked & (cpuif_addr == 32'ha4010018) & !cpuif_req_is_wr;
         for(int i0=0; i0<2; i0++) begin
             decoded_reg_strb.interface_regs.generic_input_wires[i0] = cpuif_req_masked & (cpuif_addr == 32'ha4010030 + (32)'(i0) * 32'h4);
         end
         for(int i0=0; i0<2; i0++) begin
-            decoded_reg_strb.interface_regs.generic_output_wires[i0] = cpuif_req_masked & (cpuif_addr == 32'ha4010038 + (32)'(i0) * 32'h4);
+            decoded_reg_strb.interface_regs.generic_output_wires[i0] = cpuif_req_masked & (cpuif_addr == 32'ha4010038 + (32)'(i0) * 32'h4) & !cpuif_req_is_wr;
         end
         for(int i0=0; i0<8; i0++) begin
             decoded_reg_strb.interface_regs.cptra_obf_key[i0] = cpuif_req_masked & (cpuif_addr == 32'ha4010040 + (32)'(i0) * 32'h4);
@@ -328,7 +333,7 @@ module caliptra_fpga_realtime_regs (
         decoded_reg_strb.interface_regs.soc_config_user = cpuif_req_masked & (cpuif_addr == 32'ha401010c);
         decoded_reg_strb.interface_regs.sram_config_user = cpuif_req_masked & (cpuif_addr == 32'ha4010110);
         decoded_reg_strb.interface_regs.mcu_reset_vector = cpuif_req_masked & (cpuif_addr == 32'ha4010114);
-        decoded_reg_strb.interface_regs.ss_all_error = cpuif_req_masked & (cpuif_addr == 32'ha4010118);
+        decoded_reg_strb.interface_regs.ss_all_error = cpuif_req_masked & (cpuif_addr == 32'ha4010118) & !cpuif_req_is_wr;
         decoded_reg_strb.interface_regs.mcu_config = cpuif_req_masked & (cpuif_addr == 32'ha401011c);
         decoded_reg_strb.interface_regs.uds_seed_base_addr = cpuif_req_masked & (cpuif_addr == 32'ha4010120);
         decoded_reg_strb.interface_regs.prod_debug_unlock_auth_pk_hash_reg_bank_offset = cpuif_req_masked & (cpuif_addr == 32'ha4010124);
@@ -337,11 +342,11 @@ module caliptra_fpga_realtime_regs (
             decoded_reg_strb.interface_regs.mci_generic_input_wires[i0] = cpuif_req_masked & (cpuif_addr == 32'ha401012c + (32)'(i0) * 32'h4);
         end
         for(int i0=0; i0<2; i0++) begin
-            decoded_reg_strb.interface_regs.mci_generic_output_wires[i0] = cpuif_req_masked & (cpuif_addr == 32'ha4010134 + (32)'(i0) * 32'h4);
+            decoded_reg_strb.interface_regs.mci_generic_output_wires[i0] = cpuif_req_masked & (cpuif_addr == 32'ha4010134 + (32)'(i0) * 32'h4) & !cpuif_req_is_wr;
         end
-        decoded_reg_strb.interface_regs.ss_key_release_base_addr = cpuif_req_masked & (cpuif_addr == 32'ha401013c);
-        decoded_reg_strb.interface_regs.ss_key_release_key_size = cpuif_req_masked & (cpuif_addr == 32'ha4010140);
-        decoded_reg_strb.interface_regs.ss_external_staging_area_base_addr = cpuif_req_masked & (cpuif_addr == 32'ha4010144);
+        decoded_reg_strb.interface_regs.ss_key_release_base_addr = cpuif_req_masked & (cpuif_addr == 32'ha401013c) & !cpuif_req_is_wr;
+        decoded_reg_strb.interface_regs.ss_key_release_key_size = cpuif_req_masked & (cpuif_addr == 32'ha4010140) & !cpuif_req_is_wr;
+        decoded_reg_strb.interface_regs.ss_external_staging_area_base_addr = cpuif_req_masked & (cpuif_addr == 32'ha4010144) & !cpuif_req_is_wr;
         decoded_reg_strb.interface_regs.cptra_ss_mcu_ext_int = cpuif_req_masked & (cpuif_addr == 32'ha4010148);
         for(int i0=0; i0<4; i0++) begin
             decoded_reg_strb.interface_regs.cptra_ss_raw_unlock_token_hash[i0] = cpuif_req_masked & (cpuif_addr == 32'ha401014c + (32)'(i0) * 32'h4);
@@ -350,16 +355,16 @@ module caliptra_fpga_realtime_regs (
         for(int i0=0; i0<16; i0++) begin
             decoded_reg_strb.interface_regs.ocp_lock_key_release_reg[i0] = cpuif_req_masked & (cpuif_addr == 32'ha4010200 + (32)'(i0) * 32'h4);
         end
-        decoded_reg_strb.fifo_regs.log_fifo_data = cpuif_req_masked & (cpuif_addr == 32'ha4011000);
-        decoded_reg_strb.fifo_regs.log_fifo_status = cpuif_req_masked & (cpuif_addr == 32'ha4011004);
+        decoded_reg_strb.fifo_regs.log_fifo_data = cpuif_req_masked & (cpuif_addr == 32'ha4011000) & !cpuif_req_is_wr;
+        decoded_reg_strb.fifo_regs.log_fifo_status = cpuif_req_masked & (cpuif_addr == 32'ha4011004) & !cpuif_req_is_wr;
         decoded_reg_strb.fifo_regs.itrng_fifo_data = cpuif_req_masked & (cpuif_addr == 32'ha4011008);
         decoded_reg_strb.fifo_regs.itrng_fifo_status = cpuif_req_masked & (cpuif_addr == 32'ha401100c);
-        decoded_reg_strb.fifo_regs.dbg_fifo_pop = cpuif_req_masked & (cpuif_addr == 32'ha4011010);
+        decoded_reg_strb.fifo_regs.dbg_fifo_pop = cpuif_req_masked & (cpuif_addr == 32'ha4011010) & !cpuif_req_is_wr;
         decoded_reg_strb.fifo_regs.dbg_fifo_push = cpuif_req_masked & (cpuif_addr == 32'ha4011014);
-        decoded_reg_strb.fifo_regs.dbg_fifo_status = cpuif_req_masked & (cpuif_addr == 32'ha4011018);
-        decoded_reg_strb.fifo_regs.msg_fifo_pop = cpuif_req_masked & (cpuif_addr == 32'ha401101c);
+        decoded_reg_strb.fifo_regs.dbg_fifo_status = cpuif_req_masked & (cpuif_addr == 32'ha4011018) & !cpuif_req_is_wr;
+        decoded_reg_strb.fifo_regs.msg_fifo_pop = cpuif_req_masked & (cpuif_addr == 32'ha401101c) & !cpuif_req_is_wr;
         decoded_reg_strb.fifo_regs.msg_fifo_push = cpuif_req_masked & (cpuif_addr == 32'ha4011020);
-        decoded_reg_strb.fifo_regs.msg_fifo_status = cpuif_req_masked & (cpuif_addr == 32'ha4011024);
+        decoded_reg_strb.fifo_regs.msg_fifo_status = cpuif_req_masked & (cpuif_addr == 32'ha4011024) & !cpuif_req_is_wr;
         decoded_reg_strb.primary_flash_ctrl_regs.FL_INTERRUPT_STATE = cpuif_req_masked & (cpuif_addr == 32'ha4012000);
         decoded_reg_strb.primary_flash_ctrl_regs.FL_INTERRUPT_ENABLE = cpuif_req_masked & (cpuif_addr == 32'ha4012004);
         decoded_reg_strb.primary_flash_ctrl_regs.PAGE_SIZE = cpuif_req_masked & (cpuif_addr == 32'ha4012008);
@@ -384,6 +389,7 @@ module caliptra_fpga_realtime_regs (
         for(int i0=0; i0<64; i0++) begin
             decoded_reg_strb.secondary_flash_ctrl_regs.FLASH_BUF[i0] = cpuif_req_masked & (cpuif_addr == 32'ha4013100 + (32)'(i0) * 32'h4);
         end
+        decoded_err = (~is_valid_addr | is_invalid_rw) & decoded_req;
     end
 
     // Pass down signals to next stage
@@ -3194,6 +3200,7 @@ module caliptra_fpga_realtime_regs (
             end
         end
     end
+    assign hwif_out.primary_flash_ctrl_regs.FL_INTERRUPT_STATE.ERROR.value = field_storage.primary_flash_ctrl_regs.FL_INTERRUPT_STATE.ERROR.value;
     // Field: caliptra_fpga_realtime_regs.primary_flash_ctrl_regs.FL_INTERRUPT_STATE.EVENT
     always_comb begin
         automatic logic [0:0] next_c;
@@ -3216,6 +3223,7 @@ module caliptra_fpga_realtime_regs (
             end
         end
     end
+    assign hwif_out.primary_flash_ctrl_regs.FL_INTERRUPT_STATE.EVENT.value = field_storage.primary_flash_ctrl_regs.FL_INTERRUPT_STATE.EVENT.value;
     // Field: caliptra_fpga_realtime_regs.primary_flash_ctrl_regs.FL_INTERRUPT_ENABLE.ERROR
     always_comb begin
         automatic logic [0:0] next_c;
@@ -3238,6 +3246,7 @@ module caliptra_fpga_realtime_regs (
             end
         end
     end
+    assign hwif_out.primary_flash_ctrl_regs.FL_INTERRUPT_ENABLE.ERROR.value = field_storage.primary_flash_ctrl_regs.FL_INTERRUPT_ENABLE.ERROR.value;
     // Field: caliptra_fpga_realtime_regs.primary_flash_ctrl_regs.FL_INTERRUPT_ENABLE.EVENT
     always_comb begin
         automatic logic [0:0] next_c;
@@ -3260,6 +3269,7 @@ module caliptra_fpga_realtime_regs (
             end
         end
     end
+    assign hwif_out.primary_flash_ctrl_regs.FL_INTERRUPT_ENABLE.EVENT.value = field_storage.primary_flash_ctrl_regs.FL_INTERRUPT_ENABLE.EVENT.value;
     // Field: caliptra_fpga_realtime_regs.primary_flash_ctrl_regs.PAGE_SIZE.PAGE_SIZE
     always_comb begin
         automatic logic [31:0] next_c;
@@ -3504,6 +3514,7 @@ module caliptra_fpga_realtime_regs (
             end
         end
     end
+    assign hwif_out.secondary_flash_ctrl_regs.FL_INTERRUPT_STATE.ERROR.value = field_storage.secondary_flash_ctrl_regs.FL_INTERRUPT_STATE.ERROR.value;
     // Field: caliptra_fpga_realtime_regs.secondary_flash_ctrl_regs.FL_INTERRUPT_STATE.EVENT
     always_comb begin
         automatic logic [0:0] next_c;
@@ -3526,6 +3537,7 @@ module caliptra_fpga_realtime_regs (
             end
         end
     end
+    assign hwif_out.secondary_flash_ctrl_regs.FL_INTERRUPT_STATE.EVENT.value = field_storage.secondary_flash_ctrl_regs.FL_INTERRUPT_STATE.EVENT.value;
     // Field: caliptra_fpga_realtime_regs.secondary_flash_ctrl_regs.FL_INTERRUPT_ENABLE.ERROR
     always_comb begin
         automatic logic [0:0] next_c;
@@ -3548,6 +3560,7 @@ module caliptra_fpga_realtime_regs (
             end
         end
     end
+    assign hwif_out.secondary_flash_ctrl_regs.FL_INTERRUPT_ENABLE.ERROR.value = field_storage.secondary_flash_ctrl_regs.FL_INTERRUPT_ENABLE.ERROR.value;
     // Field: caliptra_fpga_realtime_regs.secondary_flash_ctrl_regs.FL_INTERRUPT_ENABLE.EVENT
     always_comb begin
         automatic logic [0:0] next_c;
@@ -3570,6 +3583,7 @@ module caliptra_fpga_realtime_regs (
             end
         end
     end
+    assign hwif_out.secondary_flash_ctrl_regs.FL_INTERRUPT_ENABLE.EVENT.value = field_storage.secondary_flash_ctrl_regs.FL_INTERRUPT_ENABLE.EVENT.value;
     // Field: caliptra_fpga_realtime_regs.secondary_flash_ctrl_regs.PAGE_SIZE.PAGE_SIZE
     always_comb begin
         automatic logic [31:0] next_c;

--- a/hw/fpga/src/caliptra_fpga_realtime_regs_pkg.sv
+++ b/hw/fpga/src/caliptra_fpga_realtime_regs_pkg.sv
@@ -802,7 +802,40 @@ package caliptra_fpga_realtime_regs_pkg;
     } fifo_regs__out_t;
 
     typedef struct {
+        logic value;
+    } flash_ctrl_regs__FL_INTERRUPT_STATE__ERROR__out_t;
+
+    typedef struct {
+        logic value;
+    } flash_ctrl_regs__FL_INTERRUPT_STATE__EVENT__out_t;
+
+    typedef struct {
+        flash_ctrl_regs__FL_INTERRUPT_STATE__ERROR__out_t ERROR;
+        flash_ctrl_regs__FL_INTERRUPT_STATE__EVENT__out_t EVENT;
+    } flash_ctrl_regs__FL_INTERRUPT_STATE__out_t;
+
+    typedef struct {
+        logic value;
+    } flash_ctrl_regs__FL_INTERRUPT_ENABLE__ERROR__out_t;
+
+    typedef struct {
+        logic value;
+    } flash_ctrl_regs__FL_INTERRUPT_ENABLE__EVENT__out_t;
+
+    typedef struct {
+        flash_ctrl_regs__FL_INTERRUPT_ENABLE__ERROR__out_t ERROR;
+        flash_ctrl_regs__FL_INTERRUPT_ENABLE__EVENT__out_t EVENT;
+    } flash_ctrl_regs__FL_INTERRUPT_ENABLE__out_t;
+
+    typedef struct {
+        flash_ctrl_regs__FL_INTERRUPT_STATE__out_t FL_INTERRUPT_STATE;
+        flash_ctrl_regs__FL_INTERRUPT_ENABLE__out_t FL_INTERRUPT_ENABLE;
+    } flash_ctrl_regs__out_t;
+
+    typedef struct {
         interface_regs__out_t interface_regs;
         fifo_regs__out_t fifo_regs;
+        flash_ctrl_regs__out_t primary_flash_ctrl_regs;
+        flash_ctrl_regs__out_t secondary_flash_ctrl_regs;
     } caliptra_fpga_realtime_regs__out_t;
 endpackage

--- a/hw/fpga/src/caliptra_wrapper_top.sv
+++ b/hw/fpga/src/caliptra_wrapper_top.sv
@@ -1975,6 +1975,22 @@ mcu_rom (
         endcase
     end
 
+    // Flash controller interrupts: AND interrupt state with enable
+    logic primary_flash_irq;
+    logic secondary_flash_irq;
+    assign primary_flash_irq = |(
+        {hwif_out.primary_flash_ctrl_regs.FL_INTERRUPT_STATE.ERROR.value,
+         hwif_out.primary_flash_ctrl_regs.FL_INTERRUPT_STATE.EVENT.value} &
+        {hwif_out.primary_flash_ctrl_regs.FL_INTERRUPT_ENABLE.ERROR.value,
+         hwif_out.primary_flash_ctrl_regs.FL_INTERRUPT_ENABLE.EVENT.value}
+    );
+    assign secondary_flash_irq = |(
+        {hwif_out.secondary_flash_ctrl_regs.FL_INTERRUPT_STATE.ERROR.value,
+         hwif_out.secondary_flash_ctrl_regs.FL_INTERRUPT_STATE.EVENT.value} &
+        {hwif_out.secondary_flash_ctrl_regs.FL_INTERRUPT_ENABLE.ERROR.value,
+         hwif_out.secondary_flash_ctrl_regs.FL_INTERRUPT_ENABLE.EVENT.value}
+    );
+
     // Spare I3C core
     logic spare_i3c_irq_o;
     assign hwif_in.interface_regs.spare_i3c_control_sts.irq_o.next = spare_i3c_irq_o;
@@ -2250,7 +2266,7 @@ caliptra_ss_top #(
     .cptra_ss_all_error_fatal_o(hwif_in.interface_regs.ss_all_error.ss_all_error_fatal.next),
     .cptra_ss_all_error_non_fatal_o(hwif_in.interface_regs.ss_all_error.ss_all_error_non_fatal.next),
 
-    .cptra_ss_mcu_ext_int({252'b0, spare_i3c_irq_o}),
+    .cptra_ss_mcu_ext_int({250'b0, secondary_flash_irq, primary_flash_irq, spare_i3c_irq_o}),
     // MCU JTAG
     .cptra_ss_mcu_jtag_tck_i(mcu_jtag_tck_i),
     .cptra_ss_mcu_jtag_tms_i(mcu_jtag_tms_i),


### PR DESCRIPTION
These can be turned on by the hw-model and the FW can clear them (and mask).

These should be tied to PIC interrupts 4 and 5