### PR TITLE
lwip-rs: add baremetal port for network ROM

### DIFF
--- a/network/net/lwip-rs/Cargo.toml
+++ b/network/net/lwip-rs/Cargo.toml
@@ -11,18 +11,22 @@ name = "lwip_rs"
 path = "src/lib.rs"
 
 [dependencies]
-bitflags.workspace = true
-spin.workspace = true
+bitflags = { workspace = true, optional = true }
+spin = { workspace = true, optional = true }
 
 [build-dependencies]
 bindgen.workspace = true
 cc.workspace = true
 
 [features]
-default = ["alloc", "ipv4", "ipv6", "dhcp", "tftp"]
+default = ["alloc", "bitflags", "ipv4", "ipv6", "dhcp", "tftp"]
 alloc = []
 ipv4 = []
 ipv6 = []
 dhcp = ["ipv4"]
 dhcp6 = ["ipv6"]
-tftp = ["alloc"]  # TFTP requires alloc for String/CString
+tftp = ["alloc", "spin"]  # TFTP requires alloc for String/CString
+baremetal = ["ipv4", "dhcp"]  # Bare-metal port (no OS, no TAP, no alloc required)
+baremetal-ipv6 = ["baremetal", "ipv6", "dhcp6"]  # Bare-metal with IPv6/SLAAC + stateless DHCPv6 support
+baremetal-tftp = ["baremetal"]  # Bare-metal with TFTP client (no alloc, no spin)
+baremetal-tftpv6 = ["baremetal-ipv6", "baremetal-tftp"]  # Bare-metal TFTP over IPv6

--- a/network/net/lwip-rs/build.rs
+++ b/network/net/lwip-rs/build.rs
@@ -2,6 +2,10 @@
 
 //! Build script for lwip-rs
 //! Compiles lwIP C sources and generates Rust bindings
+//!
+//! Supports two modes:
+//! - Host (default): Uses Unix TAP port, links pthread/rt/util
+//! - Bare-metal (feature "baremetal"): No OS, custom netif, cross-compiles for riscv32
 
 use std::env;
 use std::path::PathBuf;
