### PR TITLE
fuses: Generate list of fuse entries from hjson file

### DIFF
--- a/hw/fuses.hjson
+++ b/hw/fuses.hjson
@@ -23,17 +23,26 @@
     {
         name: "dot_initialized",
         bits: 1,
-        description: "DOT is enabled an initialized for this part.",
+        description: "DOT is enabled and initialized for this part.",
+        partition: "VENDOR_NON_SECRET_PROD_PARTITION",
+        otp_item: "CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_0",
+        layout: {type: "LinearMajorityVote", duplication: 3},
     },
     {
       name: "dot_fuse_array",
       bits: 256,
-      description: "One-time programmable state counter for DOT transitions. Each bit represents one state change. Increments from 0 to 255."
+      description: "One-time programmable state counter for DOT transitions. Each bit represents one state change. Increments from 0 to 255.",
+      partition: "VENDOR_NON_SECRET_PROD_PARTITION",
+      otp_item: "CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_1",
+      layout: {type: "OneHot"},
     },
     {
       name: "vendor_recovery_pk_hash",
       bits: 384,
-      description: "Vendor recovery key for DOT_OVERRIDE catastrophic recovery operations"
+      description: "Vendor recovery key for DOT_OVERRIDE catastrophic recovery operations",
+      partition: "VENDOR_SECRET_PROD_PARTITION",
+      otp_item: "CPTRA_SS_VENDOR_SPECIFIC_SECRET_FUSE_0",
+      layout: {type: "Single"},
     },
   ]
 }

--- a/registers/fuses/src/codegen.rs
+++ b/registers/fuses/src/codegen.rs
@@ -1,12 +1,63 @@
 // Licensed under the Apache-2.0 license.
 
-use crate::schema::FuseConfig;
+use crate::schema::{FuseConfig, FuseLayoutPolicy};
 use anyhow::Result;
+use std::collections::HashMap;
 
