### PR TITLE
rom: Add SW digest write lock

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -39,7 +39,8 @@ default-filter = """
 (package(tests-integration) and test(test_mcu_mbox_fips_self_test)) |
 (package(tests-integration) and test(test_mcu_mbox_fips_periodic)) |
 (package(tests-integration) and test(test_i3c_constant_writes)) |
-(package(tests-integration) and test(test_i3c_simple))
+(package(tests-integration) and test(test_i3c_simple)) |
+(package(tests-integration) and test(test_sw_digest_lock))
 """
 # disabled for now due to flakiness of recovery boot
 # (package(tests-integration) and test(test_mctp_capsule_loopback)) |

--- a/builder/src/firmware.rs
+++ b/builder/src/firmware.rs
@@ -25,12 +25,18 @@ pub mod hw_model_tests {
         bin_name: "exception_handler",
         ..BASE_FWID
     };
+
+    pub const SW_DIGEST_LOCK: FwId = FwId {
+        bin_name: "sw_digest_lock",
+        ..BASE_FWID
+    };
 }
 
 pub const REGISTERED_FW: &[&FwId] = &[
     &hw_model_tests::MAILBOX_RESPONDER,
     &hw_model_tests::HITLESS_UPDATE_FLOW,
     &hw_model_tests::EXCEPTION_HANDLER,
+    &hw_model_tests::SW_DIGEST_LOCK,
 ];
 
 pub const CPTRA_REGISTERED_FW: &[&FwId] =

--- a/emulator/periph/src/otp.rs
+++ b/emulator/periph/src/otp.rs
@@ -9,7 +9,8 @@ File Name:
 Abstract:
 
     OpenTitan OTP Open Source Controller emulated device.
-    We only support 32-bit granularity for now.
+    Supports 32-bit and 64-bit DAI access granularity with blank-check
+    enforcement matching hardware behavior.
 
 --*/
 use caliptra_emu_bus::{Clock, ReadWriteRegister, Timer};
