### PR TITLE
emulator: Fix cross-thread timer scheduling race in I3C and DOE peripherals

### DIFF
--- a/emulator/app/src/emulator.rs
+++ b/emulator/app/src/emulator.rs
@@ -290,6 +290,9 @@ pub struct Emulator {
     pub doe_mbox_fsm: doe_mbox_fsm::DoeMboxFsm,
     pub i3c_address: Option<u8>,
     pub i3c_controller_join_handle: Option<JoinHandle<()>>,
+    // Synchronizes cross-thread timer scheduling (I3C / DOE controller
+    // threads) with the CPU step that advances the clock.
+    pub step_lock: Arc<Mutex<()>>,
 }
 
 impl Emulator {
@@ -518,11 +521,14 @@ impl Emulator {
         } else {
             I3cController::default()
         };
+        let step_lock = Arc::new(Mutex::new(()));
+
         let i3c = I3c::new(
             &clock.clone(),
             &mut i3c_controller,
             i3c_irq,
             cli.hw_revision.clone(),
+            step_lock.clone(),
         );
         let i3c_dynamic_address = i3c.get_dynamic_address().unwrap();
 
@@ -531,7 +537,12 @@ impl Emulator {
 
         let mut doe_mbox_fsm = doe_mbox_fsm::DoeMboxFsm::new(doe_mbox_periph.clone());
 
-        let doe_mbox = DummyDoeMbox::new(&clock.clone(), doe_event_irq, doe_mbox_periph);
+        let doe_mbox = DummyDoeMbox::new(
+            &clock.clone(),
+            doe_event_irq,
+            doe_mbox_periph,
+            step_lock.clone(),
+        );
 
         println!("Starting DOE mailbox transport thread");
 
@@ -998,6 +1009,7 @@ impl Emulator {
             doe_mbox_fsm,
             Some(i3c_dynamic_address.into()),
             i3c_controller_join_handle,
+            step_lock,
         ))
     }
 
@@ -1016,6 +1028,7 @@ impl Emulator {
         doe_mbox_fsm: doe_mbox_fsm::DoeMboxFsm,
         i3c_address: Option<u8>,
         i3c_controller_join_handle: Option<JoinHandle<()>>,
+        step_lock: Arc<Mutex<()>>,
     ) -> Self {
         // read from the console in a separate thread to prevent blocking
         let stdin_uart_clone = stdin_uart.clone();
@@ -1039,6 +1052,7 @@ impl Emulator {
             doe_mbox_fsm,
             i3c_address,
             i3c_controller_join_handle,
+            step_lock,
         }
     }
 
@@ -1068,6 +1082,11 @@ impl Emulator {
                 self.timer.schedule_poll_in(1);
             }
         }
