### PR TITLE
Embed FuseEntryInfo in provisioning firmware inputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3598,48 +3598,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
-name = "phf"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
-dependencies = [
- "phf_macros",
- "phf_shared",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
-dependencies = [
- "phf_shared",
- "rand 0.8.5",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
-dependencies = [
- "phf_generator",
- "phf_shared",
- "proc-macro2",
- "quote",
- "syn 2.0.109",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
-dependencies = [
- "siphasher",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3844,7 +3802,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "fusegen",
- "phf",
+ "registers-generated",
 ]
 
 [[package]]
@@ -4503,12 +4461,6 @@ dependencies = [
  "time",
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "siphasher"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,7 +142,6 @@ num-derive = "0.4.2"
 num-traits = "0.2"
 openssl = { version = "0.10", features = ["vendored"] }
 pkcs8 = "0.10.2"
-phf = { version = "0.11", default-features = false }
 portable-atomic = "1.7.0"
 p384 = "0.13.0"
 prettyplease = "0.2.37"

--- a/provisioning/fuses/fusegen/src/lib.rs
+++ b/provisioning/fuses/fusegen/src/lib.rs
@@ -141,15 +141,13 @@ pub fn validate_fuse_values(otp: &OtpMmap, values: &HashMap<String, FuseValue>) 
     Ok(())
 }
 
-pub fn generate_phf_fuse_value_lib(
+pub fn generate_fuse_value_list(
     otp: &OtpMmap,
     values: &HashMap<String, FuseValue>,
 ) -> Result<String> {
     let mut output = HEADER_PREFIX.to_string();
     output.push_str(HEADER_SUFFIX);
-    output.push_str(
-        "\npub static FUSE_VALUES: phf::Map<&'static str, &'static [u8]> = phf::phf_map! {\n",
-    );
+    output.push_str("\npub static FUSE_VALUES: &[(&FuseEntryInfo, &[u8])] = &[\n");
 
     // Sort keys for deterministic output
     let mut keys: Vec<&String> = values.keys().collect();
@@ -170,15 +168,15 @@ pub fn generate_phf_fuse_value_lib(
             }
         }
 
-        write!(&mut output, "    \"{}\" => &[", name)?;
+        write!(&mut output, "    (OTP_{}, &[", name.to_ascii_uppercase())?;
         for i in 0..expected_size {
             let byte = bytes.get(i).cloned().unwrap_or(0);
             write!(&mut output, "0x{:02x}, ", byte)?;
         }
-        output.push_str("],\n");
+        output.push_str("]),\n");
     }
 
-    output.push_str("};\n");
+    output.push_str("];\n");
 
     Ok(output)
 }
@@ -193,7 +191,7 @@ pub fn generate_fuse_values_file(
     let otp_values = parse_fuse_values_hjson(otp_values_path)?;
     validate_fuse_values(&otp_mmap, &otp_values)?;
 
-    let lib_content = generate_phf_fuse_value_lib(&otp_mmap, &otp_values)?;
+    let lib_content = generate_fuse_value_list(&otp_mmap, &otp_values)?;
     std::fs::write(out_lib_path, lib_content)?;
     Ok(())
 }
@@ -304,7 +302,7 @@ mod tests {
     }
 
     #[test]
-    fn test_generate_phf_library() {
+    fn test_generate_fuse_value_list() {
         let otp = OtpMmap {
             partitions: vec![OtpPartition {
                 name: "P1".to_string(),
@@ -323,9 +321,9 @@ mod tests {
         let mut values_map = HashMap::new();
         values_map.insert("F1".to_string(), FuseValue::ByteVec(vec![0xAA, 0xBB]));
 
-        let lib = generate_phf_fuse_value_lib(&otp, &values_map).unwrap();
+        let lib = generate_fuse_value_list(&otp, &values_map).unwrap();
         assert!(lib.contains("pub static FUSE_VALUES"));
-        assert!(lib.contains("phf::phf_map!"));
-        assert!(lib.contains("\"F1\" => &[0xaa, 0xbb, 0x00, 0x00, ]"));
+        assert!(lib.contains("&[(&FuseEntryInfo, &[u8])]"));
+        assert!(lib.contains("(OTP_F1, &[0xaa, 0xbb, 0x00, 0x00, ])"));
     }
 }

--- a/provisioning/fuses/lib/Cargo.toml
+++ b/provisioning/fuses/lib/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-phf = { workspace = true,  features = ["macros"] }
+registers-generated = { workspace = true }
 
 [build-dependencies]
 fusegen.workspace = true

--- a/provisioning/fuses/lib/src/lib.rs
+++ b/provisioning/fuses/lib/src/lib.rs
@@ -1,6 +1,8 @@
 // Licensed under the Apache-2.0 license
 #![no_std]
 
+use registers_generated::fuses::*;
+
 include!(concat!(
     env!("CARGO_MANIFEST_DIR"),
     "/../../../",


### PR DESCRIPTION
~~Add map for all OTP Fuse Entries~~

~~Unfortunately, the formatter (prettyplease) being used on the generated file really seems to hate this map, and the [docs](https://docs.rs/prettyplease/latest/prettyplease/#functions) don't indicate a way to modify its settings or anything, which is why I'm letting the formatter do it's think and then adding the map below.~~

instead of creating a global lookup table, which bloats code space, embed the FuseEntryInfo in the data that gets passed into the provisioning firmware to eliminate the need for one

Closes #993
