### PR TITLE
rom: Allow Caliptra mailbox and fuse users to be customized in ROM

### DIFF
--- a/common/config/src/lib.rs
+++ b/common/config/src/lib.rs
@@ -103,12 +103,6 @@ impl Default for McuMemoryMap {
 #[repr(C)]
 pub struct McuStraps {
     pub i3c_static_addr: u8,
-    pub axi_user0: u32,
-    pub axi_user1: u32,
-    /// Valid users for the MCU mailboxes. 0 values are ignored.
-    pub mcu_mbox0_axi_users: [u32; 5],
-    /// Valid users for the MCU mailboxes. 0 values are ignored.
-    pub mcu_mbox1_axi_users: [u32; 5],
     pub cptra_wdt_cfg0: u32,
     pub cptra_wdt_cfg1: u32,
     pub mcu_wdt_cfg0: u32,
@@ -123,22 +117,6 @@ impl McuStraps {
     pub const fn default() -> Self {
         McuStraps {
             i3c_static_addr: 0x3a,
-            axi_user0: 0xcccc_cccc,
-            axi_user1: 0xdddd_dddd,
-            mcu_mbox0_axi_users: [
-                0xcccc_cccc,
-                0xdddd_dddd,
-                0x0000_0000,
-                0x0000_0000,
-                0x0000_0000,
-            ],
-            mcu_mbox1_axi_users: [
-                0xcccc_cccc,
-                0xdddd_dddd,
-                0x0000_0000,
-                0x0000_0000,
-                0x0000_0000,
-            ],
             cptra_wdt_cfg0: 100_000_000,
             cptra_wdt_cfg1: 100_000_000,
             mcu_wdt_cfg0: 20_000_000,

--- a/hw/model/src/model_emulated.rs
+++ b/hw/model/src/model_emulated.rs
@@ -40,7 +40,6 @@ use emulator_registers_generated::axicdma::AxicdmaPeripheral;
 use emulator_registers_generated::primary_flash::PrimaryFlashPeripheral;
 use emulator_registers_generated::root_bus::AutoRootBus;
 use mcu_config::McuMemoryMap;
-use mcu_config::McuStraps;
 use mcu_rom_common::LifecycleControllerState;
 use mcu_rom_common::McuBootMilestones;
 use mcu_testing_common::i3c_socket_server::start_i3c_socket;
@@ -272,11 +271,7 @@ impl McuHwModel for ModelEmulated {
                 device_lifecycle,
                 req_idevid_csr,
                 use_mcu_recovery_interface,
-                extra_soc_bus: Some(
-                    params
-                        .caliptra_soc_axi_user
-                        .unwrap_or(McuStraps::default().axi_user1),
-                ),
+                extra_soc_bus: Some(params.caliptra_soc_axi_user.unwrap_or(0xdddd_dddd)),
             })
             .expect("Failed to start Caliptra CPU");
         let soc_to_caliptra_bus = soc_to_caliptra_bus.unwrap();

--- a/platforms/emulator/rom/src/riscv.rs
+++ b/platforms/emulator/rom/src/riscv.rs
@@ -70,6 +70,10 @@ pub extern "C" fn rom_entry() -> ! {
     let dot_flash: &dyn FlashStorage = &SimpleFlash::new(raw_dot_flash);
     let dot_flash = Some(dot_flash);
 
+    let axi_user0 = 0xcccc_ccccu32;
+    let axi_user1 = 0xdddd_ddddu32;
+    let mbox_axi_users = [axi_user0, axi_user1, 0, 0, 0];
+
     if cfg!(feature = "test-flash-based-boot") {
         // Initialize the flash controller for testing purposes
 
@@ -136,6 +140,12 @@ pub extern "C" fn rom_entry() -> ! {
             flash_partition_driver: Some(&mut flash_image_partition_driver),
             dot_flash,
             request_flash_boot: true,
+            cptra_mbox_axi_users: mbox_axi_users,
+            cptra_fuse_axi_user: axi_user0,
+            cptra_trng_axi_user: axi_user0,
+            cptra_dma_axi_user: axi_user0,
+            mci_mbox0_axi_users: mbox_axi_users,
+            mci_mbox1_axi_users: mbox_axi_users,
             ..Default::default()
         });
     } else if cfg!(feature = "hw-2-1") {
@@ -163,6 +173,12 @@ pub extern "C" fn rom_entry() -> ! {
             dot_flash,
             // Let the generic wire (bit 29 of mci_reg_generic_input_wires[1]) control flash boot
             // request_flash_boot defaults to false - emulator sets the wire when flash boot is requested
+            cptra_mbox_axi_users: mbox_axi_users,
+            cptra_fuse_axi_user: axi_user0,
+            cptra_trng_axi_user: axi_user0,
+            cptra_dma_axi_user: axi_user0,
+            mci_mbox0_axi_users: mbox_axi_users,
+            mci_mbox1_axi_users: mbox_axi_users,
             ..Default::default()
         });
     } else if cfg!(any(
@@ -177,12 +193,24 @@ pub extern "C" fn rom_entry() -> ! {
             dot_flash,
             otp_enable_integrity_check: true,
             otp_enable_consistency_check: true,
+            cptra_mbox_axi_users: mbox_axi_users,
+            cptra_fuse_axi_user: axi_user0,
+            cptra_trng_axi_user: axi_user0,
+            cptra_dma_axi_user: axi_user0,
+            mci_mbox0_axi_users: mbox_axi_users,
+            mci_mbox1_axi_users: mbox_axi_users,
             ..Default::default()
         };
         mcu_rom_common::rom_start(rom_parameters);
     } else {
         mcu_rom_common::rom_start(RomParameters {
             dot_flash,
+            cptra_mbox_axi_users: [axi_user0, axi_user1, 0, 0, 0],
+            cptra_fuse_axi_user: axi_user0,
+            cptra_trng_axi_user: axi_user0,
+            cptra_dma_axi_user: axi_user0,
+            mci_mbox0_axi_users: mbox_axi_users,
+            mci_mbox1_axi_users: mbox_axi_users,
             ..Default::default()
         });
     }

--- a/platforms/fpga/config/src/lib.rs
+++ b/platforms/fpga/config/src/lib.rs
@@ -50,10 +50,6 @@ pub const FPGA_MEMORY_MAP: McuMemoryMap = McuMemoryMap {
 
 pub const FPGA_MCU_STRAPS: McuStraps = McuStraps {
     i3c_static_addr: 0x3a,
-    axi_user0: 0x1,
-    axi_user1: 0x2,
-    mcu_mbox0_axi_users: [1, 2, 0, 0, 0],
-    mcu_mbox1_axi_users: [1, 2, 0, 0, 0],
     cptra_wdt_cfg0: 200_000_000,
     cptra_wdt_cfg1: 200_000_000,
     mcu_wdt_cfg0: 800_000_000, // the FPGA is slower to boot

--- a/platforms/fpga/rom/src/riscv.rs
+++ b/platforms/fpga/rom/src/riscv.rs
@@ -121,6 +121,10 @@ pub extern "C" fn rom_entry() -> ! {
         None
     };
 
+    let axi_user0 = 1;
+    let axi_user1 = 2;
+    let mbox_axi_users = [axi_user0, axi_user1, 0, 0, 0];
+
     mcu_rom_common::rom_start(RomParameters {
         lifecycle_transition,
         burn_lifecycle_tokens,
@@ -128,6 +132,12 @@ pub extern "C" fn rom_entry() -> ! {
         otp_enable_integrity_check: true,
         otp_enable_consistency_check: true,
         flash_partition_driver: Some(&mut flash_partition),
+        cptra_mbox_axi_users: mbox_axi_users,
+        cptra_fuse_axi_user: axi_user0,
+        cptra_trng_axi_user: axi_user0,
+        cptra_dma_axi_user: axi_user0,
+        mci_mbox0_axi_users: mbox_axi_users,
+        mci_mbox1_axi_users: mbox_axi_users,
         ..Default::default()
     });
 

--- a/rom/src/cold_boot.rs
+++ b/rom/src/cold_boot.rs
@@ -17,7 +17,7 @@ Abstract:
 use crate::boot_status::McuRomBootStatus;
 use crate::{
     configure_mcu_mbox_axi_users, device_ownership_transfer, fatal_error,
-    verify_mcu_mbox_axi_users, verify_prod_debug_unlock_pk_hash, BootFlow, DotBlob,
+    verify_mcu_mbox_axi_users, verify_prod_debug_unlock_pk_hash, AxiUsers, BootFlow, DotBlob,
     McuBootMilestones, RomEnv, RomParameters, MCU_MEMORY_MAP,
 };
 use caliptra_api::mailbox::{CmStableKeyType, CommandId, FeProgReq, MailboxReqHeader};
@@ -250,7 +250,14 @@ impl BootFlow for ColdBoot {
 
         romtime::println!("[mcu-rom] Writing fuses to Caliptra");
 
-        soc.set_axi_users(straps.into());
+        soc.set_axi_users(AxiUsers {
+            mbox_users: params
+                .cptra_mbox_axi_users
+                .map(|u| if u != 0 { Some(u) } else { None }),
+            fuse_user: params.cptra_fuse_axi_user,
+            trng_user: params.cptra_trng_axi_user,
+            dma_user: params.cptra_dma_axi_user,
+        });
         mci.set_flow_checkpoint(McuRomBootStatus::AxiUsersConfigured.into());
 
         romtime::println!("[mcu-rom] Populating fuses");
@@ -259,7 +266,11 @@ impl BootFlow for ColdBoot {
 
         // Configure MCU mailbox AXI users before locking
         romtime::println!("[mcu-rom] Configuring MCU mailbox AXI users");
-        let mcu_mbox_config = configure_mcu_mbox_axi_users(mci, straps);
+        let mcu_mbox_config = configure_mcu_mbox_axi_users(
+            mci,
+            &params.mci_mbox0_axi_users,
+            &params.mci_mbox1_axi_users,
+        );
         mci.set_flow_checkpoint(McuRomBootStatus::McuMboxAxiUsersConfigured.into());
 
         // Set SS_CONFIG_DONE_STICKY to lock MCI configuration registers

--- a/rom/src/warm_boot.rs
+++ b/rom/src/warm_boot.rs
@@ -15,7 +15,7 @@ Abstract:
 #![allow(clippy::empty_loop)]
 
 use crate::{
-    fatal_error, BootFlow, McuBootMilestones, McuRomBootStatus, RomEnv, RomParameters,
+    fatal_error, AxiUsers, BootFlow, McuBootMilestones, McuRomBootStatus, RomEnv, RomParameters,
     MCU_MEMORY_MAP,
 };
 use caliptra_api_types::{DeviceLifecycle, SecurityState};
@@ -74,7 +74,14 @@ impl BootFlow for WarmBoot {
             mci.set_flow_checkpoint(McuRomBootStatus::WatchdogConfigured.into());
         }
 
-        soc.set_axi_users(straps.into());
+        soc.set_axi_users(AxiUsers {
+            mbox_users: params
+                .cptra_mbox_axi_users
+                .map(|u| if u != 0 { Some(u) } else { None }),
+            fuse_user: params.cptra_fuse_axi_user,
+            trng_user: params.cptra_trng_axi_user,
+            dma_user: params.cptra_dma_axi_user,
+        });
         mci.set_flow_checkpoint(McuRomBootStatus::AxiUsersConfigured.into());
 
         // Set SS_CONFIG_DONE to lock MCI configuration registers until warm reset


### PR DESCRIPTION
Our reference ROMs use the straps to configure these, but the common ROM now accepts parameters to configure each one of these.

This removes them from the `McuStraps` so they can be, for example, read from fuses, rather than strapped in, giving a bit more configurability. It also cleans up the code paths a little.

Fixes #670