### PR TITLE
Align text sections of linker scripts

### DIFF
--- a/firmware-bundler/data/default-bare-metal-layout.ld
+++ b/firmware-bundler/data/default-bare-metal-layout.ld
@@ -17,6 +17,7 @@ SECTIONS
         *(.text.init )
         *(.text*)
         *(.rodata*)
+        . = ALIGN(4);
         _imem_end = .;
     } > RAM
 

--- a/firmware-bundler/data/default-rom-layout.ld
+++ b/firmware-bundler/data/default-rom-layout.ld
@@ -16,6 +16,7 @@ SECTIONS
         *(.text.init )
         *(.text*)
         *(.rodata*)
+        . = ALIGN(4);
     } > ROM
 
     ROM_DATA = .;


### PR DESCRIPTION
The current code shouldn't throw exceptions for the unaligned loads, but we can save having to potentially do multiple loads by aligning this section

for #458 
