### PR TITLE
[ci] increase timeout for caliptra-sw-smoke-test job

### DIFF
--- a/.github/workflows/caliptra-sw-smoke-test.yml
+++ b/.github/workflows/caliptra-sw-smoke-test.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   caliptra-sw-mcu-rom-smoke-test:
     uses: chipsalliance/caliptra-sw/.github/workflows/fpga-subsystem.yml@caliptra-2.0
+    timeout-minutes: 120
     with:
       mcu-commit: ${{ github.event.pull_request.head.sha || github.sha }}
       branch: caliptra-2.0


### PR DESCRIPTION
The caliptra-sw-mcu-rom-smoke-test job was timing out consistently at ~72 minutes. Increasing the job timeout to 120 minutes to provide more headroom for the build and test steps in the reusable fpga-subsystem.yml workflow to see if this helps.