### PR TITLE
[ROM] Configure Caliptra iTRNG parameters

### DIFF
--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -258,6 +258,21 @@ impl McuError {
             "OTP SW digest readback verification failed"
         ),
         (
+            ROM_OTP_READ_CPTRA_ITRNG_WINDOW_SIZE_ERROR,
+            0x3_000d,
+            "Failed to read CPTRA_ITRNG_WINDOW_SIZE from OTP"
+        ),
+        (
+            ROM_OTP_READ_CPTRA_ITRNG_CONFIG0_ERROR,
+            0x3_000e,
+            "Failed to read CPTRA_ITRNG_ENTROPY_CONFIG_0 from OTP"
+        ),
+        (
+            ROM_OTP_READ_CPTRA_ITRNG_CONFIG1_ERROR,
+            0x3_000f,
+            "Failed to read CPTRA_ITRNG_ENTROPY_CONFIG_1 from OTP"
+        ),
+        (
             ROM_I3C_CONFIG_RING_HEADER_ERROR,
             0x4_0000,
             "I3C config ring header error"

--- a/hw/fuses.hjson
+++ b/hw/fuses.hjson
@@ -18,6 +18,9 @@
     // Supporting 128 lock/unlock cycles (256 total state transitions)
     {"dot_initialized": 1}, // 1 bit used to indicate that DOT is enabled and blob is written
     {"dot_fuse_array": 32},  // 256 bits = 128 complete lock/unlock cycles
+    {"trng_health_test_window_size": 2},
+    {"cptra_itrng_entropy_config_0": 4},
+    {"cptra_itrng_entropy_config_1": 4},
   ],
 
   // Field definitions specify bit-level details within fuse bytes
@@ -38,6 +41,30 @@
       partition: "VENDOR_NON_SECRET_PROD_PARTITION",
       otp_item: "CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_1",
       layout: {type: "OneHot"},