@@ -9,22 +13,61 @@ use std::path::PathBuf;
 fn main() {
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
     let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+    let target = env::var("TARGET").unwrap_or_default();
+    let is_baremetal = env::var("CARGO_FEATURE_BAREMETAL").is_ok();
+    let is_baremetal_ipv6 = env::var("CARGO_FEATURE_BAREMETAL_IPV6").is_ok();
+    let is_baremetal_tftp = env::var("CARGO_FEATURE_BAREMETAL_TFTP").is_ok();
 
     // Paths to lwIP
     let lwip_dir = manifest_dir.join("../lwip");
     let lwip_src = lwip_dir.join("src");
     let lwip_contrib = lwip_dir.join("contrib");
     let include_dir = manifest_dir.join("include");
+    let baremetal_include_dir = include_dir.join("baremetal");
 
-    // Include paths
-    let includes = [
-        include_dir.clone(),
-        lwip_src.join("include"),
-        lwip_contrib.join("ports/unix/port/include"),
-    ];
+    // Build lwIP library
+    let mut builder = cc::Build::new();
+    builder.warnings(false);
 
-    // Core lwIP sources
-    let core_sources = [
+    if is_baremetal {
+        // Bare-metal build: use baremetal include dir (has arch/cc.h, lwipopts.h, etc.)
+        // baremetal include dir must come first so its lwipopts.h and arch/ take precedence
+        builder.include(&baremetal_include_dir);
+        builder.include(lwip_src.join("include"));
+
+        // Enable IPv6 for baremetal-ipv6 feature
+        if is_baremetal_ipv6 {
+            builder.define("LWIP_BAREMETAL_IPV6", "1");
+        }
+
+        // Enable TFTP for baremetal-tftp feature
+        if is_baremetal_tftp {
+            builder.define("LWIP_BAREMETAL_TFTP", "1");
+        }
+
+        // For riscv32 cross-compilation with riscv64-unknown-elf-gcc
+        if target.contains("riscv32") {
+            builder.compiler("riscv64-unknown-elf-gcc");
+            builder.flag("-march=rv32imc");
+            builder.flag("-mabi=ilp32");
+            // Freestanding build: no C library dependency.
+            // GCC still provides compiler headers (stdint.h, stddef.h, stdarg.h).
+            // Our baremetal/ stubs provide string.h, stdlib.h, stdio.h.
+            builder.flag("-ffreestanding");
+            builder.flag("-nostdlib");
+        }
+
+        // Compile libc stubs (strlen, strcmp, strncmp, strstr, atoi)
+        builder.file(manifest_dir.join("src/libc_stubs.c"));
+    } else {
+        // Host build: use standard include paths with Unix port
+        builder.include(&include_dir);
+        builder.include(lwip_src.join("include"));
+        builder.include(lwip_contrib.join("ports/unix/port/include"));
+    }
+
+    // Core lwIP sources (same for both modes, minus TCP for baremetal)
+    let core_sources_common = [
         "core/init.c",
         "core/def.c",
         "core/dns.c",
@@ -37,15 +80,27 @@ fn main() {
         "core/raw.c",
         "core/stats.c",
         "core/sys.c",
-        "core/altcp.c",
-        "core/altcp_alloc.c",
-        "core/altcp_tcp.c",
-        "core/tcp.c",
-        "core/tcp_in.c",
-        "core/tcp_out.c",
         "core/timeouts.c",
         "core/udp.c",
     ];
+    for src in &core_sources_common {
+        builder.file(lwip_src.join(src));
+    }
+
+    // TCP sources (host only - baremetal DHCP doesn't need TCP)
+    if !is_baremetal {
+        let tcp_sources = [
+            "core/altcp.c",
+            "core/altcp_alloc.c",
+            "core/altcp_tcp.c",
+            "core/tcp.c",
+            "core/tcp_in.c",
+            "core/tcp_out.c",
+        ];
+        for src in &tcp_sources {
+            builder.file(lwip_src.join(src));
+        }
+    }
 
     // IPv4 sources
     let ipv4_sources = [
@@ -59,88 +114,107 @@ fn main() {
         "core/ipv4/ip4_frag.c",
         "core/ipv4/acd.c",
     ];
-
-    // IPv6 sources
-    let ipv6_sources = [
-        "core/ipv6/dhcp6.c",
-        "core/ipv6/ethip6.c",
-        "core/ipv6/icmp6.c",
-        "core/ipv6/inet6.c",
-        "core/ipv6/ip6.c",
-        "core/ipv6/ip6_addr.c",
-        "core/ipv6/ip6_frag.c",
-        "core/ipv6/mld6.c",
-        "core/ipv6/nd6.c",
-    ];
-
-    // Netif sources
-    let netif_sources = [
-        "netif/ethernet.c",
-        "netif/bridgeif.c",
-        "netif/bridgeif_fdb.c",
-    ];
-
-    // App sources (TFTP)
-    let app_sources = ["apps/tftp/tftp.c"];
-
-    // Unix port sources
-    let port_sources = [
-        "ports/unix/port/sys_arch.c",
-        "ports/unix/port/netif/tapif.c",
-        "ports/unix/port/netif/sio.c",
-        "ports/unix/port/netif/fifo.c",
-    ];
-
-    // Build lwIP library
-    let mut builder = cc::Build::new();
-    builder.warnings(false);
-
-    // Add include paths
-    for inc in &includes {
-        builder.include(inc);
-    }
-
-    // Add core sources
-    for src in &core_sources {
-        builder.file(lwip_src.join(src));
-    }
-
-    // Add IPv4 sources
     for src in &ipv4_sources {
         builder.file(lwip_src.join(src));
     }
 
-    // Add IPv6 sources
-    for src in &ipv6_sources {
-        builder.file(lwip_src.join(src));
+    // IPv6 sources (host or baremetal-ipv6)
+    if !is_baremetal || is_baremetal_ipv6 {
+        let ipv6_sources = [
+            "core/ipv6/dhcp6.c",
+            "core/ipv6/ethip6.c",
+            "core/ipv6/icmp6.c",
+            "core/ipv6/inet6.c",
+            "core/ipv6/ip6.c",
+            "core/ipv6/ip6_addr.c",
+            "core/ipv6/ip6_frag.c",
+            "core/ipv6/mld6.c",
+            "core/ipv6/nd6.c",
+        ];
+        for src in &ipv6_sources {
+            builder.file(lwip_src.join(src));
+        }
     }
 
-    // Add netif sources
-    for src in &netif_sources {
-        builder.file(lwip_src.join(src));
+    // Netif sources
+    if is_baremetal {
+        // Only ethernet.c needed for bare-metal (plus ethip6 for IPv6)
+        builder.file(lwip_src.join("netif/ethernet.c"));
+    } else {
+        let netif_sources = [
+            "netif/ethernet.c",
+            "netif/bridgeif.c",
+            "netif/bridgeif_fdb.c",
+        ];
+        for src in &netif_sources {
+            builder.file(lwip_src.join(src));
+        }
     }
 
-    // Add app sources
-    for src in &app_sources {
-        builder.file(lwip_src.join(src));
+    // App sources
+    if !is_baremetal || is_baremetal_tftp {
+        builder.file(lwip_src.join("apps/tftp/tftp.c"));
     }
 
-    // Add port sources
-    for src in &port_sources {
-        builder.file(lwip_contrib.join(src));
+    // Port sources
+    if !is_baremetal {
+        // Unix port sources
+        let port_sources = [
+            "ports/unix/port/sys_arch.c",
+            "ports/unix/port/netif/tapif.c",
+            "ports/unix/port/netif/sio.c",
+            "ports/unix/port/netif/fifo.c",
+        ];
+        for src in &port_sources {
+            builder.file(lwip_contrib.join(src));
+        }
     }
+    // For baremetal: sys_now, sys_arch_protect, and netif callbacks are provided by Rust code
 
     builder.compile("lwip");
 
     // Generate Rust bindings
-    let bindgen_builder = bindgen::Builder::default()
-        .header(include_dir.join("wrapper.h").to_string_lossy())
-        .clang_arg(format!("-I{}", include_dir.display()))
-        .clang_arg(format!("-I{}", lwip_src.join("include").display()))
-        .clang_arg(format!(
-            "-I{}",
-            lwip_contrib.join("ports/unix/port/include").display()
-        ))
+    let mut bindgen_builder = bindgen::Builder::default();
+
+    if is_baremetal {
+        bindgen_builder = bindgen_builder
+            .header(baremetal_include_dir.join("wrapper.h").to_string_lossy())
+            .clang_arg(format!("-I{}", baremetal_include_dir.display()))
+            .clang_arg(format!("-I{}", lwip_src.join("include").display()));
+
+        // Tell clang to target riscv32 for correct struct layouts.
+        // Our baremetal/ dir provides all needed headers (stdint.h, stddef.h,
+        // stdarg.h, string.h, stdlib.h, stdio.h) so no external C library
+        // is required.
+        if target.contains("riscv32") {
+            bindgen_builder = bindgen_builder
+                .clang_arg("--target=riscv32")
+                .clang_arg("-march=rv32imc")
+                .clang_arg("-nostdinc")
+                .clang_arg(format!("-I{}", baremetal_include_dir.display()));
+        }
+
+        // Enable IPv6 defines for bindgen when baremetal-ipv6
+        if is_baremetal_ipv6 {
+            bindgen_builder = bindgen_builder.clang_arg("-DLWIP_BAREMETAL_IPV6=1");
+        }
+
+        // Enable TFTP defines for bindgen when baremetal-tftp
+        if is_baremetal_tftp {
+            bindgen_builder = bindgen_builder.clang_arg("-DLWIP_BAREMETAL_TFTP=1");
+        }
+    } else {
+        bindgen_builder = bindgen_builder
+            .header(include_dir.join("wrapper.h").to_string_lossy())
+            .clang_arg(format!("-I{}", include_dir.display()))
+            .clang_arg(format!("-I{}", lwip_src.join("include").display()))
+            .clang_arg(format!(
+                "-I{}",
+                lwip_contrib.join("ports/unix/port/include").display()
+            ));
+    }
+
+    bindgen_builder = bindgen_builder
         .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
         .allowlist_function("lwip_init")
         .allowlist_function("sys_check_timeouts")
@@ -156,51 +230,77 @@ fn main() {
         .allowlist_function("netif_set_link_callback")
         .allowlist_function("netif_input")
         .allowlist_function("ethernet_input")
-        .allowlist_function("netif_create_ip6_linklocal_address")
-        .allowlist_function("netif_ip6_addr_set_state")
         .allowlist_function("dhcp_start")
         .allowlist_function("dhcp_stop")
         .allowlist_function("dhcp_release")
         .allowlist_function("dhcp_set_struct")
         .allowlist_function("dhcp_supplied_address")
-        .allowlist_function("dhcp6_enable_stateful")
-        .allowlist_function("dhcp6_enable_stateless")
-        .allowlist_function("dhcp6_disable")
-        .allowlist_function("tftp_init_client")
-        .allowlist_function("tftp_get")
-        .allowlist_function("tftp_cleanup")
-        .allowlist_function("tapif_init")
-        .allowlist_function("tapif_poll")
-        .allowlist_function("tapif_select")
         .allowlist_function("ip4_addr_set_zero")
         .allowlist_function("ip4addr_ntoa.*")
         .allowlist_function("ip4addr_aton")
-        .allowlist_function("ip6addr_ntoa.*")
-        .allowlist_function("ip6addr_aton")
         .allowlist_function("pbuf_alloc")
         .allowlist_function("pbuf_free")
         .allowlist_function("pbuf_copy_partial")
         .allowlist_function("etharp_output")
-        .allowlist_function("ethip6_output")
         .allowlist_type("netif")
         .allowlist_type("dhcp")
         .allowlist_type("pbuf")
         .allowlist_type("pbuf_type")
         .allowlist_type("pbuf_layer")
         .allowlist_type("ip4_addr.*")
-        .allowlist_type("ip6_addr.*")
         .allowlist_type("ip_addr.*")
-        .allowlist_type("tftp_context")
         .allowlist_type("err_t")
         .allowlist_type("err_enum_t")
         .allowlist_var("ERR_.*")
         .allowlist_var("NETIF_FLAG_.*")
         .allowlist_var("PBUF_.*")
-        .allowlist_var("IP6_ADDR_.*")
-        .allowlist_var("LWIP_IPV6_NUM_ADDRESSES")
         .derive_debug(true)
         .derive_default(true)
         .use_core();
+
+    // Host-only bindings
+    if !is_baremetal {
+        bindgen_builder = bindgen_builder
+            .allowlist_function("netif_create_ip6_linklocal_address")
+            .allowlist_function("netif_ip6_addr_set_state")
+            .allowlist_function("tftp_init_client")
+            .allowlist_function("tftp_get")
+            .allowlist_function("tftp_cleanup")
+            .allowlist_function("tapif_init")
+            .allowlist_function("tapif_poll")
+            .allowlist_function("tapif_select")
+            .allowlist_function("ip6addr_ntoa.*")
+            .allowlist_function("ip6addr_aton")
+            .allowlist_function("ethip6_output")
+            .allowlist_type("ip6_addr.*")
+            .allowlist_type("tftp_context")
+            .allowlist_var("IP6_ADDR_.*")
+            .allowlist_var("LWIP_IPV6_NUM_ADDRESSES");
+    }
+
+    // Baremetal IPv6 bindings
+    if is_baremetal_ipv6 {
+        bindgen_builder = bindgen_builder
+            .allowlist_function("netif_create_ip6_linklocal_address")
+            .allowlist_function("netif_ip6_addr_set_state")
+            .allowlist_function("dhcp6_enable_stateless")
+            .allowlist_function("dhcp6_disable")
+            .allowlist_function("ip6addr_ntoa.*")
+            .allowlist_function("ethip6_output")
+            .allowlist_type("ip6_addr.*")
+            .allowlist_var("IP6_ADDR_.*")
+            .allowlist_var("LWIP_IPV6_NUM_ADDRESSES");
+    }
+
+    // Baremetal TFTP bindings
+    if is_baremetal_tftp {
+        bindgen_builder = bindgen_builder
+            .allowlist_function("tftp_init_client")
+            .allowlist_function("tftp_get")
+            .allowlist_function("tftp_cleanup")
+            .allowlist_type("tftp_context")
+            .allowlist_type("tftp_transfer_mode");
+    }
 
     let bindings = bindgen_builder
         .generate()
@@ -210,12 +310,25 @@ fn main() {
         .write_to_file(out_dir.join("bindings.rs"))
         .expect("Couldn't write bindings!");
 
-    // Link libraries
-    println!("cargo:rustc-link-lib=pthread");
-    println!("cargo:rustc-link-lib=rt");
-    println!("cargo:rustc-link-lib=util");
+    // Link libraries (host only)
+    if !is_baremetal {
+        println!("cargo:rustc-link-lib=pthread");
+        println!("cargo:rustc-link-lib=rt");
+        println!("cargo:rustc-link-lib=util");
+    }
 
     // Rerun if these change
     println!("cargo:rerun-if-changed=include/wrapper.h");
     println!("cargo:rerun-if-changed=include/lwipopts.h");
+    println!("cargo:rerun-if-changed=include/baremetal/wrapper.h");
+    println!("cargo:rerun-if-changed=include/baremetal/lwipopts.h");
+    println!("cargo:rerun-if-changed=include/baremetal/arch/cc.h");
+    println!("cargo:rerun-if-changed=include/baremetal/arch/sys_arch.h");
+    println!("cargo:rerun-if-changed=include/baremetal/stdint.h");
+    println!("cargo:rerun-if-changed=include/baremetal/stddef.h");
+    println!("cargo:rerun-if-changed=include/baremetal/stdarg.h");
+    println!("cargo:rerun-if-changed=include/baremetal/string.h");
+    println!("cargo:rerun-if-changed=include/baremetal/stdlib.h");
+    println!("cargo:rerun-if-changed=include/baremetal/stdio.h");
+    println!("cargo:rerun-if-changed=src/libc_stubs.c");
 }

--- a/network/net/lwip-rs/include/baremetal/arch/cc.h
+++ b/network/net/lwip-rs/include/baremetal/arch/cc.h
@@ -1,0 +1,59 @@
+// Licensed under the Apache-2.0 license
+
+/**
+ * @file cc.h
+ * Bare-metal RISC-V compiler/platform abstraction for lwIP
+ *
+ * Configures lwIP to not use system headers that aren't available
+ * in a freestanding environment (no libc).
+ */
+
+#ifndef __ARCH_CC_H__
+#define __ARCH_CC_H__
+
+#include <stdint.h>
+#include <stddef.h>
+
+/* Tell lwIP to skip system headers not available in freestanding mode */
+#define LWIP_NO_INTTYPES_H     1
+#define LWIP_NO_LIMITS_H       1
+#define LWIP_NO_CTYPE_H        1
+#define LWIP_NO_UNISTD_H       1
+
+/* Provide format string macros that inttypes.h would normally define */
+#define X8_F  "02x"
+#define U16_F "u"
+#define S16_F "d"
+#define X16_F "x"
+#define U32_F "u"
+#define S32_F "d"
+#define X32_F "x"
+#define SZT_F "u"
+
+/* Provide limits that limits.h would normally define */
+#define INT_MAX     2147483647
+#define SSIZE_MAX   INT_MAX
+
+/* ssize_t for bare-metal */
+typedef int ssize_t;
+
+/* Protection type (used by SYS_LIGHTWEIGHT_PROT) */
+typedef unsigned int sys_prot_t;
+
+/* Random number generator - implemented in Rust */
+extern unsigned int lwip_baremetal_rand(void);
+#define LWIP_RAND() ((u32_t)lwip_baremetal_rand())
+
+/* Diagnostics - disabled for bare-metal (no printf) */
+#define LWIP_PLATFORM_DIAG(x) do { (void)0; } while(0)
+
+/* Assertion - calls into Rust */
+extern void lwip_platform_assert(const char *msg, int line, const char *file);
+#define LWIP_PLATFORM_ASSERT(x) lwip_platform_assert(x, __LINE__, __FILE__)
+
+/* Byte order - RISC-V is little-endian */
+#ifndef BYTE_ORDER
+#define BYTE_ORDER LITTLE_ENDIAN
+#endif
+
+#endif /* __ARCH_CC_H__ */

--- a/network/net/lwip-rs/include/baremetal/arch/sys_arch.h
+++ b/network/net/lwip-rs/include/baremetal/arch/sys_arch.h
@@ -1,0 +1,16 @@
+// Licensed under the Apache-2.0 license
+
+/**
+ * @file sys_arch.h
+ * Bare-metal NO_SYS=1 port - minimal OS abstraction
+ *
+ * With NO_SYS=1, lwIP does not use semaphores, mutexes,
+ * mailboxes, or threads. Only sys_now() is needed.
+ */
+
+#ifndef __ARCH_SYS_ARCH_H__
+#define __ARCH_SYS_ARCH_H__
+
+/* No OS abstractions needed for NO_SYS=1 mode */
+
+#endif /* __ARCH_SYS_ARCH_H__ */

--- a/network/net/lwip-rs/include/baremetal/lwipopts.h
+++ b/network/net/lwip-rs/include/baremetal/lwipopts.h
@@ -1,0 +1,245 @@
+// Licensed under the Apache-2.0 license
+
+/**
+ * @file lwipopts.h
+ * lwIP configuration for bare-metal RISC-V firmware
+ *
+ * Tuned for minimal memory usage while supporting DHCP discovery.
+ */
+
+#ifndef LWIP_LWIPOPTS_H
+#define LWIP_LWIPOPTS_H
+
+#include "lwip/debug.h"
+
+/*
+   -----------------------------------------------
+   ---------- Platform specific locking ----------
+   -----------------------------------------------
+*/
+#define SYS_LIGHTWEIGHT_PROT            1
+#define NO_SYS                          1
+#define LWIP_TIMERS                     1
+#define LWIP_TIMERS_CUSTOM              0
+
+/*
+   ------------------------------------
+   ---------- Memory options ----------
+   ------------------------------------
+   Reduced for bare-metal with limited DCCM.
+*/
+#define MEM_ALIGNMENT                   4
+#ifdef LWIP_BAREMETAL_IPV6
+#define MEM_SIZE                        (4 * 1024)
+#else
+#define MEM_SIZE                        (4 * 1024)
+#endif
+
+#define MEMP_NUM_PBUF                   4
+#define MEMP_NUM_UDP_PCB                2
+#define MEMP_NUM_TCP_PCB                0
+#define MEMP_NUM_TCP_PCB_LISTEN         0
+#define MEMP_NUM_TCP_SEG                0
+#define MEMP_NUM_NETBUF                 0
+#define MEMP_NUM_NETCONN                0
+#ifdef LWIP_BAREMETAL_IPV6
+#define MEMP_NUM_SYS_TIMEOUT            12
+#else
+#define MEMP_NUM_SYS_TIMEOUT            8
+#endif
+
+#ifdef LWIP_BAREMETAL_IPV6
+#define PBUF_POOL_SIZE                  6
+#else
+#define PBUF_POOL_SIZE                  8
+#endif
+#define PBUF_POOL_BUFSIZE               1024
+
+/*
+   ---------------------------------
+   ---------- IP options ----------
+   ---------------------------------
+*/
+#define LWIP_IPV4                       1
+#ifdef LWIP_BAREMETAL_IPV6
+#define LWIP_IPV6                       1
+#else
+#define LWIP_IPV6                       0
+#endif
+#define IP_FORWARD                      0
+#define IP_OPTIONS_ALLOWED              1
+#define IP_REASSEMBLY                   0
+#define IP_FRAG                         0
+#define IP_DEFAULT_TTL                  64
+
+/*
+   ----------------------------------
+   ---------- ICMP options ----------
+   ----------------------------------
+*/
+#define LWIP_ICMP                       1
+#define ICMP_TTL                        64
+
+/*
+   ----------------------------------
+   ---------- DHCP options ----------
+   ----------------------------------
+*/
+#define LWIP_DHCP                       1
+#define DHCP_DOES_ARP_CHECK             0
+#define LWIP_DHCP_BOOTP_FILE            1
+#define LWIP_DHCP_GET_NTP_SRV           0
+
+/*
+   ----------------------------------
+   ---------- IPv6 options ----------
+   ----------------------------------
+*/
+#ifdef LWIP_BAREMETAL_IPV6
+#define LWIP_IPV6_NUM_ADDRESSES         3
+#define LWIP_IPV6_DHCP6                 1
+#define LWIP_IPV6_DHCP6_STATEFUL        0
+#define LWIP_IPV6_AUTOCONFIG            1
+#define LWIP_IPV6_FORWARD               0
+#define LWIP_ICMP6                      1
+#define LWIP_IPV6_MLD                   1
+#define LWIP_IPV6_FRAG                  0
+#define LWIP_IPV6_REASS                 0
+#define LWIP_ND6_ALLOW_RA_UPDATES       1
+#define LWIP_ND6_TCP_REACHABILITY_HINTS 0
+#define LWIP_ND6_NUM_NEIGHBORS          4
+#define LWIP_ND6_NUM_DESTINATIONS       4
+#define LWIP_ND6_NUM_PREFIXES           2
+#define LWIP_ND6_NUM_ROUTERS            1
+#define MEMP_NUM_MLD6_GROUP             2
+#define MEMP_NUM_ND6_QUEUE              2
+#endif /* LWIP_BAREMETAL_IPV6 */
+
+/*
+   ---------------------------------
+   ---------- UDP options ----------
+   ---------------------------------
+*/
+#define LWIP_UDP                        1
+#define UDP_TTL                         64
+
+/*
+   ---------------------------------
+   ---------- TCP options ----------
+   ---------------------------------
+*/
+#define LWIP_TCP                        0
+
+/*
+   -----------------------------------------
+   ---------- ARP options ----------
+   -----------------------------------------
+*/
+#define LWIP_ARP                        1
+#define ARP_TABLE_SIZE                  4
+#define ARP_QUEUEING                    1
+#define ETHARP_SUPPORT_STATIC_ENTRIES   0
+
+/*
+   ------------------------------------
+   ---------- TFTP options ----------
+   ------------------------------------
+*/
+#ifdef LWIP_BAREMETAL_TFTP
+#define LWIP_TFTP                       1
+/* TFTP timeout for the emulator environment.
+   With EMULATOR_CPU_CLOCK_HZ=1000, 1 tick = 1ms virtual.
+   ARP pending entries survive ~5000 ticks (~5ms real), so the first
+   TFTP RRQ typically goes through without needing retransmission.
+   A 5-second virtual timeout is a generous fallback. */
+#define TFTP_MAX_RETRIES                5
+#define TFTP_TIMEOUT_MSECS              5000
+#else
+#define LWIP_TFTP                       0
+#endif
+
+/*
+   ----------------------------------------
+   ---------- Statistics options ----------
+   ----------------------------------------
+*/
+#define LWIP_STATS                      0
+#define LWIP_STATS_DISPLAY              0
+
+/*
+   ---------------------------------------
+   ---------- Debugging options ----------
+   ---------------------------------------
+*/
+#define LWIP_DEBUG                      0
+
+#define ETHARP_DEBUG                    LWIP_DBG_OFF
+#define NETIF_DEBUG                     LWIP_DBG_OFF
+#define PBUF_DEBUG                      LWIP_DBG_OFF
+#define ICMP_DEBUG                      LWIP_DBG_OFF
+#define IP_DEBUG                        LWIP_DBG_OFF
+#define UDP_DEBUG                       LWIP_DBG_OFF
+#define DHCP_DEBUG                      LWIP_DBG_OFF
+#ifdef LWIP_BAREMETAL_IPV6
+#define DHCP6_DEBUG                     LWIP_DBG_OFF
+#define IP6_DEBUG                       LWIP_DBG_OFF
+#define ICMP6_DEBUG                     LWIP_DBG_OFF
+#define ND6_DEBUG                       LWIP_DBG_OFF
+#endif
+
+/*
+   ------------------------------------------
+   ---------- Checksum options ----------
+   ------------------------------------------
+*/
+#define CHECKSUM_GEN_IP                 1
+#define CHECKSUM_GEN_UDP                1
+#define CHECKSUM_GEN_TCP                0
+#define CHECKSUM_GEN_ICMP               1
+#define CHECKSUM_CHECK_IP               1
+#define CHECKSUM_CHECK_UDP              1
+#define CHECKSUM_CHECK_TCP              0
+#define CHECKSUM_CHECK_ICMP             1
+#ifdef LWIP_BAREMETAL_IPV6
+#define CHECKSUM_GEN_ICMP6              1
+#define CHECKSUM_CHECK_ICMP6            1
+#endif
+
+/*
+   ----------------------------------------------
+   ---------- Sequential API options ----------
+   ----------------------------------------------
+*/
+#define LWIP_NETCONN                    0
+#define LWIP_SOCKET                     0
+
+/*
+   ------------------------------------
+   ---------- NETIF options ----------
+   ------------------------------------
+*/
+#define LWIP_NETIF_STATUS_CALLBACK      1
+#define LWIP_NETIF_LINK_CALLBACK        1
+#define LWIP_NETIF_HOSTNAME             0
+#define LWIP_NETIF_API                  0
+#define LWIP_NETIF_TX_SINGLE_PBUF       1
+
+/*
+   ----------------------------------------
+   ---------- Misc options ----------
+   ----------------------------------------
+*/
+#define LWIP_HAVE_LOOPIF                0
+#define LWIP_LOOPBACK_MAX_PBUFS         0
+#define LWIP_SINGLE_NETIF               1
+#define LWIP_PROVIDE_ERRNO              1
+#define LWIP_ETHERNET                   1
+#define ETH_PAD_SIZE                    0
+
+/* Platform-specific assertion macro */
+void lwip_platform_assert(const char *msg, int line, const char *file);
+#ifndef LWIP_PLATFORM_ASSERT
+#define LWIP_PLATFORM_ASSERT(x) lwip_platform_assert(x, __LINE__, __FILE__)
+#endif
+
+#endif /* LWIP_LWIPOPTS_H */

--- a/network/net/lwip-rs/include/baremetal/stdarg.h
+++ b/network/net/lwip-rs/include/baremetal/stdarg.h
@@ -1,0 +1,19 @@
+// Licensed under the Apache-2.0 license
+
+/**
+ * Minimal stdarg.h for lwIP bare-metal builds.
+ *
+ * Uses GCC/Clang built-in variadic argument macros.
+ */
+
+#ifndef _STDARG_H
+#define _STDARG_H
+
+typedef __builtin_va_list va_list;
+
+#define va_start(ap, last) __builtin_va_start(ap, last)
+#define va_end(ap)         __builtin_va_end(ap)
+#define va_arg(ap, type)   __builtin_va_arg(ap, type)
+#define va_copy(dest, src) __builtin_va_copy(dest, src)
+
+#endif /* _STDARG_H */

--- a/network/net/lwip-rs/include/baremetal/stddef.h
+++ b/network/net/lwip-rs/include/baremetal/stddef.h
@@ -1,0 +1,22 @@
+// Licensed under the Apache-2.0 license
+
+/**
+ * Minimal stddef.h for lwIP bare-metal builds (riscv32 ILP32).
+ *
+ * Provides size_t, ptrdiff_t, and NULL without depending on any C library.
+ */
+
+#ifndef _STDDEF_H
+#define _STDDEF_H
+
+typedef unsigned int size_t;
+typedef int          ptrdiff_t;
+
+#ifndef NULL
+#define NULL ((void *)0)
+#endif
+
+/* offsetof macro */
+#define offsetof(type, member) __builtin_offsetof(type, member)
+
+#endif /* _STDDEF_H */

--- a/network/net/lwip-rs/include/baremetal/stdint.h
+++ b/network/net/lwip-rs/include/baremetal/stdint.h
@@ -1,0 +1,70 @@
+// Licensed under the Apache-2.0 license
+
+/**
+ * Minimal stdint.h for lwIP bare-metal builds (riscv32 ILP32).
+ *
+ * Provides fixed-width integer types without depending on any C library.
+ */
+
+#ifndef _STDINT_H
+#define _STDINT_H
+
+/* Exact-width integer types */
+typedef signed char        int8_t;
+typedef unsigned char      uint8_t;
+typedef signed short       int16_t;
+typedef unsigned short     uint16_t;
+typedef signed int         int32_t;
+typedef unsigned int       uint32_t;
+typedef signed long long   int64_t;
+typedef unsigned long long uint64_t;
+
+/* Minimum-width integer types */
+typedef int8_t   int_least8_t;
+typedef uint8_t  uint_least8_t;
+typedef int16_t  int_least16_t;
+typedef uint16_t uint_least16_t;
+typedef int32_t  int_least32_t;
+typedef uint32_t uint_least32_t;
+typedef int64_t  int_least64_t;
+typedef uint64_t uint_least64_t;
+
+/* Fastest minimum-width integer types */
+typedef int32_t  int_fast8_t;
+typedef uint32_t uint_fast8_t;
+typedef int32_t  int_fast16_t;
+typedef uint32_t uint_fast16_t;
+typedef int32_t  int_fast32_t;
+typedef uint32_t uint_fast32_t;
+typedef int64_t  int_fast64_t;
+typedef uint64_t uint_fast64_t;
+
+/* Pointer-width integer types (ILP32) */
+typedef int      intptr_t;
+typedef unsigned uintptr_t;
+
+/* Greatest-width integer types */
+typedef int64_t  intmax_t;
+typedef uint64_t uintmax_t;
+
+/* Limits */
+#define INT8_MIN    (-128)
+#define INT8_MAX    127
+#define UINT8_MAX   255
+#define INT16_MIN   (-32768)
+#define INT16_MAX   32767
+#define UINT16_MAX  65535
+#define INT32_MIN   (-2147483647 - 1)
+#define INT32_MAX   2147483647
+#define UINT32_MAX  4294967295U
+#define INT64_MIN   (-9223372036854775807LL - 1)
+#define INT64_MAX   9223372036854775807LL
+#define UINT64_MAX  18446744073709551615ULL
+
+#define INTPTR_MIN  INT32_MIN
+#define INTPTR_MAX  INT32_MAX
+#define UINTPTR_MAX UINT32_MAX
+
+#define SIZE_MAX    UINT32_MAX
+
+#endif /* _STDINT_H */

--- a/network/net/lwip-rs/include/baremetal/stdio.h
+++ b/network/net/lwip-rs/include/baremetal/stdio.h
@@ -1,0 +1,18 @@
+// Licensed under the Apache-2.0 license
+
+/**
+ * Minimal stdio.h stub for lwIP bare-metal builds.
+ *
+ * lwIP's mem.c includes stdio.h for snprintf, but only uses it under
+ * MEM_OVERFLOW_CHECK which is disabled in our baremetal config.
+ */
+
+#ifndef _STDIO_H
+#define _STDIO_H
+
+#include <stddef.h>
+#include <stdarg.h>
+
+int snprintf(char *str, size_t size, const char *format, ...);
+
+#endif /* _STDIO_H */

--- a/network/net/lwip-rs/include/baremetal/stdlib.h
+++ b/network/net/lwip-rs/include/baremetal/stdlib.h
@@ -1,0 +1,15 @@
+// Licensed under the Apache-2.0 license
+
+/**
+ * Minimal stdlib.h stub for lwIP bare-metal builds.
+ *
+ * Only declares the functions lwIP actually calls.
+ * Implementation is in libc_stubs.c.
+ */
+
+#ifndef _STDLIB_H
+#define _STDLIB_H
+
+int atoi(const char *nptr);
+
+#endif /* _STDLIB_H */

--- a/network/net/lwip-rs/include/baremetal/string.h
+++ b/network/net/lwip-rs/include/baremetal/string.h
@@ -1,0 +1,25 @@
+// Licensed under the Apache-2.0 license
+
+/**
+ * Minimal string.h stub for lwIP bare-metal builds.
+ *
+ * Only declares the functions lwIP actually calls.
+ * Implementations are provided by compiler_builtins (memcpy, memset, memmove,
+ * memcmp) and libc_stubs.c (strlen, strcmp, strncmp, strstr).
+ */
+
+#ifndef _STRING_H
+#define _STRING_H
+
+#include <stddef.h>
+
+void *memcpy(void *dest, const void *src, size_t n);
+void *memset(void *s, int c, size_t n);
+void *memmove(void *dest, const void *src, size_t n);
+int   memcmp(const void *s1, const void *s2, size_t n);
+size_t strlen(const char *s);
+int   strcmp(const char *s1, const char *s2);
+int   strncmp(const char *s1, const char *s2, size_t n);
+char *strstr(const char *haystack, const char *needle);
+
+#endif /* _STRING_H */

--- a/network/net/lwip-rs/include/baremetal/wrapper.h
+++ b/network/net/lwip-rs/include/baremetal/wrapper.h
@@ -1,0 +1,51 @@
+// Licensed under the Apache-2.0 license
+
+/**
+ * Wrapper header for bindgen - bare-metal version
+ * Excludes TAP interface and other host-specific headers.
+ */
+
+#ifndef LWIP_RS_WRAPPER_H
+#define LWIP_RS_WRAPPER_H
+
+/* Core lwIP */
+#include "lwip/init.h"
+#include "lwip/timeouts.h"
+#include "lwip/err.h"
+#include "lwip/pbuf.h"
+#include "lwip/mem.h"
+#include "lwip/memp.h"
+
+/* Network interface */
+#include "lwip/netif.h"
+#include "netif/ethernet.h"
+#include "netif/etharp.h"
+
+/* IPv4 */
+#include "lwip/ip4_addr.h"
+#include "lwip/ip4.h"
+#include "lwip/icmp.h"
+
+/* DHCP */
+#include "lwip/dhcp.h"
+
+/* UDP */
+#include "lwip/udp.h"
+
+/* TFTP (when enabled) */
+#ifdef LWIP_BAREMETAL_TFTP
+#include "lwip/apps/tftp_client.h"
+#include "lwip/apps/tftp_common.h"
+#endif
+
+/* IPv6 (when enabled) */
+#ifdef LWIP_BAREMETAL_IPV6
+#include "lwip/ip6_addr.h"
+#include "lwip/ip6.h"
+#include "lwip/icmp6.h"
+#include "lwip/nd6.h"
+#include "lwip/dhcp6.h"
+#include "lwip/ethip6.h"
+#endif /* LWIP_BAREMETAL_IPV6 */
+
+#endif /* LWIP_RS_WRAPPER_H */

--- a/network/net/lwip-rs/src/ip.rs
+++ b/network/net/lwip-rs/src/ip.rs
@@ -62,10 +62,12 @@ impl From<[u8; 4]> for Ipv4Addr {
 }
 
 /// IPv6 address wrapper
+#[cfg(feature = "ipv6")]
 #[derive(Clone, Copy, Default)]
 #[repr(transparent)]
 pub struct Ipv6Addr(pub(crate) ffi::ip6_addr_t);
 
+#[cfg(feature = "ipv6")]
 impl Ipv6Addr {
     pub fn new(segments: [u16; 8]) -> Self {
         let mut addr = ffi::ip6_addr_t::default();
@@ -74,6 +76,12 @@ impl Ipv6Addr {
         addr.addr[2] = ((segments[5] as u32) << 16) | (segments[4] as u32);
         addr.addr[3] = ((segments[7] as u32) << 16) | (segments[6] as u32);
         Ipv6Addr(addr)
+    }
+
+    /// Create an `Ipv6Addr` from raw `u32[4]` words in lwIP's internal format
+    /// (network byte order per word on little-endian targets).
+    pub const fn from_raw(addr: [u32; 4]) -> Self {
+        Ipv6Addr(ffi::ip6_addr_t { addr })
     }
 
     pub fn any() -> Self {
@@ -103,6 +111,7 @@ impl Ipv6Addr {
     }
 }
 
+#[cfg(feature = "ipv6")]
 impl fmt::Display for Ipv6Addr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let s = self.segments();
@@ -114,6 +123,7 @@ impl fmt::Display for Ipv6Addr {
     }
 }
 
+#[cfg(feature = "ipv6")]
 impl fmt::Debug for Ipv6Addr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Ipv6Addr({})", self)

--- a/network/net/lwip-rs/src/lib.rs
+++ b/network/net/lwip-rs/src/lib.rs
@@ -4,6 +4,14 @@
 //!
 //! Provides safe Rust wrappers for network stack functionality
 //! including DHCP and TFTP.
+//!
+//! ## Features
+//!
+//! - `alloc` - Enable heap-allocated wrappers (NetIf, DhcpClient)
+//! - `baremetal` - Enable bare-metal port (no OS, static storage, custom netif)
+//! - `ipv4`, `ipv6` - IP version support
+//! - `dhcp`, `dhcp6` - DHCP client support
+//! - `tftp` - TFTP client support
 
 #![no_std]
 #![allow(non_upper_case_globals)]
@@ -31,28 +39,43 @@ pub mod ffi {
 pub mod error;
 pub mod ip;
 
-#[cfg(feature = "alloc")]
+#[cfg(all(feature = "alloc", not(feature = "baremetal")))]
 pub mod netif;
 
-#[cfg(feature = "alloc")]
+#[cfg(all(feature = "alloc", not(feature = "baremetal")))]
 pub mod dhcp;
+
+#[cfg(feature = "baremetal")]
+pub mod netif_baremetal;
 
 #[cfg(feature = "tftp")]
 pub mod tftp;
 
+#[cfg(feature = "baremetal-tftp")]
+pub mod tftp_baremetal;
+
 pub mod sys;
 
 pub use error::LwipError;
-pub use ip::{Ipv4Addr, Ipv6Addr};
+pub use ip::Ipv4Addr;
 
-#[cfg(feature = "alloc")]
+#[cfg(any(not(feature = "baremetal"), feature = "baremetal-ipv6"))]
+pub use ip::Ipv6Addr;
+
+#[cfg(all(feature = "alloc", not(feature = "baremetal")))]
 pub use netif::NetIf;
 
-#[cfg(feature = "alloc")]
+#[cfg(all(feature = "alloc", not(feature = "baremetal")))]
 pub use dhcp::DhcpClient;
+
+#[cfg(feature = "baremetal")]
+pub use netif_baremetal::BaremetalNetIf;
 
 #[cfg(feature = "tftp")]
 pub use tftp::{TftpClient, TftpStorageOps};
+
+#[cfg(feature = "baremetal-tftp")]
+pub use tftp_baremetal::{BaremetalTftpClient, BaremetalTftpOps};
 
 /// Initialize the lwIP stack. Must be called before any other lwIP functions.
 pub fn init() {
@@ -79,3 +102,85 @@ pub extern "C" fn lwip_platform_assert(msg: *const c_char, line: c_int, file: *c
         msg_str, file_str, line
     );
 }
+
+#[cfg(feature = "baremetal")]
+mod baremetal_sys {
+    /// Callbacks for lwIP bare-metal system functions.
+    ///
+    /// Must be registered via [`register_sys_callbacks()`](super::register_sys_callbacks)
+    /// before calling [`init()`](super::init).
+    pub struct BaremetalSysCallbacks {
+        /// Return the current system time in milliseconds (monotonically increasing).
+        pub sys_now: fn() -> u32,
+        /// System initialization hook (called once during `lwip_init()`).
+        pub sys_init: fn(),
+        /// Enter a critical section. Returns an opaque value passed to `sys_arch_unprotect`.
+        pub sys_arch_protect: fn() -> u32,
+        /// Exit a critical section.
+        pub sys_arch_unprotect: fn(u32),
+        /// Return a random `u32` value.
+        pub rand: fn() -> u32,
+    }
+
+    static mut CALLBACKS: Option<BaremetalSysCallbacks> = None;
+
+    /// Register the bare-metal system callbacks.
+    ///
+    /// Must be called before `lwip_rs::init()`.
+    pub fn register_sys_callbacks(callbacks: BaremetalSysCallbacks) {
+        unsafe {
+            CALLBACKS = Some(callbacks);
+        }
+    }
+
+    #[no_mangle]
+    pub extern "C" fn sys_now() -> u32 {
+        unsafe {
+            match CALLBACKS {
+                Some(ref cb) => (cb.sys_now)(),
+                None => 0,
+            }
+        }
+    }
+
+    #[no_mangle]
+    pub extern "C" fn sys_init() {
+        unsafe {
+            if let Some(ref cb) = CALLBACKS {
+                (cb.sys_init)();
+            }
+        }
+    }
+
+    #[no_mangle]
+    pub extern "C" fn sys_arch_protect() -> u32 {
+        unsafe {
+            match CALLBACKS {
+                Some(ref cb) => (cb.sys_arch_protect)(),
+                None => 0,
+            }
+        }
+    }
+
+    #[no_mangle]
+    pub extern "C" fn sys_arch_unprotect(val: u32) {
+        unsafe {
+            if let Some(ref cb) = CALLBACKS {
+                (cb.sys_arch_unprotect)(val);
+            }
+        }
+    }
+
+    #[no_mangle]
+    pub extern "C" fn lwip_baremetal_rand() -> u32 {
+        unsafe {
+            match CALLBACKS {
+                Some(ref cb) => (cb.rand)(),
+                None => 0,
+            }
+        }
+    }
+}
+
+#[cfg(feature = "baremetal")]
+pub use baremetal_sys::{register_sys_callbacks, BaremetalSysCallbacks};

--- a/network/net/lwip-rs/src/libc_stubs.c
+++ b/network/net/lwip-rs/src/libc_stubs.c
@@ -1,0 +1,76 @@
+// Licensed under the Apache-2.0 license
+
+/**
+ * Minimal C library stubs for lwIP bare-metal builds.
+ *
+ * Provides only the string/stdlib functions that lwIP calls and are NOT
+ * already supplied by Rust's compiler_builtins (which provides memcpy,
+ * memset, memmove, memcmp).
+ */
+
+#include <stddef.h>
+
+size_t strlen(const char *s)
+{
+    const char *p = s;
+    while (*p)
+        p++;
+    return (size_t)(p - s);
+}
+
+int strcmp(const char *s1, const char *s2)
+{
+    while (*s1 && *s1 == *s2) {
+        s1++;
+        s2++;
+    }
+    return (unsigned char)*s1 - (unsigned char)*s2;
+}
+
+int strncmp(const char *s1, const char *s2, size_t n)
+{
+    while (n && *s1 && *s1 == *s2) {
+        s1++;
+        s2++;
+        n--;
+    }
+    if (n == 0)
+        return 0;
+    return (unsigned char)*s1 - (unsigned char)*s2;
+}
+
+char *strstr(const char *haystack, const char *needle)
+{
+    if (!*needle)
+        return (char *)haystack;
+    for (; *haystack; haystack++) {
+        const char *h = haystack;
+        const char *n = needle;
+        while (*h && *n && *h == *n) {
+            h++;
+            n++;
+        }
+        if (!*n)
+            return (char *)haystack;
+    }
+    return (void *)0;
+}
+
+int atoi(const char *nptr)
+{
+    int result = 0;
+    int sign = 1;
+    while (*nptr == ' ')
+        nptr++;
+    if (*nptr == '-') {
+        sign = -1;
+        nptr++;
+    } else if (*nptr == '+') {
+        nptr++;
+    }
+    while (*nptr >= '0' && *nptr <= '9') {
+        result = result * 10 + (*nptr - '0');
+        nptr++;
+    }
+    return sign * result;
+}

--- a/network/net/lwip-rs/src/netif_baremetal.rs
+++ b/network/net/lwip-rs/src/netif_baremetal.rs
@@ -1,0 +1,390 @@
+// Licensed under the Apache-2.0 license
+
+//! Bare-metal network interface for lwIP.
+//!
+//! Provides a static network interface backed by user-supplied function pointers
+//! for transmit, receive, and MAC address operations. Designed for `no_std`
+//! firmware on bare-metal RISC-V.
+
+use core::mem::MaybeUninit;
+use core::ptr;
+
+use crate::error::{check_err, LwipError, Result};
+use crate::ffi;
+use crate::ip::Ipv4Addr;
+#[cfg(feature = "baremetal-ipv6")]
+use crate::ip::Ipv6Addr;
+
+/// Maximum Ethernet frame size
+const ETH_FRAME_MAX: usize = 1514;
+
+/// Callbacks bridging lwIP to the hardware Ethernet driver.
+pub struct BaremetalCallbacks {
+    /// Send a raw Ethernet frame. Returns true on success.
+    pub transmit: fn(&[u8]) -> bool,
+    /// Receive a raw Ethernet frame into the buffer. Returns number of bytes received (0 if none).
+    pub receive: fn(&mut [u8]) -> usize,
+    /// Get the MAC address of the interface.
+    pub mac_addr: fn() -> [u8; 6],
+    /// Check if there's a received frame available.
+    pub rx_available: fn() -> bool,
+}
+
+/// Bare-metal network interface wrapper.
+///
+/// Must be placed in a `static mut` (or equivalent pinned storage) because
+/// lwIP holds raw C pointers into the `netif` and `dhcp` fields.
+pub struct BaremetalNetIf {
+    /// lwIP netif struct — lwIP holds raw pointers to this
+    netif: MaybeUninit<ffi::netif>,
+    /// lwIP DHCP state — lwIP holds raw pointers to this
+    dhcp: MaybeUninit<ffi::dhcp>,
+    /// Hardware driver callbacks (None until `init()` is called)
+    callbacks: Option<BaremetalCallbacks>,
+    /// Whether DHCP has been started
+    dhcp_started: bool,
+    /// Whether init() has been called successfully
+    initialized: bool,
+}
+
+impl BaremetalNetIf {
+    /// Create an uninitialized `BaremetalNetIf`.
+    pub const fn new() -> Self {
+        Self {
+            netif: MaybeUninit::uninit(),
+            dhcp: MaybeUninit::uninit(),
+            callbacks: None,
+            dhcp_started: false,
+            initialized: false,
+        }
+    }
+
+    /// Initialize the network interface with the provided hardware callbacks.
+    ///
+    /// Must only be called once. `self` must reside in pinned storage
+    /// (e.g. `static mut`) because lwIP retains raw pointers into it.
+    pub fn init(&mut self, callbacks: BaremetalCallbacks) -> Result<()> {
+        unsafe {
+            if self.initialized {
+                return Err(LwipError::AlreadyConnected);
+            }
+
+            // Store callbacks before netif_add (the init callback needs them)
+            self.callbacks = Some(callbacks);
+
+            let netif_ptr = self.netif.as_mut_ptr();
+            ptr::write_bytes(netif_ptr, 0, 1);
+
+            let ip = ffi::ip4_addr_t { addr: 0 };
+            let netmask = ffi::ip4_addr_t { addr: 0 };
+            let gateway = ffi::ip4_addr_t { addr: 0 };
+
+            let state = (self as *mut Self).cast::<core::ffi::c_void>();
+
+            let result = ffi::netif_add(
+                netif_ptr,
+                &ip,
+                &netmask,
+                &gateway,
+                state,
+                Some(baremetal_netif_init),
+                Some(ffi::netif_input),
+            );
+
+            if result.is_null() {
+                self.callbacks = None;
+                return Err(LwipError::Interface);
+            }
+
+            ffi::netif_set_default(netif_ptr);
+            ffi::netif_set_up(netif_ptr);
+            ffi::netif_set_link_up(netif_ptr);
+
+            // IPv6: create link-local address and skip DAD
+            #[cfg(feature = "baremetal-ipv6")]
+            {
+                ffi::netif_create_ip6_linklocal_address(netif_ptr, 1);
+                ffi::netif_ip6_addr_set_state(netif_ptr, 0, 0x30); // IP6_ADDR_PREFERRED
+            }
+
+            self.initialized = true;
+            Ok(())
+        }
+    }
+
+    /// Start the DHCP client on this interface.
+    pub fn dhcp_start(&mut self) -> Result<()> {
+        unsafe {
+            if self.dhcp_started {
+                return Ok(());
+            }
+
+            let netif_ptr = self.netif.as_mut_ptr();
+            let dhcp_ptr = self.dhcp.as_mut_ptr();
+            ptr::write_bytes(dhcp_ptr, 0, 1);
+
+            ffi::dhcp_set_struct(netif_ptr, dhcp_ptr);
+            let err = ffi::dhcp_start(netif_ptr);
+            check_err(err)?;
+            self.dhcp_started = true;
+            Ok(())
+        }
+    }
+
+    /// Check if DHCP has assigned an IP address.
+    pub fn dhcp_has_address(&self) -> bool {
+        unsafe {
+            if !self.dhcp_started {
+                return false;
+            }
+            ffi::dhcp_supplied_address(self.netif.as_ptr() as *mut _) != 0
+        }
+    }
+
+    /// Get the IP address assigned by DHCP.
+    pub fn dhcp_offered_ip(&self) -> Ipv4Addr {
+        unsafe {
+            let dhcp_ptr = self.dhcp.as_ptr();
+            Ipv4Addr((*dhcp_ptr).offered_ip_addr)
+        }
+    }
+
+    /// Get the netmask assigned by DHCP.
+    pub fn dhcp_offered_netmask(&self) -> Ipv4Addr {
+        unsafe {
+            let dhcp_ptr = self.dhcp.as_ptr();
+            Ipv4Addr((*dhcp_ptr).offered_sn_mask)
+        }
+    }
+
+    /// Get the gateway assigned by DHCP.
+    pub fn dhcp_offered_gateway(&self) -> Ipv4Addr {
+        unsafe {
+            let dhcp_ptr = self.dhcp.as_ptr();
+            Ipv4Addr((*dhcp_ptr).offered_gw_addr)
+        }
+    }
+
+    /// Get the DHCP server IP address.
+    pub fn dhcp_server_ip(&self) -> Ipv4Addr {
+        unsafe {
+            let dhcp_ptr = self.dhcp.as_ptr();
+            Ipv4Addr((*dhcp_ptr).offered_si_addr)
+        }
+    }
+
+    /// Get the boot file name from the DHCP response (requires `LWIP_DHCP_BOOTP_FILE = 1`).
+    pub fn dhcp_boot_file_name(&self) -> &[u8] {
+        unsafe {
+            let dhcp_ptr = self.dhcp.as_ptr();
+            let name = &(*dhcp_ptr).boot_file_name;
+            if name[0] == 0 {
+                return &[];
+            }
+            let len = name.iter().position(|&c| c == 0).unwrap_or(name.len());
+            core::slice::from_raw_parts(name.as_ptr() as *const u8, len)
+        }
+    }
+
+    /// Get the current IPv4 address of the interface.
+    pub fn ipv4_addr(&self) -> Ipv4Addr {
+        unsafe {
+            let netif_ptr = self.netif.as_ptr();
+            #[cfg(not(feature = "baremetal-ipv6"))]
+            {
+                Ipv4Addr((*netif_ptr).ip_addr)
+            }
+            #[cfg(feature = "baremetal-ipv6")]
+            {
+                Ipv4Addr((*netif_ptr).ip_addr.u_addr.ip4)
+            }
+        }
+    }
+
+    /// Poll the network interface: process received packets and lwIP timeouts.
+    pub fn poll(&mut self) {
+        unsafe {
+            let netif_ptr = self.netif.as_mut_ptr();
+            let callbacks = self.callbacks.as_ref().unwrap();
+
+            while (callbacks.rx_available)() {
+                let mut buf = [0u8; ETH_FRAME_MAX];
+                let len = (callbacks.receive)(&mut buf);
+                if len == 0 {
+                    break;
+                }
+
+                let p = ffi::pbuf_alloc(
+                    ffi::pbuf_layer_PBUF_RAW,
+                    len as u16,
+                    ffi::pbuf_type_PBUF_POOL,
+                );
+                if p.is_null() {
+                    continue;
+                }
+
+                let mut offset = 0usize;
+                let mut q = p;
+                while !q.is_null() && offset < len {
+                    let chunk_len = core::cmp::min((*q).len as usize, len - offset);
+                    core::ptr::copy_nonoverlapping(
+                        buf.as_ptr().add(offset),
+                        (*q).payload as *mut u8,
+                        chunk_len,
+                    );
+                    offset += chunk_len;
+                    q = (*q).next;
+                }
+
+                let err = ((*netif_ptr).input.unwrap())(p, netif_ptr);
+                if err != 0 {
+                    ffi::pbuf_free(p);
+                }
+            }
+
+            ffi::sys_check_timeouts();
+        }
+    }
+
+    /// Stop DHCP and clean up.
+    pub fn shutdown(&mut self) {
+        unsafe {
+            #[cfg(feature = "baremetal-ipv6")]
+            {
+                ffi::dhcp6_disable(self.netif.as_mut_ptr());
+            }
+            if self.dhcp_started {
+                ffi::dhcp_stop(self.netif.as_mut_ptr());
+                self.dhcp_started = false;
+            }
+            ffi::netif_set_down(self.netif.as_mut_ptr());
+            ffi::netif_remove(self.netif.as_mut_ptr());
+            self.callbacks = None;
+            self.initialized = false;
+        }
+    }
+
+    /// Enable stateless DHCPv6 (obtains DNS config; addresses come via SLAAC).
+    #[cfg(feature = "baremetal-ipv6")]
+    pub fn dhcp6_enable_stateless(&mut self) -> Result<()> {
+        unsafe {
+            let netif_ptr = self.netif.as_mut_ptr();
+            let err = ffi::dhcp6_enable_stateless(netif_ptr);
+            check_err(err)?;
+            Ok(())
+        }
+    }
+
+    /// Check if the interface has a valid global IPv6 address (SLAAC PREFERRED state).
+    #[cfg(feature = "baremetal-ipv6")]
+    pub fn has_global_ipv6_address(&self) -> bool {
+        unsafe {
+            let netif_ptr = self.netif.as_ptr();
+            // LWIP_IPV6_NUM_ADDRESSES = 3: index 0 = link-local, 1-2 = global
+            for i in 1..3u8 {
+                let state = (*netif_ptr).ip6_addr_state[i as usize];
+                // IP6_ADDR_PREFERRED = 0x30
+                if state >= 0x30 {
+                    return true;
+                }
+            }
+            false
+        }
+    }
+
+    /// Get the link-local IPv6 address (index 0).
+    #[cfg(feature = "baremetal-ipv6")]
+    pub fn link_local_ipv6_addr(&self) -> Ipv6Addr {
+        unsafe {
+            let netif_ptr = self.netif.as_ptr();
+            Ipv6Addr((*netif_ptr).ip6_addr[0].u_addr.ip6)
+        }
+    }
+
+    /// Get the first valid global IPv6 address (falls back to index 1).
+    #[cfg(feature = "baremetal-ipv6")]
+    pub fn global_ipv6_addr(&self) -> Ipv6Addr {
+        unsafe {
+            let netif_ptr = self.netif.as_ptr();
+            for i in 1..3usize {
+                let state = (*netif_ptr).ip6_addr_state[i];
+                if state >= 0x30 {
+                    return Ipv6Addr((*netif_ptr).ip6_addr[i].u_addr.ip6);
+                }
+            }
+            // Fallback: return index 1 even if not yet valid
+            Ipv6Addr((*netif_ptr).ip6_addr[1].u_addr.ip6)
+        }
+    }
+}
+
+/// lwIP netif initialization callback.
+unsafe extern "C" fn baremetal_netif_init(netif: *mut ffi::netif) -> ffi::err_t {
+    let instance = &*((*netif).state as *const BaremetalNetIf);
+    let callbacks = instance.callbacks.as_ref().unwrap();
+    let mac = (callbacks.mac_addr)();
+
+    (*netif).name[0] = b'e';
+    (*netif).name[1] = b'n';
+    (*netif).output = Some(ffi::etharp_output);
+    #[cfg(feature = "baremetal-ipv6")]
+    {
+        (*netif).output_ip6 = Some(ffi::ethip6_output);
+    }
+    (*netif).linkoutput = Some(baremetal_linkoutput);
+    (*netif).mtu = 1500;
+    (*netif).hwaddr_len = 6;
+    (*netif).hwaddr[0] = mac[0];
+    (*netif).hwaddr[1] = mac[1];
+    (*netif).hwaddr[2] = mac[2];
+    (*netif).hwaddr[3] = mac[3];
+    (*netif).hwaddr[4] = mac[4];
+    (*netif).hwaddr[5] = mac[5];
+    (*netif).flags = (ffi::NETIF_FLAG_BROADCAST
+        | ffi::NETIF_FLAG_ETHARP
+        | ffi::NETIF_FLAG_ETHERNET
+        | ffi::NETIF_FLAG_LINK_UP) as u8;
+
+    ffi::err_enum_t_ERR_OK as ffi::err_t
+}
+
+/// lwIP linkoutput callback — sends a raw Ethernet frame.
+unsafe extern "C" fn baremetal_linkoutput(netif: *mut ffi::netif, p: *mut ffi::pbuf) -> ffi::err_t {
+    if p.is_null() {
+        return ffi::err_enum_t_ERR_ARG as ffi::err_t;
+    }
+
+    let instance = &*((*netif).state as *const BaremetalNetIf);
+    let callbacks = instance.callbacks.as_ref().unwrap();
+
+    let total_len = (*p).tot_len as usize;
+    if total_len > ETH_FRAME_MAX {
+        return ffi::err_enum_t_ERR_BUF as ffi::err_t;
+    }
+
+    let mut buf = [0u8; ETH_FRAME_MAX];
+    let mut offset = 0usize;
+    let mut q = p;
+    while !q.is_null() {
+        let chunk_len = (*q).len as usize;
+        if offset + chunk_len > ETH_FRAME_MAX {
+            break;
+        }
+        core::ptr::copy_nonoverlapping(
+            (*q).payload as *const u8,
+            buf.as_mut_ptr().add(offset),
+            chunk_len,
+        );
+        offset += chunk_len;
+        q = (*q).next;
+    }
+
+    // Pad to minimum Ethernet frame size (60 bytes excluding FCS).
+    let send_len = if total_len < 60 { 60 } else { total_len };
+
+    if (callbacks.transmit)(&buf[..send_len]) {
+        ffi::err_enum_t_ERR_OK as ffi::err_t
+    } else {
+        ffi::err_enum_t_ERR_IF as ffi::err_t
+    }
+}

--- a/network/net/lwip-rs/src/tftp_baremetal.rs
+++ b/network/net/lwip-rs/src/tftp_baremetal.rs
@@ -1,0 +1,294 @@
+// Licensed under the Apache-2.0 license
+
+//! Bare-metal TFTP client for lwIP (`no_std`, single-threaded).
+//!
+//! The caller provides callbacks to handle received data chunks,
+//! enabling streaming verification without buffering the entire file.
+
+use core::ffi::{c_char, c_int, c_void};
+use core::ptr;
+use core::slice;
+
+use crate::error::{check_err, LwipError, Result};
+use crate::ffi;
+use crate::ip::Ipv4Addr;
+#[cfg(feature = "baremetal-ipv6")]
+use crate::ip::Ipv6Addr;
+
+const TFTP_PORT: u16 = 69;
+
+/// Callbacks for bare-metal TFTP file handling.
+#[derive(Clone, Copy)]
+pub struct BaremetalTftpOps {
+    /// Called for each chunk of received data. Return `true` to continue.
+    pub write: fn(data: &[u8]) -> bool,
+    /// Called when the TFTP server reports an error.
+    pub error: fn(err: i32, msg: &[u8]),
+}
+
+/// Internal state for the bare-metal TFTP client.
+struct TftpState {
+    ops: BaremetalTftpOps,
+    bytes_received: usize,
+    has_error: bool,
+    complete: bool,
+}
+
+/// Sentinel value used as the TFTP "file handle" (lwIP requires non-null).
+static HANDLE_SENTINEL: u8 = 0xAA;
+
+/// Global TFTP state. Safe because bare-metal is single-threaded.
+static mut STATE: Option<TftpState> = None;
+
+/// Open callback — lwIP calls this when starting a transfer.
+unsafe extern "C" fn tftp_open_cb(
+    _fname: *const c_char,
+    _mode: *const c_char,
+    is_write: u8,
+) -> *mut c_void {
+    if is_write == 0 {
+        return ptr::null_mut();
+    }
+
+    if let Some(ref mut s) = STATE {
+        s.bytes_received = 0;
+        s.has_error = false;
+        s.complete = false;
+        return (&HANDLE_SENTINEL as *const u8) as *mut c_void;
+    }
+    ptr::null_mut()
+}
+
+/// Close callback — transfer complete.
+unsafe extern "C" fn tftp_close_cb(_handle: *mut c_void) {
+    if let Some(ref mut s) = STATE {
+        s.complete = true;
+    }
+}
+
+/// Read callback — unused for GET operations.
+unsafe extern "C" fn tftp_read_cb(_handle: *mut c_void, _buf: *mut c_void, _bytes: c_int) -> c_int {
+    -1
+}
+
+/// Write callback — called for each received data block.
+unsafe extern "C" fn tftp_write_cb(_handle: *mut c_void, p: *mut ffi::pbuf) -> c_int {
+    if let Some(ref mut s) = STATE {
+        let mut current = p;
+        while !current.is_null() {
+            let pbuf_ref = &*current;
+            let data = slice::from_raw_parts(pbuf_ref.payload as *const u8, pbuf_ref.len as usize);
+
+            if !(s.ops.write)(data) {
+                s.has_error = true;
+                return -1;
+            }
+            s.bytes_received += data.len();
+            current = pbuf_ref.next;
+        }
+        return 0;
+    }
+    -1
+}
+
+/// Error callback — called when the server sends an error.
+unsafe extern "C" fn tftp_error_cb(
+    _handle: *mut c_void,
+    err: c_int,
+    msg: *const c_char,
+    size: c_int,
+) {
+    if let Some(ref mut s) = STATE {
+        let msg_bytes = if msg.is_null() || size <= 0 {
+            &[] as &[u8]
+        } else {
+            slice::from_raw_parts(msg as *const u8, size as usize)
+        };
+        (s.ops.error)(err as i32, msg_bytes);
+        s.has_error = true;
+        s.complete = true;
+    }
+}
+
+/// Static TFTP context struct passed to `tftp_init_client`.
+static TFTP_CONTEXT: ffi::tftp_context = ffi::tftp_context {
+    open: Some(tftp_open_cb),
+    close: Some(tftp_close_cb),
+    read: Some(tftp_read_cb),
+    write: Some(tftp_write_cb),
+    error: Some(tftp_error_cb),
+};
+
+/// Bare-metal TFTP client.
+///
+/// Place in a `static mut`; call `init()` then `get()` to download.
+pub struct BaremetalTftpClient {
+    initialized: bool,
+}
+
+impl BaremetalTftpClient {
+    /// Create an uninitialized TFTP client.
+    pub const fn new() -> Self {
+        Self { initialized: false }
+    }
+
+    /// Initialize the TFTP client with lwIP. Must be called after `lwip_rs::init()`.
+    pub fn init(&mut self, ops: BaremetalTftpOps) -> Result<()> {
+        unsafe {
+            STATE = Some(TftpState {
+                ops,
+                bytes_received: 0,
+                has_error: false,
+                complete: false,
+            });
+        }
+
+        let err = unsafe { ffi::tftp_init_client(&TFTP_CONTEXT) };
+        check_err(err)?;
+        self.initialized = true;
+        Ok(())
+    }
+
+    /// Initiate a TFTP GET over IPv4.
+    ///
+    /// `filename` must be null-terminated. Poll lwIP until `is_complete()`.
+    pub fn get(&mut self, server: Ipv4Addr, filename: &[u8]) -> Result<()> {
+        if !self.initialized {
+            return Err(LwipError::NotConnected);
+        }
+
+        // Verify filename is null-terminated
+        if filename.is_empty() || filename[filename.len() - 1] != 0 {
+            return Err(LwipError::IllegalArgument);
+        }
+
+        // Reset transfer state
+        unsafe {
+            if let Some(ref mut s) = STATE {
+                s.bytes_received = 0;
+                s.has_error = false;
+                s.complete = false;
+            }
+        }
+
+        // Call open to get the handle
+        let fname_ptr = filename.as_ptr() as *const c_char;
+        let mode_ptr = b"octet\0".as_ptr() as *const c_char;
+        let handle = unsafe { tftp_open_cb(fname_ptr, mode_ptr, 1) };
+        if handle.is_null() {
+            return Err(LwipError::OutOfMemory);
+        }
+
+        let mut server_addr: ffi::ip_addr_t = unsafe { core::mem::zeroed() };
+        #[cfg(not(feature = "baremetal-ipv6"))]
+        {
+            server_addr.addr = server.0.addr;
+        }
+        #[cfg(feature = "baremetal-ipv6")]
+        {
+            server_addr.u_addr.ip4 = server.0;
+            server_addr.type_ = 0; // IPADDR_TYPE_V4
+        }
+
+        let err = unsafe {
+            ffi::tftp_get(
+                handle,
+                &server_addr,
+                TFTP_PORT,
+                fname_ptr,
+                ffi::tftp_transfer_mode_TFTP_MODE_OCTET,
+            )
+        };
+
+        if err != 0 {
+            unsafe { tftp_close_cb(handle) };
+        }
+
+        check_err(err)
+    }
+
+    /// Initiate a TFTP GET over IPv6.
+    ///
+    /// `filename` must be null-terminated. Poll lwIP until `is_complete()`.
+    #[cfg(feature = "baremetal-ipv6")]
+    pub fn get_v6(&mut self, server: Ipv6Addr, filename: &[u8]) -> Result<()> {
+        if !self.initialized {
+            return Err(LwipError::NotConnected);
+        }
+
+        if filename.is_empty() || filename[filename.len() - 1] != 0 {
+            return Err(LwipError::IllegalArgument);
+        }
+
+        unsafe {
+            if let Some(ref mut s) = STATE {
+                s.bytes_received = 0;
+                s.has_error = false;
+                s.complete = false;
+            }
+        }
+
+        // Call open to get the handle
+        let fname_ptr = filename.as_ptr() as *const c_char;
+        let mode_ptr = b"octet\0".as_ptr() as *const c_char;
+        let handle = unsafe { tftp_open_cb(fname_ptr, mode_ptr, 1) };
+        if handle.is_null() {
+            return Err(LwipError::OutOfMemory);
+        }
+
+        let mut server_addr: ffi::ip_addr_t = unsafe { core::mem::zeroed() };
+        server_addr.u_addr.ip6 = server.0;
+        server_addr.type_ = 6;
+
+        let err = unsafe {
+            ffi::tftp_get(
+                handle,
+                &server_addr,
+                TFTP_PORT,
+                fname_ptr,
+                ffi::tftp_transfer_mode_TFTP_MODE_OCTET,
+            )
+        };
+
+        if err != 0 {
+            unsafe { tftp_close_cb(handle) };
+        }
+
+        check_err(err)
+    }
+
+    /// Check if the transfer is complete (success or error).
+    pub fn is_complete(&self) -> bool {
+        unsafe {
+            let ptr = ptr::addr_of!(STATE);
+            (*ptr).as_ref().map(|s| s.complete).unwrap_or(false)
+        }
+    }
+
+    /// Check if the transfer ended with an error.
+    pub fn has_error(&self) -> bool {
+        unsafe {
+            let ptr = ptr::addr_of!(STATE);
+            (*ptr).as_ref().map(|s| s.has_error).unwrap_or(false)
+        }
+    }
+
+    /// Get the total number of bytes received so far.
+    pub fn bytes_received(&self) -> usize {
+        unsafe {
+            let ptr = ptr::addr_of!(STATE);
+            (*ptr).as_ref().map(|s| s.bytes_received).unwrap_or(0)
+        }
+    }
+
+    /// Clean up the TFTP client resources.
+    pub fn cleanup(&mut self) {
+        if self.initialized {
+            unsafe {
+                ffi::tftp_cleanup();
+                STATE = None;
+            }
+            self.initialized = false;
+        }
+    }
+}


### PR DESCRIPTION
Add a bare-metal port of lwip-rs for the network ROM which runs without an OS. This includes:

- Baremetal-specific C headers (arch/cc.h, arch/sys_arch.h, lwipopts.h, wrapper.h) configured for NO_SYS=1 mode
- BaremetalTftpClient: no_std TFTP client with streaming callbacks
- Baremetal system callbacks (sys_now, sys_arch_protect, rand) provided by Rust code instead of OS primitives
