### PR TITLE
[OCP-LOCK]: MCU ROM HEK Perma bit

### DIFF
--- a/rom/src/rom.rs
+++ b/rom/src/rom.rs
@@ -41,6 +41,7 @@ use romtime::otp::{
 use romtime::LifecycleControllerState;
 use romtime::LifecycleHashedTokens;
 use romtime::LifecycleToken;
+use romtime::HEK_OFFSETS;
 use romtime::{HexWord, StaticRef};
 use tock_registers::interfaces::ReadWriteable;
 use tock_registers::interfaces::{Readable, Writeable};
@@ -53,6 +54,9 @@ const MLDSA_CALIPTRA_VALUE: u8 = 1;
 const LMS_CALIPTRA_VALUE: u8 = 3;
 const OTP_DAI_IDLE_BIT_OFFSET: u32 = 30;
 const OTP_DIRECT_ACCESS_CMD_REG_OFFSET: u32 = 0x80;
+
+// OCP LOCK v1.0rc2 hard codes this to 64 bytes.
+const OCP_LOCK_KEY_MEK_SIZE: u32 = 64;
 
 /// Trait for different boot flows (cold boot, warm reset, firmware update)
 pub trait BootFlow {
@@ -350,17 +354,38 @@ impl Soc {
 
         // OCP LOCK Fuses.
         romtime::println!("[mcu-fuse-write] Attempting to write OCP LOCK fuses");
-        for i in 0..self.registers.fuse_hek_seed.len() {
-            let word = otp
-                .read_u32_at(
-                    registers_generated::fuses::CPTRA_SS_LOCK_HEK_PROD_0_BYTE_OFFSET + i * 4,
-                )
-                .unwrap_or_else(|_| fatal_error(McuError::ROM_OTP_READ_ERROR));
-            self.registers.fuse_hek_seed[i].set(word);
+
+        if otp
+            .is_hek_perma_set()
+            .unwrap_or_else(|_| fatal_error(McuError::ROM_OTP_READ_ERROR))
+        {
+            romtime::println!("[mcu-fuse-write] HEK perma bit set, using sanitized HEK");
+            for i in 0..self.registers.fuse_hek_seed.len() {
+                self.registers.fuse_hek_seed[i].set(0xFFFF_FFFF);
+            }
+        } else {
+            let hek_slot = HEK_OFFSETS.iter().find(|&&offset| {
+                !otp.is_hek_zeroized(offset)
+                    .unwrap_or_else(|_| fatal_error(McuError::ROM_OTP_READ_ERROR))
+            });
+            if let Some(hek_slot) = hek_slot {
+                romtime::println!(
+                    "[mcu-fuse-write] Using HEK ratchet seed from offset {:x}",
+                    hek_slot
+                );
+                for i in 0..self.registers.fuse_hek_seed.len() {
+                    let word = otp
+                        .read_u32_at(hek_slot + i * 4)
+                        .unwrap_or_else(|_| fatal_error(McuError::ROM_OTP_READ_ERROR));
+                    self.registers.fuse_hek_seed[i].set(word);
+                }
+            }
         }
 
         // Key release is always 64 bytes currently
-        self.registers.ss_key_release_size.set(64);
+        self.registers
+            .ss_key_release_size
+            .set(OCP_LOCK_KEY_MEK_SIZE);
 
         // TODO(clundin): We should pass this from OTP or similar so we can configure in
         // caliptra-sw tests.

--- a/romtime/src/otp.rs
+++ b/romtime/src/otp.rs
@@ -18,6 +18,27 @@ const OTP_CONSISTENCY_CHECK_PERIOD_MASK: u32 = 0x3ff_ffff;
 const OTP_INTEGRITY_CHECK_PERIOD_MASK: u32 = 0x3ff_ffff;
 const OTP_CHECK_TIMEOUT: u32 = 0x10_0000;
 const OTP_PENDING_CHECK_MAX_ITERATIONS: u32 = 1_000_000;
+pub const HEK_ZEROIZATION_VALID_BOUND: u32 = 64 - 6;
+
+// HEK partition metadata offsets
+pub const HEK_ZER_MARKER_OFFSET: usize = 40;
+pub const HEK_ZER_MARKER_SIZE: usize = 8;
+pub const HEK_SEED_SIZE: usize = 32;
+
+// VENDOR_NON_SECRET_PROD_PARTITION offsets
+pub const HEK_PERMA_ADDR: usize = fuses::VENDOR_NON_SECRET_PROD_PARTITION_BYTE_OFFSET + (15 * 32);
+pub const HEK_PERMA_BIT_MASK: u32 = 1;
+
+pub const HEK_OFFSETS: [usize; 8] = [
+    fuses::CPTRA_SS_LOCK_HEK_PROD_0_BYTE_OFFSET,
+    fuses::CPTRA_SS_LOCK_HEK_PROD_1_BYTE_OFFSET,
+    fuses::CPTRA_SS_LOCK_HEK_PROD_2_BYTE_OFFSET,
+    fuses::CPTRA_SS_LOCK_HEK_PROD_3_BYTE_OFFSET,
+    fuses::CPTRA_SS_LOCK_HEK_PROD_4_BYTE_OFFSET,
+    fuses::CPTRA_SS_LOCK_HEK_PROD_5_BYTE_OFFSET,
+    fuses::CPTRA_SS_LOCK_HEK_PROD_6_BYTE_OFFSET,
+    fuses::CPTRA_SS_LOCK_HEK_PROD_7_BYTE_OFFSET,
+];
 
 // -------------------------------------------------------------------------
 // Fuse field offsets within partitions
@@ -711,6 +732,34 @@ impl Otp {
             .ok_or(McuError::ROM_UNSUPPORTED_FUSE_LAYOUT)?;
         let raw = crate::write_single_fuse_value(layout, value)?;
         self.write_word(entry.byte_offset / 4, raw)?;
+        Ok(())
+    }
+
+    /// Check if the HEK partition at the given offset is zeroized.
+    pub fn is_hek_zeroized(&self, partition_address: usize) -> McuResult<bool> {
+        // A partition is considered zeroized/sanitized if ALL bytes are 0xFF.
+        // HEK partitions are 48 bytes: 32 (Seed) + 8 (Digest) + 8 (ZER marker).
+        let mut partition_data = [0u8; fuses::CPTRA_SS_LOCK_HEK_PROD_0_BYTE_SIZE];
+        self.read_data(
+            partition_address,
+            fuses::CPTRA_SS_LOCK_HEK_PROD_0_BYTE_SIZE,
+            &mut partition_data,
+        )?;
+        Ok(partition_data.iter().all(|&b| b == 0xFF))
+    }
+
+    /// Check if the HEK perma bit is set in the last non-secret vendor fuse (Slot 15).
+    /// NOTE: Integrators should consider a dedicated fuse.
+    pub fn is_hek_perma_set(&self) -> McuResult<bool> {
+        let word = self.read_u32_at(HEK_PERMA_ADDR)?;
+        Ok((word & HEK_PERMA_BIT_MASK) != 0)
+    }
+
+    /// Sets the HEK perma bit.
+    pub fn set_hek_perma(&self) -> McuResult<()> {
+        let mut val = self.read_u32_at(HEK_PERMA_ADDR)?;
+        val |= HEK_PERMA_BIT_MASK;
+        self.write_word(HEK_PERMA_ADDR, val)?;
         Ok(())
     }
 

--- a/tests/integration/src/lib.rs
+++ b/tests/integration/src/lib.rs
@@ -12,6 +12,7 @@ mod test_exception_handler;
 mod test_fips_zeroization;
 mod test_firmware_update;
 mod test_fpga_flash_ctrl;
+mod test_hek;
 mod test_i3c_constant_writes;
 mod test_i3c_simple;
 mod test_mctp_capsule_loopback;

--- a/tests/integration/src/test_hek.rs
+++ b/tests/integration/src/test_hek.rs
@@ -1,0 +1,105 @@
+// Licensed under the Apache-2.0 license
+
+#[cfg(test)]
+mod test {
+    use crate::test::{get_rom_with_feature, TEST_LOCK};
+    use caliptra_api::SocManager;
+    use mcu_hw_model::{InitParams, McuHwModel};
+    use registers_generated::fuses;
+    use zerocopy::IntoBytes;
+
+    fn setup_otp_hek(otp: &mut [u8], slot: usize, sanitized: bool) {
+        let offset = [
+            fuses::CPTRA_SS_LOCK_HEK_PROD_0_BYTE_OFFSET,
+            fuses::CPTRA_SS_LOCK_HEK_PROD_1_BYTE_OFFSET,
+            fuses::CPTRA_SS_LOCK_HEK_PROD_2_BYTE_OFFSET,
+            fuses::CPTRA_SS_LOCK_HEK_PROD_3_BYTE_OFFSET,
+            fuses::CPTRA_SS_LOCK_HEK_PROD_4_BYTE_OFFSET,
+            fuses::CPTRA_SS_LOCK_HEK_PROD_5_BYTE_OFFSET,
+            fuses::CPTRA_SS_LOCK_HEK_PROD_6_BYTE_OFFSET,
+            fuses::CPTRA_SS_LOCK_HEK_PROD_7_BYTE_OFFSET,
+        ][slot];
+
+        if sanitized {
+            // Write 0xFF to the entire 48-byte partition (Seed, Digest, and ZER)
+            for i in 0..48 {
+                otp[offset + i] = 0xFF;
+            }
+        } else {
+            for i in 0..32 {
+                otp[offset + i] = (slot as u8 + 1) ^ (i as u8);
+            }
+        }
+    }
+
+    fn set_hek_perma(otp: &mut [u8]) {
+        let offset = fuses::VENDOR_NON_SECRET_PROD_PARTITION_BYTE_OFFSET + (15 * 32);
+        otp[offset] |= 1;
+    }
+
+    #[test]
+    fn test_hek_perma_bit() {
+        let _lock = TEST_LOCK.lock().unwrap();
+        let mut otp = vec![0u8; 4096];
+        set_hek_perma(&mut otp);
+        setup_otp_hek(&mut otp, 0, false);
+
+        let mut hw = mcu_hw_model::new(InitParams {
+            mcu_rom: &std::fs::read(get_rom_with_feature("")).unwrap(),
+            otp_memory: Some(&otp),
+            check_booted_to_runtime: false,
+            enable_mcu_uart_log: true,
+            ..Default::default()
+        })
+        .unwrap();
+
+        hw.step_until(|m| {
+            m.caliptra_soc_manager()
+                .soc_ifc()
+                .cptra_fuse_wr_done()
+                .read()
+                .done()
+        });
+
+        let hek_seed = hw.caliptra_soc_manager().soc_ifc().fuse_hek_seed().read();
+        for i in 0..8 {
+            assert_eq!(hek_seed[i], 0xFFFF_FFFF);
+        }
+    }
+
+    #[test]
+    fn test_hek_slot_selection() {
+        let _lock = TEST_LOCK.lock().unwrap();
+        let mut otp = vec![0u8; 4096];
+
+        let sanitized_slots = [0, 1];
+        for slot in sanitized_slots {
+            setup_otp_hek(&mut otp, slot, true);
+        }
+
+        let active_slot = sanitized_slots.len();
+        setup_otp_hek(&mut otp, active_slot, false);
+
+        let mut hw = mcu_hw_model::new(InitParams {
+            mcu_rom: &std::fs::read(get_rom_with_feature("")).unwrap(),
+            otp_memory: Some(&otp),
+            check_booted_to_runtime: false,
+            enable_mcu_uart_log: true,
+            ..Default::default()
+        })
+        .unwrap();
+
+        hw.step_until(|m| {
+            m.caliptra_soc_manager()
+                .soc_ifc()
+                .cptra_fuse_wr_done()
+                .read()
+                .done()
+        });
+
+        let hek_seed = hw.caliptra_soc_manager().soc_ifc().fuse_hek_seed().read();
+        for (idx, &byte) in hek_seed.as_bytes().iter().enumerate() {
+            assert_eq!(byte, ((active_slot + 1) ^ idx) as u8);
+        }
+    }
+}


### PR DESCRIPTION
Add support for HEK Perma bit in ROM.
  - Note this example uses a non-secret vendor fuse bit. Integrations should add a dedicated fuse.

This closes https://github.com/chipsalliance/caliptra-mcu-sw/issues/958.