### PR TITLE
[xtask-fpga]: Update caliptra-sw branch references

### DIFF
--- a/xtask/src/fpga/configurations.rs
+++ b/xtask/src/fpga/configurations.rs
@@ -268,8 +268,7 @@ impl CoreOnSubsystem {
 
 impl<'a> ActionHandler<'a> for CoreOnSubsystem {
     fn bootstrap(&self) -> Result<()> {
-        // TODO(clundin): Consider overriding branch command
-        let bootstrap_cmd= "[ -d caliptra-sw ] || git clone https://github.com/chipsalliance/caliptra-sw --branch=main-2.x --depth=1";
+        let bootstrap_cmd= "[ -d caliptra-sw ] || git clone https://github.com/chipsalliance/caliptra-sw --branch=caliptra-2.0 --depth=1";
         let target_host = self.target_host.as_deref();
         run_command(target_host, bootstrap_cmd).context("failed to clone caliptra-sw repo")?;
 
@@ -375,7 +374,7 @@ impl Core {
 
 impl<'a> ActionHandler<'a> for Core {
     fn bootstrap(&self) -> Result<()> {
-        let bootstrap_cmd= "[ -d caliptra-sw ] || git clone https://github.com/chipsalliance/caliptra-sw --branch=main-2.x --depth=1";
+        let bootstrap_cmd= "[ -d caliptra-sw ] || git clone https://github.com/chipsalliance/caliptra-sw --branch=caliptra-2.0 --depth=1";
         let target_host = self.target_host.as_deref();
         run_command(target_host, bootstrap_cmd).context("failed to clone caliptra-sw repo")?;
 


### PR DESCRIPTION
`main-2.x` is no longer used. 2.0 uses `caliptra-2.0`.