### PR TITLE
emulator: lifecycle controller reads state from fuses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1670,6 +1670,7 @@ dependencies = [
  "log",
  "mcu-mbox-common",
  "mcu-testing-common",
+ "otp-lifecycle",
  "p384",
  "pldm-common",
  "pldm-fw-pkg",
@@ -1771,6 +1772,7 @@ dependencies = [
  "mcu-testing-common",
  "num_enum",
  "otp-digest",
+ "otp-lifecycle",
  "registers-generated",
  "semver",
  "serde",
@@ -3013,6 +3015,7 @@ dependencies = [
  "mcu-rom-common",
  "mcu-testing-common",
  "nix 0.26.4",
+ "otp-lifecycle",
  "p384",
  "poll-common",
  "rand 0.8.5",
@@ -3540,6 +3543,13 @@ checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
 [[package]]
 name = "otp-digest"
 version = "0.1.0"
+
+[[package]]
+name = "otp-lifecycle"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+]
 
 [[package]]
 name = "p384"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "common/flash-image",
     "common/mcu-mbox",
     "common/otp-digest",
+    "common/otp-lifecycle",
     "common/mctp-vdm",
     "common/pldm",
     "common/poll",
@@ -219,6 +220,7 @@ mcu-testing-common = { path = "common/testing" }
 mcu-tock-veer = { path = "runtime/kernel/veer" }
 mctp-vdm-common = { path = "common/mctp-vdm" }
 otp-digest = { path = "common/otp-digest" }
+otp-lifecycle = { path = "common/otp-lifecycle" }
 pldm-common = { path = "common/pldm"}
 pldm-fw-pkg = { path = "emulator/bmc/pldm-fw-pkg" }
 pldm-ua = { path = "emulator/bmc/pldm-ua"}

--- a/common/otp-lifecycle/Cargo.toml
+++ b/common/otp-lifecycle/Cargo.toml
@@ -1,0 +1,10 @@
+# Licensed under the Apache-2.0 license
+
+[package]
+name = "otp-lifecycle"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+
+[dependencies]
+anyhow.workspace = true

--- a/common/otp-lifecycle/src/lib.rs
+++ b/common/otp-lifecycle/src/lib.rs
@@ -1,0 +1,408 @@
+// Licensed under the Apache-2.0 license
+
+//! OTP lifecycle state ECC encoding/decoding for the OpenTitan lifecycle controller.
+//!
+//! Encodes and decodes the SECDED-protected lifecycle state and transition count
+//! stored in the OTP LIFE_CYCLE partition. Uses raw `u8` state indices (0–20)
+//! to avoid pulling in ROM crate dependencies.
+
+use anyhow::{bail, Result};
+
+// These are the default lifecycle controller constants from the
+// standard Caliptra RTL. These can be overridden by vendors.
+
+// from caliptra-rtl/src/lc_ctrl/rtl/lc_ctrl_state_pkg.sv
+const _A0: u16 = 0b0110010010101110; // ECC: 6'b001010
+const B0: u16 = 0b0111010111101110; // ECC: 6'b111110
+const A1: u16 = 0b0000011110110100; // ECC: 6'b100101
+const B1: u16 = 0b0000111111111110; // ECC: 6'b111101
+const A2: u16 = 0b0011000111010010; // ECC: 6'b000111
+const B2: u16 = 0b0111101111111110; // ECC: 6'b000111
+const A3: u16 = 0b0010111001001101; // ECC: 6'b001010
+const B3: u16 = 0b0011111101101111; // ECC: 6'b111010
+const A4: u16 = 0b0100000111111000; // ECC: 6'b011010
+const B4: u16 = 0b0101111111111100; // ECC: 6'b011110
+const A5: u16 = 0b1010110010000101; // ECC: 6'b110001
+const B5: u16 = 0b1111110110011111; // ECC: 6'b110001
+const A6: u16 = 0b1001100110001100; // ECC: 6'b010110
+const B6: u16 = 0b1111100110011111; // ECC: 6'b011110
+const A7: u16 = 0b0101001100001111; // ECC: 6'b100010
+const B7: u16 = 0b1101101101101111; // ECC: 6'b100111
+const A8: u16 = 0b0111000101100000; // ECC: 6'b111001
+const B8: u16 = 0b0111001101111111; // ECC: 6'b111001
+const A9: u16 = 0b0010110001100011; // ECC: 6'b101010
+const B9: u16 = 0b0110110001101111; // ECC: 6'b111111
+const A10: u16 = 0b0110110100001000; // ECC: 6'b110011
+const B10: u16 = 0b0110111110011110; // ECC: 6'b111011
+const A11: u16 = 0b1001001001001100; // ECC: 6'b000011
+const B11: u16 = 0b1101001111011100; // ECC: 6'b111111
+const A12: u16 = 0b0111000001000000; // ECC: 6'b011110
+const B12: u16 = 0b0111011101010010; // ECC: 6'b111110
+const A13: u16 = 0b1001001010111110; // ECC: 6'b000010
+const B13: u16 = 0b1111001011111110; // ECC: 6'b101110
+const A14: u16 = 0b1001010011010010; // ECC: 6'b100011
+const B14: u16 = 0b1011110111010011; // ECC: 6'b101111
+const A15: u16 = 0b0110001010001101; // ECC: 6'b000111
+const B15: u16 = 0b0110111111001101; // ECC: 6'b011111
+const A16: u16 = 0b1011001000101000; // ECC: 6'b010111
+const B16: u16 = 0b1011001011111011; // ECC: 6'b011111
+const A17: u16 = 0b0001111001110001; // ECC: 6'b001001
+const B17: u16 = 0b1001111111110101; // ECC: 6'b011011
+const A18: u16 = 0b0010110110011011; // ECC: 6'b000100
+const B18: u16 = 0b0011111111011111; // ECC: 6'b010101
+const A19: u16 = 0b0100110110001100; // ECC: 6'b101010
+const B19: u16 = 0b1101110110111110; // ECC: 6'b101011
+
+// The C/D values are used for the encoded LC transition counter.
+
+const _C0: u16 = 0b0001010010011110; // ECC: 6'b011100
+const D0: u16 = 0b1011011011011111; // ECC: 6'b111100
+const C1: u16 = 0b0101101011000100; // ECC: 6'b111000
+const D1: u16 = 0b1111101011110100; // ECC: 6'b111101
+const C2: u16 = 0b0001111100100100; // ECC: 6'b100011
+const D2: u16 = 0b0001111110111111; // ECC: 6'b100111
+const C3: u16 = 0b1100111010000101; // ECC: 6'b011000
+const D3: u16 = 0b1100111011101111; // ECC: 6'b011011
+const C4: u16 = 0b0100001010011111; // ECC: 6'b011000
+const D4: u16 = 0b0101101110111111; // ECC: 6'b111100
+const C5: u16 = 0b1001111000100010; // ECC: 6'b111000
+const D5: u16 = 0b1111111110100010; // ECC: 6'b111110
+const C6: u16 = 0b0010011110000110; // ECC: 6'b010000
+const D6: u16 = 0b0111011111000110; // ECC: 6'b011101
+const C7: u16 = 0b0010111101000110; // ECC: 6'b000110
+const D7: u16 = 0b1010111111000110; // ECC: 6'b111111
+const C8: u16 = 0b0000001011011011; // ECC: 6'b000001
+const D8: u16 = 0b1010101111011011; // ECC: 6'b111011
+const C9: u16 = 0b0111000011000110; // ECC: 6'b110001
+const D9: u16 = 0b1111111011001110; // ECC: 6'b110011
+const C10: u16 = 0b0100001000010010; // ECC: 6'b110110
+const D10: u16 = 0b0111001010110110; // ECC: 6'b110111
+const C11: u16 = 0b0100101111110001; // ECC: 6'b000001
+const D11: u16 = 0b0110101111110011; // ECC: 6'b110111
+const C12: u16 = 0b1000100101000001; // ECC: 6'b000001
+const D12: u16 = 0b1011110101001111; // ECC: 6'b001011
+const C13: u16 = 0b1000000000010001; // ECC: 6'b011111
+const D13: u16 = 0b1001100010110011; // ECC: 6'b111111
+const C14: u16 = 0b0101110000000100; // ECC: 6'b111110
+const D14: u16 = 0b1111111010001101; // ECC: 6'b111110
+const C15: u16 = 0b1100001000001001; // ECC: 6'b001011
+const D15: u16 = 0b1110011000011011; // ECC: 6'b111011
+const C16: u16 = 0b0101001001101100; // ECC: 6'b001000
+const D16: u16 = 0b0111111001111110; // ECC: 6'b001001
+const C17: u16 = 0b0100001001110100; // ECC: 6'b010100
+const D17: u16 = 0b1100101001110111; // ECC: 6'b110110
+const C18: u16 = 0b1100000001100111; // ECC: 6'b100000
+const D18: u16 = 0b1100011101110111; // ECC: 6'b100101
+const C19: u16 = 0b1010000001001010; // ECC: 6'b101111
+const D19: u16 = 0b1111011101101010; // ECC: 6'b101111
+const C20: u16 = 0b1001001001010101; // ECC: 6'b001110
+const D20: u16 = 0b1101111011011101; // ECC: 6'b001111
+const C21: u16 = 0b1001010000011011; // ECC: 6'b100000
+const D21: u16 = 0b1001111000111011; // ECC: 6'b110101
+const C22: u16 = 0b1011101101100001; // ECC: 6'b000100
+const D22: u16 = 0b1011111101111111; // ECC: 6'b000110
+const C23: u16 = 0b1101101000000111; // ECC: 6'b001100
+const D23: u16 = 0b1101111011100111; // ECC: 6'b101110
+const ZRO: u16 = 0b0000000000000000; // ECC: 6'b000000
+
+const COUNTS: [[u16; 24]; 25] = [
+    [
+        ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO,
+        ZRO, ZRO, ZRO, ZRO, ZRO, ZRO,
+    ],
+    [
+        C23, C22, C21, C20, C19, C18, C17, C16, C15, C14, C13, C12, C11, C10, C9, C8, C7, C6, C5,
+        C4, C3, C2, C1, D0,
+    ],
+    [
+        C23, C22, C21, C20, C19, C18, C17, C16, C15, C14, C13, C12, C11, C10, C9, C8, C7, C6, C5,
+        C4, C3, C2, D1, D0,
+    ],
+    [
+        C23, C22, C21, C20, C19, C18, C17, C16, C15, C14, C13, C12, C11, C10, C9, C8, C7, C6, C5,
+        C4, C3, D2, D1, D0,
+    ],
+    [
+        C23, C22, C21, C20, C19, C18, C17, C16, C15, C14, C13, C12, C11, C10, C9, C8, C7, C6, C5,
+        C4, D3, D2, D1, D0,
+    ],
+    [
+        C23, C22, C21, C20, C19, C18, C17, C16, C15, C14, C13, C12, C11, C10, C9, C8, C7, C6, C5,
+        D4, D3, D2, D1, D0,
+    ],
+    [
+        C23, C22, C21, C20, C19, C18, C17, C16, C15, C14, C13, C12, C11, C10, C9, C8, C7, C6, D5,
+        D4, D3, D2, D1, D0,
+    ],
+    [
+        C23, C22, C21, C20, C19, C18, C17, C16, C15, C14, C13, C12, C11, C10, C9, C8, C7, D6, D5,
+        D4, D3, D2, D1, D0,
+    ],
+    [
+        C23, C22, C21, C20, C19, C18, C17, C16, C15, C14, C13, C12, C11, C10, C9, C8, D7, D6, D5,
+        D4, D3, D2, D1, D0,
+    ],
+    [
+        C23, C22, C21, C20, C19, C18, C17, C16, C15, C14, C13, C12, C11, C10, C9, D8, D7, D6, D5,
+        D4, D3, D2, D1, D0,
+    ],
+    [
+        C23, C22, C21, C20, C19, C18, C17, C16, C15, C14, C13, C12, C11, C10, D9, D8, D7, D6, D5,
+        D4, D3, D2, D1, D0,
+    ],
+    [
+        C23, C22, C21, C20, C19, C18, C17, C16, C15, C14, C13, C12, C11, D10, D9, D8, D7, D6, D5,
+        D4, D3, D2, D1, D0,
+    ],
+    [
+        C23, C22, C21, C20, C19, C18, C17, C16, C15, C14, C13, C12, D11, D10, D9, D8, D7, D6, D5,
+        D4, D3, D2, D1, D0,
+    ],
+    [
+        C23, C22, C21, C20, C19, C18, C17, C16, C15, C14, C13, D12, D11, D10, D9, D8, D7, D6, D5,
+        D4, D3, D2, D1, D0,
+    ],
+    [
+        C23, C22, C21, C20, C19, C18, C17, C16, C15, C14, D13, D12, D11, D10, D9, D8, D7, D6, D5,
+        D4, D3, D2, D1, D0,
+    ],
+    [
+        C23, C22, C21, C20, C19, C18, C17, C16, C15, D14, D13, D12, D11, D10, D9, D8, D7, D6, D5,
+        D4, D3, D2, D1, D0,
+    ],
+    [
+        C23, C22, C21, C20, C19, C18, C17, C16, D15, D14, D13, D12, D11, D10, D9, D8, D7, D6, D5,
+        D4, D3, D2, D1, D0,
+    ],
+    [
+        C23, C22, C21, C20, C19, C18, C17, D16, D15, D14, D13, D12, D11, D10, D9, D8, D7, D6, D5,
+        D4, D3, D2, D1, D0,
+    ],
+    [
+        C23, C22, C21, C20, C19, C18, D17, D16, D15, D14, D13, D12, D11, D10, D9, D8, D7, D6, D5,
+        D4, D3, D2, D1, D0,
+    ],
+    [
+        C23, C22, C21, C20, C19, D18, D17, D16, D15, D14, D13, D12, D11, D10, D9, D8, D7, D6, D5,
+        D4, D3, D2, D1, D0,
+    ],
+    [
+        C23, C22, C21, C20, D19, D18, D17, D16, D15, D14, D13, D12, D11, D10, D9, D8, D7, D6, D5,
+        D4, D3, D2, D1, D0,
+    ],
+    [
+        C23, C22, C21, D20, D19, D18, D17, D16, D15, D14, D13, D12, D11, D10, D9, D8, D7, D6, D5,
+        D4, D3, D2, D1, D0,
+    ],
+    [
+        C23, C22, D21, D20, D19, D18, D17, D16, D15, D14, D13, D12, D11, D10, D9, D8, D7, D6, D5,
+        D4, D3, D2, D1, D0,
+    ],
+    [
+        C23, D22, D21, D20, D19, D18, D17, D16, D15, D14, D13, D12, D11, D10, D9, D8, D7, D6, D5,
+        D4, D3, D2, D1, D0,
+    ],
+    [
+        D23, D22, D21, D20, D19, D18, D17, D16, D15, D14, D13, D12, D11, D10, D9, D8, D7, D6, D5,
+        D4, D3, D2, D1, D0,
+    ],
+];
+
+const STATES: [[u16; 20]; 21] = [
+    [
+        ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO,
+        ZRO, ZRO,
+    ],
+    [
+        A19, A18, A17, A16, A15, A14, A13, A12, A11, A10, A9, A8, A7, A6, A5, A4, A3, A2, A1, B0,
+    ],
+    [
+        A19, A18, A17, A16, A15, A14, A13, A12, A11, A10, A9, A8, A7, A6, A5, A4, A3, A2, B1, B0,
+    ],
+    [
+        A19, A18, A17, A16, A15, A14, A13, A12, A11, A10, A9, A8, A7, A6, A5, A4, A3, B2, B1, B0,
+    ],
+    [
+        A19, A18, A17, A16, A15, A14, A13, A12, A11, A10, A9, A8, A7, A6, A5, A4, B3, B2, B1, B0,
+    ],
+    [
+        A19, A18, A17, A16, A15, A14, A13, A12, A11, A10, A9, A8, A7, A6, A5, B4, B3, B2, B1, B0,
+    ],
+    [
+        A19, A18, A17, A16, A15, A14, A13, A12, A11, A10, A9, A8, A7, A6, B5, B4, B3, B2, B1, B0,
+    ],
+    [
+        A19, A18, A17, A16, A15, A14, A13, A12, A11, A10, A9, A8, A7, B6, B5, B4, B3, B2, B1, B0,
+    ],
+    [
+        A19, A18, A17, A16, A15, A14, A13, A12, A11, A10, A9, A8, B7, B6, B5, B4, B3, B2, B1, B0,
+    ],
+    [
+        A19, A18, A17, A16, A15, A14, A13, A12, A11, A10, A9, B8, B7, B6, B5, B4, B3, B2, B1, B0,
+    ],
+    [
+        A19, A18, A17, A16, A15, A14, A13, A12, A11, A10, B9, B8, B7, B6, B5, B4, B3, B2, B1, B0,
+    ],
+    [
+        A19, A18, A17, A16, A15, A14, A13, A12, A11, B10, B9, B8, B7, B6, B5, B4, B3, B2, B1, B0,
+    ],
+    [
+        A19, A18, A17, A16, A15, A14, A13, A12, B11, B10, B9, B8, B7, B6, B5, B4, B3, B2, B1, B0,
+    ],
+    [
+        A19, A18, A17, A16, A15, A14, A13, B12, B11, B10, B9, B8, B7, B6, B5, B4, B3, B2, B1, B0,
+    ],
+    [
+        A19, A18, A17, A16, A15, A14, B13, B12, B11, B10, B9, B8, B7, B6, B5, B4, B3, B2, B1, B0,
+    ],
+    [
+        A19, A18, A17, A16, A15, B14, B13, B12, B11, B10, B9, B8, B7, B6, B5, B4, B3, B2, B1, B0,
+    ],
+    [
+        A19, A18, A17, A16, B15, B14, B13, B12, B11, B10, B9, B8, B7, B6, B5, B4, B3, B2, B1, B0,
+    ],
+    [
+        A19, A18, A17, B16, B15, B14, B13, B12, B11, B10, B9, B8, B7, B6, B5, B4, B3, B2, B1, B0,
+    ],
+    [
+        A19, A18, B17, B16, B15, B14, B13, B12, B11, B10, B9, B8, B7, B6, B5, B4, B3, B2, B1, B0,
+    ],
+    [
+        A19, B18, B17, B16, B15, B14, B13, B12, B11, B10, B9, B8, B7, B6, B5, B4, B3, B2, B1, B0,
+    ],
+    [
+        B19, B18, B17, B16, B15, B14, B13, B12, B11, B10, B9, B8, B7, B6, B5, B4, B3, B2, B1, B0,
+    ],
+];
+
+pub const LIFECYCLE_STATE_SIZE: usize = 40;
+pub const LIFECYCLE_COUNT_SIZE: usize = 48;
+pub const LIFECYCLE_MEM_SIZE: usize = LIFECYCLE_STATE_SIZE + LIFECYCLE_COUNT_SIZE;
+
+/// Generate the OTP memory contents associated with the lifecycle state.
+pub fn lc_generate_state_mem(state: u8) -> Result<[u8; LIFECYCLE_STATE_SIZE]> {
+    if state as usize >= STATES.len() {
+        bail!("Invalid lifecycle state: {:?}", state);
+    }
+    let mut result = [0u8; 40];
+    let state_data = STATES[state as usize];
+    for (i, &value) in state_data.iter().enumerate() {
+        result[i * 2] = (value >> 8) as u8;
+        result[i * 2 + 1] = (value & 0xFF) as u8;
+    }
+    Ok(result)
+}
+
+/// Generate the OTP memory contents associated with the lifecycle transition count.
+pub fn lc_generate_count_mem(count: u8) -> Result<[u8; LIFECYCLE_COUNT_SIZE]> {
+    if count >= COUNTS.len() as u8 {
+        bail!("Invalid lifecycle count: {:?}", count);
+    }
+    let mut result = [0u8; 48];
+    let count_data = COUNTS[count as usize];
+    for (i, &value) in count_data.iter().enumerate() {
+        result[i * 2] = (value >> 8) as u8;
+        result[i * 2 + 1] = (value & 0xFF) as u8;
+    }
+    Ok(result)
+}
+
+/// Generate the OTP memory contents associated with the lifecycle state and transition count.
+pub fn lc_generate_memory(state: u8, transition_count: u8) -> Result<[u8; LIFECYCLE_MEM_SIZE]> {
+    let mut result = [0u8; LIFECYCLE_MEM_SIZE];
+    let state_bytes = lc_generate_state_mem(state)?;
+    result[..state_bytes.len()].copy_from_slice(&state_bytes);
+    let count = lc_generate_count_mem(transition_count)?;
+    result[state_bytes.len()..state_bytes.len() + count.len()].copy_from_slice(&count);
+    result.reverse();
+
+    Ok(result)
+}
+
+/// Decode the lifecycle state from OTP memory (pre-reversal format, i.e., big-endian u16 array).
+/// Returns the raw state index (0–20).
+pub fn lc_decode_state_mem(mem: &[u8; LIFECYCLE_STATE_SIZE]) -> Result<u8> {
+    let mut values = [0u16; 20];
+    for (i, value) in values.iter_mut().enumerate() {
+        *value = ((mem[i * 2] as u16) << 8) | (mem[i * 2 + 1] as u16);
+    }
+    for (state_idx, state_row) in STATES.iter().enumerate() {
+        if values == *state_row {
+            return Ok(state_idx as u8);
+        }
+    }
+    bail!("Unable to decode lifecycle state from OTP memory")
+}
+
+/// Decode the lifecycle transition count from OTP memory (pre-reversal format).
+pub fn lc_decode_count_mem(mem: &[u8; LIFECYCLE_COUNT_SIZE]) -> Result<u8> {
+    let mut values = [0u16; 24];
+    for (i, value) in values.iter_mut().enumerate() {
+        *value = ((mem[i * 2] as u16) << 8) | (mem[i * 2 + 1] as u16);
+    }
+    for (count_idx, count_row) in COUNTS.iter().enumerate() {
+        if values == *count_row {
+            return Ok(count_idx as u8);
+        }
+    }
+    bail!("Unable to decode lifecycle transition count from OTP memory")
+}
+
+/// Decode the lifecycle state and transition count from OTP memory (as stored, i.e., reversed).
+/// Returns `(state_index, transition_count)`.
+pub fn lc_decode_memory(mem: &[u8; LIFECYCLE_MEM_SIZE]) -> Result<(u8, u8)> {
+    let mut reversed = *mem;
+    reversed.reverse();
+    let state_mem: [u8; LIFECYCLE_STATE_SIZE] = reversed[..LIFECYCLE_STATE_SIZE]
+        .try_into()
+        .expect("slice length mismatch");
+    let count_mem: [u8; LIFECYCLE_COUNT_SIZE] = reversed[LIFECYCLE_STATE_SIZE..]
+        .try_into()
+        .expect("slice length mismatch");
+    let state = lc_decode_state_mem(&state_mem)?;
+    let count = lc_decode_count_mem(&count_mem)?;
+    Ok((state, count))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_decode_roundtrip_all_states() {
+        for state_val in 0..=20u8 {
+            let memory = lc_generate_memory(state_val, 1).unwrap();
+            let (decoded_state, decoded_count) = lc_decode_memory(&memory).unwrap();
+            assert_eq!(
+                decoded_state, state_val,
+                "state roundtrip failed for {state_val}"
+            );
+            assert_eq!(
+                decoded_count, 1,
+                "count roundtrip failed for state {state_val}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_decode_roundtrip_all_counts() {
+        let prod_state = 17u8; // Prod
+        for count in 0..=24u8 {
+            let memory = lc_generate_memory(prod_state, count).unwrap();
+            let (decoded_state, decoded_count) = lc_decode_memory(&memory).unwrap();
+            assert_eq!(decoded_state, prod_state);
+            assert_eq!(
+                decoded_count, count,
+                "count roundtrip failed for count {count}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_decode_raw_state() {
+        let memory = lc_generate_memory(0, 0).unwrap(); // Raw = 0
+        let (state, count) = lc_decode_memory(&memory).unwrap();
+        assert_eq!(state, 0);
+        assert_eq!(count, 0);
+    }
+}

--- a/emulator/app/Cargo.toml
+++ b/emulator/app/Cargo.toml
@@ -39,6 +39,7 @@ log.workspace = true
 lazy_static.workspace = true
 mcu-mbox-common.workspace = true
 mcu-testing-common.workspace = true
+otp-lifecycle.workspace = true
 p384.workspace = true
 pldm-common.workspace = true
 pldm-fw-pkg.workspace = true

--- a/emulator/app/src/emulator.rs
+++ b/emulator/app/src/emulator.rs
@@ -81,6 +81,19 @@ fn parse_vendor_pqc_type(s: &str) -> Result<FwVerificationPqcKeyType, String> {
     }
 }
 
+/// Map an LC state index (0–20) to the Caliptra device lifecycle string per the HW spec.
+/// TestUnlocked* → "unprovisioned", Dev → "manufacturing", all others → "production".
+fn lc_state_to_device_lifecycle_str(lc_state_index: u32) -> &'static str {
+    match lc_state_index {
+        // TestUnlocked0..TestUnlocked7 = indices 1,3,5,7,9,11,13,15
+        1 | 3 | 5 | 7 | 9 | 11 | 13 | 15 => "unprovisioned",
+        // Dev = index 16
+        16 => "manufacturing",
+        // Raw, TestLocked*, Prod, ProdEnd, Rma, Scrap, PostTransition → production
+        _ => "production",
+    }
+}
+
 #[derive(Parser, Debug, Clone)]
 #[command(version, about, long_about = None, name = "Caliptra MCU Emulator")]
 pub struct EmulatorArgs {
@@ -334,20 +347,58 @@ impl Emulator {
                 ),
             )
         })?;
+        if device_lifecycle == DeviceLifecycle::Reserved2 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "Reserved device lifecycle value (2) is not supported by the emulator",
+            ));
+        }
 
