### PR TITLE
emulator: Add optional ECC to OTP partitions

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -40,7 +40,8 @@ default-filter = """
 (package(tests-integration) and test(test_mcu_mbox_fips_periodic)) |
 (package(tests-integration) and test(test_i3c_constant_writes)) |
 (package(tests-integration) and test(test_i3c_simple)) |
-(package(tests-integration) and test(test_sw_digest_lock))
+(package(tests-integration) and test(test_sw_digest_lock)) |
+(package(tests-integration) and test(test_otp_blank_check))
 """
 # disabled for now due to flakiness of recovery boot
 # (package(tests-integration) and test(test_mctp_capsule_loopback)) |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3258,6 +3258,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "mcu-test-fw-otp-blank-check"
+version = "0.1.0"
+dependencies = [
+ "mcu-error",
+ "mcu-rom-common",
+ "mcu-test-harness",
+ "registers-generated",
+ "romtime",
+ "tock-registers",
+]
+
+[[package]]
 name = "mcu-test-fw-sw-digest-lock"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ members = [
     "hw/model/test-fw/exception-handler",
     "hw/model/test-fw/hitless-update-flow",
     "hw/model/test-fw/mailbox-responder",
+    "hw/model/test-fw/otp-blank-check",
     "hw/model/test-fw/sw-digest-lock",
     "platforms/common",
     "platforms/emulator/config",
@@ -214,6 +215,7 @@ mcu-hw-model = { path = "hw/model" }
 mcu-test-fw-exception-handler = { path = "hw/model/test-fw/exception-handler" }
 mcu-test-fw-hitless-update-flow = { path = "hw/model/test-fw/hitless-update-flow" }
 mcu-test-fw-mailbox-responder = { path = "hw/model/test-fw/mailbox-responder" }
+mcu-test-fw-otp-blank-check = { path = "hw/model/test-fw/otp-blank-check" }
 mcu-test-fw-sw-digest-lock = { path = "hw/model/test-fw/sw-digest-lock" }
 mcu-image-header = { path = "platforms/emulator/mcu-image-header" }
 mcu-mbox-comm = { path = "runtime/kernel/drivers/mcu_mbox" }

--- a/builder/src/firmware.rs
+++ b/builder/src/firmware.rs
@@ -28,6 +28,12 @@ pub mod hw_model_tests {
         bin_name: "mcu-test-fw-sw-digest-lock",
         features: &["emu"],
     };
+
+    pub const OTP_BLANK_CHECK: FwId = FwId {
+        crate_name: "mcu-test-fw-otp-blank-check",
+        bin_name: "mcu-test-fw-otp-blank-check",
+        features: &["emu"],
+    };
 }
 
 pub const REGISTERED_FW: &[&FwId] = &[
@@ -35,6 +41,7 @@ pub const REGISTERED_FW: &[&FwId] = &[
     &hw_model_tests::HITLESS_UPDATE_FLOW,
     &hw_model_tests::EXCEPTION_HANDLER,
     &hw_model_tests::SW_DIGEST_LOCK,
+    &hw_model_tests::OTP_BLANK_CHECK,
 ];
 
 pub const CPTRA_REGISTERED_FW: &[&FwId] =

--- a/emulator/periph/src/ecc_ram.rs
+++ b/emulator/periph/src/ecc_ram.rs
@@ -1,0 +1,539 @@
+/*++
+
+Licensed under the Apache-2.0 license.
+
+File Name:
+
+    ecc_ram.rs
+
+Abstract:
+
+    ECC-protected RAM using a 16/22 SECDED (Single Error Correction, Double
+    Error Detection) Hamming code. Each 16-bit data word is stored with 6
+    parity bits for a total of 22 bits. On read the syndrome is checked:
+    single-bit errors are corrected in-place and flagged as a correctable
+    interrupt; double-bit errors are flagged as uncorrectable.
+
+--*/
+
+use serde::{Deserialize, Serialize};
+
+// Parity masks
+const P0_MASK: u32 = 0x0ad5b;
+const P1_MASK: u32 = 0x0366d;
+const P2_MASK: u32 = 0x0c78e;
+const P3_MASK: u32 = 0x007f0;
+const P4_MASK: u32 = 0x0f800;
+const P5_MASK: u32 = 0x1f_ffff;
+
+/// Syndrome-to-bit-position lookup table. `SYNDROME_MAP[s]` gives the bit
+/// index (0-21) that has the error when the 5-bit syndrome equals `s`.
+/// Entries for impossible syndrome values are set to 0xFF.
+const SYNDROME_MAP: [u8; 23] = build_syndrome_map();
+
+const fn build_syndrome_map() -> [u8; 23] {
+    let mut map = [0xFFu8; 23];
+
+    // Parity bit positions (syndrome = single check-bit index)
+    map[1] = 16; // P0
+    map[2] = 17; // P1
+    map[4] = 18; // P2
+    map[8] = 19; // P3
+    map[16] = 20; // P4
+
+    // Data bit positions – computed from the parity masks.
+    let masks: [u32; 5] = [P0_MASK, P1_MASK, P2_MASK, P3_MASK, P4_MASK];
+    let mut bit: u8 = 0;
+    while bit < 16 {
+        let mut syndrome: usize = 0;
+        let mut p: usize = 0;
+        while p < 5 {
+            if masks[p] & (1 << bit) != 0 {
+                syndrome |= 1 << p;
+            }
+            p += 1;
+        }
+        if syndrome < 23 {
+            map[syndrome] = bit;
+        }
+        bit += 1;
+    }
+
+    map
+}
+
+/// Encode a 16-bit data word into a 22-bit word with ECC parity bits.
+pub fn ecc_encode(data: u16) -> u32 {
+    let mut w = data as u32;
+    w |= ((w & P0_MASK).count_ones() & 1) << 16;
+    w |= ((w & P1_MASK).count_ones() & 1) << 17;
+    w |= ((w & P2_MASK).count_ones() & 1) << 18;
+    w |= ((w & P3_MASK).count_ones() & 1) << 19;
+    w |= ((w & P4_MASK).count_ones() & 1) << 20;
+    w |= ((w & P5_MASK).count_ones() & 1) << 21;
+    w
+}
+
+/// Result of decoding a 22-bit ECC word.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EccResult {
+    /// No error detected.
+    Ok(u16),
+    /// Single-bit error corrected; returns the corrected data.
+    Corrected(u16),
+    /// Uncorrectable (double-bit) error detected; returns data as-is.
+    Uncorrectable(u16),
+}
+
+/// Decode a 22-bit stored word, checking and (if possible) correcting errors.
+fn ecc_decode(stored: u32) -> EccResult {
+    // Recompute parity from data bits (0-15) to get expected check bits.
+    let data_bits = stored & 0xFFFF;
+    let s0 = ((data_bits & P0_MASK).count_ones() ^ ((stored >> 16) & 1)) & 1;
+    let s1 = ((data_bits & P1_MASK).count_ones() ^ ((stored >> 17) & 1)) & 1;
+    let s2 = ((data_bits & P2_MASK).count_ones() ^ ((stored >> 18) & 1)) & 1;
+    let s3 = ((data_bits & P3_MASK).count_ones() ^ ((stored >> 19) & 1)) & 1;
+    let s4 = ((data_bits & P4_MASK).count_ones() ^ ((stored >> 20) & 1)) & 1;
+    let syndrome = (s4 << 4) | (s3 << 3) | (s2 << 2) | (s1 << 1) | s0;
+
+    // Overall parity of all 22 bits (should be even / 0 when no error).
+    let overall = (stored & 0x3F_FFFF).count_ones() & 1;
+
+    if syndrome == 0 && overall == 0 {
+        EccResult::Ok(data_bits as u16)
+    } else if syndrome == 0 {
+        // Error only in P5 – data is fine, still counts as correctable.
+        EccResult::Corrected(data_bits as u16)
+    } else if overall != 0 {
+        // Single-bit error; syndrome tells us which bit to flip.
+        let mut corrected = stored;
+        if (syndrome as usize) < SYNDROME_MAP.len() {
+            let bit_pos = SYNDROME_MAP[syndrome as usize];
+            if bit_pos != 0xFF {
+                corrected ^= 1 << bit_pos;
+            }
+        }
+        EccResult::Corrected((corrected & 0xFFFF) as u16)
+    } else {
+        EccResult::Uncorrectable(data_bits as u16)
+    }
+}
+
+/// ECC-protected RAM block.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct EccRam {
+    /// Backing store – one u32 per 16-bit data word.
+    words: Vec<u32>,
+    /// Sticky flag: at least one correctable (single-bit) error was seen.
+    correctable_error: bool,
+    /// Sticky flag: at least one uncorrectable (double-bit) error was seen.
+    uncorrectable_error: bool,
+}
+
+impl EccRam {
+    /// Create a new ECC RAM sized to hold `num_bytes` of data.
+    /// `num_bytes` must be a multiple of 2.
+    pub fn new(num_bytes: usize) -> Self {
+        assert_eq!(num_bytes % 2, 0);
+        let num_words = num_bytes / 2;
+        Self {
+            words: vec![0u32; num_words],
+            correctable_error: false,
+            uncorrectable_error: false,
+        }
+    }
+
+    /// Size in bytes.
+    pub fn len(&self) -> usize {
+        self.words.len() * 2
+    }
+
+    /// `true` if the RAM has zero capacity.
+    pub fn is_empty(&self) -> bool {
+        self.words.is_empty()
+    }
+
+    /// Initialize the entire RAM from raw byte data (no ECC).
+    pub fn init_from_bytes(&mut self, data: &[u8]) {
+        assert!(data.len() <= self.len());
+        for (i, word) in self.words.iter_mut().enumerate() {
+            let lo = data.get(i * 2).copied().unwrap_or(0);
+            let hi = data.get(i * 2 + 1).copied().unwrap_or(0);
+            *word = ecc_encode(u16::from_le_bytes([lo, hi]));
+        }
+    }
+
+    /// Write raw bytes starting at `offset` (byte address relative to the
+    /// start of this RAM). ECC is computed for each affected 16-bit word.
+    pub fn write_bytes(&mut self, offset: usize, data: &[u8]) {
+        for (i, &byte) in data.iter().enumerate() {
+            let byte_addr = offset + i;
+            let word_idx = byte_addr / 2;
+            if word_idx >= self.words.len() {
+                break;
+            }
+            // Decode current word to get both bytes.
+            let cur = (self.words[word_idx] & 0xFFFF) as u16;
+            let mut bytes = cur.to_le_bytes();
+            bytes[byte_addr & 1] = byte;
+            self.words[word_idx] = ecc_encode(u16::from_le_bytes(bytes));
+        }
+    }
+
+    /// Read decoded bytes. ECC is checked for each accessed word.
+    pub fn read_bytes(&mut self, offset: usize, buf: &mut [u8]) {
+        for (i, dst) in buf.iter_mut().enumerate() {
+            let byte_addr = offset + i;
+            let word_idx = byte_addr / 2;
+            if word_idx >= self.words.len() {
+                *dst = 0;
+                continue;
+            }
+            let result = ecc_decode(self.words[word_idx]);
+            let data = match result {
+                EccResult::Ok(d) => d,
+                EccResult::Corrected(d) => {
+                    self.correctable_error = true;
+                    // Correct the stored word in-place.
+                    self.words[word_idx] = ecc_encode(d);
+                    d
+                }
+                EccResult::Uncorrectable(d) => {
+                    self.uncorrectable_error = true;
+                    d
+                }
+            };
+            *dst = data.to_le_bytes()[byte_addr & 1];
+        }
+    }
+
+    /// Returns `true` if a correctable (single-bit) error has been detected
+    /// since the last call to [`clear_errors`].
+    pub fn has_correctable_error(&self) -> bool {
+        self.correctable_error
+    }
+
+    /// Returns `true` if an uncorrectable (double-bit) error has been detected
+    /// since the last call to [`clear_errors`].
+    pub fn has_uncorrectable_error(&self) -> bool {
+        self.uncorrectable_error
+    }
+
+    /// Clear both error flags.
+    pub fn clear_errors(&mut self) {
+        self.correctable_error = false;
+        self.uncorrectable_error = false;
+    }
+
+    /// Flip a single bit in the raw stored word at the given byte offset.
+    /// `bit` is a bit index within the 22-bit stored word (0-21).
+    /// Useful for injecting errors in tests.
+    pub fn flip_bit(&mut self, byte_offset: usize, bit: u8) {
+        let word_idx = byte_offset / 2;
+        if word_idx < self.words.len() && bit < 22 {
+            self.words[word_idx] ^= 1u32 << bit;
+        }
+    }
+
+    /// OTP-style OR-only write.  Computes the new 22-bit ECC word for each
+    /// affected 16-bit granule, then checks that ORing it with the currently
+    /// stored word would not require any 1→0 bit transitions (across all 22
+    /// bits, including parity).  If the check passes for every affected word
+    /// the write is committed; otherwise no words are modified and the method
+    /// returns `false`.
+    pub fn otp_write_bytes(&mut self, offset: usize, data: &[u8]) -> bool {
+        // Build the complete new data for each affected word before computing
+        // ECC, so that partial-byte updates don't produce intermediate parity.
+        let mut pending: Vec<(usize, u16)> = Vec::new();
+        for (i, &byte) in data.iter().enumerate() {
+            let byte_addr = offset + i;
+            let word_idx = byte_addr / 2;
+            if word_idx >= self.words.len() {
+                break;
+            }
+
+            // Start from a previous pending update for this word, or the
+            // stored data bits.
+            let base = pending
+                .iter()
+                .rfind(|&&(idx, _)| idx == word_idx)
+                .map(|&(_, d)| d)
+                .unwrap_or((self.words[word_idx] & 0xFFFF) as u16);
+
+            let mut bytes = base.to_le_bytes();
+            bytes[byte_addr & 1] = byte;
+            pending.push((word_idx, u16::from_le_bytes(bytes)));
+        }
+
+        // De-duplicate: keep only the last entry per word index (it has all
+        // byte updates folded in), then encode and blank-check.
+        let mut final_updates: Vec<(usize, u32)> = Vec::new();
+        for &(idx, data_val) in pending.iter().rev() {
+            if final_updates.iter().any(|&(i, _)| i == idx) {
+                continue;
+            }
+            let new_word = ecc_encode(data_val);
+            let stored = self.words[idx];
+            if (stored & new_word) != stored {
+                return false;
+            }
+            final_updates.push((idx, stored | new_word));
+        }
+
+        // All checks passed — commit.
+        for (idx, val) in final_updates {
+            self.words[idx] = val;
+        }
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode_decode_roundtrip() {
+        for val in [0u16, 1, 0x1234, 0xFFFF, 0xA5A5] {
+            let encoded = ecc_encode(val);
+            assert_eq!(ecc_decode(encoded), EccResult::Ok(val));
+        }
+    }
+
+    #[test]
+    fn single_bit_correction() {
+        let data: u16 = 0xBEEF;
+        let encoded = ecc_encode(data);
+        // Flip each of the 22 bits and verify correction.
+        for bit in 0..22u8 {
+            let corrupted = encoded ^ (1 << bit);
+            match ecc_decode(corrupted) {
+                EccResult::Corrected(d) => assert_eq!(d, data, "bit {bit}"),
+                other => panic!("bit {bit}: expected Corrected, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn double_bit_detection() {
+        let data: u16 = 0xCAFE;
+        let encoded = ecc_encode(data);
+        // Flip two distinct bits – should be uncorrectable.
+        for b1 in 0..22u8 {
+            for b2 in (b1 + 1)..22u8 {
+                let corrupted = encoded ^ (1 << b1) ^ (1 << b2);
+                match ecc_decode(corrupted) {
+                    EccResult::Uncorrectable(_) => {}
+                    other => panic!("bits {b1},{b2}: expected Uncorrectable, got {other:?}"),
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn ram_write_read() {
+        let mut ram = EccRam::new(8);
+        let data = [0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE];
+        ram.write_bytes(0, &data);
+        let mut buf = [0u8; 8];
+        ram.read_bytes(0, &mut buf);
+        assert_eq!(buf, data);
+        assert!(!ram.has_correctable_error());
+        assert!(!ram.has_uncorrectable_error());
+    }
+
+    #[test]
+    fn ram_init_from_bytes() {
+        let mut ram = EccRam::new(4);
+        ram.init_from_bytes(&[0x12, 0x34, 0x56, 0x78]);
+        let mut buf = [0u8; 4];
+        ram.read_bytes(0, &mut buf);
+        assert_eq!(buf, [0x12, 0x34, 0x56, 0x78]);
+    }
+
+    #[test]
+    fn ram_flip_bit_correctable() {
+        let mut ram = EccRam::new(4);
+        ram.write_bytes(0, &[0xAA, 0x55, 0x00, 0xFF]);
+        // Inject a single-bit error in the first word.
+        ram.flip_bit(0, 3);
+        let mut buf = [0u8; 4];
+        ram.read_bytes(0, &mut buf);
+        // Data should be corrected back.
+        assert_eq!(buf[0], 0xAA);
+        assert_eq!(buf[1], 0x55);
+        assert!(ram.has_correctable_error());
+        assert!(!ram.has_uncorrectable_error());
+    }
+
+    #[test]
+    fn ram_flip_two_bits_uncorrectable() {
+        let mut ram = EccRam::new(4);
+        ram.write_bytes(0, &[0xAA, 0x55, 0x00, 0xFF]);
+        // Inject a double-bit error in the first word.
+        ram.flip_bit(0, 0);
+        ram.flip_bit(0, 1);
+        let mut buf = [0u8; 2];
+        ram.read_bytes(0, &mut buf);
+        assert!(ram.has_uncorrectable_error());
+    }
+
+    #[test]
+    fn ram_clear_errors() {
+        let mut ram = EccRam::new(2);
+        ram.write_bytes(0, &[0xFF, 0x00]);
+        ram.flip_bit(0, 5);
+        let mut buf = [0u8; 2];
+        ram.read_bytes(0, &mut buf);
+        assert!(ram.has_correctable_error());
+        ram.clear_errors();
+        assert!(!ram.has_correctable_error());
+        assert!(!ram.has_uncorrectable_error());
+    }
+
+    #[test]
+    fn exhaustive_roundtrip() {
+        for val in 0..=u16::MAX {
+            let encoded = ecc_encode(val);
+            assert_eq!(
+                ecc_decode(encoded),
+                EccResult::Ok(val),
+                "roundtrip failed for {val:#06x}"
+            );
+        }
+    }
+
+    #[test]
+    fn exhaustive_single_bit_correction() {
+        for val in 0..=u16::MAX {
+            let encoded = ecc_encode(val);
+            for bit in 0..22u8 {
+                let corrupted = encoded ^ (1u32 << bit);
+                match ecc_decode(corrupted) {
+                    EccResult::Corrected(d) => {
+                        assert_eq!(d, val, "correction failed for {val:#06x} bit {bit}")
+                    }
+                    other => panic!("{val:#06x} bit {bit}: expected Corrected, got {other:?}"),
+                }
+            }
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn exhaustive_double_bit_detection() {
+        for val in 0..=u16::MAX {
+            let encoded = ecc_encode(val);
+            for b1 in 0..22u8 {
+                for b2 in (b1 + 1)..22u8 {
+                    let corrupted = encoded ^ (1u32 << b1) ^ (1u32 << b2);
+                    match ecc_decode(corrupted) {
+                        EccResult::Uncorrectable(_) => {}
+                        other => panic!(
+                            "{val:#06x} bits {b1},{b2}: expected Uncorrectable, got {other:?}"
+                        ),
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn otp_write_blank_succeeds() {
+        let mut ram = EccRam::new(4);
+        assert!(ram.otp_write_bytes(0, &[0xAA, 0x55]));
+        let mut buf = [0u8; 2];
+        ram.read_bytes(0, &mut buf);
+        assert_eq!(buf, [0xAA, 0x55]);
+    }
+
+    #[test]
+    fn otp_write_superset_succeeds() {
+        let mut ram = EccRam::new(4);
+        assert!(ram.otp_write_bytes(0, &[0x0F, 0x00]));
+        // 0xFF is a data-bit superset of 0x0F, but the ECC parity bits may
+        // conflict.  Verify that the write outcome matches the 22-bit check.
+        let old_ecc = ecc_encode(0x000F);
+        let new_ecc = ecc_encode(0x00FF);
+        let expected = (old_ecc & new_ecc) == old_ecc;
+        assert_eq!(ram.otp_write_bytes(0, &[0xFF, 0x00]), expected);
+    }
+
+    #[test]
+    fn otp_write_same_value_succeeds() {
+        let mut ram = EccRam::new(4);
+        assert!(ram.otp_write_bytes(0, &[0xAB, 0xCD]));
+        // Rewriting the same value should succeed (no bit transitions).
+        assert!(ram.otp_write_bytes(0, &[0xAB, 0xCD]));
+    }
+
+    #[test]
+    fn otp_write_clear_data_bit_fails() {
+        let mut ram = EccRam::new(4);
+        assert!(ram.otp_write_bytes(0, &[0xFF, 0xFF]));
+        // Trying to clear data bits should fail.
+        assert!(!ram.otp_write_bytes(0, &[0x00, 0x00]));
+        // Data should be unchanged.
+        let mut buf = [0u8; 2];
+        ram.read_bytes(0, &mut buf);
+        assert_eq!(buf, [0xFF, 0xFF]);
+    }
+
+    #[test]
+    fn otp_write_parity_conflict_fails() {
+        // Write a value whose ECC parity bits are set, then write a different
+        // value that needs some of those parity bits to be 0.  The blank
+        // check on the 22-bit word must catch this even though the new data
+        // bits are a superset of the old data bits.
+        let mut ram = EccRam::new(2);
+        // 0x0001 → parity has certain bits set
+        assert!(ram.otp_write_bytes(0, &[0x01, 0x00]));
+        // 0x0003 is a data-bit superset of 0x0001, but the ECC parity
+        // pattern changes; if any parity bit needs to go 1→0 the write
+        // must be rejected.
+        let old_ecc = ecc_encode(0x0001);
+        let new_ecc = ecc_encode(0x0003);
+        if (old_ecc & new_ecc) != old_ecc {
+            // There is a parity conflict — write must fail.
+            assert!(!ram.otp_write_bytes(0, &[0x03, 0x00]));
+        } else {
+            // No conflict for this particular pair — write is fine.
+            assert!(ram.otp_write_bytes(0, &[0x03, 0x00]));
+        }
+    }
+
+    /// Exhaustive test: for every pair (old, new) where new is a data-bit
+    /// superset of old, verify that otp_write succeeds iff the 22-bit ECC
+    /// word is also a superset.
+    #[test]
+    #[ignore]
+    fn exhaustive_otp_write_parity_consistency() {
+        for old in 0..=u16::MAX {
+            let old_ecc = ecc_encode(old);
+            // Only test superset values — skip the non-superset cases
+            // (those always fail on data bits alone).
+            // Iterate over subsets of the complement bits.
+            let complement = !old & 0xFFFF;
+            let mut extra = complement;
+            loop {
+                let new_val = old | extra;
+                let new_ecc = ecc_encode(new_val);
+                let ecc_superset = (old_ecc & new_ecc) == old_ecc;
+
+                let mut ram = EccRam::new(2);
+                assert!(ram.otp_write_bytes(0, &old.to_le_bytes()));
+                let ok = ram.otp_write_bytes(0, &new_val.to_le_bytes());
+                assert_eq!(
+                    ok, ecc_superset,
+                    "old={old:#06x} new={new_val:#06x} old_ecc={old_ecc:#08x} new_ecc={new_ecc:#08x}"
+                );
+
+                if extra == 0 {
+                    break;
+                }
+                // Enumerate subsets of `complement` using Gosper's hack.
+                extra = (extra - 1) & complement;
+            }
+        }
+    }
+}

--- a/emulator/periph/src/lib.rs
+++ b/emulator/periph/src/lib.rs
@@ -15,6 +15,7 @@ Abstract:
 mod axicdma;
 mod caliptra_to_ext_bus;
 mod doe_mbox;
+pub mod ecc_ram;
 mod emu_ctrl;
 mod flash_ctrl;
 mod i3c;

--- a/emulator/periph/src/otp.rs
+++ b/emulator/periph/src/otp.rs
@@ -13,6 +13,7 @@ Abstract:
     enforcement matching hardware behavior.
 
 --*/
+use crate::ecc_ram::EccRam;
 use caliptra_emu_bus::{Clock, ReadWriteRegister, Timer};
 use caliptra_emu_types::{RvAddr, RvData};
 use caliptra_image_types::FwVerificationPqcKeyType;
@@ -42,6 +43,9 @@ struct OtpState {
     partitions: Vec<u8>,
     calculate_digests_on_reset: HashSet<usize>,
     digests: Vec<u32>,
+    /// Per-partition ECC RAM instances (indexed by partition number).
+    #[serde(default)]
+    ecc_rams: Vec<Option<EccRam>>,
 }
 
 #[derive(Default, Clone)]
@@ -58,6 +62,12 @@ pub struct OtpArgs {
     /// Raw lifecycle partition data (LIFECYCLE_MEM_SIZE bytes) to provision.
     /// If set, written to the LIFE_CYCLE partition in OTP.
     pub lifecycle_state: Option<Vec<u8>>,
+    /// Partition indices that should have ECC protection.
+    /// Defaults to `{15}` (the lifecycle partition) when empty.
+    pub ecc_partitions: HashSet<usize>,
+    /// Which `err_code_rf_err_code_N` register index carries the DAI error code.
+    /// Defaults to `OTP_PARTITIONS.len()` (16), matching DaiIdx in the RTL.
+    pub dai_err_code_register: Option<usize>,
 }
 
 //#[derive(Bus)]
@@ -70,15 +80,19 @@ pub struct Otp {
     direct_access_buffer_hi: u32,
     direct_access_cmd: ReadWriteRegister<u32, DirectAccessCmd::Register>,
     status: ReadWriteRegister<u32, OtpStatus::Register>,
-    /// DAI error code (3-bit value written to err_code_rf_err_code_0).
-    /// 0 = NoError, 4 = MacroWriteBlankError.
-    dai_err_code: u32,
+    /// Per-register error codes (indexed 0–17).
+    err_codes: Vec<u32>,
+    /// Which `err_code_rf_err_code_N` register index carries the DAI error.
+    dai_err_code_register: usize,
     timer: Timer,
     partitions: Rc<RefCell<Vec<u8>>>,
     digests: [u32; fuses::OTP_PARTITIONS.len() * 2],
     /// Partitions to calculate digests for on reset.
     calculate_digests_on_reset: HashSet<usize>,
     generated: OtpGenerated,
+    /// Per-partition ECC RAM. `ecc_rams[i]` is `Some(…)` when partition `i`
+    /// has ECC protection enabled.
+    ecc_rams: Vec<Option<EccRam>>,
 }
 
 // Ensure that we save the state before we drop the OTP instance.
@@ -121,6 +135,27 @@ impl Otp {
 
         let partitions = Rc::new(RefCell::new(partitions));
 
+        let ecc_partitions = if args.ecc_partitions.is_empty() {
+            // Default: lifecycle partition only.
+            let mut s = HashSet::new();
+            s.insert(fuses::OTP_PARTITIONS.len() - 1); // life_cycle is last
+            s
+        } else {
+            args.ecc_partitions
+        };
+
+        let ecc_rams: Vec<Option<EccRam>> = fuses::OTP_PARTITIONS
+            .iter()
+            .enumerate()
+            .map(|(i, p)| {
+                if ecc_partitions.contains(&i) {
+                    Some(EccRam::new(p.byte_size))
+                } else {
+                    None
+                }
+            })
+            .collect();
+
         let mut otp = Self {
             file,
             direct_access_address: 0,
@@ -128,12 +163,16 @@ impl Otp {
             direct_access_buffer_hi: 0,
             direct_access_cmd: 0u32.into(),
             status: 0b100_0000_0000_0000_0000_0000u32.into(), // DAI idle state
-            dai_err_code: 0,
+            err_codes: vec![0u32; NUM_ERR_CODE_REGISTERS],
+            dai_err_code_register: args
+                .dai_err_code_register
+                .unwrap_or(fuses::OTP_PARTITIONS.len()),
             calculate_digests_on_reset: HashSet::new(),
             timer: Timer::new(clock),
             partitions,
             digests: [0; fuses::OTP_PARTITIONS.len() * 2],
             generated: OtpGenerated::default(),
+            ecc_rams,
         };
         otp.read_from_file()?;
         if let Some(mut vendor_pk_hash) = args.vendor_pk_hash {
@@ -188,6 +227,7 @@ impl Otp {
 
         // if there were digests that were pending a reset, then calculate them now
         otp.calculate_digests()?;
+        otp.sync_ecc_from_partitions();
         Ok(otp)
     }
 
@@ -232,6 +272,58 @@ impl Otp {
         Self::lifecycle_bytes_from_partitions(&state.partitions)
     }
 
+    /// Returns `true` if a correctable ECC error has been detected on any
+    /// ECC-protected partition.
+    pub fn has_correctable_ecc_error(&self) -> bool {
+        self.ecc_rams
+            .iter()
+            .any(|r| r.as_ref().is_some_and(|e| e.has_correctable_error()))
+    }
+
+    /// Returns `true` if an uncorrectable ECC error has been detected on any
+    /// ECC-protected partition.
+    pub fn has_uncorrectable_ecc_error(&self) -> bool {
+        self.ecc_rams
+            .iter()
+            .any(|r| r.as_ref().is_some_and(|e| e.has_uncorrectable_error()))
+    }
+
+    /// Clear ECC error interrupt flags on all protected partitions.
+    pub fn clear_ecc_errors(&mut self) {
+        for ram in self.ecc_rams.iter_mut().flatten() {
+            ram.clear_errors();
+        }
+    }
+
+    /// Returns a mutable reference to the ECC RAM for the given partition
+    /// index, if that partition has ECC protection enabled.
+    pub fn partition_ecc_mut(&mut self, partition_idx: usize) -> Option<&mut EccRam> {
+        self.ecc_rams.get_mut(partition_idx)?.as_mut()
+    }
+
+    /// Read the current DAI error code from the configured register.
+    fn dai_err_code(&self) -> u32 {
+        self.err_codes[self.dai_err_code_register]
+    }
+
+    /// Set the DAI error code in the configured register.
+    fn set_dai_err_code(&mut self, code: u32) {
+        self.err_codes[self.dai_err_code_register] = code;
+    }
+
+    /// Initialize all ECC RAMs from the current partition data.
+    fn sync_ecc_from_partitions(&mut self) {
+        let partitions = self.partitions.borrow();
+        for (i, ram_opt) in self.ecc_rams.iter_mut().enumerate() {
+            if let Some(ram) = ram_opt {
+                let p = &fuses::OTP_PARTITIONS[i];
+                let start = p.byte_offset;
+                let end = start + p.byte_size;
+                ram.init_from_bytes(&partitions[start..end]);
+            }
+        }
+    }
+
     fn calculate_digests(&mut self) -> Result<(), std::io::Error> {
         let partitions = self.calculate_digests_on_reset.clone();
         for partition in partitions {
@@ -264,6 +356,7 @@ impl Otp {
             partitions: self.partitions.borrow().clone(),
             calculate_digests_on_reset: self.calculate_digests_on_reset.clone(),
             digests: self.digests.to_vec(),
+            ecc_rams: self.ecc_rams.clone(),
         }
     }
 
@@ -271,6 +364,12 @@ impl Otp {
         *self.partitions.borrow_mut() = state.partitions.clone();
         self.calculate_digests_on_reset = state.calculate_digests_on_reset.clone();
         self.digests.copy_from_slice(&state.digests);
+        // Restore ECC RAMs for partitions that are both saved and enabled.
+        for (i, saved) in state.ecc_rams.iter().enumerate() {
+            if let (Some(Some(dst)), Some(src)) = (self.ecc_rams.get_mut(i), saved) {
+                *dst = src.clone();
+            }
+        }
     }
 
     fn read_from_file(&mut self) -> Result<(), std::io::Error> {
@@ -320,6 +419,9 @@ impl Otp {
 /// OTP error codes matching the hardware definition.
 const OTP_ERR_MACRO_WRITE_BLANK: u32 = 4;
 
+/// Number of OTP err_code registers (one per partition + DAI + LCI agents).
+const NUM_ERR_CODE_REGISTERS: usize = 18;
+
 /// Returns true if `byte_addr` falls within a 64-bit access granule region
 /// (digest field or secret partition data). Non-secret partition data uses
 /// 32-bit granularity.
@@ -341,6 +443,20 @@ fn is_64bit_granule(byte_addr: usize) -> bool {
         return false;
     }
     false
+}
+
+/// If `byte_addr` falls within a partition that has an ECC RAM, return the
+/// partition index and its byte offset.
+fn ecc_partition_for_addr(byte_addr: usize, ecc_rams: &[Option<EccRam>]) -> Option<(usize, usize)> {
+    for (i, p) in fuses::OTP_PARTITIONS.iter().enumerate() {
+        if byte_addr >= p.byte_offset && byte_addr < p.byte_offset + p.byte_size {
+            if ecc_rams.get(i).is_some_and(|r| r.is_some()) {
+                return Some((i, p.byte_offset));
+            }
+            return None;
+        }
+    }
+    None
 }
 
 impl emulator_registers_generated::otp::OtpPeripheral for Otp {
@@ -399,7 +515,143 @@ impl emulator_registers_generated::otp::OtpPeripheral for Otp {
         u32,
         registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
     > {
-        caliptra_emu_bus::ReadWriteRegister::new(self.dai_err_code)
+        caliptra_emu_bus::ReadWriteRegister::new(self.err_codes[0])
+    }
+    fn read_err_code_rf_err_code_1(
+        &mut self,
+    ) -> caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
+    > {
+        caliptra_emu_bus::ReadWriteRegister::new(self.err_codes[1])
+    }
+    fn read_err_code_rf_err_code_2(
+        &mut self,
+    ) -> caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
+    > {
+        caliptra_emu_bus::ReadWriteRegister::new(self.err_codes[2])
+    }
+    fn read_err_code_rf_err_code_3(
+        &mut self,
+    ) -> caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
+    > {
+        caliptra_emu_bus::ReadWriteRegister::new(self.err_codes[3])
+    }
+    fn read_err_code_rf_err_code_4(
+        &mut self,
+    ) -> caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
+    > {
+        caliptra_emu_bus::ReadWriteRegister::new(self.err_codes[4])
+    }
+    fn read_err_code_rf_err_code_5(
+        &mut self,
+    ) -> caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
+    > {
+        caliptra_emu_bus::ReadWriteRegister::new(self.err_codes[5])
+    }
+    fn read_err_code_rf_err_code_6(
+        &mut self,
+    ) -> caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
+    > {
+        caliptra_emu_bus::ReadWriteRegister::new(self.err_codes[6])
+    }
+    fn read_err_code_rf_err_code_7(
+        &mut self,
+    ) -> caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
+    > {
+        caliptra_emu_bus::ReadWriteRegister::new(self.err_codes[7])
+    }
+    fn read_err_code_rf_err_code_8(
+        &mut self,
+    ) -> caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
+    > {
+        caliptra_emu_bus::ReadWriteRegister::new(self.err_codes[8])
+    }
+    fn read_err_code_rf_err_code_9(
+        &mut self,
+    ) -> caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
+    > {
+        caliptra_emu_bus::ReadWriteRegister::new(self.err_codes[9])
+    }
+    fn read_err_code_rf_err_code_10(
+        &mut self,
+    ) -> caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
+    > {
+        caliptra_emu_bus::ReadWriteRegister::new(self.err_codes[10])
+    }
+    fn read_err_code_rf_err_code_11(
+        &mut self,
+    ) -> caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
+    > {
+        caliptra_emu_bus::ReadWriteRegister::new(self.err_codes[11])
+    }
+    fn read_err_code_rf_err_code_12(
+        &mut self,
+    ) -> caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
+    > {
+        caliptra_emu_bus::ReadWriteRegister::new(self.err_codes[12])
+    }
+    fn read_err_code_rf_err_code_13(
+        &mut self,
+    ) -> caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
+    > {
+        caliptra_emu_bus::ReadWriteRegister::new(self.err_codes[13])
+    }
+    fn read_err_code_rf_err_code_14(
+        &mut self,
+    ) -> caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
+    > {
+        caliptra_emu_bus::ReadWriteRegister::new(self.err_codes[14])
+    }
+    fn read_err_code_rf_err_code_15(
+        &mut self,
+    ) -> caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
+    > {
+        caliptra_emu_bus::ReadWriteRegister::new(self.err_codes[15])
+    }
+    fn read_err_code_rf_err_code_16(
+        &mut self,
+    ) -> caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
+    > {
+        caliptra_emu_bus::ReadWriteRegister::new(self.err_codes[16])
+    }
+    fn read_err_code_rf_err_code_17(
+        &mut self,
+    ) -> caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
+    > {
+        caliptra_emu_bus::ReadWriteRegister::new(self.err_codes[17])
     }
 
     fn read_dai_wdata_rf_direct_access_wdata_0(&mut self) -> RvData {
@@ -416,10 +668,9 @@ impl emulator_registers_generated::otp::OtpPeripheral for Otp {
 
     /// Called by Bus::poll() to indicate that time has passed
     fn poll(&mut self) {
-        // Clear any previous DAI error before processing a new command
-        self.dai_err_code = 0;
-
         if self.direct_access_cmd.reg.read(DirectAccessCmd::Wr) == 1 {
+            // Clear any previous DAI error before processing a new command.
+            self.set_dai_err_code(0);
             let use_64 = is_64bit_granule(self.direct_access_address as usize);
             // Align address to the access granule (mask low 2 or 3 bits)
             let addr = if use_64 {
@@ -430,45 +681,65 @@ impl emulator_registers_generated::otp::OtpPeripheral for Otp {
 
             let mut blank_error = false;
             if addr + 4 <= TOTAL_SIZE {
-                let mut partitions = self.partitions.borrow_mut();
-                let current_lo = u32::from_le_bytes([
-                    partitions[addr],
-                    partitions[addr + 1],
-                    partitions[addr + 2],
-                    partitions[addr + 3],
-                ]);
-
-                // Blank check: writing must not attempt to clear already-set bits
-                if (current_lo & self.direct_access_buffer) != current_lo {
-                    blank_error = true;
-                }
-
-                if use_64 && addr + 8 <= TOTAL_SIZE {
-                    let current_hi = u32::from_le_bytes([
-                        partitions[addr + 4],
-                        partitions[addr + 5],
-                        partitions[addr + 6],
-                        partitions[addr + 7],
+                let write_len = if use_64 { 8 } else { 4 };
+                if let Some((part_idx, part_off)) = ecc_partition_for_addr(addr, &self.ecc_rams) {
+                    // ECC RAM handles blank-check on all 22 bits (data + parity).
+                    let ecc_off = addr - part_off;
+                    let ram = self.ecc_rams[part_idx].as_mut().unwrap();
+                    let mut buf = [0u8; 8];
+                    buf[..4].copy_from_slice(&self.direct_access_buffer.to_le_bytes());
+                    if use_64 {
+                        buf[4..8].copy_from_slice(&self.direct_access_buffer_hi.to_le_bytes());
+                    }
+                    if ram.otp_write_bytes(ecc_off, &buf[..write_len]) {
+                        // Commit succeeded — sync data back to partitions Vec.
+                        let mut partitions = self.partitions.borrow_mut();
+                        let mut readback = [0u8; 8];
+                        ram.read_bytes(ecc_off, &mut readback[..write_len]);
+                        partitions[addr..addr + write_len].copy_from_slice(&readback[..write_len]);
+                    } else {
+                        blank_error = true;
+                    }
+                } else {
+                    let mut partitions = self.partitions.borrow_mut();
+                    let current_lo = u32::from_le_bytes([
+                        partitions[addr],
+                        partitions[addr + 1],
+                        partitions[addr + 2],
+                        partitions[addr + 3],
                     ]);
-                    if (current_hi & self.direct_access_buffer_hi) != current_hi {
+
+                    // Blank check: writing must not attempt to clear already-set bits
+                    if (current_lo & self.direct_access_buffer) != current_lo {
                         blank_error = true;
                     }
 
-                    if !blank_error {
-                        // OTP can only burn bits from 0 to 1, never clear bits.
+                    if use_64 && addr + 8 <= TOTAL_SIZE {
+                        let current_hi = u32::from_le_bytes([
+                            partitions[addr + 4],
+                            partitions[addr + 5],
+                            partitions[addr + 6],
+                            partitions[addr + 7],
+                        ]);
+                        if (current_hi & self.direct_access_buffer_hi) != current_hi {
+                            blank_error = true;
+                        }
+
+                        if !blank_error {
+                            let new_lo = current_lo | self.direct_access_buffer;
+                            let new_hi = current_hi | self.direct_access_buffer_hi;
+                            partitions[addr..addr + 4].copy_from_slice(&new_lo.to_le_bytes());
+                            partitions[addr + 4..addr + 8].copy_from_slice(&new_hi.to_le_bytes());
+                        }
+                    } else if !blank_error {
                         let new_lo = current_lo | self.direct_access_buffer;
-                        let new_hi = current_hi | self.direct_access_buffer_hi;
                         partitions[addr..addr + 4].copy_from_slice(&new_lo.to_le_bytes());
-                        partitions[addr + 4..addr + 8].copy_from_slice(&new_hi.to_le_bytes());
                     }
-                } else if !blank_error {
-                    let new_lo = current_lo | self.direct_access_buffer;
-                    partitions[addr..addr + 4].copy_from_slice(&new_lo.to_le_bytes());
                 }
             }
 
             if blank_error {
-                self.dai_err_code = OTP_ERR_MACRO_WRITE_BLANK;
+                self.set_dai_err_code(OTP_ERR_MACRO_WRITE_BLANK);
                 self.status
                     .reg
                     .set(OtpStatus::DaiIdle::SET.value | OtpStatus::DaiError::SET.value);
@@ -480,26 +751,47 @@ impl emulator_registers_generated::otp::OtpPeripheral for Otp {
             self.direct_access_buffer = 0;
             self.direct_access_buffer_hi = 0;
         } else if self.direct_access_cmd.reg.read(DirectAccessCmd::Rd) == 1 {
+            // Clear any previous DAI error before processing a new command.
+            self.set_dai_err_code(0);
             self.direct_access_cmd.reg.set(0);
             // clear bottom two bits
             let addr = (self.direct_access_address & 0xffff_fffc) as usize;
             if addr + 4 <= TOTAL_SIZE {
-                let mut buf = [0; 4];
-                let partitions = self.partitions.borrow();
-                buf.copy_from_slice(&partitions[addr..addr + 4]);
-                self.direct_access_buffer = u32::from_le_bytes(buf);
-                // Also read the high word for 64-bit granule reads
-                if addr + 8 <= TOTAL_SIZE {
-                    buf.copy_from_slice(&partitions[addr + 4..addr + 8]);
-                    self.direct_access_buffer_hi = u32::from_le_bytes(buf);
+                if let Some((part_idx, part_off)) = ecc_partition_for_addr(addr, &self.ecc_rams) {
+                    // Read through ECC RAM.
+                    let ecc_off = addr - part_off;
+                    let ram = self.ecc_rams[part_idx].as_mut().unwrap();
+                    let mut buf = [0u8; 4];
+                    ram.read_bytes(ecc_off, &mut buf);
+                    self.direct_access_buffer = u32::from_le_bytes(buf);
+                    let p = &fuses::OTP_PARTITIONS[part_idx];
+                    if addr + 8 <= p.byte_offset + p.byte_size {
+                        let mut buf_hi = [0u8; 4];
+                        ram.read_bytes(ecc_off + 4, &mut buf_hi);
+                        self.direct_access_buffer_hi = u32::from_le_bytes(buf_hi);
+                    } else {
+                        self.direct_access_buffer_hi = 0;
+                    }
                 } else {
-                    self.direct_access_buffer_hi = 0;
+                    let mut buf = [0; 4];
+                    let partitions = self.partitions.borrow();
+                    buf.copy_from_slice(&partitions[addr..addr + 4]);
+                    self.direct_access_buffer = u32::from_le_bytes(buf);
+                    // Also read the high word for 64-bit granule reads
+                    if addr + 8 <= TOTAL_SIZE {
+                        buf.copy_from_slice(&partitions[addr + 4..addr + 8]);
+                        self.direct_access_buffer_hi = u32::from_le_bytes(buf);
+                    } else {
+                        self.direct_access_buffer_hi = 0;
+                    }
                 }
             }
             // reset direct access
             self.direct_access_cmd.reg.set(0);
             self.direct_access_address = 0;
         } else if self.direct_access_cmd.reg.read(DirectAccessCmd::Digest) == 1 {
+            // Clear any previous DAI error before processing a new command.
+            self.set_dai_err_code(0);
             // clear bottom two bits
             let addr = (self.direct_access_address & 0xffff_fffc) as usize;
             if let Some(partition) = fuses::OTP_PARTITIONS
@@ -516,7 +808,7 @@ impl emulator_registers_generated::otp::OtpPeripheral for Otp {
 
         // Set idle status so that users know operations have completed.
         // Only set plain idle if no error was flagged earlier in this poll.
-        if self.dai_err_code == 0 {
+        if self.dai_err_code() == 0 {
             self.status.reg.set(OtpStatus::DaiIdle::SET.value);
         }
     }
@@ -718,7 +1010,7 @@ mod test {
             OtpStatus::DaiIdle::SET.value,
             "first write should succeed"
         );
-        assert_eq!(otp.dai_err_code, 0);
+        assert_eq!(otp.dai_err_code(), 0);
 
         // Re-write same value: should succeed (OR produces same result)
         otp.write_dai_wdata_rf_direct_access_wdata_0(0xFF00_FF00);
@@ -730,7 +1022,7 @@ mod test {
             OtpStatus::DaiIdle::SET.value,
             "rewrite of same value should succeed"
         );
-        assert_eq!(otp.dai_err_code, 0);
+        assert_eq!(otp.dai_err_code(), 0);
 
         // Write superset: should succeed (only setting more bits)
         otp.write_dai_wdata_rf_direct_access_wdata_0(0xFFFF_FFFF);
@@ -742,7 +1034,7 @@ mod test {
             OtpStatus::DaiIdle::SET.value,
             "writing superset should succeed"
         );
-        assert_eq!(otp.dai_err_code, 0);
+        assert_eq!(otp.dai_err_code(), 0);
 
         // Write value that would clear bits: should fail
         otp.write_dai_wdata_rf_direct_access_wdata_0(0x0000_0001);
@@ -754,6 +1046,192 @@ mod test {
             0,
             "clearing bits should produce DaiError"
         );
-        assert_eq!(otp.dai_err_code, OTP_ERR_MACRO_WRITE_BLANK);
+        assert_eq!(otp.dai_err_code(), OTP_ERR_MACRO_WRITE_BLANK);
+    }
+
+    /// Helper: DAI write a 32-bit value at the given byte address.
+    fn dai_write(otp: &mut Otp, addr: u32, val: u32) {
+        otp.write_dai_wdata_rf_direct_access_wdata_0(val);
+        otp.write_direct_access_address(addr.into());
+        otp.write_direct_access_cmd(2u32.into());
+        for _ in 0..100 {
+            otp.poll();
+            if otp.status.reg.read(OtpStatus::DaiIdle) != 0 {
+                break;
+            }
+        }
+    }
+
+    /// Helper: DAI read a 32-bit value from the given byte address.
+    fn dai_read(otp: &mut Otp, addr: u32) -> u32 {
+        otp.write_direct_access_address(addr.into());
+        otp.write_direct_access_cmd(1u32.into());
+        for _ in 0..100 {
+            otp.poll();
+            if otp.status.reg.read(OtpStatus::DaiIdle) != 0 {
+                break;
+            }
+        }
+        otp.read_dai_rdata_rf_direct_access_rdata_0()
+    }
+
+    #[test]
+    fn test_lifecycle_ecc_write_read() {
+        let clock = Clock::new();
+        let mut otp = Otp::new(
+            &clock,
+            OtpArgs {
+                vendor_pqc_type: FwVerificationPqcKeyType::MLDSA,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let addr = fuses::LIFE_CYCLE_BYTE_OFFSET as u32;
+        dai_write(&mut otp, addr, 0xDEAD_BEEF);
+        let readback = dai_read(&mut otp, addr);
+        assert_eq!(readback, 0xDEAD_BEEF);
+        assert!(!otp.has_correctable_ecc_error());
+        assert!(!otp.has_uncorrectable_ecc_error());
+    }
+
+    #[test]
+    fn test_lifecycle_ecc_correctable_error() {
+        let clock = Clock::new();
+        let mut otp = Otp::new(
+            &clock,
+            OtpArgs {
+                vendor_pqc_type: FwVerificationPqcKeyType::MLDSA,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let addr = fuses::LIFE_CYCLE_BYTE_OFFSET as u32;
+        dai_write(&mut otp, addr, 0xCAFE_BABE);
+
+        // Inject a single-bit error in the ECC RAM.
+        otp.partition_ecc_mut(15).unwrap().flip_bit(0, 7);
+
+        let readback = dai_read(&mut otp, addr);
+        assert_eq!(
+            readback, 0xCAFE_BABE,
+            "single-bit error should be corrected"
+        );
+        assert!(otp.has_correctable_ecc_error());
+        assert!(!otp.has_uncorrectable_ecc_error());
+
+        otp.clear_ecc_errors();
+        assert!(!otp.has_correctable_ecc_error());
+    }
+
+    #[test]
+    fn test_lifecycle_ecc_uncorrectable_error() {
+        let clock = Clock::new();
+        let mut otp = Otp::new(
+            &clock,
+            OtpArgs {
+                vendor_pqc_type: FwVerificationPqcKeyType::MLDSA,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let addr = fuses::LIFE_CYCLE_BYTE_OFFSET as u32;
+        dai_write(&mut otp, addr, 0x1234_5678);
+
+        // Inject a double-bit error in the ECC RAM.
+        otp.partition_ecc_mut(15).unwrap().flip_bit(0, 0);
+        otp.partition_ecc_mut(15).unwrap().flip_bit(0, 1);
+
+        let _readback = dai_read(&mut otp, addr);
+        assert!(otp.has_uncorrectable_ecc_error());
+    }
+
+    #[test]
+    fn test_lifecycle_ecc_or_only_write() {
+        let clock = Clock::new();
+        let mut otp = Otp::new(
+            &clock,
+            OtpArgs {
+                vendor_pqc_type: FwVerificationPqcKeyType::MLDSA,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let addr = fuses::LIFE_CYCLE_BYTE_OFFSET as u32;
+
+        // First write to blank OTP should succeed.
+        dai_write(&mut otp, addr, 0xFF00_FF00);
+        assert_eq!(otp.status.reg.get(), OtpStatus::DaiIdle::SET.value);
+        assert_eq!(otp.dai_err_code(), 0);
+
+        // Re-writing the same value should succeed (OR is a no-op).
+        dai_write(&mut otp, addr, 0xFF00_FF00);
+        assert_eq!(otp.status.reg.get(), OtpStatus::DaiIdle::SET.value);
+        assert_eq!(otp.dai_err_code(), 0);
+
+        // Verify the data reads back correctly.
+        assert_eq!(dai_read(&mut otp, addr), 0xFF00_FF00);
+
+        // Writing a value that clears data bits should fail with blank error.
+        dai_write(&mut otp, addr, 0x0000_0001);
+        assert_ne!(
+            otp.status.reg.get() & OtpStatus::DaiError::SET.value,
+            0,
+            "clearing lifecycle bits should produce DaiError"
+        );
+        assert_eq!(otp.dai_err_code(), OTP_ERR_MACRO_WRITE_BLANK);
+    }
+
+    /// Verify that a write which is a data-bit superset but causes an ECC
+    /// parity conflict is rejected with a blank error.
+    #[test]
+    fn test_lifecycle_ecc_parity_blank_check() {
+        use crate::ecc_ram::ecc_encode;
+
+        let clock = Clock::new();
+        let mut otp = Otp::new(
+            &clock,
+            OtpArgs {
+                vendor_pqc_type: FwVerificationPqcKeyType::MLDSA,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let addr = fuses::LIFE_CYCLE_BYTE_OFFSET as u32;
+
+        // Find a pair (old, new) where new's data bits are a superset of
+        // old's, but the 22-bit ECC word is NOT a superset (parity conflict).
+        let old_val: u16 = 0x0001;
+        let new_val: u16 = 0x0003;
+        let old_ecc = ecc_encode(old_val);
+        let new_ecc = ecc_encode(new_val);
+        // Precondition: data bits are a superset.
+        assert_eq!(old_val & new_val, old_val);
+        // Precondition: parity bits are NOT a superset.
+        assert_ne!(
+            old_ecc & new_ecc,
+            old_ecc,
+            "test pair should have a parity conflict"
+        );
+
+        // Write old value.
+        dai_write(&mut otp, addr, old_val as u32);
+        assert_eq!(otp.dai_err_code(), 0);
+
+        // Attempt to write new value — should fail due to parity conflict.
+        dai_write(&mut otp, addr, new_val as u32);
+        assert_ne!(
+            otp.status.reg.get() & OtpStatus::DaiError::SET.value,
+            0,
+            "parity conflict should produce DaiError"
+        );
+        assert_eq!(otp.dai_err_code(), OTP_ERR_MACRO_WRITE_BLANK);
+
+        // Original value should be preserved.
+        assert_eq!(dai_read(&mut otp, addr), old_val as u32);
     }
 }

--- a/hw/model/test-fw/otp-blank-check/Cargo.toml
+++ b/hw/model/test-fw/otp-blank-check/Cargo.toml
@@ -1,0 +1,20 @@
+# Licensed under the Apache-2.0 license
+
+[package]
+name = "mcu-test-fw-otp-blank-check"
+version.workspace = true
+edition.workspace = true
+
+[features]
+default = []
+riscv = []
+emu = []
+fpga_realtime = ["mcu-test-harness/fpga_realtime"]
+
+[dependencies]
+mcu-error.workspace = true
+mcu-rom-common.workspace = true
+mcu-test-harness.workspace = true
+registers-generated.workspace = true
+romtime.workspace = true
+tock-registers.workspace = true

--- a/hw/model/test-fw/otp-blank-check/src/main.rs
+++ b/hw/model/test-fw/otp-blank-check/src/main.rs
@@ -1,0 +1,96 @@
+// Licensed under the Apache-2.0 license
+
+//! Test ROM that verifies OTP blank-check enforcement.
+//!
+//! 1. Wait for go-bit (FPGA OTP clearing preamble).
+//! 2. Write 0x0000_000F to the first data word of vendor_test_partition.
+//! 3. Read it back to confirm.
+//! 4. Attempt to write 0x0000_0001 to the same word (clears bits 1-3).
+//! 5. Verify that the write fails (returns Err) due to blank-check.
+//! 6. Read back to confirm the original value is unchanged.
+//!
+//! Prints "PASS" on success, or a diagnostic message before fatal_error.
+
+#![no_main]
+#![no_std]
+
+use mcu_rom_common::{fatal_error, RomEnv};
+use registers_generated::fuses;
+use tock_registers::interfaces::Readable;
+
+const GO_BIT: u32 = 1 << 0;
+
+fn run() -> ! {
+    let env = RomEnv::new();
+    let otp = &env.otp;
+
+    // Wait for go-bit (FPGA OTP clearing preamble).
+    while env.mci.registers.mci_reg_generic_input_wires[0].get() & GO_BIT == 0 {}
+
+    let partition = fuses::VENDOR_TEST_PARTITION;
+    let base_word = partition.byte_offset / 4;
+
+    // Write 0x0F to a blank word.
+    romtime::println!("[otp-blank-check] Writing 0x0000000F to word {}", base_word);
+    match otp.write_word(base_word, 0x0000_000F) {
+        Ok(_) => {}
+        Err(_) => {
+            romtime::println!("[otp-blank-check] First write unexpectedly failed");
+            fatal_error(mcu_error::McuError::ROM_OTP_WRITE_WORD_ERROR);
+        }
+    }
+
+    // Read back and verify.
+    match otp.read_word(base_word) {
+        Ok(val) => {
+            if val != 0x0000_000F {
+                romtime::println!("[otp-blank-check] Read back wrong value after first write");
+                fatal_error(mcu_error::McuError::ROM_OTP_READ_ERROR);
+            }
+        }
+        Err(_) => {
+            romtime::println!("[otp-blank-check] Read after first write failed");
+            fatal_error(mcu_error::McuError::ROM_OTP_READ_ERROR);
+        }
+    }
+    romtime::println!("[otp-blank-check] First write verified OK");
+
+    // Attempt a write that would clear bits — must fail with blank-check error.
+    romtime::println!("[otp-blank-check] Attempting write of 0x00000001 (should fail)");
+    match otp.write_word(base_word, 0x0000_0001) {
+        Ok(_) => {
+            romtime::println!("[otp-blank-check] Second write succeeded but should have failed");
+            fatal_error(mcu_error::McuError::ROM_OTP_WRITE_WORD_ERROR);
+        }
+        Err(_) => {
+            romtime::println!("[otp-blank-check] Second write correctly failed");
+        }
+    }
+
+    // Confirm original value is preserved after the failed write.
+    match otp.read_word(base_word) {
+        Ok(val) => {
+            if val != 0x0000_000F {
+                romtime::println!(
+                    "[otp-blank-check] Original value not preserved, got {:#010x}",
+                    val
+                );
+                fatal_error(mcu_error::McuError::ROM_OTP_READ_ERROR);
+            }
+        }
+        Err(_) => {
+            romtime::println!("[otp-blank-check] Final readback failed");
+            fatal_error(mcu_error::McuError::ROM_OTP_READ_ERROR);
+        }
+    }
+
+    romtime::println!("[otp-blank-check] PASS");
+    #[allow(clippy::empty_loop)]
+    loop {}
+}
+
+#[no_mangle]
+pub extern "C" fn main() {
+    mcu_test_harness::set_printer();
+    run();
+}

--- a/tests/integration/src/rom/mod.rs
+++ b/tests/integration/src/rom/mod.rs
@@ -1,5 +1,6 @@
 // Licensed under the Apache-2.0 license
 
 mod test_hitless_update;
+mod test_otp_blank_check;
 mod test_sw_digest_lock;
 mod test_warm_reset;

--- a/tests/integration/src/rom/test_otp_blank_check.rs
+++ b/tests/integration/src/rom/test_otp_blank_check.rs
@@ -1,0 +1,63 @@
+// Licensed under the Apache-2.0 license
+
+//! Integration test for OTP blank-check enforcement.
+//!
+//! Boots the `otp_blank_check` test ROM which writes 0x0F then 0x01 to the
+//! same vendor_test_partition word. The second write must fail because it
+//! would clear already-set bits. The ROM prints "PASS" if blank-check
+//! behaves correctly.
+
+#[cfg(test)]
+mod test {
+    use crate::platform;
+    use mcu_builder::firmware;
+    use mcu_hw_model::{InitParams, McuHwModel};
+    use mcu_rom_common::LifecycleControllerState;
+
+    fn load_roms() -> (Vec<u8>, Vec<u8>) {
+        if let Ok(binaries) = mcu_builder::FirmwareBinaries::from_env() {
+            (
+                binaries.caliptra_rom.clone(),
+                binaries
+                    .test_rom(&firmware::hw_model_tests::OTP_BLANK_CHECK)
+                    .unwrap(),
+            )
+        } else {
+            let rom_file = mcu_builder::test_rom_build(
+                Some(platform()),
+                &firmware::hw_model_tests::OTP_BLANK_CHECK,
+            )
+            .unwrap();
+            (vec![], std::fs::read(&rom_file).unwrap())
+        }
+    }
+
+    #[test]
+    fn test_otp_blank_check() {
+        let (caliptra_rom, mcu_rom) = load_roms();
+
+        let mut hw = mcu_hw_model::new(InitParams {
+            caliptra_rom: &caliptra_rom,
+            mcu_rom: &mcu_rom,
+            check_booted_to_runtime: false,
+            enable_mcu_uart_log: true,
+            lifecycle_controller_state: Some(LifecycleControllerState::Dev),
+            ..Default::default()
+        })
+        .unwrap();
+        hw.set_mcu_generic_input_wires(&[1, 0xc000_0000]);
+
+        hw.output().set_search_term("PASS");
+        let start = std::time::Instant::now();
+        hw.step_until(|m| {
+            m.output().search_matched()
+                || m.mci_fw_fatal_error().is_some()
+                || start.elapsed().as_secs() > 30
+        });
+        let output_text = hw.output().take(usize::MAX);
+        println!("Test output:\n{output_text}");
+        assert!(start.elapsed().as_secs() <= 30, "Test timed out");
+        assert_eq!(hw.mci_fw_fatal_error(), None, "Test ROM hit fatal error");
+        assert!(output_text.contains("PASS"), "Test ROM did not print PASS");
+    }
+}


### PR DESCRIPTION
Add an ECC RAM module for doing adding a 6-bit ECC code for a 16-bit word, similar how to the hardware's reference prim_generic_otp works.

This allows OTP partitions to be protected with single-bit correction and double-bit error detection.

The OTP DAI writes enforce OR-only semantics: all 22 bits (data + parity) are blank-checked before committing, and MacroWriteBlankError (code 4) is reported if any bit would transition 1→0. The DAI error code register index is configurable via OtpArgs::dai_err_code_register (defaults to 16, matching DaiIdx in the reference hardware). Error codes are only cleared when a new DAI command begins, so firmware can read them after an error.

Add a ROM integration test (otp_blank_check) that writes 0x0F then 0x01 to vendor_test_partition and verifies the second write fails with a blank-check error. I verified this test passes on both emulator and FPGA with the exact same behavior.