### PR TITLE
Bump caliptra-sw reference; don't reinitialize FPGA in sw_digest_lock test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,7 +298,7 @@ checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 [[package]]
 name = "caliptra-api"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8d2b5823611bb2993db86c4be2256301fc08568#d8d2b5823611bb2993db86c4be2256301fc08568"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8d36b57afa01a7b3bb896c23e319f0b40d3e048e#8d36b57afa01a7b3bb896c23e319f0b40d3e048e"
 dependencies = [
  "bitflags 2.10.0",
  "caliptra-api-types",
@@ -313,7 +313,7 @@ dependencies = [
 [[package]]
 name = "caliptra-api-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8d2b5823611bb2993db86c4be2256301fc08568#d8d2b5823611bb2993db86c4be2256301fc08568"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8d36b57afa01a7b3bb896c23e319f0b40d3e048e#8d36b57afa01a7b3bb896c23e319f0b40d3e048e"
 dependencies = [
  "caliptra-image-types",
 ]
@@ -321,7 +321,7 @@ dependencies = [
 [[package]]
 name = "caliptra-auth-man-gen"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8d2b5823611bb2993db86c4be2256301fc08568#d8d2b5823611bb2993db86c4be2256301fc08568"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8d36b57afa01a7b3bb896c23e319f0b40d3e048e#8d36b57afa01a7b3bb896c23e319f0b40d3e048e"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",
@@ -336,7 +336,7 @@ dependencies = [
 [[package]]
 name = "caliptra-auth-man-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8d2b5823611bb2993db86c4be2256301fc08568#d8d2b5823611bb2993db86c4be2256301fc08568"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8d36b57afa01a7b3bb896c23e319f0b40d3e048e#8d36b57afa01a7b3bb896c23e319f0b40d3e048e"
 dependencies = [
  "bitfield",
  "bitflags 2.10.0",
@@ -351,7 +351,7 @@ dependencies = [
 [[package]]
 name = "caliptra-bitstream-downloader"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8d2b5823611bb2993db86c4be2256301fc08568#d8d2b5823611bb2993db86c4be2256301fc08568"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8d36b57afa01a7b3bb896c23e319f0b40d3e048e#8d36b57afa01a7b3bb896c23e319f0b40d3e048e"
 dependencies = [
  "anyhow",
  "clap 4.5.51",
@@ -365,7 +365,7 @@ dependencies = [
 [[package]]
 name = "caliptra-builder"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8d2b5823611bb2993db86c4be2256301fc08568#d8d2b5823611bb2993db86c4be2256301fc08568"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8d36b57afa01a7b3bb896c23e319f0b40d3e048e#8d36b57afa01a7b3bb896c23e319f0b40d3e048e"
 dependencies = [
  "anyhow",
  "caliptra-image-crypto",
@@ -390,7 +390,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cfi-derive"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8d2b5823611bb2993db86c4be2256301fc08568#d8d2b5823611bb2993db86c4be2256301fc08568"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8d36b57afa01a7b3bb896c23e319f0b40d3e048e#8d36b57afa01a7b3bb896c23e319f0b40d3e048e"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -412,7 +412,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cfi-lib"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8d2b5823611bb2993db86c4be2256301fc08568#d8d2b5823611bb2993db86c4be2256301fc08568"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8d36b57afa01a7b3bb896c23e319f0b40d3e048e#8d36b57afa01a7b3bb896c23e319f0b40d3e048e"
 dependencies = [
  "caliptra-error",
  "caliptra-registers",
@@ -427,7 +427,7 @@ source = "git+https://github.com/chipsalliance/caliptra-cfi.git?rev=a98e499d279e
 [[package]]
 name = "caliptra-coverage"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8d2b5823611bb2993db86c4be2256301fc08568#d8d2b5823611bb2993db86c4be2256301fc08568"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8d36b57afa01a7b3bb896c23e319f0b40d3e048e#8d36b57afa01a7b3bb896c23e319f0b40d3e048e"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -445,7 +445,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cpu"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8d2b5823611bb2993db86c4be2256301fc08568#d8d2b5823611bb2993db86c4be2256301fc08568"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8d36b57afa01a7b3bb896c23e319f0b40d3e048e#8d36b57afa01a7b3bb896c23e319f0b40d3e048e"
 dependencies = [
  "caliptra-drivers",
  "caliptra-registers",
@@ -455,7 +455,7 @@ dependencies = [
 [[package]]
 name = "caliptra-drivers"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8d2b5823611bb2993db86c4be2256301fc08568#d8d2b5823611bb2993db86c4be2256301fc08568"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8d36b57afa01a7b3bb896c23e319f0b40d3e048e#8d36b57afa01a7b3bb896c23e319f0b40d3e048e"
 dependencies = [
  "arrayvec",
  "bitfield",
@@ -482,7 +482,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-bus"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8d2b5823611bb2993db86c4be2256301fc08568#d8d2b5823611bb2993db86c4be2256301fc08568"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8d36b57afa01a7b3bb896c23e319f0b40d3e048e#8d36b57afa01a7b3bb896c23e319f0b40d3e048e"
 dependencies = [
  "caliptra-emu-types",
  "tock-registers",
@@ -492,7 +492,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-cpu"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8d2b5823611bb2993db86c4be2256301fc08568#d8d2b5823611bb2993db86c4be2256301fc08568"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8d36b57afa01a7b3bb896c23e319f0b40d3e048e#8d36b57afa01a7b3bb896c23e319f0b40d3e048e"
 dependencies = [
  "bit-vec",
  "bitfield",
@@ -506,7 +506,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8d2b5823611bb2993db86c4be2256301fc08568#d8d2b5823611bb2993db86c4be2256301fc08568"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8d36b57afa01a7b3bb896c23e319f0b40d3e048e#8d36b57afa01a7b3bb896c23e319f0b40d3e048e"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -521,7 +521,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-derive"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8d2b5823611bb2993db86c4be2256301fc08568#d8d2b5823611bb2993db86c4be2256301fc08568"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8d36b57afa01a7b3bb896c23e319f0b40d3e048e#8d36b57afa01a7b3bb896c23e319f0b40d3e048e"
 dependencies = [
  "caliptra-emu-bus",
  "caliptra-emu-types",
@@ -532,7 +532,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-periph"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8d2b5823611bb2993db86c4be2256301fc08568#d8d2b5823611bb2993db86c4be2256301fc08568"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8d36b57afa01a7b3bb896c23e319f0b40d3e048e#8d36b57afa01a7b3bb896c23e319f0b40d3e048e"
 dependencies = [
  "aes",
  "arrayref",
@@ -559,17 +559,17 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8d2b5823611bb2993db86c4be2256301fc08568#d8d2b5823611bb2993db86c4be2256301fc08568"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8d36b57afa01a7b3bb896c23e319f0b40d3e048e#8d36b57afa01a7b3bb896c23e319f0b40d3e048e"
 
 [[package]]
 name = "caliptra-error"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8d2b5823611bb2993db86c4be2256301fc08568#d8d2b5823611bb2993db86c4be2256301fc08568"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8d36b57afa01a7b3bb896c23e319f0b40d3e048e#8d36b57afa01a7b3bb896c23e319f0b40d3e048e"
 
 [[package]]
 name = "caliptra-gen-linker-scripts"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8d2b5823611bb2993db86c4be2256301fc08568#d8d2b5823611bb2993db86c4be2256301fc08568"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8d36b57afa01a7b3bb896c23e319f0b40d3e048e#8d36b57afa01a7b3bb896c23e319f0b40d3e048e"
 dependencies = [
  "caliptra_common",
 ]
@@ -577,7 +577,7 @@ dependencies = [
 [[package]]
 name = "caliptra-hw-model"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8d2b5823611bb2993db86c4be2256301fc08568#d8d2b5823611bb2993db86c4be2256301fc08568"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8d36b57afa01a7b3bb896c23e319f0b40d3e048e#8d36b57afa01a7b3bb896c23e319f0b40d3e048e"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -616,7 +616,7 @@ dependencies = [
 [[package]]
 name = "caliptra-hw-model-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8d2b5823611bb2993db86c4be2256301fc08568#d8d2b5823611bb2993db86c4be2256301fc08568"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8d36b57afa01a7b3bb896c23e319f0b40d3e048e#8d36b57afa01a7b3bb896c23e319f0b40d3e048e"
 dependencies = [
  "caliptra-api-types",
  "rand 0.8.5",
@@ -625,7 +625,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8d2b5823611bb2993db86c4be2256301fc08568#d8d2b5823611bb2993db86c4be2256301fc08568"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8d36b57afa01a7b3bb896c23e319f0b40d3e048e#8d36b57afa01a7b3bb896c23e319f0b40d3e048e"
 dependencies = [
  "anyhow",
  "caliptra-image-gen",
@@ -645,7 +645,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-elf"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8d2b5823611bb2993db86c4be2256301fc08568#d8d2b5823611bb2993db86c4be2256301fc08568"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8d36b57afa01a7b3bb896c23e319f0b40d3e048e#8d36b57afa01a7b3bb896c23e319f0b40d3e048e"
 dependencies = [
  "anyhow",
  "caliptra-image-gen",
@@ -656,7 +656,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-fake-keys"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8d2b5823611bb2993db86c4be2256301fc08568#d8d2b5823611bb2993db86c4be2256301fc08568"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8d36b57afa01a7b3bb896c23e319f0b40d3e048e#8d36b57afa01a7b3bb896c23e319f0b40d3e048e"
 dependencies = [
  "caliptra-image-gen",
  "caliptra-image-types",
@@ -667,7 +667,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-gen"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8d2b5823611bb2993db86c4be2256301fc08568#d8d2b5823611bb2993db86c4be2256301fc08568"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8d36b57afa01a7b3bb896c23e319f0b40d3e048e#8d36b57afa01a7b3bb896c23e319f0b40d3e048e"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",
@@ -684,7 +684,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8d2b5823611bb2993db86c4be2256301fc08568#d8d2b5823611bb2993db86c4be2256301fc08568"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8d36b57afa01a7b3bb896c23e319f0b40d3e048e#8d36b57afa01a7b3bb896c23e319f0b40d3e048e"
 dependencies = [
  "caliptra-cfi-derive",
  "caliptra-cfi-lib",
@@ -700,7 +700,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-verify"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8d2b5823611bb2993db86c4be2256301fc08568#d8d2b5823611bb2993db86c4be2256301fc08568"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8d36b57afa01a7b3bb896c23e319f0b40d3e048e#8d36b57afa01a7b3bb896c23e319f0b40d3e048e"
 dependencies = [
  "bitflags 2.10.0",
  "caliptra-cfi-derive",
@@ -715,7 +715,7 @@ dependencies = [
 [[package]]
 name = "caliptra-kat"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8d2b5823611bb2993db86c4be2256301fc08568#d8d2b5823611bb2993db86c4be2256301fc08568"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8d36b57afa01a7b3bb896c23e319f0b40d3e048e#8d36b57afa01a7b3bb896c23e319f0b40d3e048e"
 dependencies = [
  "caliptra-drivers",
  "caliptra-lms-types",
@@ -727,7 +727,7 @@ dependencies = [
 [[package]]
 name = "caliptra-lms-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8d2b5823611bb2993db86c4be2256301fc08568#d8d2b5823611bb2993db86c4be2256301fc08568"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8d36b57afa01a7b3bb896c23e319f0b40d3e048e#8d36b57afa01a7b3bb896c23e319f0b40d3e048e"
 dependencies = [
  "caliptra-cfi-derive",
  "caliptra-cfi-lib",
@@ -750,12 +750,12 @@ dependencies = [
 [[package]]
 name = "caliptra-okref"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8d2b5823611bb2993db86c4be2256301fc08568#d8d2b5823611bb2993db86c4be2256301fc08568"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8d36b57afa01a7b3bb896c23e319f0b40d3e048e#8d36b57afa01a7b3bb896c23e319f0b40d3e048e"
 
 [[package]]
 name = "caliptra-registers"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8d2b5823611bb2993db86c4be2256301fc08568#d8d2b5823611bb2993db86c4be2256301fc08568"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8d36b57afa01a7b3bb896c23e319f0b40d3e048e#8d36b57afa01a7b3bb896c23e319f0b40d3e048e"
 dependencies = [
  "caliptra-registers-latest",
 ]
@@ -763,7 +763,7 @@ dependencies = [
 [[package]]
 name = "caliptra-registers-latest"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8d2b5823611bb2993db86c4be2256301fc08568#d8d2b5823611bb2993db86c4be2256301fc08568"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8d36b57afa01a7b3bb896c23e319f0b40d3e048e#8d36b57afa01a7b3bb896c23e319f0b40d3e048e"
 dependencies = [
  "ureg",
 ]
@@ -771,7 +771,7 @@ dependencies = [
 [[package]]
 name = "caliptra-runtime"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8d2b5823611bb2993db86c4be2256301fc08568#d8d2b5823611bb2993db86c4be2256301fc08568"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8d36b57afa01a7b3bb896c23e319f0b40d3e048e#8d36b57afa01a7b3bb896c23e319f0b40d3e048e"
 dependencies = [
  "arrayvec",
  "bitfield",
@@ -806,7 +806,7 @@ dependencies = [
 [[package]]
 name = "caliptra-test"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8d2b5823611bb2993db86c4be2256301fc08568#d8d2b5823611bb2993db86c4be2256301fc08568"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8d36b57afa01a7b3bb896c23e319f0b40d3e048e#8d36b57afa01a7b3bb896c23e319f0b40d3e048e"
 dependencies = [
  "anyhow",
  "asn1",
@@ -838,7 +838,7 @@ dependencies = [
 [[package]]
 name = "caliptra-test-harness-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8d2b5823611bb2993db86c4be2256301fc08568#d8d2b5823611bb2993db86c4be2256301fc08568"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8d36b57afa01a7b3bb896c23e319f0b40d3e048e#8d36b57afa01a7b3bb896c23e319f0b40d3e048e"
 
 [[package]]
 name = "caliptra-util-host-mailbox-test-config"
@@ -852,7 +852,7 @@ dependencies = [
 [[package]]
 name = "caliptra-x509"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8d2b5823611bb2993db86c4be2256301fc08568#d8d2b5823611bb2993db86c4be2256301fc08568"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8d36b57afa01a7b3bb896c23e319f0b40d3e048e#8d36b57afa01a7b3bb896c23e319f0b40d3e048e"
 dependencies = [
  "zeroize",
 ]
@@ -860,7 +860,7 @@ dependencies = [
 [[package]]
 name = "caliptra_common"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8d2b5823611bb2993db86c4be2256301fc08568#d8d2b5823611bb2993db86c4be2256301fc08568"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8d36b57afa01a7b3bb896c23e319f0b40d3e048e#8d36b57afa01a7b3bb896c23e319f0b40d3e048e"
 dependencies = [
  "bitfield",
  "bitflags 2.10.0",
@@ -1300,7 +1300,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8d2b5823611bb2993db86c4be2256301fc08568#d8d2b5823611bb2993db86c4be2256301fc08568"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8d36b57afa01a7b3bb896c23e319f0b40d3e048e#8d36b57afa01a7b3bb896c23e319f0b40d3e048e"
 dependencies = [
  "arrayvec",
  "caliptra-cfi-derive-git",
@@ -1504,7 +1504,7 @@ dependencies = [
 [[package]]
 name = "dpe"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8d2b5823611bb2993db86c4be2256301fc08568#d8d2b5823611bb2993db86c4be2256301fc08568"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8d36b57afa01a7b3bb896c23e319f0b40d3e048e#8d36b57afa01a7b3bb896c23e319f0b40d3e048e"
 dependencies = [
  "bitflags 2.10.0",
  "caliptra-cfi-derive-git",
@@ -3454,7 +3454,7 @@ checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 [[package]]
 name = "ocp-eat"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8d2b5823611bb2993db86c4be2256301fc08568#d8d2b5823611bb2993db86c4be2256301fc08568"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8d36b57afa01a7b3bb896c23e319f0b40d3e048e#8d36b57afa01a7b3bb896c23e319f0b40d3e048e"
 dependencies = [
  "arrayvec",
 ]
@@ -3628,7 +3628,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 [[package]]
 name = "platform"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8d2b5823611bb2993db86c4be2256301fc08568#d8d2b5823611bb2993db86c4be2256301fc08568"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8d36b57afa01a7b3bb896c23e319f0b40d3e048e#8d36b57afa01a7b3bb896c23e319f0b40d3e048e"
 dependencies = [
  "arrayvec",
  "cfg-if",
@@ -5228,7 +5228,7 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 [[package]]
 name = "ureg"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=d8d2b5823611bb2993db86c4be2256301fc08568#d8d2b5823611bb2993db86c4be2256301fc08568"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8d36b57afa01a7b3bb896c23e319f0b40d3e048e#8d36b57afa01a7b3bb896c23e319f0b40d3e048e"
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -254,32 +254,32 @@ libtock_unittest = { path = "runtime/userspace/libtock/unittest" }
 tbf-header = { path = "runtime/userspace/libtock/tbf-header" }
 
 # caliptra dependencies; keep git revs in sync
-caliptra-api = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d8d2b5823611bb2993db86c4be2256301fc08568" }
-caliptra-api-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d8d2b5823611bb2993db86c4be2256301fc08568" }
-caliptra-auth-man-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d8d2b5823611bb2993db86c4be2256301fc08568" }
-caliptra-auth-man-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d8d2b5823611bb2993db86c4be2256301fc08568" }
-caliptra-bitstream-downloader = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d8d2b5823611bb2993db86c4be2256301fc08568" }
-caliptra-builder = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d8d2b5823611bb2993db86c4be2256301fc08568" }
-caliptra-drivers = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d8d2b5823611bb2993db86c4be2256301fc08568" }
-caliptra-emu-bus = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d8d2b5823611bb2993db86c4be2256301fc08568" }
-caliptra-emu-cpu = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d8d2b5823611bb2993db86c4be2256301fc08568" }
-caliptra-emu-derive = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d8d2b5823611bb2993db86c4be2256301fc08568" }
-caliptra-emu-periph = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d8d2b5823611bb2993db86c4be2256301fc08568" }
-caliptra-emu-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d8d2b5823611bb2993db86c4be2256301fc08568" }
-caliptra-error = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d8d2b5823611bb2993db86c4be2256301fc08568", default-features = false }
-caliptra-hw-model = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d8d2b5823611bb2993db86c4be2256301fc08568" }
-caliptra-hw-model-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d8d2b5823611bb2993db86c4be2256301fc08568" }
-caliptra-image-crypto = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d8d2b5823611bb2993db86c4be2256301fc08568", default-features = false, features = ["rustcrypto"] }
-caliptra-image-fake-keys = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d8d2b5823611bb2993db86c4be2256301fc08568" }
-caliptra-image-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d8d2b5823611bb2993db86c4be2256301fc08568" }
-caliptra-image-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d8d2b5823611bb2993db86c4be2256301fc08568" }
-caliptra-registers = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d8d2b5823611bb2993db86c4be2256301fc08568" }
-caliptra-test = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d8d2b5823611bb2993db86c4be2256301fc08568" }
-caliptra-test-harness = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d8d2b5823611bb2993db86c4be2256301fc08568" }
-caliptra-test-harness-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d8d2b5823611bb2993db86c4be2256301fc08568" }
-ureg = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d8d2b5823611bb2993db86c4be2256301fc08568" }
-dpe = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d8d2b5823611bb2993db86c4be2256301fc08568", default-features = false, features = ["dpe_profile_p384_sha384"] }
-ocp-eat = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "d8d2b5823611bb2993db86c4be2256301fc08568",  default-features = false  }
+caliptra-api = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8d36b57afa01a7b3bb896c23e319f0b40d3e048e" }
+caliptra-api-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8d36b57afa01a7b3bb896c23e319f0b40d3e048e" }
+caliptra-auth-man-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8d36b57afa01a7b3bb896c23e319f0b40d3e048e" }
+caliptra-auth-man-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8d36b57afa01a7b3bb896c23e319f0b40d3e048e" }
+caliptra-bitstream-downloader = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8d36b57afa01a7b3bb896c23e319f0b40d3e048e" }
+caliptra-builder = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8d36b57afa01a7b3bb896c23e319f0b40d3e048e" }
+caliptra-drivers = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8d36b57afa01a7b3bb896c23e319f0b40d3e048e" }
+caliptra-emu-bus = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8d36b57afa01a7b3bb896c23e319f0b40d3e048e" }
+caliptra-emu-cpu = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8d36b57afa01a7b3bb896c23e319f0b40d3e048e" }
+caliptra-emu-derive = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8d36b57afa01a7b3bb896c23e319f0b40d3e048e" }
+caliptra-emu-periph = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8d36b57afa01a7b3bb896c23e319f0b40d3e048e" }
+caliptra-emu-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8d36b57afa01a7b3bb896c23e319f0b40d3e048e" }
+caliptra-error = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8d36b57afa01a7b3bb896c23e319f0b40d3e048e", default-features = false }
+caliptra-hw-model = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8d36b57afa01a7b3bb896c23e319f0b40d3e048e" }
+caliptra-hw-model-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8d36b57afa01a7b3bb896c23e319f0b40d3e048e" }
+caliptra-image-crypto = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8d36b57afa01a7b3bb896c23e319f0b40d3e048e", default-features = false, features = ["rustcrypto"] }
+caliptra-image-fake-keys = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8d36b57afa01a7b3bb896c23e319f0b40d3e048e" }
+caliptra-image-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8d36b57afa01a7b3bb896c23e319f0b40d3e048e" }
+caliptra-image-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8d36b57afa01a7b3bb896c23e319f0b40d3e048e" }
+caliptra-registers = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8d36b57afa01a7b3bb896c23e319f0b40d3e048e" }
+caliptra-test = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8d36b57afa01a7b3bb896c23e319f0b40d3e048e" }
+caliptra-test-harness = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8d36b57afa01a7b3bb896c23e319f0b40d3e048e" }
+caliptra-test-harness-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8d36b57afa01a7b3bb896c23e319f0b40d3e048e" }
+ureg = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8d36b57afa01a7b3bb896c23e319f0b40d3e048e" }
+dpe = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8d36b57afa01a7b3bb896c23e319f0b40d3e048e", default-features = false, features = ["dpe_profile_p384_sha384"] }
+ocp-eat = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8d36b57afa01a7b3bb896c23e319f0b40d3e048e",  default-features = false  }
 
 # local caliptra dependency; useful when developing
 # caliptra-api = { path = "../caliptra-sw/api" }

--- a/tests/integration/src/rom/test_sw_digest_lock.rs
+++ b/tests/integration/src/rom/test_sw_digest_lock.rs
@@ -9,6 +9,7 @@
 #[cfg(test)]
 mod test {
     use crate::platform;
+    use caliptra_hw_model::HwModel;
     use mcu_builder::firmware;
     use mcu_hw_model::{InitParams, McuHwModel};
     use mcu_rom_common::LifecycleControllerState;
@@ -36,59 +37,42 @@ mod test {
     fn test_sw_digest_lock() {
         let (caliptra_rom, mcu_rom) = load_roms();
 
-        // On FPGA, OTP SRAM persists across runs. Clear vendor_test_partition
-        // before the real test. The go-bit prevents the ROM from racing.
-        #[cfg(feature = "fpga_realtime")]
-        {
-            let tmp = mcu_hw_model::new_unbooted(InitParams {
-                caliptra_rom: &caliptra_rom,
-                mcu_rom: &mcu_rom,
-                check_booted_to_runtime: false,
-                lifecycle_controller_state: Some(LifecycleControllerState::Dev),
-                ..Default::default()
-            })
-            .unwrap();
-            let p = fuses::VENDOR_TEST_PARTITION;
-            let mut copy = tmp.base.otp_slice().to_vec();
-            copy[p.byte_offset..p.byte_offset + p.byte_size].fill(0);
-            tmp.base.otp_slice().copy_from_slice(&copy);
-            drop(tmp);
-        }
-
         // Boot 1: write data + digest.
-        let otp_after_boot1;
-        {
-            let mut hw = mcu_hw_model::new(InitParams {
-                caliptra_rom: &caliptra_rom,
-                mcu_rom: &mcu_rom,
-                check_booted_to_runtime: false,
-                enable_mcu_uart_log: true,
-                lifecycle_controller_state: Some(LifecycleControllerState::Dev),
-                ..Default::default()
-            })
-            .unwrap();
-            hw.set_mcu_generic_input_wires(&[1, 0xc000_0000]);
+        let mut hw = mcu_hw_model::new(InitParams {
+            caliptra_rom: &caliptra_rom,
+            mcu_rom: &mcu_rom,
+            check_booted_to_runtime: false,
+            enable_mcu_uart_log: true,
+            lifecycle_controller_state: Some(LifecycleControllerState::Dev),
+            ..Default::default()
+        })
+        .unwrap();
+        hw.set_mcu_generic_input_wires(&[1, 0xc000_0000]);
 
-            hw.output().set_search_term("DONE");
-            let start = std::time::Instant::now();
-            hw.step_until(|m| {
-                m.output().search_matched()
-                    || m.mci_fw_fatal_error().is_some()
-                    || start.elapsed().as_secs() > 30
-            });
-            let output_text = hw.output().take(usize::MAX);
-            println!("Boot 1 output:\n{output_text}");
-            assert!(start.elapsed().as_secs() <= 30, "Boot 1 timed out");
-            assert_eq!(hw.mci_fw_fatal_error(), None, "Boot 1 fatal error");
-
-            // Capture OTP state for boot 2 (emulator doesn't persist OTP).
-            otp_after_boot1 = hw.read_otp_memory();
-        }
+        hw.output().set_search_term("DONE");
+        let start = std::time::Instant::now();
+        hw.step_until(|m| {
+            m.output().search_matched()
+                || m.mci_fw_fatal_error().is_some()
+                || start.elapsed().as_secs() > 30
+        });
+        let output_text = hw.output().take(usize::MAX);
+        println!("Boot 1 output:\n{output_text}");
+        assert!(start.elapsed().as_secs() <= 30, "Boot 1 timed out");
+        assert_eq!(hw.mci_fw_fatal_error(), None, "Boot 1 fatal error");
 
         // Boot 2: verify digest. Pass OTP from boot 1 so emulator sees the
-        // written data. On FPGA, OTP SRAM persists automatically.
+        // written data. On FPGA, OTP SRAM persists automatically, so just reset
+        #[cfg(feature = "fpga_realtime")]
+        hw.base.cold_reset();
+
+        #[cfg(not(feature = "fpga_realtime"))]
         {
-            let mut hw = mcu_hw_model::new(InitParams {
+            // Capture OTP state and reinitialize machine if running on emulator
+            // (emulator doesn't persist OTP).
+            let otp_after_boot1 = hw.read_otp_memory();
+
+            hw = mcu_hw_model::new(InitParams {
                 caliptra_rom: &caliptra_rom,
                 mcu_rom: &mcu_rom,
                 check_booted_to_runtime: false,
@@ -98,38 +82,38 @@ mod test {
                 ..Default::default()
             })
             .unwrap();
-            hw.set_mcu_generic_input_wires(&[1, 0xc000_0000]);
-
-            hw.output().set_search_term("PASS");
-            let start = std::time::Instant::now();
-            hw.step_until(|m| {
-                m.output().search_matched()
-                    || m.mci_fw_fatal_error().is_some()
-                    || start.elapsed().as_secs() > 30
-            });
-            let output_text = hw.output().take(usize::MAX);
-            println!("Boot 2 output:\n{output_text}");
-            assert!(start.elapsed().as_secs() <= 30, "Boot 2 timed out");
-            assert_eq!(hw.mci_fw_fatal_error(), None, "Boot 2 fatal error");
-
-            // Also verify digest via OTP memory readback.
-            let final_otp = hw.read_otp_memory();
-            let digest_offset = fuses::VENDOR_TEST_PARTITION
-                .digest_offset
-                .expect("vendor_test_partition should have a digest offset");
-            let digest_lo = u32::from_le_bytes(
-                final_otp[digest_offset..digest_offset + 4]
-                    .try_into()
-                    .unwrap(),
-            );
-            let digest_hi = u32::from_le_bytes(
-                final_otp[digest_offset + 4..digest_offset + 8]
-                    .try_into()
-                    .unwrap(),
-            );
-            let digest = digest_lo as u64 | ((digest_hi as u64) << 32);
-            assert_ne!(digest, 0, "Digest should have been written to OTP");
-            println!("OTP digest verified: {digest:#018x}");
         }
+        hw.set_mcu_generic_input_wires(&[1, 0xc000_0000]);
+
+        hw.output().set_search_term("PASS");
+        let start = std::time::Instant::now();
+        hw.step_until(|m| {
+            m.output().search_matched()
+                || m.mci_fw_fatal_error().is_some()
+                || start.elapsed().as_secs() > 30
+        });
+        let output_text = hw.output().take(usize::MAX);
+        println!("Boot 2 output:\n{output_text}");
+        assert!(start.elapsed().as_secs() <= 30, "Boot 2 timed out");
+        assert_eq!(hw.mci_fw_fatal_error(), None, "Boot 2 fatal error");
+
+        // Also verify digest via OTP memory readback.
+        let final_otp = hw.read_otp_memory();
+        let digest_offset = fuses::VENDOR_TEST_PARTITION
+            .digest_offset
+            .expect("vendor_test_partition should have a digest offset");
+        let digest_lo = u32::from_le_bytes(
+            final_otp[digest_offset..digest_offset + 4]
+                .try_into()
+                .unwrap(),
+        );
+        let digest_hi = u32::from_le_bytes(
+            final_otp[digest_offset + 4..digest_offset + 8]
+                .try_into()
+                .unwrap(),
+        );
+        let digest = digest_lo as u64 | ((digest_hi as u64) << 32);
+        assert_ne!(digest, 0, "Digest should have been written to OTP");
+        println!("OTP digest verified: {digest:#018x}");
     }
 }


### PR DESCRIPTION
Also, remove manual OTP clearing  and refactor `test_sw_digest_lock` to reflect the fact that OTP doesn't persist across test runs