-        let device_lifecycle_str: Option<String> = match device_lifecycle {
-            DeviceLifecycle::Manufacturing => Some("manufacturing".into()),
-            DeviceLifecycle::Production => Some("production".into()),
-            DeviceLifecycle::Unprovisioned => Some("unprovisioned".into()),
-            DeviceLifecycle::Reserved2 => {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidInput,
-                    "Reserved device lifecycle value (2) is not supported by the emulator",
-                ))
-            }
+        // Determine lifecycle state from OTP fuses (source of truth) or CLI arg.
+        // If OTP file has lifecycle fuses, decode the state from them.
+        // Otherwise, generate fuse data from the --device-security-state CLI arg.
+        let (lc_state_index, lc_transition_cnt, lifecycle_fuse_data) = if let Some(lc_bytes) = cli
+            .otp
+            .as_ref()
+            .and_then(|p| Otp::read_lifecycle_from_file(p))
+        {
+            let mem: [u8; otp_lifecycle::LIFECYCLE_MEM_SIZE] =
+                lc_bytes.try_into().map_err(|_| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "OTP lifecycle partition has wrong size",
+                    )
+                })?;
+            let (state, count) = otp_lifecycle::lc_decode_memory(&mem).map_err(|e| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("Failed to decode lifecycle from OTP fuses: {e}"),
+                )
+            })?;
+            (state as u32, count as u32, None)
+        } else {
+            // No existing fuses — generate from CLI arg.
+            let (idx, cnt) = match device_lifecycle {
+                DeviceLifecycle::Unprovisioned => (1u8, 1u8), // TestUnlocked0
+                DeviceLifecycle::Manufacturing => (16u8, 1u8), // Dev
+                DeviceLifecycle::Production => (17u8, 1u8),   // Prod
+                _ => (17u8, 1u8),
+            };
+            let fuse_data = otp_lifecycle::lc_generate_memory(idx, cnt).map_err(|e| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("Failed to generate lifecycle fuses: {e}"),
+                )
+            })?;
+            (idx as u32, cnt as u32, Some(fuse_data.to_vec()))
         };
 