-pub fn generate_fuses(spec: &FuseConfig) -> Result<String> {
+/// Information about an OTP partition item (entry) from otp_ctrl_mmap.hjson.
+#[derive(Debug, Clone)]
+pub struct PartitionItemInfo {
+    pub name: String,
+    pub byte_offset: usize,
+    pub byte_size: usize,
+    pub entry_num: usize,
+}
+
+/// Information about an OTP partition from otp_ctrl_mmap.hjson.
+#[derive(Debug, Clone)]
+pub struct PartitionMmapInfo {
+    pub partition_index: usize,
+    pub byte_offset: usize,
+    pub byte_size: usize,
+    pub items: Vec<PartitionItemInfo>,
+}
+
+fn layout_to_codegen(layout: &Option<FuseLayoutPolicy>, bits: u32) -> String {
+    match layout {
+        None | Some(FuseLayoutPolicy::Single) => {
+            format!("FuseLayoutType::Single {{ bits: {} }}", bits)
+        }
+        Some(FuseLayoutPolicy::OneHot) => {
+            format!("FuseLayoutType::OneHot {{ bits: {} }}", bits)
+        }
+        Some(FuseLayoutPolicy::LinearMajorityVote { duplication }) => {
+            format!(
+                "FuseLayoutType::LinearMajorityVote {{ bits: {}, duplication: {} }}",
+                bits, duplication
+            )
+        }
+        Some(FuseLayoutPolicy::OneHotLinearMajorityVote { duplication }) => {
+            format!(
+                "FuseLayoutType::OneHotLinearMajorityVote {{ bits: {}, duplication: {} }}",
+                bits, duplication
+            )
+        }
+        Some(FuseLayoutPolicy::WordMajorityVote { duplication }) => {
+            format!(
+                "FuseLayoutType::WordMajorityVote {{ bits: {}, duplication: {} }}",
+                bits, duplication
+            )
+        }
+    }
+}
+
+pub fn generate_fuses(
+    spec: &FuseConfig,
+    partition_mmap: Option<&HashMap<String, PartitionMmapInfo>>,
+) -> Result<String> {
     let mut output = String::new();
 
-    // Header
+    // Header types
     output.push_str(stringify!(
         #[derive(Debug, Clone)]
         pub struct Partition {
@@ -27,6 +78,31 @@ pub fn generate_fuses(spec: &FuseConfig) -> Result<String> {
         pub struct FuseField {
             pub name: &'static str,
             pub bits: Bits,
+        }
+        /// Layout type for interpreting raw fuse bits.
+        #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+        pub enum FuseLayoutType {
+            Single { bits: u32 },
+            OneHot { bits: u32 },
+            LinearMajorityVote { bits: u32, duplication: u32 },
+            OneHotLinearMajorityVote { bits: u32, duplication: u32 },
+            WordMajorityVote { bits: u32, duplication: u32 },
+        }
+        /// Entry in the fuse lookup table mapping (partition, entry) to OTP location and layout.
+        #[derive(Debug, Clone)]
+        pub struct FuseEntryInfo {
+            /// Partition number (index into OTP partitions)
+            pub partition_num: usize,
+            /// Entry number within the partition
+            pub entry_num: usize,
+            /// Byte offset from start of OTP
+            pub byte_offset: usize,
+            /// Size in bytes of the raw fuse storage
+            pub byte_size: usize,
+            /// Field name
+            pub name: &'static str,
+            /// Layout for interpreting the raw bits
+            pub layout: FuseLayoutType,
         }
     ));
 
@@ -76,6 +152,72 @@ pub fn generate_fuses(spec: &FuseConfig) -> Result<String> {
     }
     output.push_str("];");
 
+    // Fuse entry lookup table — entries with partition info
+    output.push_str(
+        "/// Lookup table mapping (partition_num, entry_num) to OTP addresses and layout.\n",
+    );
+    output.push_str(
+        "/// Only populated for fields that have a partition assignment in fuses.hjson.\n",
+    );
+    output.push_str("pub const FUSE_ENTRY_TABLE: &[FuseEntryInfo] = &[");
+    let partitions = spec.partitions.as_ref();
+    for field in &spec.fields {
+        if let Some(partition_name) = &field.partition {
+            // Look up partition index from fuses.hjson partitions list
+            let partition_num = partitions
+                .and_then(|ps| ps.iter().find(|p| &p.name == partition_name))
+                .map(|p| p.num as usize);
+
+            // Look up from OTP mmap info if available
+            let mmap_info = partition_mmap.and_then(|m| m.get(partition_name));
+
+            let (part_idx, byte_offset, byte_size, entry_num) = if let Some(mmap) = mmap_info {
+                // Try otp_item first, then fall back to field name
+                let lookup_name = field.otp_item.as_deref().unwrap_or(&field.name);
+                let item = mmap
+                    .items
+                    .iter()
+                    .find(|i| i.name.eq_ignore_ascii_case(lookup_name));
+                if let Some(item) = item {
+                    (
+                        mmap.partition_index,
+                        item.byte_offset,
+                        item.byte_size,
+                        item.entry_num,
+                    )
+                } else {
+                    // Field not found in OTP mmap items — use partition-level info
+                    let byte_size = field.bits.div_ceil(8) as usize;
+                    (mmap.partition_index, mmap.byte_offset, byte_size, 0)
+                }
+            } else {
+                // No mmap info — use partition_num from fuses.hjson
+                let byte_size = field.bits.div_ceil(8) as usize;
+                (partition_num.unwrap_or(0), 0, byte_size, 0)
+            };
+
+            let layout_str = layout_to_codegen(&field.layout, field.bits);
+            output.push_str(&format!(
+                "FuseEntryInfo {{ partition_num: {}, entry_num: {}, byte_offset: 0x{:x}, byte_size: {}, name: \"{}\", layout: {} }},",
+                part_idx, entry_num, byte_offset, byte_size, field.name, layout_str
+            ));
+        }
+    }
+    output.push_str("];");
+
+    // Named const references to individual entries
+    let mut entry_idx = 0usize;
+    for field in &spec.fields {
+        if field.partition.is_some() {
+            let const_name = field.name.to_uppercase();
+            output.push_str(&format!(
+                "/// Fuse entry for `{}`.\npub const {}: &FuseEntryInfo = &FUSE_ENTRY_TABLE[{}];",
+                field.name, const_name, entry_idx
+            ));
+            entry_idx += 1;
+        }
+    }
+
     let tokens = syn::parse_file(&output)?;
     let formatted = prettyplease::unparse(&tokens);
 
@@ -117,93 +259,69 @@ mod tests {
   other_fuses: {},
   // entries to define how many bits are in each field, and potentially other information
   fields: [
-    // set specifics on Subsystem fuses
-    // By default, all bits in each field are assumed to be backed by actual fuse bits.
-    // Names should be globally unique
-    {name: "CPTRA_SS_OWNER_ECC_REVOCATION", bits: 4}, // size in bits
-    // set specifics on vendor-specific fuses
+    {name: "CPTRA_SS_OWNER_ECC_REVOCATION", bits: 4},
     {name: "example_key_revocation", bits: 4},
   ]
 }
 "#;
 
         let config = parse_fuse_hjson_str(example_hjson).unwrap();
-        let generated_code = generate_fuses(&config).unwrap();
+        let generated_code = generate_fuses(&config, None).unwrap();
 
         println!("Generated code:\n{}", generated_code);
 
-        // The expected output should match what prettyplease generates
-        let expected_code = r#"// Licensed under the Apache-2.0 license.
-// Autogenerated file from fuses.hjson. Do not modify this file.
+        // Verify key structures are present
+        assert!(generated_code.contains("pub struct Partition"));
+        assert!(generated_code.contains("pub struct FuseEntryInfo"));
+        assert!(generated_code.contains("pub enum FuseLayoutType"));
+        assert!(generated_code.contains("pub const PARTITIONS:"));
+        assert!(generated_code.contains("pub const SECRET_VENDOR_FUSES:"));
+        assert!(generated_code.contains("pub const NON_SECRET_VENDOR_FUSES:"));
+        assert!(generated_code.contains("pub const FUSE_FIELDS:"));
+        assert!(generated_code.contains("pub const FUSE_ENTRY_TABLE:"));
+        assert!(generated_code.contains("\"device_ownership_transfer\""));
+        assert!(generated_code.contains("\"secret_vendor\""));
+        assert!(generated_code.contains("\"example_key1\""));
+        assert!(generated_code.contains("\"CPTRA_SS_OWNER_ECC_REVOCATION\""));
+    }
 
-#[derive(Debug, Clone)]
-pub struct Partition {
-    pub num: usize,
-    pub name: &'static str,
-    pub dot: bool,
+    #[test]
+    fn test_generate_fuses_with_layout_and_partition() {
+        let example_hjson = r#"
+{
+  partitions: [
+    {num: 5, name: "revocations"},
+  ],
+  secret_vendor: [],
+  non_secret_vendor: [],
+  other_fuses: {},
+  fields: [
+    {
+      name: "ecc_revocation",
+      bits: 4,
+      partition: "revocations",
+      layout: {type: "LinearMajorityVote", duplication: 3}
+    },
+    {
+      name: "simple_field",
+      bits: 32,
+      partition: "revocations",
+      layout: {type: "Single"}
+    },
+  ]
 }
-#[derive(Debug, Clone, Copy)]
-pub struct Bytes(pub usize);
-#[derive(Debug, Clone, Copy)]
-pub struct Bits(pub usize);
-#[derive(Debug, Clone)]
-pub struct Fuse {
-    pub name: &'static str,
-    pub size: Bytes,
-}
-#[derive(Debug, Clone)]
-pub struct FuseField {
-    pub name: &'static str,
-    pub bits: Bits,
-}
-pub const PARTITIONS: &[Partition] = &[
-    Partition {
-        num: 10,
-        name: "device_ownership_transfer",
-        dot: true,
-    },
-    Partition {
-        num: 11,
-        name: "secret_vendor",
-        dot: false,
-    },
-];
-pub const SECRET_VENDOR_FUSES: &[Fuse] = &[
-    Fuse {
-        name: "example_key1",
-        size: Bytes(48),
-    },
-    Fuse {
-        name: "example_key2",
-        size: Bytes(48),
-    },
-    Fuse {
-        name: "example_key3",
-        size: Bytes(48),
-    },
-    Fuse {
-        name: "example_key4",
-        size: Bytes(48),
-    },
-];
-pub const NON_SECRET_VENDOR_FUSES: &[Fuse] = &[
-    Fuse {
-        name: "example_key_revocation",
-        size: Bytes(1),
-    },
-];
-pub const FUSE_FIELDS: &[FuseField] = &[
-    FuseField {
-        name: "CPTRA_SS_OWNER_ECC_REVOCATION",
-        bits: Bits(4),
-    },
-    FuseField {
-        name: "example_key_revocation",
-        bits: Bits(4),
-    },
-];
 "#;
 
-        assert_eq!(generated_code.trim(), expected_code.trim());
+        let config = parse_fuse_hjson_str(example_hjson).unwrap();
+        let generated_code = generate_fuses(&config, None).unwrap();
+
+        println!("Generated code:\n{}", generated_code);
+
+        assert!(generated_code.contains("FUSE_ENTRY_TABLE"));
+        assert!(generated_code.contains("partition_num: 5"));
+        assert!(generated_code.contains("LinearMajorityVote"));
+        assert!(generated_code.contains("duplication: 3"));
+        assert!(generated_code.contains("\"ecc_revocation\""));
+        assert!(generated_code.contains("\"simple_field\""));
     }
 }

--- a/registers/fuses/src/schema.rs
+++ b/registers/fuses/src/schema.rs
@@ -25,12 +25,41 @@ pub struct FusePartitionInfo {
     pub dot: Option<bool>,
 }
 
+/// Describes the layout policy for interpreting raw fuse bits.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+#[serde(tag = "type")]
+pub enum FuseLayoutPolicy {
+    /// Values stored literally
+    Single,
+    /// Value is the count of bits set (one-hot encoding)
+    OneHot,
+    /// Each bit duplicated with majority vote
+    LinearMajorityVote { duplication: u32 },
+    /// One-hot with linear majority vote
+    OneHotLinearMajorityVote { duplication: u32 },
+    /// Words duplicated with per-bit majority vote
+    WordMajorityVote { duplication: u32 },
+}
+
 #[derive(Debug, Deserialize, Serialize)]
 pub struct FieldDefinition {
     /// Globally unique field name
     pub name: String,
     /// Size of the field in bits
     pub bits: u32,
+    /// Optional description
+    #[serde(default)]
+    pub description: Option<String>,
+    /// Layout policy for interpreting the raw fuse bits
+    #[serde(default)]
+    pub layout: Option<FuseLayoutPolicy>,
+    /// Name of the partition this field belongs to
+    #[serde(default)]
+    pub partition: Option<String>,
+    /// Name of the OTP mmap item this field maps to (for byte offset resolution).
+    /// Required when the field name doesn't match an OTP mmap item name exactly.
+    #[serde(default)]
+    pub otp_item: Option<String>,
 }
 
 pub fn parse_fuse_hjson(fname: &str) -> Result<FuseConfig> {

--- a/rom/src/cold_boot.rs
+++ b/rom/src/cold_boot.rs
@@ -296,7 +296,7 @@ impl BootFlow for ColdBoot {
 
         // Load DOT fuses from vendor non-secret partition
         // TODO: read these from a place specified by ROM configuration
-        let dot_fuses = match device_ownership_transfer::load_dot_fuses(&env.otp) {
+        let dot_fuses = match device_ownership_transfer::DotFuses::load_from_otp(&env.otp) {
             Ok(dot_fuses) => dot_fuses,
             Err(_) => {
                 romtime::println!("[mcu-rom] Error reading DOT fuses");

--- a/rom/src/fuse_layout.rs
+++ b/rom/src/fuse_layout.rs
@@ -408,6 +408,42 @@ pub fn extract_fuse_value<const N: usize>(
     }
 }
 
+/// Convert from the generated `FuseLayoutType` to the runtime `FuseLayout`.
+///
+/// Returns `None` if the bits or duplication value is zero (which shouldn't
+/// happen for well-formed generated code).
+impl FuseLayout {
+    pub fn from_generated(layout: &registers_generated::fuses::FuseLayoutType) -> Option<Self> {
+        use registers_generated::fuses::FuseLayoutType;
+        match *layout {
+            FuseLayoutType::Single { bits } => {
+                Some(FuseLayout::Single(Bits(NonZero::new(bits as usize)?)))
+            }
+            FuseLayoutType::OneHot { bits } => {
+                Some(FuseLayout::OneHot(Bits(NonZero::new(bits as usize)?)))
+            }
+            FuseLayoutType::LinearMajorityVote { bits, duplication } => {
+                Some(FuseLayout::LinearMajorityVote(
+                    Bits(NonZero::new(bits as usize)?),
+                    Duplication(NonZero::new(duplication as usize)?),
+                ))
+            }
+            FuseLayoutType::OneHotLinearMajorityVote { bits, duplication } => {
+                Some(FuseLayout::OneHotLinearMajorityVote(
+                    Bits(NonZero::new(bits as usize)?),
+                    Duplication(NonZero::new(duplication as usize)?),
+                ))
+            }
+            FuseLayoutType::WordMajorityVote { bits, duplication } => {
+                Some(FuseLayout::WordMajorityVote(
+                    Bits(NonZero::new(bits as usize)?),
+                    Duplication(NonZero::new(duplication as usize)?),
+                ))
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rom/src/otp.rs
+++ b/rom/src/otp.rs
@@ -3,12 +3,12 @@
 use core::fmt::Write;
 use mcu_error::{McuError, McuResult};
 use registers_generated::fuses;
-use registers_generated::fuses::Fuses;
+use registers_generated::fuses::{FuseEntryInfo, Fuses};
 use registers_generated::otp_ctrl;
 use romtime::{HexBytes, HexWord, StaticRef};
 use tock_registers::interfaces::{Readable, Writeable};
 
-use crate::{LifecycleHashedToken, LifecycleHashedTokens, LC_TOKENS_OFFSET};
+use crate::{FuseLayout, LifecycleHashedToken, LifecycleHashedTokens, LC_TOKENS_OFFSET};
 
 // TODO: use the Lifecycle controller to read the Lifecycle state
 
@@ -151,10 +151,13 @@ impl Otp {
     }
 
     fn read_data(&self, addr: usize, len: usize, data: &mut [u8]) -> McuResult<()> {
-        if data.len() < len || len % 4 != 0 {
+        if len % 4 != 0 {
             return Err(McuError::ROM_OTP_INVALID_DATA_ERROR);
         }
-        for (i, chunk) in data[..len].chunks_exact_mut(4).enumerate() {
+        let data = data
+            .get_mut(..len)
+            .ok_or(McuError::ROM_OTP_INVALID_DATA_ERROR)?;
+        for (i, chunk) in data.chunks_exact_mut(4).enumerate() {
             let word = self.read_word(addr / 4 + i)?;
             let word_bytes = word.to_le_bytes();
             chunk.copy_from_slice(&word_bytes[..chunk.len()]);
@@ -671,6 +674,47 @@ impl Otp {
             len,
             data,
         )
+    }
+
+    // -------------------------------------------------------------------------
+    // Generic fuse entry read/write using generated FuseEntryInfo
+    // -------------------------------------------------------------------------
+
+    /// Read a fuse entry's logical value using its generated FuseEntryInfo.
+    ///
+    /// Reads raw bytes from OTP at the entry's byte_offset, then applies
+    /// FuseLayout extraction to produce the logical value.
+    /// Suitable for entries whose logical value fits in a single u32.
+    pub fn read_entry(&self, entry: &FuseEntryInfo) -> McuResult<u32> {
+        let layout = FuseLayout::from_generated(&entry.layout)
+            .ok_or(McuError::ROM_UNSUPPORTED_FUSE_LAYOUT)?;
+        let raw = self.read_word(entry.byte_offset / 4)?;
+        crate::extract_single_fuse_value(layout, raw)
+    }
+
+    /// Read a fuse entry's raw bytes into a caller-provided buffer.
+    ///
+    /// Reads `entry.byte_size` bytes from OTP at `entry.byte_offset`.
+    /// No layout extraction is applied — the caller gets the raw OTP data.
+    /// Note that this will round up to the next multiple of 4 bytes to be read.
+    pub fn read_entry_raw(&self, entry: &FuseEntryInfo, buf: &mut [u8]) -> McuResult<()> {
+        let read_len = entry.byte_size.next_multiple_of(4);
+        if buf.len() < read_len {
+            return Err(McuError::ROM_OTP_INVALID_DATA_ERROR);
+        }
+        self.read_data(entry.byte_offset, read_len, buf)
+    }
+
+    /// Write a logical value to a fuse entry using its generated FuseEntryInfo.
+    ///
+    /// Applies FuseLayout encoding to produce the raw fuse value, then writes
+    /// it to OTP via DAI. Suitable for entries whose value fits in a single u32.
+    pub fn write_entry(&self, entry: &FuseEntryInfo, value: u32) -> McuResult<()> {
+        let layout = FuseLayout::from_generated(&entry.layout)
+            .ok_or(McuError::ROM_UNSUPPORTED_FUSE_LAYOUT)?;
+        let raw = crate::write_single_fuse_value(layout, value)?;
+        self.write_word(entry.byte_offset / 4, raw)?;
+        Ok(())
     }
 
     pub fn read_fuses(&self) -> McuResult<Fuses> {

--- a/tests/integration/src/lib.rs
+++ b/tests/integration/src/lib.rs
@@ -320,7 +320,7 @@ mod test {
             // Create OTP memory large enough to include the vendor non-secret prod partition
             let mut otp = vec![0u8; VENDOR_NON_SECRET_PROD_PARTITION_BYTE_OFFSET + 256];
             // Set dot_initialized to 1 at the start of the vendor non-secret prod partition
-            otp[VENDOR_NON_SECRET_PROD_PARTITION_BYTE_OFFSET] = 1;
+            otp[VENDOR_NON_SECRET_PROD_PARTITION_BYTE_OFFSET] = 0x7; // backed by 3 bits
             Some(otp)
         } else {
             None


### PR DESCRIPTION
And use it in DOT.

For example, we specify in `fuses.hjson` where the DOT_INITIALIZED fuse lives and how it is set, and then the generator gives us a `DOT_INITIALIZED: &FuseEntryInfo` that can be passed to the `Otp` struct to read or write.