### PR TITLE
[xtask/infra]: Add parallel build option

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -36,7 +36,8 @@ jobs:
         run: cargo xtask precheckin
 
   build-firmware:
-    runs-on: e2-standard-16
+    # Don't re-use the machine instance shape with non-big-disk jobs, they will steal the worker we need.
+    runs-on: [e2-standard-32, big-disk]
     timeout-minutes: 60
 
     env:
@@ -89,9 +90,8 @@ jobs:
 
       - name: Build ROM and runtime binaries
         run: |
-          # Build all test runtime features used by integration tests
-          # Note: nightly tests (test-*-spdm-*, test-caliptra-util-host-validator) are excluded
-          cargo xtask all-build --platform emulator --separate-runtimes
+          # Build with parallel-build feature to enable Rayon and unique target directories
+          cargo run -p xtask --features parallel-build -- all-build --platform emulator --separate-runtimes
           sccache --show-stats
 
       - name: Upload firmware bundle

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1267,6 +1267,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crossterm"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1531,6 +1556,12 @@ dependencies = [
  "signature",
  "spki",
 ]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elf"
@@ -2882,6 +2913,7 @@ dependencies = [
  "caliptra-image-gen",
  "caliptra-image-types",
  "cargo_metadata",
+ "cfg-if",
  "chrono",
  "elf",
  "flash-image",
@@ -2891,6 +2923,7 @@ dependencies = [
  "mcu-config-fpga",
  "mcu-firmware-bundler",
  "pldm-fw-pkg",
+ "rayon",
  "semver",
  "serde",
  "subst",
@@ -3987,6 +4020,26 @@ dependencies = [
  "network-interface",
  "rand 0.8.5",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,6 +107,7 @@ bit-vec = "0.6.3"
 cargo_metadata = "0.20.0"
 cbindgen = "0.24"
 cc = "1.0"
+cfg-if = "1.0.0"
 chrono = { version = "0.4.38", features = ["serde"] }
 clap = { version = "4.5.23", features = [
     "cargo",
@@ -153,6 +154,7 @@ prettyplease = "0.2.37"
 proc-macro2 = "1.0.66"
 quote = "1.0"
 rand = "0.8.5"
+rayon = "1.10"
 random-port = "0.1.1"
 same-file = "1"
 semver = "1.0.23"

--- a/builder/Cargo.toml
+++ b/builder/Cargo.toml
@@ -14,6 +14,7 @@ caliptra-image-fake-keys.workspace = true
 caliptra-image-gen.workspace = true
 caliptra-image-types.workspace = true
 cargo_metadata.workspace = true
+cfg-if.workspace = true
 chrono.workspace = true
 elf.workspace = true
 flash-image.workspace = true
@@ -23,6 +24,7 @@ mcu-config-emulator.workspace = true
 mcu-config-fpga.workspace = true
 mcu-firmware-bundler.workspace = true
 pldm-fw-pkg.workspace = true
+rayon = { workspace = true, optional = true }
 serde.workspace = true
 semver.workspace = true
 subst.workspace = true
@@ -32,3 +34,6 @@ uuid.workspace = true
 walkdir.workspace = true
 zerocopy.workspace = true
 zip.workspace = true
+
+[features]
+parallel-build = ["dep:rayon"]

--- a/builder/src/all.rs
+++ b/builder/src/all.rs
@@ -30,6 +30,26 @@ use crate::{firmware, ImageCfg};
 
 use std::{env::var, sync::OnceLock};
 
+struct FeatureTestResource {
+    feature: String,
+    runtime_file: tempfile::NamedTempFile,
+    soc_manifest_file: tempfile::NamedTempFile,
+    flash_image: PathBuf,
+    pldm_fw_pkg: tempfile::NamedTempFile,
+    update_flash_image: Option<PathBuf>,
+}
+
+cfg_if::cfg_if! {
+    if #[cfg(feature = "parallel-build")] {
+        use rayon::prelude::*;
+        fn maybe_par_iter<'a, T: Sync + 'a>(slice: &'a [T]) -> impl ParallelIterator<Item = &'a T> { slice.par_iter() }
+        fn maybe_into_par_iter<T: Send + 'static>(v: Vec<T>) -> impl ParallelIterator<Item = T> { v.into_par_iter() }
+    } else {
+        fn maybe_par_iter<'a, T: 'a>(slice: &'a [T]) -> impl Iterator<Item = &'a T> { slice.iter() }
+        fn maybe_into_par_iter<T: 'static>(v: Vec<T>) -> impl Iterator<Item = T> { v.into_iter() }
+    }
+}
+
 /// Features that require the example app to be included
 /// These are determined by which tests use `run_test!(test_name, example_app)` in tests/integration/src/lib.rs
 const FEATURES_WITH_EXAMPLE_APP: &[&str] = &[
@@ -454,34 +474,50 @@ pub fn all_build(args: AllBuildArgs) -> Result<()> {
     // TODO: use temp files
     let platform = platform.unwrap_or("emulator");
     let rom_features = rom_features.unwrap_or_default();
-    let mcu_rom = crate::rom_build(Some(platform.to_string()), Some(rom_features.to_string()))?;
+    let mcu_rom = crate::rom_build(
+        Some(platform.to_string()),
+        Some(rom_features.to_string()),
+        None,
+    )?;
 
-    let mut used_filenames = std::collections::HashSet::new();
-    let mut test_roms = vec![];
-    for fwid in firmware::REGISTERED_FW {
-        let bin_path = PathBuf::from(crate::test_rom_build(Some(platform), fwid)?);
-        let filename = bin_path.file_name().unwrap().to_str().unwrap().to_string();
-        if !used_filenames.insert(filename.clone()) {
-            panic!("Multiple fwids with filename {filename}")
-        }
+    let test_roms: Result<Vec<(PathBuf, String)>> =
+        maybe_into_par_iter(firmware::REGISTERED_FW.to_vec())
+            .map(|fwid| {
+                let target_dir = if cfg!(feature = "parallel-build") {
+                    Some(
+                        crate::target_dir()
+                            .join(format!("target-rom-{}-{}", fwid.crate_name, fwid.bin_name)),
+                    )
+                } else {
+                    None
+                };
+                let bin_path =
+                    PathBuf::from(crate::test_rom_build(Some(platform), fwid, target_dir)?);
+                let filename = bin_path.file_name().unwrap().to_str().unwrap().to_string();
+                Ok((bin_path, filename))
+            })
+            .collect();
+    let mut test_roms = test_roms?;
 
-        test_roms.push((bin_path, filename));
-    }
+    let cptra_test_roms: Result<Vec<(PathBuf, String)>> =
+        maybe_into_par_iter(firmware::CPTRA_REGISTERED_FW.to_vec())
+            .map(|fwid| {
+                let filename = format!("cptra-test-rom-{}-{}.bin", fwid.crate_name, fwid.bin_name);
+                let target_dir = if cfg!(feature = "parallel-build") {
+                    crate::target_dir().join(format!("target-cptra-rom-{}", filename))
+                } else {
+                    crate::target_dir()
+                };
+                let release_dir = target_dir.join(TARGET).join("release");
 
-    for fwid in firmware::CPTRA_REGISTERED_FW {
-        let filename = format!("cptra-test-rom-{}-{}.bin", fwid.crate_name, fwid.bin_name);
-        if !used_filenames.insert(filename.clone()) {
-            panic!("Multiple fwids with filename {filename}")
-        }
-        let bin_path = PROJECT_ROOT
-            .join("target")
-            .join(TARGET)
-            .join("release")
-            .join(&filename);
-        let rom_bytes = caliptra_builder::build_firmware_rom(fwid)?;
-        std::fs::write(&bin_path, rom_bytes)?;
-        test_roms.push((bin_path, filename));
-    }
+                std::fs::create_dir_all(&release_dir)?;
+                let bin_path = release_dir.join(&filename);
+                let rom_bytes = caliptra_builder::build_firmware_rom(fwid)?;
+                std::fs::write(&bin_path, rom_bytes)?;
+                Ok((bin_path, filename))
+            })
+            .collect();
+    test_roms.extend(cptra_test_roms?);
 
     let runtime_features = match runtime_features {
         Some(r) if !r.is_empty() => r.split(",").collect::<Vec<&str>>(),
@@ -516,6 +552,7 @@ pub fn all_build(args: AllBuildArgs) -> Result<()> {
         Some(base_runtime_path.to_string()),
         false,
         Some(platform),
+        None,
         None,
     )?;
 
@@ -577,138 +614,160 @@ pub fn all_build(args: AllBuildArgs) -> Result<()> {
     // Build feature-specific MCU ROMs so tests don't need to compile at runtime.
     // Only builds for features that the ROM crate supports; tests using other features
     // will fall back to the generic MCU ROM.
-    for feature in separate_features.iter() {
-        match crate::rom_build(Some(platform.to_string()), Some(feature.to_string())) {
-            Ok(rom_path) => {
-                let rom_name = format!("mcu-test-rom-feature-{}.bin", feature);
-                println!("Built feature ROM: {rom_path:?} -> {}", rom_name);
-                test_roms.push((rom_path, rom_name));
-            }
-            Err(e) => {
-                println!(
-                    "Skipping feature ROM for {}: {} (will use generic ROM)",
-                    feature, e
-                );
-            }
-        }
-    }
-
-    let mut test_runtimes = vec![];
-    for feature in separate_features.iter() {
-        let feature_runtime_file = tempfile::NamedTempFile::new().unwrap();
-        let feature_runtime_path = feature_runtime_file.path().to_str().unwrap().to_string();
-        let include_example_app = FEATURES_WITH_EXAMPLE_APP.contains(feature);
-
-        crate::runtime_build_with_apps(
-            &[feature],
-            Some(feature_runtime_path),
-            include_example_app,
-            Some(platform),
-            None,
-        )?;
-
-        let mcu_image_cfg = get_image_cfg_feature(&mcu_cfgs.clone().unwrap_or_default(), feature);
-
-        // For features that require SoC images, create default ones if not provided
-        let (feature_soc_images, feature_soc_images_paths) =
-            if FEATURES_REQUIRING_SOC_IMAGES.contains(feature) && soc_images.is_none() {
-                let (images, paths) = create_default_soc_images();
-                (Some(images), paths)
+    let feature_roms: Result<Vec<(PathBuf, String)>> = maybe_par_iter(&separate_features)
+        .filter_map(|feature| {
+            let target_dir = if cfg!(feature = "parallel-build") {
+                Some(crate::target_dir().join(format!("target-feature-rom-{}", feature)))
             } else {
-                (
-                    soc_images.clone(),
-                    soc_images
-                        .clone()
-                        .unwrap_or_default()
-                        .iter()
-                        .map(|img| img.path.clone())
-                        .collect(),
-                )
+                None
             };
+            match crate::rom_build(
+                Some(platform.to_string()),
+                Some(feature.to_string()),
+                target_dir,
+            ) {
+                Ok(rom_path) => {
+                    let rom_name = format!("mcu-test-rom-feature-{}.bin", feature);
+                    println!("Built feature ROM: {rom_path:?} -> {}", rom_name);
+                    Some(Ok((rom_path, rom_name)))
+                }
+                Err(e) => {
+                    println!(
+                        "Skipping feature ROM for {}: {} (will use generic ROM)",
+                        feature, e
+                    );
+                    None
+                }
+            }
+        })
+        .collect();
+    test_roms.extend(feature_roms?);
 
-        let mut caliptra_builder = crate::CaliptraBuilder::new(
-            fpga,
-            Some(caliptra_rom.clone()),
-            Some(caliptra_fw.clone()),
-            None,
-            Some(vendor_pk_hash.clone()),
-            Some(feature_runtime_file.path().to_path_buf()),
-            feature_soc_images.clone(),
-            mcu_image_cfg.clone(),
-            None,
-            None,
-            None,
-        );
-        let feature_soc_manifest_file = tempfile::NamedTempFile::new().unwrap();
-        caliptra_builder.get_soc_manifest(feature_soc_manifest_file.path().to_str())?;
+    let test_runtimes: Result<Vec<FeatureTestResource>> = maybe_par_iter(&separate_features)
+        .map(|feature| {
+            let target_dir = if cfg!(feature = "parallel-build") {
+                Some(crate::target_dir().join(format!("target-runtime-{}", feature)))
+            } else {
+                None
+            };
+            let feature_runtime_file = tempfile::NamedTempFile::new().unwrap();
+            let feature_runtime_path = feature_runtime_file.path().to_str().unwrap().to_string();
+            let include_example_app = FEATURES_WITH_EXAMPLE_APP.contains(feature);
 
-        // Flash-based boot features require partition table at offset 0
-        let is_flash_based_boot = FEATURES_REQUIRING_FLASH_BOOT.contains(feature);
+            crate::runtime_build_with_apps(
+                &[feature],
+                Some(feature_runtime_path),
+                include_example_app,
+                Some(platform),
+                None,
+                target_dir,
+            )?;
 
-        // Clone paths for potential second use
-        let feature_soc_images_paths_clone = feature_soc_images_paths.clone();
+            let mcu_image_cfg =
+                get_image_cfg_feature(&mcu_cfgs.clone().unwrap_or_default(), feature);
 
-        let feature_flash_image = create_flash_image(
-            Some(caliptra_fw.clone()),
-            Some(feature_soc_manifest_file.path().to_path_buf()),
-            Some(feature_runtime_file.path().to_path_buf()),
-            feature_soc_images_paths,
-            is_flash_based_boot,
-        )?;
+            // For features that require SoC images, create default ones if not provided
+            let (feature_soc_images, feature_soc_images_paths) =
+                if FEATURES_REQUIRING_SOC_IMAGES.contains(feature) && soc_images.is_none() {
+                    let (images, paths) = create_default_soc_images();
+                    (Some(images), paths)
+                } else {
+                    (
+                        soc_images.clone(),
+                        soc_images
+                            .clone()
+                            .unwrap_or_default()
+                            .iter()
+                            .map(|img| img.path.clone())
+                            .collect(),
+                    )
+                };
 
-        // For firmware update tests, create a separate "update" flash image WITHOUT partition table
-        // This is used for the PLDM update package (the downloaded firmware)
-        let is_firmware_update_feature = *feature == "test-firmware-update-flash"
-            || *feature == "test-firmware-update-streaming";
-        let feature_update_flash_image = if is_firmware_update_feature {
-            Some(create_flash_image(
+            let mut caliptra_builder = crate::CaliptraBuilder::new(
+                fpga,
+                Some(caliptra_rom.clone()),
+                Some(caliptra_fw.clone()),
+                None,
+                Some(vendor_pk_hash.clone()),
+                Some(feature_runtime_file.path().to_path_buf()),
+                feature_soc_images.clone(),
+                mcu_image_cfg.clone(),
+                None,
+                None,
+                None,
+            );
+            let feature_soc_manifest_file = tempfile::NamedTempFile::new().unwrap();
+            caliptra_builder.get_soc_manifest(feature_soc_manifest_file.path().to_str())?;
+
+            // Flash-based boot features require partition table at offset 0
+            let is_flash_based_boot = FEATURES_REQUIRING_FLASH_BOOT.contains(feature);
+
+            // Clone paths for potential second use
+            let feature_soc_images_paths_clone = feature_soc_images_paths.clone();
+
+            let feature_flash_image = create_flash_image(
                 Some(caliptra_fw.clone()),
                 Some(feature_soc_manifest_file.path().to_path_buf()),
                 Some(feature_runtime_file.path().to_path_buf()),
-                feature_soc_images_paths_clone,
-                false, // No partition table for update image
-            )?)
-        } else {
-            None
-        };
+                feature_soc_images_paths,
+                is_flash_based_boot,
+            )?;
 
-        // For PLDM package, use the update flash image (without partition table) if available
-        let pldm_source_image = feature_update_flash_image
-            .as_ref()
-            .unwrap_or(&feature_flash_image);
+            // For firmware update tests, create a separate "update" flash image WITHOUT partition table
+            // This is used for the PLDM update package (the downloaded firmware)
+            let is_firmware_update_feature = *feature == "test-firmware-update-flash"
+                || *feature == "test-firmware-update-streaming";
+            let feature_update_flash_image = if is_firmware_update_feature {
+                Some(create_flash_image(
+                    Some(caliptra_fw.clone()),
+                    Some(feature_soc_manifest_file.path().to_path_buf()),
+                    Some(feature_runtime_file.path().to_path_buf()),
+                    feature_soc_images_paths_clone,
+                    false, // No partition table for update image
+                )?)
+            } else {
+                None
+            };
 
-        let feature_pldm_manifest = match pldm_manifest {
-            Some(path) => {
-                let mut file = std::fs::File::open(path)?;
-                let mut data = Vec::new();
-                file.read_to_end(&mut data)?;
-                FirmwareManifest::decode_firmware_package(&path.to_string(), None)?
-            }
-            None => {
-                let dev_uuid = get_device_uuid();
-                let mut file = std::fs::File::open(pldm_source_image.clone())?;
-                let mut data = Vec::new();
-                file.read_to_end(&mut data)?;
-                get_default_pldm_fw_manifest(&dev_uuid, &data)
-            }
-        };
-        let feature_pldm_fw_pkg = tempfile::NamedTempFile::new().unwrap();
-        let pldm_fw_pkg_path = feature_pldm_fw_pkg
-            .path()
-            .to_str()
-            .ok_or_else(|| anyhow::anyhow!("Invalid path"))?
-            .to_string();
-        feature_pldm_manifest.generate_firmware_package(&pldm_fw_pkg_path)?;
+            // For PLDM package, use the update flash image (without partition table) if available
+            let pldm_source_image = feature_update_flash_image
+                .as_ref()
+                .unwrap_or(&feature_flash_image);
 
-        test_runtimes.push((
-            feature.to_string(),
-            feature_runtime_file,
-            feature_soc_manifest_file,
-            feature_flash_image,
-            feature_pldm_fw_pkg,
-            feature_update_flash_image,
-        ));
-    }
+            let feature_pldm_manifest = match pldm_manifest {
+                Some(path) => {
+                    let mut file = std::fs::File::open(path)?;
+                    let mut data = Vec::new();
+                    file.read_to_end(&mut data)?;
+                    FirmwareManifest::decode_firmware_package(&path.to_string(), None)?
+                }
+                None => {
+                    let dev_uuid = get_device_uuid();
+                    let mut file = std::fs::File::open(pldm_source_image.clone())?;
+                    let mut data = Vec::new();
+                    file.read_to_end(&mut data)?;
+                    get_default_pldm_fw_manifest(&dev_uuid, &data)
+                }
+            };
+            let feature_pldm_fw_pkg = tempfile::NamedTempFile::new().unwrap();
+            let pldm_fw_pkg_path = feature_pldm_fw_pkg
+                .path()
+                .to_str()
+                .ok_or_else(|| anyhow::anyhow!("Invalid path"))?
+                .to_string();
+            feature_pldm_manifest.generate_firmware_package(&pldm_fw_pkg_path)?;
+
+            Ok(FeatureTestResource {
+                feature: feature.to_string(),
+                runtime_file: feature_runtime_file,
+                soc_manifest_file: feature_soc_manifest_file,
+                flash_image: feature_flash_image,
+                pldm_fw_pkg: feature_pldm_fw_pkg,
+                update_flash_image: feature_update_flash_image,
+            })
+        })
+        .collect();
+    let test_runtimes = test_runtimes?;
 
     let default_path = crate::target_dir().join("all-fw.zip");
     let path = output.map(Path::new).unwrap_or(&default_path);
@@ -761,8 +820,14 @@ pub fn all_build(args: AllBuildArgs) -> Result<()> {
         add_to_zip(&test_rom, &name, &mut zip, options)?;
     }
 
-    for (feature, runtime, soc_manifest, flash_image, pldm_fw_pkg, update_flash_image) in
-        test_runtimes
+    for FeatureTestResource {
+        feature,
+        runtime_file: runtime,
+        soc_manifest_file: soc_manifest,
+        flash_image,
+        pldm_fw_pkg,
+        update_flash_image,
+    } in test_runtimes
     {
         let runtime_name = format!("mcu-test-runtime-{}.bin", feature);
         println!("Adding {} -> {}", runtime.path().display(), runtime_name);

--- a/builder/src/rom.rs
+++ b/builder/src/rom.rs
@@ -10,7 +10,11 @@ use crate::PROJECT_ROOT;
 use caliptra_builder::FwId;
 use mcu_firmware_bundler::args::{BuildArgs, Commands, Common, LdArgs};
 
-pub fn rom_build(platform: Option<String>, features: Option<String>) -> Result<PathBuf> {
+pub fn rom_build(
+    platform: Option<String>,
+    features: Option<String>,
+    target_dir: Option<PathBuf>,
+) -> Result<PathBuf> {
     let feature_suffix = match &features {
         Some(f) => format!("-{f}"),
         None => String::new(),
@@ -24,6 +28,7 @@ pub fn rom_build(platform: Option<String>, features: Option<String>) -> Result<P
     let manifest = manifest_file(platform.as_deref(), false)?;
     let common = Common {
         manifest,
+        target_dir,
         ..Default::default()
     };
     let rom_binary = common.release_dir().map(|t| t.join(format!("{rom}.bin")))?;
@@ -46,7 +51,11 @@ pub fn rom_build(platform: Option<String>, features: Option<String>) -> Result<P
     Ok(rom_binary)
 }
 
-pub fn test_rom_build(platform: Option<&str>, fwid: &FwId) -> Result<String> {
+pub fn test_rom_build(
+    platform: Option<&str>,
+    fwid: &FwId,
+    target_dir: Option<PathBuf>,
+) -> Result<String> {
     let platform = platform.unwrap_or("emulator");
 
     let template_name = if platform == "fpga" {
@@ -66,6 +75,7 @@ pub fn test_rom_build(platform: Option<&str>, fwid: &FwId) -> Result<String> {
 
     let common = Common {
         manifest: manifest_file.path().to_path_buf(),
+        target_dir,
         ..Default::default()
     };
 

--- a/builder/src/runtime.rs
+++ b/builder/src/runtime.rs
@@ -24,6 +24,7 @@ pub fn runtime_build_with_apps(
     example_app: bool,
     platform: Option<&str>,
     svn: Option<u16>,
+    target_dir: Option<PathBuf>,
 ) -> Result<PathBuf> {
     let manifest = manifest_file(platform, example_app)?;
     let platform = platform.unwrap_or("emulator");
@@ -32,6 +33,7 @@ pub fn runtime_build_with_apps(
     let common = Common {
         manifest,
         svn,
+        target_dir,
         ..Default::default()
     };
     let runtime_bin = common.release_dir()?.join(&output_name);

--- a/firmware-bundler/src/args.rs
+++ b/firmware-bundler/src/args.rs
@@ -26,6 +26,11 @@ pub struct Common {
     /// McuImageHeader with the given svn value, and the binaries moved appropriately.
     #[arg(long)]
     pub svn: Option<u16>,
+
+    /// The target directory to use for this build.  If not specified the tool will attempt to find
+    /// the target directory based on the workspace directory.
+    #[arg(long)]
+    pub target_dir: Option<PathBuf>,
 }
 
 impl Common {
@@ -39,8 +44,12 @@ impl Common {
     }
 
     /// Retrieve the target directory, either derived from the command line specification for the
-    /// workspace directory or algorithmically based on the current execution directory.
+    /// workspace directory, algorithmically based on the current execution directory, or
+    /// explicitly overridden via the `target_dir` field.
     pub fn target_dir(&self) -> Result<PathBuf> {
+        if let Some(td) = &self.target_dir {
+            return Ok(td.clone());
+        }
         match &self.workspace_dir {
             Some(wd) => Ok(wd.join("target")),
             None => utils::find_target_directory(),
@@ -62,6 +71,7 @@ impl Common {
             manifest: workspace_dir.join("manifest.toml"),
             workspace_dir: Some(workspace_dir),
             svn: None,
+            target_dir: None,
         }
     }
 }

--- a/firmware-bundler/src/build.rs
+++ b/firmware-bundler/src/build.rs
@@ -124,6 +124,7 @@ struct BuildPass<'a> {
     build_definition: &'a BuildDefinition,
     build_args: &'a BuildArgs,
     binary_dir: PathBuf,
+    target_dir: PathBuf,
     objcopy: PathBuf,
 }
 
@@ -138,6 +139,7 @@ impl<'a> BuildPass<'a> {
         // Determine the release directory which elf files will be placed by `rustc` and where we
         // wish to place binaries.
         let binary_dir = common.release_dir()?;
+        let target_dir = common.target_dir()?;
 
         let objcopy = match &build_args.objcopy {
             Some(o) => o.clone(),
@@ -149,6 +151,7 @@ impl<'a> BuildPass<'a> {
             build_definition,
             build_args,
             binary_dir,
+            target_dir,
             objcopy,
         })
     }
@@ -234,6 +237,8 @@ impl<'a> BuildPass<'a> {
             .arg(&app.name)
             .arg("--target")
             .arg(&self.manifest.platform.tuple)
+            .arg("--target-dir")
+            .arg(&self.target_dir)
             .arg("--release");
 
         if let Some(f) = features {

--- a/hw/model/src/lib.rs
+++ b/hw/model/src/lib.rs
@@ -888,6 +888,7 @@ mod tests {
             let rom_file = mcu_builder::test_rom_build(
                 Some(platform()),
                 &firmware::hw_model_tests::MAILBOX_RESPONDER,
+                None,
             )?;
             std::fs::read(&rom_file)?
         };

--- a/hw/model/src/model_emulated.rs
+++ b/hw/model/src/model_emulated.rs
@@ -702,8 +702,8 @@ mod test {
 
     #[test]
     fn test_new_unbooted() {
-        let mcu_rom = mcu_builder::rom_build(None, None).expect("Could not build MCU ROM");
-        let mcu_runtime = &mcu_builder::runtime_build_with_apps(&[], None, false, None, None)
+        let mcu_rom = mcu_builder::rom_build(None, None, None).expect("Could not build MCU ROM");
+        let mcu_runtime = &mcu_builder::runtime_build_with_apps(&[], None, false, None, None, None)
             .expect("Could not build MCU runtime");
         let mut caliptra_builder = mcu_builder::CaliptraBuilder::new(
             false,

--- a/tests/integration/src/lib.rs
+++ b/tests/integration/src/lib.rs
@@ -131,9 +131,12 @@ mod test {
         } else {
             feature
         };
-        let output: PathBuf =
-            mcu_builder::rom_build(Some(platform().to_string()), Some(feature.to_string()))
-                .expect("ROM build failed");
+        let output: PathBuf = mcu_builder::rom_build(
+            Some(platform().to_string()),
+            Some(feature.to_string()),
+            None,
+        )
+        .expect("ROM build failed");
         assert!(output.exists());
         output
     }
@@ -156,6 +159,7 @@ mod test {
             Some(name),
             example_app,
             Some(platform),
+            None,
             None,
         )
         .expect("Runtime failed to compile");
@@ -886,8 +890,15 @@ mod test {
         let test_runtime = target_binary(&name);
 
         println!("Compiling test firmware {}", &feature);
-        mcu_builder::runtime_build_with_apps(&[feature], Some(name), true, None, Some(image_svn))
-            .expect("Runtime build failed");
+        mcu_builder::runtime_build_with_apps(
+            &[feature],
+            Some(name),
+            true,
+            None,
+            Some(image_svn),
+            None,
+        )
+        .expect("Runtime build failed");
         assert!(test_runtime.exists());
 
         let fuse_vendor_hashes_prod_partition = {

--- a/tests/integration/src/rom/test_hitless_update.rs
+++ b/tests/integration/src/rom/test_hitless_update.rs
@@ -17,7 +17,7 @@ fn test_hitless_update_flow() -> Result<()> {
             binaries.test_rom(mcu_rom_id)?,
         )
     } else {
-        let rom_file = mcu_builder::test_rom_build(Some(platform()), mcu_rom_id)?;
+        let rom_file = mcu_builder::test_rom_build(Some(platform()), mcu_rom_id, None)?;
         (
             caliptra_builder::build_firmware_rom(cptra_rom_id).unwrap(),
             std::fs::read(&rom_file)?,

--- a/tests/integration/src/rom/test_otp_blank_check.rs
+++ b/tests/integration/src/rom/test_otp_blank_check.rs
@@ -26,6 +26,7 @@ mod test {
             let rom_file = mcu_builder::test_rom_build(
                 Some(platform()),
                 &firmware::hw_model_tests::OTP_BLANK_CHECK,
+                None,
             )
             .unwrap();
             (vec![], std::fs::read(&rom_file).unwrap())

--- a/tests/integration/src/rom/test_sw_digest_lock.rs
+++ b/tests/integration/src/rom/test_sw_digest_lock.rs
@@ -27,6 +27,7 @@ mod test {
             let rom_file = mcu_builder::test_rom_build(
                 Some(platform()),
                 &firmware::hw_model_tests::SW_DIGEST_LOCK,
+                None,
             )
             .unwrap();
             (vec![], std::fs::read(&rom_file).unwrap())

--- a/tests/integration/src/test_exception_handler.rs
+++ b/tests/integration/src/test_exception_handler.rs
@@ -22,6 +22,7 @@ mod test {
             let rom_file = mcu_builder::test_rom_build(
                 Some(platform()),
                 &firmware::hw_model_tests::EXCEPTION_HANDLER,
+                None,
             )
             .unwrap();
             std::fs::read(&rom_file).unwrap()

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -6,6 +6,7 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
+parallel-build = ["mcu-builder/parallel-build"]
 fpga_realtime = [
 	"mcu-hw-model/fpga_realtime",
 	"dep:caliptra-hw-model",

--- a/xtask/src/fpga/configurations.rs
+++ b/xtask/src/fpga/configurations.rs
@@ -287,8 +287,11 @@ impl<'a> ActionHandler<'a> for CoreOnSubsystem {
     }
     fn build(&self, args: &'a BuildArgs<'a>) -> Result<()> {
         let caliptra_sw = caliptra_sw_workspace_root();
-        let rom_path =
-            mcu_builder::rom_build(Some("fpga".to_string()), Some("core_test".to_string()))?;
+        let rom_path = mcu_builder::rom_build(
+            Some("fpga".to_string()),
+            Some("core_test".to_string()),
+            None,
+        )?;
         if !args.mcu {
             build_caliptra_firmware(&caliptra_sw, args.fw_id.as_deref())?;
         }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -493,12 +493,13 @@ fn main() {
                 false,
                 platform.as_deref(),
                 None,
+                None,
             )
             .map(|_| ())
         }
         Commands::Rom { trace } => rom::rom_run(*trace),
         Commands::RomBuild { platform, features } => {
-            mcu_builder::rom_build(platform.clone(), features.clone()).map(|_| ())
+            mcu_builder::rom_build(platform.clone(), features.clone(), None).map(|_| ())
         }
         Commands::FlashImage { subcommand } => match subcommand {
             FlashImageCommands::Create {

--- a/xtask/src/precheckin.rs
+++ b/xtask/src/precheckin.rs
@@ -10,8 +10,8 @@ pub(crate) fn precheckin() -> Result<()> {
     crate::deps::check()?;
     crate::docs::check_docs()?;
     crate::registers::autogen(true, &[], &[], None, None)?;
-    mcu_builder::runtime_build_with_apps(&[], None, false, None, None)?;
-    mcu_builder::runtime_build_with_apps(&[], None, false, Some("fpga"), None)?;
+    mcu_builder::runtime_build_with_apps(&[], None, false, None, None, None)?;
+    mcu_builder::runtime_build_with_apps(&[], None, false, Some("fpga"), None, None)?;
     crate::test::test_panic_missing()?;
     crate::test::e2e_tests()?;
     crate::test::test_hello_c_emulator()?;

--- a/xtask/src/rom.rs
+++ b/xtask/src/rom.rs
@@ -6,7 +6,7 @@ use std::process::Command;
 
 pub(crate) fn rom_run(trace: bool) -> Result<()> {
     let platform = None;
-    let rom_binary = mcu_builder::rom_build(platform, None)?;
+    let rom_binary = mcu_builder::rom_build(platform, None, None)?;
     let mut cargo_run_args = vec![
         "run",
         "-p",

--- a/xtask/src/runtime.rs
+++ b/xtask/src/runtime.rs
@@ -35,8 +35,8 @@ pub(crate) fn runtime_run(args: Commands) -> Result<()> {
     }
     // include debug features since this is interactive
     features.push("debug");
-    let rom_binary = mcu_builder::rom_build(None, None)?;
-    let tock_binary = runtime_build_with_apps(&features, None, false, None, None)?;
+    let rom_binary = mcu_builder::rom_build(None, None, None)?;
+    let tock_binary = runtime_build_with_apps(&features, None, false, None, None, None)?;
 
     let mut caliptra_builder = CaliptraBuilder::new(
         false,

--- a/xtask/src/test.rs
+++ b/xtask/src/test.rs
@@ -218,11 +218,11 @@ pub(crate) fn test_panic_missing() -> Result<()> {
         .join("mcu-rom-emulator");
 
     // Check default build
-    rom_build(None, None)?;
+    rom_build(None, None, None)?;
     check_no_panic(&rom_elf_path, "default")?;
 
     // Check test-flash-based-boot build
-    rom_build(None, Some("test-flash-based-boot".to_string()))?;
+    rom_build(None, Some("test-flash-based-boot".to_string()), None)?;
     check_no_panic(&rom_elf_path, "test-flash-based-boot")?;
 
     Ok(())


### PR DESCRIPTION
Support building firmware in multiple directories to saturate the builder CPU & speed up firmware build step.

This reduces the firmware build step by roughy ~50%