### PR TITLE
flash layout: Add Platform Descriptor Store (PDS)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3564,6 +3564,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pds"
+version = "0.1.0"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "builder",
     "common/config",
     "common/flash-image",
+    "common/pds",
     "common/mcu-mbox",
     "common/otp-digest",
     "common/mctp-vdm",
@@ -193,6 +194,7 @@ flash-ctrl-emulator = { path = "platforms/emulator/runtime/kernel/drivers/flash_
 flash-ctrl-fpga = { path = "platforms/fpga/runtime/drivers/flash_ctrl"}
 flash-driver = { path = "runtime/kernel/drivers/flash" }
 flash-image = { path = "common/flash-image" }
+pds = { path = "common/pds" }
 i3c-driver = { path = "runtime/kernel/drivers/i3c" }
 libtockasync = { path = "runtime/userspace/libtockasync" }
 mcu-builder = { path = "builder" }

--- a/builder/src/all.rs
+++ b/builder/src/all.rs
@@ -913,6 +913,7 @@ fn create_flash_image(
         &caliptra_fw_path.map(|p| p.to_string_lossy().to_string()),
         &soc_manifest_path.map(|p| p.to_string_lossy().to_string()),
         &mcu_runtime_path.map(|p| p.to_string_lossy().to_string()),
+        &None, // pds_path
         &Some(
             soc_images_paths
                 .iter()

--- a/builder/src/flash_image.rs
+++ b/builder/src/flash_image.rs
@@ -3,7 +3,8 @@
 use anyhow::{anyhow, bail, Result};
 use flash_image::{
     FlashHeader, ImageHeader, CALIPTRA_FMC_RT_IDENTIFIER, FLASH_IMAGE_MAGIC_NUMBER, HEADER_VERSION,
-    MCU_RT_IDENTIFIER, SOC_IMAGES_BASE_IDENTIFIER, SOC_MANIFEST_IDENTIFIER,
+    MCU_RT_IDENTIFIER, PLATFORM_DESCRIPTOR_STORE_IDENTIFIER, SOC_IMAGES_BASE_IDENTIFIER,
+    SOC_MANIFEST_IDENTIFIER,
 };
 use mcu_config_emulator::flash::{
     PartitionTable, StandAloneChecksumCalculator, IMAGE_A_PARTITION, IMAGE_B_PARTITION,
@@ -199,6 +200,7 @@ pub fn flash_image_create(
     caliptra_fw_path: &Option<String>,
     soc_manifest_path: &Option<String>,
     mcu_runtime_path: &Option<String>,
+    pds_path: &Option<String>,
     soc_image_paths: &Option<Vec<String>>,
     offset: usize,
     output_path: &str,
@@ -221,6 +223,12 @@ pub fn flash_image_create(
     if let Some(mcu_runtime_path) = mcu_runtime_path {
         content = load_file(mcu_runtime_path)?;
         images.push(FirmwareImage::new(MCU_RT_IDENTIFIER, &content)?);
+    }
+
+    let pds_content;
+    if let Some(pds_path) = pds_path {
+        pds_content = load_file(pds_path)?;
+        images.push(FirmwareImage::new(PLATFORM_DESCRIPTOR_STORE_IDENTIFIER, &pds_content)?);
     }
 
     // Load SOC images into a buffer
@@ -427,6 +435,7 @@ mod tests {
             &Some(caliptra_fw.path().to_str().unwrap().to_string()),
             &Some(soc_manifest.path().to_str().unwrap().to_string()),
             &Some(mcu_runtime.path().to_str().unwrap().to_string()),
+            &None, // pds_path
             &soc_image_paths,
             0,
             output_path,

--- a/common/flash-image/src/lib.rs
+++ b/common/flash-image/src/lib.rs
@@ -8,6 +8,7 @@ use zerocopy::{byteorder::U32, FromBytes, Immutable, IntoBytes, KnownLayout};
 pub const CALIPTRA_FMC_RT_IDENTIFIER: u32 = 0x00000000;
 pub const SOC_MANIFEST_IDENTIFIER: u32 = 0x00000001;
 pub const MCU_RT_IDENTIFIER: u32 = 0x00000002;
+pub const PLATFORM_DESCRIPTOR_STORE_IDENTIFIER: u32 = 0x00000003;
 pub const SOC_IMAGES_BASE_IDENTIFIER: u32 = 0x00001000;
 
 pub const FLASH_IMAGE_MAGIC_NUMBER: u32 = u32::from_be_bytes(*b"FLSH");

--- a/common/pds/Cargo.toml
+++ b/common/pds/Cargo.toml
@@ -1,0 +1,10 @@
+# Licensed under the Apache-2.0 license
+
+[package]
+name = "pds"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+
+[dependencies]
+zerocopy.workspace = true

--- a/common/pds/src/lib.rs
+++ b/common/pds/src/lib.rs
@@ -1,0 +1,513 @@
+// Licensed under the Apache-2.0 license
+
+//! Platform Descriptor Store (PDS) parser.
+//!
+//! Provides a `no_std` parser for the PDS binary format, which stores
+//! platform-level data as a linked list of UUID-typed descriptors with
+//! variable-size payloads.
+
+#![no_std]
+
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
+
+/// PDS header magic number: "PDS1" in little-endian ASCII.
+pub const PDS_MAGIC: u32 = 0x50445331;
+
+/// Current PDS header version.
+pub const PDS_HEADER_VERSION: u32 = 1;
+
+/// CRC-32/CKSUM polynomial used for header CRC validation.
+const CRC_POLY: u32 = 0x04C11DB7;
+
+/// Byte offset where CRC computation begins (after magic, header_size, header_crc).
+const CRC_START_OFFSET: usize = 12;
+
+/// Default maximum number of descriptors to traverse before aborting.
+pub const DEFAULT_MAX_DESCRIPTORS: usize = 32;
+
+/// UUID type: 16-byte array per RFC 4122.
+pub type Uuid = [u8; 16];
+
+/// Errors returned by PDS parsing operations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PdsError {
+    /// Input buffer is too small to contain the expected structure.
+    BufferTooSmall,
+    /// Magic number does not match PDS_MAGIC.
+    InvalidMagic { found: u32, expected: u32 },
+    /// Header version is below the minimum supported version.
+    InvalidVersion { found: u32, expected: u32 },
+    /// Header size field is smaller than the minimum header structure size.
+    InvalidHeaderSize { found: u32, expected: u32 },
+    /// CRC-32 checksum does not match the computed value.
+    InvalidCrc { found: u32, computed: u32 },
+    /// Descriptor offset points outside the PDS buffer.
+    DescriptorOutOfBounds { offset: u32 },
+    /// Descriptor payload range extends beyond the PDS buffer.
+    PayloadOutOfBounds { offset: u32, size: u32 },
+    /// Descriptor chain contains a loop (visited same offset twice).
+    DescriptorLoop { offset: u32 },
+    /// Descriptor header_size is smaller than the minimum descriptor header size.
+    InvalidDescriptorHeaderSize { found: u32, expected: u32 },
+    /// Maximum descriptor traversal count exceeded.
+    MaxDescriptorsExceeded,
+}
+
+/// PDS Header (version 1).
+///
+/// All fields are little-endian.
+///
+/// All fields are naturally aligned at 4-byte boundaries.
+/// Parsers should read from flash into a local copy of this struct
+/// to guarantee alignment on architectures that require it (e.g., RISC-V).
+#[repr(C)]
+#[derive(Debug, Clone, Copy, FromBytes, IntoBytes, Immutable, KnownLayout)]
+pub struct PdsHeaderV1 {
+    /// Must be PDS_MAGIC (0x50445331).
+    pub magic: u32,
+    /// Size of this header structure in bytes.
+    pub header_size: u32,
+    /// CRC-32 computed over bytes from offset 12 to header_size.
+    pub header_crc: u32,
+    /// Header format version (currently 1).
+    pub version: u32,
+    /// Byte offset from PDS start to the first descriptor, or 0 if none.
+    pub first_descriptor_offset: u32,
+    /// Null-terminated UTF-8 version string.
+    pub pds_version_string: [u8; 128],
+}
+
+/// PDS Descriptor Header (version 1).
+///
+/// All fields are little-endian.
+///
+/// All fields are naturally aligned at 4-byte boundaries.
+/// Parsers should read from flash into a local copy of this struct
+/// to guarantee alignment on architectures that require it (e.g., RISC-V).
+#[repr(C)]
+#[derive(Debug, Clone, Copy, FromBytes, IntoBytes, Immutable, KnownLayout)]
+pub struct PdsDescriptorHeaderV1 {
+    /// Size of this descriptor header in bytes.
+    pub header_size: u32,
+    /// Byte offset from PDS start to the payload data.
+    pub payload_offset: u32,
+    /// Size of the payload in bytes.
+    pub payload_size: u32,
+    /// Byte offset from PDS start to the next descriptor, or 0 if last.
+    pub next_descriptor_offset: u32,
+    /// UUID identifying the descriptor type.
+    pub descriptor_type: Uuid,
+}
+
+/// A parsed descriptor reference pointing into the original PDS buffer.
+#[derive(Debug, Clone, Copy)]
+pub struct PdsDescriptor<'a> {
+    /// UUID identifying the descriptor type.
+    pub descriptor_type: Uuid,
+    /// Payload data slice (references the original PDS buffer).
+    pub payload: &'a [u8],
+}
+
+/// Compute CRC-32/CKSUM over the given data.
+fn crc32_cksum(data: &[u8]) -> u32 {
+    let mut crc: u32 = 0;
+    for &byte in data {
+        crc ^= (byte as u32) << 24;
+        for _ in 0..8 {
+            if crc & 0x8000_0000 != 0 {
+                crc = (crc << 1) ^ CRC_POLY;
+            } else {
+                crc <<= 1;
+            }
+        }
+    }
+    crc
+}
+
+/// Parse and validate a PDS binary, returning an iterator over descriptors.
+///
+/// # Arguments
+/// * `data` - The raw PDS binary data.
+/// * `max_descriptors` - Maximum number of descriptors to traverse.
+///
+/// # Errors
+/// Returns a `PdsError` if the header is invalid, CRC fails, or the
+/// descriptor chain is malformed.
+pub fn validate_header(data: &[u8]) -> Result<PdsHeaderV1, PdsError> {
+    let header_size = core::mem::size_of::<PdsHeaderV1>() as u32;
+
+    let (header, _) =
+        PdsHeaderV1::read_from_prefix(data).map_err(|_| PdsError::BufferTooSmall)?;
+
+    if header.magic != PDS_MAGIC {
+        return Err(PdsError::InvalidMagic {
+            found: header.magic,
+            expected: PDS_MAGIC,
+        });
+    }
+
+    if header.version < PDS_HEADER_VERSION {
+        return Err(PdsError::InvalidVersion {
+            found: header.version,
+            expected: PDS_HEADER_VERSION,
+        });
+    }
+
+    if header.header_size < header_size {
+        return Err(PdsError::InvalidHeaderSize {
+            found: header.header_size,
+            expected: header_size,
+        });
+    }
+
+    let crc_end = header.header_size as usize;
+    if crc_end > data.len() {
+        return Err(PdsError::BufferTooSmall);
+    }
+
+    let crc_data = &data[CRC_START_OFFSET..crc_end];
+    let computed_crc = crc32_cksum(crc_data);
+    if computed_crc != header.header_crc {
+        return Err(PdsError::InvalidCrc {
+            found: header.header_crc,
+            computed: computed_crc,
+        });
+    }
+
+    Ok(header)
+}
+
+/// Iterate over all descriptors in a validated PDS buffer.
+///
+/// The caller must first call `validate_header` to ensure the PDS is valid.
+///
+/// # Arguments
+/// * `data` - The raw PDS binary data (already validated).
+/// * `header` - A validated PDS header reference.
+/// * `max_descriptors` - Maximum number of descriptors to traverse.
+/// * `callback` - Called for each descriptor. Return `true` to continue, `false` to stop.
+///
+/// # Errors
+/// Returns a `PdsError` if the descriptor chain is malformed.
+pub fn for_each_descriptor<F>(
+    data: &[u8],
+    header: &PdsHeaderV1,
+    max_descriptors: usize,
+    mut callback: F,
+) -> Result<(), PdsError>
+where
+    F: FnMut(PdsDescriptor<'_>) -> bool,
+{
+    let desc_header_size = core::mem::size_of::<PdsDescriptorHeaderV1>() as u32;
+    let mut next_offset = header.first_descriptor_offset;
+    let mut count = 0usize;
+    let mut prev_offset = 0u32;
+
+    while next_offset != 0 {
+        if count >= max_descriptors {
+            return Err(PdsError::MaxDescriptorsExceeded);
+        }
+
+        // Forward-only check (skip for first descriptor)
+        if count > 0 && next_offset <= prev_offset {
+            return Err(PdsError::DescriptorLoop {
+                offset: next_offset,
+            });
+        }
+
+        let offset = next_offset as usize;
+        if offset.checked_add(desc_header_size as usize).map_or(true, |end| end > data.len()) {
+            return Err(PdsError::DescriptorOutOfBounds {
+                offset: next_offset,
+            });
+        }
+
+        let (desc, _) = PdsDescriptorHeaderV1::read_from_prefix(&data[offset..])
+            .map_err(|_| PdsError::DescriptorOutOfBounds {
+                offset: next_offset,
+            })?;
+
+        if desc.header_size < desc_header_size {
+            return Err(PdsError::InvalidDescriptorHeaderSize {
+                found: desc.header_size,
+                expected: desc_header_size,
+            });
+        }
+
+        let payload_start = desc.payload_offset as usize;
+        let payload_end = payload_start
+            .checked_add(desc.payload_size as usize)
+            .ok_or(PdsError::PayloadOutOfBounds {
+                offset: desc.payload_offset,
+                size: desc.payload_size,
+            })?;
+
+        if payload_end > data.len() {
+            return Err(PdsError::PayloadOutOfBounds {
+                offset: desc.payload_offset,
+                size: desc.payload_size,
+            });
+        }
+
+        let descriptor = PdsDescriptor {
+            descriptor_type: desc.descriptor_type,
+            payload: &data[payload_start..payload_end],
+        };
+
+        if !callback(descriptor) {
+            return Ok(());
+        }
+
+        prev_offset = next_offset;
+        next_offset = desc.next_descriptor_offset;
+        count += 1;
+    }
+
+    Ok(())
+}
+
+/// Find the first descriptor matching the given UUID.
+///
+/// # Arguments
+/// * `data` - The raw PDS binary data (already validated).
+/// * `header` - A validated PDS header reference.
+/// * `uuid` - The descriptor type UUID to search for.
+///
+/// # Returns
+/// The payload slice if found, or `None` if not found.
+pub fn find_descriptor<'a>(
+    data: &'a [u8],
+    header: &PdsHeaderV1,
+    uuid: &Uuid,
+) -> Result<Option<&'a [u8]>, PdsError> {
+    let desc_header_size = core::mem::size_of::<PdsDescriptorHeaderV1>() as u32;
+    let mut next_offset = header.first_descriptor_offset;
+    let mut count = 0usize;
+    let mut prev_offset = 0u32;
+
+    while next_offset != 0 {
+        if count >= DEFAULT_MAX_DESCRIPTORS {
+            return Err(PdsError::MaxDescriptorsExceeded);
+        }
+
+        if count > 0 && next_offset <= prev_offset {
+            return Err(PdsError::DescriptorLoop {
+                offset: next_offset,
+            });
+        }
+
+        let offset = next_offset as usize;
+        if offset.checked_add(desc_header_size as usize).map_or(true, |end| end > data.len()) {
+            return Err(PdsError::DescriptorOutOfBounds {
+                offset: next_offset,
+            });
+        }
+
+        let (desc, _) = PdsDescriptorHeaderV1::read_from_prefix(&data[offset..])
+            .map_err(|_| PdsError::DescriptorOutOfBounds {
+                offset: next_offset,
+            })?;
+
+        if desc.descriptor_type == *uuid {
+            let payload_start = desc.payload_offset as usize;
+            let payload_end = payload_start
+                .checked_add(desc.payload_size as usize)
+                .ok_or(PdsError::PayloadOutOfBounds {
+                    offset: desc.payload_offset,
+                    size: desc.payload_size,
+                })?;
+
+            if payload_end > data.len() {
+                return Err(PdsError::PayloadOutOfBounds {
+                    offset: desc.payload_offset,
+                    size: desc.payload_size,
+                });
+            }
+
+            return Ok(Some(&data[payload_start..payload_end]));
+        }
+
+        prev_offset = next_offset;
+        next_offset = desc.next_descriptor_offset;
+        count += 1;
+    }
+
+    Ok(None)
+}
+
+#[cfg(test)]
+extern crate alloc;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec::Vec;
+
+    fn build_pds(descriptors: &[(Uuid, &[u8])]) -> Vec<u8> {
+        let mut buf = Vec::new();
+        let header_size = core::mem::size_of::<PdsHeaderV1>();
+        let desc_header_size = core::mem::size_of::<PdsDescriptorHeaderV1>();
+
+        // Reserve space for header
+        buf.resize(header_size, 0);
+
+        let first_offset = if descriptors.is_empty() {
+            0u32
+        } else {
+            header_size as u32
+        };
+
+        // Write descriptors
+        for (i, (uuid, payload)) in descriptors.iter().enumerate() {
+            let current_offset = buf.len();
+            let payload_offset = (current_offset + desc_header_size) as u32;
+
+            let next_offset = if i + 1 < descriptors.len() {
+                (current_offset + desc_header_size + payload.len()) as u32
+            } else {
+                0
+            };
+
+            let desc = PdsDescriptorHeaderV1 {
+                header_size: desc_header_size as u32,
+                payload_offset,
+                payload_size: payload.len() as u32,
+                next_descriptor_offset: next_offset,
+                descriptor_type: *uuid,
+            };
+            buf.extend_from_slice(desc.as_bytes());
+            buf.extend_from_slice(payload);
+        }
+
+        // Write header
+        let mut header = PdsHeaderV1 {
+            magic: PDS_MAGIC,
+            header_size: header_size as u32,
+            header_crc: 0,
+            version: PDS_HEADER_VERSION,
+            first_descriptor_offset: first_offset,
+            pds_version_string: [0u8; 128],
+        };
+
+        // Compute CRC
+        let header_bytes = header.as_bytes().to_vec();
+        let crc_data = &header_bytes[CRC_START_OFFSET..];
+        header.header_crc = crc32_cksum(crc_data);
+
+        buf[..header_size].copy_from_slice(header.as_bytes());
+
+        buf
+    }
+
+    #[test]
+    fn test_empty_pds() {
+        let pds = build_pds(&[]);
+        let header = validate_header(&pds).unwrap();
+        assert_eq!(header.first_descriptor_offset, 0);
+
+        let mut count = 0;
+        for_each_descriptor(&pds, &header, DEFAULT_MAX_DESCRIPTORS, |_| {
+            count += 1;
+            true
+        })
+        .unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn test_single_descriptor() {
+        let uuid: Uuid = [
+            0x53, 0x19, 0xD6, 0xF1, 0x57, 0xB3, 0x4D, 0x1A, 0x96, 0xC6, 0xE0, 0xED, 0xAF, 0x90,
+            0x7A, 0x12,
+        ];
+        let payload = b"hello world";
+        let pds = build_pds(&[(uuid, payload)]);
+
+        let header = validate_header(&pds).unwrap();
+        let found = find_descriptor(&pds, &header, &uuid).unwrap();
+        assert_eq!(found, Some(payload.as_slice()));
+    }
+
+    #[test]
+    fn test_multiple_descriptors() {
+        let uuid1: Uuid = [1; 16];
+        let uuid2: Uuid = [2; 16];
+        let uuid3: Uuid = [3; 16];
+
+        let pds = build_pds(&[
+            (uuid1, b"first"),
+            (uuid2, b"second"),
+            (uuid3, b"third"),
+        ]);
+
+        let header = validate_header(&pds).unwrap();
+
+        assert_eq!(
+            find_descriptor(&pds, &header, &uuid1).unwrap(),
+            Some(b"first".as_slice())
+        );
+        assert_eq!(
+            find_descriptor(&pds, &header, &uuid2).unwrap(),
+            Some(b"second".as_slice())
+        );
+        assert_eq!(
+            find_descriptor(&pds, &header, &uuid3).unwrap(),
+            Some(b"third".as_slice())
+        );
+    }
+
+    #[test]
+    fn test_unknown_uuid_returns_none() {
+        let uuid: Uuid = [1; 16];
+        let unknown: Uuid = [99; 16];
+
+        let pds = build_pds(&[(uuid, b"data")]);
+        let header = validate_header(&pds).unwrap();
+
+        assert_eq!(find_descriptor(&pds, &header, &unknown).unwrap(), None);
+    }
+
+    #[test]
+    fn test_invalid_magic() {
+        let mut pds = build_pds(&[]);
+        pds[0] = 0xFF; // corrupt magic
+        assert!(matches!(
+            validate_header(&pds),
+            Err(PdsError::InvalidMagic { .. })
+        ));
+    }
+
+    #[test]
+    fn test_invalid_crc() {
+        let mut pds = build_pds(&[]);
+        // Corrupt version string area to invalidate CRC
+        pds[20] = 0xFF;
+        assert!(matches!(
+            validate_header(&pds),
+            Err(PdsError::InvalidCrc { .. })
+        ));
+    }
+
+    #[test]
+    fn test_buffer_too_small() {
+        assert!(matches!(
+            validate_header(&[0u8; 4]),
+            Err(PdsError::BufferTooSmall)
+        ));
+    }
+
+    #[test]
+    fn test_descriptor_count() {
+        let uuid: Uuid = [1; 16];
+        let pds = build_pds(&[(uuid, b"a"), (uuid, b"b"), (uuid, b"c")]);
+        let header = validate_header(&pds).unwrap();
+
+        let mut count = 0;
+        for_each_descriptor(&pds, &header, DEFAULT_MAX_DESCRIPTORS, |_| {
+            count += 1;
+            true
+        })
+        .unwrap();
+        assert_eq!(count, 3);
+    }
+}

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -7,6 +7,7 @@
 - [Runtime Specification](./runtime.md)
     - [PLDM Package](./pldm_package.md)
     - [Flash Layout](./flash_layout.md)
+        - [Platform Descriptor Store](./platform_descriptor_store.md)
     - [Flash Controller](./flash_controller.md)
     - [Image Loading](./image_loading.md)
     - [MCTP](./mctp.md)

--- a/docs/src/flash_layout.md
+++ b/docs/src/flash_layout.md
@@ -22,12 +22,14 @@ The Payload contains the following fields:
 | Image Info (Caliptra FMC + RT) |
 | Image Info (SoC Manifest)      |
 | Image Info (MCU RT)            |
+| Image Info (PDS)               |
 | Image Info (SoC Image 1)       |
 | ...                            |
 | Image Info (SoC Image N)       |
 | Caliptra FMC + RT Package      |
 | SoC Manifest                   |
 | MCU RT                         |
+| Platform Descriptor Store      |
 | SoC Image 1                    |
 | ...                            |
 | SoC Image N                    |
@@ -35,6 +37,7 @@ The Payload contains the following fields:
 * Caliptra FMC and RT (refer to the [Caliptra Firmware Image Bundle Format](https://github.com/chipsalliance/caliptra-sw/blob/main/rom/dev/README.md#firmware-image-bundle))
 * SoC Manifest (refer to the description of the [SoC Manifest](https://github.com/chipsalliance/caliptra-sw/blob/main/auth-manifest/README.md))
 * MCU RT: This is the image binary of the MCU Runtime firmware
+* Platform Descriptor Store (PDS): An extensible, self-describing binary region for platform-level data. See [Platform Descriptor Store](./platform_descriptor_store.md)
 * Other SoC images (if any)
 
 ## Header
@@ -58,7 +61,9 @@ The Image Information section is repeated for each image and provides detailed m
 | Identifier          | 4            | Vendor selected unique value to distinguish between images.                            |
 |                     |              | `0x00000000`: Caliptra FMC+RT                                                              |
 |                     |              | `0x00000001`: SoC Manifest                                                                |
-|                     |              | `0x00000002`: MCU RT<br />`0x00001000`-`0xFFFFFFFF` - Reserved for other Vendor-defined SoC images |
+|                     |              | `0x00000002`: MCU RT                                   |
+|                     |              | `0x00000003`: Platform Descriptor Store (PDS). See [Platform Descriptor Store](./platform_descriptor_store.md) |
+|                     |              | `0x00001000`-`0xFFFFFFFF` - Reserved for other Vendor-defined SoC images |
 | ImageLocationOffset | 4            | Offset in bytes from byte 0 of the header to where the image content begins. Used in flash-based boot.
 | Size                | 4            | Size in bytes of the image. This is the actual size of the image without padding.      |
 |                     |              | The image itself as written to the flash should be 4-byte aligned and additional       |

--- a/docs/src/platform_descriptor_store.md
+++ b/docs/src/platform_descriptor_store.md
@@ -1,0 +1,150 @@
+# Platform Descriptor Store (PDS)
+
+The Platform Descriptor Store (PDS) is an extensible, self-describing binary region within the flash layout that stores platform-level data as a linked list of UUID-typed descriptors with variable-size payloads.
+
+## Purpose
+
+The PDS provides a generic mechanism for embedding non-firmware data in the IFWI without modifying the flash layout specification. This enables late-in-the-program additions such as:
+
+- Device identity binding
+- Build provenance tracking (e.g., build origin, tool versions)
+- Platform compatibility information (e.g., flavor, SKU)
+- Impactless update version lists
+- Configuration attributes or debug policy flags
+
+## Identifier
+
+The PDS uses a Caliptra-defined Identifier:
+
+| Identifier | Name |
+|-----------|------|
+| `0x00000003` | Platform Descriptor Store |
+
+The PDS is stored as a standard image within each slot, with its own Image Information entry in the flash layout.
+
+## Verification
+
+The PDS is included in the Caliptra verification flow:
+
+1. An Image Metadata Entry (IME) in the SoC Manifest contains the SHA-384 hash of the PDS binary
+2. During boot, Caliptra RT verifies the PDS hash against the SoC Manifest digest via `authorize_and_stash`
+3. After verification, firmware can parse the PDS content with confidence that it has not been tampered with
+
+The PDS is a build-time artifact. It is written during IFWI generation and is read-only at runtime. Any change to the PDS content requires re-signing the SoC Manifest.
+
+## Binary Format
+
+All integer fields are little-endian byte-ordered.
+
+### Alignment Requirements
+
+**Flash alignment:**
+
+- The PDS image must be aligned to flash erase block boundaries within the slot, consistent with other images in the flash layout
+
+**Binary alignment:**
+
+- Descriptor headers must start at 4-byte aligned offsets within the PDS binary. Generation tools must insert 0-3 padding bytes after a payload if needed to align the next descriptor header
+- Payload data has no alignment requirement since payloads are accessed as byte arrays
+- The PDS header size (148 bytes) and descriptor header size (32 bytes) are both multiples of 4 bytes
+
+**Parser requirements:**
+
+- Parsers must copy headers from the source buffer into a local aligned struct before accessing fields. This ensures correct behavior on architectures that do not support unaligned memory access (e.g., RISC-V). The recommended pattern is:
+  1. Read the raw bytes from flash (or from an in-memory copy of flash) into a local struct-sized buffer
+  2. Interpret the local copy as the header struct
+  3. Access fields from the local copy, which is guaranteed to be aligned on the stack
+- This is equivalent to the C pattern: read from flash into a local variable, then access fields directly from that local copy
+- Parsers must not cast arbitrary buffer offsets to struct pointers, as the source buffer may not be aligned
+
+**Physical layout:**
+
+- Descriptor headers and payloads may appear at arbitrary (aligned) offsets within the PDS, not necessarily in sequential order
+- Parsers must follow the offset chain (`first_descriptor_offset`, `next_descriptor_offset`, `payload_offset`) to discover locations rather than assuming sequential layout
+- Multiple descriptors may reference the same payload offset (shared data)
+
+### PDS Header
+
+The PDS begins with a header:
+
+```c
+typedef struct __attribute__((packed)) {
+    uint32_t magic;                       // Must be 0x50445331 ("PDS1")
+    uint32_t header_size;                 // Size of this header (currently 148 bytes)
+    uint32_t header_crc;                  // CRC-32 over bytes from offset 12 to header_size
+    uint32_t version;                     // Header version (currently 1)
+    uint32_t first_descriptor_offset;     // Byte offset from PDS start to first descriptor, or 0
+    uint8_t  pds_version_string[128];     // Null-terminated UTF-8 version string
+} PdsHeaderV1;
+```
+
+| Field | Size (bytes) | Description |
+|-------|-------------|-------------|
+| magic | 4 | Must be `0x50445331` ("PDS1" in little-endian ASCII) |
+| header_size | 4 | Size of this header structure in bytes. Currently 148 |
+| header_crc | 4 | CRC-32 (CRC-32/CKSUM polynomial) computed over bytes from offset 12 (`version` field) through `header_size` |
+| version | 4 | Header format version. Currently `1` |
+| first_descriptor_offset | 4 | Byte offset from the start of the PDS to the first descriptor header. `0` if no descriptors are present |
+| pds_version_string | 128 | Null-terminated UTF-8 string. Optional version identifier for the PDS content. Unused bytes must be zero |
+
+### PDS Descriptor Header
+
+Each descriptor in the chain begins with a descriptor header:
+
+```c
+typedef struct __attribute__((packed)) {
+    uint32_t header_size;              // Size of this descriptor header (currently 32 bytes)
+    uint32_t payload_offset;           // Byte offset from PDS start to payload data
+    uint32_t payload_size;             // Size of payload in bytes
+    uint32_t next_descriptor_offset;   // Byte offset from PDS start to next descriptor, or 0
+    uint8_t  descriptor_type[16];      // UUID (RFC 4122) identifying descriptor type
+} PdsDescriptorHeaderV1;
+```
+
+| Field | Size (bytes) | Description |
+|-------|-------------|-------------|
+| header_size | 4 | Size of this descriptor header in bytes. Currently 32 |
+| payload_offset | 4 | Byte offset from the start of the PDS to the payload data for this descriptor |
+| payload_size | 4 | Size of the payload data in bytes |
+| next_descriptor_offset | 4 | Byte offset from the start of the PDS to the next descriptor header. `0` if this is the last descriptor in the chain |
+| descriptor_type | 16 | UUID (RFC 4122) identifying the type of this descriptor. Used by parsers to match descriptors to known types |
+
+## Descriptor Chain Rules
+
+1. Descriptors form a singly linked list via `next_descriptor_offset`
+2. Each `next_descriptor_offset` must point to a location strictly greater than the current descriptor's offset (forward-only, prevents loops)
+3. A `next_descriptor_offset` of `0` indicates the last descriptor
+4. Headers and payloads may appear at arbitrary offsets within the PDS (not necessarily contiguous). Parsers must follow offset fields to discover locations
+5. Multiple descriptors of the same type (same UUID) are permitted
+6. Multiple descriptors may reference the same payload offset (shared payload data)
+7. Parsers must enforce a maximum descriptor count to bound traversal time. Recommended default: 32
+
+## Versioning and Extension Rules
+
+These rules apply to both the PDS Header and PDS Descriptor Header:
+
+1. Future versions may append additional fields at the end while keeping existing fields intact. The `header_size` field will increase to reflect the new size
+2. Parsers encountering a `header_size` larger than expected must ignore additional bytes beyond the fields they understand
+3. Parsers encountering a `header_size` smaller than expected must use appropriate default values for the missing fields
+4. Breaking changes that are not backwards compatible require both a new `version` value and a new `magic` number
+
+## Descriptor Types
+
+Descriptor type UUIDs and their payload formats are vendor-defined. The Caliptra specification defines only the PDS container format (header, descriptor chain, CRC, versioning rules).
+
+Each vendor defines their own descriptor types by:
+
+1. Assigning a UUID (RFC 4122) for the descriptor type
+2. Defining the payload binary format
+3. Implementing serialization in their IFWI generation tooling
+4. Implementing deserialization in their firmware
+
+This separation ensures that no vendor-specific data types or business logic are required in the Caliptra open-source codebase.
+
+## Backwards Compatibility
+
+The PDS is backwards compatible along three dimensions:
+
+- **Old firmware, new IFWI:** Firmware that does not know about the PDS skips the Image Information entry with Identifier `0x00000003` because it does not match any known Identifier. The PDS image is never loaded.
+- **New firmware, old IFWI:** Firmware that expects a PDS searches for Identifier `0x00000003`, does not find it, and handles the absence gracefully (e.g., skips descriptor-dependent operations).
+- **Unknown descriptors:** Firmware walks the descriptor chain comparing each UUID against known types. Unrecognized UUIDs are skipped without error.

--- a/tests/integration/src/test_firmware_update.rs
+++ b/tests/integration/src/test_firmware_update.rs
@@ -92,6 +92,7 @@ mod test {
             &caliptra_fw_path_str,
             &soc_manifest_path_str,
             &mcu_runtime_path_str,
+            &None, // pds_path
             &Some(
                 soc_images_paths
                     .iter()

--- a/tests/integration/src/test_soc_boot.rs
+++ b/tests/integration/src/test_soc_boot.rs
@@ -89,6 +89,7 @@ mod test {
             &caliptra_fw_path_str,
             &soc_manifest_path_str,
             &mcu_runtime_path_str,
+            &None, // pds_path
             &Some(
                 soc_images_paths
                     .iter()

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -304,6 +304,10 @@ enum FlashImageCommands {
         #[arg(long, value_name = "MCU_RUNTIME", required = true)]
         mcu_runtime: Option<String>,
 
+        /// Path to the Platform Descriptor Store (PDS) binary
+        #[arg(long, value_name = "PDS", required = false)]
+        pds: Option<String>,
+
         /// List of SoC images
         /// Example: --soc-images /tmp/a.bin --soc-images /tmp/b.bin
         #[arg(long, value_name = "SOC_IMAGE", num_args=1.., required = false)]
@@ -430,12 +434,14 @@ fn main() {
                 caliptra_fw,
                 soc_manifest,
                 mcu_runtime,
+                pds,
                 soc_images,
                 output,
             } => mcu_builder::flash_image::flash_image_create(
                 caliptra_fw,
                 soc_manifest,
                 mcu_runtime,
+                pds,
                 soc_images,
                 0,
                 output,


### PR DESCRIPTION
Introduce a Platform Descriptor Store (PDS) as a Caliptra-defined image type in the flash layout. The PDS is a self-describing, extensible binary region that stores platform-level data as a linked list of UUID-typed descriptors with variable-size payloads.

This enables vendors to embed non-firmware data (device identity binding, build provenance, platform compatibility information, configuration attributes) in the IFWI without modifying the flash layout specification or requiring new Identifier assignments.

Changes:
- Define PLATFORM_DESCRIPTOR_STORE_IDENTIFIER (0x00000003) in the Caliptra-defined Identifier range
- Add PDS spec page documenting the binary format, descriptor chain rules, versioning rules, verification flow, and backwards compatibility
- Add no_std PDS parser crate (common/pds) with header validation, descriptor chain traversal, and UUID-based descriptor lookup
- Update flash image builder and CLI to accept an optional PDS binary
- Update existing callers to pass the new parameter