### PR TITLE
Make xtask depend on mcu-rom-common only for fpga_realtime

### DIFF
--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -10,6 +10,7 @@ fpga_realtime = [
 	"mcu-hw-model/fpga_realtime",
 	"dep:caliptra-hw-model",
 	"dep:mcu-hw-model",
+	"dep:mcu-rom-common",
 ]
 
 [dependencies]
@@ -33,7 +34,7 @@ mcu-config-emulator.workspace = true
 mcu-config-fpga.workspace = true
 mcu-firmware-bundler.workspace = true
 fusegen.workspace = true
-mcu-rom-common.workspace = true
+mcu-rom-common = { workspace = true, optional = true }
 mcu-hw-model = { workspace = true, optional = true }
 mcu-fuses-generator.workspace = true
 p384.workspace = true


### PR DESCRIPTION
## Summary

Make `mcu-rom-common` optional in `xtask`.

## Details

`mcu-rom-common` is only needed for `fpga_realtime`, so this change:
- marks it as an optional dependency
- enables it through the `fpga_realtime` feature

This avoids pulling it in for `xtask` configurations that do not use that feature.