### PR TITLE
rom: Implement FIPS zeroization flow for secret fuses (#883)

### DIFF
--- a/emulator/app/src/emulator.rs
+++ b/emulator/app/src/emulator.rs
@@ -806,6 +806,7 @@ impl Emulator {
             Some(mcu_mailbox1),
             Some(soc_ifc),
             [0, 0],
+            false,
         );
 
         let mut auto_root_bus = AutoRootBus::new(

--- a/emulator/periph/src/lc_ctrl.rs
+++ b/emulator/periph/src/lc_ctrl.rs
@@ -15,7 +15,7 @@ Abstract:
 use caliptra_emu_bus::ReadWriteRegister;
 use emulator_registers_generated::lc::LcGenerated;
 use registers_generated::lc_ctrl;
-use tock_registers::interfaces::Readable;
+use tock_registers::interfaces::{ReadWriteable, Readable};
 
 pub struct LcCtrl {
     status: ReadWriteRegister<u32, lc_ctrl::bits::Status::Register>,
@@ -44,5 +44,19 @@ impl emulator_registers_generated::lc::LcPeripheral for LcCtrl {
 
     fn read_status(&mut self) -> ReadWriteRegister<u32, lc_ctrl::bits::Status::Register> {
         ReadWriteRegister::new(self.status.reg.get())
+    }
+
+    fn write_transition_cmd(
+        &mut self,
+        val: ReadWriteRegister<u32, lc_ctrl::bits::TransitionCmd::Register>,
+    ) {
+        if let Some(generated) = self.generated() {
+            generated.write_transition_cmd(val);
+        }
+        // When firmware writes the transition command, immediately report success
+        // so the polling loop in lifecycle.rs completes.
+        self.status
+            .reg
+            .modify(lc_ctrl::bits::Status::TransitionSuccessful::SET);
     }
 }

--- a/emulator/periph/src/mci.rs
+++ b/emulator/periph/src/mci.rs
@@ -46,9 +46,11 @@ pub struct Mci {
     #[allow(dead_code)]
     generic_input_wires: [u32; 2],
     reset_requested: bool,
+    fips_zeroization: bool,
 }
 
 impl Mci {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         clock: &Clock,
         ext_mci_regs: caliptra_emu_periph::mci::Mci,
@@ -57,6 +59,7 @@ impl Mci {
         mcu_mailbox1: Option<McuMailbox0Internal>,
         soc_regs: Option<RegisterBlock<BusMmio<SocToCaliptraBus>>>,
         generic_input_wires: [u32; 2],
+        fips_zeroization: bool,
     ) -> Self {
         // Clear the reset status, MCU and Caiptra are out of reset
         ext_mci_regs.regs.borrow_mut().reset_status = 0;
@@ -85,6 +88,7 @@ impl Mci {
             mcu_mailbox0,
             generic_input_wires,
             reset_requested: false,
+            fips_zeroization,
 
             // --- init mtimecmp ---
             mtimecmp: default_mtimecmp,
@@ -956,6 +960,15 @@ impl MciPeripheral for Mci {
             .read_mcu_mbox0_csr_mbox_hw_status()
     }
 
+    fn read_mci_reg_fc_fips_zerozation_sts(
+        &mut self,
+    ) -> caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::mci::bits::FcFipsZerozationSts::Register,
+    > {
+        caliptra_emu_bus::ReadWriteRegister::new(if self.fips_zeroization { 1 } else { 0 })
+    }
+
     fn read_mci_reg_hw_rev_id(
         &mut self,
     ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::mci::bits::HwRevId::Register>
@@ -1178,6 +1191,7 @@ mod tests {
             None,
             None,
             [0, 0],
+            false,
         );
         let mut mci_bus = MciBus {
             periph: Box::new(mci_reg),
@@ -1273,6 +1287,7 @@ mod tests {
             None,
             None,
             [0, 0],
+            false,
         );
         let mut mcu_mailbox = mci_reg.mcu_mailbox0.clone().unwrap();
         let mut mci_bus = MciBus {
@@ -1312,6 +1327,7 @@ mod tests {
             None,
             None,
             [0, 0],
+            false,
         );
 
         let hi: u32 = 0x0022_3344;
@@ -1342,6 +1358,7 @@ mod tests {
             None,
             None,
             [0, 0],
+            false,
         );
 
         let lo: u32 = 0x0000_FFFF;
@@ -1372,6 +1389,7 @@ mod tests {
             None,
             None,
             [0, 0],
+            false,
         );
 
         // Seed a known value.
@@ -1400,6 +1418,7 @@ mod tests {
             None,
             None,
             [0, 0],
+            false,
         );
 
         // use a safe 48-bit range: 0x0000_DEAD_FFFF_FFFE
@@ -1431,6 +1450,7 @@ mod tests {
             None,
             None,
             [0, 0],
+            false,
         );
 
         // Initial time is 0
@@ -1458,6 +1478,7 @@ mod tests {
             None,
             None,
             [0, 0],
+            false,
         );
 
         // Move time to a known value.
@@ -1494,6 +1515,7 @@ mod tests {
             None,
             None,
             [0, 0],
+            false,
         );
 
         // Advance by 2^32 + 1 -> high = 1, low = 1, as clock start at 0

--- a/emulator/periph/src/mcu_mbox0.rs
+++ b/emulator/periph/src/mcu_mbox0.rs
@@ -532,6 +532,7 @@ mod tests {
             None,
             None,
             [0, 0],
+            false,
         );
         AutoRootBus::new(
             vec![],

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -162,6 +162,21 @@ impl McuError {
             "Lifecycle OTP partition error"
         ),
         (
+            ROM_FIPS_ZEROIZATION_LC_TRANSITION_ERROR,
+            0x2_0008,
+            "FIPS zeroization lifecycle transition to SCRAP failed"
+        ),
+        (
+            ROM_FIPS_ZEROIZATION_UDS_FE_START_ERROR,
+            0x2_0009,
+            "FIPS zeroization failed to start ZEROIZE_UDS_FE command"
+        ),
+        (
+            ROM_FIPS_ZEROIZATION_UDS_FE_FINISH_ERROR,
+            0x2_000a,
+            "FIPS zeroization failed to finish ZEROIZE_UDS_FE command"
+        ),
+        (
             ROM_OTP_INIT_STATUS_ERROR,
             0x3_0000,
             "OTP controller status error during initialization"
@@ -346,6 +361,11 @@ impl McuError {
             ROM_COLD_BOOT_ENCRYPTED_FW_ACTIVATE_FINISH_ERROR,
             0x1_0015,
             "Cold boot encrypted firmware activate finish error"
+        ),
+        (
+            ROM_SOC_WDT_CFG_OUT_OF_RANGE,
+            0x5_0013,
+            "Caliptra WDT config index out of range"
         ),
         (
             GENERIC_EXCEPTION,

--- a/hw/model/src/lib.rs
+++ b/hw/model/src/lib.rs
@@ -225,6 +225,10 @@ pub struct InitParams<'a> {
 
     pub flash_boot: bool,
 
+    /// When true, the emulator pre-sets the `FC_FIPS_ZEROZATION_STS` register
+    /// so that MCU ROM detects FIPS zeroization on cold boot.
+    pub fips_zeroization: bool,
+
     /// Override the default AXI user that the model uses to access the Caliptra SoC interface.
     pub caliptra_soc_axi_user: Option<u32>,
 }
@@ -299,6 +303,7 @@ impl Default for InitParams<'_> {
             check_booted_to_runtime: true,
             rom_callback: None,
             flash_boot: false,
+            fips_zeroization: false,
             caliptra_soc_axi_user: None,
         }
     }

--- a/hw/model/src/model_emulated.rs
+++ b/hw/model/src/model_emulated.rs
@@ -298,6 +298,7 @@ impl McuHwModel for ModelEmulated {
             Some(mcu_mailbox1),
             None,
             mci_generic_input_wires,
+            params.fips_zeroization,
         );
 
         let delegates: Vec<Box<dyn caliptra_emu_bus::Bus>> =

--- a/rom/src/boot_status.rs
+++ b/rom/src/boot_status.rs
@@ -16,6 +16,7 @@ use bitflags::bitflags;
 
 const ROM_INITIALIZATION_BASE: u16 = 1;
 const LIFECYCLE_MANAGEMENT_BASE: u16 = 65;
+const FIPS_ZEROIZATION_BASE: u16 = 97;
 const OTP_FUSE_OPERATIONS_BASE: u16 = 129;
 const CALIPTRA_SETUP_BASE: u16 = 193;
 const FIRMWARE_LOADING_BASE: u16 = 257;
@@ -42,6 +43,20 @@ pub enum McuRomBootStatus {
     LifecycleTransitionComplete = LIFECYCLE_MANAGEMENT_BASE + 2,
     LifecycleTokenBurningStarted = LIFECYCLE_MANAGEMENT_BASE + 3,
     LifecycleTokenBurningComplete = LIFECYCLE_MANAGEMENT_BASE + 4,
+
+    // FIPS Zeroization Flow Statuses
+    /// FIPS zeroization PPD signal detected; MCU ROM is authorizing zeroization.
+    FipsZeroizationDetected = FIPS_ZEROIZATION_BASE,
+    /// Caliptra ZEROIZE_UDS_FE command sent to zeroize UDS and field entropy.
+    FipsZeroizationUdsFeStarted = FIPS_ZEROIZATION_BASE + 1,
+    /// Caliptra ZEROIZE_UDS_FE command completed.
+    FipsZeroizationUdsFeComplete = FIPS_ZEROIZATION_BASE + 2,
+    /// MCU ROM zeroization mask register set to 0xFFFF_FFFF.
+    FipsZeroizationMaskSet = FIPS_ZEROIZATION_BASE + 3,
+    /// LC transition to SCRAP state started (takes effect after cold reset).
+    FipsZeroizationScrapTransitionStarted = FIPS_ZEROIZATION_BASE + 4,
+    /// FIPS zeroization flow complete; MCU ROM is halted waiting for cold reset.
+    FipsZeroizationComplete = FIPS_ZEROIZATION_BASE + 5,
 
     // OTP and Fuse Operations
     OtpControllerInitialized = OTP_FUSE_OPERATIONS_BASE,

--- a/rom/src/cold_boot.rs
+++ b/rom/src/cold_boot.rs
@@ -29,7 +29,7 @@ use caliptra_api_types::{DeviceLifecycle, SecurityState};
 use core::fmt::Write;
 use core::ops::Deref;
 use mcu_error::McuError;
-use romtime::{CaliptraSoC, HexWord};
+use romtime::{CaliptraSoC, HexWord, LifecycleControllerState, LifecycleToken};
 use tock_registers::interfaces::Readable;
 use zerocopy::{transmute, FromBytes, Immutable, IntoBytes, KnownLayout};
 
@@ -426,6 +426,91 @@ impl ColdBoot {
             _ => 0xdead_ffff,
         }
     }
+
+    /// Execute the FIPS zeroization flow.
+    ///
+    /// Per the Caliptra SS Hardware Specification, when the PPD signal is
+    /// asserted the MCU ROM must:
+    ///   1. Command Caliptra to zeroize UDS and field entropy via
+    ///      ZEROIZE_UDS_FE (secret fuses can only be zeroized by Caliptra).
+    ///   2. Write 0xFFFF_FFFF to FC_FIPS_ZEROZATION mask to authorize the
+    ///      fuse controller to zeroize non-secret fuses.
+    ///   3. Request an LC transition to SCRAP (no token required).
+    ///   4. Halt, waiting for the SoC to issue a cold reset.
+    ///
+    /// This function never returns.
+    fn handle_fips_zeroization(
+        mci: &romtime::Mci,
+        lc: &romtime::Lifecycle,
+        soc_manager: &mut CaliptraSoC,
+    ) -> ! {
+        romtime::println!("[mcu-rom] Executing FIPS zeroization flow");
+
+        // Step 1: Command Caliptra to zeroize UDS and all field entropy partitions.
+        romtime::println!("[mcu-rom] Sending ZEROIZE_UDS_FE to Caliptra");
+        mci.set_flow_checkpoint(McuRomBootStatus::FipsZeroizationUdsFeStarted.into());
+
+        let flags = caliptra_api::mailbox::ZEROIZE_UDS_FLAG
+            | caliptra_api::mailbox::ZEROIZE_FE0_FLAG
+            | caliptra_api::mailbox::ZEROIZE_FE1_FLAG
+            | caliptra_api::mailbox::ZEROIZE_FE2_FLAG
+            | caliptra_api::mailbox::ZEROIZE_FE3_FLAG;
+
+        let mut req = caliptra_api::mailbox::ZeroizeUdsFeReq {
+            flags,
+            ..Default::default()
+        };
+        let chksum = calc_checksum(
+            CommandId::ZEROIZE_UDS_FE.into(),
+            &req.as_bytes()[core::mem::size_of::<MailboxReqHeader>()..],
+        );
+        req.hdr.chksum = chksum;
+
+        if let Err(err) =
+            soc_manager.start_mailbox_req_bytes(CommandId::ZEROIZE_UDS_FE.into(), req.as_bytes())
+        {
+            romtime::println!(
+                "[mcu-rom] FIPS zeroization: ZEROIZE_UDS_FE send failed: {}",
+                HexWord(Self::err_code(&err))
+            );
+            fatal_error(McuError::ROM_FIPS_ZEROIZATION_UDS_FE_START_ERROR);
+        }
+        {
+            let mut resp_buf = [0u8; core::mem::size_of::<MailboxRespHeader>()];
+            if let Err(err) = soc_manager.finish_mailbox_resp_bytes(&mut resp_buf) {
+                romtime::println!(
+                    "[mcu-rom] FIPS zeroization: ZEROIZE_UDS_FE finish failed: {}",
+                    HexWord(Self::err_code(&err))
+                );
+                fatal_error(McuError::ROM_FIPS_ZEROIZATION_UDS_FE_FINISH_ERROR);
+            }
+        }
+        romtime::println!("[mcu-rom] ZEROIZE_UDS_FE completed successfully");
+        mci.set_flow_checkpoint(McuRomBootStatus::FipsZeroizationUdsFeComplete.into());
+
+        // Step 2: Authorize fuse controller zeroization of non-secret fuses.
+        mci.set_fips_zeroization_mask();
+        mci.set_flow_checkpoint(McuRomBootStatus::FipsZeroizationMaskSet.into());
+
+        // Step 3: Request LC transition to SCRAP. The transition is recorded
+        // in OTP and takes effect permanently after the next cold reset.
+        romtime::println!("[mcu-rom] Requesting LC transition to SCRAP for FIPS zeroization");
+        mci.set_flow_checkpoint(McuRomBootStatus::FipsZeroizationScrapTransitionStarted.into());
+        if let Err(err) = lc.transition(LifecycleControllerState::Scrap, &LifecycleToken([0u8; 16]))
+        {
+            romtime::println!(
+                "[mcu-rom] FIPS zeroization: LC SCRAP transition failed: {:?}",
+                err
+            );
+            fatal_error(McuError::ROM_FIPS_ZEROIZATION_LC_TRANSITION_ERROR);
+        }
+
+        // Step 4: Halt. The SoC must issue a cold reset for the SCRAP
+        // transition and fuse zeroization to take effect.
+        romtime::println!("[mcu-rom] FIPS zeroization complete; halting for cold reset");
+        mci.set_flow_checkpoint(McuRomBootStatus::FipsZeroizationComplete.into());
+        loop {}
+    }
 }
 
 impl BootFlow for ColdBoot {
@@ -459,6 +544,18 @@ impl BootFlow for ColdBoot {
 
         lc.init().unwrap();
         mci.set_flow_checkpoint(McuRomBootStatus::LifecycleControllerInitialized.into());
+
+        // Check for FIPS zeroization PPD signal early. The full zeroization
+        // flow (including the Caliptra ZEROIZE_UDS_FE command) runs later,
+        // after Caliptra is ready for mailbox commands.
+        let fips_zeroization = mci.fips_zeroization_requested();
+        if fips_zeroization {
+            romtime::println!(
+                "[mcu-rom] FIPS zeroization PPD signal detected; \
+                 will execute zeroization after Caliptra boot"
+            );
+            mci.set_flow_checkpoint(McuRomBootStatus::FipsZeroizationDetected.into());
+        }
 
         if let Some((state, token)) = params.lifecycle_transition {
             mci.set_flow_checkpoint(McuRomBootStatus::LifecycleTransitionStarted.into());
@@ -636,6 +733,12 @@ impl BootFlow for ColdBoot {
 
         romtime::println!("[mcu-rom] Caliptra is ready for mailbox commands",);
         mci.set_flow_checkpoint(McuRomBootStatus::CaliptraReadyForMailbox.into());
+
+        // Execute full FIPS zeroization flow now that Caliptra is ready for
+        // mailbox commands. This never returns (halts for cold reset).
+        if fips_zeroization {
+            ColdBoot::handle_fips_zeroization(mci, lc, &mut env.soc_manager);
+        }
 
         // Load DOT fuses from vendor non-secret partition
         // TODO: read these from a place specified by ROM configuration

--- a/rom/src/rom.rs
+++ b/rom/src/rom.rs
@@ -105,7 +105,11 @@ impl Soc {
     }
 
     pub fn set_cptra_wdt_cfg(&self, index: usize, value: u32) {
-        self.registers.cptra_wdt_cfg[index].set(value);
+        if let Some(reg) = self.registers.cptra_wdt_cfg.get(index) {
+            reg.set(value);
+        } else {
+            fatal_error(McuError::ROM_SOC_WDT_CFG_OUT_OF_RANGE);
+        }
     }
 
     pub fn set_cptra_mbox_valid_axi_user(&self, index: usize, value: u32) {
@@ -325,7 +329,9 @@ impl Soc {
                     .read_u32_at(hash_base_offset + word_idx * 4)
                     .unwrap_or_else(|_| fatal_error(McuError::ROM_OTP_READ_ERROR));
                 let reg_idx = hash_idx * 12 + word_idx;
-                mci.registers.mci_reg_prod_debug_unlock_pk_hash_reg[reg_idx].set(word);
+                if !mci.write_prod_debug_unlock_pk_hash(reg_idx, word) {
+                    fatal_error(McuError::ROM_SOC_PROD_DEBUG_UNLOCK_PKS_HASH_LEN_MISMATCH);
+                }
             }
         }
 

--- a/romtime/src/mci.rs
+++ b/romtime/src/mci.rs
@@ -317,4 +317,40 @@ impl Mci {
             false
         }
     }
+
+    /// Check if FIPS zeroization has been requested via the PPD input pin.
+    ///
+    /// Returns true if `cptra_ss_FIPS_ZEROIZATION_PPD_i` is asserted (HIGH),
+    /// as reflected in the `FC_FIPS_ZEROZATION_STS` register.
+    pub fn fips_zeroization_requested(&self) -> bool {
+        self.registers
+            .mci_reg_fc_fips_zerozation_sts
+            .is_set(mci::bits::FcFipsZerozationSts::Status)
+    }
+
+    /// Set the MCU ROM zeroization mask to authorize fuse controller zeroization.
+    ///
+    /// Writes `0xFFFF_FFFF` to the `FC_FIPS_ZEROZATION` mask register. This
+    /// must be set by MCU ROM when `fips_zeroization_requested()` returns true;
+    /// if not set, the fuse controller will abort the zeroization request.
+    /// The register is locked once `SS_CONFIG_DONE` is set.
+    pub fn set_fips_zeroization_mask(&self) {
+        self.registers.mci_reg_fc_fips_zerozation.set(0xFFFF_FFFF);
+    }
+
+    /// Write a word to the production debug unlock PK hash register at the given index.
+    ///
+    /// Returns true if the write succeeded, false if the index is out of bounds.
+    pub fn write_prod_debug_unlock_pk_hash(&self, index: usize, value: u32) -> bool {
+        if let Some(reg) = self
+            .registers
+            .mci_reg_prod_debug_unlock_pk_hash_reg
+            .get(index)
+        {
+            reg.set(value);
+            true
+        } else {
+            false
+        }
+    }
 }

--- a/tests/integration/src/lib.rs
+++ b/tests/integration/src/lib.rs
@@ -9,6 +9,7 @@ mod network;
 mod rom;
 mod test_dot;
 mod test_exception_handler;
+mod test_fips_zeroization;
 mod test_firmware_update;
 mod test_fpga_flash_ctrl;
 mod test_i3c_constant_writes;
@@ -69,6 +70,8 @@ mod test {
         pub custom_caliptra_fw: Option<CustomCaliptraFw>,
         /// Custom OTP memory contents. If provided, takes precedence over dot_enabled.
         pub otp_memory: Option<Vec<u8>>,
+        /// Enable FIPS zeroization PPD signal for cold boot testing.
+        pub fips_zeroization: bool,
     }
 
     static PROJECT_ROOT: LazyLock<PathBuf> = LazyLock::new(|| {
@@ -374,6 +377,7 @@ mod test {
             otp_memory: otp_memory.as_deref(),
             primary_flash_initial_contents: flash_image,
             flash_boot: params.flash_boot,
+            fips_zeroization: params.fips_zeroization,
             ..Default::default()
         })
         .unwrap()

--- a/tests/integration/src/test_fips_zeroization.rs
+++ b/tests/integration/src/test_fips_zeroization.rs
@@ -1,0 +1,48 @@
+// Licensed under the Apache-2.0 license
+
+#[cfg(test)]
+mod test {
+    use crate::test::{start_runtime_hw_model, TestParams, TEST_LOCK};
+    use mcu_hw_model::McuHwModel;
+    use mcu_rom_common::McuRomBootStatus;
+    use std::sync::atomic::Ordering;
+
+    const MAX_ZEROIZATION_CYCLES: u64 = 500_000_000;
+
+    /// Test that the FIPS zeroization flow triggers on cold boot when the
+    /// PPD signal is asserted, and that the ROM reaches the expected
+    /// FipsZeroizationDetected checkpoint.
+    ///
+    /// NOTE: We check `FipsZeroizationDetected` rather than
+    /// `FipsZeroizationComplete` because the emulated Caliptra DMA cannot
+    /// access fuse-controller OTP, so ZEROIZE_UDS_FE panics in the model.
+    /// Extend to `FipsZeroizationComplete` once the emulator supports it.
+    #[test]
+    fn test_fips_zeroization_cold_boot() {
+        let lock = TEST_LOCK.lock().unwrap();
+        lock.fetch_add(1, Ordering::Relaxed);
+
+        let mut hw = start_runtime_hw_model(TestParams {
+            rom_only: true,
+            fips_zeroization: true,
+            ..Default::default()
+        });
+
+        let expected_checkpoint = McuRomBootStatus::FipsZeroizationDetected as u16;
+
+        hw.step_until(|hw| {
+            let checkpoint = hw.mci_boot_checkpoint();
+            checkpoint >= expected_checkpoint || hw.cycle_count() >= MAX_ZEROIZATION_CYCLES
+        });
+
+        let checkpoint = hw.mci_boot_checkpoint();
+        assert!(
+            checkpoint >= expected_checkpoint,
+            "ROM should reach FipsZeroizationDetected checkpoint (expected >= {}, got {})",
+            expected_checkpoint,
+            checkpoint
+        );
+
+        lock.fetch_add(1, Ordering::Relaxed);
+    }
+}


### PR DESCRIPTION
MCU ROM now checks the FIPS_ZEROIZATION_PPD_i signal on cold boot and,
when asserted, authorizes fuse controller zeroization by setting the
MCI mask register then transitions the lifecycle to SCRAP before halting
for a cold reset.

Also replaces direct array indexing with bounds-checked .get() in
populate_fuses (PK hash writes), set_cptra_wdt_cfg, and adds
corresponding error codes and boot status checkpoints.