### PR TITLE
[provisioning] move fuse lib generator to crate and build script

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -35,26 +35,6 @@ jobs:
       - name: Run precheckin
         run: cargo xtask precheckin
 
-  xtask-flows:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: Install required packages
-        run: |
-          sudo apt-get update -qy && \
-          sudo apt-get install -qy build-essential curl git && \
-          rustup toolchain install -c clippy,rust-src,llvm-tools,rustfmt,rustc-dev
-
-      - name: Generate test fuse lib
-        run: |
-          cargo xtask autogen-fuse-lib
-
   build-firmware:
     runs-on: e2-standard-8
     timeout-minutes: 60

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3737,6 +3737,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.109",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3933,6 +3975,17 @@ dependencies = [
  "quote",
  "syn 2.0.109",
  "version_check",
+]
+
+[[package]]
+name = "provisioning-fuses"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "hex",
+ "phf",
+ "serde",
+ "serde-hjson",
 ]
 
 [[package]]
@@ -4598,6 +4651,12 @@ dependencies = [
  "time",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "slab"
@@ -5913,6 +5972,7 @@ dependencies = [
  "mcu-rom-common",
  "pldm-fw-pkg",
  "proc-macro2",
+ "provisioning-fuses",
  "quote",
  "registers-generator",
  "registers-systemrdl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ members = [
     "platforms/fpga/rom",
     "platforms/fpga/runtime",
     "platforms/test_harness",
+    "provisioning/fuses/autogen",
     "registers/fuses",
     "registers/generated-emulator",
     "registers/generated-firmware",
@@ -144,6 +145,7 @@ num-derive = "0.4.2"
 num-traits = "0.2"
 openssl = { version = "0.10", features = ["vendored"] }
 pkcs8 = "0.10.2"
+phf = "0.11"
 portable-atomic = "1.7.0"
 p384 = "0.13.0"
 prettyplease = "0.2.37"
@@ -207,6 +209,7 @@ mcu-config-emulator = { path = "platforms/emulator/config" }
 mcu-config-fpga = { path = "platforms/fpga/config" }
 mcu-error = { path = "error" }
 mcu-firmware-bundler = { path = "firmware-bundler" }
+provisioning-fuses = { path = "provisioning/fuses/autogen" }
 mcu-fuses-generator = { path = "registers/fuses" }
 mcu-hw-model = { path = "hw/model" }
 mcu-hw-model-test-fw = { path = "hw/model/test-fw" }

--- a/provisioning/fuses/autogen/Cargo.toml
+++ b/provisioning/fuses/autogen/Cargo.toml
@@ -1,0 +1,19 @@
+# Licensed under the Apache-2.0 license
+
+[package]
+name = "provisioning-fuses"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+anyhow.workspace = true
+hex.workspace = true
+phf = { workspace = true, features = ["macros"] }
+serde = { workspace = true }
+serde-hjson = { workspace = true }
+
+[build-dependencies]
+anyhow.workspace = true
+hex.workspace = true
+serde.workspace = true
+serde-hjson.workspace = true

--- a/provisioning/fuses/autogen/build.rs
+++ b/provisioning/fuses/autogen/build.rs
@@ -1,0 +1,25 @@
+// Licensed under the Apache-2.0 license
+
+use std::path::PathBuf;
+
+#[path = "src/lib_generator.rs"]
+mod lib_generator;
+
+fn main() {
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+    let project_root = PathBuf::from(manifest_dir).join("../../..");
+
+    let otp_mmap = project_root.join(lib_generator::OTP_CTRL_MMAP_DEFAULT_PATH);
+    let otp_values = project_root.join(lib_generator::FUSE_VALUES_DEFAULT_PATH);
+
+    let dest_path = project_root.join(lib_generator::FUSE_LIB_DEFAULT_PATH);
+
+    if let Some(parent) = dest_path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+
+    lib_generator::generate_fuse_values_file(&otp_mmap, &otp_values, &dest_path).unwrap();
+
+    println!("cargo:rerun-if-changed={}", otp_mmap.display());
+    println!("cargo:rerun-if-changed={}", otp_values.display());
+}

--- a/provisioning/fuses/autogen/src/lib.rs
+++ b/provisioning/fuses/autogen/src/lib.rs
@@ -1,0 +1,9 @@
+// Licensed under the Apache-2.0 license
+
+pub mod lib_generator;
+
+include!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../../",
+    "target/provisioning/fuses/test.rs"
+));

