### PR TITLE
[firmware-bundler] enable building bare metal binaries

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -267,6 +267,7 @@ jobs:
         run: |
           cargo --config "$EXTRA_CARGO_CONFIG" nextest archive \
             --workspace \
+            --exclude bare-metal-runtime \
             --exclude mcu-rom-emulator \
             --exclude mcu-rom-fpga \
             --exclude mcu-runtime-emulator \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,6 +197,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "bare-metal-runtime"
+version = "0.1.0"
+dependencies = [
+ "caliptra-drivers",
+ "romtime",
+ "rv32i",
+]
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ members = [
     "registers/systemrdl",
     "rom",
     "romtime",
+    "runtime/bare-metal",
     "runtime/kernel/capsules",
     "runtime/kernel/components",
     "runtime/kernel/drivers/doe",

--- a/builder/src/lib.rs
+++ b/builder/src/lib.rs
@@ -13,7 +13,7 @@ pub use all::{
 };
 pub use caliptra::{AuthManifestOwnerConfig, CaliptraBuilder, ImageCfg};
 pub use rom::{rom_build, rom_ld_script, test_rom_build};
-pub use runtime::runtime_build_with_apps;
+pub use runtime::{bare_metal_build, runtime_build_with_apps};
 
 use anyhow::{anyhow, Result};
 use std::{
@@ -106,6 +106,7 @@ pub fn objcopy() -> Result<String> {
     })
 }
 
