### PR TITLE
docs: Update links from caliptra-sw main-2.x to main

### DIFF
--- a/docs/src/external_mailbox_cmds.md
+++ b/docs/src/external_mailbox_cmds.md
@@ -458,7 +458,7 @@ Command Code: `0x4D44_5554` ("MDUT")
 
 ### Cryptographic Command Format
 
-The MCI mailbox cryptographic commands are mapped to their corresponding Caliptra Mailbox Cryptographic commands. The mapping is detailed in the table below. For the specific format of each command, refer to the [Mailbox Commands: Cryptographic Mailbox (2.0)](https://github.com/chipsalliance/caliptra-sw/blob/main-2.x/runtime/README.md#mailbox-commands-cryptographic-mailbox-20).
+The MCI mailbox cryptographic commands are mapped to their corresponding Caliptra Mailbox Cryptographic commands. The mapping is detailed in the table below. For the specific format of each command, refer to the [Mailbox Commands: Cryptographic Mailbox (2.0)](https://github.com/chipsalliance/caliptra-sw/blob/main/runtime/README.md#mailbox-commands-cryptographic-mailbox-20).
 
 *Table: mapping MCI Mailbox Crypto Commands to Caliptra Crypto Mailbox Commands*
 | **MCI Mailbox Crypto Commands** | **Caliptra Mailbox Crypto Commands**         |

--- a/docs/src/flash_layout.md
+++ b/docs/src/flash_layout.md
@@ -32,8 +32,8 @@ The Payload contains the following fields:
 | ...                            |
 | SoC Image N                    |
 
-* Caliptra FMC and RT (refer to the [Caliptra Firmware Image Bundle Format](https://github.com/chipsalliance/caliptra-sw/blob/main-2.x/rom/dev/README.md#firmware-image-bundle))
-* SoC Manifest (refer to the description of the [SoC Manifest](https://github.com/chipsalliance/caliptra-sw/blob/main-2.x/auth-manifest/README.md))
+* Caliptra FMC and RT (refer to the [Caliptra Firmware Image Bundle Format](https://github.com/chipsalliance/caliptra-sw/blob/main/rom/dev/README.md#firmware-image-bundle))
+* SoC Manifest (refer to the description of the [SoC Manifest](https://github.com/chipsalliance/caliptra-sw/blob/main/auth-manifest/README.md))
 * MCU RT: This is the image binary of the MCU Runtime firmware
 * Other SoC images (if any)
 

--- a/docs/src/pldm_package.md
+++ b/docs/src/pldm_package.md
@@ -127,11 +127,11 @@ There are no Downstream Device ID records for this package
 
 ## Component 1 - Caliptra FMC + RT
 
-This is the package bundle for the Caliptra FMC + RT defined in [Caliptra Firmware Image Bundle Format](https://github.com/chipsalliance/caliptra-sw/blob/main-2.x/rom/dev/README.md#firmware-image-bundle).
+This is the package bundle for the Caliptra FMC + RT defined in [Caliptra Firmware Image Bundle Format](https://github.com/chipsalliance/caliptra-sw/blob/main/rom/dev/README.md#firmware-image-bundle).
 
 ## Component 2 - SOC Manifest
 
-This is the SoC Manifest defined in [SoC Manifest](https://github.com/chipsalliance/caliptra-sw/blob/main-2.x/auth-manifest/README.md).
+This is the SoC Manifest defined in [SoC Manifest](https://github.com/chipsalliance/caliptra-sw/blob/main/auth-manifest/README.md).
 
 It provides the signature verification and specific data needed to decode the image.
 


### PR DESCRIPTION
So that they link to the latest documentation, rather than the stale main-2.x branch.