### PR TITLE
Redundant partition table with dual-copy protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2875,6 +2875,7 @@ dependencies = [
  "subst",
  "tbf-header",
  "tempfile",
+ "toml 0.8.23",
  "uuid",
  "walkdir",
  "zerocopy",
@@ -2917,6 +2918,7 @@ name = "mcu-config-emulator"
 version = "0.1.0"
 dependencies = [
  "mcu-config",
+ "partition-table",
  "zerocopy",
 ]
 
@@ -3555,6 +3557,14 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "partition-table"
+version = "0.1.0"
+dependencies = [
+ "mcu-config",
+ "zerocopy",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "builder",
     "common/config",
     "common/flash-image",
+    "common/partition-table",
     "common/mcu-mbox",
     "common/otp-digest",
     "common/mctp-vdm",
@@ -193,6 +194,7 @@ flash-ctrl-emulator = { path = "platforms/emulator/runtime/kernel/drivers/flash_
 flash-ctrl-fpga = { path = "platforms/fpga/runtime/drivers/flash_ctrl"}
 flash-driver = { path = "runtime/kernel/drivers/flash" }
 flash-image = { path = "common/flash-image" }
+partition-table = { path = "common/partition-table" }
 i3c-driver = { path = "runtime/kernel/drivers/i3c" }
 libtockasync = { path = "runtime/userspace/libtockasync" }
 mcu-builder = { path = "builder" }

--- a/builder/Cargo.toml
+++ b/builder/Cargo.toml
@@ -24,6 +24,7 @@ mcu-config-fpga.workspace = true
 mcu-firmware-bundler.workspace = true
 pldm-fw-pkg.workspace = true
 serde.workspace = true
+toml.workspace = true
 semver.workspace = true
 subst.workspace = true
 tbf-header.workspace = true

--- a/builder/src/flash_image.rs
+++ b/builder/src/flash_image.rs
@@ -355,6 +355,8 @@ pub fn write_partition_table(
     offset: usize,
     filename: &str,
 ) -> Result<()> {
+    use mcu_config_emulator::flash::{PARTITION_TABLE_COPY_0_OFFSET, PARTITION_TABLE_COPY_1_OFFSET};
+
     let mut file = OpenOptions::new()
         .write(true)
         .create(true)
@@ -362,14 +364,32 @@ pub fn write_partition_table(
         .open(filename)
         .map_err(|e| anyhow!(format!("Unable to open file {}: {}", filename, e)))?;
 
-    // Seek to the specified offset before writing
-    file.seek(std::io::SeekFrom::Start(offset as u64))
-        .map_err(|e| {
-            anyhow!(format!(
-                "Unable to seek to offset {} in file {}: {}",
-                offset, filename, e
-            ))
-        })?;
+    // Write copy 0
+    file.seek(std::io::SeekFrom::Start(
+        (offset + PARTITION_TABLE_COPY_0_OFFSET) as u64,
+    ))
+    .map_err(|e| {
+        anyhow!(format!(
+            "Unable to seek to offset {} in file {}: {}",
+            offset + PARTITION_TABLE_COPY_0_OFFSET,
+            filename,
+            e
+        ))
+    })?;
+    file.write_all(partition_table.as_bytes())?;
+
+    // Write copy 1
+    file.seek(std::io::SeekFrom::Start(
+        (offset + PARTITION_TABLE_COPY_1_OFFSET) as u64,
+    ))
+    .map_err(|e| {
+        anyhow!(format!(
+            "Unable to seek to offset {} in file {}: {}",
+            offset + PARTITION_TABLE_COPY_1_OFFSET,
+            filename,
+            e
+        ))
+    })?;
     file.write_all(partition_table.as_bytes())?;
 
     Ok(())

--- a/builder/src/flash_layout_config.rs
+++ b/builder/src/flash_layout_config.rs
@@ -1,0 +1,201 @@
+// Licensed under the Apache-2.0 license
+
+use anyhow::{anyhow, Result};
+use serde::Deserialize;
+use std::fs;
+use std::path::Path;
+
+/// Top-level flash layout configuration.
+#[derive(Debug, Deserialize)]
+pub struct FlashLayoutConfig {
+    pub flash: FlashConfig,
+    pub partition_table: PartitionTableConfig,
+    pub slot_a: SlotConfig,
+    pub slot_b: SlotConfig,
+    pub staging: Option<SlotConfig>,
+}
+
+/// Global flash parameters.
+#[derive(Debug, Deserialize)]
+pub struct FlashConfig {
+    pub block_size: u64,
+}
+
+/// Partition table location and redundancy offsets.
+#[derive(Debug, Deserialize)]
+pub struct PartitionTableConfig {
+    pub offset: u64,
+    pub size: u64,
+    pub copy_0_offset: u64,
+    pub copy_1_offset: u64,
+}
+
+/// A single flash slot (image partition or staging area).
+#[derive(Debug, Deserialize)]
+pub struct SlotConfig {
+    pub name: String,
+    pub flash: String,
+    pub offset: u64,
+    pub size: u64,
+}
+
+impl FlashLayoutConfig {
+    /// Load a flash layout configuration from a TOML file.
+    pub fn from_file(path: &Path) -> Result<Self> {
+        let content = fs::read_to_string(path)
+            .map_err(|e| anyhow!("Failed to read flash layout config {}: {}", path.display(), e))?;
+        let config: FlashLayoutConfig = toml::from_str(&content)
+            .map_err(|e| anyhow!("Failed to parse flash layout config {}: {}", path.display(), e))?;
+        Ok(config)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn test_load_valid_config() {
+        let toml_content = r#"
+[flash]
+block_size = 65536
+
+[partition_table]
+offset = 0x00000000
+size = 65536
+copy_0_offset = 0x00000000
+copy_1_offset = 0x00008000
+
+[slot_a]
+name = "image_a"
+flash = "primary"
+offset = 0x00010000
+size = 0x00200000
+
+[slot_b]
+name = "image_b"
+flash = "secondary"
+offset = 0x00000000
+size = 0x00100000
+"#;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("flash_layout.toml");
+        let mut f = fs::File::create(&path).unwrap();
+        f.write_all(toml_content.as_bytes()).unwrap();
+
+        let config = FlashLayoutConfig::from_file(&path).unwrap();
+        assert_eq!(config.flash.block_size, 65536);
+        assert_eq!(config.partition_table.size, 65536);
+        assert_eq!(config.slot_a.name, "image_a");
+        assert_eq!(config.slot_b.name, "image_b");
+        assert!(config.staging.is_none());
+    }
+
+    #[test]
+    fn test_load_config_with_staging() {
+        let toml_content = r#"
+[flash]
+block_size = 65536
+
+[partition_table]
+offset = 0x00000000
+size = 65536
+copy_0_offset = 0x00000000
+copy_1_offset = 0x00008000
+
+[slot_a]
+name = "image_a"
+flash = "primary"
+offset = 0x00010000
+size = 0x00200000
+
+[slot_b]
+name = "image_b"
+flash = "secondary"
+offset = 0x00000000
+size = 0x00100000
+
+[staging]
+name = "staging"
+flash = "secondary"
+offset = 0x00100000
+size = 0x00100000
+"#;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("flash_layout.toml");
+        let mut f = fs::File::create(&path).unwrap();
+        f.write_all(toml_content.as_bytes()).unwrap();
+
+        let config = FlashLayoutConfig::from_file(&path).unwrap();
+        let staging = config.staging.unwrap();
+        assert_eq!(staging.name, "staging");
+        assert_eq!(staging.flash, "secondary");
+        assert_eq!(staging.offset, 0x00100000);
+        assert_eq!(staging.size, 0x00100000);
+    }
+
+    #[test]
+    fn test_load_config_missing_field() {
+        let toml_content = r#"
+[flash]
+block_size = 65536
+
+[partition_table]
+offset = 0x00000000
+size = 65536
+copy_0_offset = 0x00000000
+copy_1_offset = 0x00008000
+
+[slot_a]
+name = "image_a"
+flash = "primary"
+offset = 0x00010000
+"#;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("flash_layout.toml");
+        let mut f = fs::File::create(&path).unwrap();
+        f.write_all(toml_content.as_bytes()).unwrap();
+
+        let result = FlashLayoutConfig::from_file(&path);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_load_config_invalid_toml() {
+        let toml_content = "this is not valid toml {{{}}}";
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("flash_layout.toml");
+        let mut f = fs::File::create(&path).unwrap();
+        f.write_all(toml_content.as_bytes()).unwrap();
+
+        let result = FlashLayoutConfig::from_file(&path);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_load_config_nonexistent_file() {
+        let path = Path::new("/tmp/nonexistent_flash_layout_config.toml");
+        let result = FlashLayoutConfig::from_file(path);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_load_emulator_reference_config() {
+        let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let repo_root = manifest_dir.parent().unwrap();
+        let config_path = repo_root.join("platforms/emulator/flash_layout.toml");
+        let config = FlashLayoutConfig::from_file(&config_path)
+            .expect("Failed to load emulator reference flash_layout.toml");
+
+        assert_eq!(config.flash.block_size, 65536);
+        assert_eq!(config.partition_table.offset, 0);
+        assert_eq!(config.partition_table.copy_1_offset, 0x00008000);
+        assert_eq!(config.slot_a.name, "image_a");
+        assert_eq!(config.slot_a.flash, "primary");
+        assert_eq!(config.slot_b.name, "image_b");
+        assert_eq!(config.slot_b.flash, "secondary");
+        let staging = config.staging.expect("Emulator config should have staging");
+        assert_eq!(staging.name, "staging");
+    }
+}

--- a/builder/src/lib.rs
+++ b/builder/src/lib.rs
@@ -4,6 +4,7 @@ mod all;
 mod caliptra;
 pub mod firmware;
 pub mod flash_image;
+pub mod flash_layout_config;
 mod rom;
 mod runtime;
 mod utils;

--- a/common/partition-table/Cargo.toml
+++ b/common/partition-table/Cargo.toml
@@ -1,12 +1,11 @@
 # Licensed under the Apache-2.0 license
 
 [package]
-name = "mcu-config-emulator"
+name = "partition-table"
 version.workspace = true
-authors.workspace = true
 edition.workspace = true
+authors.workspace = true
 
 [dependencies]
 mcu-config.workspace = true
-partition-table.workspace = true
 zerocopy.workspace = true

--- a/common/partition-table/src/lib.rs
+++ b/common/partition-table/src/lib.rs
@@ -1,0 +1,451 @@
+// Licensed under the Apache-2.0 license
+
+#![no_std]
+
+use core::mem::offset_of;
+use zerocopy::{FromBytes, Immutable, IntoBytes};
+
+pub use mcu_config::boot::{PartitionId, PartitionStatus, RollbackEnable};
+
+/// On-flash partition table layout (two redundant copies expected).
+#[repr(C, packed)]
+#[derive(Debug, Clone, FromBytes, IntoBytes, Immutable, PartialEq, Default)]
+pub struct PartitionTable {
+    pub active_partition: u32,
+    pub partition_a_boot_count: u16,
+    pub partition_a_status: u16,
+    pub partition_b_boot_count: u16,
+    pub partition_b_status: u16,
+    pub rollback_enable: u32,
+    pub generation: u32,
+    pub reserved: u32,
+    pub checksum: u32,
+}
+
+/// Trait for computing / verifying the partition-table checksum.
+///
+/// The default implementation uses a simple additive checksum over the
+/// u32 words preceding the `checksum` field.
+pub trait ChecksumCalculator {
+    fn calculate(&self, data: &[u8]) -> u32 {
+        let words = data.len() / 4;
+        let mut sum: u32 = 0;
+        for i in 0..words {
+            let offset = i * 4;
+            let word = u32::from_le_bytes([
+                data[offset],
+                data[offset + 1],
+                data[offset + 2],
+                data[offset + 3],
+            ]);
+            sum = sum.wrapping_add(word);
+        }
+        sum
+    }
+}
+
+/// A stand-alone (no-dependency) checksum calculator that uses the default
+/// additive implementation.
+#[derive(Default)]
+pub struct StandAloneChecksumCalculator;
+
+impl StandAloneChecksumCalculator {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl ChecksumCalculator for StandAloneChecksumCalculator {}
+
+impl PartitionTable {
+    /// Create a new `PartitionTable` with the given parameters.
+    ///
+    /// The checksum is **not** populated by this constructor — call
+    /// [`populate_checksum`](Self::populate_checksum) afterwards.
+    pub fn new(
+        active_partition: PartitionId,
+        partition_a_boot_count: u16,
+        partition_a_status: PartitionStatus,
+        partition_b_boot_count: u16,
+        partition_b_status: PartitionStatus,
+        rollback_enable: RollbackEnable,
+    ) -> Self {
+        Self {
+            active_partition: active_partition as u32,
+            partition_a_boot_count,
+            partition_a_status: partition_a_status as u16,
+            partition_b_boot_count,
+            partition_b_status: partition_b_status as u16,
+            rollback_enable: rollback_enable as u32,
+            generation: 0,
+            reserved: 0,
+            checksum: 0,
+        }
+    }
+
+    /// Return the active partition identifier.
+    pub fn get_active_partition_id(&self) -> PartitionId {
+        let val = self.active_partition;
+        PartitionId::try_from(val).unwrap_or(PartitionId::None)
+    }
+
+    /// Set the active partition.
+    pub fn set_active_partition(&mut self, partition: PartitionId) {
+        self.active_partition = partition as u32;
+    }
+
+    /// Retrieve the status of the given partition.
+    pub fn get_partition_status(&self, partition: PartitionId) -> PartitionStatus {
+        let raw = match partition {
+            PartitionId::A => self.partition_a_status,
+            PartitionId::B => self.partition_b_status,
+            _ => return PartitionStatus::Invalid,
+        };
+        PartitionStatus::try_from(raw).unwrap_or(PartitionStatus::Invalid)
+    }
+
+    /// Set the status of the given partition.
+    pub fn set_partition_status(&mut self, partition: PartitionId, status: PartitionStatus) {
+        match partition {
+            PartitionId::A => self.partition_a_status = status as u16,
+            PartitionId::B => self.partition_b_status = status as u16,
+            _ => {}
+        }
+    }
+
+    /// Returns `true` when rollback is enabled.
+    pub fn is_rollback_enabled(&self) -> bool {
+        self.rollback_enable == RollbackEnable::Enabled as u32
+    }
+
+    /// Compute and store the checksum using the supplied calculator.
+    pub fn populate_checksum<C: ChecksumCalculator>(&mut self, calculator: &C) {
+        self.checksum = 0;
+        let bytes = self.as_bytes();
+        let payload = &bytes[..offset_of!(PartitionTable, checksum)];
+        self.checksum = calculator.calculate(payload);
+    }
+
+    /// Verify the stored checksum using the supplied calculator.
+    pub fn verify_checksum<C: ChecksumCalculator>(&self, calculator: &C) -> bool {
+        let bytes = self.as_bytes();
+        let payload = &bytes[..offset_of!(PartitionTable, checksum)];
+        let expected = calculator.calculate(payload);
+        self.checksum == expected
+    }
+}
+
+/// Parse a byte slice into a `PartitionTable`, returning `None` if the
+/// slice is too small or the checksum does not verify.
+pub fn parse_partition_table(data: &[u8]) -> Option<PartitionTable> {
+    let pt = PartitionTable::read_from_bytes(data).ok()?;
+    let calc = StandAloneChecksumCalculator;
+    if pt.verify_checksum(&calc) {
+        Some(pt)
+    } else {
+        None
+    }
+}
+
+/// Given two (possibly invalid) copies of the partition table, select the
+/// best one.  Higher generation wins; on a tie, `copy_0` is preferred.
+pub fn select_partition_table(
+    copy_0: Option<PartitionTable>,
+    copy_1: Option<PartitionTable>,
+) -> Option<PartitionTable> {
+    match (copy_0, copy_1) {
+        (Some(c0), Some(c1)) => {
+            let g0 = c0.generation;
+            let g1 = c1.generation;
+            if g1 > g0 {
+                Some(c1)
+            } else {
+                Some(c0)
+            }
+        }
+        (Some(c0), None) => Some(c0),
+        (None, Some(c1)) => Some(c1),
+        (None, None) => None,
+    }
+}
+
+/// Prepare a dual-write of the partition table.
+///
+/// * Bumps the generation (wrapping at `u32::MAX`).
+/// * Recomputes the checksum.
+/// * Returns `(first_write_offset, second_write_offset)` so that the
+///   *older* copy is written first (minimising the window where both
+///   copies are stale).
+///
+/// If both copies have the same generation (or are both invalid), copy 0
+/// is written first.
+pub fn prepare_dual_write(
+    pt: &mut PartitionTable,
+    gen_0: Option<u32>,
+    gen_1: Option<u32>,
+    offset_0: u32,
+    offset_1: u32,
+) -> (u32, u32) {
+    // Determine next generation: max of the two valid generations + 1, wrapping.
+    let max_gen = match (gen_0, gen_1) {
+        (Some(g0), Some(g1)) => {
+            if g0 >= g1 {
+                g0
+            } else {
+                g1
+            }
+        }
+        (Some(g), None) | (None, Some(g)) => g,
+        (None, None) => 0,
+    };
+    pt.generation = max_gen.wrapping_add(1);
+
+    let calc = StandAloneChecksumCalculator;
+    pt.populate_checksum(&calc);
+
+    // Write the older copy first.
+    match (gen_0, gen_1) {
+        (Some(g0), Some(g1)) => {
+            if g1 > g0 {
+                // copy_0 is older
+                (offset_0, offset_1)
+            } else if g0 > g1 {
+                // copy_1 is older
+                (offset_1, offset_0)
+            } else {
+                // tie — copy_0 first
+                (offset_0, offset_1)
+            }
+        }
+        (None, Some(_)) => {
+            // copy_0 is invalid → write it first
+            (offset_0, offset_1)
+        }
+        (Some(_), None) => {
+            // copy_1 is invalid → write it first
+            (offset_1, offset_0)
+        }
+        (None, None) => {
+            // both invalid → copy_0 first
+            (offset_0, offset_1)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate alloc;
+
+    use super::*;
+    use zerocopy::IntoBytes;
+
+    fn make_valid_pt() -> PartitionTable {
+        let mut pt = PartitionTable::new(
+            PartitionId::A,
+            0,
+            PartitionStatus::Valid,
+            0,
+            PartitionStatus::Invalid,
+            RollbackEnable::Disabled,
+        );
+        let calc = StandAloneChecksumCalculator;
+        pt.populate_checksum(&calc);
+        pt
+    }
+
+    #[test]
+    fn test_new_partition_table() {
+        let pt = PartitionTable::new(
+            PartitionId::A,
+            1,
+            PartitionStatus::Valid,
+            2,
+            PartitionStatus::BootFailed,
+            RollbackEnable::Enabled,
+        );
+        let active = pt.active_partition;
+        assert_eq!(active, PartitionId::A as u32);
+        let a_count = pt.partition_a_boot_count;
+        assert_eq!(a_count, 1);
+        let a_status = pt.partition_a_status;
+        assert_eq!(a_status, PartitionStatus::Valid as u16);
+        let b_count = pt.partition_b_boot_count;
+        assert_eq!(b_count, 2);
+        let b_status = pt.partition_b_status;
+        assert_eq!(b_status, PartitionStatus::BootFailed as u16);
+        let rb = pt.rollback_enable;
+        assert_eq!(rb, RollbackEnable::Enabled as u32);
+        let gen = pt.generation;
+        assert_eq!(gen, 0);
+    }
+
+    #[test]
+    fn test_checksum_detects_corruption() {
+        let mut pt = make_valid_pt();
+        let calc = StandAloneChecksumCalculator;
+        assert!(pt.verify_checksum(&calc));
+        pt.active_partition = PartitionId::B as u32;
+        assert!(!pt.verify_checksum(&calc));
+    }
+
+    #[test]
+    fn test_select_both_valid_higher_gen_wins() {
+        let mut pt0 = make_valid_pt();
+        pt0.generation = 5;
+        let calc = StandAloneChecksumCalculator;
+        pt0.populate_checksum(&calc);
+
+        let mut pt1 = make_valid_pt();
+        pt1.generation = 10;
+        pt1.populate_checksum(&calc);
+
+        let selected = select_partition_table(Some(pt0), Some(pt1.clone())).unwrap();
+        assert_eq!(selected, pt1);
+    }
+
+    #[test]
+    fn test_select_one_valid() {
+        let pt = make_valid_pt();
+        let selected = select_partition_table(None, Some(pt.clone())).unwrap();
+        assert_eq!(selected, pt);
+
+        let selected = select_partition_table(Some(pt.clone()), None).unwrap();
+        assert_eq!(selected, pt);
+    }
+
+    #[test]
+    fn test_select_both_invalid() {
+        let result = select_partition_table(None, None);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_select_both_same_generation_prefers_copy_0() {
+        let mut pt0 = make_valid_pt();
+        pt0.generation = 7;
+        let calc = StandAloneChecksumCalculator;
+        pt0.populate_checksum(&calc);
+
+        let mut pt1 = make_valid_pt();
+        pt1.generation = 7;
+        // Make pt1 slightly different so we can distinguish
+        pt1.partition_b_boot_count = 99;
+        pt1.populate_checksum(&calc);
+
+        let selected = select_partition_table(Some(pt0.clone()), Some(pt1)).unwrap();
+        assert_eq!(selected, pt0);
+    }
+
+    #[test]
+    fn test_prepare_dual_write_older_first() {
+        let mut pt = make_valid_pt();
+        let (first, second) = prepare_dual_write(&mut pt, Some(3), Some(5), 0x1000, 0x2000);
+        // copy_0 (gen 3) is older → written first
+        assert_eq!(first, 0x1000);
+        assert_eq!(second, 0x2000);
+        let gen = pt.generation;
+        assert_eq!(gen, 6);
+    }
+
+    #[test]
+    fn test_prepare_dual_write_one_copy_invalid() {
+        let mut pt = make_valid_pt();
+        // copy_1 is invalid → write it first
+        let (first, second) = prepare_dual_write(&mut pt, Some(4), None, 0x1000, 0x2000);
+        assert_eq!(first, 0x2000);
+        assert_eq!(second, 0x1000);
+        let gen = pt.generation;
+        assert_eq!(gen, 5);
+    }
+
+    #[test]
+    fn test_prepare_dual_write_both_invalid() {
+        let mut pt = make_valid_pt();
+        let (first, second) = prepare_dual_write(&mut pt, None, None, 0x1000, 0x2000);
+        assert_eq!(first, 0x1000);
+        assert_eq!(second, 0x2000);
+        let gen = pt.generation;
+        assert_eq!(gen, 1);
+    }
+
+    #[test]
+    fn test_prepare_dual_write_generation_wraps() {
+        let mut pt = make_valid_pt();
+        let (_, _) = prepare_dual_write(&mut pt, Some(u32::MAX), Some(u32::MAX - 1), 0x1000, 0x2000);
+        let gen = pt.generation;
+        assert_eq!(gen, 0); // u32::MAX wraps to 0
+    }
+
+    #[test]
+    fn test_parse_valid() {
+        let pt = make_valid_pt();
+        let bytes = pt.as_bytes();
+        let parsed = parse_partition_table(bytes).unwrap();
+        assert_eq!(parsed, pt);
+    }
+
+    #[test]
+    fn test_parse_corrupt() {
+        let mut pt = make_valid_pt();
+        let calc = StandAloneChecksumCalculator;
+        pt.populate_checksum(&calc);
+        let mut bytes = alloc::vec::Vec::from(pt.as_bytes());
+        // Corrupt one byte
+        bytes[0] ^= 0xFF;
+        let result = parse_partition_table(&bytes);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_parse_too_small() {
+        let result = parse_partition_table(&[0u8; 4]);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_partition_status_round_trip() {
+        let mut pt = make_valid_pt();
+        pt.set_partition_status(PartitionId::A, PartitionStatus::BootSuccessful);
+        assert_eq!(
+            pt.get_partition_status(PartitionId::A),
+            PartitionStatus::BootSuccessful
+        );
+        pt.set_partition_status(PartitionId::B, PartitionStatus::BootFailed);
+        assert_eq!(
+            pt.get_partition_status(PartitionId::B),
+            PartitionStatus::BootFailed
+        );
+    }
+
+    #[test]
+    fn test_rollback_enable() {
+        let pt_disabled = PartitionTable::new(
+            PartitionId::A,
+            0,
+            PartitionStatus::Valid,
+            0,
+            PartitionStatus::Invalid,
+            RollbackEnable::Disabled,
+        );
+        assert!(!pt_disabled.is_rollback_enabled());
+
+        let pt_enabled = PartitionTable::new(
+            PartitionId::A,
+            0,
+            PartitionStatus::Valid,
+            0,
+            PartitionStatus::Invalid,
+            RollbackEnable::Enabled,
+        );
+        assert!(pt_enabled.is_rollback_enabled());
+    }
+
+    #[test]
+    fn test_set_active_partition_round_trip() {
+        let mut pt = make_valid_pt();
+        pt.set_active_partition(PartitionId::B);
+        assert_eq!(pt.get_active_partition_id(), PartitionId::B);
+        pt.set_active_partition(PartitionId::A);
+        assert_eq!(pt.get_active_partition_id(), PartitionId::A);
+    }
+}

--- a/docs/src/firmware_update.md
+++ b/docs/src/firmware_update.md
@@ -340,44 +340,15 @@ The location of A/B partitions can either reside on a single flash device or be 
 
 - **Partition Table**
 
-For the A/B partition mechanism, the bootloader (MCU ROM) determines which partition to load the firmware image from by using a partition selection mechanism. The implementation of partition selection is system-specific. A common approach involves using a partition table stored in a reserved area of flash. The table below shows an example partition table format:
-
-| Field Name         | Size   | Description                                 |
-|---------------------|--------|--------------------------------------------|
-| Active Partition    | 1 byte | Indicates the active partition (A or B).   |
-| Partition A Status   | 1 byte | Refer to Partition Status  for values |
-| Partition B Status   | 1 byte | Refer to Partition Status  for values.   |
-| Rollback Flag       | 1 byte | Indicates if rollback is required.         |
-| Reserved            | 4 byte | Reserved                                   |
-| CheckSum            | 4 byte |                                            |
-
-- **Partition Status**
-
-Bits 7:4:  Boot Attempt Count
-
-Bits 3:0:
-| Value | Description     |
-|-------|-----------------|
-|   0   | Invalid         |
-|   1   | Valid           |
-|   2   | Boot Failed     |
-|   3   | Boot Successful |
+The partition table format, including field definitions, partition status values, and the dual-copy redundancy protocol, is defined in [Flash Layout](./flash_layout.md#partition-table).
 
 - **Partition Table Usage**
     - During Normal Boot
-        - The  MCU ROM reads the partition table to determine:
-            - The active partition to boot from.
-            - Whether the active partition is valid and bootable.
-        - If the active partition is valid, the bootloader loads the firmware image from it and boots the system.
-        - If the firmware in the active partition fails to boot (e.g., due to corruption or verification failure), the bootloader:
-            - Checks the Rollback Flag.
-            - Switches to the other partition if rollback is required.
+        - MCU ROM reads the partition table to determine the active partition and whether it is valid and bootable.
+        - If the active partition is valid, the bootloader loads the firmware image and boots.
+        - If boot fails, the bootloader checks the Rollback Enable flag and switches to the other partition if rollback is enabled.
     - During Firmware Update
-        - In the `ActivateFirmware` phase, the partition table or status flags are updated to mark the inactive partition as the new active partition.
-        - Steps to Update:
-            1. Set the `Active Partition` field to the inactive partition (A or B).
-            2. Optionally mark the previously active partition as inactive or valid for rollback.
-            3. Write the updated partition table or status flags back to the reserved area in non-volatile memory.
+        - In the `ActivateFirmware` phase, the partition table is updated to mark the inactive partition as the new active partition using the dual-copy write protocol.
 
 ### Partial firmware update
 

--- a/docs/src/flash_layout.md
+++ b/docs/src/flash_layout.md
@@ -10,10 +10,11 @@ The specific images of the flash consists of the Caliptra FW, MCU RT, SoC Manife
 
 A typical overall flash layout is:
 
-| Flash Layout |
-| ------------ |
-| Header       |
-| Payload      |
+| Flash Layout    |
+| --------------- |
+| Partition Table |
+| Header          |
+| Payload         |
 
 The Payload contains the following fields:
 
@@ -36,6 +37,54 @@ The Payload contains the following fields:
 * SoC Manifest (refer to the description of the [SoC Manifest](https://github.com/chipsalliance/caliptra-sw/blob/main/auth-manifest/README.md))
 * MCU RT: This is the image binary of the MCU Runtime firmware
 * Other SoC images (if any)
+
+## Partition Table
+
+The partition table is stored in a reserved region of flash and maintains metadata
+for A/B partition selection. Two copies are maintained for power-loss resilience.
+
+| Field                  | Size (bytes) | Description                                                |
+| ---------------------- | ------------ | ---------------------------------------------------------- |
+| Active Partition       | 4            | Indicates the currently active partition (A or B)          |
+| Partition A Boot Count | 2            | Number of boot attempts from Partition A                   |
+| Partition A Status     | 2            | Current status of Partition A (see Partition Status Values) |
+| Partition B Boot Count | 2            | Number of boot attempts from Partition B                   |
+| Partition B Status     | 2            | Current status of Partition B (see Partition Status Values) |
+| Rollback Enable        | 4            | Flag indicating whether rollback to the other partition is allowed |
+| Generation             | 4            | Monotonically increasing counter for determining the newer copy |
+| Reserved               | 4            | Reserved for future use                                    |
+| Checksum               | 4            | Checksum calculated over all preceding fields              |
+
+Total size: 28 bytes
+
+### Partition Status Values
+
+| Value | Description     |
+| ----- | --------------- |
+| 0     | Invalid         |
+| 1     | Valid           |
+| 2     | Boot Failed     |
+| 3     | Boot Successful |
+
+### Dual-Copy Redundancy
+
+Two copies of the partition table are stored at separate offsets to protect against
+power-loss during writes.
+
+#### Read Protocol
+
+1. Read both copies and validate their checksums.
+2. If both are valid, use the copy with the higher Generation value.
+3. If only one is valid, use that copy.
+4. If neither is valid, the partition table is considered corrupt.
+
+#### Write Protocol
+
+1. Increment the Generation field.
+2. Compute the Checksum over all fields.
+3. Write the updated partition table to the *non-active* copy location.
+4. Validate the write by reading back and verifying the checksum.
+5. Write the same data to the *active* copy location.
 
 ## Header
 

--- a/platforms/emulator/config/src/flash.rs
+++ b/platforms/emulator/config/src/flash.rs
@@ -1,9 +1,12 @@
 // Licensed under the Apache-2.0 license
 
-use core::mem::offset_of;
-use mcu_config::boot::{PartitionId, PartitionStatus, RollbackEnable};
 use mcu_config::flash::FlashPartition;
-use zerocopy::{FromBytes, Immutable, IntoBytes};
+
+pub use partition_table::{
+    prepare_dual_write, parse_partition_table, select_partition_table,
+    ChecksumCalculator, PartitionId, PartitionStatus, PartitionTable,
+    RollbackEnable, StandAloneChecksumCalculator,
+};
 
 pub const FLASH_PARTITIONS_COUNT: usize = 4; // Number of flash partitions
 
@@ -12,6 +15,9 @@ pub const DRIVER_NUM_START: usize = 0x7000_0006; // Base driver number for flash
 pub const DRIVER_NUM_END: usize = 0x7000_0009; // End driver number for flash partitions
 
 pub const BLOCK_SIZE: usize = 64 * 1024; // Block size for flash partitions
+
+pub const PARTITION_TABLE_COPY_0_OFFSET: usize = 0;
+pub const PARTITION_TABLE_COPY_1_OFFSET: usize = BLOCK_SIZE / 2;
 
 pub const PARTITION_TABLE: FlashPartition = FlashPartition {
     name: "partition_table",
@@ -57,131 +63,19 @@ macro_rules! flash_partition_list_secondary {
     }};
 }
 
-#[derive(Debug, Clone, FromBytes, IntoBytes, Immutable, PartialEq, Default)]
-#[repr(C, packed)]
-pub struct PartitionTable {
-    pub active_partition: u32,       // Valid values defined in PartitionId
-    pub partition_a_boot_count: u16, // Boot count for partition A
-    pub partition_a_status: u16,     // Valid values defined in PartitionStatus
-    pub partition_b_boot_count: u16, // Boot count for partition A
-    pub partition_b_status: u16,     // Valid values defined in PartitionStatus
-    pub rollback_enable: u32,        // Valid values defined in RollbackEnable
-    pub reserved: u32,
-    pub checksum: u32,
+/// Map the active partition in a [`PartitionTable`] to the platform-specific
+/// [`FlashPartition`] constant.
+pub fn get_active_partition(
+    pt: &PartitionTable,
+) -> (PartitionId, Option<&'static FlashPartition>) {
+    let id = pt.get_active_partition_id();
+    let partition = match id {
+        PartitionId::A => Some(&IMAGE_A_PARTITION),
+        PartitionId::B => Some(&IMAGE_B_PARTITION),
+        _ => None,
+    };
+    (id, partition)
 }
-
-impl PartitionTable {
-    pub fn new(
-        active_partition: PartitionId,
-        partition_a_boot_count: u16,
-        partition_a_status: PartitionStatus,
-        partition_b_boot_count: u16,
-        partition_b_status: PartitionStatus,
-        rollback_enable: RollbackEnable,
-    ) -> Self {
-        let reserved = 0; // Reserved field, can be set to zero
-        let checksum = 0; // Placeholder for checksum, should be calculated later
-
-        PartitionTable {
-            active_partition: active_partition as u32,
-            partition_a_boot_count,
-            partition_a_status: partition_a_status as u16,
-            partition_b_boot_count,
-            partition_b_status: partition_b_status as u16,
-            rollback_enable: rollback_enable as u32,
-            reserved,
-            checksum,
-        }
-    }
-
-    pub fn get_active_partition(&self) -> (PartitionId, Option<&FlashPartition>) {
-        let id = PartitionId::try_from(self.active_partition).unwrap_or(PartitionId::None);
-        let partition = match id {
-            PartitionId::A => Some(&IMAGE_A_PARTITION),
-            PartitionId::B => Some(&IMAGE_B_PARTITION),
-            _ => None,
-        };
-        // Make sure the status of the partition is valid
-        match self.get_partition_status(id) {
-            PartitionStatus::Valid => (id, partition),
-            PartitionStatus::BootSuccessful => (id, partition),
-            _ => (id, partition),
-        }
-    }
-
-    pub fn set_active_partition(&mut self, partition: PartitionId) {
-        self.active_partition = partition as u32;
-    }
-
-    pub fn get_partition_status(&self, partition: PartitionId) -> PartitionStatus {
-        match partition {
-            PartitionId::A => PartitionStatus::try_from(self.partition_a_status)
-                .unwrap_or(PartitionStatus::Invalid),
-            PartitionId::B => PartitionStatus::try_from(self.partition_b_status)
-                .unwrap_or(PartitionStatus::Invalid),
-            _ => PartitionStatus::Invalid,
-        }
-    }
-
-    pub fn set_partition_status(&mut self, partition: PartitionId, status: PartitionStatus) {
-        match partition {
-            PartitionId::A => self.partition_a_status = status as u16,
-            PartitionId::B => self.partition_b_status = status as u16,
-            _ => {}
-        }
-    }
-
-    pub fn set_active_partition_status(&mut self, status: PartitionStatus) {
-        let (active_partition, _) = self.get_active_partition();
-        self.set_partition_status(active_partition, status);
-    }
-
-    pub fn is_rollback_enabled(&self) -> bool {
-        self.rollback_enable == RollbackEnable::Enabled as u32
-    }
-
-    pub fn set_rollback_enable(&mut self, enable: RollbackEnable) {
-        self.rollback_enable = enable as u32;
-    }
-
-    pub fn populate_checksum<C: ChecksumCalculator>(&mut self, calculator: &C) {
-        self.checksum = calculator.calc_checksum(&self.as_bytes()[0..offset_of!(Self, checksum)]);
-    }
-
-    pub fn verify_checksum<C: ChecksumCalculator>(&self, calculator: &C) -> bool {
-        calculator.verify_checksum(
-            self.checksum,
-            &self.as_bytes()[0..offset_of!(Self, checksum)],
-        )
-    }
-}
-
-pub trait ChecksumCalculator {
-    fn calc_checksum(&self, data: &[u8]) -> u32 {
-        let mut checksum = 0u32;
-        for d in data {
-            checksum = checksum.wrapping_add(*d as u32);
-        }
-        0u32.wrapping_sub(checksum)
-    }
-    fn verify_checksum(&self, checksum: u32, data: &[u8]) -> bool {
-        self.calc_checksum(data) == checksum
-    }
-}
-
-pub struct StandAloneChecksumCalculator;
-impl Default for StandAloneChecksumCalculator {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl StandAloneChecksumCalculator {
-    pub fn new() -> Self {
-        StandAloneChecksumCalculator {}
-    }
-}
-impl ChecksumCalculator for StandAloneChecksumCalculator {}
 
 // Logging flash configuration for emulator platform
 #[derive(Debug, Clone, Copy)]

--- a/platforms/emulator/flash_layout.toml
+++ b/platforms/emulator/flash_layout.toml
@@ -1,0 +1,32 @@
+# Caliptra MCU Flash Layout Configuration - Emulator Platform
+#
+# This file defines the flash layout for the emulator reference platform.
+# Vendors should create their own flash_layout.toml with platform-specific
+# values and pass it via --flash-config to the build tools.
+
+[flash]
+block_size = 65536
+
+[partition_table]
+offset = 0x00000000
+size = 65536
+copy_0_offset = 0x00000000
+copy_1_offset = 0x00008000
+
+[slot_a]
+name = "image_a"
+flash = "primary"
+offset = 0x00010000
+size = 0x00200000
+
+[slot_b]
+name = "image_b"
+flash = "secondary"
+offset = 0x00000000
+size = 0x00100000
+
+[staging]
+name = "staging"
+flash = "secondary"
+offset = 0x00100000
+size = 0x00100000

--- a/platforms/emulator/rom/src/flash/flash_boot_cfg.rs
+++ b/platforms/emulator/rom/src/flash/flash_boot_cfg.rs
@@ -1,9 +1,14 @@
 // Licensed under the Apache-2.0 license
 
 use mcu_config::boot::{BootConfig, BootConfigError, PartitionId, PartitionStatus, RollbackEnable};
-use mcu_config_emulator::flash::{PartitionTable, StandAloneChecksumCalculator};
+use mcu_config_emulator::flash::{
+    PartitionTable, StandAloneChecksumCalculator,
+    PARTITION_TABLE_COPY_0_OFFSET, PARTITION_TABLE_COPY_1_OFFSET,
+    prepare_dual_write, select_partition_table,
+};
 use mcu_rom_common::flash::flash_partition::FlashPartition;
 use zerocopy::{FromBytes, IntoBytes};
+
 pub struct FlashBootCfg<'a> {
     flash_driver: &'a mut FlashPartition<'a>,
 }
@@ -14,21 +19,69 @@ impl<'a> FlashBootCfg<'a> {
         Self { flash_driver }
     }
 
-    pub fn read_partition_table(&self) -> Result<PartitionTable, ()> {
-        let mut partition_table_data: [u8; core::mem::size_of::<PartitionTable>()] =
+    fn read_partition_table_copy(&self, offset: usize) -> Option<PartitionTable> {
+        let mut buf: [u8; core::mem::size_of::<PartitionTable>()] =
             [0; core::mem::size_of::<PartitionTable>()];
+        if self.flash_driver.read(offset, &mut buf).is_err() {
+            return None;
+        }
+        let (pt, _) = PartitionTable::read_from_prefix(&buf).ok()?;
+        let calc = StandAloneChecksumCalculator::new();
+        if pt.verify_checksum(&calc) {
+            Some(pt)
+        } else {
+            None
+        }
+    }
+
+    pub fn read_partition_table(&self) -> Result<PartitionTable, ()> {
+        let copy_0 = self.read_partition_table_copy(PARTITION_TABLE_COPY_0_OFFSET);
+        let copy_1 = self.read_partition_table_copy(PARTITION_TABLE_COPY_1_OFFSET);
+
+        match select_partition_table(copy_0, copy_1) {
+            Some(pt) => Ok(pt),
+            None => {
+                romtime::println!(
+                    "[mcu-rom] Both partition table copies invalid, creating default"
+                );
+                let mut pt = PartitionTable::new(
+                    PartitionId::A,
+                    0,
+                    PartitionStatus::Valid,
+                    0,
+                    PartitionStatus::Invalid,
+                    RollbackEnable::Enabled,
+                );
+                pt.populate_checksum(&StandAloneChecksumCalculator::new());
+                Ok(pt)
+            }
+        }
+    }
+
+    fn write_partition_table_dual(&mut self, pt: &mut PartitionTable) -> Result<(), ()> {
+        let gen_0 = self
+            .read_partition_table_copy(PARTITION_TABLE_COPY_0_OFFSET)
+            .map(|p| p.generation);
+        let gen_1 = self
+            .read_partition_table_copy(PARTITION_TABLE_COPY_1_OFFSET)
+            .map(|p| p.generation);
+
+        let (first, second) = prepare_dual_write(
+            pt,
+            gen_0,
+            gen_1,
+            PARTITION_TABLE_COPY_0_OFFSET as u32,
+            PARTITION_TABLE_COPY_1_OFFSET as u32,
+        );
+
         self.flash_driver
-            .read(0, &mut partition_table_data)
+            .write(first as usize, pt.as_bytes())
+            .map_err(|_| ())?;
+        self.flash_driver
+            .write(second as usize, pt.as_bytes())
             .map_err(|_| ())?;
 
-        let (partition_table, _) =
-            PartitionTable::read_from_prefix(&partition_table_data).map_err(|_| ())?;
-        // Verify checksum
-        let checksum_calculator = StandAloneChecksumCalculator::new();
-        if !partition_table.verify_checksum(&checksum_calculator) {
-            return Err(());
-        }
-        Ok(partition_table)
+        Ok(())
     }
 }
 
@@ -38,7 +91,7 @@ impl<'a> BootConfig for FlashBootCfg<'a> {
             .read_partition_table()
             .map_err(|_| BootConfigError::ReadFailed)?;
 
-        let (active_partition, _) = partition_table.get_active_partition();
+        let active_partition = partition_table.get_active_partition_id();
         Ok(active_partition)
     }
 
@@ -47,9 +100,7 @@ impl<'a> BootConfig for FlashBootCfg<'a> {
             .read_partition_table()
             .map_err(|_| BootConfigError::ReadFailed)?;
         partition_table.set_active_partition(partition_id);
-        partition_table.populate_checksum(&StandAloneChecksumCalculator::new());
-        self.flash_driver
-            .write(0, partition_table.as_bytes())
+        self.write_partition_table_dual(&mut partition_table)
             .map_err(|_| BootConfigError::WriteFailed)?;
         Ok(())
     }
@@ -69,13 +120,30 @@ impl<'a> BootConfig for FlashBootCfg<'a> {
             }
             _ => return Err(BootConfigError::InvalidPartition),
         };
-        // Write the updated partition table back to flash
-        let checksum_calculator = StandAloneChecksumCalculator::new();
-        partition_table.populate_checksum(&checksum_calculator);
+
+        // Dual-copy write
+        let gen_0 = self
+            .read_partition_table_copy(PARTITION_TABLE_COPY_0_OFFSET)
+            .map(|p| p.generation);
+        let gen_1 = self
+            .read_partition_table_copy(PARTITION_TABLE_COPY_1_OFFSET)
+            .map(|p| p.generation);
+
+        let (first, second) = prepare_dual_write(
+            &mut partition_table,
+            gen_0,
+            gen_1,
+            PARTITION_TABLE_COPY_0_OFFSET as u32,
+            PARTITION_TABLE_COPY_1_OFFSET as u32,
+        );
 
         self.flash_driver
-            .write(0, partition_table.as_bytes())
+            .write(first as usize, partition_table.as_bytes())
             .map_err(|_| BootConfigError::WriteFailed)?;
+        self.flash_driver
+            .write(second as usize, partition_table.as_bytes())
+            .map_err(|_| BootConfigError::WriteFailed)?;
+
         Ok(boot_count)
     }
 
@@ -99,9 +167,7 @@ impl<'a> BootConfig for FlashBootCfg<'a> {
         } else {
             RollbackEnable::Disabled as u32
         };
-        partition_table.populate_checksum(&StandAloneChecksumCalculator::new());
-        self.flash_driver
-            .write(0, partition_table.as_bytes())
+        self.write_partition_table_dual(&mut partition_table)
             .map_err(|_| BootConfigError::WriteFailed)?;
         Ok(())
     }
@@ -119,12 +185,7 @@ impl<'a> BootConfig for FlashBootCfg<'a> {
             PartitionId::B => partition_table.partition_b_status = status as u16,
             _ => return Err(BootConfigError::InvalidPartition),
         }
-        // Write the updated partition table back to flash
-        let checksum_calculator = StandAloneChecksumCalculator::new();
-        partition_table.populate_checksum(&checksum_calculator);
-
-        self.flash_driver
-            .write(0, partition_table.as_bytes())
+        self.write_partition_table_dual(&mut partition_table)
             .map_err(|_| BootConfigError::WriteFailed)?;
         Ok(())
     }

--- a/platforms/emulator/runtime/userspace/api/caliptra-api/src/image_loading/flash_boot_cfg.rs
+++ b/platforms/emulator/runtime/userspace/api/caliptra-api/src/image_loading/flash_boot_cfg.rs
@@ -9,7 +9,8 @@ use mcu_config::boot::{
 use mcu_config::flash::FlashPartition;
 use mcu_config_emulator::flash::{
     PartitionTable, StandAloneChecksumCalculator, IMAGE_A_PARTITION, IMAGE_B_PARTITION,
-    PARTITION_TABLE,
+    PARTITION_TABLE, PARTITION_TABLE_COPY_0_OFFSET, PARTITION_TABLE_COPY_1_OFFSET,
+    prepare_dual_write, select_partition_table,
 };
 use zerocopy::{FromBytes, IntoBytes};
 
@@ -30,24 +31,77 @@ impl FlashBootConfig {
         }
     }
 
-    pub async fn read_partition_table(&self) -> Result<PartitionTable, ErrorCode> {
-        let mut partition_table_data: [u8; core::mem::size_of::<PartitionTable>()] =
+    async fn read_partition_table_copy(&self, offset: usize) -> Option<PartitionTable> {
+        let mut buf: [u8; core::mem::size_of::<PartitionTable>()] =
             [0; core::mem::size_of::<PartitionTable>()];
+        if self
+            .flash_partition_syscall
+            .read(offset, core::mem::size_of::<PartitionTable>(), &mut buf)
+            .await
+            .is_err()
+        {
+            return None;
+        }
+        let (pt, _) = PartitionTable::read_from_prefix(&buf).ok()?;
+        let calc = StandAloneChecksumCalculator::new();
+        if pt.verify_checksum(&calc) {
+            Some(pt)
+        } else {
+            None
+        }
+    }
+
+    pub async fn read_partition_table(&self) -> Result<PartitionTable, ErrorCode> {
+        let copy_0 = self
+            .read_partition_table_copy(PARTITION_TABLE_COPY_0_OFFSET)
+            .await;
+        let copy_1 = self
+            .read_partition_table_copy(PARTITION_TABLE_COPY_1_OFFSET)
+            .await;
+
+        match select_partition_table(copy_0, copy_1) {
+            Some(pt) => Ok(pt),
+            None => Err(ErrorCode::Fail),
+        }
+    }
+
+    async fn write_partition_table_dual(
+        &self,
+        pt: &mut PartitionTable,
+    ) -> Result<(), ErrorCode> {
+        let gen_0 = self
+            .read_partition_table_copy(PARTITION_TABLE_COPY_0_OFFSET)
+            .await
+            .map(|p| p.generation);
+        let gen_1 = self
+            .read_partition_table_copy(PARTITION_TABLE_COPY_1_OFFSET)
+            .await
+            .map(|p| p.generation);
+
+        let (first, second) = prepare_dual_write(
+            pt,
+            gen_0,
+            gen_1,
+            PARTITION_TABLE_COPY_0_OFFSET as u32,
+            PARTITION_TABLE_COPY_1_OFFSET as u32,
+        );
+
         self.flash_partition_syscall
-            .read(
-                0,
+            .write(
+                first as usize,
                 core::mem::size_of::<PartitionTable>(),
-                &mut partition_table_data,
+                pt.as_bytes(),
             )
             .await?;
-        let (partition_table, _) =
-            PartitionTable::read_from_prefix(&partition_table_data).map_err(|_| ErrorCode::Fail)?;
-        // Verify checksum
-        let checksum_calculator = StandAloneChecksumCalculator::new();
-        if !partition_table.verify_checksum(&checksum_calculator) {
-            return Err(ErrorCode::Fail);
-        }
-        Ok(partition_table)
+        self.flash_partition_syscall
+            .write(
+                second as usize,
+                core::mem::size_of::<PartitionTable>(),
+                pt.as_bytes(),
+            )
+            .await?;
+
+        Ok(())
     }
 
     pub fn get_partition_from_id(
@@ -98,16 +152,7 @@ impl BootConfigAsync for FlashBootConfig {
             PartitionId::B => partition_table.partition_b_status = status as u16,
             _ => return Err(BootConfigError::InvalidPartition),
         }
-        // Write the updated partition table back to flash
-        let checksum_calculator = StandAloneChecksumCalculator::new();
-        partition_table.populate_checksum(&checksum_calculator);
-
-        self.flash_partition_syscall
-            .write(
-                0,
-                core::mem::size_of::<PartitionTable>(),
-                partition_table.as_bytes(),
-            )
+        self.write_partition_table_dual(&mut partition_table)
             .await
             .map_err(|_| BootConfigError::WriteFailed)?;
         Ok(())
@@ -126,7 +171,7 @@ impl BootConfigAsync for FlashBootConfig {
             .read_partition_table()
             .await
             .map_err(|_| BootConfigError::ReadFailed)?;
-        let (active_partition, _) = partition_table.get_active_partition();
+        let active_partition = partition_table.get_active_partition_id();
         Ok(active_partition)
     }
 
@@ -135,7 +180,7 @@ impl BootConfigAsync for FlashBootConfig {
             .read_partition_table()
             .await
             .map_err(|_| BootConfigError::ReadFailed)?;
-        let (active_partition, _) = partition_table.get_active_partition();
+        let active_partition = partition_table.get_active_partition_id();
 
         let other_partition = match active_partition {
             PartitionId::A => Ok(PartitionId::B),
@@ -155,7 +200,7 @@ impl BootConfigAsync for FlashBootConfig {
             .read_partition_table()
             .await
             .map_err(|_| BootConfigError::ReadFailed)?;
-        let (active_partition, _) = partition_table.get_active_partition();
+        let active_partition = partition_table.get_active_partition_id();
         match active_partition {
             PartitionId::A => Ok(PartitionId::B),
             PartitionId::B => Ok(PartitionId::A),
@@ -172,13 +217,7 @@ impl BootConfigAsync for FlashBootConfig {
             .await
             .map_err(|_| BootConfigError::ReadFailed)?;
         partition_table.set_active_partition(partition_id);
-        partition_table.populate_checksum(&StandAloneChecksumCalculator::new());
-        self.flash_partition_syscall
-            .write(
-                0,
-                core::mem::size_of::<PartitionTable>(),
-                partition_table.as_bytes(),
-            )
+        self.write_partition_table_dual(&mut partition_table)
             .await
             .map_err(|_| BootConfigError::WriteFailed)?;
         Ok(())
@@ -203,18 +242,42 @@ impl BootConfigAsync for FlashBootConfig {
             }
             _ => return Err(BootConfigError::InvalidPartition),
         };
-        // Write the updated partition table back to flash
-        let checksum_calculator = StandAloneChecksumCalculator::new();
-        partition_table.populate_checksum(&checksum_calculator);
+
+        // Dual-copy write
+        let gen_0 = self
+            .read_partition_table_copy(PARTITION_TABLE_COPY_0_OFFSET)
+            .await
+            .map(|p| p.generation);
+        let gen_1 = self
+            .read_partition_table_copy(PARTITION_TABLE_COPY_1_OFFSET)
+            .await
+            .map(|p| p.generation);
+
+        let (first, second) = prepare_dual_write(
+            &mut partition_table,
+            gen_0,
+            gen_1,
+            PARTITION_TABLE_COPY_0_OFFSET as u32,
+            PARTITION_TABLE_COPY_1_OFFSET as u32,
+        );
 
         self.flash_partition_syscall
             .write(
-                0,
+                first as usize,
                 core::mem::size_of::<PartitionTable>(),
                 partition_table.as_bytes(),
             )
             .await
             .map_err(|_| BootConfigError::WriteFailed)?;
+        self.flash_partition_syscall
+            .write(
+                second as usize,
+                core::mem::size_of::<PartitionTable>(),
+                partition_table.as_bytes(),
+            )
+            .await
+            .map_err(|_| BootConfigError::WriteFailed)?;
+
         Ok(boot_count)
     }
 
@@ -240,13 +303,7 @@ impl BootConfigAsync for FlashBootConfig {
         } else {
             RollbackEnable::Disabled as u32
         };
-        partition_table.populate_checksum(&StandAloneChecksumCalculator::new());
-        self.flash_partition_syscall
-            .write(
-                0,
-                core::mem::size_of::<PartitionTable>(),
-                partition_table.as_bytes(),
-            )
+        self.write_partition_table_dual(&mut partition_table)
             .await
             .map_err(|_| BootConfigError::WriteFailed)?;
         Ok(())

--- a/tests/integration/src/test_firmware_update.rs
+++ b/tests/integration/src/test_firmware_update.rs
@@ -12,7 +12,7 @@ mod test {
     use mcu_builder::{CaliptraBuilder, FirmwareBinaries, ImageCfg};
     use mcu_config::boot::{PartitionId, PartitionStatus, RollbackEnable};
     use mcu_config_emulator::flash::{
-        PartitionTable, StandAloneChecksumCalculator, STAGING_PARTITION,
+        PartitionTable, StandAloneChecksumCalculator, STAGING_PARTITION, get_active_partition,
     };
     use mcu_config_emulator::EMULATOR_MEMORY_MAP;
     use mcu_testing_common::DeviceLifecycle;
@@ -679,8 +679,7 @@ mod test {
         let checksum_calculator = StandAloneChecksumCalculator::new();
         partition_table.populate_checksum(&checksum_calculator);
 
-        let flash_offset = partition_table
-            .get_active_partition()
+        let flash_offset = get_active_partition(&partition_table)
             .1
             .map_or(0, |p| p.offset);
 
@@ -805,8 +804,7 @@ mod test {
         let checksum_calculator = StandAloneChecksumCalculator::new();
         partition_table.populate_checksum(&checksum_calculator);
 
-        let flash_offset = partition_table
-            .get_active_partition()
+        let flash_offset = get_active_partition(&partition_table)
             .1
             .map_or(0, |p| p.offset);
         let (soc_images_paths, primary_flash_image_path) = create_flash_image(

--- a/tests/integration/src/test_soc_boot.rs
+++ b/tests/integration/src/test_soc_boot.rs
@@ -11,7 +11,7 @@ mod test {
     use mcu_builder::{CaliptraBuilder, FirmwareBinaries, ImageCfg};
     use mcu_config::boot::{PartitionId, PartitionStatus, RollbackEnable};
     use mcu_config_emulator::flash::{
-        PartitionTable, StandAloneChecksumCalculator, IMAGE_A_PARTITION, IMAGE_B_PARTITION,
+        PartitionTable, StandAloneChecksumCalculator, IMAGE_A_PARTITION, IMAGE_B_PARTITION, get_active_partition,
     };
     use mcu_testing_common::DeviceLifecycle;
     use pldm_fw_pkg::manifest::{
@@ -261,7 +261,7 @@ mod test {
         let flash_offset = opts
             .partition_table
             .as_ref()
-            .and_then(|pt| pt.get_active_partition().1.as_ref().map(|p| p.offset))
+            .and_then(|pt| get_active_partition(&pt).1.as_ref().map(|p| p.offset))
             .unwrap_or(0);
         let (_, flash_image_path) = create_flash_image(
             new_options.builder.as_mut().unwrap().get_caliptra_fw().ok(),
@@ -333,7 +333,7 @@ mod test {
         let flash_offset = opts
             .partition_table
             .as_ref()
-            .and_then(|pt| pt.get_active_partition().1.as_ref().map(|p| p.offset))
+            .and_then(|pt| get_active_partition(&pt).1.as_ref().map(|p| p.offset))
             .unwrap_or(0);
         let (_, flash_image_path) = create_flash_image(
             new_options.builder.as_mut().unwrap().get_caliptra_fw().ok(),
@@ -635,7 +635,7 @@ mod test {
         let flash_offset = opts
             .partition_table
             .as_ref()
-            .and_then(|pt| pt.get_active_partition().1.as_ref().map(|p| p.offset))
+            .and_then(|pt| get_active_partition(&pt).1.as_ref().map(|p| p.offset))
             .unwrap_or(0);
 
         // Same image for all SOCs
@@ -839,8 +839,7 @@ mod test {
         let checksum_calculator = StandAloneChecksumCalculator::new();
         partition_table.populate_checksum(&checksum_calculator);
 
-        let flash_offset = partition_table
-            .get_active_partition()
+        let flash_offset = get_active_partition(&partition_table)
             .1
             .map_or(0, |p| p.offset);
 
@@ -943,8 +942,7 @@ mod test {
         let checksum_calculator = StandAloneChecksumCalculator::new();
         partition_table.populate_checksum(&checksum_calculator);
 
-        let flash_offset = partition_table
-            .get_active_partition()
+        let flash_offset = get_active_partition(&partition_table)
             .1
             .map_or(0, |p| p.offset);
         let (soc_images_paths, flash_image_path) = create_flash_image(

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -292,6 +292,10 @@ enum Commands {
 enum FlashImageCommands {
     /// Create a new flash image
     Create {
+        /// Path to the flash layout configuration TOML file
+        #[arg(long, value_name = "FLASH_CONFIG", required = false)]
+        flash_config: Option<String>,
+
         /// Path to the Caliptra firmware file
         #[arg(long, value_name = "CALIPTRA_FW", required = true)]
         caliptra_fw: Option<String>,
@@ -427,6 +431,7 @@ fn main() {
         }
         Commands::FlashImage { subcommand } => match subcommand {
             FlashImageCommands::Create {
+                flash_config: _flash_config,
                 caliptra_fw,
                 soc_manifest,
                 mcu_runtime,


### PR DESCRIPTION
Add power-loss resilient partition table management by maintaining two copies with a generation counter. This ensures at least one valid copy is always available, even if power is lost during a write.

Changes:
- Add platform-agnostic partition-table crate (common/partition-table) with PartitionTable struct, generation counter, checksum calculator, dual-copy selection and write protocol, and 16 unit tests
- Move PartitionTable definition from emulator config to common crate with proper API boundary (no platform-specific FlashPartition in common code)
- Add get_active_partition free function in emulator config for platform-specific partition mapping
- Update MCU ROM and MCU RT flash boot config with dual-copy read and write protocol
- Update builder to write both partition table copies
- Add flash layout TOML configuration file support for config-driven IFWI generation (platforms/emulator/flash_layout.toml)
- Add flash_layout_config parser with 6 tests
- Add --flash-config CLI argument to xtask
- Add partition table spec to flash_layout.md with field definitions, status values, and dual-copy redundancy protocol
- Simplify firmware_update.md partition table section to reference flash_layout.md