+    },
+    {
+      name: "cptra_itrng_health_test_window_size",
+      bits: 16,
+      description: "Health test window size for FIPS mode. See [spec](https://chipsalliance.github.io/caliptra-web/docs/2.1/firmware/rom_spec.html#entropy-source-configuration-registers) for details.",
+      partition: "VENDOR_NON_SECRET_PROD_PARTITION",
+      otp_item: "CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_2",
+      layout: {type: "Single"},
+    },
+    {
+      name: "cptra_itrng_entropy_config_0",
+      bits: 32,
+      description: "Entropy config 0: Low threshold (bits 15:0), High threshold (bits 31:16)",
+      partition: "VENDOR_NON_SECRET_PROD_PARTITION",
+      otp_item: "CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_3",
+      layout: {type: "Single"},
+    },
+    {
+      name: "cptra_itrng_entropy_config_1",
+      bits: 32,
+      description: "Entropy config 1: Repetition count (bits 15:0), Alert threshold (bits 31:16). See [spec](https://chipsalliance.github.io/caliptra-web/docs/2.1/firmware/rom_spec.html#entropy-source-configuration-registers) for details.",
+      partition: "VENDOR_NON_SECRET_PROD_PARTITION",
+      otp_item: "CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_4",
+      layout: {type: "Single"},
     },
     {
       name: "vendor_recovery_pk_hash",

--- a/registers/generated-firmware/src/fuse_map.md
+++ b/registers/generated-firmware/src/fuse_map.md
@@ -267,4 +267,7 @@
 |------|------|-----------|----------|--------|-------------|
 | dot_initialized | 1 | VENDOR_NON_SECRET_PROD_PARTITION | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_0 | LinearMajorityVote(3x) | DOT is enabled and initialized for this part. |
 | dot_fuse_array | 256 | VENDOR_NON_SECRET_PROD_PARTITION | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_1 | OneHot | One-time programmable state counter for DOT transitions. Each bit represents one state change. Increments from 0 to 255. |
+| cptra_itrng_health_test_window_size | 16 | VENDOR_NON_SECRET_PROD_PARTITION | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_2 | Single | Health test window size for FIPS mode. See [spec](https://chipsalliance.github.io/caliptra-web/docs/2.1/firmware/rom_spec.html#entropy-source-configuration-registers) for details. |
+| cptra_itrng_entropy_config_0 | 32 | VENDOR_NON_SECRET_PROD_PARTITION | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_3 | Single | Entropy config 0: Low threshold (bits 15:0), High threshold (bits 31:16) |
+| cptra_itrng_entropy_config_1 | 32 | VENDOR_NON_SECRET_PROD_PARTITION | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_4 | Single | Entropy config 1: Repetition count (bits 15:0), Alert threshold (bits 31:16). See [spec](https://chipsalliance.github.io/caliptra-web/docs/2.1/firmware/rom_spec.html#entropy-source-configuration-registers) for details. |
 | vendor_recovery_pk_hash | 384 | VENDOR_SECRET_PROD_PARTITION | CPTRA_SS_VENDOR_SPECIFIC_SECRET_FUSE_0 | Single | Vendor recovery key for DOT_OVERRIDE catastrophic recovery operations |

--- a/registers/generated-firmware/src/fuses.rs
+++ b/registers/generated-firmware/src/fuses.rs
@@ -340,6 +340,18 @@ pub const NON_SECRET_VENDOR_FUSES: &[Fuse] = &[
         name: "dot_fuse_array",
         size: Bytes(32),
     },
+    Fuse {
+        name: "trng_health_test_window_size",
+        size: Bytes(2),
+    },
+    Fuse {
+        name: "cptra_itrng_entropy_config_0",
+        size: Bytes(4),
+    },
+    Fuse {
+        name: "cptra_itrng_entropy_config_1",
+        size: Bytes(4),
+    },
 ];
 pub const FUSE_FIELDS: &[FuseField] = &[
     FuseField {
@@ -349,6 +361,18 @@ pub const FUSE_FIELDS: &[FuseField] = &[
     FuseField {
         name: "dot_fuse_array",
         bits: Bits(256),
+    },
+    FuseField {
+        name: "cptra_itrng_health_test_window_size",
+        bits: Bits(16),
+    },
+    FuseField {
+        name: "cptra_itrng_entropy_config_0",
+        bits: Bits(32),
+    },
+    FuseField {
+        name: "cptra_itrng_entropy_config_1",
+        bits: Bits(32),
     },
     FuseField {
         name: "vendor_recovery_pk_hash",
@@ -378,6 +402,30 @@ pub const FUSE_ENTRY_TABLE: &[FuseEntryInfo] = &[
         layout: FuseLayoutType::OneHot { bits: 256 },
     },
     FuseEntryInfo {
+        partition_num: 14,
+        entry_num: 2,
+        byte_offset: 0xab8,
+        byte_size: 32,
+        name: "cptra_itrng_health_test_window_size",
+        layout: FuseLayoutType::Single { bits: 16 },
+    },
+    FuseEntryInfo {
+        partition_num: 14,
+        entry_num: 3,
+        byte_offset: 0xad8,
+        byte_size: 32,
+        name: "cptra_itrng_entropy_config_0",
+        layout: FuseLayoutType::Single { bits: 32 },
+    },
+    FuseEntryInfo {
+        partition_num: 14,
+        entry_num: 4,
+        byte_offset: 0xaf8,
+        byte_size: 32,
+        name: "cptra_itrng_entropy_config_1",
+        layout: FuseLayoutType::Single { bits: 32 },
+    },
+    FuseEntryInfo {
         partition_num: 13,
         entry_num: 0,
         byte_offset: 0x870,
@@ -390,8 +438,14 @@ pub const FUSE_ENTRY_TABLE: &[FuseEntryInfo] = &[
 pub const DOT_INITIALIZED: &FuseEntryInfo = &FUSE_ENTRY_TABLE[0];
 /// Fuse entry for `dot_fuse_array`.
 pub const DOT_FUSE_ARRAY: &FuseEntryInfo = &FUSE_ENTRY_TABLE[1];
+/// Fuse entry for `cptra_itrng_health_test_window_size`.
+pub const CPTRA_ITRNG_HEALTH_TEST_WINDOW_SIZE: &FuseEntryInfo = &FUSE_ENTRY_TABLE[2];
+/// Fuse entry for `cptra_itrng_entropy_config_0`.
+pub const CPTRA_ITRNG_ENTROPY_CONFIG_0: &FuseEntryInfo = &FUSE_ENTRY_TABLE[3];
+/// Fuse entry for `cptra_itrng_entropy_config_1`.
+pub const CPTRA_ITRNG_ENTROPY_CONFIG_1: &FuseEntryInfo = &FUSE_ENTRY_TABLE[4];
 /// Fuse entry for `vendor_recovery_pk_hash`.
-pub const VENDOR_RECOVERY_PK_HASH: &FuseEntryInfo = &FUSE_ENTRY_TABLE[2];
+pub const VENDOR_RECOVERY_PK_HASH: &FuseEntryInfo = &FUSE_ENTRY_TABLE[5];
 /// OTP item entry for `CPTRA_SS_MANUF_DEBUG_UNLOCK_TOKEN`.
 pub const OTP_CPTRA_SS_MANUF_DEBUG_UNLOCK_TOKEN: &FuseEntryInfo = &FuseEntryInfo {
     partition_num: 0,
@@ -1610,32 +1664,32 @@ pub const OTP_CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_1: &FuseEntryInfo = &Fuse
     name: "dot_fuse_array",
     layout: FuseLayoutType::OneHot { bits: 256 },
 };
-/// OTP item entry for `CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_2`.
+/// OTP item entry for `cptra_itrng_health_test_window_size`.
 pub const OTP_CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_2: &FuseEntryInfo = &FuseEntryInfo {
     partition_num: 14,
     entry_num: 2,
     byte_offset: 0xab8,
     byte_size: 32,
-    name: "CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_2",
-    layout: FuseLayoutType::Single { bits: 256 },
+    name: "cptra_itrng_health_test_window_size",
+    layout: FuseLayoutType::Single { bits: 16 },
 };
-/// OTP item entry for `CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_3`.
+/// OTP item entry for `cptra_itrng_entropy_config_0`.
 pub const OTP_CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_3: &FuseEntryInfo = &FuseEntryInfo {
     partition_num: 14,
     entry_num: 3,
     byte_offset: 0xad8,
     byte_size: 32,
-    name: "CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_3",
-    layout: FuseLayoutType::Single { bits: 256 },
+    name: "cptra_itrng_entropy_config_0",
+    layout: FuseLayoutType::Single { bits: 32 },
 };
-/// OTP item entry for `CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_4`.
+/// OTP item entry for `cptra_itrng_entropy_config_1`.
 pub const OTP_CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_4: &FuseEntryInfo = &FuseEntryInfo {
     partition_num: 14,
     entry_num: 4,
     byte_offset: 0xaf8,
     byte_size: 32,
-    name: "CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_4",
-    layout: FuseLayoutType::Single { bits: 256 },
+    name: "cptra_itrng_entropy_config_1",
+    layout: FuseLayoutType::Single { bits: 32 },
 };
 /// OTP item entry for `CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_5`.
 pub const OTP_CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_5: &FuseEntryInfo = &FuseEntryInfo {

--- a/rom/src/cold_boot.rs
+++ b/rom/src/cold_boot.rs
@@ -27,6 +27,7 @@ use caliptra_api_types::{DeviceLifecycle, SecurityState};
 use core::fmt::Write;
 use core::ops::Deref;
 use mcu_error::McuError;
+use registers_generated::fuses;
 use romtime::{CaliptraSoC, HexWord};
 use tock_registers::interfaces::Readable;
 use zerocopy::{transmute, IntoBytes};
@@ -381,6 +382,26 @@ impl BootFlow for ColdBoot {
             dma_user: params.cptra_dma_axi_user,
         });
         mci.set_flow_checkpoint(McuRomBootStatus::AxiUsersConfigured.into());
+
+        // Configure iTRNG
+        let Ok(window_size) = otp.read_entry(fuses::CPTRA_ITRNG_HEALTH_TEST_WINDOW_SIZE) else {
+            romtime::println!("[mcu-rom] Error reading CPTRA_ITRNG_WINDOW_SIZE");
+            fatal_error(McuError::ROM_OTP_READ_CPTRA_ITRNG_WINDOW_SIZE_ERROR);
+        };
+        let Ok(config0) = otp.read_entry(fuses::CPTRA_ITRNG_ENTROPY_CONFIG_0) else {
+            romtime::println!("[mcu-rom] Error reading CPTRA_ITRNG_ENTROPY_CONFIG_0");
+            fatal_error(McuError::ROM_OTP_READ_CPTRA_ITRNG_CONFIG0_ERROR);
+        };
+        let Ok(config1) = otp.read_entry(fuses::CPTRA_ITRNG_ENTROPY_CONFIG_1) else {
+            romtime::println!("[mcu-rom] Error reading CPTRA_ITRNG_ENTROPY_CONFIG_1");
+            fatal_error(McuError::ROM_OTP_READ_CPTRA_ITRNG_CONFIG1_ERROR);
+        };
+        soc.configure_itrng(crate::CptraItrngArgs {
+            bypass_mode: params.itrng_entropy_bypass_mode,
+            window_size: window_size as u16,
+            config0,
+            config1,
+        });
 
         romtime::println!("[mcu-rom] Populating fuses");
         soc.populate_fuses(otp, mci);

--- a/rom/src/rom.rs
+++ b/rom/src/rom.rs
@@ -395,6 +395,30 @@ impl Soc {
         // Clear the reset request interrupt
         notif0.modify(mci::bits::Notif0IntrT::NotifCptraMcuResetReqSts::SET);
     }
+
+    /// Configure the Caliptra iTRNG parameters.
+    pub fn configure_itrng(&self, args: CptraItrngArgs) {
+        let bypass_mode = u32::from(args.bypass_mode) << 31;
+        let window_size = u32::from(args.window_size);
+        self.registers.ss_strap_generic[2].set(bypass_mode | window_size);
+        self.registers
+            .cptra_i_trng_entropy_config_0
+            .set(args.config0);
+        self.registers
+            .cptra_i_trng_entropy_config_1
+            .set(args.config1);
+    }
+}
+
+/// Caliptra iTRNG configuration parameters.
+///
+/// See the [spec](https://chipsalliance.github.io/caliptra-web/docs/2.1/firmware/rom_spec.html#entropy-source-configuration-registers)
+/// for more details.
+pub struct CptraItrngArgs {
+    pub bypass_mode: bool,
+    pub window_size: u16,
+    pub config0: u32,
+    pub config1: u32,
 }
 
 /// Number of users supported by the MCU MBOX ACL mechanism.
@@ -648,6 +672,9 @@ pub struct RomParameters<'a> {
     /// Required to use `Otp::compute_sw_digest` and `Otp::write_sw_digest_and_lock`.
     pub otp_digest_iv: Option<u64>,
     pub otp_digest_const: Option<u128>,
+    /// Caliptra entropy bypass mode. See [spec](https://chipsalliance.github.io/caliptra-web/docs/2.1/firmware/rom_spec.html#entropy-source-configuration-registers)
+    /// for more details.
+    pub itrng_entropy_bypass_mode: bool,
 }
 
 #[inline(always)]


### PR DESCRIPTION
This fixes https://github.com/chipsalliance/caliptra-embargoed/issues/41 and https://github.com/chipsalliance/caliptra-embargoed/issues/45

This adds vendor fuses for CPTRA_ITRNG_ENTROPY_CONFIG_0 and CPTRA_ITRNG_ENTROPY_CONFIG_1 and health test window size. The ROM then reads those fuses on Cold Reset and sets the Caliptra registers with the given values.

The entropy bypass mode is set by RomParameters so it can be integration specific.