### PR TITLE
rom: mtvec must be 256-byte aligned (2.1)

### DIFF
--- a/platforms/emulator/rom/src/start.s
+++ b/platforms/emulator/rom/src/start.s
@@ -74,11 +74,11 @@ end_copy_data:
 .equ  EMU_CTRL_EXIT, 0x2000F000
 
 .section .text.init
-.align 2
+.align 8
 _exception_handler:
     # Save the SP to mscratch
     csrw mscratch, sp
-    
+
     # Switch to the exception stack
     la sp, ESTACK_START
 

--- a/platforms/fpga/rom/src/start.s
+++ b/platforms/fpga/rom/src/start.s
@@ -68,11 +68,12 @@ end_copy_data:
     call main
 
 .section .text.init
-.align 2
+.align 8
+
 _exception_handler:
     # Save the SP to mscratch
     csrw mscratch, sp
-    
+
     # Switch to the exception stack
     la sp, ESTACK_START
 

--- a/platforms/test_harness/src/emulator-start.s
+++ b/platforms/test_harness/src/emulator-start.s
@@ -74,14 +74,13 @@ end_copy_data:
 .equ  EMU_CTRL_EXIT, 0x2000F000
 
 .section .text.init
-.align 2
+.align 8
 _exception_handler:
     # Save the SP to mscratch
     csrw mscratch, sp
-    
+
     # Switch to the exception stack
     la sp, ESTACK_START
 
     # Switch to the exception handler function
     jal exception_handler
-    

--- a/platforms/test_harness/src/fpga-start.s
+++ b/platforms/test_harness/src/fpga-start.s
@@ -69,11 +69,11 @@ end_copy_data:
 
 
 .section .text.init
-.align 2
+.align 8
 _exception_handler:
     # Save the SP to mscratch
     csrw mscratch, sp
-    
+
     # Switch to the exception stack
     la sp, ESTACK_START
 


### PR DESCRIPTION
This is a requirement in the RISC-V spec.

Without this, the current caliptra-sw fails on update reset because the FPGA MCU ROM gets into a crash loop, due to an illegal instruction exception in the default MCU FW, which triggers an interrupt, which then resets due to a bad `mtvec`.