+
+        // Hold the step lock while advancing clocks so that cross-thread
+        // callers (I3C / DOE PollScheduler::incoming) cannot observe a
+        // mid-step clock value.
+        let _step_guard = self.step_lock.lock().unwrap();
 
         let action = if let Some(ref mut trace_file) = self.trace_file {
             let trace_fn: &mut dyn FnMut(u32, RvInstr) = &mut |pc, instr| match instr {

--- a/emulator/periph/src/doe_mbox.rs
+++ b/emulator/periph/src/doe_mbox.rs
@@ -15,10 +15,13 @@ pub struct DummyDoeMbox {
 
 struct PollScheduler {
     timer: Timer,
+    // Held while scheduling to prevent the clock from advancing mid-operation.
+    step_lock: Arc<Mutex<()>>,
 }
 
 impl IncomingDoeMboxWrite for PollScheduler {
     fn incoming(&self) {
+        let _guard = self.step_lock.lock().unwrap();
         println!("Incoming write to DOE mailbox detected, scheduling poll.");
         // trigger interrupt check next tick
         self.timer.schedule_poll_in(1);
@@ -30,11 +33,17 @@ pub trait IncomingDoeMboxWrite {
 
 impl DummyDoeMbox {
     const DOE_MBOX_TICKS: u64 = 1000; // Example value, adjust as needed
-    pub fn new(clock: &Clock, event_irq: Irq, mut periph: DoeMboxPeriph) -> Self {
+    pub fn new(
+        clock: &Clock,
+        event_irq: Irq,
+        mut periph: DoeMboxPeriph,
+        step_lock: Arc<Mutex<()>>,
+    ) -> Self {
         let timer = Timer::new(clock);
         timer.schedule_poll_in(Self::DOE_MBOX_TICKS);
         let poll_scheduler = PollScheduler {
             timer: timer.clone(),
+            step_lock,
         };
         periph.set_incoming_write_client(Arc::new(poll_scheduler));
 
@@ -148,27 +157,30 @@ impl DoeMboxPeriph {
     }
 
     pub fn write_data(&mut self, data: Vec<u8>) -> Result<(), String> {
-        let mut inner = self.inner.lock().unwrap();
-        if data.len() > inner.max_sram_dword_size * 4 {
-            return Err(format!(
-                "invalida data length: {} bytes exceeds maximum allowed size: {} bytes",
-                data.len(),
-                inner.max_sram_dword_size * 4
-            ));
-        }
-        // Write the data to SRAM as u32 words, chunking every 4 bytes
-        for (word_idx, chunk) in data.chunks(4).enumerate() {
-            let mut buf = [0u8; 4];
-            for (i, &b) in chunk.iter().enumerate() {
-                buf[i] = b;
+        {
+            let mut inner = self.inner.lock().unwrap();
+            if data.len() > inner.max_sram_dword_size * 4 {
+                return Err(format!(
+                    "invalida data length: {} bytes exceeds maximum allowed size: {} bytes",
+                    data.len(),
+                    inner.max_sram_dword_size * 4
+                ));
             }
-            let word = u32::from_le_bytes(buf);
-            inner.write_doe_sram(word, word_idx);
+            // Write the data to SRAM as u32 words, chunking every 4 bytes
+            for (word_idx, chunk) in data.chunks(4).enumerate() {
+                let mut buf = [0u8; 4];
+                for (i, &b) in chunk.iter().enumerate() {
+                    buf[i] = b;
+                }
+                let word = u32::from_le_bytes(buf);
+                inner.write_doe_sram(word, word_idx);
+            }
+            let data_len = data.len() / 4;
+            inner.mbox_dlen.reg.set(data_len as u32);
+            inner.set_event_data_ready();
         }
-        let data_len = data.len() / 4;
-        inner.mbox_dlen.reg.set(data_len as u32);
-        inner.set_event_data_ready();
-
+        // Release the inner lock before calling incoming() to avoid a
+        // lock-ordering inversion with the emulator step lock.
         if let Some(client) = self.incoming_write_client.lock().unwrap().clone() {
             client.incoming();
         }
@@ -177,10 +189,13 @@ impl DoeMboxPeriph {
     }
 
     pub fn request_reset(&mut self) {
-        let mut inner = self.inner.lock().unwrap();
-        // PERIPHERAL LOGIC: Set EVENT.RESET_REQ bit
-        inner.set_event_reset_req();
-
+        {
+            let mut inner = self.inner.lock().unwrap();
+            // PERIPHERAL LOGIC: Set EVENT.RESET_REQ bit
+            inner.set_event_reset_req();
+        }
+        // Release the inner lock before calling incoming() to avoid a
+        // lock-ordering inversion with the emulator step lock.
         if let Some(client) = self.incoming_write_client.lock().unwrap().clone() {
             client.incoming();
         }
@@ -366,7 +381,13 @@ mod tests {
             incoming_write_client: Arc::new(Mutex::new(None)),
         };
 
-        let doe_mbox = Box::new(DummyDoeMbox::new(clock, doe_event_irq, doe_periph));
+        let step_lock = Arc::new(Mutex::new(()));
+        let doe_mbox = Box::new(DummyDoeMbox::new(
+            clock,
+            doe_event_irq,
+            doe_periph,
+            step_lock,
+        ));
 
         AutoRootBus::new(
             vec![],

--- a/emulator/periph/src/i3c.rs
+++ b/emulator/periph/src/i3c.rs
@@ -23,7 +23,7 @@ use registers_generated::i3c::bits::{
 use semver::Version;
 use std::collections::VecDeque;
 use std::sync::mpsc;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use tock_registers::interfaces::{ReadWriteable, Readable, Writeable};
 use zerocopy::FromBytes;
 
@@ -31,10 +31,13 @@ const I3C_REC_INT_BYPASS_I3C_CORE: u32 = 0x0;
 const I3C_REC_INT_BYPASS_AXI_DIRECT: u32 = 0x1;
 struct PollScheduler {
     timer: Timer,
+    // Held while scheduling to prevent the clock from advancing mid-operation.
+    step_lock: Arc<Mutex<()>>,
 }
 
 impl I3cIncomingCommandClient for PollScheduler {
     fn incoming(&self) {
+        let _guard = self.step_lock.lock().unwrap();
         // trigger interrupt check next tick
         self.timer.schedule_poll_in(1);
     }
@@ -100,6 +103,7 @@ impl I3c {
         controller: &mut I3cController,
         irq: Irq,
         hw_revision: Version,
+        step_lock: Arc<Mutex<()>>,
     ) -> Self {
         let mut i3c_target = I3cTarget::default();
 
@@ -108,6 +112,7 @@ impl I3c {
         timer.schedule_poll_in(Self::HCI_TICKS);
         let poll_scheduler = PollScheduler {
             timer: timer.clone(),
+            step_lock,
         };
         i3c_target.set_incoming_command_client(Arc::new(poll_scheduler));
 
@@ -1072,11 +1077,13 @@ mod tests {
         let pic = Pic::new();
         let irq = pic.register_irq(2);
         let mut i3c_controller = I3cController::default();
+        let step_lock = Arc::new(Mutex::new(()));
         let mut i3c = Box::new(I3c::new(
             &clock,
             &mut i3c_controller,
             irq,
             Version::new(2, 0, 0),
+            step_lock,
         ));
 
         assert_eq!(i3c.read_i3c_base_hci_version(), I3c::HCI_VERSION);

--- a/emulator/periph/src/i3c_protocol.rs
+++ b/emulator/periph/src/i3c_protocol.rs
@@ -230,9 +230,11 @@ impl I3cTarget {
     }
 
     pub fn send_command(&mut self, cmd: I3cTcriCommandXfer) {
-        let mut target = self.target.lock().unwrap();
-        target.rx_buffer.push_back(cmd);
-        if let Some(client) = self.incoming_command_client.lock().unwrap().clone() {
+        // Release the target lock before calling incoming() to avoid a
+        // lock-ordering inversion with the emulator step lock.
+        self.target.lock().unwrap().rx_buffer.push_back(cmd);
+        let client = self.incoming_command_client.lock().unwrap().clone();
+        if let Some(client) = client {
             client.incoming();
         }
     }

--- a/hw/model/src/model_emulated.rs
+++ b/hw/model/src/model_emulated.rs
@@ -55,6 +55,7 @@ use std::path::PathBuf;
 use std::rc::Rc;
 use std::sync::atomic::Ordering;
 use std::sync::mpsc;
+use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
 
 const BOOT_CYCLES: u64 = 100_000_000;
@@ -87,6 +88,9 @@ pub struct ModelEmulated {
     dot_flash: Rc<RefCell<Ram>>,
     otp_partitions: Rc<RefCell<Vec<u8>>>,
     check_booted_to_runtime: bool,
+    // Synchronises cross-thread timer scheduling (I3C controller thread)
+    // with the CPU step that advances the clock.
+    step_lock: Arc<Mutex<()>>,
 }
 
 fn hash_slice(slice: &[u8]) -> u64 {
@@ -154,7 +158,15 @@ impl McuHwModel for ModelEmulated {
             Version::new(2, 0, 0)
         };
 
-        let i3c = I3c::new(&clock.clone(), &mut i3c_controller, i3c_irq, hw_version);
+        let step_lock = Arc::new(Mutex::new(()));
+
+        let i3c = I3c::new(
+            &clock.clone(),
+            &mut i3c_controller,
+            i3c_irq,
+            hw_version,
+            step_lock.clone(),
+        );
 
         let i3c_dynamic_address = i3c.get_dynamic_address().unwrap();
 
@@ -397,6 +409,7 @@ impl McuHwModel for ModelEmulated {
             dot_flash,
             otp_partitions,
             check_booted_to_runtime: params.check_booted_to_runtime,
+            step_lock,
         };
         // Turn tracing on if the trace path was set
         m.tracing_hint(true);
@@ -445,9 +458,15 @@ impl McuHwModel for ModelEmulated {
 
     fn step(&mut self) {
         if self.cpu_enabled.get() {
-            self.cpu.step(self.caliptra_trace_fn.as_deref_mut());
-            self.caliptra_cpu
-                .step(self.caliptra_trace_fn.as_deref_mut());
+            {
+                // Hold the step lock while advancing the clock so that
+                // cross-thread callers (e.g. I3C PollScheduler::incoming)
+                // cannot observe a mid-step clock value.
+                let _guard = self.step_lock.lock().unwrap();
+                self.cpu.step(self.caliptra_trace_fn.as_deref_mut());
+                self.caliptra_cpu
+                    .step(self.caliptra_trace_fn.as_deref_mut());
+            }
             if let Some(ref mut bmc) = self.bmc {
                 bmc.step();
             }


### PR DESCRIPTION
The I3C controller thread calls `PollScheduler::incoming()` which invokes `timer.schedule_poll_in(1)`. Inside `caliptra-sw`'s `Clock` `schedule_poll_in` reads `now()` once to compute the absolute time, then `schedule_action_at` reads `now()` again to assert the delta is `< i64::MAX`. When the main CPU step thread advances the clock between these two reads, the scheduled time appears to be in the past, wrapping to a huge delta that trips the assertion.

Add a shared step_lock (`Arc<Mutex<()>>`) that both the `PollScheduler` callbacks and the CPU step code acquire, ensuring the clock cannot advance while a timer action is being scheduled from another thread.

Also fix a lock-ordering inversion in `I3cTarget::send_command()` that would otherwise deadlock: release the target device mutex before calling `incoming()` (which now acquires the step lock).