### PR TITLE
Support extended external interrupt range (0-255] in emulator C binding

### DIFF
--- a/emulator/cbinding/src/lib.rs
+++ b/emulator/cbinding/src/lib.rs
@@ -1138,7 +1138,7 @@ pub unsafe extern "C" fn emulator_write_pc(
 ///
 /// # Arguments
 /// * `emulator_memory` - Pointer to the initialized emulator
-/// * `irq_num` - IRQ number to set (0-31)
+/// * `irq_num` - IRQ number to set (0-255]
 /// * `is_high` - 1 to set interrupt high, 0 to set interrupt low
 ///
 /// # Returns
@@ -1157,7 +1157,7 @@ pub unsafe extern "C" fn emulator_set_external_interrupt(
         return EmulatorError::NullPointer;
     }
 
-    if irq_num > 31 {
+    if irq_num == 0 || irq_num > 255 {
         return EmulatorError::InvalidArgs;
     }
 


### PR DESCRIPTION
This change updates emulator_set_external_interrupt to accept IRQ numbers in the range 1–255 (previously 0–31), and rejects IRQ 0 as invalid. This aligns the C binding with hardware that supports a wider set of external interrupt lines, where interrupt 0 is reserved/unused