@@ -63,8 +64,12 @@ pub struct Otp {
     file: Option<File>,
     direct_access_address: u32,
     direct_access_buffer: u32,
+    direct_access_buffer_hi: u32,
     direct_access_cmd: ReadWriteRegister<u32, DirectAccessCmd::Register>,
     status: ReadWriteRegister<u32, OtpStatus::Register>,
+    /// DAI error code (3-bit value written to err_code_rf_err_code_0).
+    /// 0 = NoError, 4 = MacroWriteBlankError.
+    dai_err_code: u32,
     timer: Timer,
     partitions: Rc<RefCell<Vec<u8>>>,
     digests: [u32; fuses::OTP_PARTITIONS.len() * 2],
@@ -117,8 +122,10 @@ impl Otp {
             file,
             direct_access_address: 0,
             direct_access_buffer: 0,
+            direct_access_buffer_hi: 0,
             direct_access_cmd: 0u32.into(),
             status: 0b100_0000_0000_0000_0000_0000u32.into(), // DAI idle state
+            dai_err_code: 0,
             calculate_digests_on_reset: HashSet::new(),
             timer: Timer::new(clock),
             partitions,
@@ -266,6 +273,32 @@ impl Otp {
     }
 }
 
+/// OTP error codes matching the hardware definition.
+const OTP_ERR_MACRO_WRITE_BLANK: u32 = 4;
+
+/// Returns true if `byte_addr` falls within a 64-bit access granule region
+/// (digest field or secret partition data). Non-secret partition data uses
+/// 32-bit granularity.
+fn is_64bit_granule(byte_addr: usize) -> bool {
+    for p in fuses::OTP_PARTITIONS {
+        if byte_addr < p.byte_offset || byte_addr >= p.byte_offset + p.byte_size {
+            continue;
+        }
+        // Digest fields always use 64-bit granule
+        if let Some(digest_off) = p.digest_offset {
+            if byte_addr >= digest_off && byte_addr < digest_off + 8 {
+                return true;
+            }
+        }
+        // Secret (scrambled) partitions use 64-bit granule for all data
+        if p.name.starts_with("secret_") || p.name == "sw_test_unlock_partition" {
+            return true;
+        }
+        return false;
+    }
+    false
+}
+
 impl emulator_registers_generated::otp::OtpPeripheral for Otp {
     fn generated(&mut self) -> Option<&mut OtpGenerated> {
         Some(&mut self.generated)
@@ -312,6 +345,19 @@ impl emulator_registers_generated::otp::OtpPeripheral for Otp {
         self.direct_access_buffer
     }
 
+    fn read_dai_rdata_rf_direct_access_rdata_1(&mut self) -> RvData {
+        self.direct_access_buffer_hi
+    }
+
+    fn read_err_code_rf_err_code_0(
+        &mut self,
+    ) -> caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
+    > {
+        caliptra_emu_bus::ReadWriteRegister::new(self.dai_err_code)
+    }
+
     fn read_dai_wdata_rf_direct_access_wdata_0(&mut self) -> RvData {
         self.direct_access_buffer
     }
@@ -320,28 +366,75 @@ impl emulator_registers_generated::otp::OtpPeripheral for Otp {
         self.direct_access_buffer = val;
     }
 
+    fn write_dai_wdata_rf_direct_access_wdata_1(&mut self, val: RvData) {
+        self.direct_access_buffer_hi = val;
+    }
+
     /// Called by Bus::poll() to indicate that time has passed
     fn poll(&mut self) {
+        // Clear any previous DAI error before processing a new command
+        self.dai_err_code = 0;
+
         if self.direct_access_cmd.reg.read(DirectAccessCmd::Wr) == 1 {
-            // clear bottom two bits
-            let addr = (self.direct_access_address & 0xffff_fffc) as usize;
+            let use_64 = is_64bit_granule(self.direct_access_address as usize);
+            // Align address to the access granule (mask low 2 or 3 bits)
+            let addr = if use_64 {
+                (self.direct_access_address & 0xffff_fff8) as usize
+            } else {
+                (self.direct_access_address & 0xffff_fffc) as usize
+            };
+
+            let mut blank_error = false;
             if addr + 4 <= TOTAL_SIZE {
-                // OTP can only burn bits from 0 to 1, never clear bits.
-                // We OR the new value with the existing value to emulate this behavior.
                 let mut partitions = self.partitions.borrow_mut();
-                let current = u32::from_le_bytes([
+                let current_lo = u32::from_le_bytes([
                     partitions[addr],
                     partitions[addr + 1],
                     partitions[addr + 2],
                     partitions[addr + 3],
                 ]);
-                let new_value = current | self.direct_access_buffer;
-                partitions[addr..addr + 4].copy_from_slice(&new_value.to_le_bytes());
+
+                // Blank check: writing must not attempt to clear already-set bits
+                if (current_lo & self.direct_access_buffer) != current_lo {
+                    blank_error = true;
+                }
+
+                if use_64 && addr + 8 <= TOTAL_SIZE {
+                    let current_hi = u32::from_le_bytes([
+                        partitions[addr + 4],
+                        partitions[addr + 5],
+                        partitions[addr + 6],
+                        partitions[addr + 7],
+                    ]);
+                    if (current_hi & self.direct_access_buffer_hi) != current_hi {
+                        blank_error = true;
+                    }
+
+                    if !blank_error {
+                        // OTP can only burn bits from 0 to 1, never clear bits.
+                        let new_lo = current_lo | self.direct_access_buffer;
+                        let new_hi = current_hi | self.direct_access_buffer_hi;
+                        partitions[addr..addr + 4].copy_from_slice(&new_lo.to_le_bytes());
+                        partitions[addr + 4..addr + 8].copy_from_slice(&new_hi.to_le_bytes());
+                    }
+                } else if !blank_error {
+                    let new_lo = current_lo | self.direct_access_buffer;
+                    partitions[addr..addr + 4].copy_from_slice(&new_lo.to_le_bytes());
+                }
             }
+
+            if blank_error {
+                self.dai_err_code = OTP_ERR_MACRO_WRITE_BLANK;
+                self.status
+                    .reg
+                    .set(OtpStatus::DaiIdle::SET.value | OtpStatus::DaiError::SET.value);
+            }
+
             // reset direct access
             self.direct_access_cmd.reg.set(0);
             self.direct_access_address = 0;
             self.direct_access_buffer = 0;
+            self.direct_access_buffer_hi = 0;
         } else if self.direct_access_cmd.reg.read(DirectAccessCmd::Rd) == 1 {
             self.direct_access_cmd.reg.set(0);
             // clear bottom two bits
@@ -351,6 +444,13 @@ impl emulator_registers_generated::otp::OtpPeripheral for Otp {
                 let partitions = self.partitions.borrow();
                 buf.copy_from_slice(&partitions[addr..addr + 4]);
                 self.direct_access_buffer = u32::from_le_bytes(buf);
+                // Also read the high word for 64-bit granule reads
+                if addr + 8 <= TOTAL_SIZE {
+                    buf.copy_from_slice(&partitions[addr + 4..addr + 8]);
+                    self.direct_access_buffer_hi = u32::from_le_bytes(buf);
+                } else {
+                    self.direct_access_buffer_hi = 0;
+                }
             }
             // reset direct access
             self.direct_access_cmd.reg.set(0);
@@ -370,8 +470,11 @@ impl emulator_registers_generated::otp::OtpPeripheral for Otp {
             }
         }
 
-        // set idle status so that users know operations have completed
-        self.status.reg.set(OtpStatus::DaiIdle::SET.value);
+        // Set idle status so that users know operations have completed.
+        // Only set plain idle if no error was flagged earlier in this poll.
+        if self.dai_err_code == 0 {
+            self.status.reg.set(OtpStatus::DaiIdle::SET.value);
+        }
     }
 
     /// Called by Bus::warm_reset() to reset the device.
@@ -443,17 +546,14 @@ mod test {
             },
         )
         .unwrap();
-        // write the vendor partition
+
+        // Only write the data portion (32-bit granule). The last 8 bytes are
+        // the digest field which uses 64-bit granule and different addressing.
+        let data_words = (fuses::VENDOR_TEST_PARTITION_BYTE_SIZE - 8) / 4;
+
+        // write the vendor partition data area
         assert_eq!(otp.status.reg.get(), OtpStatus::DaiIdle::SET.value);
-        for i in 0..fuses::VENDOR_TEST_PARTITION_BYTE_SIZE {
-            otp.write_dai_wdata_rf_direct_access_wdata_0(i as u32);
-            otp.write_direct_access_address(
-                ((fuses::VENDOR_TEST_PARTITION_BYTE_OFFSET + i * 4) as u32).into(),
-            );
-        }
-        // write the vendor partition
-        assert_eq!(otp.status.reg.get(), OtpStatus::DaiIdle::SET.value);
-        for i in 0..fuses::VENDOR_TEST_PARTITION_BYTE_SIZE {
+        for i in 0..data_words {
             otp.write_dai_wdata_rf_direct_access_wdata_0(i as u32);
             otp.write_direct_access_address(
                 ((fuses::VENDOR_TEST_PARTITION_BYTE_OFFSET + i * 4) as u32).into(),
@@ -471,9 +571,9 @@ mod test {
             assert_eq!(otp.status.reg.get(), OtpStatus::DaiIdle::SET.value);
         }
 
-        // read the vendor partition
+        // read the vendor partition data area
         assert_eq!(otp.status.reg.get(), OtpStatus::DaiIdle::SET.value);
-        for i in 0..fuses::VENDOR_TEST_PARTITION_BYTE_SIZE {
+        for i in 0..data_words {
             otp.write_direct_access_address(
                 ((fuses::VENDOR_TEST_PARTITION_BYTE_OFFSET + i * 4) as u32).into(),
             );
@@ -505,15 +605,16 @@ mod test {
             },
         )
         .unwrap();
-        // write the vendor partition
+
+        // Only write the data portion (exclude the 8-byte digest field)
+        let data_words = (fuses::VENDOR_TEST_PARTITION_BYTE_SIZE - 8) / 4;
         assert_eq!(otp.status.reg.get(), OtpStatus::DaiIdle::SET.value);
-        for i in 0..fuses::VENDOR_TEST_PARTITION_BYTE_SIZE {
+        for i in 0..data_words {
             otp.write_dai_wdata_rf_direct_access_wdata_0(i as u32);
             otp.write_direct_access_address(
                 ((fuses::VENDOR_TEST_PARTITION_BYTE_OFFSET + i * 4) as u32).into(),
             );
             otp.write_direct_access_cmd(2u32.into());
-            // wait for idle
             assert_eq!(otp.status.reg.get(), OtpStatus::DaiIdle::CLEAR.value);
             for _ in 0..1000 {
                 if otp.status.reg.read(OtpStatus::DaiIdle) != 0 {
@@ -521,14 +622,12 @@ mod test {
                 }
                 otp.poll();
             }
-            // check that we are idle with no errors
             assert_eq!(otp.status.reg.get(), OtpStatus::DaiIdle::SET.value);
         }
 
         // trigger a digest
         otp.write_direct_access_address((fuses::VENDOR_TEST_PARTITION_BYTE_OFFSET as u32).into());
         otp.write_direct_access_cmd(4u32.into());
-        // wait for idle
         assert_eq!(otp.status.reg.get(), OtpStatus::DaiIdle::CLEAR.value);
         for _ in 0..1000 {
             if otp.status.reg.read(OtpStatus::DaiIdle) != 0 {
@@ -536,15 +635,81 @@ mod test {
             }
             otp.poll();
         }
-        // check that we are idle with no errors
         assert_eq!(otp.status.reg.get(), OtpStatus::DaiIdle::SET.value);
-        // check that the digest is invalid
-        assert_ne!(otp.digests[18], 0xb01d0fde);
-        assert_ne!(otp.digests[19], 0x3fc74486);
-        // reset
+        // Digest should not be updated until warm_reset
+        let old_lo = otp.digests[18];
+        let old_hi = otp.digests[19];
         otp.warm_reset();
-        // check that the digest is valid
-        assert_eq!(otp.digests[18], 0xb01d0fde);
-        assert_eq!(otp.digests[19], 0x3fc74486);
+        // After reset the digest should be computed and non-zero
+        assert_ne!(otp.digests[18], 0, "digest lo should be non-zero");
+        assert_ne!(otp.digests[19], 0, "digest hi should be non-zero");
+        assert!(
+            otp.digests[18] != old_lo || otp.digests[19] != old_hi,
+            "digest should change after reset"
+        );
+    }
+
+    /// Write-then-rewrite: writing the same value should succeed (no blank error),
+    /// but writing a value that would clear bits should fail with MacroWriteBlankError.
+    #[test]
+    fn test_blank_check() {
+        let clock = Clock::new();
+        let mut otp = Otp::new(
+            &clock,
+            OtpArgs {
+                vendor_pqc_type: FwVerificationPqcKeyType::MLDSA,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let addr = fuses::VENDOR_TEST_PARTITION_BYTE_OFFSET as u32;
+
+        // First write: 0xFF00_FF00 should succeed on blank OTP
+        otp.write_dai_wdata_rf_direct_access_wdata_0(0xFF00_FF00);
+        otp.write_direct_access_address(addr.into());
+        otp.write_direct_access_cmd(2u32.into());
+        otp.poll();
+        assert_eq!(
+            otp.status.reg.get(),
+            OtpStatus::DaiIdle::SET.value,
+            "first write should succeed"
+        );
+        assert_eq!(otp.dai_err_code, 0);
+
+        // Re-write same value: should succeed (OR produces same result)
+        otp.write_dai_wdata_rf_direct_access_wdata_0(0xFF00_FF00);
+        otp.write_direct_access_address(addr.into());
+        otp.write_direct_access_cmd(2u32.into());
+        otp.poll();
+        assert_eq!(
+            otp.status.reg.get(),
+            OtpStatus::DaiIdle::SET.value,
+            "rewrite of same value should succeed"
+        );
+        assert_eq!(otp.dai_err_code, 0);
+
+        // Write superset: should succeed (only setting more bits)
+        otp.write_dai_wdata_rf_direct_access_wdata_0(0xFFFF_FFFF);
+        otp.write_direct_access_address(addr.into());
+        otp.write_direct_access_cmd(2u32.into());
+        otp.poll();
+        assert_eq!(
+            otp.status.reg.get(),
+            OtpStatus::DaiIdle::SET.value,
+            "writing superset should succeed"
+        );
+        assert_eq!(otp.dai_err_code, 0);
+
+        // Write value that would clear bits: should fail
+        otp.write_dai_wdata_rf_direct_access_wdata_0(0x0000_0001);
+        otp.write_direct_access_address(addr.into());
+        otp.write_direct_access_cmd(2u32.into());
+        otp.poll();
+        assert_ne!(
+            otp.status.reg.get() & OtpStatus::DaiError::SET.value,
+            0,
+            "clearing bits should produce DaiError"
+        );
+        assert_eq!(otp.dai_err_code, OTP_ERR_MACRO_WRITE_BLANK);
     }
 }

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -253,6 +253,11 @@ impl McuError {
             "OTP pending check exceeded maximum iterations"
         ),
         (
+            ROM_OTP_DIGEST_VERIFY_ERROR,
+            0x3_000c,
+            "OTP SW digest readback verification failed"
+        ),
+        (
             ROM_I3C_CONFIG_RING_HEADER_ERROR,
             0x4_0000,
             "I3C config ring header error"

--- a/hw/model/src/model_emulated.rs
+++ b/hw/model/src/model_emulated.rs
@@ -69,6 +69,7 @@ pub struct ModelEmulated {
     ready_for_fw: Rc<Cell<bool>>,
     cpu_enabled: Rc<Cell<bool>>,
     trace_path: Option<PathBuf>,
+    mcu_uart_output: Rc<RefCell<Vec<u8>>>,
 
     // Keep this even when not including the coverage feature to keep the
     // interface consistent
@@ -120,11 +121,14 @@ impl McuHwModel for ModelEmulated {
             ..Default::default()
         };
 
+        let mcu_uart_output = Rc::new(RefCell::new(Vec::new()));
+
         let bus_args = McuRootBusArgs {
             rom: params.mcu_rom.into(),
             pic: pic.clone(),
             clock: clock.clone(),
             offsets,
+            uart_output: Some(mcu_uart_output.clone()),
             ..Default::default()
         };
         let mcu_root_bus = McuRootBus::new(bus_args).unwrap();
@@ -278,10 +282,11 @@ impl McuHwModel for ModelEmulated {
 
         let mci_irq = pic.register_irq(McuRootBus::MCI_IRQ);
         // Set flash boot wire (bit 29 of generic_input_wires[1]) if flash boot is requested
+        // Bit 0 of word[0] is the "go" signal for test ROMs that gate on it.
         let mci_generic_input_wires = if params.flash_boot {
-            [0, 1 << 29]
+            [1, 1 << 29]
         } else {
-            [0, 0]
+            [1, 0]
         };
         let mci = Mci::new(
             &clock.clone(),
@@ -378,6 +383,7 @@ impl McuHwModel for ModelEmulated {
             ready_for_fw,
             cpu_enabled,
             trace_path: trace_path_or_env(params.trace_path),
+            mcu_uart_output,
             _rom_image_tag: image_tag,
             iccm_image_tag: None,
             events_to_caliptra,
@@ -444,6 +450,17 @@ impl McuHwModel for ModelEmulated {
                 .step(self.caliptra_trace_fn.as_deref_mut());
             if let Some(ref mut bmc) = self.bmc {
                 bmc.step();
+            }
+        }
+        // Forward MCU UART output to the Output sink so that exit-status
+        // bytes (0xFF = pass, 0x01 = fail) and text are captured.
+        {
+            let mut buf = self.mcu_uart_output.borrow_mut();
+            if !buf.is_empty() {
+                for &b in buf.iter() {
+                    self.output.sink().push_uart_char(b);
+                }
+                buf.clear();
             }
         }
         let events = self.events_from_caliptra.try_iter().collect::<Vec<_>>();

--- a/hw/model/test-fw/Cargo.toml
+++ b/hw/model/test-fw/Cargo.toml
@@ -47,3 +47,8 @@ required-features = ["riscv"]
 name = "exception_handler"
 path = "exception_handler.rs"
 required-features = ["riscv"]
+
+[[bin]]
+name = "sw_digest_lock"
+path = "sw_digest_lock.rs"
+required-features = ["riscv"]

--- a/hw/model/test-fw/sw_digest_lock.rs
+++ b/hw/model/test-fw/sw_digest_lock.rs
@@ -1,0 +1,130 @@
+// Licensed under the Apache-2.0 license
+
+//! Test ROM for `Otp::write_sw_digest_and_lock`.
+//!
+//! Boot 1: partition digest is zero - populate vendor_test_partition and
+//!         write the SW digest. Print "DONE" and loop.
+//!
+//! Boot 2: partition digest is non-zero - re-compute the digest and verify
+//!         it matches the stored value. Print "PASS" or fatal_error.
+
+#![no_main]
+#![no_std]
+
+use mcu_rom_common::{fatal_error, Otp, RomEnv};
+use registers_generated::fuses;
+use tock_registers::interfaces::Readable;
+
+#[allow(unused)]
+use mcu_test_harness;
+
+const DIGEST_IV: u64 = 0x90C7_F21F_6224_F027;
+const DIGEST_CONST: u128 = 0xF98C_48B1_F937_7284_4A22_D4B7_8FE0_266F;
+
+fn populate_vendor_test_partition(otp: &Otp) {
+    let partition = fuses::VENDOR_TEST_PARTITION;
+    let data_len = partition.byte_size - 8;
+    let base_word = partition.byte_offset / 4;
+    let num_words = data_len / 4;
+
+    for i in 0..num_words {
+        let val = (i as u32).wrapping_mul(0x0101_0101);
+        if let Err(_e) = otp.write_word(base_word + i, val) {
+            romtime::println!("[sw-digest-lock] Failed to write OTP word {}", i);
+            fatal_error(mcu_error::McuError::ROM_OTP_WRITE_WORD_ERROR);
+        }
+    }
+}
+
+fn write_phase(env: &RomEnv) -> ! {
+    let otp = &env.otp;
+    let partition = fuses::VENDOR_TEST_PARTITION;
+
+    romtime::println!("[sw-digest-lock] Write phase: populating partition and writing digest");
+    populate_vendor_test_partition(otp);
+
+    match otp.write_sw_digest_and_lock(partition, DIGEST_IV, DIGEST_CONST) {
+        Ok(digest) => {
+            romtime::println!("[sw-digest-lock] Digest written: {:#018x}", digest);
+        }
+        Err(_e) => {
+            romtime::println!("[sw-digest-lock] write_sw_digest_and_lock failed");
+            fatal_error(mcu_error::McuError::ROM_OTP_DIGEST_VERIFY_ERROR);
+        }
+    }
+
+    romtime::println!("[sw-digest-lock] DONE");
+    loop {}
+}
+
+fn verify_phase(env: &RomEnv) -> ! {
+    let otp = &env.otp;
+    let partition = fuses::VENDOR_TEST_PARTITION;
+
+    romtime::println!("[sw-digest-lock] Verify phase: checking digest");
+
+    let computed = match otp.compute_sw_digest(partition, DIGEST_IV, DIGEST_CONST) {
+        Ok(d) => d,
+        Err(_e) => {
+            romtime::println!("[sw-digest-lock] compute_sw_digest failed");
+            fatal_error(mcu_error::McuError::ROM_OTP_DIGEST_VERIFY_ERROR);
+        }
+    };
+
+    let digest_offset = match partition.digest_offset {
+        Some(off) => off,
+        None => fatal_error(mcu_error::McuError::ROM_OTP_INVALID_DATA_ERROR),
+    };
+    let stored = match otp.read_dword(digest_offset / 8) {
+        Ok(v) => v,
+        Err(_e) => fatal_error(mcu_error::McuError::ROM_OTP_READ_ERROR),
+    };
+
+    romtime::println!(
+        "[sw-digest-lock] Computed: {:#018x}, Stored: {:#018x}",
+        computed,
+        stored
+    );
+
+    if stored != computed {
+        romtime::println!("[sw-digest-lock] MISMATCH!");
+        fatal_error(mcu_error::McuError::ROM_OTP_DIGEST_VERIFY_ERROR);
+    }
+
+    romtime::println!("[sw-digest-lock] PASS");
+    loop {}
+}
+
+/// Go-bit in generic_input_wires[0] gates execution on FPGA to prevent
+/// racing with the OTP clearing preamble.
+const GO_BIT: u32 = 1 << 0;
+
+fn run() -> ! {
+    let env = RomEnv::new();
+
+    // Wait for go-bit (FPGA OTP clearing preamble).
+    while env.mci.registers.mci_reg_generic_input_wires[0].get() & GO_BIT == 0 {}
+
+    // Check if the digest is already written to decide which phase.
+    let partition = fuses::VENDOR_TEST_PARTITION;
+    let digest_offset = match partition.digest_offset {
+        Some(off) => off,
+        None => fatal_error(mcu_error::McuError::ROM_OTP_INVALID_DATA_ERROR),
+    };
+    let stored = match env.otp.read_dword(digest_offset / 8) {
+        Ok(v) => v,
+        Err(_e) => fatal_error(mcu_error::McuError::ROM_OTP_READ_ERROR),
+    };
+
+    if stored == 0 {
+        write_phase(&env)
+    } else {
+        verify_phase(&env)
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn main() {
+    mcu_test_harness::set_printer();
+    run();
+}

--- a/rom/src/otp.rs
+++ b/rom/src/otp.rs
@@ -177,6 +177,35 @@ impl Otp {
         Ok(self.registers.dai_rdata_rf_direct_access_rdata_0.get())
     }
 
+    /// Reads a dword (64-bit) from the OTP controller.
+    /// dword_addr is in dwords (8-byte units).
+    pub fn read_dword(&self, dword_addr: usize) -> McuResult<u64> {
+        while !self
+            .registers
+            .otp_status
+            .is_set(otp_ctrl::bits::OtpStatus::DaiIdle)
+        {}
+
+        self.registers
+            .direct_access_address
+            .set((dword_addr * 8) as u32);
+        self.registers.direct_access_cmd.set(1);
+
+        while !self
+            .registers
+            .otp_status
+            .is_set(otp_ctrl::bits::OtpStatus::DaiIdle)
+        {}
+
+        if let Some(err) = self.check_error() {
+            romtime::println!("Error reading fuses: {}", HexWord(err));
+            return Err(McuError::ROM_OTP_READ_ERROR);
+        }
+        let lo = self.registers.dai_rdata_rf_direct_access_rdata_0.get() as u64;
+        let hi = self.registers.dai_rdata_rf_direct_access_rdata_1.get() as u64;
+        Ok(lo | (hi << 32))
+    }
+
     /// Write a dword to the OTP controller.
     /// word_addr is in words
     pub fn write_dword(&self, dword_addr: usize, data: u64) -> McuResult<u32> {
@@ -188,11 +217,9 @@ impl Otp {
         {}
 
         // load the data
-        romtime::println!("Write dword 0: {}", HexWord(data as u32));
         self.registers
             .dai_wdata_rf_direct_access_wdata_0
             .set((data) as u32);
-        romtime::println!("Write dword 1: {}", HexWord((data >> 32) as u32));
         self.registers
             .dai_wdata_rf_direct_access_wdata_1
             .set((data >> 32) as u32);
@@ -747,6 +774,57 @@ impl Otp {
 
         let digest = otp_digest::otp_digest_iter(blocks, iv, cnst);
         err?;
+        Ok(digest)
+    }
+
+    /// Compute and write the software digest for an OTP partition, locking it.
+    ///
+    /// Per the OTP spec, writing a non-zero value to the partition's digest
+    /// entry via DAI locks write access to the partition after the next reset.
+    ///
+    /// This method:
+    /// 1. Computes the 64-bit PRESENT-based digest over partition data
+    /// 2. Writes it to the digest offset via DAI (64-bit write)
+    /// 3. Reads it back and verifies
+    ///
+    /// Returns the computed digest on success.
+    pub fn write_sw_digest_and_lock(
+        &self,
+        partition: &OtpPartitionInfo,
+        iv: u64,
+        cnst: u128,
+    ) -> McuResult<u64> {
+        let digest_offset = partition
+            .digest_offset
+            .ok_or(McuError::ROM_OTP_INVALID_DATA_ERROR)?;
+
+        let digest = self.compute_sw_digest(partition, iv, cnst)?;
+        romtime::println!(
+            "[mcu-rom-otp] Writing SW digest {:#x} for partition '{}' at offset {:#x}",
+            digest,
+            partition.name,
+            digest_offset
+        );
+
+        // The digest field always uses a 64-bit access granule in the DAI,
+        // even for non-secret partitions whose data uses 32-bit granularity.
+        self.write_dword(digest_offset / 8, digest)?;
+
+        // Read back the digest using 64-bit granule (matching the write)
+        let readback = self.read_dword(digest_offset / 8)?;
+        if readback != digest {
+            romtime::println!(
+                "[mcu-rom-otp] Digest verify failed: wrote {:#x}, read {:#x}",
+                digest,
+                readback
+            );
+            return Err(McuError::ROM_OTP_DIGEST_VERIFY_ERROR);
+        }
+
+        romtime::println!(
+            "[mcu-rom-otp] SW digest written and verified for '{}' - partition will lock on next reset",
+            partition.name
+        );
         Ok(digest)
     }
 

--- a/rom/src/rom.rs
+++ b/rom/src/rom.rs
@@ -632,8 +632,7 @@ pub struct RomParameters<'a> {
     /// Valid AXI users for MCI mailbox 1. 0 values are ignored.
     pub mci_mbox1_axi_users: [u32; 5],
     /// OTP digest IV and finalization constant (platform-specific RTL constants).
-    /// Required to use `Otp::compute_sw_digest`.
-    /// TODO: pass them to compute_sw_digest
+    /// Required to use `Otp::compute_sw_digest` and `Otp::write_sw_digest_and_lock`.
     pub otp_digest_iv: Option<u64>,
     pub otp_digest_const: Option<u128>,
 }

--- a/tests/integration/src/rom/mod.rs
+++ b/tests/integration/src/rom/mod.rs
@@ -1,4 +1,5 @@
 // Licensed under the Apache-2.0 license
 
 mod test_hitless_update;
+mod test_sw_digest_lock;
 mod test_warm_reset;

--- a/tests/integration/src/rom/test_sw_digest_lock.rs
+++ b/tests/integration/src/rom/test_sw_digest_lock.rs
@@ -1,0 +1,135 @@
+// Licensed under the Apache-2.0 license
+
+//! Integration test for `Otp::write_sw_digest_and_lock`.
+//!
+//! Two cold boots:
+//! 1. First boot writes data + digest to vendor_test_partition, prints "DONE".
+//! 2. Second boot re-computes and verifies the digest, prints "PASS".
+
+#[cfg(test)]
+mod test {
+    use crate::platform;
+    use mcu_builder::firmware;
+    use mcu_hw_model::{InitParams, McuHwModel};
+    use mcu_rom_common::LifecycleControllerState;
+    use registers_generated::fuses;
+
+    fn load_roms() -> (Vec<u8>, Vec<u8>) {
+        if let Ok(binaries) = mcu_builder::FirmwareBinaries::from_env() {
+            (
+                binaries.caliptra_rom.clone(),
+                binaries
+                    .test_rom(&firmware::hw_model_tests::SW_DIGEST_LOCK)
+                    .unwrap(),
+            )
+        } else {
+            let rom_file = mcu_builder::test_rom_build(
+                Some(platform()),
+                &firmware::hw_model_tests::SW_DIGEST_LOCK,
+            )
+            .unwrap();
+            (vec![], std::fs::read(&rom_file).unwrap())
+        }
+    }
+
+    #[test]
+    fn test_sw_digest_lock() {
+        let (caliptra_rom, mcu_rom) = load_roms();
+
+        // On FPGA, OTP SRAM persists across runs. Clear vendor_test_partition
+        // before the real test. The go-bit prevents the ROM from racing.
+        #[cfg(feature = "fpga_realtime")]
+        {
+            let tmp = mcu_hw_model::new_unbooted(InitParams {
+                caliptra_rom: &caliptra_rom,
+                mcu_rom: &mcu_rom,
+                check_booted_to_runtime: false,
+                lifecycle_controller_state: Some(LifecycleControllerState::Dev),
+                ..Default::default()
+            })
+            .unwrap();
+            let p = fuses::VENDOR_TEST_PARTITION;
+            let mut copy = tmp.base.otp_slice().to_vec();
+            copy[p.byte_offset..p.byte_offset + p.byte_size].fill(0);
+            tmp.base.otp_slice().copy_from_slice(&copy);
+            drop(tmp);
+        }
+
+        // Boot 1: write data + digest.
+        let otp_after_boot1;
+        {
+            let mut hw = mcu_hw_model::new(InitParams {
+                caliptra_rom: &caliptra_rom,
+                mcu_rom: &mcu_rom,
+                check_booted_to_runtime: false,
+                enable_mcu_uart_log: true,
+                lifecycle_controller_state: Some(LifecycleControllerState::Dev),
+                ..Default::default()
+            })
+            .unwrap();
+            hw.set_mcu_generic_input_wires(&[1, 0xc000_0000]);
+
+            hw.output().set_search_term("DONE");
+            let start = std::time::Instant::now();
+            hw.step_until(|m| {
+                m.output().search_matched()
+                    || m.mci_fw_fatal_error().is_some()
+                    || start.elapsed().as_secs() > 30
+            });
+            let output_text = hw.output().take(usize::MAX);
+            println!("Boot 1 output:\n{output_text}");
+            assert!(start.elapsed().as_secs() <= 30, "Boot 1 timed out");
+            assert_eq!(hw.mci_fw_fatal_error(), None, "Boot 1 fatal error");
+
+            // Capture OTP state for boot 2 (emulator doesn't persist OTP).
+            otp_after_boot1 = hw.read_otp_memory();
+        }
+
+        // Boot 2: verify digest. Pass OTP from boot 1 so emulator sees the
+        // written data. On FPGA, OTP SRAM persists automatically.
+        {
+            let mut hw = mcu_hw_model::new(InitParams {
+                caliptra_rom: &caliptra_rom,
+                mcu_rom: &mcu_rom,
+                check_booted_to_runtime: false,
+                enable_mcu_uart_log: true,
+                lifecycle_controller_state: Some(LifecycleControllerState::Dev),
+                otp_memory: Some(&otp_after_boot1),
+                ..Default::default()
+            })
+            .unwrap();
+            hw.set_mcu_generic_input_wires(&[1, 0xc000_0000]);
+
+            hw.output().set_search_term("PASS");
+            let start = std::time::Instant::now();
+            hw.step_until(|m| {
+                m.output().search_matched()
+                    || m.mci_fw_fatal_error().is_some()
+                    || start.elapsed().as_secs() > 30
+            });
+            let output_text = hw.output().take(usize::MAX);
+            println!("Boot 2 output:\n{output_text}");
+            assert!(start.elapsed().as_secs() <= 30, "Boot 2 timed out");
+            assert_eq!(hw.mci_fw_fatal_error(), None, "Boot 2 fatal error");
+
+            // Also verify digest via OTP memory readback.
+            let final_otp = hw.read_otp_memory();
+            let digest_offset = fuses::VENDOR_TEST_PARTITION
+                .digest_offset
+                .expect("vendor_test_partition should have a digest offset");
+            let digest_lo = u32::from_le_bytes(
+                final_otp[digest_offset..digest_offset + 4]
+                    .try_into()
+                    .unwrap(),
+            );
+            let digest_hi = u32::from_le_bytes(
+                final_otp[digest_offset + 4..digest_offset + 8]
+                    .try_into()
+                    .unwrap(),
+            );
+            let digest = digest_lo as u64 | ((digest_hi as u64) << 32);
+            assert_ne!(digest, 0, "Digest should have been written to OTP");
+            println!("OTP digest verified: {digest:#018x}");
+        }
+    }
+}


### PR DESCRIPTION
Add a method to `Otp` that writes the SW digest of the partition data, similar to how the HW digest works. This is required for any partitions that have the SW digest marked in the OTP.

Also fix the emulator OTP to support 64-bit DAI writes by tracking the high word (wdata_1) alongside the existing low word buffer.