-        let req_idevid_csr: Option<bool> = if device_lifecycle == DeviceLifecycle::Manufacturing {
+        // Map LC state index to Caliptra device lifecycle string per the HW spec.
+        let device_lifecycle_str: Option<String> =
+            Some(lc_state_to_device_lifecycle_str(lc_state_index).into());
+
+        let req_idevid_csr: Option<bool> = if lc_state_index == 16 {
+            // Dev state → manufacturing
             Some(true)
         } else {
             None
@@ -787,7 +838,10 @@ impl Emulator {
             .fuse_vendor_test_partition
             .map(|fuse| hex::decode(fuse).expect("Invalid hex in vendor_test_partition"));
 
-        let lc = LcCtrl::new();
+        // Map DeviceLifecycle to LC state index per the Caliptra SS HW spec
+        // (caliptra-ss docs/CaliptraSSHardwareSpecification.md, LCC state table).
+        // The lifecycle state was already resolved above from fuses or CLI arg.
+        let lc = LcCtrl::with_state(lc_state_index, lc_transition_cnt);
 
         let otp = Otp::new(
             &clock.clone(),
@@ -800,6 +854,7 @@ impl Emulator {
                 soc_manifest_max_svn: cli.fuse_soc_manifest_max_svn.map(|v| v as u8),
                 vendor_hashes_prod_partition: fuse_vendor_hashes_prod_partition,
                 vendor_test_partition: fuse_vendor_test_partition,
+                lifecycle_state: lifecycle_fuse_data,
                 ..Default::default()
             },
         )?;

--- a/emulator/periph/Cargo.toml
+++ b/emulator/periph/Cargo.toml
@@ -22,6 +22,7 @@ lazy_static.workspace = true
 mcu-testing-common.workspace = true
 num_enum.workspace = true
 otp-digest.workspace = true
+otp-lifecycle.workspace = true
 registers-generated.workspace = true
 semver.workspace = true
 serde_json.workspace = true

--- a/emulator/periph/src/lc_ctrl.rs
+++ b/emulator/periph/src/lc_ctrl.rs
@@ -9,6 +9,7 @@ File Name:
 Abstract:
 
     OpenTitan Lifecycle controller emulated device.
+    Reads the lifecycle state and transition count from OTP fuse data.
 
 --*/
 
@@ -17,21 +18,36 @@ use emulator_registers_generated::lc::LcGenerated;
 use registers_generated::lc_ctrl;
 use tock_registers::interfaces::Readable;
 
+/// Compute the 30-bit LC state mnemonic from a 5-bit state index
+/// by replicating it 6 times across the 30-bit field.
+fn calc_lc_state_mnemonic(state_5bit: u32) -> u32 {
+    let s = state_5bit & 0x1F;
+    (s << 25) | (s << 20) | (s << 15) | (s << 10) | (s << 5) | s
+}
+
 pub struct LcCtrl {
     status: ReadWriteRegister<u32, lc_ctrl::bits::Status::Register>,
+    /// 30-bit lifecycle state mnemonic (5-bit state replicated 6×).
+    lc_state: u32,
+    /// Lifecycle transition count.
+    lc_transition_cnt: u32,
     generated: LcGenerated,
 }
 
 impl Default for LcCtrl {
     fn default() -> Self {
-        Self::new()
+        Self::with_state(0, 0)
     }
 }
 
 impl LcCtrl {
-    pub fn new() -> Self {
+    /// Create a new lifecycle controller with the given raw state index (0-20)
+    /// and transition count. The state index is encoded into the 30-bit mnemonic.
+    pub fn with_state(lc_state_index: u32, lc_transition_cnt: u32) -> Self {
         Self {
             status: 0x3.into(), // initialized and ready
+            lc_state: calc_lc_state_mnemonic(lc_state_index),
+            lc_transition_cnt,
             generated: LcGenerated::default(),
         }
     }
@@ -44,5 +60,15 @@ impl emulator_registers_generated::lc::LcPeripheral for LcCtrl {
 
     fn read_status(&mut self) -> ReadWriteRegister<u32, lc_ctrl::bits::Status::Register> {
         ReadWriteRegister::new(self.status.reg.get())
+    }
+
+    fn read_lc_state(&mut self) -> ReadWriteRegister<u32, lc_ctrl::bits::LcState::Register> {
+        ReadWriteRegister::new(self.lc_state)
+    }
+
+    fn read_lc_transition_cnt(
+        &mut self,
+    ) -> ReadWriteRegister<u32, lc_ctrl::bits::LcTransitionCnt::Register> {
+        ReadWriteRegister::new(self.lc_transition_cnt)
     }
 }

--- a/emulator/periph/src/otp.rs
+++ b/emulator/periph/src/otp.rs
@@ -23,8 +23,8 @@ use serde::{Deserialize, Serialize};
 use std::cell::RefCell;
 use std::collections::HashSet;
 use std::fs::File;
-use std::io::Seek;
-use std::path::PathBuf;
+use std::io::{Read, Seek};
+use std::path::{Path, PathBuf};
 use std::rc::Rc;
 #[allow(unused_imports)] // Rust compiler doesn't like these
 use tock_registers::interfaces::{Readable, Writeable};
@@ -55,6 +55,9 @@ pub struct OtpArgs {
     pub soc_manifest_max_svn: Option<u8>,
     pub vendor_hashes_prod_partition: Option<Vec<u8>>,
     pub vendor_test_partition: Option<Vec<u8>>,
+    /// Raw lifecycle partition data (LIFECYCLE_MEM_SIZE bytes) to provision.
+    /// If set, written to the LIFE_CYCLE partition in OTP.
+    pub lifecycle_state: Option<Vec<u8>>,
 }
 
 //#[derive(Bus)]
@@ -170,6 +173,17 @@ impl Otp {
                 partitions[dst_start..dst_start + copy_len]
                     .copy_from_slice(&vendor_test_partition[..copy_len]);
             }
+
+            // Provision lifecycle fuses if provided and current fuses are blank.
+            if let Some(lc_data) = args.lifecycle_state {
+                let lc_start = fuses::LIFE_CYCLE_BYTE_OFFSET;
+                let lc_end = lc_start + fuses::LIFE_CYCLE_BYTE_SIZE;
+                let current_lc = &partitions[lc_start..lc_end];
+                if current_lc.iter().all(|&b| b == 0) {
+                    let copy_len = lc_data.len().min(fuses::LIFE_CYCLE_BYTE_SIZE);
+                    partitions[lc_start..lc_start + copy_len].copy_from_slice(&lc_data[..copy_len]);
+                }
+            }
         }
 
         // if there were digests that were pending a reset, then calculate them now
@@ -186,6 +200,36 @@ impl Otp {
     /// This allows the model to hold a reference to the OTP memory.
     pub fn partitions_ref(&self) -> Rc<RefCell<Vec<u8>>> {
         self.partitions.clone()
+    }
+
+    /// Extract the raw lifecycle partition bytes from OTP partition data.
+    /// Returns None if the lifecycle region is all zeros (unprovisioned).
+    pub fn lifecycle_bytes_from_partitions(partitions: &[u8]) -> Option<Vec<u8>> {
+        let lc_start = fuses::LIFE_CYCLE_BYTE_OFFSET;
+        let lc_end = lc_start + fuses::LIFE_CYCLE_BYTE_SIZE;
+        if partitions.len() < lc_end {
+            return None;
+        }
+        let lc_data = &partitions[lc_start..lc_end];
+        if lc_data.iter().all(|&b| b == 0) {
+            None
+        } else {
+            Some(lc_data.to_vec())
+        }
+    }
+
+    /// Read the lifecycle partition bytes from a saved OTP file.
+    /// Returns None if file doesn't exist, is empty, or lifecycle is unprovisioned.
+    pub fn read_lifecycle_from_file(path: &Path) -> Option<Vec<u8>> {
+        let mut file = File::open(path).ok()?;
+        let len = file.metadata().ok()?.len();
+        if len == 0 {
+            return None;
+        }
+        let mut contents = Vec::new();
+        file.read_to_end(&mut contents).ok()?;
+        let state: OtpState = serde_json::from_slice(&contents).ok()?;
+        Self::lifecycle_bytes_from_partitions(&state.partitions)
     }
 
     fn calculate_digests(&mut self) -> Result<(), std::io::Error> {

--- a/hw/model/Cargo.toml
+++ b/hw/model/Cargo.toml
@@ -40,6 +40,7 @@ mcu-config-fpga = { workspace = true, optional = true }
 mcu-config.workspace = true
 mcu-rom-common.workspace = true
 mcu-testing-common.workspace = true
+otp-lifecycle.workspace = true
 p384.workspace = true
 poll-common.workspace = true
 rand.workspace = true

--- a/hw/model/src/lib.rs
+++ b/hw/model/src/lib.rs
@@ -48,7 +48,7 @@ mod mcu_mgr;
 mod model_emulated;
 #[cfg(feature = "fpga_realtime")]
 mod model_fpga_realtime;
-mod otp_provision;
+pub mod otp_provision;
 mod vmem;
 
 pub enum ShaAccMode {

--- a/hw/model/src/model_emulated.rs
+++ b/hw/model/src/model_emulated.rs
@@ -197,7 +197,20 @@ impl McuHwModel for ModelEmulated {
                 .copy_from_slice(&mem);
         }
 
-        let lc = LcCtrl::new();
+        // Derive LC state from the provisioned OTP fuses (source of truth).
+        let lc_bytes = &otp_mem[fuses::LIFE_CYCLE_BYTE_OFFSET
+            ..fuses::LIFE_CYCLE_BYTE_OFFSET + fuses::LIFE_CYCLE_BYTE_SIZE];
+        let (lc_state_index, lc_transition_cnt) = if lc_bytes.iter().any(|&b| b != 0) {
+            let mem: [u8; otp_lifecycle::LIFECYCLE_MEM_SIZE] = lc_bytes
+                .try_into()
+                .expect("lifecycle partition size mismatch");
+            let (state_idx, count) = otp_lifecycle::lc_decode_memory(&mem)?;
+            (state_idx as u32, count as u32)
+        } else {
+            (0, 0)
+        };
+
+        let lc = LcCtrl::with_state(lc_state_index, lc_transition_cnt);
 
         let otp = Otp::new(
             &clock.clone(),
@@ -264,9 +277,21 @@ impl McuHwModel for ModelEmulated {
 
         emulator_periph::AxiCDMA::set_dma_ram(&mut dma_ctrl, dma_ram.clone());
 
+        // Map LC state to Caliptra device lifecycle per the Caliptra SS HW spec
+        // (caliptra-ss docs/CaliptraSSHardwareSpecification.md, LCC state table).
         let device_lifecycle: Option<String> = match params.lifecycle_controller_state {
             Some(LifecycleControllerState::Dev) => Some("manufacturing".into()),
-            Some(LifecycleControllerState::Raw) => Some("unprovisioned".into()),
+            Some(
+                LifecycleControllerState::TestUnlocked0
+                | LifecycleControllerState::TestUnlocked1
+                | LifecycleControllerState::TestUnlocked2
+                | LifecycleControllerState::TestUnlocked3
+                | LifecycleControllerState::TestUnlocked4
+                | LifecycleControllerState::TestUnlocked5
+                | LifecycleControllerState::TestUnlocked6
+                | LifecycleControllerState::TestUnlocked7,
+            ) => Some("unprovisioned".into()),
+            // Raw, TestLocked*, Prod, ProdEnd, Rma, Scrap all map to production
             _ => Some("production".into()),
         };
 

--- a/hw/model/src/otp_provision.rs
+++ b/hw/model/src/otp_provision.rs
@@ -5,306 +5,16 @@ use emulator_periph::{otp_digest, otp_scramble, otp_unscramble};
 use mcu_rom_common::LifecycleControllerState;
 use sha3::{digest::ExtendableOutput, digest::Update, CShake128, CShake128Core};
 
-// These are the default lifecycle controller constants from the
-// standard Caliptra RTL. These can be overridden by vendors.
-
-// from caliptra-rtl/src/lc_ctrl/rtl/lc_ctrl_state_pkg.sv
-const _A0: u16 = 0b0110010010101110; // ECC: 6'b001010
-const B0: u16 = 0b0111010111101110; // ECC: 6'b111110
-const A1: u16 = 0b0000011110110100; // ECC: 6'b100101
-const B1: u16 = 0b0000111111111110; // ECC: 6'b111101
-const A2: u16 = 0b0011000111010010; // ECC: 6'b000111
-const B2: u16 = 0b0111101111111110; // ECC: 6'b000111
-const A3: u16 = 0b0010111001001101; // ECC: 6'b001010
-const B3: u16 = 0b0011111101101111; // ECC: 6'b111010
-const A4: u16 = 0b0100000111111000; // ECC: 6'b011010
-const B4: u16 = 0b0101111111111100; // ECC: 6'b011110
-const A5: u16 = 0b1010110010000101; // ECC: 6'b110001
-const B5: u16 = 0b1111110110011111; // ECC: 6'b110001
-const A6: u16 = 0b1001100110001100; // ECC: 6'b010110
-const B6: u16 = 0b1111100110011111; // ECC: 6'b011110
-const A7: u16 = 0b0101001100001111; // ECC: 6'b100010
-const B7: u16 = 0b1101101101101111; // ECC: 6'b100111
-const A8: u16 = 0b0111000101100000; // ECC: 6'b111001
-const B8: u16 = 0b0111001101111111; // ECC: 6'b111001
-const A9: u16 = 0b0010110001100011; // ECC: 6'b101010
-const B9: u16 = 0b0110110001101111; // ECC: 6'b111111
-const A10: u16 = 0b0110110100001000; // ECC: 6'b110011
-const B10: u16 = 0b0110111110011110; // ECC: 6'b111011
-const A11: u16 = 0b1001001001001100; // ECC: 6'b000011
-const B11: u16 = 0b1101001111011100; // ECC: 6'b111111
-const A12: u16 = 0b0111000001000000; // ECC: 6'b011110
-const B12: u16 = 0b0111011101010010; // ECC: 6'b111110
-const A13: u16 = 0b1001001010111110; // ECC: 6'b000010
-const B13: u16 = 0b1111001011111110; // ECC: 6'b101110
-const A14: u16 = 0b1001010011010010; // ECC: 6'b100011
-const B14: u16 = 0b1011110111010011; // ECC: 6'b101111
-const A15: u16 = 0b0110001010001101; // ECC: 6'b000111
-const B15: u16 = 0b0110111111001101; // ECC: 6'b011111
-const A16: u16 = 0b1011001000101000; // ECC: 6'b010111
-const B16: u16 = 0b1011001011111011; // ECC: 6'b011111
-const A17: u16 = 0b0001111001110001; // ECC: 6'b001001
-const B17: u16 = 0b1001111111110101; // ECC: 6'b011011
-const A18: u16 = 0b0010110110011011; // ECC: 6'b000100
-const B18: u16 = 0b0011111111011111; // ECC: 6'b010101
-const A19: u16 = 0b0100110110001100; // ECC: 6'b101010
-const B19: u16 = 0b1101110110111110; // ECC: 6'b101011
-
-// The C/D values are used for the encoded LC transition counter.
-
-const _C0: u16 = 0b0001010010011110; // ECC: 6'b011100
-const D0: u16 = 0b1011011011011111; // ECC: 6'b111100
-const C1: u16 = 0b0101101011000100; // ECC: 6'b111000
-const D1: u16 = 0b1111101011110100; // ECC: 6'b111101
-const C2: u16 = 0b0001111100100100; // ECC: 6'b100011
-const D2: u16 = 0b0001111110111111; // ECC: 6'b100111
-const C3: u16 = 0b1100111010000101; // ECC: 6'b011000
-const D3: u16 = 0b1100111011101111; // ECC: 6'b011011
-const C4: u16 = 0b0100001010011111; // ECC: 6'b011000
-const D4: u16 = 0b0101101110111111; // ECC: 6'b111100
-const C5: u16 = 0b1001111000100010; // ECC: 6'b111000
-const D5: u16 = 0b1111111110100010; // ECC: 6'b111110
-const C6: u16 = 0b0010011110000110; // ECC: 6'b010000
-const D6: u16 = 0b0111011111000110; // ECC: 6'b011101
-const C7: u16 = 0b0010111101000110; // ECC: 6'b000110
-const D7: u16 = 0b1010111111000110; // ECC: 6'b111111
-const C8: u16 = 0b0000001011011011; // ECC: 6'b000001
-const D8: u16 = 0b1010101111011011; // ECC: 6'b111011
-const C9: u16 = 0b0111000011000110; // ECC: 6'b110001
-const D9: u16 = 0b1111111011001110; // ECC: 6'b110011
-const C10: u16 = 0b0100001000010010; // ECC: 6'b110110
-const D10: u16 = 0b0111001010110110; // ECC: 6'b110111
-const C11: u16 = 0b0100101111110001; // ECC: 6'b000001
-const D11: u16 = 0b0110101111110011; // ECC: 6'b110111
-const C12: u16 = 0b1000100101000001; // ECC: 6'b000001
-const D12: u16 = 0b1011110101001111; // ECC: 6'b001011
-const C13: u16 = 0b1000000000010001; // ECC: 6'b011111
-const D13: u16 = 0b1001100010110011; // ECC: 6'b111111
-const C14: u16 = 0b0101110000000100; // ECC: 6'b111110
-const D14: u16 = 0b1111111010001101; // ECC: 6'b111110
-const C15: u16 = 0b1100001000001001; // ECC: 6'b001011
-const D15: u16 = 0b1110011000011011; // ECC: 6'b111011
-const C16: u16 = 0b0101001001101100; // ECC: 6'b001000
-const D16: u16 = 0b0111111001111110; // ECC: 6'b001001
-const C17: u16 = 0b0100001001110100; // ECC: 6'b010100
-const D17: u16 = 0b1100101001110111; // ECC: 6'b110110
-const C18: u16 = 0b1100000001100111; // ECC: 6'b100000
-const D18: u16 = 0b1100011101110111; // ECC: 6'b100101
-const C19: u16 = 0b1010000001001010; // ECC: 6'b101111
-const D19: u16 = 0b1111011101101010; // ECC: 6'b101111
-const C20: u16 = 0b1001001001010101; // ECC: 6'b001110
-const D20: u16 = 0b1101111011011101; // ECC: 6'b001111
-const C21: u16 = 0b1001010000011011; // ECC: 6'b100000
-const D21: u16 = 0b1001111000111011; // ECC: 6'b110101
-const C22: u16 = 0b1011101101100001; // ECC: 6'b000100
-const D22: u16 = 0b1011111101111111; // ECC: 6'b000110
-const C23: u16 = 0b1101101000000111; // ECC: 6'b001100
-const D23: u16 = 0b1101111011100111; // ECC: 6'b101110
-const ZRO: u16 = 0b0000000000000000; // ECC: 6'b000000
-
-const COUNTS: [[u16; 24]; 25] = [
-    [
-        ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO,
-        ZRO, ZRO, ZRO, ZRO, ZRO, ZRO,
-    ],
-    [
-        C23, C22, C21, C20, C19, C18, C17, C16, C15, C14, C13, C12, C11, C10, C9, C8, C7, C6, C5,
-        C4, C3, C2, C1, D0,
-    ],
-    [
-        C23, C22, C21, C20, C19, C18, C17, C16, C15, C14, C13, C12, C11, C10, C9, C8, C7, C6, C5,
-        C4, C3, C2, D1, D0,
-    ],
-    [
-        C23, C22, C21, C20, C19, C18, C17, C16, C15, C14, C13, C12, C11, C10, C9, C8, C7, C6, C5,
-        C4, C3, D2, D1, D0,
-    ],
-    [
-        C23, C22, C21, C20, C19, C18, C17, C16, C15, C14, C13, C12, C11, C10, C9, C8, C7, C6, C5,
-        C4, D3, D2, D1, D0,
-    ],
-    [
-        C23, C22, C21, C20, C19, C18, C17, C16, C15, C14, C13, C12, C11, C10, C9, C8, C7, C6, C5,
-        D4, D3, D2, D1, D0,
-    ],
-    [
-        C23, C22, C21, C20, C19, C18, C17, C16, C15, C14, C13, C12, C11, C10, C9, C8, C7, C6, D5,
-        D4, D3, D2, D1, D0,
-    ],
-    [
-        C23, C22, C21, C20, C19, C18, C17, C16, C15, C14, C13, C12, C11, C10, C9, C8, C7, D6, D5,
-        D4, D3, D2, D1, D0,
-    ],
-    [
-        C23, C22, C21, C20, C19, C18, C17, C16, C15, C14, C13, C12, C11, C10, C9, C8, D7, D6, D5,
-        D4, D3, D2, D1, D0,
-    ],
-    [
-        C23, C22, C21, C20, C19, C18, C17, C16, C15, C14, C13, C12, C11, C10, C9, D8, D7, D6, D5,
-        D4, D3, D2, D1, D0,
-    ],
-    [
-        C23, C22, C21, C20, C19, C18, C17, C16, C15, C14, C13, C12, C11, C10, D9, D8, D7, D6, D5,
-        D4, D3, D2, D1, D0,
-    ],
-    [
-        C23, C22, C21, C20, C19, C18, C17, C16, C15, C14, C13, C12, C11, D10, D9, D8, D7, D6, D5,
-        D4, D3, D2, D1, D0,
-    ],
-    [
-        C23, C22, C21, C20, C19, C18, C17, C16, C15, C14, C13, C12, D11, D10, D9, D8, D7, D6, D5,
-        D4, D3, D2, D1, D0,
-    ],
-    [
-        C23, C22, C21, C20, C19, C18, C17, C16, C15, C14, C13, D12, D11, D10, D9, D8, D7, D6, D5,
-        D4, D3, D2, D1, D0,
-    ],
-    [
-        C23, C22, C21, C20, C19, C18, C17, C16, C15, C14, D13, D12, D11, D10, D9, D8, D7, D6, D5,
-        D4, D3, D2, D1, D0,
-    ],
-    [
-        C23, C22, C21, C20, C19, C18, C17, C16, C15, D14, D13, D12, D11, D10, D9, D8, D7, D6, D5,
-        D4, D3, D2, D1, D0,
-    ],
-    [
-        C23, C22, C21, C20, C19, C18, C17, C16, D15, D14, D13, D12, D11, D10, D9, D8, D7, D6, D5,
-        D4, D3, D2, D1, D0,
-    ],
-    [
-        C23, C22, C21, C20, C19, C18, C17, D16, D15, D14, D13, D12, D11, D10, D9, D8, D7, D6, D5,
-        D4, D3, D2, D1, D0,
-    ],
-    [
-        C23, C22, C21, C20, C19, C18, D17, D16, D15, D14, D13, D12, D11, D10, D9, D8, D7, D6, D5,
-        D4, D3, D2, D1, D0,
-    ],
-    [
-        C23, C22, C21, C20, C19, D18, D17, D16, D15, D14, D13, D12, D11, D10, D9, D8, D7, D6, D5,
-        D4, D3, D2, D1, D0,
-    ],
-    [
-        C23, C22, C21, C20, D19, D18, D17, D16, D15, D14, D13, D12, D11, D10, D9, D8, D7, D6, D5,
-        D4, D3, D2, D1, D0,
-    ],
-    [
-        C23, C22, C21, D20, D19, D18, D17, D16, D15, D14, D13, D12, D11, D10, D9, D8, D7, D6, D5,
-        D4, D3, D2, D1, D0,
-    ],
-    [
-        C23, C22, D21, D20, D19, D18, D17, D16, D15, D14, D13, D12, D11, D10, D9, D8, D7, D6, D5,
-        D4, D3, D2, D1, D0,
-    ],
-    [
-        C23, D22, D21, D20, D19, D18, D17, D16, D15, D14, D13, D12, D11, D10, D9, D8, D7, D6, D5,
-        D4, D3, D2, D1, D0,
-    ],
-    [
-        D23, D22, D21, D20, D19, D18, D17, D16, D15, D14, D13, D12, D11, D10, D9, D8, D7, D6, D5,
-        D4, D3, D2, D1, D0,
-    ],
-];
-
-const STATES: [[u16; 20]; 21] = [
-    [
-        ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO,
-        ZRO, ZRO,
-    ],
-    [
-        A19, A18, A17, A16, A15, A14, A13, A12, A11, A10, A9, A8, A7, A6, A5, A4, A3, A2, A1, B0,
-    ],
-    [
-        A19, A18, A17, A16, A15, A14, A13, A12, A11, A10, A9, A8, A7, A6, A5, A4, A3, A2, B1, B0,
-    ],
-    [
-        A19, A18, A17, A16, A15, A14, A13, A12, A11, A10, A9, A8, A7, A6, A5, A4, A3, B2, B1, B0,
-    ],
-    [
-        A19, A18, A17, A16, A15, A14, A13, A12, A11, A10, A9, A8, A7, A6, A5, A4, B3, B2, B1, B0,
-    ],
-    [
-        A19, A18, A17, A16, A15, A14, A13, A12, A11, A10, A9, A8, A7, A6, A5, B4, B3, B2, B1, B0,
-    ],
-    [
-        A19, A18, A17, A16, A15, A14, A13, A12, A11, A10, A9, A8, A7, A6, B5, B4, B3, B2, B1, B0,
-    ],
-    [
-        A19, A18, A17, A16, A15, A14, A13, A12, A11, A10, A9, A8, A7, B6, B5, B4, B3, B2, B1, B0,
-    ],
-    [
-        A19, A18, A17, A16, A15, A14, A13, A12, A11, A10, A9, A8, B7, B6, B5, B4, B3, B2, B1, B0,
-    ],
-    [
-        A19, A18, A17, A16, A15, A14, A13, A12, A11, A10, A9, B8, B7, B6, B5, B4, B3, B2, B1, B0,
-    ],
-    [
-        A19, A18, A17, A16, A15, A14, A13, A12, A11, A10, B9, B8, B7, B6, B5, B4, B3, B2, B1, B0,
-    ],
-    [
-        A19, A18, A17, A16, A15, A14, A13, A12, A11, B10, B9, B8, B7, B6, B5, B4, B3, B2, B1, B0,
-    ],
-    [
-        A19, A18, A17, A16, A15, A14, A13, A12, B11, B10, B9, B8, B7, B6, B5, B4, B3, B2, B1, B0,
-    ],
-    [
-        A19, A18, A17, A16, A15, A14, A13, B12, B11, B10, B9, B8, B7, B6, B5, B4, B3, B2, B1, B0,
-    ],
-    [
-        A19, A18, A17, A16, A15, A14, B13, B12, B11, B10, B9, B8, B7, B6, B5, B4, B3, B2, B1, B0,
-    ],
-    [
-        A19, A18, A17, A16, A15, B14, B13, B12, B11, B10, B9, B8, B7, B6, B5, B4, B3, B2, B1, B0,
-    ],
-    [
-        A19, A18, A17, A16, B15, B14, B13, B12, B11, B10, B9, B8, B7, B6, B5, B4, B3, B2, B1, B0,
-    ],
-    [
-        A19, A18, A17, B16, B15, B14, B13, B12, B11, B10, B9, B8, B7, B6, B5, B4, B3, B2, B1, B0,
-    ],
-    [
-        A19, A18, B17, B16, B15, B14, B13, B12, B11, B10, B9, B8, B7, B6, B5, B4, B3, B2, B1, B0,
-    ],
-    [
-        A19, B18, B17, B16, B15, B14, B13, B12, B11, B10, B9, B8, B7, B6, B5, B4, B3, B2, B1, B0,
-    ],
-    [
-        B19, B18, B17, B16, B15, B14, B13, B12, B11, B10, B9, B8, B7, B6, B5, B4, B3, B2, B1, B0,
-    ],
-];
-
-pub const LIFECYCLE_STATE_SIZE: usize = 40;
-pub const LIFECYCLE_COUNT_SIZE: usize = 48;
-pub const LIFECYCLE_MEM_SIZE: usize = LIFECYCLE_STATE_SIZE + LIFECYCLE_COUNT_SIZE;
+// Re-export lifecycle ECC encode/decode from the common crate.
+pub use otp_lifecycle::{
+    lc_generate_count_mem, LIFECYCLE_COUNT_SIZE, LIFECYCLE_MEM_SIZE, LIFECYCLE_STATE_SIZE,
+};
 
 /// Generate the OTP memory contents associated with the lifecycle state.
 pub fn lc_generate_state_mem(
     state: LifecycleControllerState,
 ) -> Result<[u8; LIFECYCLE_STATE_SIZE]> {
-    let state = u8::from(state);
-    if state >= STATES.len() as u8 {
-        bail!("Invalid lifecycle state: {:?}", state);
-    }
-    let mut result = [0u8; 40];
-    let state_data = STATES[state as usize];
-    for (i, &value) in state_data.iter().enumerate() {
-        result[i * 2] = (value >> 8) as u8;
-        result[i * 2 + 1] = (value & 0xFF) as u8;
-    }
-    Ok(result)
-}
-
-/// Generate the OTP memory contents associated with the lifecycle transition count.
-pub fn lc_generate_count_mem(count: u8) -> Result<[u8; LIFECYCLE_COUNT_SIZE]> {
-    if count >= COUNTS.len() as u8 {
-        bail!("Invalid lifecycle count: {:?}", count);
-    }
-    let mut result = [0u8; 48];
-    let count_data = COUNTS[count as usize];
-    for (i, &value) in count_data.iter().enumerate() {
-        result[i * 2] = (value >> 8) as u8;
-        result[i * 2 + 1] = (value & 0xFF) as u8;
-    }
-    Ok(result)
+    otp_lifecycle::lc_generate_state_mem(u8::from(state))
 }
 
 /// Generate the OTP memory contents associated with the lifecycle state and transition count.
@@ -312,14 +22,24 @@ pub fn lc_generate_memory(
     state: LifecycleControllerState,
     transition_count: u8,
 ) -> Result<[u8; LIFECYCLE_MEM_SIZE]> {
-    let mut result = [0u8; LIFECYCLE_MEM_SIZE];
-    let state = lc_generate_state_mem(state)?;
-    result[..state.len()].copy_from_slice(&state);
-    let count = lc_generate_count_mem(transition_count)?;
-    result[state.len()..state.len() + count.len()].copy_from_slice(&count);
-    result.reverse();
+    otp_lifecycle::lc_generate_memory(u8::from(state), transition_count)
+}
 
-    Ok(result)
+/// Decode the lifecycle state and transition count from OTP memory (as stored, i.e., reversed).
+pub fn lc_decode_memory(mem: &[u8; LIFECYCLE_MEM_SIZE]) -> Result<(LifecycleControllerState, u8)> {
+    let (state_idx, count) = otp_lifecycle::lc_decode_memory(mem)?;
+    Ok((LifecycleControllerState::from(state_idx), count))
+}
+
+/// Decode the lifecycle state from OTP memory (pre-reversal format).
+pub fn lc_decode_state_mem(mem: &[u8; LIFECYCLE_STATE_SIZE]) -> Result<LifecycleControllerState> {
+    let state_idx = otp_lifecycle::lc_decode_state_mem(mem)?;
+    Ok(LifecycleControllerState::from(state_idx))
+}
+
+/// Decode the lifecycle transition count from OTP memory (pre-reversal format).
+pub fn lc_decode_count_mem(mem: &[u8; LIFECYCLE_COUNT_SIZE]) -> Result<u8> {
+    otp_lifecycle::lc_decode_count_mem(mem)
 }
 
 /// Hash a token using cSHAKE128 for the lifecycle controller.
@@ -499,5 +219,43 @@ mod tests {
             0x9b, 0x2d, 0x8c, 0x4d,
         ];
         assert_eq!(memory, expected);
+    }
+
+    #[test]
+    fn test_decode_roundtrip_all_states() {
+        for state_val in 0..=20u8 {
+            let state = LifecycleControllerState::from(state_val);
+            let memory = lc_generate_memory(state, 1).unwrap();
+            let (decoded_state, decoded_count) = lc_decode_memory(&memory).unwrap();
+            assert_eq!(
+                decoded_state, state,
+                "state roundtrip failed for {state_val}"
+            );
+            assert_eq!(
+                decoded_count, 1,
+                "count roundtrip failed for state {state_val}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_decode_roundtrip_all_counts() {
+        for count in 0..=24u8 {
+            let memory = lc_generate_memory(LifecycleControllerState::Prod, count).unwrap();
+            let (decoded_state, decoded_count) = lc_decode_memory(&memory).unwrap();
+            assert_eq!(decoded_state, LifecycleControllerState::Prod);
+            assert_eq!(
+                decoded_count, count,
+                "count roundtrip failed for count {count}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_decode_raw_state() {
+        let memory = lc_generate_memory(LifecycleControllerState::Raw, 0).unwrap();
+        let (state, count) = lc_decode_memory(&memory).unwrap();
+        assert_eq!(state, LifecycleControllerState::Raw);
+        assert_eq!(count, 0);
     }
 }


### PR DESCRIPTION
This makes OTP fuses the source of truth for lifecycle state.

The emulator now:
- Reads lifecycle state from OTP file fuses if they exist
- Falls back to generating fuse data from --device-security-state CLI arg
- Passes lifecycle fuse data to OTP for provisioning when blank
- Derives Caliptra security state from the resolved LC state index
- Creates LcCtrl from the same decoded/computed state

We extracted the lifecycle encoding/decodign code into a common crate so both the emulator and hw-model can share it.

Fixes #839