### PR TITLE
tests: Re-enable firmware update (#819)

### DIFF
--- a/tests/integration/src/test_firmware_update.rs
+++ b/tests/integration/src/test_firmware_update.rs
@@ -852,7 +852,6 @@ mod test {
     }
 
     // Flash-based firmware update tests
-    #[ignore]
     #[test]
     fn test_firmware_update_flash_successful() {
         let lock = TEST_LOCK.lock().unwrap();


### PR DESCRIPTION
This test has been fixed by the same peripheral event handling and interrupt disabling during MCI reset as the `...._fast` variant.  Herego it can be re-enabled as well.