### PR TITLE
[rom] add support for detecting ICCM and DCCM ECC uncorrectable errors

### DIFF
--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -353,6 +353,16 @@ impl McuError {
             "SS_CONFIG_DONE or SS_CONFIG_DONE_STICKY verification failed after setting"
         ),
         (
+            ROM_SOC_ICCM_ECC_UNC,
+            0x5_0011,
+            "ICCM uncorrectable ECC error"
+        ),
+        (
+            ROM_SOC_DCCM_ECC_UNC,
+            0x5_0012,
+            "DCCM uncorrectable ECC error"
+        ),
+        (
             GENERIC_EXCEPTION,
             0xF_0000,
             "Machine level exception was encountered during ROM execution"

--- a/rom/src/cold_boot.rs
+++ b/rom/src/cold_boot.rs
@@ -444,6 +444,7 @@ impl BootFlow for ColdBoot {
                 romtime::println!("[mcu-rom] Caliptra reported a fatal error");
                 fatal_error(McuError::ROM_COLD_BOOT_CALIPTRA_FATAL_ERROR_BEFORE_MB_READY);
             }
+            soc.check_hw_errors();
         }
 
         romtime::println!("[mcu-rom] Caliptra is ready for mailbox commands",);
@@ -630,7 +631,9 @@ impl BootFlow for ColdBoot {
         romtime::println!(
             "[mcu-rom] Waiting for Caliptra RT to be ready for runtime mailbox commands"
         );
-        while !soc.ready_for_runtime() {}
+        while !soc.ready_for_runtime() {
+            soc.check_hw_errors();
+        }
         mci.set_flow_checkpoint(McuRomBootStatus::CaliptraRuntimeReady.into());
 
         romtime::println!("[mcu-rom] Finished common initialization");

--- a/rom/src/rom.rs
+++ b/rom/src/rom.rs
@@ -98,6 +98,18 @@ impl Soc {
         self.registers.cptra_fw_error_fatal.get() != 0
     }
 
+    pub fn check_hw_errors(&self) {
+        let hw_error = self.registers.cptra_hw_error_fatal.extract();
+        if hw_error.is_set(soc::bits::CptraHwErrorFatal::IccmEccUnc) {
+            romtime::println!("[mcu-rom] Caliptra reported an ICCM ECC uncorrectable error");
+            fatal_error(McuError::ROM_SOC_ICCM_ECC_UNC);
+        }
+        if hw_error.is_set(soc::bits::CptraHwErrorFatal::DccmEccUnc) {
+            romtime::println!("[mcu-rom] Caliptra reported a DCCM ECC uncorrectable error");
+            fatal_error(McuError::ROM_SOC_DCCM_ECC_UNC);
+        }
+    }
+
     pub fn set_cptra_wdt_cfg(&self, index: usize, value: u32) {
         self.registers.cptra_wdt_cfg[index].set(value);
     }
@@ -378,6 +390,7 @@ impl Soc {
                 romtime::println!("[mcu-rom] Caliptra reported a fatal error");
                 fatal_error(McuError::ROM_SOC_CALIPTRA_FATAL_ERROR_BEFORE_FW_READY);
             }
+            self.check_hw_errors();
         }
         // Clear the reset request interrupt
         notif0.modify(mci::bits::Notif0IntrT::NotifCptraMcuResetReqSts::SET);

--- a/tests/integration/src/rom/mod.rs
+++ b/tests/integration/src/rom/mod.rs
@@ -1,5 +1,6 @@
 // Licensed under the Apache-2.0 license
 
+mod test_ecc_errors;
 mod test_hitless_update;
 mod test_otp_blank_check;
 mod test_sw_digest_lock;

