### PR TITLE
firmware-bundler: Increase grant_space for emulator user-app to 16KB

### DIFF
--- a/firmware-bundler/reference/emulator/user-app.toml
+++ b/firmware-bundler/reference/emulator/user-app.toml
@@ -34,4 +34,5 @@ stack = 0x0_7000
 [[app]]
 name = "user-app"
 stack = 0xae00
+grant_space = 0x4000
 


### PR DESCRIPTION
The MCU mailbox capsule's App struct contains a BufferedMessage with a [u32; 1024] array (~4KB), which requires more than the default 4KB grant space. This caused NOMEM errors when userspace applications tried to allocate grants for the mcu_mbox driver.

Increase grant_space from the default 4KB to 16KB (0x4000) to accommodate the larger buffer and ensure successful grant allocation.