### PR TITLE
tests: cap MCTP capsule loopback test to 250 bytes

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -40,9 +40,8 @@ default-filter = """
 (package(tests-integration) and test(test_mcu_mbox_fips_periodic)) |
 (package(tests-integration) and test(test_i3c_constant_writes)) |
 (package(tests-integration) and test(test_i3c_simple)) |
-(package(tests-integration) and test(test_sw_digest_lock))
+(package(tests-integration) and test(test_sw_digest_lock)) |
+(package(tests-integration) and test(test_mctp_capsule_loopback))
 """
-# disabled for now due to flakiness of recovery boot
-# (package(tests-integration) and test(test_mctp_capsule_loopback)) |
 # disabled for now due to flakiness of firmware update
 # (package(tests-integration) and test(test_firmware_update_streaming_fpga)) |

--- a/runtime/kernel/capsules/src/test/mctp.rs
+++ b/runtime/kernel/capsules/src/test/mctp.rs
@@ -11,9 +11,8 @@ use kernel::ErrorCode;
 use romtime::println;
 
 pub const MCTP_TEST_REMOTE_EID: u8 = 0x20;
-pub const MCTP_TEST_MSG_SIZE: usize = 1000;
 
-static TEST_MSG_LEN_ARR: [usize; 4] = [64, 63, 256, 1000];
+static TEST_MSG_LEN_ARR: [usize; 7] = [1, 5, 32, 63, 64, 128, 250];
 
 pub trait TestClient {
     fn test_result(&self, passed: bool, npassed: usize, ntotal: usize);


### PR DESCRIPTION
And re-enable on FPGA, as there is no reason this shouldn't work now.

The FPGA has fixed buffer sizes of 256 bytes though, so anything larger than that can be flaky to send or receive.