### PR TITLE
Change segmented DCP check 2.1

### DIFF
--- a/hw/fpga/fpga_configuration.tcl
+++ b/hw/fpga/fpga_configuration.tcl
@@ -478,19 +478,19 @@ if {$BUILD} {
       # Lock the NoC path segments and save the solution for later builds.
       set_property lock true [get_noc_net_routes -of [get_noc_logical_paths -filter {initial_boot == 1}]]
       write_noc_solution -file $fpgaDir/saved_noc_solution.ncr
-      file copy -force $outputDir/caliptra_fpga_project.runs/impl_1/caliptra_fpga_project_bd_wrapper_routed.dcp $fpgaDir/fpga_2px_golden_routed.dcp
-      puts stderr "Replace file in GCS bucket: [exec realpath $fpgaDir/fpga_2px_golden_routed.dcp]"
+      file copy -force $outputDir/caliptra_fpga_project.runs/impl_1/caliptra_fpga_project_bd_wrapper_routed.dcp $fpgaDir/ss_golden_segmented_routed.dcp
+      puts stderr "Replace file in GCS bucket: [exec realpath $fpgaDir/ss_golden_segmented_routed.dcp]"
     } else {
       # Verify that the NoC Solutions are identical and the PLD images are compatible.
-      exec curl -s -O "https://storage.googleapis.com/caliptra-github-ci-bitstreams/scratch/fpga_2px_golden_routed.dcp"
-      pr_verify -initial $fpgaDir/fpga_2px_golden_routed.dcp -additional $outputDir/caliptra_fpga_project.runs/impl_1/caliptra_fpga_project_bd_wrapper_routed.dcp
+      exec curl -s -O "https://storage.googleapis.com/caliptra-github-ci-bitstreams/scratch/ss_golden_segmented_routed.dcp"
+      pr_verify -initial $fpgaDir/ss_golden_segmented_routed.dcp -additional $outputDir/caliptra_fpga_project.runs/impl_1/caliptra_fpga_project_bd_wrapper_routed.dcp
     }
     # Copy the PDI containing runtime info to a more convenient location.
-    file copy $outputDir/caliptra_fpga_project.runs/impl_1/caliptra_fpga_project_bd_wrapper_pld.pdi $outputDir/runtime_$VERSION.pdi
+    file copy $outputDir/caliptra_fpga_project.runs/impl_1/caliptra_fpga_project_bd_wrapper_pld.pdi $outputDir/runtime_${VERSION}.pdi
 
-    set xsa_name xsa_ss2p1_$VERSION_segmented.xsa
+    set xsa_name xsa_ss2p1_${VERSION}_segmented.xsa
   } else {
-    set xsa_name xsa_ss2p1_$VERSION.xsa
+    set xsa_name xsa_ss2p1_${VERSION}.xsa
   }
 
   write_hw_platform -fixed -include_bit -force -file $outputDir/$xsa_name


### PR DESCRIPTION
DCP check used a stale incorrect file, now updated to be for a DCP built off of a SS segmented build. Core segmented build needs a unique file since as of now the two are not compatible.
Fixed incorrect syntax for referencing the VERSION in the tcl script.