### PR TITLE
Fix emulator MCI warm reset reason handling to distinguish fresh vs stale FW update bits

### DIFF
--- a/emulator/periph/src/mci.rs
+++ b/emulator/periph/src/mci.rs
@@ -2,9 +2,7 @@
 
 use crate::mcu_mbox0::McuMailbox0Internal;
 use crate::reset_reason::ResetReasonEmulator;
-use caliptra_emu_bus::{
-    ActionHandle, Bus, BusMmio, Clock, Ram, ReadWriteRegister, Timer, TimerAction,
-};
+use caliptra_emu_bus::{ActionHandle, BusMmio, Clock, ReadWriteRegister, Timer, TimerAction};
 use caliptra_emu_cpu::Irq;
 use caliptra_emu_periph::SocToCaliptraBus;
 use caliptra_emu_types::RvData;


### PR DESCRIPTION
## Summary

Fixes the emulator MCI reset reason register logic so that firmware update bits (`FW_BOOT_UPD_RESET`, `FW_HITLESS_UPD_RESET`) written by Caliptra via DMA are correctly preserved on the **first** MCU reset request after cold boot, and correctly cleared as stale on subsequent warm resets.

## Problem

Previously, `write_mci_reg_reset_request` would unconditionally call `handle_warm_reset()` whenever the reset reason was zero or already set to `WARM_RESET`. This meant:
- On the first reset after cold boot, if Caliptra had written FW update bits via DMA before MCU_REQ, those bits could be overwritten with `WARM_RESET`.
- On subsequent resets, stale FW update bits from a previous cycle were never cleared.

## Changes

All changes are in `emulator/periph/src/mci.rs`:

### New `reset_cycle_complete` field on `Mci`
- Tracks whether the current reset cycle has completed, distinguishing fresh FW update bits (written by Caliptra for the current reset) from stale bits left over from a prior cycle.
- Initialized to `false`; set to `true` when a reboot completes in `poll()`.

### Revised reset reason logic in `write_mci_reg_reset_request`
- Checks whether FW update bits (`FW_BOOT_UPD_RESET` or `FW_HITLESS_UPD_RESET`) are present **and** the reset cycle has not yet completed.
  - If so, preserves the Caliptra-written FW update bits (first reset after cold boot).
  - Otherwise, calls `handle_warm_reset()` to clear stale FW bits and set `WARM_RESET`, matching the hardware spec behavior of `mci_rst_b` toggle.

### Restructured hitless update coordination in `poll()`
- Moved the `ss_generic_fw_exec_ctrl` register read inside the `is_hitless_update` branch so it is only performed when actually needed (hitless updates), improving clarity.
- Sets `reset_cycle_complete = true` when the MCU proceeds with reboot.

### New unit tests
- `test_reset_reason_fw_boot_then_warm`: Validates the full scenario -- cold boot -> Caliptra writes `FW_BOOT_UPD_RESET` -> first MCU_REQ preserves it -> second MCU_REQ produces `WARM_RESET`.
- `test_reset_reason_plain_warm_reset`: Validates that a plain warm reset (no FW update bits) always produces `WARM_RESET`.