+#[allow(dead_code)]
 pub(crate) fn target_binary(name: &str) -> PathBuf {
     PROJECT_ROOT
         .join("target")

--- a/builder/src/runtime.rs
+++ b/builder/src/runtime.rs
@@ -11,20 +11,12 @@
 #![allow(dead_code)]
 
 use crate::utils::manifest_file;
-use crate::{objcopy, target_binary, target_dir, OBJCOPY_FLAGS, PROJECT_ROOT, SYSROOT, TARGET};
-use anyhow::{anyhow, bail, Result};
-use elf::endian::AnyEndian;
-use elf::ElfBytes;
-use mcu_config::McuMemoryMap;
-use mcu_config_emulator::flash::LoggingFlashConfig;
+use crate::PROJECT_ROOT;
+use anyhow::Result;
 use mcu_firmware_bundler::args::{
     BuildArgs, BundleArgs, Commands as BundleCommands, Common, LdArgs,
 };
-use serde::{Deserialize, Serialize};
-use std::fs::File;
-use std::io::{Read, Write};
 use std::path::PathBuf;
-use std::process::Command;
 
 pub fn runtime_build_with_apps(
     features: &[&str],
@@ -56,6 +48,29 @@ pub fn runtime_build_with_apps(
             runtime_features,
             ..Default::default()
         },
+        bundle: BundleArgs {
+            bundle_name: Some(output_name),
+        },
+    };
+
+    mcu_firmware_bundler::execute(bundle_cmd)?;
+    Ok(runtime_bin)
+}
+
+pub fn bare_metal_build() -> Result<PathBuf> {
+    let manifest = PROJECT_ROOT.join("runtime/bare-metal/manifest.toml");
+    let output_name = "runtime-bare-metal.bin".to_string();
+
+    let common = Common {
+        manifest,
+        ..Default::default()
+    };
+    let runtime_bin = common.release_dir()?.join(&output_name);
+
+    let bundle_cmd = BundleCommands::Bundle {
+        common,
+        ld: LdArgs::default(),
+        build: BuildArgs::default(),
         bundle: BundleArgs {
             bundle_name: Some(output_name),
         },

--- a/emulator/app/Cargo.toml
+++ b/emulator/app/Cargo.toml
@@ -70,6 +70,7 @@ path = "src/lib.rs"
 
 [features]
 default = []
+test-bare-metal = []
 test-caliptra-certs = []
 test-caliptra-crypto = []
 test-caliptra-mailbox = []

--- a/firmware-bundler/data/default-bare-metal-layout.ld
+++ b/firmware-bundler/data/default-bare-metal-layout.ld
@@ -1,0 +1,74 @@
+
+/* Licensed under the Apache-2.0 license. */
+
+ENTRY(_start)
+
+MEMORY
+{
+  ROM   (rx) : ORIGIN = ROM_START, LENGTH = ROM_LENGTH
+  RAM  (rwx) : ORIGIN = RAM_START, LENGTH = RAM_LENGTH
+}
+
+SECTIONS
+{
+    .text :
+    {
+        _textstart = .;
+        *(.text.init )
+        *(.text*)
+        *(.rodata*)
+        _imem_end = .;
+    } > RAM
+
+    .stack (NOLOAD):
+    {
+        _ssram = .;
+        . = ALIGN(4);
+        . = . + STACK_SIZE;
+        . = ALIGN(4);
+    } > RAM
+
+    .estack (NOLOAD):
+    {
+        . = ALIGN(4);
+        . = . + ESTACK_SIZE;
+        . = ALIGN(4);
+        PROVIDE(ESTACK_START = . );
+    } > RAM
+
+    /DISCARD/ :
+    {
+        *(.eh_frame*)
+    }
+
+    .data :
+    {
+        . = ALIGN(4);
+        *(.data*);
+        *(.sdata*);
+        . = ALIGN(4);
+        PROVIDE( GLOBAL_POINTER = . + 0x800 );
+        . = ALIGN(4);
+    } > RAM
+
+    .bss (NOLOAD) :
+    {
+        . = ALIGN(4);
+        *(.bss*)
+        *(.sbss*)
+        *(COMMON)
+        . = ALIGN(4);
+        _kernel_ram_done = .;
+    } > RAM
+
+    _end = . ;
+}
+
+BSS_START = ADDR(.bss);
+BSS_END = BSS_START + SIZEOF(.bss);
+DATA_START = ADDR(.data);
+DATA_END = DATA_START + SIZEOF(.data);
+ROM_DATA_START = LOADADDR(.data);
+STACK_TOP = ORIGIN(RAM) + SIZEOF(.stack);
+STACK_ORIGIN = ORIGIN(RAM);
+MRAC_VALUE = 0xaaa9a5aa;

--- a/firmware-bundler/src/args.rs
+++ b/firmware-bundler/src/args.rs
@@ -83,6 +83,11 @@ pub struct LdArgs {
     /// usage.  If not specified the default tockOS app layout file will be used.
     #[arg(long)]
     pub app_ld_base: Option<PathBuf>,
+
+    /// The base bare metal linker layout. If not specified the default bare metal layout file will
+    /// be used.
+    #[arg(long)]
+    pub bare_metal_ld_base: Option<PathBuf>,
 }
 
 /// Arguments required for commands which execute the build step of the bundle process.

--- a/firmware-bundler/src/build.rs
+++ b/firmware-bundler/src/build.rs
@@ -11,6 +11,7 @@ use std::{path::PathBuf, process::Command};
 use anyhow::{anyhow, bail, Result};
 use tbf_header::TbfHeader;
 
+use crate::manifest::RuntimeVariant;
 use crate::{
     args::{BuildArgs, Common},
     ld::{BuildDefinition, LinkerScript},
@@ -23,6 +24,7 @@ const ROM_OBJCOPY_FLAGS: &str = "--strip-sections --strip-all";
 const KERNEL_OBJCOPY_FLAGS: &str =
     "--strip-sections --strip-all --remove-section .apps --remove-section .attributes";
 const APP_OBJCOPY_FLAGS: &str = "--strip-sections --strip-all";
+const RUNTIME_OBJCOPY_FLAGS: &str = "--strip-sections --strip-all";
 
 /// A pairing of application name to the linker script it should be built with.
 #[derive(Debug, Clone)]
@@ -45,7 +47,7 @@ pub struct BuiltApp {
 #[derive(Debug, Clone)]
 pub struct BuildOutput {
     pub rom: Option<BuiltBinary>,
-    pub kernel: (BuiltBinary, Memory),
+    pub runtime: RuntimeVariant<(BuiltBinary, Memory)>,
     pub apps: Vec<BuiltApp>,
 }
 
@@ -88,11 +90,19 @@ pub fn build_single_target(
         .iter()
         .map(|a| (a.linker.clone(), &build.runtime_features, APP_OBJCOPY_FLAGS))
         .collect::<Vec<_>>();
+
+    let runtime_linker = &build_definition.runtime.inner().0;
+    let runtime_objcopy_flags = if build_definition.runtime.is_bare_metal() {
+        RUNTIME_OBJCOPY_FLAGS
+    } else {
+        KERNEL_OBJCOPY_FLAGS
+    };
     binaries.push((
-        build_definition.kernel.0.clone(),
+        runtime_linker.clone(),
         &build.runtime_features,
-        KERNEL_OBJCOPY_FLAGS,
+        runtime_objcopy_flags,
     ));
+
     if let Some(rom) = &build_definition.rom {
         binaries.push((rom.clone(), &build.rom_features, ROM_OBJCOPY_FLAGS));
     }
@@ -146,22 +156,38 @@ impl<'a> BuildPass<'a> {
     /// Execute a BuildPass run.  This will include both building the elf with the specified linker
     /// file via `rustc` and then using `objcopy` to produce a binary file from that elf.
     fn run(&self) -> Result<BuildOutput> {
-        let rom = self
-            .build_definition
-            .rom
-            .as_ref()
-            .map(|r| self.build_binary(r, &self.build_args.rom_features, ROM_OBJCOPY_FLAGS))
-            .transpose()?;
+        let rom = if let Some(r) = &self.build_definition.rom {
+            Some(self.build_binary(r, &self.build_args.rom_features, ROM_OBJCOPY_FLAGS)?)
+        } else {
+            None
+        };
 
-        let (kernal_linker, kernel_instructions) = &self.build_definition.kernel;
-        let kernel = (
-            self.build_binary(
-                kernal_linker,
-                &self.build_args.runtime_features,
-                KERNEL_OBJCOPY_FLAGS,
-            )?,
-            kernel_instructions.clone(),
-        );
+        let runtime_objcopy_flags = if self.build_definition.runtime.is_bare_metal() {
+            RUNTIME_OBJCOPY_FLAGS
+        } else {
+            KERNEL_OBJCOPY_FLAGS
+        };
+
+        let runtime: RuntimeVariant<Result<(BuiltBinary, Memory)>> = self
+            .build_definition
+            .runtime
+            .clone()
+            .map(|(linker, instructions)| {
+                Ok((
+                    self.build_binary(
+                        &linker,
+                        &self.build_args.runtime_features,
+                        runtime_objcopy_flags,
+                    )?,
+                    instructions,
+                ))
+            });
+
+        // Convert RuntimeVariant<Result<...>> to Result<RuntimeVariant<...>>
+        let runtime = match runtime {
+            RuntimeVariant::Kernel(r) => RuntimeVariant::Kernel(r?),
+            RuntimeVariant::BareMetal(r) => RuntimeVariant::BareMetal(r?),
+        };
 
         let apps = self
             .build_definition
@@ -180,7 +206,7 @@ impl<'a> BuildPass<'a> {
             })
             .collect::<Result<_>>()?;
 
-        Ok(BuildOutput { rom, kernel, apps })
+        Ok(BuildOutput { rom, runtime, apps })
     }
 
     /// Execute the build step for a single binary.

--- a/firmware-bundler/src/bundle.rs
+++ b/firmware-bundler/src/bundle.rs
@@ -13,7 +13,7 @@ use mcu_image_header::McuImageHeader;
 use crate::{
     args::{BundleArgs, Common},
     build::BuildOutput,
-    manifest::Manifest,
+    manifest::{Manifest, RuntimeVariant},
     tbf::generate_tbf_header,
 };
 
@@ -50,34 +50,42 @@ pub fn bundle(
         );
     }
     let header_len: u64 = runtime.len().try_into()?;
-    runtime.append(&mut std::fs::read(&output.kernel.0.binary)?);
 
-    let base_addr = output.kernel.1.offset;
-    for app in output.apps.clone().into_iter() {
-        // Find the location the the binary should occupy in the blob.  There could be padding
-        // between the end of one application and the beginning of the next.
-        let app_start: usize =
-            (app.instruction_block.offset - base_addr + header_len).try_into()?;
-        match runtime.len().cmp(&app_start) {
-            Ordering::Less => runtime.resize(app_start, 0),
-            Ordering::Greater => bail!(
-                "Error in bundling, binary already exceeds app {} start offset",
-                &app.binary.name
-            ),
-            Ordering::Equal => { /* no op */ }
-        };
+    match &output.runtime {
+        RuntimeVariant::Kernel((kernel, instructions)) => {
+            runtime.append(&mut std::fs::read(&kernel.binary)?);
 
-        let elf = app.binary.binary.with_extension("");
-        let header_bytes = generate_tbf_header(
-            app.header,
-            app.instruction_block,
-            elf,
-            app.binary.binary.clone(),
-        )?;
-        runtime.extend(header_bytes.into_iter());
+            let base_addr = instructions.offset;
+            for app in output.apps.clone().into_iter() {
+                // Find the location the the binary should occupy in the blob.  There could be padding
+                // between the end of one application and the beginning of the next.
+                let app_start: usize =
+                    (app.instruction_block.offset - base_addr + header_len).try_into()?;
+                match runtime.len().cmp(&app_start) {
+                    Ordering::Less => runtime.resize(app_start, 0),
+                    Ordering::Greater => bail!(
+                        "Error in bundling, binary already exceeds app {} start offset",
+                        &app.binary.name
+                    ),
+                    Ordering::Equal => { /* no op */ }
+                };
 
-        let app = std::fs::read(&app.binary.binary)?;
-        runtime.extend(app.into_iter());
+                let elf = app.binary.binary.with_extension("");
+                let header_bytes = generate_tbf_header(
+                    app.header,
+                    app.instruction_block,
+                    elf,
+                    app.binary.binary.clone(),
+                )?;
+                runtime.extend(header_bytes.into_iter());
+
+                let app_bin = std::fs::read(&app.binary.binary)?;
+                runtime.extend(app_bin.into_iter());
+            }
+        }
+        RuntimeVariant::BareMetal((bare_metal, _)) => {
+            runtime.append(&mut std::fs::read(&bare_metal.binary)?);
+        }
     }
 
     // Firmware validated by Caliptra is required to be 256 byte aligned.

--- a/firmware-bundler/src/ld.rs
+++ b/firmware-bundler/src/ld.rs
@@ -14,7 +14,7 @@ use tbf_header::TbfHeader;
 
 use crate::{
     args::{Common, LdArgs},
-    manifest::{Binary, Manifest, Memory, RuntimeMemory},
+    manifest::{Binary, Manifest, Memory, RuntimeMemory, RuntimeVariant},
     tbf::create_tbf_header,
     TOCK_ALIGNMENT,
 };
@@ -28,9 +28,11 @@ use crate::{
 const BASE_ROM_LD_PREFIX: &str = "bundler-rom-layout";
 const BASE_KERNEL_LD_PREFIX: &str = "bundler-kernel-layout";
 const BASE_APP_LD_PREFIX: &str = "bundler-app-layout";
+const BASE_BARE_METAL_LD_PREFIX: &str = "bundler-bare-metal-layout";
 const BASE_ROM_LD_CONTENTS: &str = include_str!("../data/default-rom-layout.ld");
 const BASE_KERNEL_LD_CONTENTS: &str = include_str!("../data/default-kernel-layout.ld");
 const BASE_APP_LD_CONTENTS: &str = include_str!("../data/default-app-layout.ld");
+const BASE_BARE_METAL_LD_CONTENTS: &str = include_str!("../data/default-bare-metal-layout.ld");
 
 /// A pairing of application name to the linker script it should be built with.
 #[derive(Debug, Clone)]
@@ -52,7 +54,7 @@ pub struct App {
 #[derive(Debug, Clone)]
 pub struct BuildDefinition {
     pub rom: Option<LinkerScript>,
-    pub kernel: (LinkerScript, Memory),
+    pub runtime: RuntimeVariant<(LinkerScript, Memory)>,
     pub apps: Vec<App>,
 }
 
@@ -93,6 +95,7 @@ struct LdGeneration<'a> {
     base_rom: PathBuf,
     base_kernel: PathBuf,
     base_app: PathBuf,
+    base_bare_metal: PathBuf,
 }
 
 impl<'a> LdGeneration<'a> {
@@ -130,12 +133,20 @@ impl<'a> LdGeneration<'a> {
         };
         let base_app = content_aware_write(BASE_APP_LD_PREFIX, app_contents, &linker_dir)?;
 
+        let bare_metal_contents = match &ld.bare_metal_ld_base {
+            Some(user_base) => &String::from_utf8(std::fs::read(user_base)?)?,
+            None => BASE_BARE_METAL_LD_CONTENTS,
+        };
+        let base_bare_metal =
+            content_aware_write(BASE_BARE_METAL_LD_PREFIX, bare_metal_contents, &linker_dir)?;
+
         Ok(LdGeneration {
             manifest,
             linker_dir,
             base_rom,
             base_kernel,
             base_app,
+            base_bare_metal,
         })
     }
 
@@ -186,20 +197,30 @@ impl<'a> LdGeneration<'a> {
             });
         }
 
-        // Then generate a kernel linker file with the entirety of ITCM and DTCM space.
-        let kernel = &self.manifest.kernel;
-        let content = self
-            .kernel_linker_content(itcm.clone(), None, dtcm.clone(), itcm.clone(), dtcm.clone())
-            .with_context(|| binary_context(&kernel.name, "context generation"))?;
-        let path = self.output_ld_file(kernel, &content)?;
-        let kernel_def = LinkerScript {
-            name: kernel.name.clone(),
-            linker_script: path,
-        };
+        let runtime_binary = self.manifest.runtime.inner();
+        let content = if self.manifest.runtime.is_bare_metal() {
+            let mut combined = itcm.clone();
+            combined.size += dtcm.size;
+            self.bare_metal_linker_content(runtime_binary, itcm.clone(), combined)
+        } else {
+            self.kernel_linker_content(itcm.clone(), None, dtcm.clone(), itcm.clone(), dtcm.clone())
+        }
+        .with_context(|| binary_context(&runtime_binary.name, "context generation"))?;
+
+        let path = self.output_ld_file(runtime_binary, &content)?;
+        let runtime_def = self.manifest.runtime.clone().map(|_| {
+            (
+                LinkerScript {
+                    name: runtime_binary.name.clone(),
+                    linker_script: path,
+                },
+                itcm.clone(),
+            )
+        });
 
         Ok(BuildDefinition {
             rom: None,
-            kernel: (kernel_def, itcm.clone()),
+            runtime: runtime_def,
             apps: app_defs,
         })
     }
@@ -240,16 +261,14 @@ impl<'a> LdGeneration<'a> {
             })
             .transpose()?;
 
-        let kernel = &self.manifest.kernel;
-        let kernel_exec_mem = kernel.exec_mem()?;
-
         // Now get trackers for runtime instruction and data memory.
         let (mut itcm_tracker, mut dtcm_tracker) =
             match self.manifest.platform.runtime_memory.clone() {
                 RuntimeMemory::Sram(mut mem) => {
                     // Determine the amount of space required within SRAM for the instructions.  It is
-                    // equal to the kernel imem plus each apps imem, with padding for Tock alignment.
-                    let mut split = kernel_exec_mem.size;
+                    // equal to the runtime binary imem plus each apps imem, with padding for Tock alignment.
+                    let mut split = self.manifest.runtime.inner().exec_mem()?.size;
+
                     for app in &self.manifest.apps {
                         split += app.binary.exec_mem()?.size;
                     }
@@ -264,47 +283,50 @@ impl<'a> LdGeneration<'a> {
         let initial_itcm = itcm_tracker.clone();
         let initial_dtcm = dtcm_tracker.clone();
 
-        // The kernel should be the first element in both ITCM and RAM, therefore allocate it.  Wait
+        let mut first_app_instructions = None;
+
+        let runtime_binary = self.manifest.runtime.inner();
+        let runtime_exec_mem = runtime_binary.exec_mem()?;
+        // The runtime should be the first element in both ITCM and RAM, therefore allocate it.  Wait
         // before creating the LD file, as application alignment can effect the value of some LD
         // variables.
         let instructions = self
             .get_mem_block(
-                kernel_exec_mem.size,
-                kernel_exec_mem.alignment,
+                runtime_exec_mem.size,
+                runtime_exec_mem.alignment,
                 &mut itcm_tracker,
             )
-            .with_context(|| binary_context(&kernel.name, "instruction allocation"))?;
-        let kernel_data_mem = kernel.data_mem()?;
+            .with_context(|| binary_context(&runtime_binary.name, "instruction allocation"))?;
+        let runtime_data_mem = runtime_binary.data_mem()?;
         let data = self
             .get_mem_block(
-                kernel_data_mem.size,
-                kernel_data_mem.alignment,
+                runtime_data_mem.size,
+                runtime_data_mem.alignment,
                 &mut dtcm_tracker,
             )
-            .with_context(|| binary_context(&kernel.name, "data allocation"))?;
+            .with_context(|| binary_context(&runtime_binary.name, "data allocation"))?;
 
         // Now iterate through each application and allocate its ITCM and RAM requirements.
-        let mut first_app_instructions = None;
         let mut app_defs = Vec::new();
         for app in &self.manifest.apps {
             let binary = &app.binary;
             let header = create_tbf_header(binary)?;
 
             let exec_mem = binary.exec_mem()?;
-            let instructions = self
+            let app_instructions = self
                 .get_mem_block(exec_mem.size, exec_mem.alignment, &mut itcm_tracker)
                 .with_context(|| binary_context(&binary.name, "instruction allocation"))?;
             let data_mem = binary.data_mem()?;
-            let data = self
+            let app_data = self
                 .get_mem_block(data_mem.size, data_mem.alignment, &mut dtcm_tracker)
                 .with_context(|| binary_context(&binary.name, "data allocation"))?;
 
             if first_app_instructions.is_none() {
-                first_app_instructions = Some(instructions.clone());
+                first_app_instructions = Some(app_instructions.clone());
             }
 
             let content = self
-                .app_linker_content(binary, &header, instructions.clone(), data)
+                .app_linker_content(binary, &header, app_instructions.clone(), app_data)
                 .with_context(|| binary_context(&binary.name, "context generation"))?;
             let path = self.output_ld_file(binary, &content)?;
             app_defs.push(App {
@@ -313,29 +335,40 @@ impl<'a> LdGeneration<'a> {
                     linker_script: path,
                 },
                 header,
-                instruction_block: instructions,
+                instruction_block: app_instructions,
             });
         }
 
-        // Finally generate the linker file for the kernel.
-        let content = self
-            .kernel_linker_content(
+        // Finally generate the linker file for the runtime.
+        let content = if self.manifest.runtime.is_bare_metal() {
+            let mut combined = instructions.clone();
+            combined.size += data.size;
+            self.bare_metal_linker_content(runtime_binary, instructions.clone(), combined)
+        } else {
+            self.kernel_linker_content(
                 instructions.clone(),
                 first_app_instructions,
                 data,
                 initial_itcm,
                 initial_dtcm,
             )
-            .with_context(|| binary_context(&kernel.name, "context generation"))?;
-        let path = self.output_ld_file(kernel, &content)?;
-        let kernel_def = LinkerScript {
-            name: kernel.name.clone(),
-            linker_script: path,
-        };
+        }
+        .with_context(|| binary_context(&runtime_binary.name, "context generation"))?;
+
+        let path = self.output_ld_file(runtime_binary, &content)?;
+        let runtime_def = self.manifest.runtime.clone().map(|_| {
+            (
+                LinkerScript {
+                    name: runtime_binary.name.clone(),
+                    linker_script: path,
+                },
+                instructions,
+            )
+        });
 
         Ok(BuildDefinition {
             rom: rom_def,
-            kernel: (kernel_def, instructions),
+            runtime: runtime_def,
             apps: app_defs,
         })
     }
@@ -405,6 +438,44 @@ INCLUDE $BASE_LD_CONTENTS
         );
 
         subst::substitute(ROM_LD_TEMPLATE, &sub_map).map_err(|e| e.into())
+    }
+
+    fn bare_metal_linker_content(
+        &self,
+        binary: &Binary,
+        instructions: Memory,
+        data: Memory,
+    ) -> Result<String> {
+        const BARE_METAL_LD_TEMPLATE: &str = r#"
+ROM_START = $ROM_START;
+ROM_LENGTH = $ROM_LENGTH;
+RAM_START = $RAM_START;
+RAM_LENGTH = $RAM_LENGTH;
+STACK_SIZE = $STACK_SIZE;
+ESTACK_SIZE = $ESTACK_SIZE;
+INCLUDE $BASE_LD_CONTENTS
+"#;
+
+        let base_ld_file = self.linker_dir.join(&self.base_bare_metal);
+
+        let mut sub_map = HashMap::new();
+        sub_map.insert("ROM_START", format!("{:#x}", instructions.offset));
+        sub_map.insert("ROM_LENGTH", format!("{:#x}", instructions.size));
+        sub_map.insert("RAM_START", format!("{:#x}", data.offset));
+        sub_map.insert("RAM_LENGTH", format!("{:#x}", data.size));
+        // If the stack isn't specified we are in a sizing build, and it doesnt matter.  Therefore
+        // default to 0.
+        sub_map.insert(
+            "STACK_SIZE",
+            format!("{:#x}", binary.stack().unwrap_or_default()),
+        );
+        sub_map.insert("ESTACK_SIZE", format!("{:#x}", binary.exception_stack));
+        sub_map.insert(
+            "BASE_LD_CONTENTS",
+            base_ld_file.to_string_lossy().to_string(),
+        );
+
+        subst::substitute(BARE_METAL_LD_TEMPLATE, &sub_map).map_err(|e| e.into())
     }
 
     fn kernel_linker_content(
@@ -482,11 +553,6 @@ INCLUDE $BASE_LD_CONTENTS
             .map(|pg| format!("PAGE_SIZE = {};", pg))
             .unwrap_or_default();
         sub_map.insert("PAGE_SIZE", page_size);
-
-        sub_map.insert(
-            "BASE_LD_CONTENTS",
-            base_ld_file.to_string_lossy().to_string(),
-        );
 
         subst::substitute(KERNEL_LD_TEMPLATE, &sub_map).map_err(|e| e.into())
     }
@@ -585,7 +651,7 @@ fn content_aware_write(prefix: &str, content: &str, linker_dir: &Path) -> Result
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::manifest::{App, Platform};
+    use crate::manifest::{App, Platform, Runtime};
     use tempfile::TempDir;
 
     /// Create a platform with configurable memory sizes.
@@ -643,6 +709,7 @@ mod tests {
             rom_ld_base: None,
             kernel_ld_base: None,
             app_ld_base: None,
+            bare_metal_ld_base: None,
         }
     }
 
@@ -650,13 +717,13 @@ mod tests {
     fn test_manifest(
         platform: Platform,
         rom: Option<Binary>,
-        kernel: Binary,
+        runtime: Runtime,
         apps: Vec<App>,
     ) -> Manifest {
         Manifest {
             platform,
             rom,
-            kernel,
+            runtime,
             apps,
         }
     }
@@ -669,7 +736,7 @@ mod tests {
         let manifest = test_manifest(
             test_platform(0x1000, 0x1000, 0x1000, 0x1000),
             None,
-            test_binary("kernel", 0x100, 0x100),
+            RuntimeVariant::Kernel(test_binary("kernel", 0x100, 0x100)),
             vec![],
         );
         let result = generate(&manifest, &test_common(&temp), &test_ld_args());
@@ -677,7 +744,25 @@ mod tests {
 
         let build_def = result.unwrap();
         assert!(build_def.rom.is_none());
-        assert_eq!(build_def.kernel.0.name, "kernel");
+        assert_eq!(build_def.runtime.inner().0.name, "kernel");
+        assert!(build_def.apps.is_empty());
+    }
+
+    #[test]
+    fn bare_metal_only_fits() {
+        let temp = TempDir::new().unwrap();
+        let manifest = test_manifest(
+            test_platform(0x1000, 0x1000, 0x1000, 0x1000),
+            None,
+            RuntimeVariant::BareMetal(test_binary("bare_metal", 0x100, 0x100)),
+            vec![],
+        );
+        let result = generate(&manifest, &test_common(&temp), &test_ld_args());
+        assert!(result.is_ok());
+
+        let build_def = result.unwrap();
+        assert!(build_def.rom.is_none());
+        assert_eq!(build_def.runtime.inner().0.name, "bare_metal");
         assert!(build_def.apps.is_empty());
     }
 
@@ -687,7 +772,7 @@ mod tests {
         let manifest = test_manifest(
             test_platform(0x1000, 0x1000, 0x1000, 0x1000),
             Some(test_binary("rom", 0x100, 0x100)),
-            test_binary("kernel", 0x100, 0x100),
+            RuntimeVariant::Kernel(test_binary("kernel", 0x100, 0x100)),
             vec![],
         );
         let result = generate(&manifest, &test_common(&temp), &test_ld_args());
@@ -696,7 +781,7 @@ mod tests {
         let build_def = result.unwrap();
         assert!(build_def.rom.is_some());
         assert_eq!(build_def.rom.as_ref().unwrap().name, "rom");
-        assert_eq!(build_def.kernel.0.name, "kernel");
+        assert_eq!(build_def.runtime.inner().0.name, "kernel");
         assert!(build_def.apps.is_empty());
     }
 
@@ -706,7 +791,7 @@ mod tests {
         let manifest = test_manifest(
             test_platform(0x1000, 0x1000, 0x1000, 0x1000),
             None,
-            test_binary("kernel", 0x100, 0x100),
+            RuntimeVariant::Kernel(test_binary("kernel", 0x100, 0x100)),
             vec![test_app("app1", 0x100, 0x100)],
         );
         let result = generate(&manifest, &test_common(&temp), &test_ld_args());
@@ -714,7 +799,7 @@ mod tests {
 
         let build_def = result.unwrap();
         assert!(build_def.rom.is_none());
-        assert_eq!(build_def.kernel.0.name, "kernel");
+        assert_eq!(build_def.runtime.inner().0.name, "kernel");
         assert_eq!(build_def.apps.len(), 1);
         assert_eq!(build_def.apps[0].linker.name, "app1");
     }
@@ -725,7 +810,7 @@ mod tests {
         let manifest = test_manifest(
             test_platform(0x1000, 0x2000, 0x2000, 0x1000),
             None,
-            test_binary("kernel", 0x100, 0x100),
+            RuntimeVariant::Kernel(test_binary("kernel", 0x100, 0x100)),
             vec![
                 test_app("app1", 0x100, 0x100),
                 test_app("app2", 0x100, 0x100),
@@ -748,7 +833,7 @@ mod tests {
         let manifest = test_manifest(
             test_platform(0x1000, 0x2000, 0x2000, 0x1000),
             Some(test_binary("rom", 0x200, 0x200)),
-            test_binary("kernel", 0x200, 0x200),
+            RuntimeVariant::Kernel(test_binary("kernel", 0x200, 0x200)),
             vec![
                 test_app("app1", 0x100, 0x100),
                 test_app("app2", 0x100, 0x100),
@@ -760,7 +845,7 @@ mod tests {
         let build_def = result.unwrap();
         assert!(build_def.rom.is_some());
         assert_eq!(build_def.rom.as_ref().unwrap().name, "rom");
-        assert_eq!(build_def.kernel.0.name, "kernel");
+        assert_eq!(build_def.runtime.inner().0.name, "kernel");
         assert_eq!(build_def.apps.len(), 2);
     }
 
@@ -773,14 +858,14 @@ mod tests {
         let manifest = test_manifest(
             test_platform(0x1000, 0x200, 0x200, 0x1000),
             None,
-            test_binary("kernel", 0x100, 0x100),
+            RuntimeVariant::Kernel(test_binary("kernel", 0x100, 0x100)),
             vec![test_app("app1", 0x100, 0x100)],
         );
         let result = generate(&manifest, &test_common(&temp), &test_ld_args());
         assert!(result.is_ok());
 
         let build_def = result.unwrap();
-        assert_eq!(build_def.kernel.0.name, "kernel");
+        assert_eq!(build_def.runtime.inner().0.name, "kernel");
         assert_eq!(build_def.apps.len(), 1);
     }
 
@@ -790,7 +875,7 @@ mod tests {
         let manifest = test_manifest(
             test_platform(0x1000, 0x1000, 0x1000, 0x1000),
             Some(test_binary("my_rom", 0x100, 0x100)),
-            test_binary("my_kernel", 0x100, 0x100),
+            RuntimeVariant::Kernel(test_binary("my_kernel", 0x100, 0x100)),
             vec![test_app("my_app", 0x100, 0x100)],
         );
         let result = generate(&manifest, &test_common(&temp), &test_ld_args());
@@ -800,7 +885,7 @@ mod tests {
 
         // Verify linker script files exist on disk
         assert!(build_def.rom.as_ref().unwrap().linker_script.exists());
-        assert!(build_def.kernel.0.linker_script.exists());
+        assert!(build_def.runtime.inner().0.linker_script.exists());
         assert!(build_def.apps[0].linker.linker_script.exists());
 
         // Verify base layout files also exist (with UUID suffixes)
@@ -832,7 +917,7 @@ mod tests {
         let manifest = test_manifest(
             test_platform(0x1000, 0x100, 0x1000, 0x1000), // Small ITCM
             None,
-            test_binary("kernel", 0x200, 0x100), // Kernel exec_mem > ITCM
+            RuntimeVariant::Kernel(test_binary("kernel", 0x200, 0x100)), // Kernel exec_mem > ITCM
             vec![],
         );
         let result = generate(&manifest, &test_common(&temp), &test_ld_args());
@@ -845,7 +930,7 @@ mod tests {
         let manifest = test_manifest(
             test_platform(0x1000, 0x1000, 0x100, 0x1000), // Small RAM
             None,
-            test_binary("kernel", 0x100, 0x200), // Kernel RAM > platform RAM
+            RuntimeVariant::Kernel(test_binary("kernel", 0x100, 0x200)), // Kernel RAM > platform RAM
             vec![],
         );
         let result = generate(&manifest, &test_common(&temp), &test_ld_args());
@@ -858,7 +943,7 @@ mod tests {
         let manifest = test_manifest(
             test_platform(0x100, 0x1000, 0x1000, 0x1000), // Small ROM
             Some(test_binary("rom", 0x200, 0x100)),       // ROM exec_mem > platform ROM
-            test_binary("kernel", 0x100, 0x100),
+            RuntimeVariant::Kernel(test_binary("kernel", 0x100, 0x100)),
             vec![],
         );
         let result = generate(&manifest, &test_common(&temp), &test_ld_args());
@@ -871,7 +956,7 @@ mod tests {
         let manifest = test_manifest(
             test_platform(0x1000, 0x1000, 0x100, 0x100), // Small RAM and DCCM
             Some(test_binary("rom", 0x100, 0x200)),      // ROM RAM > platform DCCM
-            test_binary("kernel", 0x100, 0x100),
+            RuntimeVariant::Kernel(test_binary("kernel", 0x100, 0x100)),
             vec![],
         );
         let result = generate(&manifest, &test_common(&temp), &test_ld_args());
@@ -885,7 +970,7 @@ mod tests {
         let manifest = test_manifest(
             test_platform(0x1000, 0x200, 0x1000, 0x1000),
             None,
-            test_binary("kernel", 0x100, 0x100),
+            RuntimeVariant::Kernel(test_binary("kernel", 0x100, 0x100)),
             vec![test_app("app1", 0x200, 0x100)], // App needs 0x200, only 0x100 available
         );
         let result = generate(&manifest, &test_common(&temp), &test_ld_args());
@@ -899,7 +984,7 @@ mod tests {
         let manifest = test_manifest(
             test_platform(0x1000, 0x1000, 0x200, 0x1000),
             None,
-            test_binary("kernel", 0x100, 0x100),
+            RuntimeVariant::Kernel(test_binary("kernel", 0x100, 0x100)),
             vec![test_app("app1", 0x100, 0x200)], // App needs 0x200 RAM, only 0x100 available
         );
         let result = generate(&manifest, &test_common(&temp), &test_ld_args());
@@ -914,7 +999,7 @@ mod tests {
         let manifest = test_manifest(
             test_platform(0x1000, 0x300, 0x1000, 0x1000),
             None,
-            test_binary("kernel", 0x100, 0x100),
+            RuntimeVariant::Kernel(test_binary("kernel", 0x100, 0x100)),
             vec![
                 test_app("app1", 0x100, 0x50),
                 test_app("app2", 0x100, 0x50),
@@ -933,7 +1018,7 @@ mod tests {
         let manifest = test_manifest(
             test_platform(0x1000, 0x1000, 0x300, 0x1000),
             None,
-            test_binary("kernel", 0x100, 0x100),
+            RuntimeVariant::Kernel(test_binary("kernel", 0x100, 0x100)),
             vec![
                 test_app("app1", 0x50, 0x100),
                 test_app("app2", 0x50, 0x100),
@@ -952,7 +1037,7 @@ mod tests {
         let manifest = test_manifest(
             test_platform(0x1000, 0x280, 0x1000, 0x1000),
             None,
-            test_binary("kernel", 0x100, 0x100),
+            RuntimeVariant::Kernel(test_binary("kernel", 0x100, 0x100)),
             vec![
                 test_app("app1", 0x80, 0x50),
                 test_app("app2", 0x80, 0x50),
@@ -971,7 +1056,7 @@ mod tests {
         let manifest = test_manifest(
             test_platform(0x1000, 0x1000, 0x280, 0x1000),
             None,
-            test_binary("kernel", 0x100, 0x100),
+            RuntimeVariant::Kernel(test_binary("kernel", 0x100, 0x100)),
             vec![
                 test_app("app1", 0x50, 0x80),
                 test_app("app2", 0x50, 0x80),
@@ -989,7 +1074,7 @@ mod tests {
         let manifest = test_manifest(
             test_platform(0x1000, 0x0, 0x1000, 0x1000),
             None,
-            test_binary("kernel", 0x100, 0x100),
+            RuntimeVariant::Kernel(test_binary("kernel", 0x100, 0x100)),
             vec![],
         );
         let result = generate(&manifest, &test_common(&temp), &test_ld_args());

--- a/firmware-bundler/src/lib.rs
+++ b/firmware-bundler/src/lib.rs
@@ -120,15 +120,29 @@ fn dynamically_size(
         });
     }
 
-    // Update the kernels memory requirments.
-    manifest.kernel.exec_mem = Some(AllocationRequest {
-        size: sizes.kernel.instructions.next_multiple_of(TOCK_ALIGNMENT),
-        alignment: None,
-    });
-    manifest.kernel.data_mem = Some(AllocationRequest {
-        size: sizes.kernel.data.next_multiple_of(TOCK_ALIGNMENT),
-        alignment: None,
-    });
+    let is_bare_metal = manifest.runtime.is_bare_metal();
+    let runtime_binary = manifest.runtime.inner_mut();
+    let runtime_size = sizes.runtime.inner();
+
+    if is_bare_metal {
+        runtime_binary.exec_mem = Some(AllocationRequest {
+            size: runtime_size.instructions,
+            alignment: None,
+        });
+        runtime_binary.data_mem = Some(AllocationRequest {
+            size: runtime_size.data,
+            alignment: None,
+        });
+    } else {
+        runtime_binary.exec_mem = Some(AllocationRequest {
+            size: runtime_size.instructions.next_multiple_of(TOCK_ALIGNMENT),
+            alignment: None,
+        });
+        runtime_binary.data_mem = Some(AllocationRequest {
+            size: runtime_size.data.next_multiple_of(TOCK_ALIGNMENT),
+            alignment: None,
+        });
+    }
 
     // Update the requirements for each application.
     manifest

--- a/firmware-bundler/src/manifest.rs
+++ b/firmware-bundler/src/manifest.rs
@@ -18,14 +18,61 @@ pub struct Manifest {
     /// sole access to the ROM memory, and assumed to have full access to the RAM memory.
     pub rom: Option<Binary>,
 
-    /// The tock kernel application.  This will be placed at the beginning of ITCM.
-    pub kernel: Binary,
+    /// The primary runtime binary. This can either be a Tock kernel or a bare metal binary.
+    #[serde(flatten)]
+    pub runtime: Runtime,
 
     /// The set of userspace apps which should be deployed to the given platform.  The ordering of
     /// binaries indicates the order applications should be allocated memory from the space
     /// remaining after the kernel allocation.
-    #[serde(rename = "app")]
+    #[serde(rename = "app", default)]
     pub apps: Vec<App>,
+}
+
+/// The primary runtime binary.
+pub type Runtime = RuntimeVariant<Binary>;
+
+/// A generic wrapper for a runtime binary, supporting both Tock kernel and bare metal variants.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum RuntimeVariant<T> {
+    /// A Tock kernel binary.
+    #[serde(rename = "kernel")]
+    Kernel(T),
+
+    /// A bare metal runtime binary.
+    #[serde(rename = "bare_metal")]
+    BareMetal(T),
+}
+
+impl<T> RuntimeVariant<T> {
+    /// Retrieve a reference to the inner value.
+    pub fn inner(&self) -> &T {
+        match self {
+            Self::Kernel(t) => t,
+            Self::BareMetal(t) => t,
+        }
+    }
+
+    /// Retrieve a mutable reference to the inner value.
+    pub fn inner_mut(&mut self) -> &mut T {
+        match self {
+            Self::Kernel(t) => t,
+            Self::BareMetal(t) => t,
+        }
+    }
+
+    /// Return true if this is a bare metal runtime.
+    pub fn is_bare_metal(&self) -> bool {
+        matches!(self, Self::BareMetal(_))
+    }
+
+    /// Map the inner value.
+    pub fn map<U, F: FnOnce(T) -> U>(self, f: F) -> RuntimeVariant<U> {
+        match self {
+            Self::Kernel(t) => RuntimeVariant::Kernel(f(t)),
+            Self::BareMetal(t) => RuntimeVariant::BareMetal(f(t)),
+        }
+    }
 }
 
 impl Manifest {
@@ -64,9 +111,16 @@ impl Manifest {
             }
         }
 
-        self.kernel.validate(dynamic_sizing)?;
-        for app in &self.apps {
-            app.binary.validate(dynamic_sizing)?;
+        self.runtime.inner().validate(dynamic_sizing)?;
+
+        if self.runtime.is_bare_metal() {
+            if !self.apps.is_empty() {
+                bail!("Apps are not supported with bare_metal runtime");
+            }
+        } else {
+            for app in &self.apps {
+                app.binary.validate(dynamic_sizing)?;
+            }
         }
 
         Ok(())
@@ -373,7 +427,10 @@ impl App {
 
 #[cfg(test)]
 mod tests {
-    use super::{AllocationRequest, Binary, Memory};
+    use super::{
+        AllocationRequest, App, Binary, Manifest, Memory, Platform, Runtime, RuntimeMemory,
+        RuntimeVariant,
+    };
 
     #[test]
     fn memory_consume_with_room() {
@@ -529,5 +586,102 @@ mod tests {
             .unwrap_err()
             .to_string()
             .contains("no stack specified"));
+    }
+
+    // ==================== Manifest::validate() Tests ====================
+
+    #[test]
+    fn manifest_validate_kernel_no_apps() {
+        // A manifest with only a kernel is valid.
+        let manifest = test_manifest(
+            test_platform(0x1000, 0x1000, 0x1000, 0x1000),
+            None,
+            RuntimeVariant::Kernel(test_binary("kernel", 0x100, 0x100)),
+            vec![],
+        );
+        assert!(manifest.validate().is_ok());
+    }
+
+    #[test]
+    fn manifest_validate_bare_metal_no_apps() {
+        // A manifest with only a bare_metal runtime is valid.
+        let manifest = test_manifest(
+            test_platform(0x1000, 0x1000, 0x1000, 0x1000),
+            None,
+            RuntimeVariant::BareMetal(test_binary("bare_metal", 0x100, 0x100)),
+            vec![],
+        );
+        assert!(manifest.validate().is_ok());
+    }
+
+    #[test]
+    fn manifest_validate_bare_metal_with_apps() {
+        // A manifest with a bare_metal runtime cannot also specify Tock applications.
+        let manifest = test_manifest(
+            test_platform(0x1000, 0x1000, 0x1000, 0x1000),
+            None,
+            RuntimeVariant::BareMetal(test_binary("bare_metal", 0x100, 0x100)),
+            vec![test_app("app1", 0x100, 0x100)],
+        );
+        let result = manifest.validate();
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Apps are not supported with bare_metal"));
+    }
+
+    fn test_platform(rom_size: u64, itcm_size: u64, ram_size: u64, dccm_size: u64) -> Platform {
+        Platform {
+            name: "test".to_string(),
+            tuple: "riscv32imc-unknown-none-elf".to_string(),
+            dynamic_sizing: Some(false),
+            default_alignment: Some(8),
+            page_size: Some(256),
+            rom: Memory {
+                offset: 0x0,
+                size: rom_size,
+            },
+            runtime_memory: RuntimeMemory::Tcm {
+                itcm: Memory {
+                    offset: 0x10000,
+                    size: itcm_size,
+                },
+                dtcm: Memory {
+                    offset: 0x20000,
+                    size: ram_size,
+                },
+            },
+            dccm: Some(Memory {
+                offset: 0x30000,
+                size: dccm_size,
+            }),
+            flash: None,
+        }
+    }
+
+    fn test_binary(name: &str, exec_size: u64, ram_size: u64) -> Binary {
+        Binary::new_for_test(name, exec_size, ram_size, None, 0)
+    }
+
+    fn test_app(name: &str, exec_size: u64, ram_size: u64) -> App {
+        App {
+            binary: test_binary(name, exec_size, ram_size),
+            grant_space: None,
+        }
+    }
+
+    fn test_manifest(
+        platform: Platform,
+        rom: Option<Binary>,
+        runtime: Runtime,
+        apps: Vec<App>,
+    ) -> Manifest {
+        Manifest {
+            platform,
+            rom,
+            runtime,
+            apps,
+        }
     }
 }

--- a/firmware-bundler/src/size.rs
+++ b/firmware-bundler/src/size.rs
@@ -5,7 +5,10 @@
 use anyhow::{anyhow, Result};
 use elf::{endian::AnyEndian, ElfBytes};
 
-use crate::build::{BuildOutput, BuiltBinary};
+use crate::{
+    build::{BuildOutput, BuiltBinary},
+    manifest::RuntimeVariant,
+};
 
 trait BinarySymbols {
     const INSTRUCTION_START_SYMBOL: &str;
@@ -52,14 +55,23 @@ pub struct BinarySize {
 /// The output from doing a sizing pass.
 #[derive(Debug, Clone)]
 pub struct SizeOutput {
-    pub kernel: BinarySize,
+    pub runtime: RuntimeVariant<BinarySize>,
     pub apps: Vec<BinarySize>,
 }
 
 /// Determine the sizes of the runtime applications. This could fail if the required symbols are not
 /// located within the elf.
 pub fn sizes(build: &BuildOutput) -> Result<SizeOutput> {
-    let kernel = binary_size::<KernelSymbols>(&build.kernel.0)?;
+    let runtime = build
+        .runtime
+        .clone()
+        .map(|(built, _)| binary_size::<KernelSymbols>(&built));
+
+    // Convert RuntimeVariant<Result<...>> to Result<RuntimeVariant<...>>
+    let runtime = match runtime {
+        RuntimeVariant::Kernel(r) => RuntimeVariant::Kernel(r?),
+        RuntimeVariant::BareMetal(r) => RuntimeVariant::BareMetal(r?),
+    };
 
     let apps = build
         .apps
@@ -67,7 +79,7 @@ pub fn sizes(build: &BuildOutput) -> Result<SizeOutput> {
         .map(|app| binary_size::<ApplicationSymbols>(&app.binary))
         .collect::<Result<Vec<_>>>()?;
 
-    Ok(SizeOutput { kernel, apps })
+    Ok(SizeOutput { runtime, apps })
 }
 
 /// Determine the instruction and data sizes of an application.

--- a/runtime/bare-metal/Cargo.toml
+++ b/runtime/bare-metal/Cargo.toml
@@ -1,0 +1,20 @@
+# Licensed under the Apache-2.0 license
+
+[package]
+name = "bare-metal-runtime"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+
+[dependencies]
+caliptra-drivers.workspace = true
+romtime.workspace = true
+
+[target.'cfg(target_arch = "riscv32")'.dependencies]
+rv32i.workspace = true
+
+[profile.release]
+panic = "abort"
+lto = true
+opt-level = "z"
+codegen-units = 1

--- a/runtime/bare-metal/manifest.toml
+++ b/runtime/bare-metal/manifest.toml
@@ -1,0 +1,27 @@
+# Licensed under the Apache-2.0 license
+
+[platform]
+name = "bare-metal"
+tuple = "riscv32imc-unknown-none-elf"
+dynamic_sizing = true
+page_size = 256
+
+[platform.rom]
+offset = 0x80000000
+size = 0x20000
+
+[platform.runtime_memory]
+sram = { offset = 0x40000000, size = 0x80000 }
+
+[platform.dccm]
+offset = 0x50000000
+size = 0x4000
+
+[platform.flash]
+offset = 0x3BFE0000
+size = 0x20000
+
+[bare_metal]
+name = "bare-metal-runtime"
+stack = 0x4000
+exception_stack = 0x400

--- a/runtime/bare-metal/src/main.rs
+++ b/runtime/bare-metal/src/main.rs
@@ -1,0 +1,46 @@
+// Licensed under the Apache-2.0 license
+//
+// A simple bare metal runtime that prints to the emulator UART.
+
+#![cfg_attr(target_arch = "riscv32", no_std)]
+#![no_main]
+
+#[cfg(target_arch = "riscv32")]
+use core::arch::global_asm;
+
+#[cfg(target_arch = "riscv32")]
+use core::panic::PanicInfo;
+
+#[cfg(target_arch = "riscv32")]
+global_asm!(include_str!("start.S"));
+
+#[cfg(target_arch = "riscv32")]
+const MSG: &[u8; 31] = b"Hello from Bare Metal Runtime!\n";
+
+#[cfg(target_arch = "riscv32")]
+#[no_mangle]
+pub extern "C" fn main() {
+    // Write the message to the console.
+    const UART0: *mut u8 = 0x1000_1041 as *mut u8;
+    unsafe {
+        for byte in MSG {
+            core::ptr::write_volatile(UART0, *byte);
+        }
+        core::ptr::write_volatile(UART0, b'\n');
+    }
+    // Exit the emulator.
+    unsafe {
+        core::ptr::write_volatile(0x1000_2000 as *mut u32, 0);
+    }
+}
+
+#[cfg(target_arch = "riscv32")]
+#[panic_handler]
+fn panic(_info: &PanicInfo) -> ! {
+    loop {}
+}
+
+// Dummy main for non-RISC-V targets.
+#[cfg(not(target_arch = "riscv32"))]
+#[no_mangle]
+pub extern "C" fn main() {}

--- a/runtime/bare-metal/src/start.S
+++ b/runtime/bare-metal/src/start.S
@@ -1,0 +1,38 @@
+// Licensed under the Apache-2.0 license.
+
+.option norvc
+
+.section .text.init
+.global _start
+_start:
+
+.option push
+.option norelax
+    la gp, GLOBAL_POINTER
+.option pop
+
+    # Initialize the stack pointer
+    la sp, STACK_TOP
+
+    # Copy BSS
+    la t0, BSS_START
+    la t1, BSS_END
+copy_bss:
+    bge t0, t1, end_copy_bss
+    sw x0, 0(t0)
+    addi t0, t0, 4
+    j copy_bss
+end_copy_bss:
+
+    # In bare-metal-runtime, we are running entirely from RAM (LMA=VMA).
+    # Data is already where it needs to be, so no need to copy from ROM to RAM.
+
+    # call main entry point
+    call main
+
+    # exit the emulator
+    la t0, EMU_CTRL_EXIT
+    sw zero, 0(t0)
+
+.section .data
+.equ  EMU_CTRL_EXIT, 0x10002000

--- a/tests/integration/src/lib.rs
+++ b/tests/integration/src/lib.rs
@@ -5,6 +5,7 @@ mod i3c_socket;
 mod jtag;
 #[cfg(test)]
 mod rom;
+mod test_bare_metal;
 mod test_dot;
 mod test_exception_handler;
 mod test_firmware_update;
@@ -158,6 +159,12 @@ mod test {
             None,
         )
         .expect("Runtime failed to compile");
+        assert!(output.exists());
+        output
+    }
+
+    pub fn compile_bare_metal_runtime() -> PathBuf {
+        let output = mcu_builder::bare_metal_build().expect("Bare-metal runtime failed to compile");
         assert!(output.exists());
         output
     }

--- a/tests/integration/src/test_bare_metal.rs
+++ b/tests/integration/src/test_bare_metal.rs
@@ -1,0 +1,39 @@
+// Licensed under the Apache-2.0 license
+
+#[cfg(test)]
+mod test {
+    use crate::test::{compile_bare_metal_runtime, run_runtime, ROM, TEST_LOCK};
+    use mcu_testing_common::DeviceLifecycle;
+    use random_port::PortPicker;
+
+    #[test]
+    fn test_bare_metal_runtime_boot() {
+        let lock = TEST_LOCK.lock().unwrap();
+
+        let rom_path = ROM.clone();
+        let runtime_path = compile_bare_metal_runtime();
+
+        let i3c_port = PortPicker::new().random(true).pick().unwrap().to_string();
+
+        let status = run_runtime(
+            "test-bare-metal",
+            rom_path,
+            runtime_path,
+            i3c_port,
+            true, // active_mode
+            DeviceLifecycle::Production,
+            None,                      // soc_images
+            None,                      // streaming_boot_package_path
+            None,                      // primary_flash_image_path
+            None,                      // secondary_flash_image_path
+            None,                      // caliptra_builder
+            Some("2.1.0".to_string()), // hw_revision
+            None,                      // fuse_soc_manifest_svn
+            None,                      // fuse_soc_manifest_max_svn
+            None,                      // fuse_vendor_test_partition
+        );
+
+        assert_eq!(status, 0);
+        lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+}


### PR DESCRIPTION
This updates the firmware bundler to build bare metal binaries which will be required for building reference provisioning firmware that needs to be as lean as possible to minize firmware load times, and thus, time on the tester. Additionally, this adds an example test that runs the bare metal runtime binary.

Fixes #976.