### PR TITLE
fpga: Install clang as part of xtask-fpga fpga build-test

### DIFF
--- a/xtask/src/fpga/utils.rs
+++ b/xtask/src/fpga/utils.rs
@@ -208,7 +208,9 @@ impl NextestArchiveCommand {
     }
 
     pub fn build(self) -> String {
-        let mut cmd = format!("cd {} && ", self.work_dir);
+        let mut cmd =
+            String::from("apt-get update -qq && apt-get install -y -qq clang >/dev/null 2>&1 && ");
+        cmd.push_str(&format!("cd {} && ", self.work_dir));
         cmd.push_str("CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc ");
         cmd.push_str("cargo nextest archive ");
 


### PR DESCRIPTION
`clang` is not part of the base Docker image, but is required for lwip, which is a dependency of the network boot code. This code will probably be moved out of the caliptra-mcu-sw repo sometime soon, but for now, this is required to build tests for the FPGA locally for me.