### PR TITLE
rom: After loading MCU firmware, optionally leave recovery ifc open

### DIFF
--- a/rom/src/cold_boot.rs
+++ b/rom/src/cold_boot.rs
@@ -492,7 +492,13 @@ impl BootFlow for ColdBoot {
             mci.set_flow_checkpoint(McuRomBootStatus::FieldEntropyProgrammingComplete.into());
         }
 
-        env.i3c.disable_recovery();
+        if params.recovery_status_open {
+            romtime::println!("[mcu-rom] Leaving recovery interface open");
+            env.i3c.set_recovery_status_open();
+        } else {
+            romtime::println!("[mcu-rom] Disabling recovery interface");
+            env.i3c.disable_recovery();
+        }
 
         // Reset so FirmwareBootReset can jump to firmware
         romtime::println!("[mcu-rom] Resetting to boot firmware");

--- a/rom/src/i3c.rs
+++ b/rom/src/i3c.rs
@@ -3,8 +3,9 @@
 use mcu_error::McuError;
 use registers_generated::i3c;
 use registers_generated::i3c::bits::{
-    DeviceStatus0, HcControl, IndirectFifoCtrl0, QueueThldCtrl, RingHeadersSectionOffset,
-    StbyCrCapabilities, StbyCrControl, StbyCrDeviceAddr, StbyCrVirtDeviceAddr, TtiQueueThldCtrl,
+    DeviceStatus0, HcControl, IndirectFifoCtrl0, QueueThldCtrl, RecoveryStatus,
+    RingHeadersSectionOffset, StbyCrCapabilities, StbyCrControl, StbyCrDeviceAddr,
+    StbyCrVirtDeviceAddr, TtiQueueThldCtrl,
 };
 use romtime::{HexWord, StaticRef};
 use tock_registers::interfaces::{ReadWriteable, Readable, Writeable};
@@ -170,7 +171,16 @@ impl I3c {
 
     pub fn disable_recovery(&mut self) {
         self.registers
+            .sec_fw_recovery_if_recovery_status
+            .write(RecoveryStatus::DevRecStatus.val(3)); // recovery successful
+        self.registers
             .sec_fw_recovery_if_device_status_0
             .write(DeviceStatus0::DevStatus.val(0));
+    }
+
+    pub fn set_recovery_status_open(&self) {
+        self.registers
+            .sec_fw_recovery_if_recovery_status
+            .write(RecoveryStatus::DevRecStatus.val(2)); // booting recovery image, so that the BMC knows that we might still want more images
     }
 }

--- a/rom/src/rom.rs
+++ b/rom/src/rom.rs
@@ -601,6 +601,11 @@ pub struct RomParameters<'a> {
     pub otp_check_timeout_override: Option<u32>,
     /// Request flash boot (AXI recovery bypass).
     pub request_flash_boot: bool,
+    /// By default, we will set recovery status as successful after loading MCU firmware.
+    /// Set this to true if you want to leave recovery status as open for further firmware image loading.
+    /// Note that in 2.0, Caliptra already sets recovery status as successful so there may be a race
+    /// condition depending on when a BMC reads the recovery status.
+    pub recovery_status_open: bool,
 }
 
 #[inline(always)]


### PR DESCRIPTION
This option allows the MCU rom (or runtime) to use the recovery interface to load additional images if desired.

Note that in 2.0, this is not reliable since Caliptra core will set recovery status as successful when it finishes loading MCU firmware, so there is a race condition depending on when the BMC would next read the recovery status.

Fixes #880