### PR TITLE
rom: discard .eh_frame and eliminate panics in flash-boot ROM

### DIFF
--- a/builder/src/rom.rs
+++ b/builder/src/rom.rs
@@ -135,12 +135,16 @@ SECTIONS
 
     ROM_DATA = .;
 
+    /DISCARD/ :
+    {
+        *(.eh_frame*)
+    }
+
     .data : AT(ROM_DATA)
     {
         . = ALIGN(4);
         *(.data*);
         *(.sdata*);
-        KEEP(*(.eh_frame))
         . = ALIGN(4);
         PROVIDE( GLOBAL_POINTER = . + 0x800 );
         . = ALIGN(4);

--- a/firmware-bundler/data/default-rom-layout.ld
+++ b/firmware-bundler/data/default-rom-layout.ld
@@ -35,12 +35,16 @@ SECTIONS
         PROVIDE(ESTACK_START = . );
     } > RAM
 
+    /DISCARD/ :
+    {
+        *(.eh_frame*)
+    }
+
     .data : AT(ROM_DATA)
     {
         . = ALIGN(4);
         *(.data*);
         *(.sdata*);
-        KEEP(*(.eh_frame))
         . = ALIGN(4);
         PROVIDE( GLOBAL_POINTER = . + 0x800 );
         . = ALIGN(4);
@@ -66,4 +70,3 @@ ROM_DATA_START = LOADADDR(.data);
 STACK_TOP = ORIGIN(RAM) + SIZEOF(.stack);
 STACK_ORIGIN = ORIGIN(RAM);
 MRAC_VALUE = 0xaaa9a5aa;
-

--- a/platforms/emulator/rom/src/flash/flash_boot_cfg.rs
+++ b/platforms/emulator/rom/src/flash/flash_boot_cfg.rs
@@ -19,7 +19,7 @@ impl<'a> FlashBootCfg<'a> {
             [0; core::mem::size_of::<PartitionTable>()];
         self.flash_driver
             .read(0, &mut partition_table_data)
-            .expect("Failed to read partition table data");
+            .map_err(|_| ())?;
 
         let (partition_table, _) =
             PartitionTable::read_from_prefix(&partition_table_data).map_err(|_| ())?;

--- a/platforms/emulator/rom/src/flash/flash_drv.rs
+++ b/platforms/emulator/rom/src/flash/flash_drv.rs
@@ -100,8 +100,16 @@ impl FlashStorage for EmulatedFlashCtrl {
             // Read the page into page_buf
             self.read_page(page_number, &mut page_buf)?;
 
-            buf[buf_offset..buf_offset + to_read]
-                .copy_from_slice(&page_buf.0[page_offset..page_offset + to_read]);
+            let dst = buf
+                .get_mut(buf_offset..buf_offset + to_read)
+                .ok_or(FlashDrvError::INVAL)?;
+            let src = page_buf
+                .0
+                .get(page_offset..page_offset + to_read)
+                .ok_or(FlashDrvError::INVAL)?;
+            for (d, s) in dst.iter_mut().zip(src.iter()) {
+                *d = *s;
+            }
 
             remaining -= to_read;
             buf_offset += to_read;
@@ -132,8 +140,16 @@ impl FlashStorage for EmulatedFlashCtrl {
                 EmulatedFlashPage::default()
             };
 
-            page_buf.0[page_offset..page_offset + to_write]
-                .copy_from_slice(&buf[buf_offset..buf_offset + to_write]);
+            let dst = page_buf
+                .0
+                .get_mut(page_offset..page_offset + to_write)
+                .ok_or(FlashDrvError::INVAL)?;
+            let src = buf
+                .get(buf_offset..buf_offset + to_write)
+                .ok_or(FlashDrvError::INVAL)?;
+            for (d, s) in dst.iter_mut().zip(src.iter()) {
+                *d = *s;
+            }
 
             self.write_page(page_number, &mut page_buf)?;
 

--- a/platforms/emulator/rom/src/riscv.rs
+++ b/platforms/emulator/rom/src/riscv.rs
@@ -86,20 +86,12 @@ pub extern "C" fn rom_entry() -> ! {
             PARTITION_TABLE.offset,
             PARTITION_TABLE.size,
         )
-        .map_err(|_| {
-            fatal_error(EmulatorError::InitFlashPartitionDriver.into());
-        })
-        .ok()
-        .unwrap();
+        .unwrap_or_else(|_| fatal_error(EmulatorError::InitFlashPartitionDriver.into()));
 
         let boot_cfg = FlashBootCfg::new(&mut partition_table_driver);
         let active_partition = boot_cfg
             .get_active_partition()
-            .map_err(|_| {
-                fatal_error(EmulatorError::InitBootCfg.into());
-            })
-            .ok()
-            .unwrap();
+            .unwrap_or_else(|_| fatal_error(EmulatorError::InitBootCfg.into()));
 
         let partition_a = FlashPartition::new(
             &primary_flash_ctrl,
@@ -107,22 +99,14 @@ pub extern "C" fn rom_entry() -> ! {
             IMAGE_A_PARTITION.offset,
             IMAGE_A_PARTITION.size,
         )
-        .map_err(|_| {
-            fatal_error(EmulatorError::InitFlashPartitionA.into());
-        })
-        .ok()
-        .unwrap();
+        .unwrap_or_else(|_| fatal_error(EmulatorError::InitFlashPartitionA.into()));
         let partition_b = FlashPartition::new(
             &secondary_flash_ctrl,
             "Image B",
             IMAGE_B_PARTITION.offset,
             IMAGE_B_PARTITION.size,
         )
-        .map_err(|_| {
-            fatal_error(EmulatorError::InitFlashPartitionB.into());
-        })
-        .ok()
-        .unwrap();
+        .unwrap_or_else(|_| fatal_error(EmulatorError::InitFlashPartitionB.into()));
 
         let mut flash_image_partition_driver = match active_partition {
             PartitionId::A => {
@@ -160,11 +144,7 @@ pub extern "C" fn rom_entry() -> ! {
             0, // Start at offset 0
             primary_flash_ctrl.capacity(),
         )
-        .map_err(|_| {
-            fatal_error(EmulatorError::InitFlashPartitionDriver.into());
-        })
-        .ok()
-        .unwrap();
+        .unwrap_or_else(|_| fatal_error(EmulatorError::InitFlashPartitionDriver.into()));
 
         romtime::println!("[mcu-rom] Booting from flash");
 

--- a/rom/src/cold_boot.rs
+++ b/rom/src/cold_boot.rs
@@ -444,8 +444,7 @@ impl BootFlow for ColdBoot {
                 mci.set_flow_checkpoint(McuRomBootStatus::FlashRecoveryFlowStarted.into());
 
                 crate::recovery::load_flash_image_to_recovery(i3c_base, flash_driver)
-                    .map_err(|_| fatal_error(McuError::ROM_COLD_BOOT_LOAD_IMAGE_ERROR))
-                    .unwrap();
+                    .unwrap_or_else(|_| fatal_error(McuError::ROM_COLD_BOOT_LOAD_IMAGE_ERROR));
 
                 romtime::println!("[mcu-rom] Flash Recovery flow complete");
                 mci.set_flow_checkpoint(McuRomBootStatus::FlashRecoveryFlowComplete.into());


### PR DESCRIPTION
* Discard `.eh_frame` sections in ROM linker scripts instead of keeping them in `.data`, saving ~3KB of DCCM that was wasted on DWARF unwind data.
* Eliminate panic paths in the test-flash-based-boot ROM build:
  * Replace `.expect()` with `.map_err()?` in `flash_boot_cfg.rs`
  * Replace `.map_err(fatal_error).ok().unwrap()` with `.unwrap_or_else(|_| fatal_error())` in `riscv.rs` and `cold_boot.rs`
  * Replace panicking slice indexing and `copy_from_slice` with `get`/`get_mut` and iterator-based copy in `flash_drv.rs`
* Extend precheckin panic check to also verify the `test-flash-based-boot` ROM build has no `panic_is_possible` symbol.