### PR TITLE
tests: Actually use random ports for I3C

### DIFF
--- a/tests/integration/src/lib.rs
+++ b/tests/integration/src/lib.rs
@@ -712,7 +712,7 @@ mod test {
 
         let feature = feature.replace("_", "-");
         let test_runtime = get_or_compile_runtime(&feature, example_app);
-        let i3c_port = PortPicker::new().pick().unwrap().to_string();
+        let i3c_port = PortPicker::new().random(true).pick().unwrap().to_string();
 
         // Try to create CaliptraBuilder with prebuilt binaries
         let caliptra_builder =
@@ -820,7 +820,7 @@ mod test {
 
         let feature = "test-exit-immediately".to_string();
         let test_runtime = get_or_compile_runtime(&feature, false);
-        let i3c_port = PortPicker::new().pick().unwrap().to_string();
+        let i3c_port = PortPicker::new().random(true).pick().unwrap().to_string();
         let caliptra_builder =
             create_caliptra_builder_with_prebuilt(test_runtime.clone(), &feature);
         let test = run_runtime(
@@ -853,7 +853,7 @@ mod test {
 
         let feature = "test-mcu-rom-flash-access".to_string();
         let test_runtime = get_or_compile_runtime(&feature, false);
-        let i3c_port = PortPicker::new().pick().unwrap().to_string();
+        let i3c_port = PortPicker::new().random(true).pick().unwrap().to_string();
         let caliptra_builder =
             create_caliptra_builder_with_prebuilt(test_runtime.clone(), &feature);
         let test = run_runtime(
@@ -906,7 +906,7 @@ mod test {
             val.to_le_bytes()
         };
 
-        let i3c_port = PortPicker::new().pick().unwrap().to_string();
+        let i3c_port = PortPicker::new().random(true).pick().unwrap().to_string();
         Some(run_runtime(
             feature,
             get_rom_with_feature(feature),

--- a/tests/integration/src/test_firmware_update.rs
+++ b/tests/integration/src/test_firmware_update.rs
@@ -510,7 +510,7 @@ mod test {
             format!("0x{:016x}", MCI_BASE_AXI_ADDRESS),
         );
 
-        let i3c_port = PortPicker::new().pick().unwrap().into();
+        let i3c_port = PortPicker::new().random(true).pick().unwrap().into();
 
         // Check if we have prebuilt binaries for this feature
         if has_prebuilt_binaries(feature) {

--- a/tests/integration/src/test_fpga_flash_ctrl.rs
+++ b/tests/integration/src/test_fpga_flash_ctrl.rs
@@ -26,7 +26,7 @@ pub mod test {
 
         let mut hw = start_runtime_hw_model(TestParams {
             feature: Some(&feature),
-            i3c_port: Some(PortPicker::new().pick().unwrap()),
+            i3c_port: Some(PortPicker::new().random(true).pick().unwrap()),
             ..Default::default()
         });
 

--- a/tests/integration/src/test_i3c_constant_writes.rs
+++ b/tests/integration/src/test_i3c_constant_writes.rs
@@ -20,7 +20,7 @@ mod test {
 
         let mut hw = start_runtime_hw_model(TestParams {
             feature: Some("test-i3c-constant-writes"),
-            i3c_port: Some(PortPicker::new().pick().unwrap()),
+            i3c_port: Some(PortPicker::new().random(true).pick().unwrap()),
             ..Default::default()
         });
 

--- a/tests/integration/src/test_i3c_simple.rs
+++ b/tests/integration/src/test_i3c_simple.rs
@@ -16,7 +16,7 @@ mod test {
 
         let mut hw = start_runtime_hw_model(TestParams {
             feature: Some("test-i3c-simple"),
-            i3c_port: Some(PortPicker::new().pick().unwrap()),
+            i3c_port: Some(PortPicker::new().random(true).pick().unwrap()),
             ..Default::default()
         });
 

--- a/tests/integration/src/test_mctp_capsule_loopback.rs
+++ b/tests/integration/src/test_mctp_capsule_loopback.rs
@@ -21,7 +21,7 @@ mod test {
         let feature = feature.replace("_", "-");
         let mut hw = start_runtime_hw_model(TestParams {
             feature: Some(&feature),
-            i3c_port: Some(PortPicker::new().pick().unwrap()),
+            i3c_port: Some(PortPicker::new().random(true).pick().unwrap()),
             ..Default::default()
         });
 

--- a/tests/integration/src/test_mctp_vdm_cmds.rs
+++ b/tests/integration/src/test_mctp_vdm_cmds.rs
@@ -292,7 +292,7 @@ pub mod test {
         let feature = feature.replace("_", "-");
         let mut hw = start_runtime_hw_model(TestParams {
             feature: Some(&feature),
-            i3c_port: Some(PortPicker::new().pick().unwrap()),
+            i3c_port: Some(PortPicker::new().random(true).pick().unwrap()),
             ..Default::default()
         });
 

--- a/tests/integration/src/test_mcu_mbox.rs
+++ b/tests/integration/src/test_mcu_mbox.rs
@@ -90,7 +90,7 @@ pub mod test {
 
         let mut hw = start_runtime_hw_model(TestParams {
             feature: Some(&feature),
-            i3c_port: Some(PortPicker::new().pick().unwrap()),
+            i3c_port: Some(PortPicker::new().random(true).pick().unwrap()),
             ..Default::default()
         });
 

--- a/tests/integration/src/test_pldm_fw_update.rs
+++ b/tests/integration/src/test_pldm_fw_update.rs
@@ -41,7 +41,7 @@ pub mod test {
         let feature = feature.replace("_", "-");
         let mut hw = start_runtime_hw_model(TestParams {
             feature: Some(&feature),
-            i3c_port: Some(PortPicker::new().pick().unwrap()),
+            i3c_port: Some(PortPicker::new().random(true).pick().unwrap()),
             ..Default::default()
         });
 

--- a/tests/integration/src/test_soc_boot.rs
+++ b/tests/integration/src/test_soc_boot.rs
@@ -696,7 +696,7 @@ mod test {
         } else {
             "test-pldm-streaming-boot"
         };
-        let i3c_port = PortPicker::new().pick().unwrap().into();
+        let i3c_port = PortPicker::new().random(true).pick().unwrap().into();
 
         // Check if we have prebuilt binaries for this feature
         if has_prebuilt_binaries(feature) {


### PR DESCRIPTION
I added `PortPicker` to change the ports used by each test for I3C. I thought that would pick random ports by default, but it turns out, it will just pick port 1024, then 1025, etc., which can cause race conditions if two tests are running at once (they both check that it is unused, see that it is, and then attempt to use it at the same time).

This changes the uses of `PortPicker` to actually use random ports, which drastically reduces the chances of two tests simultaneously picking the same port.