--- a/provisioning/fuses/autogen/src/lib_generator.rs
+++ b/provisioning/fuses/autogen/src/lib_generator.rs
@@ -1,0 +1,331 @@
+// Licensed under the Apache-2.0 license
+
+use anyhow::{anyhow, bail, Result};
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::fmt::Write;
+use std::path::Path;
+
+pub const HEADER_PREFIX: &str = r"/*
+Licensed under the Apache-2.0 license.
+";
+
+pub const HEADER_SUFFIX: &str = r"
+*/
+";
+
+pub const SKIP_PARTITIONS: &[&str] = &[
+    "SECRET_MANUF_PARTITION",
+    "SECRET_PROD_PARTITION_0",
+    "SECRET_PROD_PARTITION_1",
+    "SECRET_PROD_PARTITION_2",
+    "SECRET_PROD_PARTITION_3",
+    "LIFE_CYCLE",
+];
+
+/// The default Caliptra Subsystem OTP memory map file.
+pub const OTP_CTRL_MMAP_DEFAULT_PATH: &str =
+    "hw/caliptra-ss/src/fuse_ctrl/data/otp_ctrl_mmap.hjson";
+
+/// Default fuse values for testing provisioning flows.
+pub const FUSE_VALUES_DEFAULT_PATH: &str = "provisioning/fuses/test.hjson";
+
+/// Default fuse library for testing provisioning flows.
+pub const FUSE_LIB_DEFAULT_PATH: &str = "target/provisioning/fuses/test.rs";
+
+#[derive(Debug, Deserialize)]
+pub struct OtpMmap {
+    pub partitions: Vec<OtpPartition>,
+}
+
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)] // Fields are required for HJSON deserialization
+pub struct OtpPartition {
+    pub name: String,
+    pub size: Option<String>, // bytes
+    pub secret: bool,
+    pub items: Vec<OtpPartitionItem>,
+    pub desc: String,
+    pub sw_digest: bool,
+    pub hw_digest: bool,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct OtpPartitionItem {
+    pub name: String,
+    pub size: String, // bytes
+}
+
+#[derive(Debug, PartialEq)]
+pub enum FuseValue {
+    ByteVec(Vec<u8>),
+}
+
+impl FuseValue {
+    pub fn from_hjson_value(val: &serde_hjson::Value) -> Result<Self> {
+        match val {
+            serde_hjson::Value::I64(n) => {
+                let n = *n as u64;
+                Ok(FuseValue::ByteVec(n.to_le_bytes().to_vec()))
+            }
+            serde_hjson::Value::U64(n) => Ok(FuseValue::ByteVec(n.to_le_bytes().to_vec())),
+            serde_hjson::Value::String(s) => {
+                let s = s.trim();
+                let s = s.strip_prefix("0x").unwrap_or(s);
+                let s = s.trim_end_matches(',');
+                let s = s.replace(['_', ' '], "");
+                // hex::decode requires an even number of digits.
+                let s = if s.len() % 2 != 0 {
+                    format!("0{}", s)
+                } else {
+                    s.to_string()
+                };
+                let bytes = hex::decode(s)?;
+                Ok(FuseValue::ByteVec(bytes))
+            }
+            serde_hjson::Value::Array(arr) => {
+                let bytes: Result<Vec<u8>> = arr
+                    .iter()
+                    .map(|v| {
+                        v.as_u64()
+                            .and_then(|n| if n <= 255 { Some(n as u8) } else { None })
+                            .ok_or_else(|| anyhow!("Array elements must be bytes (0-255)"))
+                    })
+                    .collect();
+                Ok(FuseValue::ByteVec(bytes?))
+            }
+            _ => bail!("Unsupported HJSON value type for fuse"),
+        }
+    }
+}
+
+pub fn parse_fuse_values_hjson(path: &Path) -> Result<HashMap<String, FuseValue>> {
+    let content = std::fs::read_to_string(path)?;
+    let raw_map: HashMap<String, serde_hjson::Value> = serde_hjson::from_str(&content)?;
+    let mut result = HashMap::new();
+    for (name, val) in raw_map {
+        result.insert(name, FuseValue::from_hjson_value(&val)?);
+    }
+    Ok(result)
+}
+
+pub fn validate_fuse_values(otp: &OtpMmap, values: &HashMap<String, FuseValue>) -> Result<()> {
+    // Collect all valid fuse item names and their sizes.
+    let mut item_map = HashMap::new();
+    for partition in &otp.partitions {
+        if !SKIP_PARTITIONS.contains(&partition.name.as_str()) {
+            for item in &partition.items {
+                item_map.insert(item.name.clone(), item.size.parse::<usize>()?);
+            }
+        }
+    }
+    // Check if field and value size are valid.
+    for (name, val) in values {
+        let expected_size = item_map
+            .get(name)
+            .ok_or_else(|| anyhow!("Fuse field '{}' not found in OTP map", name))?;
+        let FuseValue::ByteVec(bytes) = val;
+        // Check if the value fits in the fuse field. We allow the value to be
+        // larger than the field size if the extra bytes are all zeros. This
+        // is necessary because HJSON integers are parsed as 8-byte values
+        // (i64/u64). See: https://docs.rs/serde-hjson/latest/serde_hjson/enum.Value.html
+        if bytes.len() > *expected_size && bytes[*expected_size..].iter().any(|&b| b != 0) {
+            bail!(
+                "Value for fuse field '{}' is too large ({} bytes, max {} bytes)",
+                name,
+                bytes.len(),
+                expected_size
+            );
+        }
+    }
+    Ok(())
+}
+
+pub fn generate_phf_fuse_value_lib(
+    otp: &OtpMmap,
+    values: &HashMap<String, FuseValue>,
+) -> Result<String> {
+    let mut output = HEADER_PREFIX.to_string();
+    output.push_str(HEADER_SUFFIX);
+    output.push_str(
+        "\npub static FUSE_VALUES: phf::Map<&'static str, &'static [u8]> = phf::phf_map! {\n",
+    );
+
+    // Sort keys for deterministic output
+    let mut keys: Vec<&String> = values.keys().collect();
+    keys.sort();
+
+    for name in keys {
+        let val = values.get(name).unwrap();
+        let FuseValue::ByteVec(bytes) = val;
+
+        // Find expected size to pad with zeros if needed
+        let mut expected_size = 0;
+        'outer: for p in &otp.partitions {
+            for item in &p.items {
+                if item.name == *name {
+                    expected_size = item.size.parse::<usize>()?;
+                    break 'outer;
+                }
+            }
+        }
+
+        write!(&mut output, "    \"{}\" => &[", name)?;
+        for i in 0..expected_size {
+            let byte = bytes.get(i).cloned().unwrap_or(0);
+            write!(&mut output, "0x{:02x}, ", byte)?;
+        }
+        output.push_str("],\n");
+    }
+
+    output.push_str("};\n");
+
+    Ok(output)
+}
+
+pub fn generate_fuse_values_file(
+    otp_mmap_path: &Path,
+    otp_values_path: &Path,
+    out_lib_path: &Path,
+) -> Result<()> {
+    let otp_mmap_content = std::fs::read_to_string(otp_mmap_path)?;
+    let otp_mmap: OtpMmap = serde_hjson::from_str(&otp_mmap_content)?;
+    let otp_values = parse_fuse_values_hjson(otp_values_path)?;
+    validate_fuse_values(&otp_mmap, &otp_values)?;
+
+    let lib_content = generate_phf_fuse_value_lib(&otp_mmap, &otp_values)?;
+    std::fs::write(out_lib_path, lib_content)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_fuse_value_from_number() {
+        let val = serde_hjson::Value::U64(0x1234);
+        let fuse_val = FuseValue::from_hjson_value(&val).unwrap();
+        let FuseValue::ByteVec(bytes) = fuse_val;
+        // 0x1234 in little-endian is [0x34, 0x12, 0, 0, 0, 0, 0, 0]
+        assert_eq!(bytes[0], 0x34);
+        assert_eq!(bytes[1], 0x12);
+        assert_eq!(bytes.len(), 8);
+    }
+
+    #[test]
+    fn test_fuse_value_from_hex_string() {
+        // With 0x
+        let val = serde_hjson::Value::String("0xDEADBEEF".to_string());
+        let fuse_val = FuseValue::from_hjson_value(&val).unwrap();
+        assert_eq!(fuse_val, FuseValue::ByteVec(vec![0xDE, 0xAD, 0xBE, 0xEF]));
+
+        // Without 0x
+        let val = serde_hjson::Value::String("CAFEBABE".to_string());
+        let fuse_val = FuseValue::from_hjson_value(&val).unwrap();
+        assert_eq!(fuse_val, FuseValue::ByteVec(vec![0xCA, 0xFE, 0xBA, 0xBE]));
+
+        // With underscores and spaces
+        let val = serde_hjson::Value::String("0xDE AD_BE EF".to_string());
+        let fuse_val = FuseValue::from_hjson_value(&val).unwrap();
+        assert_eq!(fuse_val, FuseValue::ByteVec(vec![0xDE, 0xAD, 0xBE, 0xEF]));
+
+        // With trailing comma (HJSON artifact)
+        let val = serde_hjson::Value::String("0x1234,".to_string());
+        let fuse_val = FuseValue::from_hjson_value(&val).unwrap();
+        assert_eq!(fuse_val, FuseValue::ByteVec(vec![0x12, 0x34]));
+
+        // With odd number of digits
+        let val = serde_hjson::Value::String("0x123".to_string());
+        let fuse_val = FuseValue::from_hjson_value(&val).unwrap();
+        assert_eq!(fuse_val, FuseValue::ByteVec(vec![0x01, 0x23]));
+    }
+
+    #[test]
+    fn test_fuse_value_from_array() {
+        let val = serde_hjson::Value::Array(vec![
+            serde_hjson::Value::U64(1),
+            serde_hjson::Value::U64(2),
+            serde_hjson::Value::U64(3),
+            serde_hjson::Value::U64(4),
+        ]);
+        let fuse_val = FuseValue::from_hjson_value(&val).unwrap();
+        assert_eq!(fuse_val, FuseValue::ByteVec(vec![1, 2, 3, 4]));
+    }
+
+    #[test]
+    fn test_fuse_value_invalid_string() {
+        let val = serde_hjson::Value::String("not hex".to_string());
+        let res = FuseValue::from_hjson_value(&val);
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn test_validate_fuse_values() {
+        let otp = OtpMmap {
+            partitions: vec![OtpPartition {
+                name: "P1".to_string(),
+                size: Some("4".to_string()),
+                secret: false,
+                items: vec![OtpPartitionItem {
+                    name: "F1".to_string(),
+                    size: "4".to_string(),
+                }],
+                desc: "".to_string(),
+                sw_digest: false,
+                hw_digest: false,
+            }],
+        };
+
+        let mut values = HashMap::new();
+        values.insert("F1".to_string(), FuseValue::ByteVec(vec![1, 2, 3, 4]));
+
+        assert!(validate_fuse_values(&otp, &values).is_ok());
+
+        // Test missing field
+        values.insert("F2".to_string(), FuseValue::ByteVec(vec![1]));
+        assert!(validate_fuse_values(&otp, &values).is_err());
+        values.remove("F2");
+
+        // Test value too large
+        values.insert("F1".to_string(), FuseValue::ByteVec(vec![1, 2, 3, 4, 5]));
+        assert!(validate_fuse_values(&otp, &values).is_err());
+
+        // Test value from number (will be 8 bytes) for a 4-byte fuse
+        let val = serde_hjson::Value::U64(1);
+        values.insert("F1".to_string(), FuseValue::from_hjson_value(&val).unwrap());
+        // This should now PASS because the extra 4 bytes are zero
+        assert!(validate_fuse_values(&otp, &values).is_ok());
+
+        // Test value from number that is actually too large
+        let val = serde_hjson::Value::U64(0x1_0000_0000);
+        values.insert("F1".to_string(), FuseValue::from_hjson_value(&val).unwrap());
+        assert!(validate_fuse_values(&otp, &values).is_err());
+    }
+
+    #[test]
+    fn test_generate_phf_library() {
+        let otp = OtpMmap {
+            partitions: vec![OtpPartition {
+                name: "P1".to_string(),
+                size: Some("4".to_string()),
+                secret: false,
+                items: vec![OtpPartitionItem {
+                    name: "F1".to_string(),
+                    size: "4".to_string(),
+                }],
+                desc: "".to_string(),
+                sw_digest: false,
+                hw_digest: false,
+            }],
+        };
+
+        let mut values_map = HashMap::new();
+        values_map.insert("F1".to_string(), FuseValue::ByteVec(vec![0xAA, 0xBB]));
+
+        let lib = generate_phf_fuse_value_lib(&otp, &values_map).unwrap();
+        assert!(lib.contains("pub static FUSE_VALUES"));
+        assert!(lib.contains("phf::phf_map!"));
+        assert!(lib.contains("\"F1\" => &[0xaa, 0xbb, 0x00, 0x00, ]"));
+    }
+}

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -30,6 +30,7 @@ mcu-builder.workspace = true
 mcu-config-emulator.workspace = true
 mcu-config-fpga.workspace = true
 mcu-firmware-bundler.workspace = true
+provisioning-fuses.workspace = true
 mcu-rom-common.workspace = true
 mcu-hw-model = { workspace = true, optional = true }
 mcu-fuses-generator.workspace = true

--- a/xtask/src/fuses.rs
+++ b/xtask/src/fuses.rs
@@ -1,56 +1,17 @@
 // Licensed under the Apache-2.0 license
 
-use crate::registers::{file_check_contents, rustfmt, write_file, HEADER_PREFIX, HEADER_SUFFIX};
-use anyhow::{anyhow, bail, Result};
+use crate::registers::{file_check_contents, rustfmt, write_file};
+use anyhow::Result;
 use mcu_builder::PROJECT_ROOT;
+use provisioning_fuses::lib_generator::{
+    OtpMmap, HEADER_PREFIX, HEADER_SUFFIX, OTP_CTRL_MMAP_DEFAULT_PATH, SKIP_PARTITIONS,
+};
 use registers_generator::snake_case;
-use serde::Deserialize;
-use std::collections::HashMap;
 use std::fmt::Write;
 use std::path::{Path, PathBuf};
 
-// The default Caliptra Subsystem OTP memory map file.
-const OTP_CTRL_MMAP_DEFAULT_PATH: &str = "hw/caliptra-ss/src/fuse_ctrl/data/otp_ctrl_mmap.hjson";
-
-// Default fuse values for testing provisioning flows.
-const FUSE_VALUES_DEFAULT_PATH: &str = "provisioning/fuses/test.hjson";
-
-// Default fuse library for testing provisioning flows.
-const FUSE_LIB_DEFAULT_PATH: &str = "provisioning/fuses/test.rs";
-
 // Default in-field provisioning fuse configuration.
 const IFP_SPECIFIC_FUSES_DEFAULT_PATH: &str = "hw/fuses.hjson";
-
-const SKIP_PARTITIONS: &[&str] = &[
-    "SECRET_MANUF_PARTITION",
-    "SECRET_PROD_PARTITION_0",
-    "SECRET_PROD_PARTITION_1",
-    "SECRET_PROD_PARTITION_2",
-    "SECRET_PROD_PARTITION_3",
-    "LIFE_CYCLE",
-];
-
-#[derive(Debug, Deserialize)]
-struct OtpMmap {
-    partitions: Vec<OtpPartition>,
-}
-
-#[derive(Debug, Deserialize)]
-struct OtpPartition {
-    name: String,
-    size: Option<String>, // bytes
-    secret: bool,
-    items: Vec<OtpPartitionItem>,
-    desc: String,
-    sw_digest: bool,
-    hw_digest: bool,
-}
-
-#[derive(Debug, Deserialize)]
-struct OtpPartitionItem {
-    name: String,
-    size: String, // bytes
-}
 
 fn get_file_path_or_default(input_path: Option<&Path>, default: &str) -> PathBuf {
     if let Some(path) = input_path {
@@ -123,159 +84,6 @@ pub(crate) fn autogen_fuses(
     Ok(())
 }
 
-/// Generate a rust library with static fuse values for use during manufacturing provisioning.
-pub(crate) fn autogen_fuse_lib(
-    otp_mmap_hjson_path: Option<&Path>,
-    otp_values_hjson_path: Option<&Path>,
-    lib_path: Option<&Path>,
-) -> Result<()> {
-    // Get input / output file paths.
-    let otp_mmap_path = get_file_path_or_default(otp_mmap_hjson_path, OTP_CTRL_MMAP_DEFAULT_PATH);
-    let otp_values_path = get_file_path_or_default(otp_values_hjson_path, FUSE_VALUES_DEFAULT_PATH);
-    let out_lib_path = get_file_path_or_default(lib_path, FUSE_LIB_DEFAULT_PATH);
-
-    // Parse OTP memory map and desired fuse values.
-    let otp_mmap_content = std::fs::read_to_string(otp_mmap_path)?;
-    let otp_mmap: OtpMmap = serde_hjson::from_str(&otp_mmap_content)?;
-    let otp_values = parse_fuse_values_hjson(&otp_values_path)?;
-    validate_fuse_values(&otp_mmap, &otp_values)?;
-    println!("Parsed fuse config from: {:?}", otp_values_path);
-
-    // Generate the rust library.
-    let lib_content = generate_phf_fuse_value_lib(&otp_mmap, &otp_values)?;
-    write_file(&out_lib_path, &rustfmt(&lib_content)?)?;
-    println!("Generated fuse config library: {:?}", out_lib_path);
-
-    Ok(())
-}
-
-#[derive(Debug, PartialEq)]
-enum FuseValue {
-    ByteVec(Vec<u8>),
-}
-
-impl FuseValue {
-    fn from_hjson_value(val: &serde_hjson::Value) -> Result<Self> {
-        match val {
-            serde_hjson::Value::I64(n) => {
-                let n = *n as u64;
-                Ok(FuseValue::ByteVec(n.to_le_bytes().to_vec()))
-            }
-            serde_hjson::Value::U64(n) => Ok(FuseValue::ByteVec(n.to_le_bytes().to_vec())),
-            serde_hjson::Value::String(s) => {
-                let s = s.trim();
-                let s = s.strip_prefix("0x").unwrap_or(s);
-                let s = s.trim_end_matches(',');
-                let s = s.replace(['_', ' '], "");
-                // hex::decode requires an even number of digits.
-                let s = if s.len() % 2 != 0 {
-                    format!("0{}", s)
-                } else {
-                    s.to_string()
-                };
-                let bytes = hex::decode(s)?;
-                Ok(FuseValue::ByteVec(bytes))
-            }
-            serde_hjson::Value::Array(arr) => {
-                let bytes: Result<Vec<u8>> = arr
-                    .iter()
-                    .map(|v| {
-                        v.as_u64()
-                            .and_then(|n| if n <= 255 { Some(n as u8) } else { None })
-                            .ok_or_else(|| anyhow!("Array elements must be bytes (0-255)"))
-                    })
-                    .collect();
-                Ok(FuseValue::ByteVec(bytes?))
-            }
-            _ => bail!("Unsupported HJSON value type for fuse"),
-        }
-    }
-}
-
-fn parse_fuse_values_hjson(path: &Path) -> Result<HashMap<String, FuseValue>> {
-    let content = std::fs::read_to_string(path)?;
-    let raw_map: HashMap<String, serde_hjson::Value> = serde_hjson::from_str(&content)?;
-    let mut result = HashMap::new();
-    for (name, val) in raw_map {
-        result.insert(name, FuseValue::from_hjson_value(&val)?);
-    }
-    Ok(result)
-}
-
-fn validate_fuse_values(otp: &OtpMmap, values: &HashMap<String, FuseValue>) -> Result<()> {
-    // Collect all valid fuse item names and their sizes.
-    let mut item_map = HashMap::new();
-    for partition in &otp.partitions {
-        if !SKIP_PARTITIONS.contains(&partition.name.as_str()) {
-            for item in &partition.items {
-                item_map.insert(item.name.clone(), item.size.parse::<usize>()?);
-            }
-        }
-    }
-    // Check if field and value size are valid.
-    for (name, val) in values {
-        let expected_size = item_map
-            .get(name)
-            .ok_or_else(|| anyhow!("Fuse field '{}' not found in OTP map", name))?;
-        let FuseValue::ByteVec(bytes) = val;
-        // Check if the value fits in the fuse field. We allow the value to be
-        // larger than the field size if the extra bytes are all zeros. This
-        // is necessary because HJSON integers are parsed as 8-byte values
-        // (i64/u64). See: https://docs.rs/serde-hjson/latest/serde_hjson/enum.Value.html
-        if bytes.len() > *expected_size && bytes[*expected_size..].iter().any(|&b| b != 0) {
-            bail!(
-                "Value for fuse field '{}' is too large ({} bytes, max {} bytes)",
-                name,
-                bytes.len(),
-                expected_size
-            );
-        }
-    }
-    Ok(())
-}
-
-fn generate_phf_fuse_value_lib(
-    otp: &OtpMmap,
-    values: &HashMap<String, FuseValue>,
-) -> Result<String> {
-    let mut output = HEADER_PREFIX.to_string();
-    output.push_str(HEADER_SUFFIX);
-    output.push_str(
-        "\npub static FUSE_VALUES: phf::Map<&'static str, &'static [u8]> = phf::phf_map! {\n",
-    );
-
-    // Sort keys for deterministic output
-    let mut keys: Vec<&String> = values.keys().collect();
-    keys.sort();
-
-    for name in keys {
-        let val = values.get(name).unwrap();
-        let FuseValue::ByteVec(bytes) = val;
-
-        // Find expected size to pad with zeros if needed
-        let mut expected_size = 0;
-        'outer: for p in &otp.partitions {
-            for item in &p.items {
-                if item.name == *name {
-                    expected_size = item.size.parse::<usize>()?;
-                    break 'outer;
-                }
-            }
-        }
-
-        write!(&mut output, "    \"{}\" => &[", name)?;
-        for i in 0..expected_size {
-            let byte = bytes.get(i).cloned().unwrap_or(0);
-            write!(&mut output, "0x{:02x}, ", byte)?;
-        }
-        output.push_str("],\n");
-    }
-
-    output.push_str("};\n");
-
-    Ok(output)
-}
-
 /// Build a map of partition name → PartitionMmapInfo from the parsed OTP mmap.
 fn build_partition_mmap(
     otp: &OtpMmap,
@@ -284,7 +92,6 @@ fn build_partition_mmap(
 
     let mut map = std::collections::HashMap::new();
     let mut offset: usize = 0;
-
     for (partition_index, partition) in otp.partitions.iter().enumerate() {
         let digest_size: usize = if partition.hw_digest || partition.sw_digest {
             8
@@ -356,6 +163,7 @@ fn generate_fuse_partitions_from_otp(otp: &OtpMmap) -> Result<String> {
     default_impl_output += "Self {\n";
     let mut const_output = "".to_string();
     let mut offset = 0;
+
     otp.partitions.iter().for_each(|partition| {
         let name = snake_case(&partition.name);
         let digest_size: usize = if partition.hw_digest || partition.sw_digest {
@@ -457,136 +265,4 @@ fn generate_detailed_fuses(
     let generated_code =
         mcu_fuses_generator::codegen::generate_fuses(&config, Some(partition_mmap))?;
     Ok(generated_code)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_fuse_value_from_number() {
-        let val = serde_hjson::Value::U64(0x1234);
-        let fuse_val = FuseValue::from_hjson_value(&val).unwrap();
-        let FuseValue::ByteVec(bytes) = fuse_val;
-        // 0x1234 in little-endian is [0x34, 0x12, 0, 0, 0, 0, 0, 0]
-        assert_eq!(bytes[0], 0x34);
-        assert_eq!(bytes[1], 0x12);
-        assert_eq!(bytes.len(), 8);
-    }
-
-    #[test]
-    fn test_fuse_value_from_hex_string() {
-        // With 0x
-        let val = serde_hjson::Value::String("0xDEADBEEF".to_string());
-        let fuse_val = FuseValue::from_hjson_value(&val).unwrap();
-        assert_eq!(fuse_val, FuseValue::ByteVec(vec![0xDE, 0xAD, 0xBE, 0xEF]));
-
-        // Without 0x
-        let val = serde_hjson::Value::String("CAFEBABE".to_string());
-        let fuse_val = FuseValue::from_hjson_value(&val).unwrap();
-        assert_eq!(fuse_val, FuseValue::ByteVec(vec![0xCA, 0xFE, 0xBA, 0xBE]));
-
-        // With underscores and spaces
-        let val = serde_hjson::Value::String("0xDE AD_BE EF".to_string());
-        let fuse_val = FuseValue::from_hjson_value(&val).unwrap();
-        assert_eq!(fuse_val, FuseValue::ByteVec(vec![0xDE, 0xAD, 0xBE, 0xEF]));
-
-        // With trailing comma (HJSON artifact)
-        let val = serde_hjson::Value::String("0x1234,".to_string());
-        let fuse_val = FuseValue::from_hjson_value(&val).unwrap();
-        assert_eq!(fuse_val, FuseValue::ByteVec(vec![0x12, 0x34]));
-
-        // With odd number of digits
-        let val = serde_hjson::Value::String("0x123".to_string());
-        let fuse_val = FuseValue::from_hjson_value(&val).unwrap();
-        assert_eq!(fuse_val, FuseValue::ByteVec(vec![0x01, 0x23]));
-    }
-
-    #[test]
-    fn test_fuse_value_from_array() {
-        let val = serde_hjson::Value::Array(vec![
-            serde_hjson::Value::U64(1),
-            serde_hjson::Value::U64(2),
-            serde_hjson::Value::U64(3),
-            serde_hjson::Value::U64(4),
-        ]);
-        let fuse_val = FuseValue::from_hjson_value(&val).unwrap();
-        assert_eq!(fuse_val, FuseValue::ByteVec(vec![1, 2, 3, 4]));
-    }
-
-    #[test]
-    fn test_fuse_value_invalid_string() {
-        let val = serde_hjson::Value::String("not hex".to_string());
-        let res = FuseValue::from_hjson_value(&val);
-        assert!(res.is_err());
-    }
-
-    #[test]
-    fn test_validate_fuse_values() {
-        let otp = OtpMmap {
-            partitions: vec![OtpPartition {
-                name: "P1".to_string(),
-                size: Some("4".to_string()),
-                secret: false,
-                items: vec![OtpPartitionItem {
-                    name: "F1".to_string(),
-                    size: "4".to_string(),
-                }],
-                desc: "".to_string(),
-                sw_digest: false,
-                hw_digest: false,
-            }],
-        };
-
-        let mut values = HashMap::new();
-        values.insert("F1".to_string(), FuseValue::ByteVec(vec![1, 2, 3, 4]));
-
-        assert!(validate_fuse_values(&otp, &values).is_ok());
-
-        // Test missing field
-        values.insert("F2".to_string(), FuseValue::ByteVec(vec![1]));
-        assert!(validate_fuse_values(&otp, &values).is_err());
-        values.remove("F2");
-
-        // Test value too large
-        values.insert("F1".to_string(), FuseValue::ByteVec(vec![1, 2, 3, 4, 5]));
-        assert!(validate_fuse_values(&otp, &values).is_err());
-
-        // Test value from number (will be 8 bytes) for a 4-byte fuse
-        let val = serde_hjson::Value::U64(1);
-        values.insert("F1".to_string(), FuseValue::from_hjson_value(&val).unwrap());
-        // This should now PASS because the extra 4 bytes are zero
-        assert!(validate_fuse_values(&otp, &values).is_ok());
-
-        // Test value from number that is actually too large
-        let val = serde_hjson::Value::U64(0x1_0000_0000);
-        values.insert("F1".to_string(), FuseValue::from_hjson_value(&val).unwrap());
-        assert!(validate_fuse_values(&otp, &values).is_err());
-    }
-
-    #[test]
-    fn test_generate_phf_library() {
-        let otp = OtpMmap {
-            partitions: vec![OtpPartition {
-                name: "P1".to_string(),
-                size: Some("4".to_string()),
-                secret: false,
-                items: vec![OtpPartitionItem {
-                    name: "F1".to_string(),
-                    size: "4".to_string(),
-                }],
-                desc: "".to_string(),
-                sw_digest: false,
-                hw_digest: false,
-            }],
-        };
-
-        let mut values = HashMap::new();
-        values.insert("F1".to_string(), FuseValue::ByteVec(vec![0xAA, 0xBB]));
-
-        let lib = generate_phf_fuse_value_lib(&otp, &values).unwrap();
-        assert!(lib.contains("pub static FUSE_VALUES"));
-        assert!(lib.contains("phf::phf_map!"));
-        assert!(lib.contains("\"F1\" => &[0xaa, 0xbb, 0x00, 0x00, ]"));
-    }
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -223,20 +223,6 @@ enum Commands {
         #[arg(long)]
         otp_mmap_hjson: Option<PathBuf>,
     },
-    /// Generate a rust library with static fuse values.
-    AutogenFuseLib {
-        /// Path to otp_ctrl_mmap.hjson file. Default: hw/caliptra-ss/src/fuse_ctrl/data/otp_ctrl_mmap.hjson
-        #[arg(long)]
-        otp_mmap_hjson: Option<PathBuf>,
-
-        /// Path to fuse values HJSON file.
-        #[arg(long)]
-        otp_values_hjson: Option<PathBuf>,
-
-        /// Path to output rust library file.
-        #[arg(long)]
-        otp_values_lib: Option<PathBuf>,
-    },
     /// Check dependencies
     Deps,
     /// Manage FPGA Life cycle
@@ -490,15 +476,6 @@ fn main() {
             addrmap,
             fuses_hjson.as_deref(),
             otp_mmap_hjson.as_deref(),
-        ),
-        Commands::AutogenFuseLib {
-            otp_mmap_hjson,
-            otp_values_hjson,
-            otp_values_lib,
-        } => fuses::autogen_fuse_lib(
-            otp_mmap_hjson.as_deref(),
-            otp_values_hjson.as_deref(),
-            otp_values_lib.as_deref(),
         ),
         Commands::Deps => deps::check(),
         #[cfg(feature = "fpga_realtime")]

--- a/xtask/src/registers.rs
+++ b/xtask/src/registers.rs
@@ -3,6 +3,7 @@
 use anyhow::{anyhow, bail, Result};
 use mcu_builder::PROJECT_ROOT;
 use proc_macro2::{Ident, Literal, TokenStream};
+use provisioning_fuses::lib_generator::{HEADER_PREFIX, HEADER_SUFFIX};
 use quote::{format_ident, quote};
 use registers_generator::{
     camel_case, has_single_32_bit_field, hex_const, snake_case, FieldType, Register, RegisterBlock,
@@ -20,14 +21,6 @@ use std::str::FromStr;
 use std::sync::LazyLock;
 
 use crate::fuses::autogen_fuses;
-
-pub(crate) static HEADER_PREFIX: &str = r"/*
-Licensed under the Apache-2.0 license.
-";
-
-pub(crate) static HEADER_SUFFIX: &str = r"
-*/
-";
 
 static SKIP_TYPES: LazyLock<HashSet<&str>> = LazyLock::new(|| {
     HashSet::from([


### PR DESCRIPTION
This fixes #948. In doing so, we remove the legacy xtask flow.