### PR TITLE
[cherry-pick] optimize execute_dpe_cmd and cleanup imports (original: #935)

### DIFF
--- a/runtime/userspace/api/caliptra-api/src/certificate.rs
+++ b/runtime/userspace/api/caliptra-api/src/certificate.rs
@@ -7,8 +7,8 @@ use crate::mailbox_api::{
 };
 use caliptra_api::mailbox::{
     CommandId, GetFmcAliasEcc384CertReq, GetIdevCsrReq, GetIdevCsrResp, GetLdevCertResp,
-    GetLdevEcc384CertReq, GetRtAliasEcc384CertReq, InvokeDpeReq, MailboxReqHeader,
-    MailboxRespHeader, PopulateIdevEcc384CertReq, Request,
+    GetLdevEcc384CertReq, GetRtAliasEcc384CertReq, InvokeDpeReq, MailboxRespHeader,
+    PopulateIdevEcc384CertReq, Request,
 };
 use dpe::commands::{
     CertifyKeyCmd, CertifyKeyFlags, Command, CommandHdr, GetCertificateChainCmd, SignCmd, SignFlags,
@@ -281,24 +281,18 @@ impl CertContext {
         &mut self,
         dpe_cmd: &mut Command<'_>,
     ) -> CaliptraApiResult<DpeResponse> {
-        let mut cmd_data: [u8; InvokeDpeReq::DATA_MAX_SIZE] = [0; InvokeDpeReq::DATA_MAX_SIZE];
-        let dpe_cmd_id: u32 = Self::dpe_cmd_id(dpe_cmd);
+        let mut mbox_req = InvokeDpeReq::new_zeroed();
 
+        let dpe_cmd_id: u32 = Self::dpe_cmd_id(dpe_cmd);
         let cmd_hdr = CommandHdr::new_for_test(dpe_cmd_id);
 
         let cmd_hdr_bytes = cmd_hdr.as_bytes();
-        cmd_data[..cmd_hdr_bytes.len()].copy_from_slice(cmd_hdr_bytes);
+        mbox_req.data[..cmd_hdr_bytes.len()].copy_from_slice(cmd_hdr_bytes);
 
         let dpe_cmd_bytes = Self::dpe_cmd_as_bytes(dpe_cmd);
-        cmd_data[cmd_hdr_bytes.len()..cmd_hdr_bytes.len() + dpe_cmd_bytes.len()]
+        mbox_req.data[cmd_hdr_bytes.len()..cmd_hdr_bytes.len() + dpe_cmd_bytes.len()]
             .copy_from_slice(dpe_cmd_bytes);
-        let cmd_data_len = cmd_hdr_bytes.len() + dpe_cmd_bytes.len();
-
-        let mut mbox_req = InvokeDpeReq {
-            hdr: MailboxReqHeader { chksum: 0 },
-            data_size: cmd_data_len as u32,
-            data: cmd_data,
-        };
+        mbox_req.data_size = (cmd_hdr_bytes.len() + dpe_cmd_bytes.len()) as u32;
 
         let mut mbox_resp = DpeEcResp::default();
 
@@ -310,10 +304,7 @@ impl CertContext {
         )
         .await?;
 
-        let mut resp = DpeEcResp::new_zeroed();
-        let resp_size = size_of::<DpeEcResp>();
-        resp.as_mut_bytes()[..].copy_from_slice(&mbox_resp.as_mut_bytes()[..resp_size]);
-        self.parse_dpe_response(dpe_cmd, &resp)
+        self.parse_dpe_response(dpe_cmd, &mbox_resp)
     }
 
     fn dpe_cmd_id(dpe_cmd: &mut Command) -> u32 {


### PR DESCRIPTION
Optimized execute_dpe_cmd to reduce stack usage by avoiding redundant local copies of large mailbox request structures. Also cleaned up unused imports in certificate.rs and test_dot.rs.

(cherry picked from commit 6c92cc5668ebb1aaf897864bffc0477b08f770b5)