### PR TITLE
[i3c-socket] refactor BufferedStream to handle interleaved packets

### DIFF
--- a/common/testing/src/i3c_socket.rs
+++ b/common/testing/src/i3c_socket.rs
@@ -161,7 +161,7 @@ impl BufferedStream {
         })
     }
 
-    fn read_packet(&mut self, target_addr: u8) -> Option<Packet> {
+    fn read_packet(&mut self) -> Option<Packet> {
         let mut out_header_bytes: [u8; 6] = [0u8; 6];
         match self.stream.read_exact(&mut out_header_bytes) {
             Ok(()) => {
@@ -169,19 +169,23 @@ impl BufferedStream {
                 let desc = header.response_descriptor;
                 let data_len = desc.data_length() as usize;
                 let mut data = vec![0u8; data_len];
-                self.stream.set_nonblocking(false).unwrap();
-                self.stream
-                    .read_exact(&mut data)
-                    .expect("Failed to read message from socket");
-                self.stream.set_nonblocking(true).unwrap();
-                if header.from_addr == target_addr {
-                    Some(Packet { header, data })
-                } else {
-                    None
+                if data_len > 0 {
+                    self.stream.set_nonblocking(false).unwrap();
+                    self.stream
+                        .read_exact(&mut data)
+                        .expect("Failed to read message from socket");
+                    self.stream.set_nonblocking(true).unwrap();
                 }
+                Some(Packet { header, data })
             }
             Err(ref e) if e.kind() == ErrorKind::WouldBlock => None,
             Err(e) => panic!("Error reading message from socket: {}", e),
+        }
+    }
+
+    fn fill_buffer(&mut self) {
+        while let Some(packet) = self.read_packet() {
+            self.read_buffer.push_back(packet);
         }
     }
 
@@ -203,38 +207,33 @@ impl BufferedStream {
     }
 
     pub fn receive_ibi(&mut self, target_addr: u8) -> bool {
-        loop {
-            match self.read_packet(target_addr) {
-                Some(packet) => {
-                    if packet.header.ibi != 0 {
-                        let pvt_read_cmd = prepare_private_read_cmd(target_addr);
-                        self.stream.set_nonblocking(false).unwrap();
-                        self.stream.write_all(&pvt_read_cmd).unwrap();
-                        self.stream.set_nonblocking(true).unwrap();
-                        return true;
-                    } else {
-                        self.read_buffer.push_back(packet);
-                    }
-                }
-                _ => {
-                    return false;
-                }
+        self.fill_buffer();
+        let mut i = 0;
+        while i < self.read_buffer.len() {
+            if self.read_buffer[i].header.from_addr == target_addr
+                && self.read_buffer[i].header.ibi != 0
+            {
+                self.read_buffer.remove(i);
+                let pvt_read_cmd = prepare_private_read_cmd(target_addr);
+                self.stream.set_nonblocking(false).unwrap();
+                self.stream.write_all(&pvt_read_cmd).unwrap();
+                self.stream.set_nonblocking(true).unwrap();
+                return true;
             }
+            i += 1;
         }
+        false
     }
 
     pub fn receive_private_read(&mut self, target_addr: u8) -> Option<Vec<u8>> {
-        let mut packet = None;
-        while !self.read_buffer.is_empty() {
-            let read = self.read_buffer.pop_front().unwrap();
-            if read.header.from_addr == target_addr {
-                packet = Some(read);
-                break;
-            }
-        }
-
-        match packet.or_else(|| self.read_packet(target_addr)) {
-            Some(Packet { data, .. }) => {
+        self.fill_buffer();
+        let mut i = 0;
+        while i < self.read_buffer.len() {
+            if self.read_buffer[i].header.from_addr == target_addr
+                && self.read_buffer[i].header.ibi == 0
+            {
+                let packet = self.read_buffer.remove(i).unwrap();
+                let data = packet.data;
                 if data.is_empty() {
                     println!("Received empty data packet");
                     return None;
@@ -248,10 +247,11 @@ impl BufferedStream {
                     );
                     return None;
                 }
-                Some(data[..data.len() - 1].to_vec())
+                return Some(data[..data.len() - 1].to_vec());
             }
-            _ => None,
+            i += 1;
         }
+        None
     }
 
     pub fn set_nonblocking(&self, blocking: bool) -> std::io::Result<()> {


### PR DESCRIPTION
Refactored the I3C test socket's BufferedStream to correctly buffer all incoming packets and selectively consume them by type (IBI vs Data) and destination address.

This resolves a potential race condition where asynchronous MCTP/I3C activity from Caliptra RT (e.g., SPDM tasks) would cause the test runner to misinterpret IBI packets as empty data packets during multi-packet loopback tests, leading to timeout failures.