### PR TITLE
[CI]: Tweak runners for build-test

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -36,7 +36,7 @@ jobs:
         run: cargo xtask precheckin
 
   build-firmware:
-    runs-on: e2-standard-8
+    runs-on: e2-standard-16
     timeout-minutes: 60
 
     env:
@@ -102,7 +102,7 @@ jobs:
           retention-days: 1
 
   build-emulators:
-    runs-on: e2-standard-8
+    runs-on: e2-standard-16
     timeout-minutes: 60
 
     env:
@@ -168,7 +168,7 @@ jobs:
           retention-days: 1
 
   build-tests:
-    runs-on: e2-standard-8
+    runs-on: e2-standard-16
     timeout-minutes: 60
 
     env:
@@ -241,7 +241,7 @@ jobs:
           retention-days: 1
 
   test_emulator:
-    runs-on: e2-standard-2
+    runs-on: ubuntu-latest
     needs: [precheckin, build-firmware, build-emulators, build-tests]
     timeout-minutes: 90
     strategy:


### PR DESCRIPTION
* Use bigger instance for emulator & rom build.
* Use GitHub runners for test runners. We are hitting issues with stuck jobs & we can use GitHub runners to execute the tests.