--- a/tests/integration/src/rom/test_ecc_errors.rs
+++ b/tests/integration/src/rom/test_ecc_errors.rs
@@ -1,0 +1,99 @@
+// Licensed under the Apache-2.0 license
+
+//! This file contains integration tests for the MCU ROM to verify it correctly
+//! detects and handles ICCM and DCCM ECC uncorrectable errors reported by Caliptra
+//! via the `cptra_hw_error_fatal` register.
+
+use anyhow::Result;
+use caliptra_api::SocManager;
+use caliptra_image_types::FwVerificationPqcKeyType;
+use mcu_builder::flash_image::build_flash_image_bytes;
+use mcu_hw_model::McuHwModel;
+use mcu_hw_model::{new, Fuses, InitParams};
+use mcu_rom_common::McuBootMilestones;
+use std::io::Write;
+
+fn test_rom_hw_error(inject_val: u32, expected_error: u32, expected_message: &str) -> Result<()> {
+    let binaries = mcu_builder::FirmwareBinaries::from_env()?;
+
+    // Build flash image from firmware binaries
+    let flash_image = build_flash_image_bytes(
+        Some(&binaries.caliptra_fw),
+        Some(&binaries.soc_manifest),
+        Some(&binaries.mcu_runtime),
+    );
+
+    // Instantiate the hw model.
+    let mut hw = new(InitParams {
+        fuses: Fuses {
+            fuse_pqc_key_type: FwVerificationPqcKeyType::LMS as u32,
+            vendor_pk_hash: {
+                let mut vendor_pk_hash = [0u32; 12];
+                binaries
+                    .vendor_pk_hash()
+                    .unwrap()
+                    .chunks(4)
+                    .enumerate()
+                    .for_each(|(i, chunk)| {
+                        let mut array = [0u8; 4];
+                        array.copy_from_slice(chunk);
+                        vendor_pk_hash[i] = u32::from_be_bytes(array);
+                    });
+                vendor_pk_hash
+            },
+            ..Default::default()
+        },
+        caliptra_rom: &binaries.caliptra_rom,
+        mcu_rom: &binaries.mcu_rom,
+        vendor_pk_hash: binaries.vendor_pk_hash(),
+        active_mode: true,
+        vendor_pqc_type: Some(FwVerificationPqcKeyType::LMS),
+        primary_flash_initial_contents: Some(flash_image),
+        check_booted_to_runtime: false, // Don't wait for runtime boot to complete
+        ..Default::default()
+    })?;
+
+    // Step until Caliptra fuses are written, just before waiting for mailbox ready
+    hw.step_until(|hw| {
+        hw.mci_boot_milestones()
+            .contains(McuBootMilestones::CPTRA_FUSES_WRITTEN)
+    });
+
+    // Inject the hardware error.
+    println!("Injecting hardware error value: 0x{:x}", inject_val);
+    hw.caliptra_soc_manager()
+        .soc_ifc()
+        .cptra_hw_error_fatal()
+        .write(|_| inject_val.into());
+
+    // Step until fatal error is reported in MCI
+    hw.step_until(|hw| hw.mci_fw_fatal_error().is_some());
+    let fatal_error = hw.mci_fw_fatal_error().unwrap();
+    assert_eq!(fatal_error, expected_error);
+
+    // Verify UART output showing the hardware error was caught by the MCU ROM.
+    let mut output = Vec::new();
+    output.write_all(hw.output().take(usize::MAX).as_bytes())?;
+    let output_str = String::from_utf8_lossy(&output);
+    assert!(output_str.contains(expected_message));
+
+    Ok(())
+}
+
+#[test]
+fn test_rom_iccm_ecc_unc() -> Result<()> {
+    test_rom_hw_error(
+        0x1,
+        0x5_0011,
+        "[mcu-rom] Caliptra reported an ICCM ECC uncorrectable error",
+    )
+}
+
+#[test]
+fn test_rom_dccm_ecc_unc() -> Result<()> {
+    test_rom_hw_error(
+        0x2,
+        0x5_0012,
+        "[mcu-rom] Caliptra reported a DCCM ECC uncorrectable error",
+    )
+}


### PR DESCRIPTION
The MCU ROM currently does not check for ICCM or DCCM ECC uncorrectable errors reported by Caliptra. This can lead to undefined behavior if such errors occur during the boot process.

This fixes the issue by adding logic to the MCU ROM to poll the cptra_hw_error_fatal register for ECC uncorrectable errors during critical boot phases, such as while waiting for Caliptra to become ready. If an error is detected, the ROM will now trigger a fatal error with a specific error code (ROM_SOC_ICCM_ECC_UNC or ROM_SOC_DCCM_ECC_UNC).

Fixes #678.