### PR TITLE
Unify build features for FPGA firmware builds

### DIFF
--- a/.github/workflows/fpga.yml
+++ b/.github/workflows/fpga.yml
@@ -119,12 +119,6 @@ jobs:
           key: openssl-${{ env.CACHE_BUSTER }}
 
       - name: Build test firmware
-        env:
-          RUNTIME_FEATURES: >-
-            test-i3c-simple,test-i3c-constant-writes,test-mctp-capsule-loopback,
-            test-fpga-flash-ctrl,test-pldm-fw-update-e2e,test-firmware-update-streaming,
-            test-mcu-mbox-usermode,test-mcu-mbox-cmds,test-mctp-vdm-cmds,
-            test-mcu-mbox-fips-self-test,test-mcu-mbox-fips-periodic,test-exit-immediately
         run: |
           # In the CI we really want to avoid lengthy build steps.
           # Vendoring OpenSSL is a huge time sink, and instead linking a prebuilt
@@ -142,7 +136,6 @@ jobs:
 
           export MCU_STAGING_ADDR=0xB00C0000
           cargo xtask-fpga all-build --platform fpga \
-            --runtime-features "${RUNTIME_FEATURES// /}" \
             --rom-features "core_test" \
             --mcu_cfg mcu,0x0,$MCU_STAGING_ADDR,2,2,2,test-fpga-flash-ctrl \
             --separate-runtimes

--- a/builder/src/all.rs
+++ b/builder/src/all.rs
@@ -487,7 +487,11 @@ pub fn all_build(args: AllBuildArgs) -> Result<()> {
         Some(r) if !r.is_empty() => r.split(",").collect::<Vec<&str>>(),
         _ => {
             if separate_runtimes {
-                crate::features::RUNTIME_TEST_FEATURES.to_vec()
+                if platform == "fpga" {
+                    crate::features::FPGA_RUNTIME_TEST_FEATURES.to_vec()
+                } else {
+                    crate::features::EMULATOR_RUNTIME_TEST_FEATURES.to_vec()
+                }
             } else {
                 vec![]
             }

--- a/builder/src/features.rs
+++ b/builder/src/features.rs
@@ -1,6 +1,6 @@
 // Licensed under the Apache-2.0 license
 
-pub const RUNTIME_TEST_FEATURES: &[&str] = &[
+pub const EMULATOR_RUNTIME_TEST_FEATURES: &[&str] = &[
     "test-i3c-simple",
     "test-i3c-constant-writes",
     "test-mctp-capsule-loopback",
@@ -78,4 +78,19 @@ pub const EMULATOR_TEST_FEATURES: &[&str] = &[
     "test-pldm-fw-update-e2e",
     "test-pldm-streaming-boot",
     "test-warm-reset",
+];
+
+pub const FPGA_RUNTIME_TEST_FEATURES: &[&str] = &[
+    "test-i3c-simple",
+    "test-i3c-constant-writes",
+    "test-mctp-capsule-loopback",
+    "test-fpga-flash-ctrl",
+    "test-pldm-fw-update-e2e",
+    "test-firmware-update-streaming",
+    "test-mcu-mbox-usermode",
+    "test-mcu-mbox-cmds",
+    "test-mctp-vdm-cmds",
+    "test-mcu-mbox-fips-self-test",
+    "test-mcu-mbox-fips-periodic",
+    "test-exit-immediately",
 ];

--- a/xtask/src/fpga/configurations.rs
+++ b/xtask/src/fpga/configurations.rs
@@ -196,7 +196,6 @@ impl<'a> ActionHandler<'a> for Subsystem {
         let args = AllBuildArgs {
             output: Some("all-fw.zip"),
             platform: Some("fpga"),
-            runtime_features: Some("test-mctp-capsule-loopback,test-fpga-flash-ctrl,test-pldm-fw-update-e2e,test-firmware-update-streaming"),
             mcu_cfgs: mcu_cfgs,
             separate_runtimes: true,
             ..Default::default()


### PR DESCRIPTION
This was causing FPGA test failures when running locally on dev FPGAs, as the list of features fell out of sync between xtask and CI. This change fulfills DRY by establishing a single source of truth for these features.

other FPGA tests still failing locally for other reasons - will diagnose those in a later PR
