### PR TITLE
Add caliptra-core facade crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,7 +14,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "generic-array",
 ]
 
@@ -26,7 +26,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -63,9 +63,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -78,44 +78,44 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.10"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arbitrary"
@@ -147,8 +147,18 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2affba5e62ee09eeba078f01a00c4aed45ac4287e091298eccbb0d4802efbdc5"
 dependencies = [
- "asn1_derive",
+ "asn1_derive 0.13.0",
  "chrono",
+]
+
+[[package]]
+name = "asn1"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca7444bb097e58fd76ae2b3929d8f5bdb3748000eb51b79141ed7c7b6a9dcdbc"
+dependencies = [
+ "asn1_derive 0.23.1",
+ "itoa",
 ]
 
 [[package]]
@@ -163,6 +173,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "asn1_derive"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0dcd11549aa9d043141c7d54839771cbf9a8d38084808c6fa00e62b46b114f0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -170,7 +191,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -200,7 +221,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 name = "bare-metal-runtime"
 version = "0.1.0"
 dependencies = [
- "caliptra-drivers",
+ "caliptra-core-firmware",
  "romtime",
  "rv32i",
 ]
@@ -219,9 +240,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.8.0"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bit-vec"
@@ -246,9 +267,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "block-buffer"
@@ -257,6 +278,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array 0.4.8",
 ]
 
 [[package]]
@@ -279,9 +309,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "byteorder"
@@ -291,23 +321,46 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "caliptra-api"
+version = "0.1.0"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c#49927b620f317ad4c459811f49baa56de197126c"
+dependencies = [
+ "bitflags 2.11.0",
+ "caliptra-api-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-emu-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-error 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-image-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-registers 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "ureg 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "zerocopy",
+]
 
 [[package]]
 name = "caliptra-api"
 version = "0.1.0"
 source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644#8bfab8d1fa6dda44c86300c6d9d2de6919482644"
 dependencies = [
- "bitflags 2.10.0",
- "caliptra-api-types",
- "caliptra-emu-types",
- "caliptra-error",
- "caliptra-image-types",
- "caliptra-registers",
- "ureg",
+ "bitflags 2.11.0",
+ "caliptra-api-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-emu-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-error 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-image-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-registers 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "ureg 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
  "zerocopy",
+]
+
+[[package]]
+name = "caliptra-api-types"
+version = "0.1.0"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c#49927b620f317ad4c459811f49baa56de197126c"
+dependencies = [
+ "caliptra-image-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
 ]
 
 [[package]]
@@ -315,7 +368,23 @@ name = "caliptra-api-types"
 version = "0.1.0"
 source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644#8bfab8d1fa6dda44c86300c6d9d2de6919482644"
 dependencies = [
- "caliptra-image-types",
+ "caliptra-image-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+]
+
+[[package]]
+name = "caliptra-auth-man-gen"
+version = "0.1.0"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c#49927b620f317ad4c459811f49baa56de197126c"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.0",
+ "caliptra-auth-man-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-image-fake-keys 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-image-gen 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-image-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-lms-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "memoffset 0.8.0",
+ "zerocopy",
 ]
 
 [[package]]
@@ -324,13 +393,28 @@ version = "0.1.0"
 source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644#8bfab8d1fa6dda44c86300c6d9d2de6919482644"
 dependencies = [
  "anyhow",
- "bitflags 2.10.0",
- "caliptra-auth-man-types",
- "caliptra-image-gen",
- "caliptra-image-types",
- "caliptra-lms-types",
+ "bitflags 2.11.0",
+ "caliptra-auth-man-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-image-gen 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-image-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-lms-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
  "memoffset 0.8.0",
  "zerocopy",
+]
+
+[[package]]
+name = "caliptra-auth-man-types"
+version = "0.1.0"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c#49927b620f317ad4c459811f49baa56de197126c"
+dependencies = [
+ "bitfield",
+ "bitflags 2.11.0",
+ "caliptra-error 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-image-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-lms-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "memoffset 0.8.0",
+ "zerocopy",
+ "zeroize",
 ]
 
 [[package]]
@@ -339,10 +423,10 @@ version = "0.1.0"
 source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644#8bfab8d1fa6dda44c86300c6d9d2de6919482644"
 dependencies = [
  "bitfield",
- "bitflags 2.10.0",
- "caliptra-error",
- "caliptra-image-types",
- "caliptra-lms-types",
+ "bitflags 2.11.0",
+ "caliptra-error 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-image-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-lms-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
  "memoffset 0.8.0",
  "zerocopy",
  "zeroize",
@@ -354,25 +438,25 @@ version = "0.1.0"
 source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644#8bfab8d1fa6dda44c86300c6d9d2de6919482644"
 dependencies = [
  "anyhow",
- "clap 4.5.51",
+ "clap 4.6.0",
  "hex",
  "reqwest",
  "serde",
  "sha2",
- "toml 0.9.8",
+ "toml 0.9.12+spec-1.1.0",
 ]
 
 [[package]]
 name = "caliptra-builder"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644#8bfab8d1fa6dda44c86300c6d9d2de6919482644"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c#49927b620f317ad4c459811f49baa56de197126c"
 dependencies = [
  "anyhow",
- "caliptra-image-crypto",
- "caliptra-image-elf",
- "caliptra-image-fake-keys",
- "caliptra-image-gen",
- "caliptra-image-types",
+ "caliptra-image-crypto 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-image-elf 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-image-fake-keys 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-image-gen 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-image-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
  "clap 3.2.25",
  "elf",
  "fslock",
@@ -385,6 +469,42 @@ dependencies = [
  "sha2",
  "toml 0.7.8",
  "zerocopy",
+]
+
+[[package]]
+name = "caliptra-builder"
+version = "0.1.0"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644#8bfab8d1fa6dda44c86300c6d9d2de6919482644"
+dependencies = [
+ "anyhow",
+ "caliptra-image-crypto 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-image-elf 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-image-fake-keys 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-image-gen 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-image-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "clap 3.2.25",
+ "elf",
+ "fslock",
+ "hex",
+ "memoffset 0.8.0",
+ "once_cell",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sha2",
+ "toml 0.7.8",
+ "zerocopy",
+]
+
+[[package]]
+name = "caliptra-cfi-derive"
+version = "0.1.0"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c#49927b620f317ad4c459811f49baa56de197126c"
+dependencies = [
+ "paste",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -412,10 +532,20 @@ dependencies = [
 [[package]]
 name = "caliptra-cfi-lib"
 version = "0.1.0"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c#49927b620f317ad4c459811f49baa56de197126c"
+dependencies = [
+ "caliptra-error 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-registers 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "ufmt 0.2.0",
+]
+
+[[package]]
+name = "caliptra-cfi-lib"
+version = "0.1.0"
 source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644#8bfab8d1fa6dda44c86300c6d9d2de6919482644"
 dependencies = [
- "caliptra-error",
- "caliptra-registers",
+ "caliptra-error 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-registers 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
  "ufmt 0.2.0",
 ]
 
@@ -425,15 +555,94 @@ version = "0.1.0"
 source = "git+https://github.com/chipsalliance/caliptra-cfi.git?rev=a98e499d279e81ae85881991b1e9eee354151189#a98e499d279e81ae85881991b1e9eee354151189"
 
 [[package]]
+name = "caliptra-core-firmware"
+version = "0.1.0"
+dependencies = [
+ "caliptra-api 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-api 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-api-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-api-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-auth-man-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-auth-man-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-drivers 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-drivers 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-error 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-error 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-registers 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-registers 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "ocp-eat 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "ocp-eat 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "ureg 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "ureg 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+]
+
+[[package]]
+name = "caliptra-core-tools"
+version = "0.1.0"
+dependencies = [
+ "caliptra-auth-man-gen 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-auth-man-gen 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-builder 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-builder 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-core-firmware",
+ "caliptra-emu-bus 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-emu-bus 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-emu-cpu 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-emu-cpu 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-emu-derive 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-emu-derive 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-emu-periph 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-emu-periph 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-emu-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-emu-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-hw-model 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-hw-model 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-hw-model-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-hw-model-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-image-crypto 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-image-crypto 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-image-fake-keys 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-image-fake-keys 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-image-gen 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-image-gen 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-image-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-image-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-test 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-test 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-test-harness 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-test-harness 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-test-harness-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-test-harness-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+]
+
+[[package]]
+name = "caliptra-coverage"
+version = "0.1.0"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c#49927b620f317ad4c459811f49baa56de197126c"
+dependencies = [
+ "anyhow",
+ "bit-vec",
+ "caliptra-builder 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-drivers 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-image-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "elf",
+ "hex",
+ "rand 0.8.5",
+ "regex",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "caliptra-coverage"
 version = "0.1.0"
 source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644#8bfab8d1fa6dda44c86300c6d9d2de6919482644"
 dependencies = [
  "anyhow",
  "bit-vec",
- "caliptra-builder",
- "caliptra-drivers",
- "caliptra-image-types",
+ "caliptra-builder 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-drivers 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-image-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
  "elf",
  "hex",
  "rand 0.8.5",
@@ -445,11 +654,48 @@ dependencies = [
 [[package]]
 name = "caliptra-cpu"
 version = "0.1.0"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c#49927b620f317ad4c459811f49baa56de197126c"
+dependencies = [
+ "caliptra-drivers 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-registers 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "cfg-if",
+]
+
+[[package]]
+name = "caliptra-cpu"
+version = "0.1.0"
 source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644#8bfab8d1fa6dda44c86300c6d9d2de6919482644"
 dependencies = [
- "caliptra-drivers",
- "caliptra-registers",
+ "caliptra-drivers 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-registers 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
  "cfg-if",
+]
+
+[[package]]
+name = "caliptra-drivers"
+version = "0.1.0"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c#49927b620f317ad4c459811f49baa56de197126c"
+dependencies = [
+ "arrayvec",
+ "bitfield",
+ "bitflags 2.11.0",
+ "caliptra-api 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-auth-man-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-cfi-derive 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-cfi-derive-git",
+ "caliptra-cfi-lib 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-cfi-lib-git",
+ "caliptra-error 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-image-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-lms-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-okref 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-registers 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "cfg-if",
+ "dpe 0.1.0 (git+https://github.com/chipsalliance/caliptra-dpe?rev=4fa31d99abca3b9d09cea06eb9a57c819ac17596)",
+ "ufmt 0.2.0",
+ "ureg 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "zerocopy",
+ "zeroize",
 ]
 
 [[package]]
@@ -459,22 +705,22 @@ source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c
 dependencies = [
  "arrayvec",
  "bitfield",
- "bitflags 2.10.0",
- "caliptra-api",
- "caliptra-auth-man-types",
- "caliptra-cfi-derive",
+ "bitflags 2.11.0",
+ "caliptra-api 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-auth-man-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-cfi-derive 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
  "caliptra-cfi-derive-git",
- "caliptra-cfi-lib",
+ "caliptra-cfi-lib 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
  "caliptra-cfi-lib-git",
- "caliptra-error",
- "caliptra-image-types",
- "caliptra-lms-types",
- "caliptra-okref",
- "caliptra-registers",
+ "caliptra-error 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-image-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-lms-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-okref 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-registers 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
  "cfg-if",
- "dpe",
+ "dpe 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
  "ufmt 0.2.0",
- "ureg",
+ "ureg 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
  "zerocopy",
  "zeroize",
 ]
@@ -482,11 +728,35 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-bus"
 version = "0.1.0"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c#49927b620f317ad4c459811f49baa56de197126c"
+dependencies = [
+ "caliptra-emu-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "tock-registers",
+ "ureg 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+]
+
+[[package]]
+name = "caliptra-emu-bus"
+version = "0.1.0"
 source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644#8bfab8d1fa6dda44c86300c6d9d2de6919482644"
 dependencies = [
- "caliptra-emu-types",
+ "caliptra-emu-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
  "tock-registers",
- "ureg",
+ "ureg 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+]
+
+[[package]]
+name = "caliptra-emu-cpu"
+version = "0.1.0"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c#49927b620f317ad4c459811f49baa56de197126c"
+dependencies = [
+ "bit-vec",
+ "bitfield",
+ "caliptra-emu-bus 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-emu-derive 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-emu-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "lazy_static",
+ "tock-registers",
 ]
 
 [[package]]
@@ -496,11 +766,27 @@ source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c
 dependencies = [
  "bit-vec",
  "bitfield",
- "caliptra-emu-bus",
- "caliptra-emu-derive",
- "caliptra-emu-types",
+ "caliptra-emu-bus 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-emu-derive 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-emu-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
  "lazy_static",
  "tock-registers",
+]
+
+[[package]]
+name = "caliptra-emu-crypto"
+version = "0.1.0"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c#49927b620f317ad4c459811f49baa56de197126c"
+dependencies = [
+ "aes",
+ "aes-gcm",
+ "cbc",
+ "cipher",
+ "ctr",
+ "p384",
+ "rfc6979",
+ "sha2",
+ "sha3 0.10.8",
 ]
 
 [[package]]
@@ -521,12 +807,52 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-derive"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644#8bfab8d1fa6dda44c86300c6d9d2de6919482644"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c#49927b620f317ad4c459811f49baa56de197126c"
 dependencies = [
- "caliptra-emu-bus",
- "caliptra-emu-types",
+ "caliptra-emu-bus 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-emu-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
  "proc-macro2",
  "quote",
+]
+
+[[package]]
+name = "caliptra-emu-derive"
+version = "0.1.0"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644#8bfab8d1fa6dda44c86300c6d9d2de6919482644"
+dependencies = [
+ "caliptra-emu-bus 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-emu-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "caliptra-emu-periph"
+version = "0.1.0"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c#49927b620f317ad4c459811f49baa56de197126c"
+dependencies = [
+ "aes",
+ "arrayref",
+ "bitfield",
+ "caliptra-api-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-emu-bus 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-emu-cpu 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-emu-crypto 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-emu-derive 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-emu-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-hw-model-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-registers 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "const-random",
+ "fips204",
+ "lazy_static",
+ "ml-dsa",
+ "ml-kem",
+ "rand 0.8.5",
+ "sha2",
+ "sha3 0.10.8",
+ "smlang",
+ "tock-registers",
+ "zerocopy",
 ]
 
 [[package]]
@@ -537,24 +863,29 @@ dependencies = [
  "aes",
  "arrayref",
  "bitfield",
- "caliptra-api-types",
- "caliptra-emu-bus",
- "caliptra-emu-cpu",
- "caliptra-emu-crypto",
- "caliptra-emu-derive",
- "caliptra-emu-types",
- "caliptra-hw-model-types",
- "caliptra-registers",
+ "caliptra-api-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-emu-bus 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-emu-cpu 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-emu-crypto 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-emu-derive 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-emu-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-hw-model-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-registers 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
  "const-random",
  "fips204",
  "lazy_static",
  "rand 0.8.5",
  "sha2",
- "sha3",
+ "sha3 0.10.8",
  "smlang",
  "tock-registers",
  "zerocopy",
 ]
+
+[[package]]
+name = "caliptra-emu-types"
+version = "0.1.0"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c#49927b620f317ad4c459811f49baa56de197126c"
 
 [[package]]
 name = "caliptra-emu-types"
@@ -564,14 +895,65 @@ source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c
 [[package]]
 name = "caliptra-error"
 version = "0.1.0"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c#49927b620f317ad4c459811f49baa56de197126c"
+
+[[package]]
+name = "caliptra-error"
+version = "0.1.0"
 source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644#8bfab8d1fa6dda44c86300c6d9d2de6919482644"
+
+[[package]]
+name = "caliptra-gen-linker-scripts"
+version = "0.1.0"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c#49927b620f317ad4c459811f49baa56de197126c"
+dependencies = [
+ "caliptra_common 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+]
 
 [[package]]
 name = "caliptra-gen-linker-scripts"
 version = "0.1.0"
 source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644#8bfab8d1fa6dda44c86300c6d9d2de6919482644"
 dependencies = [
- "caliptra_common",
+ "caliptra_common 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+]
+
+[[package]]
+name = "caliptra-hw-model"
+version = "0.1.0"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c#49927b620f317ad4c459811f49baa56de197126c"
+dependencies = [
+ "anyhow",
+ "bit-vec",
+ "bitfield",
+ "bitflags 2.11.0",
+ "caliptra-api 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-api-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-coverage 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-emu-bus 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-emu-cpu 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-emu-periph 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-emu-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-hw-model-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-image-fake-keys 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-image-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-registers 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "libc",
+ "nix 0.26.4",
+ "once_cell",
+ "rand 0.8.5",
+ "regex",
+ "rustix 1.1.4",
+ "scopeguard",
+ "serde",
+ "sha2",
+ "sha3 0.10.8",
+ "smlang",
+ "thiserror 2.0.18",
+ "tock-registers",
+ "uio",
+ "ureg 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "zerocopy",
 ]
 
 [[package]]
@@ -582,35 +964,44 @@ dependencies = [
  "anyhow",
  "bit-vec",
  "bitfield",
- "bitflags 2.10.0",
- "caliptra-api",
- "caliptra-api-types",
- "caliptra-coverage",
- "caliptra-emu-bus",
- "caliptra-emu-cpu",
- "caliptra-emu-periph",
- "caliptra-emu-types",
- "caliptra-hw-model-types",
- "caliptra-image-fake-keys",
- "caliptra-image-types",
- "caliptra-registers",
- "caliptra_common",
+ "bitflags 2.11.0",
+ "caliptra-api 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-api-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-coverage 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-emu-bus 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-emu-cpu 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-emu-periph 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-emu-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-hw-model-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-image-fake-keys 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-image-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-registers 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra_common 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
  "libc",
  "nix 0.26.4",
  "once_cell",
  "rand 0.8.5",
  "regex",
- "rustix 1.1.2",
+ "rustix 1.1.4",
  "scopeguard",
  "serde",
  "sha2",
- "sha3",
+ "sha3 0.10.8",
  "smlang",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tock-registers",
  "uio",
- "ureg",
+ "ureg 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
  "zerocopy",
+]
+
+[[package]]
+name = "caliptra-hw-model-types"
+version = "0.1.0"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c#49927b620f317ad4c459811f49baa56de197126c"
+dependencies = [
+ "caliptra-api-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -618,8 +1009,28 @@ name = "caliptra-hw-model-types"
 version = "0.1.0"
 source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644#8bfab8d1fa6dda44c86300c6d9d2de6919482644"
 dependencies = [
- "caliptra-api-types",
+ "caliptra-api-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
  "rand 0.8.5",
+]
+
+[[package]]
+name = "caliptra-image-crypto"
+version = "0.1.0"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c#49927b620f317ad4c459811f49baa56de197126c"
+dependencies = [
+ "anyhow",
+ "caliptra-image-gen 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-image-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-lms-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "cfg-if",
+ "ecdsa",
+ "fips204",
+ "openssl",
+ "p384",
+ "rand 0.8.5",
+ "sec1",
+ "sha2",
+ "zerocopy",
 ]
 
 [[package]]
@@ -628,9 +1039,9 @@ version = "0.1.0"
 source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644#8bfab8d1fa6dda44c86300c6d9d2de6919482644"
 dependencies = [
  "anyhow",
- "caliptra-image-gen",
- "caliptra-image-types",
- "caliptra-lms-types",
+ "caliptra-image-gen 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-image-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-lms-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
  "cfg-if",
  "ecdsa",
  "fips204",
@@ -645,12 +1056,34 @@ dependencies = [
 [[package]]
 name = "caliptra-image-elf"
 version = "0.1.0"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c#49927b620f317ad4c459811f49baa56de197126c"
+dependencies = [
+ "anyhow",
+ "caliptra-image-gen 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-image-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "elf",
+]
+
+[[package]]
+name = "caliptra-image-elf"
+version = "0.1.0"
 source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644#8bfab8d1fa6dda44c86300c6d9d2de6919482644"
 dependencies = [
  "anyhow",
- "caliptra-image-gen",
- "caliptra-image-types",
+ "caliptra-image-gen 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-image-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
  "elf",
+]
+
+[[package]]
+name = "caliptra-image-fake-keys"
+version = "0.1.0"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c#49927b620f317ad4c459811f49baa56de197126c"
+dependencies = [
+ "caliptra-image-gen 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-image-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-lms-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "zerocopy",
 ]
 
 [[package]]
@@ -658,9 +1091,26 @@ name = "caliptra-image-fake-keys"
 version = "0.1.0"
 source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644#8bfab8d1fa6dda44c86300c6d9d2de6919482644"
 dependencies = [
- "caliptra-image-gen",
- "caliptra-image-types",
- "caliptra-lms-types",
+ "caliptra-image-gen 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-image-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-lms-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "zerocopy",
+]
+
+[[package]]
+name = "caliptra-image-gen"
+version = "0.1.0"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c#49927b620f317ad4c459811f49baa56de197126c"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.0",
+ "caliptra-image-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-lms-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "fips204",
+ "memoffset 0.8.0",
+ "rand 0.8.5",
+ "serde",
+ "serde_derive",
  "zerocopy",
 ]
 
@@ -670,9 +1120,9 @@ version = "0.1.0"
 source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644#8bfab8d1fa6dda44c86300c6d9d2de6919482644"
 dependencies = [
  "anyhow",
- "bitflags 2.10.0",
- "caliptra-image-types",
- "caliptra-lms-types",
+ "bitflags 2.11.0",
+ "caliptra-image-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-lms-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
  "fips204",
  "memoffset 0.8.0",
  "rand 0.8.5",
@@ -684,12 +1134,28 @@ dependencies = [
 [[package]]
 name = "caliptra-image-types"
 version = "0.1.0"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c#49927b620f317ad4c459811f49baa56de197126c"
+dependencies = [
+ "caliptra-cfi-derive 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-cfi-lib 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-error 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-lms-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "memoffset 0.8.0",
+ "serde",
+ "serde_derive",
+ "zerocopy",
+ "zeroize",
+]
+
+[[package]]
+name = "caliptra-image-types"
+version = "0.1.0"
 source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644#8bfab8d1fa6dda44c86300c6d9d2de6919482644"
 dependencies = [
- "caliptra-cfi-derive",
- "caliptra-cfi-lib",
- "caliptra-error",
- "caliptra-lms-types",
+ "caliptra-cfi-derive 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-cfi-lib 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-error 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-lms-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
  "memoffset 0.8.0",
  "serde",
  "serde_derive",
@@ -700,15 +1166,42 @@ dependencies = [
 [[package]]
 name = "caliptra-image-verify"
 version = "0.1.0"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c#49927b620f317ad4c459811f49baa56de197126c"
+dependencies = [
+ "bitflags 2.11.0",
+ "caliptra-cfi-derive 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-cfi-lib 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-drivers 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-image-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-registers 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "memoffset 0.8.0",
+ "zerocopy",
+]
+
+[[package]]
+name = "caliptra-image-verify"
+version = "0.1.0"
 source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644#8bfab8d1fa6dda44c86300c6d9d2de6919482644"
 dependencies = [
- "bitflags 2.10.0",
- "caliptra-cfi-derive",
- "caliptra-cfi-lib",
- "caliptra-drivers",
- "caliptra-image-types",
- "caliptra-registers",
+ "bitflags 2.11.0",
+ "caliptra-cfi-derive 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-cfi-lib 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-drivers 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-image-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-registers 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
  "memoffset 0.8.0",
+ "zerocopy",
+]
+
+[[package]]
+name = "caliptra-kat"
+version = "0.1.0"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c#49927b620f317ad4c459811f49baa56de197126c"
+dependencies = [
+ "caliptra-drivers 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-lms-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-registers 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "ufmt 0.2.0",
  "zerocopy",
 ]
 
@@ -717,9 +1210,9 @@ name = "caliptra-kat"
 version = "0.1.0"
 source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644#8bfab8d1fa6dda44c86300c6d9d2de6919482644"
 dependencies = [
- "caliptra-drivers",
- "caliptra-lms-types",
- "caliptra-registers",
+ "caliptra-drivers 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-lms-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-registers 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
  "ufmt 0.2.0",
  "zerocopy",
 ]
@@ -727,10 +1220,23 @@ dependencies = [
 [[package]]
 name = "caliptra-lms-types"
 version = "0.1.0"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c#49927b620f317ad4c459811f49baa56de197126c"
+dependencies = [
+ "caliptra-cfi-derive 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-cfi-lib 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "serde",
+ "serde_derive",
+ "zerocopy",
+ "zeroize",
+]
+
+[[package]]
+name = "caliptra-lms-types"
+version = "0.1.0"
 source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644#8bfab8d1fa6dda44c86300c6d9d2de6919482644"
 dependencies = [
- "caliptra-cfi-derive",
- "caliptra-cfi-lib",
+ "caliptra-cfi-derive 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-cfi-lib 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
  "serde",
  "serde_derive",
  "zerocopy",
@@ -743,9 +1249,14 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "caliptra-util-host-mailbox-test-config",
- "clap 4.5.51",
+ "clap 4.6.0",
  "zerocopy",
 ]
+
+[[package]]
+name = "caliptra-okref"
+version = "0.1.0"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c#49927b620f317ad4c459811f49baa56de197126c"
 
 [[package]]
 name = "caliptra-okref"
@@ -755,9 +1266,25 @@ source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c
 [[package]]
 name = "caliptra-registers"
 version = "0.1.0"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c#49927b620f317ad4c459811f49baa56de197126c"
+dependencies = [
+ "caliptra-registers-latest 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+]
+
+[[package]]
+name = "caliptra-registers"
+version = "0.1.0"
 source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644#8bfab8d1fa6dda44c86300c6d9d2de6919482644"
 dependencies = [
- "caliptra-registers-latest",
+ "caliptra-registers-latest 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+]
+
+[[package]]
+name = "caliptra-registers-latest"
+version = "0.1.0"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c#49927b620f317ad4c459811f49baa56de197126c"
+dependencies = [
+ "ureg 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
 ]
 
 [[package]]
@@ -765,7 +1292,42 @@ name = "caliptra-registers-latest"
 version = "0.1.0"
 source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644#8bfab8d1fa6dda44c86300c6d9d2de6919482644"
 dependencies = [
- "ureg",
+ "ureg 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+]
+
+[[package]]
+name = "caliptra-runtime"
+version = "0.1.0"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c#49927b620f317ad4c459811f49baa56de197126c"
+dependencies = [
+ "arrayvec",
+ "bitfield",
+ "bitflags 2.11.0",
+ "caliptra-api 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-auth-man-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-cfi-derive-git",
+ "caliptra-cfi-lib-git",
+ "caliptra-cpu 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-drivers 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-error 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-gen-linker-scripts 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-image-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-image-verify 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-kat 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-lms-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-registers 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-x509 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra_common 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "cfg-if",
+ "constant_time_eq 0.3.1",
+ "crypto 0.1.0 (git+https://github.com/chipsalliance/caliptra-dpe?rev=4fa31d99abca3b9d09cea06eb9a57c819ac17596)",
+ "dpe 0.1.0 (git+https://github.com/chipsalliance/caliptra-dpe?rev=4fa31d99abca3b9d09cea06eb9a57c819ac17596)",
+ "memoffset 0.8.0",
+ "platform 0.1.0 (git+https://github.com/chipsalliance/caliptra-dpe?rev=4fa31d99abca3b9d09cea06eb9a57c819ac17596)",
+ "ufmt 0.2.0",
+ "ureg 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "zerocopy",
+ "zeroize",
 ]
 
 [[package]]
@@ -775,32 +1337,75 @@ source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c
 dependencies = [
  "arrayvec",
  "bitfield",
- "bitflags 2.10.0",
- "caliptra-api",
- "caliptra-auth-man-types",
+ "bitflags 2.11.0",
+ "caliptra-api 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-auth-man-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
  "caliptra-cfi-derive-git",
  "caliptra-cfi-lib-git",
- "caliptra-cpu",
- "caliptra-drivers",
- "caliptra-error",
- "caliptra-gen-linker-scripts",
- "caliptra-image-types",
- "caliptra-image-verify",
- "caliptra-kat",
- "caliptra-lms-types",
- "caliptra-registers",
- "caliptra-x509",
- "caliptra_common",
+ "caliptra-cpu 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-drivers 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-error 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-gen-linker-scripts 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-image-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-image-verify 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-kat 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-lms-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-registers 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-x509 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra_common 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
  "cfg-if",
  "constant_time_eq 0.3.1",
- "crypto",
- "dpe",
+ "crypto 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "dpe 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
  "memoffset 0.8.0",
- "platform",
+ "platform 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
  "ufmt 0.2.0",
- "ureg",
+ "ureg 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
  "zerocopy",
  "zeroize",
+]
+
+[[package]]
+name = "caliptra-test"
+version = "0.1.0"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c#49927b620f317ad4c459811f49baa56de197126c"
+dependencies = [
+ "aes-gcm",
+ "anyhow",
+ "asn1 0.23.1",
+ "caliptra-api 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-api-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-auth-man-gen 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-auth-man-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-builder 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-coverage 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-drivers 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-hw-model 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-hw-model-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-image-crypto 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-image-elf 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-image-fake-keys 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-image-gen 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-image-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-image-verify 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-runtime 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra_common 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "der 0.7.10",
+ "dpe 0.1.0 (git+https://github.com/chipsalliance/caliptra-dpe?rev=4fa31d99abca3b9d09cea06eb9a57c819ac17596)",
+ "elf",
+ "hex",
+ "hkdf",
+ "hpke",
+ "ml-kem",
+ "openssl",
+ "rand 0.8.5",
+ "regex",
+ "serde",
+ "serde_json",
+ "sha2",
+ "sha3 0.10.8",
+ "ureg 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "zerocopy",
 ]
 
 [[package]]
@@ -809,31 +1414,54 @@ version = "0.1.0"
 source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644#8bfab8d1fa6dda44c86300c6d9d2de6919482644"
 dependencies = [
  "anyhow",
- "asn1",
- "caliptra-api",
- "caliptra-api-types",
- "caliptra-builder",
- "caliptra-coverage",
- "caliptra-drivers",
- "caliptra-hw-model",
- "caliptra-hw-model-types",
- "caliptra-image-crypto",
- "caliptra-image-elf",
- "caliptra-image-fake-keys",
- "caliptra-image-gen",
- "caliptra-image-types",
- "caliptra-image-verify",
- "caliptra-runtime",
- "caliptra_common",
- "der",
- "dpe",
+ "asn1 0.13.0",
+ "caliptra-api 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-api-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-builder 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-coverage 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-drivers 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-hw-model 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-hw-model-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-image-crypto 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-image-elf 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-image-fake-keys 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-image-gen 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-image-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-image-verify 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-runtime 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra_common 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "der 0.7.10",
+ "dpe 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
  "elf",
  "openssl",
  "rand 0.8.5",
  "regex",
- "ureg",
+ "ureg 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
  "zerocopy",
 ]
+
+[[package]]
+name = "caliptra-test-harness"
+version = "0.1.0"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c#49927b620f317ad4c459811f49baa56de197126c"
+dependencies = [
+ "caliptra-drivers 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "cfg-if",
+]
+
+[[package]]
+name = "caliptra-test-harness"
+version = "0.1.0"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644#8bfab8d1fa6dda44c86300c6d9d2de6919482644"
+dependencies = [
+ "caliptra-drivers 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "cfg-if",
+]
+
+[[package]]
+name = "caliptra-test-harness-types"
+version = "0.1.0"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c#49927b620f317ad4c459811f49baa56de197126c"
 
 [[package]]
 name = "caliptra-test-harness-types"
@@ -852,8 +1480,41 @@ dependencies = [
 [[package]]
 name = "caliptra-x509"
 version = "0.1.0"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c#49927b620f317ad4c459811f49baa56de197126c"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "caliptra-x509"
+version = "0.1.0"
 source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644#8bfab8d1fa6dda44c86300c6d9d2de6919482644"
 dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "caliptra_common"
+version = "0.1.0"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c#49927b620f317ad4c459811f49baa56de197126c"
+dependencies = [
+ "bitfield",
+ "bitflags 2.11.0",
+ "caliptra-api 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-cfi-derive-git",
+ "caliptra-cfi-lib 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-cfi-lib-git",
+ "caliptra-cpu 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-drivers 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-error 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-image-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-image-verify 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-registers 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "caliptra-x509 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c)",
+ "memoffset 0.8.0",
+ "riscv 0.13.0",
+ "ufmt 0.2.0",
+ "zerocopy",
  "zeroize",
 ]
 
@@ -863,18 +1524,18 @@ version = "0.1.0"
 source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644#8bfab8d1fa6dda44c86300c6d9d2de6919482644"
 dependencies = [
  "bitfield",
- "bitflags 2.10.0",
- "caliptra-api",
+ "bitflags 2.11.0",
+ "caliptra-api 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
  "caliptra-cfi-derive-git",
- "caliptra-cfi-lib",
+ "caliptra-cfi-lib 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
  "caliptra-cfi-lib-git",
- "caliptra-cpu",
- "caliptra-drivers",
- "caliptra-error",
- "caliptra-image-types",
- "caliptra-image-verify",
- "caliptra-registers",
- "caliptra-x509",
+ "caliptra-cpu 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-drivers 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-error 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-image-types 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-image-verify 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-registers 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "caliptra-x509 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
  "memoffset 0.8.0",
  "riscv 0.13.0",
  "ufmt 0.2.0",
@@ -884,9 +1545,9 @@ dependencies = [
 
 [[package]]
 name = "camino"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "276a59bf2b2c967788139340c9f0c5b12d7fd6630315c15c217e559de85d2609"
+checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
 dependencies = [
  "serde_core",
 ]
@@ -929,7 +1590,7 @@ name = "capsules-runtime"
 version = "0.1.0"
 dependencies = [
  "bitfield",
- "caliptra-api",
+ "caliptra-core-firmware",
  "capsules-core",
  "capsules-extra",
  "doe-transport",
@@ -940,7 +1601,6 @@ dependencies = [
  "registers-generated",
  "romtime",
  "tock-registers",
- "ureg",
  "zerocopy",
 ]
 
@@ -990,7 +1650,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1023,9 +1683,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.44"
+version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37521ac7aabe3d13122dc382493e20c9416f299d2ccd5b3a5340a2570cdeb0f3"
+checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -1044,10 +1704,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
-name = "chrono"
-version = "0.4.42"
+name = "chacha20"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -1063,8 +1747,9 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -1084,9 +1769,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.51"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c26d721170e0295f191a69bd9a1f93efcdb0aff38684b61ab5750468972e5f5"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1103,13 +1788,13 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.51"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75835f0c7bf681bfd05abe44e965760fea999a5286c6eb2d59883634fd02011a"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
- "clap_lex 0.7.6",
+ "clap_lex 1.1.0",
  "strsim 0.11.1",
  "terminal_size",
  "unicase",
@@ -1118,14 +1803,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.49"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1139,35 +1824,33 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.6"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "colored"
-version = "3.0.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "compliance-test"
 version = "0.1.0"
 dependencies = [
- "caliptra-emu-bus",
- "caliptra-emu-cpu",
- "caliptra-emu-types",
- "clap 4.5.51",
+ "caliptra-core-tools",
+ "clap 4.6.0",
  "emulator-consts",
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -1190,6 +1873,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "const-random"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1204,7 +1893,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "once_cell",
  "tiny-keccak",
 ]
@@ -1237,10 +1926,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "crc"
-version = "3.3.0"
+name = "cpufeatures"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
 dependencies = [
  "crc-catalog",
 ]
@@ -1297,7 +1995,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "crossterm_winapi",
  "mio",
  "parking_lot",
@@ -1325,6 +2023,19 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crypto"
 version = "0.1.0"
+source = "git+https://github.com/chipsalliance/caliptra-dpe?rev=4fa31d99abca3b9d09cea06eb9a57c819ac17596#4fa31d99abca3b9d09cea06eb9a57c819ac17596"
+dependencies = [
+ "arrayvec",
+ "caliptra-cfi-derive-git",
+ "caliptra-cfi-lib-git",
+ "constant_time_eq 0.3.1",
+ "zerocopy",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto"
+version = "0.1.0"
 source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644#8bfab8d1fa6dda44c86300c6d9d2de6919482644"
 dependencies = [
  "arrayvec",
@@ -1347,13 +2058,22 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "rand_core 0.6.4",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array 0.4.8",
 ]
 
 [[package]]
@@ -1367,13 +2087,38 @@ dependencies = [
 
 [[package]]
 name = "ctrlc"
-version = "3.5.1"
+version = "3.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73736a89c4aff73035ba2ed2e565061954da00d4970fc9ac25dcc85a2a20d790"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
 dependencies = [
  "dispatch2",
- "nix 0.30.1",
+ "nix 0.31.2",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1397,7 +2142,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1408,7 +2153,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1417,9 +2162,19 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "der_derive",
  "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+dependencies = [
+ "const-oid 0.10.2",
  "zeroize",
 ]
 
@@ -1431,14 +2186,14 @@ checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "deranged"
-version = "0.5.5"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
 ]
@@ -1451,7 +2206,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1460,19 +2215,29 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
 [[package]]
-name = "dispatch2"
-version = "0.3.0"
+name = "digest"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
 dependencies = [
- "bitflags 2.10.0",
+ "block-buffer 0.12.0",
+ "crypto-common 0.2.1",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.11.0",
  "block2",
  "libc",
  "objc2",
@@ -1486,7 +2251,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1529,15 +2294,32 @@ dependencies = [
 [[package]]
 name = "dpe"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644#8bfab8d1fa6dda44c86300c6d9d2de6919482644"
+source = "git+https://github.com/chipsalliance/caliptra-dpe?rev=4fa31d99abca3b9d09cea06eb9a57c819ac17596#4fa31d99abca3b9d09cea06eb9a57c819ac17596"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "caliptra-cfi-derive-git",
  "caliptra-cfi-lib-git",
  "cfg-if",
  "constant_time_eq 0.3.1",
- "crypto",
- "platform",
+ "crypto 0.1.0 (git+https://github.com/chipsalliance/caliptra-dpe?rev=4fa31d99abca3b9d09cea06eb9a57c819ac17596)",
+ "platform 0.1.0 (git+https://github.com/chipsalliance/caliptra-dpe?rev=4fa31d99abca3b9d09cea06eb9a57c819ac17596)",
+ "ufmt 0.2.0",
+ "zerocopy",
+ "zeroize",
+]
+
+[[package]]
+name = "dpe"
+version = "0.1.0"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644#8bfab8d1fa6dda44c86300c6d9d2de6919482644"
+dependencies = [
+ "bitflags 2.11.0",
+ "caliptra-cfi-derive-git",
+ "caliptra-cfi-lib-git",
+ "cfg-if",
+ "constant_time_eq 0.3.1",
+ "crypto 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
+ "platform 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
  "ufmt 0.2.0",
  "zerocopy",
  "zeroize",
@@ -1549,12 +2331,12 @@ version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der",
- "digest",
+ "der 0.7.10",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
- "signature",
- "spki",
+ "signature 2.2.0",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -1577,13 +2359,13 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
  "hkdf",
  "pem-rfc7468",
- "pkcs8",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
  "sec1",
  "subtle",
@@ -1611,7 +2393,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1670,18 +2452,11 @@ name = "emulator"
 version = "0.1.0"
 dependencies = [
  "bitfield",
- "caliptra-api-types",
- "caliptra-emu-bus",
- "caliptra-emu-cpu",
- "caliptra-emu-periph",
- "caliptra-emu-types",
- "caliptra-image-types",
+ "caliptra-core-tools",
  "caliptra-mailbox-server",
- "caliptra-registers",
- "caliptra-test",
  "caliptra-util-host-mailbox-test-config",
  "chrono",
- "clap 4.5.51",
+ "clap 4.6.0",
  "clap-num",
  "crc",
  "crossterm",
@@ -1727,9 +2502,7 @@ dependencies = [
 name = "emulator-bmc"
 version = "0.1.0"
 dependencies = [
- "caliptra-emu-bus",
- "caliptra-emu-cpu",
- "caliptra-emu-periph",
+ "caliptra-core-tools",
  "smlang",
  "tock-registers",
 ]
@@ -1738,12 +2511,8 @@ dependencies = [
 name = "emulator-caliptra"
 version = "0.1.0"
 dependencies = [
- "caliptra-api-types",
- "caliptra-emu-bus",
- "caliptra-emu-cpu",
- "caliptra-emu-periph",
- "caliptra-registers",
- "clap 4.5.51",
+ "caliptra-core-tools",
+ "clap 4.6.0",
  "ctrlc",
  "elf",
  "emulator-consts",
@@ -1757,11 +2526,7 @@ dependencies = [
 name = "emulator-cbinding"
 version = "0.1.0"
 dependencies = [
- "caliptra-api-types",
- "caliptra-emu-bus",
- "caliptra-emu-cpu",
- "caliptra-emu-types",
- "caliptra-image-types",
+ "caliptra-core-tools",
  "cbindgen",
  "emulator",
  "libc",
@@ -1773,14 +2538,14 @@ dependencies = [
 name = "emulator-consts"
 version = "0.1.0"
 dependencies = [
- "caliptra-emu-cpu",
+ "caliptra-core-tools",
 ]
 
 [[package]]
 name = "emulator-mcu-mbox"
 version = "0.1.0"
 dependencies = [
- "caliptra-emu-bus",
+ "caliptra-core-tools",
  "emulator-consts",
  "emulator-periph",
  "registers-generated",
@@ -1792,13 +2557,7 @@ name = "emulator-periph"
 version = "0.1.0"
 dependencies = [
  "bitfield",
- "caliptra-emu-bus",
- "caliptra-emu-cpu",
- "caliptra-emu-derive",
- "caliptra-emu-periph",
- "caliptra-emu-types",
- "caliptra-image-types",
- "caliptra-registers",
+ "caliptra-core-tools",
  "emulator-consts",
  "emulator-registers-generated",
  "lazy_static",
@@ -1820,8 +2579,7 @@ dependencies = [
 name = "emulator-registers-generated"
 version = "0.1.0"
 dependencies = [
- "caliptra-emu-bus",
- "caliptra-emu-types",
+ "caliptra-core-tools",
  "registers-generated",
  "tock-registers",
 ]
@@ -1839,9 +2597,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "erased-serde"
-version = "0.4.8"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "259d404d09818dec19332e31d94558aeb442fea04c817006456c24b5460bbd4b"
+checksum = "d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec"
 dependencies = [
  "serde",
  "serde_core",
@@ -1862,9 +2620,7 @@ dependencies = [
 name = "example-app"
 version = "0.1.0"
 dependencies = [
- "caliptra-api",
- "caliptra-auth-man-types",
- "caliptra-error",
+ "caliptra-core-firmware",
  "critical-section",
  "embassy-executor",
  "embedded-alloc",
@@ -1911,10 +2667,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "find-msvc-tools"
-version = "0.1.4"
+name = "fiat-crypto"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fips204"
@@ -1924,7 +2686,7 @@ checksum = "c9fb5a367b9846933e271a3c2a992930743f82ae5e8cb7faa780715a80fa0b15"
 dependencies = [
  "rand_core 0.6.4",
  "sha2",
- "sha3",
+ "sha3 0.10.8",
  "zeroize",
 ]
 
@@ -1968,13 +2730,12 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.1.5"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
- "crc32fast",
- "libz-rs-sys",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -1982,6 +2743,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
@@ -2039,9 +2806,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2054,9 +2821,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2064,15 +2831,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2081,38 +2848,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2122,7 +2889,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -2152,9 +2918,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.9"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
@@ -2163,9 +2929,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2183,9 +2949,22 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -2226,9 +3005,18 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.16.0"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "heapless"
@@ -2266,6 +3054,9 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "hkdf"
@@ -2282,7 +3073,29 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hpke"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4917627a14198c3603282c5158b815ad5534795451d3c074b53cf3cee0960b11"
+dependencies = [
+ "aead",
+ "aes-gcm",
+ "chacha20poly1305",
+ "digest 0.10.7",
+ "generic-array",
+ "hkdf",
+ "hmac",
+ "p256",
+ "p384",
+ "rand_core 0.6.4",
+ "sha2",
+ "subtle",
+ "x25519-dalek",
+ "zeroize",
 ]
 
 [[package]]
@@ -2325,6 +3138,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "hybrid-array"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2d35805454dc9f8662a98d6d61886ffe26bd465f5960e0e55345c70d5c0d2a9"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8655f91cd07f2b9d0c24137bd650fe69617773435ee5ec83022377777ce65ef1"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2364,14 +3195,13 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.18"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52e9a2a24dc5c6821e71a7030e1e14b7b632acac55c40e9d2e082c621261bb56"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
  "base64",
  "bytes",
  "futures-channel",
- "futures-core",
  "futures-util",
  "http",
  "http-body",
@@ -2400,9 +3230,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.64"
+version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -2470,9 +3300,9 @@ checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e93fcd3157766c0c8da2f8cff6ce651a31f0810eaa1c51ec363ef790bbb5fb99"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -2484,9 +3314,9 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02845b3647bb045f1100ecd6480ff52f34c35f82d9880e029d329c21d1054899"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
 
 [[package]]
 name = "icu_provider"
@@ -2502,6 +3332,12 @@ dependencies = [
  "zerotrie",
  "zerovec",
 ]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "ident_case"
@@ -2542,12 +3378,14 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.12.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.0",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2569,20 +3407,20 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.9"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f867b9d1d896b67beb18518eda36fdb77a32ea590de864f1325b294a6d14397"
+checksum = "d8e7418f59cc01c88316161279a7f665217ae316b388e58a0d10e29f54f1e5eb"
 dependencies = [
  "memchr",
  "serde",
@@ -2596,15 +3434,15 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.82"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -2612,11 +3450,31 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "keccak"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "kem"
+version = "0.3.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b8645470337db67b01a7f966decf7d0bafedbae74147d33e641c67a91df239f"
+dependencies = [
+ "rand_core 0.6.4",
+ "zeroize",
 ]
 
 [[package]]
@@ -2636,14 +3494,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libapi-caliptra"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "caliptra-api",
- "caliptra-auth-man-types",
- "caliptra-error",
- "dpe",
+ "caliptra-core-firmware",
+ "dpe 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644)",
  "embassy-executor",
  "embassy-sync",
  "embedded-alloc",
@@ -2655,7 +3517,6 @@ dependencies = [
  "libtock_runtime",
  "libtock_unittest",
  "libtockasync",
- "ocp-eat",
  "pldm-common",
  "pldm-lib",
  "zerocopy",
@@ -2677,16 +3538,16 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libsyscall-caliptra"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "caliptra-api",
+ "caliptra-core-firmware",
  "embassy-sync",
  "libtock_console",
  "libtock_platform",
@@ -2801,15 +3662,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libz-rs-sys"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "840db8cf39d9ec4dd794376f38acc40d0fc65eec2a8f484f7fd375b84602becd"
-dependencies = [
- "zlib-rs",
-]
-
-[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2832,9 +3684,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -2859,9 +3711,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru-slab"
@@ -2908,13 +3760,7 @@ name = "mcu-builder"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "caliptra-auth-man-gen",
- "caliptra-auth-man-types",
- "caliptra-builder",
- "caliptra-image-crypto",
- "caliptra-image-fake-keys",
- "caliptra-image-gen",
- "caliptra-image-types",
+ "caliptra-core-tools",
  "cargo_metadata",
  "cfg-if",
  "chrono",
@@ -2993,7 +3839,7 @@ name = "mcu-firmware-bundler"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "clap 4.5.51",
+ "clap 4.6.0",
  "elf",
  "mcu-image-header",
  "serde",
@@ -3016,7 +3862,7 @@ dependencies = [
  "quote",
  "serde",
  "serde-hjson",
- "syn 2.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3025,18 +3871,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bitfield",
- "caliptra-api",
- "caliptra-api-types",
- "caliptra-builder",
- "caliptra-emu-bus",
- "caliptra-emu-cpu",
- "caliptra-emu-periph",
- "caliptra-emu-types",
- "caliptra-hw-model",
- "caliptra-hw-model-types",
- "caliptra-image-types",
- "caliptra-registers",
- "caliptra-test-harness-types",
+ "caliptra-core-tools",
  "ecdsa",
  "emulator-bmc",
  "emulator-caliptra",
@@ -3059,11 +3894,10 @@ dependencies = [
  "romtime",
  "semver",
  "sha2",
- "sha3",
- "thiserror 2.0.17",
+ "sha3 0.10.8",
+ "thiserror 2.0.18",
  "tock-registers",
  "uio",
- "ureg",
  "zerocopy",
 ]
 
@@ -3085,7 +3919,7 @@ dependencies = [
 name = "mcu-mbox-common"
 version = "0.1.0"
 dependencies = [
- "caliptra-api",
+ "caliptra-core-firmware",
  "zerocopy",
 ]
 
@@ -3104,7 +3938,7 @@ dependencies = [
 name = "mcu-mbox-lib"
 version = "0.1.0"
 dependencies = [
- "caliptra-api",
+ "caliptra-core-firmware",
  "embassy-executor",
  "embassy-sync",
  "external-cmds-common",
@@ -3123,7 +3957,7 @@ dependencies = [
 name = "mcu-otp-lifecycle"
 version = "0.1.0"
 dependencies = [
- "sha3",
+ "sha3 0.10.8",
 ]
 
 [[package]]
@@ -3144,7 +3978,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "same-file",
- "winnow 0.7.13",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -3152,10 +3986,8 @@ name = "mcu-rom-common"
 version = "0.1.0"
 dependencies = [
  "bitfield",
- "bitflags 2.10.0",
- "caliptra-api",
- "caliptra-api-types",
- "caliptra-drivers",
+ "bitflags 2.11.0",
+ "caliptra-core-firmware",
  "constant_time_eq 0.4.2",
  "flash-image",
  "mcu-config",
@@ -3272,6 +4104,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "mcu-sw-root"
+version = "0.1.0"
+dependencies = [
+ "caliptra-core-firmware",
+ "caliptra-core-tools",
+]
+
+[[package]]
 name = "mcu-test-fw-exception-handler"
 version = "0.1.0"
 dependencies = [
@@ -3339,8 +4179,7 @@ dependencies = [
 name = "mcu-test-harness"
 version = "0.1.0"
 dependencies = [
- "caliptra-api",
- "caliptra-registers",
+ "caliptra-core-tools",
  "mcu-config",
  "mcu-config-emulator",
  "mcu-config-fpga",
@@ -3355,7 +4194,7 @@ name = "mcu-testing-common"
 version = "0.1.0"
 dependencies = [
  "bitfield",
- "caliptra-api-types",
+ "caliptra-core-firmware",
  "crc",
  "hex",
  "mctp-vdm-common",
@@ -3389,9 +4228,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memoffset"
@@ -3423,14 +4262,51 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "ml-dsa"
+version = "0.1.0-rc.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af6e554a2affc86740759dbe568a92abd58b47fea4e28ebe1b7bb4da99e490d4"
+dependencies = [
+ "const-oid 0.10.2",
+ "hybrid-array 0.4.8",
+ "module-lattice",
+ "pkcs8 0.11.0-rc.11",
+ "rand_core 0.10.0",
+ "sha3 0.11.0-rc.9",
+ "signature 3.0.0-rc.10",
+]
+
+[[package]]
+name = "ml-kem"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de49b3df74c35498c0232031bb7e85f9389f913e2796169c8ab47a53993a18f"
+dependencies = [
+ "hybrid-array 0.2.3",
+ "kem",
+ "rand_core 0.6.4",
+ "sha3 0.10.8",
+]
+
+[[package]]
+name = "module-lattice"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dfecc750073acc09af2f8899b2342d520d570392ba1c3aed53eeb0d84ca4103"
+dependencies = [
+ "hybrid-array 0.4.8",
+ "num-traits",
 ]
 
 [[package]]
@@ -3460,11 +4336,11 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.30.1"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -3472,9 +4348,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-derive"
@@ -3484,7 +4360,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3498,9 +4374,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1207a7e20ad57b847bbddc6776b968420d38292bbfe2089accff5e19e82454c"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
 dependencies = [
  "num_enum_derive",
  "rustversion",
@@ -3508,14 +4384,14 @@ dependencies = [
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3529,9 +4405,9 @@ dependencies = [
 
 [[package]]
 name = "objc2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c2599ce0ec54857b29ce62166b0ed9b4f6f1a70ccc9a71165b6154caca8c05"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
 dependencies = [
  "objc2-encode",
 ]
@@ -3545,6 +4421,14 @@ checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 [[package]]
 name = "ocp-eat"
 version = "0.1.0"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c#49927b620f317ad4c459811f49baa56de197126c"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
+name = "ocp-eat"
+version = "0.1.0"
 source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644#8bfab8d1fa6dda44c86300c6d9d2de6919482644"
 dependencies = [
  "arrayvec",
@@ -3552,9 +4436,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -3573,7 +4457,7 @@ name = "openssl"
 version = "0.10.72"
 source = "git+https://github.com/clundin25/rust-openssl.git?rev=4ada1c1d7c264e052e7bb71ecddbd196a5c2a0c7#4ada1c1d7c264e052e7bb71ecddbd196a5c2a0c7"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -3589,14 +4473,14 @@ source = "git+https://github.com/clundin25/rust-openssl.git?rev=4ada1c1d7c264e05
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "openssl-src"
-version = "300.5.4+3.5.4"
+version = "300.5.5+3.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507b3792995dae9b0df8a1c1e3771e8418b7c2d9f0baeba32e6fe8b06c7cb72"
+checksum = "3f1787d533e03597a7934fd0a765f0d28e94ecc5fb7789f8053b1e699a56f709"
 dependencies = [
  "cc",
 ]
@@ -3631,6 +4515,16 @@ checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
 [[package]]
 name = "otp-digest"
 version = "0.1.0"
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "elliptic-curve",
+ "primeorder",
+]
 
 [[package]]
 name = "p384"
@@ -3690,9 +4584,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pin-utils"
@@ -3706,8 +4600,18 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
- "spki",
+ "der 0.7.10",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.11.0-rc.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12922b6296c06eb741b02d7b5161e3aaa22864af38dfa025a1a3ba3f68c84577"
+dependencies = [
+ "der 0.8.0",
+ "spki 0.8.0-rc.4",
 ]
 
 [[package]]
@@ -3715,6 +4619,16 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "platform"
+version = "0.1.0"
+source = "git+https://github.com/chipsalliance/caliptra-dpe?rev=4fa31d99abca3b9d09cea06eb9a57c819ac17596#4fa31d99abca3b9d09cea06eb9a57c819ac17596"
+dependencies = [
+ "arrayvec",
+ "cfg-if",
+ "ufmt 0.2.0",
+]
 
 [[package]]
 name = "platform"
@@ -3739,7 +4653,7 @@ name = "pldm-fw-pkg"
 version = "0.1.0"
 dependencies = [
  "chrono",
- "clap 4.5.51",
+ "clap 4.6.0",
  "crc",
  "num-derive",
  "num-traits",
@@ -3788,22 +4702,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "polyval"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.1"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 dependencies = [
  "critical-section",
 ]
@@ -3839,7 +4764,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3853,11 +4778,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.23.7",
+ "toml_edit 0.25.8+spec-1.1.0",
 ]
 
 [[package]]
@@ -3868,9 +4793,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.103"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -3883,7 +4808,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.117",
  "version_check",
 ]
 
@@ -3910,7 +4835,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -3918,9 +4843,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
@@ -3931,7 +4856,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -3953,9 +4878,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.42"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -3965,6 +4890,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -3984,7 +4915,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -4004,7 +4935,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -4013,17 +4944,23 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
 name = "random-port"
@@ -4062,14 +4999,14 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4079,9 +5016,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4090,9 +5027,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "registers-generated"
@@ -4119,9 +5056,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.24"
+version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d0946410b9f7b082a427e4ef5c8ff541a88b357bc6c637c40db3a68ac70a36f"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
@@ -4175,7 +5112,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -4220,7 +5157,7 @@ checksum = "e8c4aa1ea1af6dcc83a61be12e8189f9b293c3ba5a487778a4cd89fb060fdbbc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4233,13 +5170,11 @@ checksum = "8188909339ccc0c68cfb5a04648313f09621e8b87dc03095454f1a11f6c5d436"
 name = "romtime"
 version = "0.1.0"
 dependencies = [
- "caliptra-api",
- "caliptra-registers",
+ "caliptra-core-firmware",
  "registers-generated",
  "riscv-csr",
  "rv32i",
  "tock-registers",
- "ureg",
  "zerocopy",
 ]
 
@@ -4250,12 +5185,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -4264,22 +5208,22 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.2"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "errno",
  "libc",
- "linux-raw-sys 0.11.0",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.35"
+version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "once_cell",
  "ring",
@@ -4291,9 +5235,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "708c0f9d5f54ba0272468c1d306a52c495b31fa155e91bc25371e6df7996908c"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "web-time",
  "zeroize",
@@ -4301,9 +5245,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.8"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -4329,9 +5273,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.20"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -4355,9 +5299,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct",
- "der",
+ "der 0.7.10",
  "generic-array",
- "pkcs8",
+ "pkcs8 0.10.2",
  "subtle",
  "zeroize",
 ]
@@ -4442,20 +5386,20 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -4469,9 +5413,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e24345aa0fe688594e73770a5f6d1b216508b4f93484c0026d521acd30134392"
+checksum = "876ac351060d4f882bb1032b6369eb0aef79ad9df1ea8bc404874d8cc3d0cd98"
 dependencies = [
  "serde_core",
 ]
@@ -4495,8 +5439,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4505,8 +5449,18 @@ version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
- "digest",
- "keccak",
+ "digest 0.10.7",
+ "keccak 0.1.6",
+]
+
+[[package]]
+name = "sha3"
+version = "0.11.0-rc.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b233a7d59d7bfc027208506a33ffc9532b2acb24ddc61fe7e758dc2250db431"
+dependencies = [
+ "digest 0.11.2",
+ "keccak 0.2.0",
 ]
 
 [[package]]
@@ -4538,10 +5492,11 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.6"
+version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
+ "errno",
  "libc",
 ]
 
@@ -4551,21 +5506,31 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
 [[package]]
-name = "simd-adler32"
-version = "0.3.7"
+name = "signature"
+version = "3.0.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+checksum = "7f1880df446116126965eeec169136b2e0251dba37c6223bcc819569550edea3"
+dependencies = [
+ "digest 0.11.2",
+ "rand_core 0.10.0",
+]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
 name = "simple_logger"
-version = "5.1.0"
+version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291bee647ce7310b0ea721bfd7e0525517b4468eb7c7e15eb8bd774343179702"
+checksum = "c7038d0e96661bf9ce647e1a6f6ef6d6f3663f66d9bf741abf14ba4876071c17"
 dependencies = [
  "colored",
  "log",
@@ -4575,9 +5540,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -4608,12 +5573,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4623,7 +5588,7 @@ dependencies = [
  "arrayvec",
  "async-trait",
  "bitfield",
- "caliptra-api",
+ "caliptra-core-firmware",
  "constant_time_eq 0.4.2",
  "libapi-caliptra",
  "libsyscall-caliptra",
@@ -4640,7 +5605,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.10",
+]
+
+[[package]]
+name = "spki"
+version = "0.8.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8baeff88f34ed0691978ec34440140e1572b68c7dd4a495fd14a3dc1944daa80"
+dependencies = [
+ "base64ct",
+ "der 0.8.0",
 ]
 
 [[package]]
@@ -4734,9 +5709,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.109"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f17c7e013e88258aa9543dcbe81aca68a667a9ac37cd69c9fbc07858bfe0e2f"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4760,7 +5735,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4777,14 +5752,14 @@ version = "0.0.0"
 
 [[package]]
 name = "tempfile"
-version = "3.23.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
- "rustix 1.1.2",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -4799,12 +5774,12 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
- "rustix 1.1.2",
- "windows-sys 0.60.2",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4817,15 +5792,7 @@ version = "0.1.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
- "caliptra-api",
- "caliptra-api-types",
- "caliptra-auth-man-types",
- "caliptra-builder",
- "caliptra-hw-model",
- "caliptra-hw-model-types",
- "caliptra-image-fake-keys",
- "caliptra-image-gen",
- "caliptra-image-types",
+ "caliptra-core-tools",
  "chrono",
  "crc",
  "ecdsa",
@@ -4882,11 +5849,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.17",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -4897,18 +5864,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4918,9 +5885,9 @@ source = "git+https://github.com/tock/tock.git?rev=release-2.2#9554639b17501a9f5
 
 [[package]]
 name = "time"
-version = "0.3.44"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
@@ -4928,22 +5895,22 @@ dependencies = [
  "num-conv",
  "num_threads",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.24"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
@@ -4970,9 +5937,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -5000,9 +5967,9 @@ source = "git+https://github.com/tock/tock.git?rev=release-2.2#9554639b17501a9f5
 
 [[package]]
 name = "tokio"
-version = "1.48.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
@@ -5057,17 +6024,17 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.8"
+version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0dc8b1fb61449e27716ec0e1bdf0f6b8f3e8f6b05391e8497b8b6d7804ea6d8"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "indexmap 2.12.0",
+ "indexmap 2.13.0",
  "serde_core",
- "serde_spanned 1.0.3",
- "toml_datetime 0.7.3",
+ "serde_spanned 1.1.0",
+ "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 0.7.13",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -5081,9 +6048,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.3"
+version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2cdb639ebbc97961c51720f858597f7f24c4fc295327923af55b74c3c724533"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.0+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
 dependencies = [
  "serde_core",
 ]
@@ -5094,7 +6070,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.12.0",
+ "indexmap 2.13.0",
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
@@ -5107,33 +6083,33 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.12.0",
+ "indexmap 2.13.0",
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_write",
- "winnow 0.7.13",
+ "winnow 0.7.15",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.23.7"
+version = "0.25.8+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6485ef6d0d9b5d0ec17244ff7eb05310113c3f316f2d14200d4de56b3cb98f8d"
+checksum = "16bff38f1d86c47f9ff0647e6838d7bb362522bdf44006c7068c2b1e606f1f3c"
 dependencies = [
- "indexmap 2.12.0",
- "toml_datetime 0.7.3",
+ "indexmap 2.13.0",
+ "toml_datetime 1.1.0+spec-1.1.0",
  "toml_parser",
- "winnow 0.7.13",
+ "winnow 1.0.0",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.4"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
+checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
 dependencies = [
- "winnow 0.7.13",
+ "winnow 1.0.0",
 ]
 
 [[package]]
@@ -5144,15 +6120,15 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
-version = "1.0.4"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df8b2b54733674ad286d16267dcfc7a71ed5c776e4ac7aa3c3e2561f7c637bf2"
+checksum = "d282ade6016312faf3e41e57ebbba0c073e4056dab1232ab1cb624199648f8ed"
 
 [[package]]
 name = "tower"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -5165,11 +6141,11 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf146f99d442e8e68e585f5d798ccd3cad9a7835b917e09728880a862706456"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "bytes",
  "futures-util",
  "http",
@@ -5195,9 +6171,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d15d90a0b5c19378952d479dc858407149d7bb45a14de0142f6c534b16fc647"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
  "tracing-core",
@@ -5205,9 +6181,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.35"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a04e24fab5c89c6a36eb8558c9656f30d81de51dfa4d3b45f26b21d61fa0a6c"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
 ]
@@ -5281,9 +6257,9 @@ source = "git+https://github.com/korran/ufmt.git?rev=1d0743c1ffffc68bc05ca8eeb81
 
 [[package]]
 name = "uio"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe6429670644060fac2d02d8d284c7f9369a1e71948a654d7f064dbba07fb508"
+checksum = "61b53822f7484f16c346add4898cee6523f4aaa503777da3fc861356084a9477"
 dependencies = [
  "fs2",
  "libc",
@@ -5292,15 +6268,15 @@ dependencies = [
 
 [[package]]
 name = "unicase"
-version = "2.8.1"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-width"
@@ -5326,7 +6302,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -5339,13 +6315,18 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 [[package]]
 name = "ureg"
 version = "0.1.0"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=49927b620f317ad4c459811f49baa56de197126c#49927b620f317ad4c459811f49baa56de197126c"
+
+[[package]]
+name = "ureg"
+version = "0.1.0"
 source = "git+https://github.com/chipsalliance/caliptra-sw?rev=8bfab8d1fa6dda44c86300c6d9d2de6919482644#8bfab8d1fa6dda44c86300c6d9d2de6919482644"
 
 [[package]]
 name = "url"
-version = "2.5.7"
+version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -5359,7 +6340,7 @@ version = "0.1.0"
 dependencies = [
  "arrayvec",
  "async-trait",
- "caliptra-api",
+ "caliptra-core-firmware",
  "critical-section",
  "embassy-executor",
  "embassy-sync",
@@ -5382,7 +6363,6 @@ dependencies = [
  "mcu-config-fpga",
  "mcu-mbox-common",
  "mcu-mbox-lib",
- "ocp-eat",
  "pldm-common",
  "pldm-lib",
  "portable-atomic",
@@ -5406,13 +6386,13 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.18.1"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
+checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "js-sys",
- "serde",
+ "serde_core",
  "wasm-bindgen",
 ]
 
@@ -5455,18 +6435,27 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.105"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da95793dfc411fbbd93f5be7715b0578ec61fe87cb1a42b12eb625caa5c5ea60"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5477,11 +6466,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.55"
+version = "0.4.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "551f88106c6d5e7ccc7cd9a16f312dd3b5d36ea8b4954304657d5dfba115d4a0"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
 dependencies = [
  "cfg-if",
+ "futures-util",
  "js-sys",
  "once_cell",
  "wasm-bindgen",
@@ -5490,9 +6480,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.105"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04264334509e04a7bf8690f2384ef5265f05143a4bff3889ab7a3269adab59c2"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5500,31 +6490,65 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.105"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "420bc339d9f322e562942d52e115d57e950d12d88983a14c79b86859ee6c7ebc"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.105"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.82"
+name = "wasm-encoder"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a1f95c0d03a47f4ae1f7a64643a6bb97465d9b740f0fa8f90ea33915c99a9a1"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.13.0",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.11.0",
+ "hashbrown 0.15.5",
+ "indexmap 2.13.0",
+ "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5542,9 +6566,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.4"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2878ef029c47c6e8cf779119f20fcf52bde7ad42a731b2a304bc221df17571e"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -5601,7 +6625,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5612,7 +6636,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5815,18 +6839,109 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.13"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "wit-bindgen"
-version = "0.46.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "indexmap 2.13.0",
+ "prettyplease",
+ "syn 2.0.117",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.0",
+ "indexmap 2.13.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.13.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"
@@ -5835,21 +6950,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "xtask"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "base64",
- "caliptra-api-types",
- "caliptra-auth-man-types",
  "caliptra-bitstream-downloader",
- "caliptra-builder",
- "caliptra-hw-model",
- "caliptra-image-gen",
- "caliptra-image-types",
+ "caliptra-core-tools",
  "cargo_metadata",
  "cc",
- "clap 4.5.51",
+ "clap 4.6.0",
  "clap-num",
  "ecdsa",
  "elf",
@@ -5901,28 +7021,28 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.117",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.27"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.27"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5942,7 +7062,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -5957,13 +7077,13 @@ dependencies = [
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5996,7 +7116,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6009,16 +7129,22 @@ dependencies = [
  "chrono",
  "crc32fast",
  "flate2",
- "indexmap 2.12.0",
+ "indexmap 2.13.0",
  "memchr",
  "zopfli",
 ]
 
 [[package]]
 name = "zlib-rs"
-version = "0.5.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f06ae92f42f5e5c42443fd094f245eb656abf56dd7cce9b8b263236565e00f2"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zopfli"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,20 @@
 # Licensed under the Apache-2.0 license
 
+[package]
+name = "mcu-sw-root"
+version = "0.1.0"
+edition = "2021"
+authors = ["Caliptra contributors"]
+
+[dependencies]
+caliptra-core-firmware = { path = "common/caliptra-core-firmware", optional = true }
+caliptra-core-tools = { path = "common/caliptra-core-tools", optional = true }
+
+[features]
+default = ["2_0"]
+"2_0" = ["caliptra-core-tools/2_0"]
+"2_1" = ["caliptra-core-tools/2_1"]
+
 [workspace]
 members = [
     "builder",
@@ -12,6 +27,8 @@ members = [
     "common/pldm",
     "common/poll",
     "common/testing",
+    "common/caliptra-core-firmware",
+    "common/caliptra-core-tools",
     "emulator/app",
     "emulator/app/mcu-mbox",
     "emulator/bmc/pldm-fw-pkg",
@@ -45,6 +62,7 @@ members = [
     "platforms/fpga/config",
     "platforms/fpga/rom",
     "platforms/fpga/runtime",
+    "platforms/fpga/runtime/drivers/flash_ctrl",
     "platforms/test_harness",
     "provisioning/fuses/fusegen",
     "provisioning/fuses/lib",
@@ -60,6 +78,7 @@ members = [
     "runtime/kernel/capsules",
     "runtime/kernel/components",
     "runtime/kernel/drivers/doe",
+    "runtime/kernel/drivers/flash",
     "runtime/kernel/drivers/i3c",
     "runtime/kernel/drivers/mcu_mbox",
     "runtime/kernel/veer",
@@ -103,7 +122,7 @@ arrayvec = { version = "0.7.4", default-features = false }
 async-trait = "0.1.87"
 base64 = "0.22"
 bitfield = "0.14.0"
-bitflags = "2.4.0"
+bitflags = { version = "2.4.0", default-features = false }
 bit-vec = "0.6.3"
 cargo_metadata = "0.20.0"
 cbindgen = "0.24"
@@ -160,7 +179,7 @@ random-port = "0.1.1"
 same-file = "1"
 semver = "1.0.23"
 sec1 = { version = "0.7.3" }
-serde = { version = "1.0.209", features = ["alloc", "derive", "serde_derive"] }
+serde = { version = "1.0.209", default-features = false, features = ["alloc", "derive", "serde_derive"] }
 serde_json = { version = "1.0.127", features = ["alloc"] }
 serde-hjson = "1.1.0"
 sha2 = { version = "0.10.8", default-features = false }
@@ -267,60 +286,65 @@ libtock_small_panic = { path = "runtime/userspace/libtock/panic_handlers/small_p
 libtock_unittest = { path = "runtime/userspace/libtock/unittest" }
 tbf-header = { path = "runtime/userspace/libtock/tbf-header" }
 
-# caliptra dependencies; keep git revs in sync
-caliptra-api = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8bfab8d1fa6dda44c86300c6d9d2de6919482644" }
-caliptra-api-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8bfab8d1fa6dda44c86300c6d9d2de6919482644" }
-caliptra-auth-man-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8bfab8d1fa6dda44c86300c6d9d2de6919482644" }
-caliptra-auth-man-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8bfab8d1fa6dda44c86300c6d9d2de6919482644" }
-caliptra-bitstream-downloader = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8bfab8d1fa6dda44c86300c6d9d2de6919482644" }
-caliptra-builder = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8bfab8d1fa6dda44c86300c6d9d2de6919482644" }
-caliptra-drivers = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8bfab8d1fa6dda44c86300c6d9d2de6919482644" }
-caliptra-emu-bus = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8bfab8d1fa6dda44c86300c6d9d2de6919482644" }
-caliptra-emu-cpu = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8bfab8d1fa6dda44c86300c6d9d2de6919482644" }
-caliptra-emu-derive = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8bfab8d1fa6dda44c86300c6d9d2de6919482644" }
-caliptra-emu-periph = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8bfab8d1fa6dda44c86300c6d9d2de6919482644" }
-caliptra-emu-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8bfab8d1fa6dda44c86300c6d9d2de6919482644" }
-caliptra-error = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8bfab8d1fa6dda44c86300c6d9d2de6919482644", default-features = false }
-caliptra-hw-model = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8bfab8d1fa6dda44c86300c6d9d2de6919482644" }
-caliptra-hw-model-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8bfab8d1fa6dda44c86300c6d9d2de6919482644" }
-caliptra-image-crypto = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8bfab8d1fa6dda44c86300c6d9d2de6919482644", default-features = false, features = ["rustcrypto"] }
-caliptra-image-fake-keys = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8bfab8d1fa6dda44c86300c6d9d2de6919482644" }
-caliptra-image-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8bfab8d1fa6dda44c86300c6d9d2de6919482644" }
-caliptra-image-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8bfab8d1fa6dda44c86300c6d9d2de6919482644" }
-caliptra-registers = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8bfab8d1fa6dda44c86300c6d9d2de6919482644" }
-caliptra-test = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8bfab8d1fa6dda44c86300c6d9d2de6919482644" }
-caliptra-test-harness = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8bfab8d1fa6dda44c86300c6d9d2de6919482644" }
-caliptra-test-harness-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8bfab8d1fa6dda44c86300c6d9d2de6919482644" }
-ureg = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8bfab8d1fa6dda44c86300c6d9d2de6919482644" }
-dpe = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8bfab8d1fa6dda44c86300c6d9d2de6919482644", default-features = false, features = ["dpe_profile_p384_sha384"] }
-ocp-eat = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8bfab8d1fa6dda44c86300c6d9d2de6919482644",  default-features = false  }
+# caliptra-core centralized dependencies
+caliptra-core-firmware = { path = "common/caliptra-core-firmware" }
+caliptra-core-tools = { path = "common/caliptra-core-tools" }
 
-# local caliptra dependency; useful when developing
-# caliptra-api = { path = "../caliptra-sw/api" }
-# caliptra-api-types = { path = "../caliptra-sw/api/types" }
-# caliptra-auth-man-gen = { path = "../caliptra-sw/auth-manifest/gen", default-features = false }
-# caliptra-auth-man-types = { path = "../caliptra-sw/auth-manifest/types", default-features = false }
-# caliptra-bitstream-downloader = { path = "../caliptra-sw/ci-tools/bitstream-downloader" }
-# caliptra-builder = { path = "../caliptra-sw/builder" }
-# caliptra-drivers = { path = "../caliptra-sw/drivers" }
-# caliptra-emu-bus = { path = "../caliptra-sw/sw-emulator/lib/bus" }
-# caliptra-emu-cpu = { path = "../caliptra-sw/sw-emulator/lib/cpu" }
-# caliptra-emu-derive = { path = "../caliptra-sw/sw-emulator/lib/derive" }
-# caliptra-emu-periph = { path = "../caliptra-sw/sw-emulator/lib/periph" }
-# caliptra-emu-types = { path = "../caliptra-sw/sw-emulator/lib/types" }
-# caliptra-error = { path = "../caliptra-sw/error", default-features = false }
-# caliptra-hw-model = { path = "../caliptra-sw/hw-model" }
-# caliptra-hw-model-types = { path = "../caliptra-sw/hw-model/types" }
-# caliptra-image-crypto = { path = "../caliptra-sw/image/crypto", default-features = false, features = ["rustcrypto"] }
-# caliptra-image-fake-keys = { path = "../caliptra-sw/image/fake-keys" }
-# caliptra-image-gen = { path = "../caliptra-sw/image/gen" }
-# caliptra-image-types = { path = "../caliptra-sw/image/types" }
-# caliptra-registers = { path = "../caliptra-sw/registers" }
-# caliptra-test = { path = "../caliptra-sw/test" }
-# caliptra-test-harness-types = { path = "../caliptra-sw/test-harness/types" }
-# ureg = { path = "../caliptra-sw/ureg" }
-# dpe = { path = "../caliptra-sw/dpe/dpe", default-features = false, features = ["dpe_profile_p384_sha384"] }
-# ocp-eat = { path = "../caliptra-sw/common/eat",  default-features = false  }
+# caliptra-sw 2.0 components
+caliptra-api-2_0 = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8bfab8d1fa6dda44c86300c6d9d2de6919482644", package = "caliptra-api", default-features = false }
+caliptra-api-types-2_0 = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8bfab8d1fa6dda44c86300c6d9d2de6919482644", package = "caliptra-api-types", default-features = false }
+caliptra-auth-man-gen-2_0 = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8bfab8d1fa6dda44c86300c6d9d2de6919482644", package = "caliptra-auth-man-gen", default-features = false }
+caliptra-auth-man-types-2_0 = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8bfab8d1fa6dda44c86300c6d9d2de6919482644", package = "caliptra-auth-man-types", default-features = false }
+caliptra-builder-2_0 = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8bfab8d1fa6dda44c86300c6d9d2de6919482644", package = "caliptra-builder" }
+caliptra-drivers-2_0 = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8bfab8d1fa6dda44c86300c6d9d2de6919482644", package = "caliptra-drivers", default-features = false }
+caliptra-emu-bus-2_0 = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8bfab8d1fa6dda44c86300c6d9d2de6919482644", package = "caliptra-emu-bus" }
+caliptra-emu-cpu-2_0 = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8bfab8d1fa6dda44c86300c6d9d2de6919482644", package = "caliptra-emu-cpu" }
+caliptra-emu-derive-2_0 = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8bfab8d1fa6dda44c86300c6d9d2de6919482644", package = "caliptra-emu-derive" }
+caliptra-emu-periph-2_0 = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8bfab8d1fa6dda44c86300c6d9d2de6919482644", package = "caliptra-emu-periph" }
+caliptra-emu-types-2_0 = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8bfab8d1fa6dda44c86300c6d9d2de6919482644", package = "caliptra-emu-types" }
+caliptra-error-2_0 = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8bfab8d1fa6dda44c86300c6d9d2de6919482644", package = "caliptra-error", default-features = false }
+caliptra-hw-model-2_0 = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8bfab8d1fa6dda44c86300c6d9d2de6919482644", package = "caliptra-hw-model" }
+caliptra-hw-model-types-2_0 = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8bfab8d1fa6dda44c86300c6d9d2de6919482644", package = "caliptra-hw-model-types" }
+caliptra-image-crypto-2_0 = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8bfab8d1fa6dda44c86300c6d9d2de6919482644", package = "caliptra-image-crypto", default-features = false, features = ["rustcrypto"] }
+caliptra-image-fake-keys-2_0 = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8bfab8d1fa6dda44c86300c6d9d2de6919482644", package = "caliptra-image-fake-keys" }
+caliptra-image-gen-2_0 = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8bfab8d1fa6dda44c86300c6d9d2de6919482644", package = "caliptra-image-gen" }
+caliptra-image-types-2_0 = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8bfab8d1fa6dda44c86300c6d9d2de6919482644", package = "caliptra-image-types", default-features = false }
+caliptra-registers-2_0 = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8bfab8d1fa6dda44c86300c6d9d2de6919482644", package = "caliptra-registers", default-features = false }
+caliptra-test-2_0 = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8bfab8d1fa6dda44c86300c6d9d2de6919482644", package = "caliptra-test" }
+caliptra-test-harness-2_0 = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8bfab8d1fa6dda44c86300c6d9d2de6919482644", package = "caliptra-test-harness" }
+caliptra-test-harness-types-2_0 = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8bfab8d1fa6dda44c86300c6d9d2de6919482644", package = "caliptra-test-harness-types", default-features = false }
+ocp-eat-2_0 = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8bfab8d1fa6dda44c86300c6d9d2de6919482644", package = "ocp-eat", default-features = false }
+ureg-2_0 = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8bfab8d1fa6dda44c86300c6d9d2de6919482644", package = "ureg", default-features = false }
+
+# caliptra-sw 2.1 components
+caliptra-api-2_1 = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "49927b620f317ad4c459811f49baa56de197126c", package = "caliptra-api", default-features = false }
+caliptra-api-types-2_1 = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "49927b620f317ad4c459811f49baa56de197126c", package = "caliptra-api-types", default-features = false }
+caliptra-auth-man-gen-2_1 = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "49927b620f317ad4c459811f49baa56de197126c", package = "caliptra-auth-man-gen", default-features = false }
+caliptra-auth-man-types-2_1 = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "49927b620f317ad4c459811f49baa56de197126c", package = "caliptra-auth-man-types", default-features = false }
+caliptra-builder-2_1 = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "49927b620f317ad4c459811f49baa56de197126c", package = "caliptra-builder" }
+caliptra-drivers-2_1 = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "49927b620f317ad4c459811f49baa56de197126c", package = "caliptra-drivers", default-features = false }
+caliptra-emu-bus-2_1 = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "49927b620f317ad4c459811f49baa56de197126c", package = "caliptra-emu-bus" }
+caliptra-emu-cpu-2_1 = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "49927b620f317ad4c459811f49baa56de197126c", package = "caliptra-emu-cpu" }
+caliptra-emu-derive-2_1 = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "49927b620f317ad4c459811f49baa56de197126c", package = "caliptra-emu-derive" }
+caliptra-emu-periph-2_1 = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "49927b620f317ad4c459811f49baa56de197126c", package = "caliptra-emu-periph" }
+caliptra-emu-types-2_1 = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "49927b620f317ad4c459811f49baa56de197126c", package = "caliptra-emu-types" }
+caliptra-error-2_1 = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "49927b620f317ad4c459811f49baa56de197126c", package = "caliptra-error", default-features = false }
+caliptra-hw-model-2_1 = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "49927b620f317ad4c459811f49baa56de197126c", package = "caliptra-hw-model" }
+caliptra-hw-model-types-2_1 = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "49927b620f317ad4c459811f49baa56de197126c", package = "caliptra-hw-model-types" }
+caliptra-image-crypto-2_1 = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "49927b620f317ad4c459811f49baa56de197126c", package = "caliptra-image-crypto", default-features = false, features = ["rustcrypto"] }
+caliptra-image-fake-keys-2_1 = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "49927b620f317ad4c459811f49baa56de197126c", package = "caliptra-image-fake-keys" }
+caliptra-image-gen-2_1 = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "49927b620f317ad4c459811f49baa56de197126c", package = "caliptra-image-gen" }
+caliptra-image-types-2_1 = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "49927b620f317ad4c459811f49baa56de197126c", package = "caliptra-image-types", default-features = false }
+caliptra-registers-2_1 = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "49927b620f317ad4c459811f49baa56de197126c", package = "caliptra-registers", default-features = false }
+caliptra-test-2_1 = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "49927b620f317ad4c459811f49baa56de197126c", package = "caliptra-test" }
+caliptra-test-harness-2_1 = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "49927b620f317ad4c459811f49baa56de197126c", package = "caliptra-test-harness" }
+caliptra-test-harness-types-2_1 = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "49927b620f317ad4c459811f49baa56de197126c", package = "caliptra-test-harness-types", default-features = false }
+ocp-eat-2_1 = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "49927b620f317ad4c459811f49baa56de197126c", package = "ocp-eat", default-features = false }
+ureg-2_1 = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "49927b620f317ad4c459811f49baa56de197126c", package = "ureg", default-features = false }
+
+# caliptra dependencies
+caliptra-bitstream-downloader = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8bfab8d1fa6dda44c86300c6d9d2de6919482644" }
+dpe = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "8bfab8d1fa6dda44c86300c6d9d2de6919482644", default-features = false, features = ["dpe_profile_p384_sha384"] }
 
 # tock dependencies; keep git revs in sync
 capsules-core = { git = "https://github.com/tock/tock.git", rev = "release-2.2" }

--- a/README.md
+++ b/README.md
@@ -68,6 +68,16 @@ The table below details which versions of Caliptra are compatible with each othe
 | main-2.1        | main         | 2.1.x RTL      |
 | main            | caliptra-2.0 | 2.0.x RTL      |
 
+### Caliptra Core Facade
+
+Versions of the Caliptra core library are managed through the `caliptra-core` facade crate located in `common/caliptra-core`. This crate re-exports the various `caliptra-sw` components and allows switching between different versions (e.g., 2.0, 2.1, or a local path) using Cargo features.
+
+To select a specific version in your workspace, enable the corresponding feature for `caliptra-core` in the root `Cargo.toml`:
+
+* `2_0`: (Default) Uses Caliptra 2.0 components.
+* `2_1`: Uses Caliptra 2.1 components.
+* `local`: Uses a local checkout of `caliptra-sw` located at `../caliptra-sw`.
+
 ## Documentation
 
 The specification is published [here](https://chipsalliance.github.io/caliptra-mcu-sw/).

--- a/builder/Cargo.toml
+++ b/builder/Cargo.toml
@@ -6,13 +6,7 @@ edition = "2021"
 
 [dependencies]
 anyhow.workspace = true
-caliptra-auth-man-gen.workspace = true
-caliptra-auth-man-types.workspace = true
-caliptra-builder.workspace = true
-caliptra-image-crypto.workspace = true
-caliptra-image-fake-keys.workspace = true
-caliptra-image-gen.workspace = true
-caliptra-image-types.workspace = true
+caliptra-core-tools = { workspace = true, features = ["2_0"] }
 cargo_metadata.workspace = true
 cfg-if.workspace = true
 chrono.workspace = true

--- a/builder/src/all.rs
+++ b/builder/src/all.rs
@@ -1,8 +1,8 @@
 // Licensed under the Apache-2.0 license
 
 use anyhow::{bail, Result};
-use caliptra_builder::FwId;
-use caliptra_image_types::ImageManifest;
+use caliptra_core_tools::caliptra_builder::FwId;
+use caliptra_core_tools::caliptra_image_types::ImageManifest;
 use chrono::{TimeZone, Utc};
 use mcu_config::boot::{PartitionId, PartitionStatus, RollbackEnable};
 use mcu_config_emulator::flash::{PartitionTable, StandAloneChecksumCalculator, IMAGE_A_PARTITION};
@@ -505,7 +505,7 @@ pub fn all_build(args: AllBuildArgs) -> Result<()> {
 
                 std::fs::create_dir_all(&release_dir)?;
                 let bin_path = release_dir.join(&filename);
-                let rom_bytes = caliptra_builder::build_firmware_rom(fwid)?;
+                let rom_bytes = caliptra_core_tools::caliptra_builder::build_firmware_rom(fwid)?;
                 std::fs::write(&bin_path, rom_bytes)?;
                 Ok((bin_path, filename))
             })

--- a/builder/src/caliptra.rs
+++ b/builder/src/caliptra.rs
@@ -5,20 +5,20 @@
 
 use crate::target_dir;
 use anyhow::{bail, Result};
-use caliptra_auth_man_gen::{
+use caliptra_core_tools::caliptra_auth_man_gen::{
     AuthManifestGenerator, AuthManifestGeneratorConfig, AuthManifestGeneratorKeyConfig,
 };
-use caliptra_auth_man_types::{
+use caliptra_core_tools::caliptra_auth_man_types::{
     Addr64, AuthManifestFlags, AuthManifestImageMetadata, AuthManifestPrivKeysConfig,
     AuthManifestPubKeysConfig, AuthorizationManifest, ImageMetadataFlags,
 };
-use caliptra_image_crypto::RustCrypto as Crypto;
-use caliptra_image_fake_keys::*;
-use caliptra_image_gen::{
+use caliptra_core_tools::caliptra_image_crypto::RustCrypto as Crypto;
+use caliptra_core_tools::caliptra_image_fake_keys::*;
+use caliptra_core_tools::caliptra_image_gen::{
     from_hw_format, ImageGenerator, ImageGeneratorConfig, ImageGeneratorCrypto,
     ImageGeneratorExecutable, ImageGeneratorOwnerConfig,
 };
-use caliptra_image_types::{
+use caliptra_core_tools::caliptra_image_types::{
     FwVerificationPqcKeyType, ImageBundle, ImageManifest, ImageRevision, IMAGE_MANIFEST_BYTE_SIZE,
 };
 use cargo_metadata::MetadataCommand;
@@ -474,9 +474,11 @@ impl CaliptraBuilder {
 
     fn compile_caliptra_rom_uncached(fpga: bool) -> Result<PathBuf> {
         let rom_bytes = if fpga {
-            caliptra_builder::build_firmware_rom(&caliptra_builder::firmware::ROM_FPGA_WITH_UART)?
+            caliptra_core_tools::caliptra_builder::build_firmware_rom(
+                &caliptra_core_tools::caliptra_builder::firmware::ROM_FPGA_WITH_UART,
+            )?
         } else {
-            caliptra_builder::rom_for_fw_integration_tests()?.to_vec()
+            caliptra_core_tools::caliptra_builder::rom_for_fw_integration_tests()?.to_vec()
         };
         let path = target_dir().join("caliptra-rom.bin");
         std::fs::write(&path, rom_bytes)?;
@@ -606,7 +608,7 @@ impl CaliptraBuilder {
             fmc: fmc_exe,
             runtime: rt_exe,
             fw_svn: manifest.header.svn,
-            vendor_config: caliptra_image_fake_keys::VENDOR_CONFIG_KEY_0,
+            vendor_config: caliptra_core_tools::caliptra_image_fake_keys::VENDOR_CONFIG_KEY_0,
             owner_config: Some(owner_config),
             pqc_key_type: FwVerificationPqcKeyType::LMS,
         })?;
@@ -618,21 +620,21 @@ impl CaliptraBuilder {
     }
 
     fn compile_caliptra_fw_uncached(fpga: bool) -> Result<(PathBuf, String)> {
-        let opts = caliptra_builder::ImageOptions {
+        let opts = caliptra_core_tools::caliptra_builder::ImageOptions {
             pqc_key_type: FwVerificationPqcKeyType::LMS,
             ..Default::default()
         };
 
         let bundle = if fpga {
-            caliptra_builder::build_and_sign_image(
-                &caliptra_builder::firmware::FMC_FPGA_WITH_UART,
-                &caliptra_builder::firmware::APP_WITH_UART_FPGA,
+            caliptra_core_tools::caliptra_builder::build_and_sign_image(
+                &caliptra_core_tools::caliptra_builder::firmware::FMC_FPGA_WITH_UART,
+                &caliptra_core_tools::caliptra_builder::firmware::APP_WITH_UART_FPGA,
                 opts,
             )?
         } else {
-            caliptra_builder::build_and_sign_image(
-                &caliptra_builder::firmware::FMC_WITH_UART,
-                &caliptra_builder::firmware::APP_WITH_UART,
+            caliptra_core_tools::caliptra_builder::build_and_sign_image(
+                &caliptra_core_tools::caliptra_builder::firmware::FMC_WITH_UART,
+                &caliptra_core_tools::caliptra_builder::firmware::APP_WITH_UART,
                 opts,
             )?
         };

--- a/builder/src/firmware.rs
+++ b/builder/src/firmware.rs
@@ -1,6 +1,6 @@
 // Licensed under the Apache-2.0 license
 
-use caliptra_builder::FwId;
+use caliptra_core_tools::caliptra_builder::FwId;
 
 pub mod hw_model_tests {
     use super::*;
@@ -52,4 +52,4 @@ pub const REGISTERED_FW: &[&FwId] = &[
 ];
 
 pub const CPTRA_REGISTERED_FW: &[&FwId] =
-    &[&caliptra_builder::firmware::hw_model_tests::MCU_HITLESS_UPDATE_FLOW];
+    &[&caliptra_core_tools::caliptra_builder::firmware::hw_model_tests::MCU_HITLESS_UPDATE_FLOW];

--- a/builder/src/rom.rs
+++ b/builder/src/rom.rs
@@ -7,7 +7,7 @@ use anyhow::Result;
 
 use crate::utils::manifest_file;
 use crate::PROJECT_ROOT;
-use caliptra_builder::FwId;
+use caliptra_core_tools::caliptra_builder::FwId;
 use mcu_firmware_bundler::args::{BuildArgs, Commands, Common, LdArgs};
 
 pub fn rom_build(

--- a/common/caliptra-core-firmware/Cargo.toml
+++ b/common/caliptra-core-firmware/Cargo.toml
@@ -1,0 +1,69 @@
+# Licensed under the Apache-2.0 license
+
+[package]
+name = "caliptra-core-firmware"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+
+[dependencies]
+caliptra-api-2_0 = { workspace = true, optional = true }
+caliptra-api-types-2_0 = { workspace = true, optional = true }
+caliptra-auth-man-types-2_0 = { workspace = true, optional = true }
+caliptra-drivers-2_0 = { workspace = true, optional = true }
+caliptra-error-2_0 = { workspace = true, optional = true }
+caliptra-registers-2_0 = { workspace = true, optional = true }
+ureg-2_0 = { workspace = true, optional = true }
+ocp-eat-2_0 = { workspace = true, optional = true }
+
+caliptra-api-2_1 = { workspace = true, optional = true }
+caliptra-api-types-2_1 = { workspace = true, optional = true }
+caliptra-auth-man-types-2_1 = { workspace = true, optional = true }
+caliptra-drivers-2_1 = { workspace = true, optional = true }
+caliptra-error-2_1 = { workspace = true, optional = true }
+caliptra-registers-2_1 = { workspace = true, optional = true }
+ureg-2_1 = { workspace = true, optional = true }
+ocp-eat-2_1 = { workspace = true, optional = true }
+
+[features]
+default = ["2_0"]
+
+2_0 = [
+    "caliptra-api-2_0",
+    "caliptra-api-types-2_0",
+    "caliptra-auth-man-types-2_0",
+    "caliptra-drivers-2_0",
+    "caliptra-error-2_0",
+    "caliptra-registers-2_0",
+    "ureg-2_0",
+    "ocp-eat-2_0",
+]
+
+2_1 = [
+    "caliptra-api-2_1",
+    "caliptra-api-types-2_1",
+    "caliptra-auth-man-types-2_1",
+    "caliptra-drivers-2_1",
+    "caliptra-error-2_1",
+    "caliptra-registers-2_1",
+    "ureg-2_1",
+    "ocp-eat-2_1",
+]
+
+# Individual dependency activation
+caliptra-api-2_0 = ["dep:caliptra-api-2_0"]
+caliptra-api-2_1 = ["dep:caliptra-api-2_1"]
+caliptra-api-types-2_0 = ["dep:caliptra-api-types-2_0"]
+caliptra-api-types-2_1 = ["dep:caliptra-api-types-2_1"]
+caliptra-auth-man-types-2_0 = ["dep:caliptra-auth-man-types-2_0"]
+caliptra-auth-man-types-2_1 = ["dep:caliptra-auth-man-types-2_1"]
+caliptra-drivers-2_0 = ["dep:caliptra-drivers-2_0"]
+caliptra-drivers-2_1 = ["dep:caliptra-drivers-2_1"]
+caliptra-error-2_0 = ["dep:caliptra-error-2_0"]
+caliptra-error-2_1 = ["dep:caliptra-error-2_1"]
+caliptra-registers-2_0 = ["dep:caliptra-registers-2_0"]
+caliptra-registers-2_1 = ["dep:caliptra-registers-2_1"]
+ureg-2_0 = ["dep:ureg-2_0"]
+ureg-2_1 = ["dep:ureg-2_1"]
+ocp-eat-2_0 = ["dep:ocp-eat-2_0"]
+ocp-eat-2_1 = ["dep:ocp-eat-2_1"]

--- a/common/caliptra-core-firmware/src/lib.rs
+++ b/common/caliptra-core-firmware/src/lib.rs
@@ -1,0 +1,42 @@
+// Licensed under the Apache-2.0 license
+#![no_std]
+
+#[cfg(feature = "2_0")]
+pub use caliptra_api_2_0 as caliptra_api;
+#[cfg(feature = "2_1")]
+pub use caliptra_api_2_1 as caliptra_api;
+
+#[cfg(feature = "2_0")]
+pub use caliptra_api_types_2_0 as caliptra_api_types;
+#[cfg(feature = "2_1")]
+pub use caliptra_api_types_2_1 as caliptra_api_types;
+
+#[cfg(feature = "2_0")]
+pub use caliptra_auth_man_types_2_0 as caliptra_auth_man_types;
+#[cfg(feature = "2_1")]
+pub use caliptra_auth_man_types_2_1 as caliptra_auth_man_types;
+
+#[cfg(feature = "2_0")]
+pub use caliptra_drivers_2_0 as caliptra_drivers;
+#[cfg(feature = "2_1")]
+pub use caliptra_drivers_2_1 as caliptra_drivers;
+
+#[cfg(feature = "2_0")]
+pub use caliptra_error_2_0 as caliptra_error;
+#[cfg(feature = "2_1")]
+pub use caliptra_error_2_1 as caliptra_error;
+
+#[cfg(feature = "2_0")]
+pub use caliptra_registers_2_0 as caliptra_registers;
+#[cfg(feature = "2_1")]
+pub use caliptra_registers_2_1 as caliptra_registers;
+
+#[cfg(feature = "2_0")]
+pub use ureg_2_0 as ureg;
+#[cfg(feature = "2_1")]
+pub use ureg_2_1 as ureg;
+
+#[cfg(feature = "2_0")]
+pub use ocp_eat_2_0 as ocp_eat;
+#[cfg(feature = "2_1")]
+pub use ocp_eat_2_1 as ocp_eat;

--- a/common/caliptra-core-tools/Cargo.toml
+++ b/common/caliptra-core-tools/Cargo.toml
@@ -1,0 +1,129 @@
+# Licensed under the Apache-2.0 license
+
+[package]
+name = "caliptra-core-tools"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+
+[dependencies]
+# Shared firmware types (re-exported)
+caliptra-core-firmware = { workspace = true }
+
+# 2.0 host-only dependencies
+caliptra-auth-man-gen-2_0 = { workspace = true, optional = true }
+caliptra-builder-2_0 = { workspace = true, optional = true }
+caliptra-emu-bus-2_0 = { workspace = true, optional = true }
+caliptra-emu-cpu-2_0 = { workspace = true, optional = true }
+caliptra-emu-derive-2_0 = { workspace = true, optional = true }
+caliptra-emu-periph-2_0 = { workspace = true, optional = true }
+caliptra-emu-types-2_0 = { workspace = true, optional = true }
+caliptra-hw-model-2_0 = { workspace = true, optional = true }
+caliptra-hw-model-types-2_0 = { workspace = true, optional = true }
+caliptra-image-crypto-2_0 = { workspace = true, optional = true }
+caliptra-image-fake-keys-2_0 = { workspace = true, optional = true }
+caliptra-image-gen-2_0 = { workspace = true, optional = true }
+caliptra-image-types-2_0 = { workspace = true, optional = true }
+caliptra-test-2_0 = { workspace = true, optional = true }
+caliptra-test-harness-2_0 = { workspace = true, optional = true }
+caliptra-test-harness-types-2_0 = { workspace = true, optional = true }
+
+# 2.1 host-only dependencies
+caliptra-auth-man-gen-2_1 = { workspace = true, optional = true }
+caliptra-builder-2_1 = { workspace = true, optional = true }
+caliptra-emu-bus-2_1 = { workspace = true, optional = true }
+caliptra-emu-cpu-2_1 = { workspace = true, optional = true }
+caliptra-emu-derive-2_1 = { workspace = true, optional = true }
+caliptra-emu-periph-2_1 = { workspace = true, optional = true }
+caliptra-emu-types-2_1 = { workspace = true, optional = true }
+caliptra-hw-model-2_1 = { workspace = true, optional = true }
+caliptra-hw-model-types-2_1 = { workspace = true, optional = true }
+caliptra-image-crypto-2_1 = { workspace = true, optional = true }
+caliptra-image-fake-keys-2_1 = { workspace = true, optional = true }
+caliptra-image-gen-2_1 = { workspace = true, optional = true }
+caliptra-image-types-2_1 = { workspace = true, optional = true }
+caliptra-test-2_1 = { workspace = true, optional = true }
+caliptra-test-harness-2_1 = { workspace = true, optional = true }
+caliptra-test-harness-types-2_1 = { workspace = true, optional = true }
+
+[features]
+default = ["2_0"]
+
+2_0 = [
+    "caliptra-core-firmware/2_0",
+    "caliptra-auth-man-gen-2_0",
+    "caliptra-builder-2_0",
+    "caliptra-emu-bus-2_0",
+    "caliptra-emu-cpu-2_0",
+    "caliptra-emu-derive-2_0",
+    "caliptra-emu-periph-2_0",
+    "caliptra-emu-types-2_0",
+    "caliptra-hw-model-2_0",
+    "caliptra-hw-model-types-2_0",
+    "caliptra-image-crypto-2_0",
+    "caliptra-image-fake-keys-2_0",
+    "caliptra-image-gen-2_0",
+    "caliptra-image-types-2_0",
+    "caliptra-test-2_0",
+    "caliptra-test-harness-2_0",
+    "caliptra-test-harness-types-2_0",
+]
+
+2_1 = [
+    "caliptra-core-firmware/2_1",
+    "caliptra-auth-man-gen-2_1",
+    "caliptra-builder-2_1",
+    "caliptra-emu-bus-2_1",
+    "caliptra-emu-cpu-2_1",
+    "caliptra-emu-derive-2_1",
+    "caliptra-emu-periph-2_1",
+    "caliptra-emu-types-2_1",
+    "caliptra-hw-model-2_1",
+    "caliptra-hw-model-types-2_1",
+    "caliptra-image-crypto-2_1",
+    "caliptra-image-fake-keys-2_1",
+    "caliptra-image-gen-2_1",
+    "caliptra-image-types-2_1",
+    "caliptra-test-2_1",
+    "caliptra-test-harness-2_1",
+    "caliptra-test-harness-types-2_1",
+]
+
+# Individual dependency activation
+caliptra-auth-man-gen-2_0 = ["dep:caliptra-auth-man-gen-2_0"]
+caliptra-auth-man-gen-2_1 = ["dep:caliptra-auth-man-gen-2_1"]
+caliptra-builder-2_0 = ["dep:caliptra-builder-2_0"]
+caliptra-builder-2_1 = ["dep:caliptra-builder-2_1"]
+caliptra-emu-bus-2_0 = ["dep:caliptra-emu-bus-2_0"]
+caliptra-emu-bus-2_1 = ["dep:caliptra-emu-bus-2_1"]
+caliptra-emu-cpu-2_0 = ["dep:caliptra-emu-cpu-2_0"]
+caliptra-emu-cpu-2_1 = ["dep:caliptra-emu-cpu-2_1"]
+caliptra-emu-derive-2_0 = ["dep:caliptra-emu-derive-2_0"]
+caliptra-emu-derive-2_1 = ["dep:caliptra-emu-derive-2_1"]
+caliptra-emu-periph-2_0 = ["dep:caliptra-emu-periph-2_0"]
+caliptra-emu-periph-2_1 = ["dep:caliptra-emu-periph-2_1"]
+caliptra-emu-types-2_0 = ["dep:caliptra-emu-types-2_0"]
+caliptra-emu-types-2_1 = ["dep:caliptra-emu-types-2_1"]
+caliptra-hw-model-2_0 = ["dep:caliptra-hw-model-2_0"]
+caliptra-hw-model-2_1 = ["dep:caliptra-hw-model-2_1"]
+caliptra-hw-model-types-2_0 = ["dep:caliptra-hw-model-types-2_0"]
+caliptra-hw-model-types-2_1 = ["dep:caliptra-hw-model-types-2_1"]
+caliptra-image-crypto-2_0 = ["dep:caliptra-image-crypto-2_0"]
+caliptra-image-crypto-2_1 = ["dep:caliptra-image-crypto-2_1"]
+caliptra-image-fake-keys-2_0 = ["dep:caliptra-image-fake-keys-2_0"]
+caliptra-image-fake-keys-2_1 = ["dep:caliptra-image-fake-keys-2_1"]
+caliptra-image-gen-2_0 = ["dep:caliptra-image-gen-2_0"]
+caliptra-image-gen-2_1 = ["dep:caliptra-image-gen-2_1"]
+caliptra-image-types-2_0 = ["dep:caliptra-image-types-2_0"]
+caliptra-image-types-2_1 = ["dep:caliptra-image-types-2_1"]
+caliptra-test-2_0 = ["dep:caliptra-test-2_0"]
+caliptra-test-2_1 = ["dep:caliptra-test-2_1"]
+caliptra-test-harness-2_0 = ["dep:caliptra-test-harness-2_0"]
+caliptra-test-harness-2_1 = ["dep:caliptra-test-harness-2_1"]
+caliptra-test-harness-types-2_0 = ["dep:caliptra-test-harness-types-2_0"]
+caliptra-test-harness-types-2_1 = ["dep:caliptra-test-harness-types-2_1"]
+
+hw-model-fpga_subsystem = [
+    "caliptra-hw-model-2_0?/fpga_subsystem",
+    "caliptra-hw-model-2_1?/fpga_subsystem",
+]

--- a/common/caliptra-core-tools/src/lib.rs
+++ b/common/caliptra-core-tools/src/lib.rs
@@ -1,0 +1,84 @@
+// Licensed under the Apache-2.0 license
+
+// Re-export shared firmware API
+pub use caliptra_core_firmware::*;
+
+#[cfg(feature = "2_0")]
+pub use caliptra_auth_man_gen_2_0 as caliptra_auth_man_gen;
+#[cfg(feature = "2_1")]
+pub use caliptra_auth_man_gen_2_1 as caliptra_auth_man_gen;
+
+#[cfg(feature = "2_0")]
+pub use caliptra_builder_2_0 as caliptra_builder;
+#[cfg(feature = "2_1")]
+pub use caliptra_builder_2_1 as caliptra_builder;
+
+#[cfg(feature = "2_0")]
+pub use caliptra_emu_bus_2_0 as caliptra_emu_bus;
+#[cfg(feature = "2_1")]
+pub use caliptra_emu_bus_2_1 as caliptra_emu_bus;
+
+#[cfg(feature = "2_0")]
+pub use caliptra_emu_cpu_2_0 as caliptra_emu_cpu;
+#[cfg(feature = "2_1")]
+pub use caliptra_emu_cpu_2_1 as caliptra_emu_cpu;
+
+#[cfg(feature = "2_0")]
+pub use caliptra_emu_derive_2_0 as caliptra_emu_derive;
+#[cfg(feature = "2_1")]
+pub use caliptra_emu_derive_2_1 as caliptra_emu_derive;
+
+#[cfg(feature = "2_0")]
+pub use caliptra_emu_periph_2_0 as caliptra_emu_periph;
+#[cfg(feature = "2_1")]
+pub use caliptra_emu_periph_2_1 as caliptra_emu_periph;
+
+#[cfg(feature = "2_0")]
+pub use caliptra_emu_types_2_0 as caliptra_emu_types;
+#[cfg(feature = "2_1")]
+pub use caliptra_emu_types_2_1 as caliptra_emu_types;
+
+#[cfg(feature = "2_0")]
+pub use caliptra_hw_model_2_0 as caliptra_hw_model;
+#[cfg(feature = "2_1")]
+pub use caliptra_hw_model_2_1 as caliptra_hw_model;
+
+#[cfg(feature = "2_0")]
+pub use caliptra_hw_model_types_2_0 as caliptra_hw_model_types;
+#[cfg(feature = "2_1")]
+pub use caliptra_hw_model_types_2_1 as caliptra_hw_model_types;
+
+#[cfg(feature = "2_0")]
+pub use caliptra_image_crypto_2_0 as caliptra_image_crypto;
+#[cfg(feature = "2_1")]
+pub use caliptra_image_crypto_2_1 as caliptra_image_crypto;
+
+#[cfg(feature = "2_0")]
+pub use caliptra_image_fake_keys_2_0 as caliptra_image_fake_keys;
+#[cfg(feature = "2_1")]
+pub use caliptra_image_fake_keys_2_1 as caliptra_image_fake_keys;
+
+#[cfg(feature = "2_0")]
+pub use caliptra_image_gen_2_0 as caliptra_image_gen;
+#[cfg(feature = "2_1")]
+pub use caliptra_image_gen_2_1 as caliptra_image_gen;
+
+#[cfg(feature = "2_0")]
+pub use caliptra_image_types_2_0 as caliptra_image_types;
+#[cfg(feature = "2_1")]
+pub use caliptra_image_types_2_1 as caliptra_image_types;
+
+#[cfg(feature = "2_0")]
+pub use caliptra_test_2_0 as caliptra_test;
+#[cfg(feature = "2_1")]
+pub use caliptra_test_2_1 as caliptra_test;
+
+#[cfg(feature = "2_0")]
+pub use caliptra_test_harness_2_0 as caliptra_test_harness;
+#[cfg(feature = "2_1")]
+pub use caliptra_test_harness_2_1 as caliptra_test_harness;
+
+#[cfg(feature = "2_0")]
+pub use caliptra_test_harness_types_2_0 as caliptra_test_harness_types;
+#[cfg(feature = "2_1")]
+pub use caliptra_test_harness_types_2_1 as caliptra_test_harness_types;

--- a/common/mcu-mbox/Cargo.toml
+++ b/common/mcu-mbox/Cargo.toml
@@ -7,5 +7,5 @@ edition.workspace = true
 authors.workspace = true
 
 [dependencies]
-caliptra-api.workspace = true
+caliptra-core-firmware = { workspace = true, default-features = false, features = ["2_0"] }
 zerocopy.workspace = true

--- a/common/mcu-mbox/src/messages.rs
+++ b/common/mcu-mbox/src/messages.rs
@@ -1,6 +1,6 @@
 // Licensed under the Apache-2.0 license
 
-pub use caliptra_api::mailbox::{
+pub use caliptra_core_firmware::caliptra_api::mailbox::{
     CmAesDecryptInitReq, CmAesDecryptUpdateReq, CmAesEncryptInitReq, CmAesEncryptInitResp,
     CmAesEncryptInitRespHeader, CmAesEncryptUpdateReq, CmAesGcmDecryptFinalReq,
     CmAesGcmDecryptFinalResp, CmAesGcmDecryptFinalRespHeader, CmAesGcmDecryptInitReq,
@@ -18,7 +18,7 @@ pub use caliptra_api::mailbox::{
     ResponseVarSize, CMB_AES_ENCRYPTED_CONTEXT_SIZE, CMB_AES_GCM_ENCRYPTED_CONTEXT_SIZE,
     CMB_ECDH_EXCHANGE_DATA_MAX_SIZE, CMB_HMAC_MAX_SIZE, MAX_CMB_DATA_SIZE,
 };
-pub use caliptra_api::{calc_checksum, verify_checksum};
+pub use caliptra_core_firmware::caliptra_api::{calc_checksum, verify_checksum};
 use core::convert::From;
 use core::num::NonZeroU32;
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};

--- a/common/testing/Cargo.toml
+++ b/common/testing/Cargo.toml
@@ -7,7 +7,7 @@ edition.workspace = true
 authors.workspace = true
 
 [dependencies]
-caliptra-api-types.workspace = true
+caliptra-core-firmware = { workspace = true, default-features = false, features = ["2_0"] }
 bitfield.workspace = true
 crc.workspace = true
 mctp-vdm-common.workspace = true

--- a/common/testing/src/lib.rs
+++ b/common/testing/src/lib.rs
@@ -13,7 +13,7 @@ pub mod mctp_vdm_transport;
 pub mod mctp_util;
 pub mod spdm_responder_validator;
 
-pub use caliptra_api_types::DeviceLifecycle;
+pub use caliptra_core_firmware::caliptra_api_types::DeviceLifecycle;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Condvar, Mutex};
 use std::time::Duration;

--- a/docs/src/fpga.md
+++ b/docs/src/fpga.md
@@ -87,7 +87,7 @@ The xtask flows supports three different configurations:
 * "Subsystem": This mode configures the FPGA to run Caliptra MCU flows.
 * "Core-on-Subsystem": This mode configures the FPGA to run Caliptra-SW flows for a subsystem Caliptra.
 * "Core": This mode allows running Caliptra in Core mode on the FPGA.
-  * Note: You will need to override caliptra-sw to point to a local directory in the workspace [Cargo.toml](../../Cargo.toml).
+  * Note: You will need to use the `local` feature of `caliptra-core` to point to a local directory. This is done by enabling the `local` feature in the workspace [Cargo.toml](../../Cargo.toml) and ensuring that the `caliptra-sw` repository is located at `../../../caliptra-sw` relative to the `common/caliptra-core` directory.
 
 For example:
 

--- a/emulator/app/Cargo.toml
+++ b/emulator/app/Cargo.toml
@@ -9,15 +9,9 @@ edition = "2021"
 
 [dependencies]
 bitfield.workspace = true
-caliptra-emu-bus.workspace = true
-caliptra-emu-cpu.workspace = true
-caliptra-emu-periph.workspace = true
+caliptra-core-tools.workspace = true
 caliptra-util-host-mailbox-test-config.workspace = true
 caliptra-mailbox-server.workspace = true
-caliptra-emu-types.workspace = true
-caliptra-api-types.workspace = true
-caliptra-image-types.workspace = true
-caliptra-registers.workspace = true
 chrono.workspace = true
 clap.workspace = true
 clap-num.workspace = true
@@ -62,7 +56,7 @@ uuid.workspace = true
 zerocopy.workspace = true
 
 [dev-dependencies]
-caliptra-test.workspace = true
+caliptra-core-tools.workspace = true
 
 [[bin]]
 name = "emulator"

--- a/emulator/app/mcu-mbox/Cargo.toml
+++ b/emulator/app/mcu-mbox/Cargo.toml
@@ -8,6 +8,6 @@ edition.workspace = true
 [dependencies]
 emulator-consts.workspace = true
 emulator-periph.workspace = true
-caliptra-emu-bus.workspace = true
+caliptra-core-tools.workspace = true
 registers-generated.workspace = true
 tock-registers.workspace = true

--- a/emulator/app/mcu-mbox/src/mcu_mailbox_transport.rs
+++ b/emulator/app/mcu-mbox/src/mcu_mailbox_transport.rs
@@ -58,9 +58,11 @@ impl McuMailboxTransport {
             .regs
             .lock()
             .unwrap()
-            .write_mcu_mbox0_csr_mbox_execute(caliptra_emu_bus::ReadWriteRegister::new(
-                MboxExecute::Execute::SET.value,
-            ));
+            .write_mcu_mbox0_csr_mbox_execute(
+                caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+                    MboxExecute::Execute::SET.value,
+                ),
+            );
 
         Ok(())
     }
@@ -139,9 +141,11 @@ impl McuMailboxTransport {
             .regs
             .lock()
             .unwrap()
-            .write_mcu_mbox0_csr_mbox_execute(caliptra_emu_bus::ReadWriteRegister::new(
-                MboxExecute::Execute::CLEAR.value,
-            ));
+            .write_mcu_mbox0_csr_mbox_execute(
+                caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+                    MboxExecute::Execute::CLEAR.value,
+                ),
+            );
     }
 }
 

--- a/emulator/app/src/emulator.rs
+++ b/emulator/app/src/emulator.rs
@@ -16,13 +16,13 @@ use crate::dis;
 use crate::doe_mbox_fsm;
 use crate::elf;
 use crate::tests;
-use caliptra_api_types::DeviceLifecycle;
-use caliptra_emu_bus::BusMmio;
-use caliptra_emu_bus::{Bus, Clock, Timer};
-use caliptra_emu_cpu::{Cpu, Pic, RvInstr, StepAction};
-use caliptra_emu_periph::CaliptraRootBus as CaliptraMainRootBus;
-use caliptra_emu_periph::MailboxRequester;
-use caliptra_image_types::FwVerificationPqcKeyType;
+use caliptra_core_tools::caliptra_api_types::DeviceLifecycle;
+use caliptra_core_tools::caliptra_emu_bus::BusMmio;
+use caliptra_core_tools::caliptra_emu_bus::{Bus, Clock, Timer};
+use caliptra_core_tools::caliptra_emu_cpu::{Cpu, Pic, RvInstr, StepAction};
+use caliptra_core_tools::caliptra_emu_periph::CaliptraRootBus as CaliptraMainRootBus;
+use caliptra_core_tools::caliptra_emu_periph::MailboxRequester;
+use caliptra_core_tools::caliptra_image_types::FwVerificationPqcKeyType;
 use clap::{ArgAction, Parser};
 use clap_num::maybe_hex;
 use crossterm::event::{Event, KeyCode, KeyEvent};
@@ -60,13 +60,18 @@ use std::thread::JoinHandle;
 use tests::pldm_request_response_test::PldmRequestResponseTest;
 
 // Type aliases for external shim callbacks
-pub type ExternalReadCallback =
-    Box<dyn Fn(caliptra_emu_types::RvSize, caliptra_emu_types::RvAddr, &mut u32) -> bool>;
+pub type ExternalReadCallback = Box<
+    dyn Fn(
+        caliptra_core_tools::caliptra_emu_types::RvSize,
+        caliptra_core_tools::caliptra_emu_types::RvAddr,
+        &mut u32,
+    ) -> bool,
+>;
 pub type ExternalWriteCallback = Box<
     dyn Fn(
-        caliptra_emu_types::RvSize,
-        caliptra_emu_types::RvAddr,
-        caliptra_emu_types::RvData,
+        caliptra_core_tools::caliptra_emu_types::RvSize,
+        caliptra_core_tools::caliptra_emu_types::RvAddr,
+        caliptra_core_tools::caliptra_emu_types::RvData,
     ) -> bool,
 >;
 
@@ -725,45 +730,46 @@ impl Emulator {
             PldmRequestResponseTest::run(pldm_socket, test_feature.to_string());
         }
 
-        let create_flash_controller =
-            |default_path: &str,
-             error_irq: u8,
-             event_irq: u8,
-             initial_content: Option<&[u8]>,
-             direct_read_region: Option<Rc<RefCell<caliptra_emu_bus::Ram>>>| {
-                // Use a temporary file for flash storage if we're running a test
-                let is_test = test_feature == "test-flash-ctrl-init"
-                    || test_feature == "test-flash-ctrl-read-write-page"
-                    || test_feature == "test-flash-ctrl-erase-page"
-                    || test_feature == "test-flash-storage-read-write"
-                    || test_feature == "test-flash-storage-erase"
-                    || test_feature == "test-flash-usermode"
-                    || test_feature == "test-mcu-rom-flash-access"
-                    || test_feature == "test-log-flash-linear"
-                    || test_feature == "test-log-flash-circular"
-                    || test_feature == "test-log-flash-usermode";
+        let create_flash_controller = |default_path: &str,
+                                       error_irq: u8,
+                                       event_irq: u8,
+                                       initial_content: Option<&[u8]>,
+                                       direct_read_region: Option<
+            Rc<RefCell<caliptra_core_tools::caliptra_emu_bus::Ram>>,
+        >| {
+            // Use a temporary file for flash storage if we're running a test
+            let is_test = test_feature == "test-flash-ctrl-init"
+                || test_feature == "test-flash-ctrl-read-write-page"
+                || test_feature == "test-flash-ctrl-erase-page"
+                || test_feature == "test-flash-storage-read-write"
+                || test_feature == "test-flash-storage-erase"
+                || test_feature == "test-flash-usermode"
+                || test_feature == "test-mcu-rom-flash-access"
+                || test_feature == "test-log-flash-linear"
+                || test_feature == "test-log-flash-circular"
+                || test_feature == "test-log-flash-usermode";
 
-                let flash_file = if is_test {
-                    Some(
-                        tempfile::NamedTempFile::new()
-                            .unwrap()
-                            .into_temp_path()
-                            .to_path_buf(),
-                    )
-                } else {
-                    Some(PathBuf::from(default_path))
-                };
-
-                DummyFlashCtrl::new(
-                    &clock.clone(),
-                    direct_read_region,
-                    flash_file,
-                    pic.register_irq(error_irq),
-                    pic.register_irq(event_irq),
-                    initial_content,
+            let flash_file = if is_test {
+                Some(
+                    tempfile::NamedTempFile::new()
+                        .unwrap()
+                        .into_temp_path()
+                        .to_path_buf(),
                 )
-                .unwrap()
+            } else {
+                Some(PathBuf::from(default_path))
             };
+
+            DummyFlashCtrl::new(
+                &clock.clone(),
+                direct_read_region,
+                flash_file,
+                pic.register_irq(error_irq),
+                pic.register_irq(event_irq),
+                initial_content,
+            )
+            .unwrap()
+        };
 
         let primary_flash_initial_content = if cli.primary_flash_image.is_some() {
             let flash_image_path = cli.primary_flash_image.as_ref().unwrap();
@@ -879,7 +885,7 @@ impl Emulator {
         lc.set_otp_partitions(otp.partitions_ref());
         let ext_mcu_mailbox0 = mcu_mailbox0.as_external(MciMailboxRequester::SocAgent(1));
         let soc_ifc = unsafe {
-            caliptra_registers::soc_ifc::RegisterBlock::new_with_mmio(
+            caliptra_core_tools::caliptra_registers::soc_ifc::RegisterBlock::new_with_mmio(
                 cli.soc_offset.unwrap_or(0x3003_0000) as *mut u32,
                 BusMmio::new(
                     caliptra_cpu
@@ -1192,15 +1198,17 @@ impl Emulator {
         }
 
         let caliptra_action = if self.trace_file.is_some() {
-            let caliptra_trace_fn: &mut dyn FnMut(u32, caliptra_emu_cpu::RvInstr) =
-                &mut |pc, instr| match instr {
-                    caliptra_emu_cpu::RvInstr::Instr32(instr32) => {
-                        println!("{{caliptra cpu}} {}", disassemble(pc, instr32));
-                    }
-                    caliptra_emu_cpu::RvInstr::Instr16(instr16) => {
-                        println!("{{caliptra cpu}} {}", disassemble(pc, instr16 as u32));
-                    }
-                };
+            let caliptra_trace_fn: &mut dyn FnMut(
+                u32,
+                caliptra_core_tools::caliptra_emu_cpu::RvInstr,
+            ) = &mut |pc, instr| match instr {
+                caliptra_core_tools::caliptra_emu_cpu::RvInstr::Instr32(instr32) => {
+                    println!("{{caliptra cpu}} {}", disassemble(pc, instr32));
+                }
+                caliptra_core_tools::caliptra_emu_cpu::RvInstr::Instr16(instr16) => {
+                    println!("{{caliptra cpu}} {}", disassemble(pc, instr16 as u32));
+                }
+            };
             self.caliptra_cpu.step(Some(caliptra_trace_fn))
         } else {
             self.caliptra_cpu.step(None)

--- a/emulator/app/src/gdb/gdb_target.rs
+++ b/emulator/app/src/gdb/gdb_target.rs
@@ -12,9 +12,9 @@ Abstract:
 
 --*/
 
-use caliptra_emu_cpu::xreg_file::XReg;
-use caliptra_emu_cpu::WatchPtrKind;
-use caliptra_emu_types::RvSize;
+use caliptra_core_tools::caliptra_emu_cpu::xreg_file::XReg;
+use caliptra_core_tools::caliptra_emu_cpu::WatchPtrKind;
+use caliptra_core_tools::caliptra_emu_types::RvSize;
 use gdbstub::arch::SingleStepGdbBehavior;
 use gdbstub::common::Signal;
 use gdbstub::stub::SingleThreadStopReason;
@@ -29,7 +29,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use crate::emulator::Emulator;
-use caliptra_emu_cpu::StepAction as SystemStepAction;
+use caliptra_core_tools::caliptra_emu_cpu::StepAction as SystemStepAction;
 
 pub enum ExecMode {
     Step,

--- a/emulator/app/src/main.rs
+++ b/emulator/app/src/main.rs
@@ -12,7 +12,7 @@ Abstract:
 
 --*/
 
-use caliptra_emu_cpu::StepAction;
+use caliptra_core_tools::caliptra_emu_cpu::StepAction;
 use clap::Parser;
 use emulator::{gdb, Emulator, EmulatorArgs};
 use mcu_testing_common::MCU_RUNNING;

--- a/emulator/bmc/Cargo.toml
+++ b/emulator/bmc/Cargo.toml
@@ -6,8 +6,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-caliptra-emu-bus.workspace = true
-caliptra-emu-cpu.workspace = true
-caliptra-emu-periph.workspace = true
+caliptra-core-tools.workspace = true
 smlang.workspace = true
 tock-registers.workspace = true

--- a/emulator/bmc/src/bmc.rs
+++ b/emulator/bmc/src/bmc.rs
@@ -1,7 +1,7 @@
 // Licensed under the Apache-2.0 license
 
 use crate::recovery;
-use caliptra_emu_bus::{Device, Event, EventData, RecoveryCommandCode};
+use caliptra_core_tools::caliptra_emu_bus::{Device, Event, EventData, RecoveryCommandCode};
 use std::sync::mpsc;
 
 pub struct Bmc {

--- a/emulator/bmc/src/recovery.rs
+++ b/emulator/bmc/src/recovery.rs
@@ -1,7 +1,9 @@
 // Licensed under the Apache-2.0 license
 
-use caliptra_emu_bus::{Device, Event, EventData, ReadWriteRegister, RecoveryCommandCode};
-use caliptra_emu_periph::dma::recovery::RecoveryStatus;
+use caliptra_core_tools::caliptra_emu_bus::{
+    Device, Event, EventData, ReadWriteRegister, RecoveryCommandCode,
+};
+use caliptra_core_tools::caliptra_emu_periph::dma::recovery::RecoveryStatus;
 use smlang::statemachine;
 use std::sync::mpsc;
 use tock_registers::interfaces::Readable;

--- a/emulator/caliptra/Cargo.toml
+++ b/emulator/caliptra/Cargo.toml
@@ -8,11 +8,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-caliptra-api-types.workspace = true
-caliptra-emu-bus.workspace = true
-caliptra-emu-cpu.workspace = true
-caliptra-emu-periph.workspace = true
-caliptra-registers.workspace = true
+caliptra-core-tools.workspace = true
 clap.workspace = true
 ctrlc.workspace = true
 elf.workspace = true

--- a/emulator/caliptra/src/caliptra.rs
+++ b/emulator/caliptra/src/caliptra.rs
@@ -12,11 +12,11 @@ Abstract:
 
 --*/
 
-use caliptra_api_types::{DeviceLifecycle, SecurityState};
-use caliptra_emu_bus::{BusMmio, Clock};
-use caliptra_emu_cpu::{Cpu, CpuArgs, Pic};
-use caliptra_emu_periph::soc_reg::DebugManufService;
-use caliptra_emu_periph::{
+use caliptra_core_tools::caliptra_api_types::{DeviceLifecycle, SecurityState};
+use caliptra_core_tools::caliptra_emu_bus::{BusMmio, Clock};
+use caliptra_core_tools::caliptra_emu_cpu::{Cpu, CpuArgs, Pic};
+use caliptra_core_tools::caliptra_emu_periph::soc_reg::DebugManufService;
+use caliptra_core_tools::caliptra_emu_periph::{
     CaliptraRootBus, CaliptraRootBusArgs, DownloadIdevidCsrCb, MailboxInternal, MailboxRequester,
     Mci, ReadyForFwCb, SocToCaliptraBus, TbServicesCb, UploadUpdateFwCb,
 };
@@ -169,7 +169,7 @@ pub fn start_caliptra(
 
     let root_bus = CaliptraRootBus::new(bus_args);
     let soc_ifc = unsafe {
-        caliptra_registers::soc_ifc::RegisterBlock::new_with_mmio(
+        caliptra_core_tools::caliptra_registers::soc_ifc::RegisterBlock::new_with_mmio(
             0x3003_0000 as *mut u32,
             BusMmio::new(root_bus.soc_to_caliptra_bus(MAILBOX_USER)),
         )

--- a/emulator/cbinding/Cargo.toml
+++ b/emulator/cbinding/Cargo.toml
@@ -12,11 +12,7 @@ crate-type = ["staticlib"]
 [dependencies]
 emulator.workspace = true
 libc.workspace = true
-caliptra-emu-bus.workspace = true
-caliptra-emu-cpu.workspace = true
-caliptra-emu-types.workspace = true
-caliptra-image-types.workspace = true
-caliptra-api-types.workspace = true
+caliptra-core-tools.workspace = true
 mcu-testing-common.workspace = true
 semver.workspace = true
 

--- a/emulator/cbinding/src/lib.rs
+++ b/emulator/cbinding/src/lib.rs
@@ -11,11 +11,11 @@ Abstract:
     C bindings for the Caliptra MCU Emulator.
 
 --*/
-use caliptra_api_types::DeviceLifecycle;
-use caliptra_emu_bus::Bus;
-use caliptra_emu_cpu::xreg_file::XReg;
-use caliptra_emu_cpu::StepAction;
-use caliptra_emu_types::{RvAddr, RvSize};
+use caliptra_core_tools::caliptra_api_types::DeviceLifecycle;
+use caliptra_core_tools::caliptra_emu_bus::Bus;
+use caliptra_core_tools::caliptra_emu_cpu::xreg_file::XReg;
+use caliptra_core_tools::caliptra_emu_cpu::StepAction;
+use caliptra_core_tools::caliptra_emu_types::{RvAddr, RvSize};
 use emulator::{
     gdb::{self, ControlledGdbServer},
     Emulator, EmulatorArgs, ExternalReadCallback, ExternalWriteCallback,
@@ -321,10 +321,11 @@ pub unsafe extern "C" fn emulator_init(
             .unwrap_or(DeviceLifecycle::Production) as u32,
         test_feature: None,
         vendor_pk_hash: convert_optional_c_string(config.vendor_pk_hash),
-        vendor_pqc_type: caliptra_image_types::FwVerificationPqcKeyType::from_u8(
-            config.vendor_pqc_type,
-        )
-        .unwrap_or(caliptra_image_types::FwVerificationPqcKeyType::LMS),
+        vendor_pqc_type:
+            caliptra_core_tools::caliptra_image_types::FwVerificationPqcKeyType::from_u8(
+                config.vendor_pqc_type,
+            )
+            .unwrap_or(caliptra_core_tools::caliptra_image_types::FwVerificationPqcKeyType::LMS),
         owner_pk_hash: convert_optional_c_string(config.owner_pk_hash),
         streaming_boot: convert_optional_c_string(config.streaming_boot_path).map(|s| s.into()),
         primary_flash_image: convert_optional_c_string(config.primary_flash_image_path)
@@ -1582,7 +1583,7 @@ pub unsafe extern "C" fn emulator_set_external_interrupt(
 
     // Use the PIC to set the external interrupt level
     // We need to register an IRQ and then set its level
-    let pic: &std::rc::Rc<caliptra_emu_cpu::Pic> = match &mut state.wrapper {
+    let pic: &std::rc::Rc<caliptra_core_tools::caliptra_emu_cpu::Pic> = match &mut state.wrapper {
         EmulatorWrapper::Normal(emulator) => &emulator.pic,
         EmulatorWrapper::Gdb(gdb_target) => &gdb_target.emulator().pic,
     };
@@ -1691,9 +1692,9 @@ pub unsafe extern "C" fn emulator_read_auto_root_bus(
 
     // Convert size to RvSize
     let rv_size = match size {
-        1 => caliptra_emu_types::RvSize::Byte,
-        2 => caliptra_emu_types::RvSize::HalfWord,
-        4 => caliptra_emu_types::RvSize::Word,
+        1 => caliptra_core_tools::caliptra_emu_types::RvSize::Byte,
+        2 => caliptra_core_tools::caliptra_emu_types::RvSize::HalfWord,
+        4 => caliptra_core_tools::caliptra_emu_types::RvSize::Word,
         _ => return EmulatorError::InvalidArgs,
     };
 
@@ -1710,8 +1711,12 @@ pub unsafe extern "C" fn emulator_read_auto_root_bus(
             EmulatorError::Success
         }
         Err(bus_error) => match bus_error {
-            caliptra_emu_bus::BusError::LoadAccessFault => EmulatorError::BusLoadAccessFault,
-            caliptra_emu_bus::BusError::LoadAddrMisaligned => EmulatorError::BusLoadAddrMisaligned,
+            caliptra_core_tools::caliptra_emu_bus::BusError::LoadAccessFault => {
+                EmulatorError::BusLoadAccessFault
+            }
+            caliptra_core_tools::caliptra_emu_bus::BusError::LoadAddrMisaligned => {
+                EmulatorError::BusLoadAddrMisaligned
+            }
             _ => EmulatorError::InvalidArgs, // Fallback for other bus errors
         },
     }
@@ -1746,9 +1751,9 @@ pub unsafe extern "C" fn emulator_write_auto_root_bus(
 
     // Convert size to RvSize
     let rv_size = match size {
-        1 => caliptra_emu_types::RvSize::Byte,
-        2 => caliptra_emu_types::RvSize::HalfWord,
-        4 => caliptra_emu_types::RvSize::Word,
+        1 => caliptra_core_tools::caliptra_emu_types::RvSize::Byte,
+        2 => caliptra_core_tools::caliptra_emu_types::RvSize::HalfWord,
+        4 => caliptra_core_tools::caliptra_emu_types::RvSize::Word,
         _ => return EmulatorError::InvalidArgs,
     };
 
@@ -1764,8 +1769,10 @@ pub unsafe extern "C" fn emulator_write_auto_root_bus(
     match result {
         Ok(_) => EmulatorError::Success,
         Err(bus_error) => match bus_error {
-            caliptra_emu_bus::BusError::StoreAccessFault => EmulatorError::BusStoreAccessFault,
-            caliptra_emu_bus::BusError::StoreAddrMisaligned => {
+            caliptra_core_tools::caliptra_emu_bus::BusError::StoreAccessFault => {
+                EmulatorError::BusStoreAccessFault
+            }
+            caliptra_core_tools::caliptra_emu_bus::BusError::StoreAddrMisaligned => {
                 EmulatorError::BusStoreAddrMisaligned
             }
             _ => EmulatorError::InvalidArgs, // Fallback for other bus errors

--- a/emulator/cbinding/src/simple_test.rs
+++ b/emulator/cbinding/src/simple_test.rs
@@ -12,7 +12,7 @@ Abstract:
 
 --*/
 
-use caliptra_image_types::FwVerificationPqcKeyType;
+use caliptra_core_tools::caliptra_image_types::FwVerificationPqcKeyType;
 use emulator::{Emulator, EmulatorArgs};
 use mcu_testing_common::DeviceLifecycle;
 

--- a/emulator/compliance-test/Cargo.toml
+++ b/emulator/compliance-test/Cargo.toml
@@ -9,8 +9,6 @@ edition = "2021"
 
 [dependencies]
 clap.workspace = true
-caliptra-emu-types.workspace = true
-caliptra-emu-bus.workspace = true
-caliptra-emu-cpu.workspace = true
+caliptra-core-tools.workspace = true
 emulator-consts.workspace = true
 getrandom.workspace = true

--- a/emulator/compliance-test/src/main.rs
+++ b/emulator/compliance-test/src/main.rs
@@ -12,9 +12,9 @@ Abstract:
 
 --*/
 
-use caliptra_emu_bus::{Bus, Clock, Ram};
-use caliptra_emu_cpu::{Cpu, Pic, StepAction};
-use caliptra_emu_types::RvSize;
+use caliptra_core_tools::caliptra_emu_bus::{Bus, Clock, Ram};
+use caliptra_core_tools::caliptra_emu_cpu::{Cpu, Pic, StepAction};
+use caliptra_core_tools::caliptra_emu_types::RvSize;
 use clap::{arg, value_parser};
 use emulator_consts::DEFAULT_CPU_ARGS;
 use fs::TempDir;

--- a/emulator/consts/Cargo.toml
+++ b/emulator/consts/Cargo.toml
@@ -6,4 +6,4 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-caliptra-emu-cpu.workspace = true
+caliptra-core-tools.workspace = true

--- a/emulator/consts/src/lib.rs
+++ b/emulator/consts/src/lib.rs
@@ -12,7 +12,7 @@ Abstract:
 
 --*/
 
-use caliptra_emu_cpu::{CpuArgs, CpuOrgArgs};
+use caliptra_core_tools::caliptra_emu_cpu::{CpuArgs, CpuOrgArgs};
 
 pub const DEFAULT_CPU_ARGS: CpuArgs = CpuArgs {
     org: CpuOrgArgs {

--- a/emulator/periph/Cargo.toml
+++ b/emulator/periph/Cargo.toml
@@ -8,14 +8,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+caliptra-core-tools.workspace = true
 bitfield.workspace = true
-caliptra-emu-bus.workspace = true
-caliptra-emu-cpu.workspace = true
-caliptra-emu-types.workspace = true
-caliptra-emu-derive.workspace = true
-caliptra-image-types.workspace = true
-caliptra-emu-periph.workspace = true
-caliptra-registers.workspace = true
 emulator-consts.workspace = true
 emulator-registers-generated.workspace = true
 lazy_static.workspace = true

--- a/emulator/periph/src/axicdma.rs
+++ b/emulator/periph/src/axicdma.rs
@@ -4,8 +4,8 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 use crate::McuMailbox0Internal;
-use caliptra_emu_bus::{ActionHandle, Clock, Ram, ReadWriteRegister, Timer};
-use caliptra_emu_cpu::Irq;
+use caliptra_core_tools::caliptra_emu_bus::{ActionHandle, Clock, Ram, ReadWriteRegister, Timer};
+use caliptra_core_tools::caliptra_emu_cpu::Irq;
 use emulator_consts::{RAM_ORG, RAM_SIZE};
 use emulator_registers_generated::axicdma::{AxicdmaGenerated, AxicdmaPeripheral};
 use registers_generated::axicdma::bits::{AxicdmaBytesToTransfer, AxicdmaControl, AxicdmaStatus};
@@ -287,7 +287,10 @@ impl AxicdmaPeripheral for AxiCDMA {
         Some(&mut self.generated)
     }
 
-    fn set_dma_ram(&mut self, ram: std::rc::Rc<std::cell::RefCell<caliptra_emu_bus::Ram>>) {
+    fn set_dma_ram(
+        &mut self,
+        ram: std::rc::Rc<std::cell::RefCell<caliptra_core_tools::caliptra_emu_bus::Ram>>,
+    ) {
         self.mcu_sram = Some(ram);
     }
 
@@ -299,12 +302,16 @@ impl AxicdmaPeripheral for AxiCDMA {
 
     fn read_axicdma_control(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, AxicdmaControl::Register> {
-        caliptra_emu_bus::ReadWriteRegister::new(self.control.reg.get())
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<u32, AxicdmaControl::Register>
+    {
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.control.reg.get())
     }
     fn write_axicdma_control(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<u32, AxicdmaControl::Register>,
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+            u32,
+            AxicdmaControl::Register,
+        >,
     ) {
         if self.status.reg.is_set(AxicdmaStatus::IrqError)
             && val.reg.is_set(AxicdmaControl::ErrIrqEn)
@@ -338,12 +345,13 @@ impl AxicdmaPeripheral for AxiCDMA {
     }
     fn read_axicdma_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, AxicdmaStatus::Register> {
-        caliptra_emu_bus::ReadWriteRegister::new(self.status.reg.get())
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<u32, AxicdmaStatus::Register>
+    {
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.status.reg.get())
     }
     fn write_axicdma_status(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::axicdma::bits::AxicdmaStatus::Register,
         >,
@@ -355,38 +363,44 @@ impl AxicdmaPeripheral for AxiCDMA {
             self.clear_interrupt(DmaCtrlIntType::Event);
         }
     }
-    fn read_axicdma_src_addr(&mut self) -> caliptra_emu_types::RvData {
+    fn read_axicdma_src_addr(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         self.src_addr_lsb.reg.get()
     }
-    fn write_axicdma_src_addr(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_axicdma_src_addr(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         self.src_addr_lsb.reg.set(val);
     }
-    fn read_axicdma_src_addr_msb(&mut self) -> caliptra_emu_types::RvData {
+    fn read_axicdma_src_addr_msb(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         self.src_addr_msb.reg.get()
     }
-    fn write_axicdma_src_addr_msb(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_axicdma_src_addr_msb(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         self.src_addr_msb.reg.set(val);
     }
-    fn read_axicdma_dst_addr(&mut self) -> caliptra_emu_types::RvData {
+    fn read_axicdma_dst_addr(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         self.dst_addr_lsb.reg.get()
     }
-    fn write_axicdma_dst_addr(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_axicdma_dst_addr(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         self.dst_addr_lsb.reg.set(val);
     }
-    fn read_axicdma_dst_addr_msb(&mut self) -> caliptra_emu_types::RvData {
+    fn read_axicdma_dst_addr_msb(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         self.dst_addr_msb.reg.get()
     }
-    fn write_axicdma_dst_addr_msb(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_axicdma_dst_addr_msb(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         self.dst_addr_msb.reg.set(val);
     }
     fn read_axicdma_bytes_to_transfer(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, AxicdmaBytesToTransfer::Register> {
-        caliptra_emu_bus::ReadWriteRegister::new(self.btt.reg.get())
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        AxicdmaBytesToTransfer::Register,
+    > {
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.btt.reg.get())
     }
     fn write_axicdma_bytes_to_transfer(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<u32, AxicdmaBytesToTransfer::Register>,
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+            u32,
+            AxicdmaBytesToTransfer::Register,
+        >,
     ) {
         self.btt.reg.set(val.reg.get());
         self.status.reg.modify(AxicdmaStatus::Idle::CLEAR);
@@ -401,9 +415,9 @@ impl AxicdmaPeripheral for AxiCDMA {
 mod test {
     use super::*;
 
-    use caliptra_emu_bus::{Bus, Clock};
-    use caliptra_emu_cpu::Pic;
-    use caliptra_emu_types::RvSize;
+    use caliptra_core_tools::caliptra_emu_bus::{Bus, Clock};
+    use caliptra_core_tools::caliptra_emu_cpu::Pic;
+    use caliptra_core_tools::caliptra_emu_types::RvSize;
     use emulator_consts::{EXTERNAL_TEST_SRAM_SIZE, RAM_SIZE};
     use emulator_registers_generated::root_bus::AutoRootBus;
     use registers_generated::axicdma::bits::{AxicdmaControl, AxicdmaStatus};

--- a/emulator/periph/src/caliptra_to_ext_bus.rs
+++ b/emulator/periph/src/caliptra_to_ext_bus.rs
@@ -13,8 +13,8 @@ Abstract:
 
 --*/
 
-use caliptra_emu_bus::{Bus, BusError};
-use caliptra_emu_types::{RvAddr, RvData, RvSize};
+use caliptra_core_tools::caliptra_emu_bus::{Bus, BusError};
+use caliptra_core_tools::caliptra_emu_types::{RvAddr, RvData, RvSize};
 use std::{rc::Rc, sync::mpsc};
 
 type ReadCallback = Box<dyn Fn(RvSize, RvAddr, &mut u32) -> bool>;
@@ -119,11 +119,14 @@ impl Bus for CaliptraToExtBus {
         // External communication doesn't need reset handling
     }
 
-    fn register_outgoing_events(&mut self, _sender: mpsc::Sender<caliptra_emu_bus::Event>) {
+    fn register_outgoing_events(
+        &mut self,
+        _sender: mpsc::Sender<caliptra_core_tools::caliptra_emu_bus::Event>,
+    ) {
         // External communication doesn't need event handling
     }
 
-    fn incoming_event(&mut self, _event: Rc<caliptra_emu_bus::Event>) {
+    fn incoming_event(&mut self, _event: Rc<caliptra_core_tools::caliptra_emu_bus::Event>) {
         // External communication doesn't need event handling
     }
 }

--- a/emulator/periph/src/doe_mbox.rs
+++ b/emulator/periph/src/doe_mbox.rs
@@ -1,6 +1,6 @@
 // Licensed under the Apache-2.0 license
-use caliptra_emu_bus::{Clock, ReadWriteRegister, Timer};
-use caliptra_emu_cpu::Irq;
+use caliptra_core_tools::caliptra_emu_bus::{Clock, ReadWriteRegister, Timer};
+use caliptra_core_tools::caliptra_emu_cpu::Irq;
 use emulator_registers_generated::doe_mbox::{DoeMboxGenerated, DoeMboxPeripheral};
 use registers_generated::doe_mbox::bits::{DoeMboxEvent, DoeMboxStatus};
 use std::sync::{Arc, Mutex};
@@ -67,27 +67,27 @@ impl DoeMboxPeripheral for DummyDoeMbox {
         self.timer.schedule_poll_in(Self::DOE_MBOX_TICKS);
     }
 
-    fn read_doe_mbox_dlen(&mut self) -> caliptra_emu_types::RvData {
+    fn read_doe_mbox_dlen(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         self.periph.inner.lock().unwrap().mbox_dlen.reg.get()
     }
-    fn write_doe_mbox_dlen(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_doe_mbox_dlen(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         self.periph.inner.lock().unwrap().mbox_dlen.reg.set(val);
     }
 
     fn read_doe_mbox_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::doe_mbox::bits::DoeMboxStatus::Register,
     > {
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.periph.inner.lock().unwrap().mbox_status.reg.get(),
         )
     }
 
     fn write_doe_mbox_status(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::doe_mbox::bits::DoeMboxStatus::Register,
         >,
@@ -105,18 +105,18 @@ impl DoeMboxPeripheral for DummyDoeMbox {
 
     fn read_doe_mbox_event(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::doe_mbox::bits::DoeMboxEvent::Register,
     > {
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.periph.inner.lock().unwrap().mbox_event.reg.get(),
         )
     }
 
     fn write_doe_mbox_event(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::doe_mbox::bits::DoeMboxEvent::Register,
         >,
@@ -129,11 +129,18 @@ impl DoeMboxPeripheral for DummyDoeMbox {
         self.timer.schedule_poll_in(1);
     }
 
-    fn read_doe_mbox_sram(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_doe_mbox_sram(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         self.periph.inner.lock().unwrap().read_doe_sram(index)
     }
 
-    fn write_doe_mbox_sram(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    fn write_doe_mbox_sram(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+        index: usize,
+    ) {
         self.periph.inner.lock().unwrap().write_doe_sram(val, index);
     }
 }
@@ -287,7 +294,7 @@ impl DoeMboxInner {
             || (event_val & DoeMboxEvent::ResetReq::SET.value != 0)
     }
 
-    fn read_doe_sram(&self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_doe_sram(&self, index: usize) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if index >= self.max_sram_dword_size {
             panic!("Index out of bounds for DOE mailbox SRAM");
         }
@@ -299,7 +306,11 @@ impl DoeMboxInner {
         }
     }
 
-    fn write_doe_sram(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    fn write_doe_sram(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+        index: usize,
+    ) {
         if index >= self.max_sram_dword_size {
             panic!("Index out of bounds for DOE mailbox SRAM");
         }
@@ -358,9 +369,9 @@ impl DoeMboxInner {
 mod tests {
     use super::*;
     use crate::McuRootBus;
-    use caliptra_emu_bus::{Bus, Clock};
-    use caliptra_emu_cpu::Pic;
-    use caliptra_emu_types::RvSize;
+    use caliptra_core_tools::caliptra_emu_bus::{Bus, Clock};
+    use caliptra_core_tools::caliptra_emu_cpu::Pic;
+    use caliptra_core_tools::caliptra_emu_types::RvSize;
     use emulator_registers_generated::root_bus::AutoRootBus;
     use registers_generated::doe_mbox::bits::{DoeMboxEvent, DoeMboxStatus};
     use registers_generated::doe_mbox::DOE_MBOX_ADDR;

--- a/emulator/periph/src/emu_ctrl.rs
+++ b/emulator/periph/src/emu_ctrl.rs
@@ -12,8 +12,8 @@ Abstract:
 
 --*/
 
-use caliptra_emu_bus::{Bus, BusError};
-use caliptra_emu_types::{RvAddr, RvData, RvSize};
+use caliptra_core_tools::caliptra_emu_bus::{Bus, BusError};
+use caliptra_core_tools::caliptra_emu_types::{RvAddr, RvData, RvSize};
 use std::process::exit;
 
 /// Emulation Control

--- a/emulator/periph/src/flash_ctrl.rs
+++ b/emulator/periph/src/flash_ctrl.rs
@@ -12,9 +12,11 @@ Abstract:
 
 --*/
 
-use caliptra_emu_bus::{ActionHandle, Bus, Clock, Ram, ReadOnlyRegister, ReadWriteRegister, Timer};
-use caliptra_emu_cpu::Irq;
-use caliptra_emu_types::{RvData, RvSize};
+use caliptra_core_tools::caliptra_emu_bus::{
+    ActionHandle, Bus, Clock, Ram, ReadOnlyRegister, ReadWriteRegister, Timer,
+};
+use caliptra_core_tools::caliptra_emu_cpu::Irq;
+use caliptra_core_tools::caliptra_emu_types::{RvData, RvSize};
 use core::convert::TryInto;
 use emulator_consts::{RAM_ORG, RAM_SIZE, ROM_DEDICATED_RAM_ORG, ROM_DEDICATED_RAM_SIZE};
 use emulator_registers_generated::primary_flash::{PrimaryFlashGenerated, PrimaryFlashPeripheral};
@@ -437,12 +439,18 @@ impl PrimaryFlashPeripheral for DummyFlashCtrl {
         Some(&mut self.primary_generated)
     }
 
-    fn set_dma_ram(&mut self, ram: std::rc::Rc<std::cell::RefCell<caliptra_emu_bus::Ram>>) {
+    fn set_dma_ram(
+        &mut self,
+        ram: std::rc::Rc<std::cell::RefCell<caliptra_core_tools::caliptra_emu_bus::Ram>>,
+    ) {
         self.dma_ram = Some(ram);
     }
 
     // Assign ROM dedicated SRAM as the DMA RAM for ROM flash operations.
-    fn set_dma_rom_sram(&mut self, ram: std::rc::Rc<std::cell::RefCell<caliptra_emu_bus::Ram>>) {
+    fn set_dma_rom_sram(
+        &mut self,
+        ram: std::rc::Rc<std::cell::RefCell<caliptra_core_tools::caliptra_emu_bus::Ram>>,
+    ) {
         self.dma_rom_sram = Some(ram);
     }
 
@@ -454,16 +462,18 @@ impl PrimaryFlashPeripheral for DummyFlashCtrl {
 
     fn read_fl_interrupt_state(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::primary_flash_ctrl::bits::FlInterruptState::Register,
     > {
-        caliptra_emu_bus::ReadWriteRegister::new(self.interrupt_state.reg.get())
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.interrupt_state.reg.get(),
+        )
     }
 
     fn write_fl_interrupt_state(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::primary_flash_ctrl::bits::FlInterruptState::Register,
         >,
@@ -485,16 +495,18 @@ impl PrimaryFlashPeripheral for DummyFlashCtrl {
 
     fn read_fl_interrupt_enable(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::primary_flash_ctrl::bits::FlInterruptEnable::Register,
     > {
-        caliptra_emu_bus::ReadWriteRegister::new(self.interrupt_enable.reg.get())
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.interrupt_enable.reg.get(),
+        )
     }
 
     fn write_fl_interrupt_enable(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::primary_flash_ctrl::bits::FlInterruptEnable::Register,
         >,
@@ -547,16 +559,16 @@ impl PrimaryFlashPeripheral for DummyFlashCtrl {
 
     fn read_fl_control(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::primary_flash_ctrl::bits::FlControl::Register,
     > {
-        caliptra_emu_bus::ReadWriteRegister::new(self.control.reg.get())
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.control.reg.get())
     }
 
     fn write_fl_control(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::primary_flash_ctrl::bits::FlControl::Register,
         >,
@@ -578,16 +590,16 @@ impl PrimaryFlashPeripheral for DummyFlashCtrl {
 
     fn read_op_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::primary_flash_ctrl::bits::OpStatus::Register,
     > {
-        caliptra_emu_bus::ReadWriteRegister::new(self.op_status.reg.get())
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.op_status.reg.get())
     }
 
     fn write_op_status(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::primary_flash_ctrl::bits::OpStatus::Register,
         >,
@@ -597,11 +609,11 @@ impl PrimaryFlashPeripheral for DummyFlashCtrl {
 
     fn read_ctrl_regwen(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::primary_flash_ctrl::bits::CtrlRegwen::Register,
     > {
-        caliptra_emu_bus::ReadWriteRegister::new(self.ctrl_regwen.reg.get())
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.ctrl_regwen.reg.get())
     }
 }
 
@@ -610,11 +622,17 @@ impl SecondaryFlashPeripheral for DummyFlashCtrl {
         Some(&mut self.secondary_generated)
     }
 
-    fn set_dma_ram(&mut self, ram: std::rc::Rc<std::cell::RefCell<caliptra_emu_bus::Ram>>) {
+    fn set_dma_ram(
+        &mut self,
+        ram: std::rc::Rc<std::cell::RefCell<caliptra_core_tools::caliptra_emu_bus::Ram>>,
+    ) {
         self.dma_ram = Some(ram);
     }
 
-    fn set_dma_rom_sram(&mut self, ram: std::rc::Rc<std::cell::RefCell<caliptra_emu_bus::Ram>>) {
+    fn set_dma_rom_sram(
+        &mut self,
+        ram: std::rc::Rc<std::cell::RefCell<caliptra_core_tools::caliptra_emu_bus::Ram>>,
+    ) {
         self.dma_rom_sram = Some(ram);
     }
 
@@ -629,16 +647,18 @@ impl SecondaryFlashPeripheral for DummyFlashCtrl {
 
     fn read_fl_interrupt_state(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::primary_flash_ctrl::bits::FlInterruptState::Register,
     > {
-        caliptra_emu_bus::ReadWriteRegister::new(self.interrupt_state.reg.get())
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.interrupt_state.reg.get(),
+        )
     }
 
     fn write_fl_interrupt_state(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::primary_flash_ctrl::bits::FlInterruptState::Register,
         >,
@@ -660,16 +680,18 @@ impl SecondaryFlashPeripheral for DummyFlashCtrl {
 
     fn read_fl_interrupt_enable(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::primary_flash_ctrl::bits::FlInterruptEnable::Register,
     > {
-        caliptra_emu_bus::ReadWriteRegister::new(self.interrupt_enable.reg.get())
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.interrupt_enable.reg.get(),
+        )
     }
 
     fn write_fl_interrupt_enable(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::primary_flash_ctrl::bits::FlInterruptEnable::Register,
         >,
@@ -722,16 +744,16 @@ impl SecondaryFlashPeripheral for DummyFlashCtrl {
 
     fn read_fl_control(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::primary_flash_ctrl::bits::FlControl::Register,
     > {
-        caliptra_emu_bus::ReadWriteRegister::new(self.control.reg.get())
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.control.reg.get())
     }
 
     fn write_fl_control(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::primary_flash_ctrl::bits::FlControl::Register,
         >,
@@ -753,16 +775,16 @@ impl SecondaryFlashPeripheral for DummyFlashCtrl {
 
     fn read_op_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::primary_flash_ctrl::bits::OpStatus::Register,
     > {
-        caliptra_emu_bus::ReadWriteRegister::new(self.op_status.reg.get())
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.op_status.reg.get())
     }
 
     fn write_op_status(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::primary_flash_ctrl::bits::OpStatus::Register,
         >,
@@ -772,11 +794,11 @@ impl SecondaryFlashPeripheral for DummyFlashCtrl {
 
     fn read_ctrl_regwen(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::primary_flash_ctrl::bits::CtrlRegwen::Register,
     > {
-        caliptra_emu_bus::ReadWriteRegister::new(self.ctrl_regwen.reg.get())
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.ctrl_regwen.reg.get())
     }
 }
 
@@ -784,9 +806,9 @@ impl SecondaryFlashPeripheral for DummyFlashCtrl {
 mod test {
     use super::*;
 
-    use caliptra_emu_bus::{Bus, Clock};
-    use caliptra_emu_cpu::Pic;
-    use caliptra_emu_types::RvSize;
+    use caliptra_core_tools::caliptra_emu_bus::{Bus, Clock};
+    use caliptra_core_tools::caliptra_emu_cpu::Pic;
+    use caliptra_core_tools::caliptra_emu_types::RvSize;
     use core::panic;
     use emulator_consts::{RAM_ORG, RAM_SIZE};
     use emulator_registers_generated::root_bus::AutoRootBus;

--- a/emulator/periph/src/i3c.rs
+++ b/emulator/periph/src/i3c.rs
@@ -8,10 +8,10 @@ Abstract:
 
 use crate::i3c_protocol::I3cController;
 use crate::{I3cIncomingCommandClient, I3cTarget};
-use caliptra_emu_bus::{Clock, ReadWriteRegister, Timer};
-use caliptra_emu_bus::{Device, Event, EventData};
-use caliptra_emu_cpu::Irq;
-use caliptra_emu_types::RvData;
+use caliptra_core_tools::caliptra_emu_bus::{Clock, ReadWriteRegister, Timer};
+use caliptra_core_tools::caliptra_emu_bus::{Device, Event, EventData};
+use caliptra_core_tools::caliptra_emu_cpu::Irq;
+use caliptra_core_tools::caliptra_emu_types::RvData;
 use emulator_registers_generated::i3c::{I3cGenerated, I3cPeripheral};
 use mcu_testing_common::i3c::{
     DynamicI3cAddress, I3cTcriCommand, I3cTcriResponseXfer, IbiDescriptor, ResponseDescriptor,
@@ -255,9 +255,10 @@ impl I3c {
             EventData::MemoryRead { start_addr, len } => {
                 let mut response = Vec::new();
                 for _ in 0..(*len) / std::mem::size_of::<u32>() as u32 {
-                    match self
-                        .read_recovery_interface(caliptra_emu_types::RvSize::Word, *start_addr)
-                    {
+                    match self.read_recovery_interface(
+                        caliptra_core_tools::caliptra_emu_types::RvSize::Word,
+                        *start_addr,
+                    ) {
                         Ok(data) => {
                             response.extend_from_slice(&data.to_be_bytes());
                         }
@@ -283,9 +284,11 @@ impl I3c {
             }
             EventData::MemoryWrite { start_addr, data } => {
                 self.write_recovery_interface(
-                    caliptra_emu_types::RvSize::Word,
+                    caliptra_core_tools::caliptra_emu_types::RvSize::Word,
                     *start_addr,
-                    caliptra_emu_types::RvData::from_le_bytes(data[0..4].try_into().unwrap()),
+                    caliptra_core_tools::caliptra_emu_types::RvData::from_le_bytes(
+                        data[0..4].try_into().unwrap(),
+                    ),
                 )
                 .unwrap();
             }
@@ -323,27 +326,30 @@ impl I3c {
 
     fn read_recovery_interface(
         &mut self,
-        size: caliptra_emu_types::RvSize,
-        addr: caliptra_emu_types::RvAddr,
-    ) -> Result<caliptra_emu_types::RvData, caliptra_emu_bus::BusError> {
-        if addr & 0x3 != 0 || size != caliptra_emu_types::RvSize::Word {
-            return Err(caliptra_emu_bus::BusError::LoadAddrMisaligned);
+        size: caliptra_core_tools::caliptra_emu_types::RvSize,
+        addr: caliptra_core_tools::caliptra_emu_types::RvAddr,
+    ) -> Result<
+        caliptra_core_tools::caliptra_emu_types::RvData,
+        caliptra_core_tools::caliptra_emu_bus::BusError,
+    > {
+        if addr & 0x3 != 0 || size != caliptra_core_tools::caliptra_emu_types::RvSize::Word {
+            return Err(caliptra_core_tools::caliptra_emu_bus::BusError::LoadAddrMisaligned);
         }
         match addr {
-            0x000 => Ok(caliptra_emu_types::RvData::from(
+            0x000 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.read_i3c_ec_sec_fw_recovery_if_extcap_header()
                     .reg
                     .get(),
             )),
             0x004 => Ok(self.read_i3c_ec_sec_fw_recovery_if_prot_cap_0()),
             0x008 => Ok(self.read_i3c_ec_sec_fw_recovery_if_prot_cap_1()),
-            0x00c => Ok(caliptra_emu_types::RvData::from(
+            0x00c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.read_i3c_ec_sec_fw_recovery_if_prot_cap_2().reg.get(),
             )),
-            0x010 => Ok(caliptra_emu_types::RvData::from(
+            0x010 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.read_i3c_ec_sec_fw_recovery_if_prot_cap_3().reg.get(),
             )),
-            0x014 => Ok(caliptra_emu_types::RvData::from(
+            0x014 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.read_i3c_ec_sec_fw_recovery_if_device_id_0().reg.get(),
             )),
             0x018 => Ok(self.read_i3c_ec_sec_fw_recovery_if_device_id_1()),
@@ -352,39 +358,39 @@ impl I3c {
             0x024 => Ok(self.read_i3c_ec_sec_fw_recovery_if_device_id_4()),
             0x028 => Ok(self.read_i3c_ec_sec_fw_recovery_if_device_id_5()),
             0x02c => Ok(self.read_i3c_ec_sec_fw_recovery_if_device_id_reserved()),
-            0x030 => Ok(caliptra_emu_types::RvData::from(
+            0x030 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.read_i3c_ec_sec_fw_recovery_if_device_status_0()
                     .reg
                     .get(),
             )),
-            0x034 => Ok(caliptra_emu_types::RvData::from(
+            0x034 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.read_i3c_ec_sec_fw_recovery_if_device_status_1()
                     .reg
                     .get(),
             )),
-            0x038 => Ok(caliptra_emu_types::RvData::from(
+            0x038 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.read_i3c_ec_sec_fw_recovery_if_device_reset().reg.get(),
             )),
-            0x03c => Ok(caliptra_emu_types::RvData::from(
+            0x03c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.read_i3c_ec_sec_fw_recovery_if_recovery_ctrl()
                     .reg
                     .get(),
             )),
-            0x040 => Ok(caliptra_emu_types::RvData::from(
+            0x040 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.read_i3c_ec_sec_fw_recovery_if_recovery_status()
                     .reg
                     .get(),
             )),
-            0x044 => Ok(caliptra_emu_types::RvData::from(
+            0x044 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.read_i3c_ec_sec_fw_recovery_if_hw_status().reg.get(),
             )),
-            0x048 => Ok(caliptra_emu_types::RvData::from(
+            0x048 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.read_i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_0()
                     .reg
                     .get(),
             )),
             0x04c => Ok(self.read_i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_1()),
-            0x050 => Ok(caliptra_emu_types::RvData::from(
+            0x050 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.read_i3c_ec_sec_fw_recovery_if_indirect_fifo_status_0()
                     .reg
                     .get(),
@@ -400,35 +406,35 @@ impl I3c {
                 .reg
                 .get()),
 
-            _ => Err(caliptra_emu_bus::BusError::LoadAccessFault),
+            _ => Err(caliptra_core_tools::caliptra_emu_bus::BusError::LoadAccessFault),
         }
     }
 
     fn write_recovery_interface(
         &mut self,
-        size: caliptra_emu_types::RvSize,
-        addr: caliptra_emu_types::RvAddr,
-        val: caliptra_emu_types::RvData,
-    ) -> Result<(), caliptra_emu_bus::BusError> {
-        if addr & 0x3 != 0 || size != caliptra_emu_types::RvSize::Word {
-            return Err(caliptra_emu_bus::BusError::StoreAddrMisaligned);
+        size: caliptra_core_tools::caliptra_emu_types::RvSize,
+        addr: caliptra_core_tools::caliptra_emu_types::RvAddr,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) -> Result<(), caliptra_core_tools::caliptra_emu_bus::BusError> {
+        if addr & 0x3 != 0 || size != caliptra_core_tools::caliptra_emu_types::RvSize::Word {
+            return Err(caliptra_core_tools::caliptra_emu_bus::BusError::StoreAddrMisaligned);
         }
         match addr {
             0x00c => {
                 self.write_i3c_ec_sec_fw_recovery_if_prot_cap_2(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x010 => {
                 self.write_i3c_ec_sec_fw_recovery_if_prot_cap_3(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x014 => {
                 self.write_i3c_ec_sec_fw_recovery_if_device_id_0(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
@@ -454,43 +460,43 @@ impl I3c {
             }
             0x030 => {
                 self.write_i3c_ec_sec_fw_recovery_if_device_status_0(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x034 => {
                 self.write_i3c_ec_sec_fw_recovery_if_device_status_1(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x038 => {
                 self.write_i3c_ec_sec_fw_recovery_if_device_reset(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x03c => {
                 self.write_i3c_ec_sec_fw_recovery_if_recovery_ctrl(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x040 => {
                 self.write_i3c_ec_sec_fw_recovery_if_recovery_status(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x044 => {
                 self.write_i3c_ec_sec_fw_recovery_if_hw_status(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x048 => {
                 self.write_i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_0(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
@@ -500,11 +506,11 @@ impl I3c {
             }
             0x210 => {
                 self.write_i3c_ec_soc_mgmt_if_rec_intf_reg_w1_c_access(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
-            _ => Err(caliptra_emu_bus::BusError::StoreAccessFault),
+            _ => Err(caliptra_core_tools::caliptra_emu_bus::BusError::StoreAccessFault),
         }
     }
 }
@@ -532,8 +538,10 @@ impl I3cPeripheral for I3c {
 
     fn read_i3c_ec_tti_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::Status::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::Status::Register,
+    > {
         self.ibi_status
             .take()
             .unwrap_or_else(|| ReadWriteRegister::new(0))
@@ -541,26 +549,30 @@ impl I3cPeripheral for I3c {
 
     fn read_i3c_ec_tti_interrupt_enable(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::InterruptEnable::Register,
     > {
-        caliptra_emu_bus::ReadWriteRegister::new(self.interrupt_enable.reg.get())
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.interrupt_enable.reg.get(),
+        )
     }
 
     fn read_i3c_ec_tti_interrupt_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::InterruptStatus::Register,
     > {
-        caliptra_emu_bus::ReadWriteRegister::new(self.interrupt_status.reg.get())
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.interrupt_status.reg.get(),
+        )
     }
 
     fn write_i3c_ec_tti_interrupt_status(
         &mut self,
 
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::InterruptStatus::Register,
         >,
@@ -575,7 +587,7 @@ impl I3cPeripheral for I3c {
     fn write_i3c_ec_tti_interrupt_enable(
         &mut self,
 
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::InterruptEnable::Register,
         >,
@@ -667,18 +679,22 @@ impl I3cPeripheral for I3c {
                     .get();
                 let address = (write_index * 4) as usize;
                 self.indirect_fifo_data.resize(
-                    address + std::mem::size_of::<caliptra_emu_types::RvData>(),
+                    address
+                        + std::mem::size_of::<caliptra_core_tools::caliptra_emu_types::RvData>(),
                     0,
                 );
-                self.indirect_fifo_data
-                    [address..address + std::mem::size_of::<caliptra_emu_types::RvData>()]
+                self.indirect_fifo_data[address
+                    ..address
+                        + std::mem::size_of::<caliptra_core_tools::caliptra_emu_types::RvData>()]
                     .copy_from_slice(val.to_le_bytes().as_ref());
                 // head pointer must be aligned to 4 bytes at the end
                 self.i3c_ec_sec_fw_recovery_if_indirect_fifo_status_1
                     .reg
                     .set(
-                        ((address + std::mem::size_of::<caliptra_emu_types::RvData>())
-                            .next_multiple_of(std::mem::size_of::<u32>())
+                        ((address
+                            + std::mem::size_of::<caliptra_core_tools::caliptra_emu_types::RvData>(
+                            ))
+                        .next_multiple_of(std::mem::size_of::<u32>())
                             / std::mem::size_of::<u32>()) as u32,
                     );
             } else {
@@ -699,7 +715,7 @@ impl I3cPeripheral for I3c {
 
     fn write_i3c_ec_sec_fw_recovery_if_prot_cap_2(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::ProtCap2::Register,
         >,
@@ -711,16 +727,18 @@ impl I3cPeripheral for I3c {
 
     fn read_i3c_ec_sec_fw_recovery_if_prot_cap_2(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::ProtCap2::Register>
-    {
-        caliptra_emu_bus::ReadWriteRegister::new(
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::ProtCap2::Register,
+    > {
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.i3c_ec_sec_fw_recovery_if_prot_cap_2.reg.get(),
         )
     }
 
     fn write_i3c_ec_sec_fw_recovery_if_device_status_0(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::DeviceStatus0::Register,
         >,
@@ -753,18 +771,18 @@ impl I3cPeripheral for I3c {
 
     fn read_i3c_ec_sec_fw_recovery_if_device_status_0(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::DeviceStatus0::Register,
     > {
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.i3c_ec_sec_fw_recovery_if_device_status_0.reg.get(),
         )
     }
 
     fn write_i3c_ec_sec_fw_recovery_if_recovery_status(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::RecoveryStatus::Register,
         >,
@@ -776,18 +794,18 @@ impl I3cPeripheral for I3c {
 
     fn read_i3c_ec_sec_fw_recovery_if_recovery_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::RecoveryStatus::Register,
     > {
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.i3c_ec_sec_fw_recovery_if_recovery_status.reg.get(),
         )
     }
 
     fn write_i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_0(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::IndirectFifoCtrl0::Register,
         >,
@@ -799,8 +817,8 @@ impl I3cPeripheral for I3c {
 
     fn read_i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_1(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
-        caliptra_emu_types::RvData::from(
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
+        caliptra_core_tools::caliptra_emu_types::RvData::from(
             self.i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_1
                 .reg
                 .get(),
@@ -809,7 +827,7 @@ impl I3cPeripheral for I3c {
 
     fn write_i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_1(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         self.indirect_fifo_data.clear();
         self.i3c_ec_sec_fw_recovery_if_indirect_fifo_status_0
@@ -826,7 +844,9 @@ impl I3cPeripheral for I3c {
             .set(val);
     }
 
-    fn read_i3c_ec_sec_fw_recovery_if_indirect_fifo_data(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_sec_fw_recovery_if_indirect_fifo_data(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         let cms = self
             .i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_0
             .reg
@@ -867,11 +887,11 @@ impl I3cPeripheral for I3c {
 
     fn read_i3c_ec_sec_fw_recovery_if_indirect_fifo_status_0(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::IndirectFifoStatus0::Register,
     > {
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.i3c_ec_sec_fw_recovery_if_indirect_fifo_status_0
                 .reg
                 .get(),
@@ -880,8 +900,8 @@ impl I3cPeripheral for I3c {
 
     fn read_i3c_ec_sec_fw_recovery_if_indirect_fifo_status_1(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
-        caliptra_emu_types::RvData::from(
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
+        caliptra_core_tools::caliptra_emu_types::RvData::from(
             self.i3c_ec_sec_fw_recovery_if_indirect_fifo_status_1
                 .reg
                 .get(),
@@ -890,8 +910,8 @@ impl I3cPeripheral for I3c {
 
     fn read_i3c_ec_sec_fw_recovery_if_indirect_fifo_status_2(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
-        caliptra_emu_types::RvData::from(
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
+        caliptra_core_tools::caliptra_emu_types::RvData::from(
             self.i3c_ec_sec_fw_recovery_if_indirect_fifo_status_2
                 .reg
                 .get(),
@@ -900,29 +920,29 @@ impl I3cPeripheral for I3c {
 
     fn read_i3c_ec_sec_fw_recovery_if_recovery_ctrl(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::RecoveryCtrl::Register,
     > {
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.i3c_ec_sec_fw_recovery_if_recovery_ctrl.reg.get(),
         )
     }
 
     fn read_i3c_ec_soc_mgmt_if_rec_intf_reg_w1_c_access(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::RecIntfRegW1cAccess::Register,
     > {
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.i3c_ec_soc_mgmt_if_rec_intf_reg_w1_c_access.reg.get(),
         )
     }
 
     fn write_i3c_ec_sec_fw_recovery_if_recovery_ctrl(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::RecoveryCtrl::Register,
         >,
@@ -933,15 +953,17 @@ impl I3cPeripheral for I3c {
     }
     fn read_i3c_ec_soc_mgmt_if_rec_intf_cfg(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::RecIntfCfg::Register,
     > {
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_soc_mgmt_if_rec_intf_cfg.reg.get())
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_soc_mgmt_if_rec_intf_cfg.reg.get(),
+        )
     }
     fn write_i3c_ec_soc_mgmt_if_rec_intf_cfg(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::RecIntfCfg::Register,
         >,
@@ -951,7 +973,7 @@ impl I3cPeripheral for I3c {
 
     fn write_i3c_ec_soc_mgmt_if_rec_intf_reg_w1_c_access(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::RecIntfRegW1cAccess::Register,
         >,
@@ -1059,9 +1081,9 @@ impl I3cPeripheral for I3c {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use caliptra_emu_bus::Bus;
-    use caliptra_emu_cpu::Pic;
-    use caliptra_emu_types::{RvAddr, RvSize};
+    use caliptra_core_tools::caliptra_emu_bus::Bus;
+    use caliptra_core_tools::caliptra_emu_cpu::Pic;
+    use caliptra_core_tools::caliptra_emu_types::{RvAddr, RvSize};
     use emulator_registers_generated::root_bus::AutoRootBus;
     use mcu_testing_common::i3c::{
         DynamicI3cAddress, I3cTcriCommand, I3cTcriCommandXfer, ImmediateDataTransferCommand,

--- a/emulator/periph/src/lc_ctrl.rs
+++ b/emulator/periph/src/lc_ctrl.rs
@@ -17,7 +17,7 @@ Abstract:
 use std::cell::RefCell;
 use std::rc::Rc;
 
-use caliptra_emu_bus::ReadWriteRegister;
+use caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister;
 use emulator_registers_generated::lc::LcGenerated;
 use registers_generated::lc_ctrl;
 use tock_registers::interfaces::Readable;
@@ -381,25 +381,25 @@ impl emulator_registers_generated::lc::LcPeripheral for LcCtrl {
         }
     }
 
-    fn write_transition_token_0(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_transition_token_0(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if self.mutex_claimed {
             self.token[0] = val;
         }
     }
 
-    fn write_transition_token_1(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_transition_token_1(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if self.mutex_claimed {
             self.token[1] = val;
         }
     }
 
-    fn write_transition_token_2(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_transition_token_2(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if self.mutex_claimed {
             self.token[2] = val;
         }
     }
 
-    fn write_transition_token_3(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_transition_token_3(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if self.mutex_claimed {
             self.token[3] = val;
         }

--- a/emulator/periph/src/mci.rs
+++ b/emulator/periph/src/mci.rs
@@ -2,11 +2,13 @@
 
 use crate::mcu_mbox0::McuMailbox0Internal;
 use crate::reset_reason::ResetReasonEmulator;
-use caliptra_emu_bus::{ActionHandle, BusMmio, Clock, ReadWriteRegister, Timer, TimerAction};
-use caliptra_emu_cpu::Irq;
-use caliptra_emu_periph::SocToCaliptraBus;
-use caliptra_emu_types::RvData;
-use caliptra_registers::soc_ifc::RegisterBlock;
+use caliptra_core_tools::caliptra_emu_bus::{
+    ActionHandle, BusMmio, Clock, ReadWriteRegister, Timer, TimerAction,
+};
+use caliptra_core_tools::caliptra_emu_cpu::Irq;
+use caliptra_core_tools::caliptra_emu_periph::SocToCaliptraBus;
+use caliptra_core_tools::caliptra_emu_types::RvData;
+use caliptra_core_tools::caliptra_registers::soc_ifc::RegisterBlock;
 use emulator_registers_generated::mci::{MciGenerated, MciPeripheral};
 use registers_generated::mci::bits::{
     Error0IntrT, Notif0IntrEnT, Notif0IntrT, ResetReason, ResetRequest, SecurityState, WdtStatus,
@@ -25,7 +27,7 @@ fn clamp_timer_period(period: u64) -> u64 {
 }
 
 pub struct Mci {
-    ext_mci_regs: caliptra_emu_periph::mci::Mci,
+    ext_mci_regs: caliptra_core_tools::caliptra_emu_periph::mci::Mci,
     generated: MciGenerated,
 
     error0_internal_intr_r: ReadWriteRegister<u32, Error0IntrT::Register>,
@@ -54,7 +56,7 @@ pub struct Mci {
 impl Mci {
     pub fn new(
         clock: &Clock,
-        ext_mci_regs: caliptra_emu_periph::mci::Mci,
+        ext_mci_regs: caliptra_core_tools::caliptra_emu_periph::mci::Mci,
         irq: Rc<RefCell<Irq>>,
         mcu_mailbox0: Option<McuMailbox0Internal>,
         mcu_mailbox1: Option<McuMailbox0Internal>,
@@ -131,15 +133,21 @@ impl MciPeripheral for Mci {
         Some(&mut self.generated)
     }
 
-    fn read_mci_reg_generic_input_wires(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_generic_input_wires(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         self.ext_mci_regs.regs.borrow().generic_input_wires[index]
     }
 
-    fn read_mci_reg_fw_flow_status(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_fw_flow_status(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         self.ext_mci_regs.regs.borrow().flow_status
     }
 
-    fn write_mci_reg_fw_flow_status(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mci_reg_fw_flow_status(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         self.ext_mci_regs.regs.borrow_mut().flow_status = val;
     }
 
@@ -176,33 +184,51 @@ impl MciPeripheral for Mci {
     }
 
     //  mtime mcu_rv_mtime_l and cu_rv_mtime_h
-    fn read_mci_reg_mcu_rv_mtime_l(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_mcu_rv_mtime_l(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         self.timer.now() as u32
     }
 
-    fn write_mci_reg_mcu_rv_mtime_l(&mut self, _val: caliptra_emu_types::RvData) {}
+    fn write_mci_reg_mcu_rv_mtime_l(
+        &mut self,
+        _val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
+    }
 
-    fn read_mci_reg_mcu_rv_mtime_h(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_mcu_rv_mtime_h(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         (self.timer.now() >> 32) as u32
     }
 
-    fn write_mci_reg_mcu_rv_mtime_h(&mut self, _val: caliptra_emu_types::RvData) {}
+    fn write_mci_reg_mcu_rv_mtime_h(
+        &mut self,
+        _val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
+    }
 
     //  mtime mcu_rv_mtimecmp_l and cu_rv_mtimecmp_h
-    fn read_mci_reg_mcu_rv_mtimecmp_l(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_mcu_rv_mtimecmp_l(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         (self.mtimecmp) as u32
     }
 
-    fn write_mci_reg_mcu_rv_mtimecmp_l(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mci_reg_mcu_rv_mtimecmp_l(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         self.mtimecmp = (self.mtimecmp & 0xffff_ffff_0000_0000) | val as u64;
         self.arm_mtime_interrupt();
     }
 
-    fn read_mci_reg_mcu_rv_mtimecmp_h(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_mcu_rv_mtimecmp_h(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         (self.mtimecmp >> 32) as u32
     }
 
-    fn write_mci_reg_mcu_rv_mtimecmp_h(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mci_reg_mcu_rv_mtimecmp_h(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         self.mtimecmp = (self.mtimecmp & 0x0000_0000_ffff_ffff) | ((val as u64) << 32);
         self.arm_mtime_interrupt();
     }
@@ -349,7 +375,7 @@ impl MciPeripheral for Mci {
 
     fn read_mci_reg_intr_block_rf_notif0_intr_trig_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::Notif0IntrTrigT::Register,
     > {
@@ -361,7 +387,7 @@ impl MciPeripheral for Mci {
     }
     fn write_mci_reg_intr_block_rf_notif0_intr_trig_r(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::Notif0IntrTrigT::Register,
         >,
@@ -390,7 +416,7 @@ impl MciPeripheral for Mci {
 
     fn write_mci_reg_reset_request(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::ResetRequest::Register,
         >,
@@ -425,7 +451,7 @@ impl MciPeripheral for Mci {
 
     fn read_mci_reg_intr_block_rf_notif0_internal_intr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::Notif0IntrT::Register,
     > {
@@ -438,7 +464,7 @@ impl MciPeripheral for Mci {
 
     fn write_mci_reg_intr_block_rf_notif0_internal_intr_r(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::Notif0IntrT::Register,
         >,
@@ -462,7 +488,7 @@ impl MciPeripheral for Mci {
 
     fn read_mci_reg_intr_block_rf_notif0_intr_en_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::Notif0IntrEnT::Register,
     > {
@@ -475,7 +501,7 @@ impl MciPeripheral for Mci {
 
     fn write_mci_reg_intr_block_rf_notif0_intr_en_r(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::Notif0IntrEnT::Register,
         >,
@@ -486,7 +512,10 @@ impl MciPeripheral for Mci {
             .intr_block_rf_notif0_intr_en_r = val.reg.get();
     }
 
-    fn read_mcu_mbox0_csr_mbox_sram(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_mcu_mbox0_csr_mbox_sram(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         self.mcu_mailbox0
             .as_mut()
             .expect("mcu_mbox0 is not initialized")
@@ -496,7 +525,11 @@ impl MciPeripheral for Mci {
             .read_mcu_mbox0_csr_mbox_sram(index)
     }
 
-    fn write_mcu_mbox0_csr_mbox_sram(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    fn write_mcu_mbox0_csr_mbox_sram(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+        index: usize,
+    ) {
         self.mcu_mailbox0
             .as_mut()
             .expect("mcu_mbox0 is not initialized")
@@ -508,8 +541,10 @@ impl MciPeripheral for Mci {
 
     fn read_mcu_mbox0_csr_mbox_lock(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::mci::bits::MboxLock::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::mci::bits::MboxLock::Register,
+    > {
         self.mcu_mailbox0
             .as_mut()
             .expect("mcu_mbox0 is not initialized")
@@ -519,7 +554,7 @@ impl MciPeripheral for Mci {
             .read_mcu_mbox0_csr_mbox_lock()
     }
 
-    fn read_mcu_mbox0_csr_mbox_user(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mcu_mbox0_csr_mbox_user(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         self.mcu_mailbox0
             .as_mut()
             .expect("mcu_mbox0 is not initialized")
@@ -529,7 +564,9 @@ impl MciPeripheral for Mci {
             .read_mcu_mbox0_csr_mbox_user()
     }
 
-    fn read_mcu_mbox0_csr_mbox_target_user(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mcu_mbox0_csr_mbox_target_user(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         self.mcu_mailbox0
             .as_mut()
             .expect("mcu_mbox0 is not initialized")
@@ -539,7 +576,10 @@ impl MciPeripheral for Mci {
             .read_mcu_mbox0_csr_mbox_target_user()
     }
 
-    fn write_mcu_mbox0_csr_mbox_target_user(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mcu_mbox0_csr_mbox_target_user(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         self.mcu_mailbox0
             .as_mut()
             .expect("mcu_mbox0 is not initialized")
@@ -551,7 +591,7 @@ impl MciPeripheral for Mci {
 
     fn read_mcu_mbox0_csr_mbox_target_user_valid(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::MboxTargetUserValid::Register,
     > {
@@ -566,7 +606,7 @@ impl MciPeripheral for Mci {
 
     fn write_mcu_mbox0_csr_mbox_target_user_valid(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::MboxTargetUserValid::Register,
         >,
@@ -580,7 +620,7 @@ impl MciPeripheral for Mci {
             .write_mcu_mbox0_csr_mbox_target_user_valid(val);
     }
 
-    fn read_mcu_mbox0_csr_mbox_cmd(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mcu_mbox0_csr_mbox_cmd(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         self.mcu_mailbox0
             .as_mut()
             .expect("mcu_mbox0 is not initialized")
@@ -590,7 +630,10 @@ impl MciPeripheral for Mci {
             .read_mcu_mbox0_csr_mbox_cmd()
     }
 
-    fn write_mcu_mbox0_csr_mbox_cmd(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mcu_mbox0_csr_mbox_cmd(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         self.mcu_mailbox0
             .as_mut()
             .expect("mcu_mbox0 is not initialized")
@@ -600,7 +643,7 @@ impl MciPeripheral for Mci {
             .write_mcu_mbox0_csr_mbox_cmd(val);
     }
 
-    fn read_mcu_mbox0_csr_mbox_dlen(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mcu_mbox0_csr_mbox_dlen(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         self.mcu_mailbox0
             .as_mut()
             .expect("mcu_mbox0 is not initialized")
@@ -610,7 +653,10 @@ impl MciPeripheral for Mci {
             .read_mcu_mbox0_csr_mbox_dlen()
     }
 
-    fn write_mcu_mbox0_csr_mbox_dlen(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mcu_mbox0_csr_mbox_dlen(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         self.mcu_mailbox0
             .as_mut()
             .expect("mcu_mbox0 is not initialized")
@@ -622,7 +668,7 @@ impl MciPeripheral for Mci {
 
     fn read_mcu_mbox0_csr_mbox_execute(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::MboxExecute::Register,
     > {
@@ -637,7 +683,7 @@ impl MciPeripheral for Mci {
 
     fn write_mcu_mbox0_csr_mbox_execute(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::MboxExecute::Register,
         >,
@@ -653,7 +699,7 @@ impl MciPeripheral for Mci {
 
     fn read_mcu_mbox0_csr_mbox_target_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::MboxTargetStatus::Register,
     > {
@@ -668,7 +714,7 @@ impl MciPeripheral for Mci {
 
     fn write_mcu_mbox0_csr_mbox_target_status(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::MboxTargetStatus::Register,
         >,
@@ -684,7 +730,7 @@ impl MciPeripheral for Mci {
 
     fn read_mcu_mbox0_csr_mbox_cmd_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::MboxCmdStatus::Register,
     > {
@@ -699,7 +745,7 @@ impl MciPeripheral for Mci {
 
     fn write_mcu_mbox0_csr_mbox_cmd_status(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::MboxCmdStatus::Register,
         >,
@@ -715,7 +761,7 @@ impl MciPeripheral for Mci {
 
     fn read_mcu_mbox0_csr_mbox_hw_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::MboxHwStatus::Register,
     > {
@@ -728,7 +774,10 @@ impl MciPeripheral for Mci {
             .read_mcu_mbox0_csr_mbox_hw_status()
     }
 
-    fn read_mcu_mbox1_csr_mbox_sram(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_mcu_mbox1_csr_mbox_sram(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         self.mcu_mailbox1
             .as_mut()
             .expect("mcu_mbox1 is not initialized")
@@ -738,7 +787,11 @@ impl MciPeripheral for Mci {
             .read_mcu_mbox0_csr_mbox_sram(index)
     }
 
-    fn write_mcu_mbox1_csr_mbox_sram(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    fn write_mcu_mbox1_csr_mbox_sram(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+        index: usize,
+    ) {
         self.mcu_mailbox1
             .as_mut()
             .expect("mcu_mbox1 is not initialized")
@@ -750,8 +803,10 @@ impl MciPeripheral for Mci {
 
     fn read_mcu_mbox1_csr_mbox_lock(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::mci::bits::MboxLock::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::mci::bits::MboxLock::Register,
+    > {
         self.mcu_mailbox1
             .as_mut()
             .expect("mcu_mbox1 is not initialized")
@@ -761,7 +816,7 @@ impl MciPeripheral for Mci {
             .read_mcu_mbox0_csr_mbox_lock()
     }
 
-    fn read_mcu_mbox1_csr_mbox_user(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mcu_mbox1_csr_mbox_user(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         self.mcu_mailbox1
             .as_mut()
             .expect("mcu_mbox1 is not initialized")
@@ -771,7 +826,9 @@ impl MciPeripheral for Mci {
             .read_mcu_mbox0_csr_mbox_user()
     }
 
-    fn read_mcu_mbox1_csr_mbox_target_user(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mcu_mbox1_csr_mbox_target_user(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         self.mcu_mailbox1
             .as_mut()
             .expect("mcu_mbox1 is not initialized")
@@ -781,7 +838,10 @@ impl MciPeripheral for Mci {
             .read_mcu_mbox0_csr_mbox_target_user()
     }
 
-    fn write_mcu_mbox1_csr_mbox_target_user(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mcu_mbox1_csr_mbox_target_user(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         self.mcu_mailbox1
             .as_mut()
             .expect("mcu_mbox1 is not initialized")
@@ -793,7 +853,7 @@ impl MciPeripheral for Mci {
 
     fn read_mcu_mbox1_csr_mbox_target_user_valid(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::MboxTargetUserValid::Register,
     > {
@@ -808,7 +868,7 @@ impl MciPeripheral for Mci {
 
     fn write_mcu_mbox1_csr_mbox_target_user_valid(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::MboxTargetUserValid::Register,
         >,
@@ -822,7 +882,7 @@ impl MciPeripheral for Mci {
             .write_mcu_mbox0_csr_mbox_target_user_valid(val);
     }
 
-    fn read_mcu_mbox1_csr_mbox_cmd(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mcu_mbox1_csr_mbox_cmd(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         self.mcu_mailbox1
             .as_mut()
             .expect("mcu_mbox1 is not initialized")
@@ -832,7 +892,10 @@ impl MciPeripheral for Mci {
             .read_mcu_mbox0_csr_mbox_cmd()
     }
 
-    fn write_mcu_mbox1_csr_mbox_cmd(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mcu_mbox1_csr_mbox_cmd(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         self.mcu_mailbox1
             .as_mut()
             .expect("mcu_mbox1 is not initialized")
@@ -842,7 +905,7 @@ impl MciPeripheral for Mci {
             .write_mcu_mbox0_csr_mbox_cmd(val);
     }
 
-    fn read_mcu_mbox1_csr_mbox_dlen(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mcu_mbox1_csr_mbox_dlen(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         self.mcu_mailbox1
             .as_mut()
             .expect("mcu_mbox1 is not initialized")
@@ -852,7 +915,10 @@ impl MciPeripheral for Mci {
             .read_mcu_mbox0_csr_mbox_dlen()
     }
 
-    fn write_mcu_mbox1_csr_mbox_dlen(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mcu_mbox1_csr_mbox_dlen(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         self.mcu_mailbox1
             .as_mut()
             .expect("mcu_mbox1 is not initialized")
@@ -864,7 +930,7 @@ impl MciPeripheral for Mci {
 
     fn read_mcu_mbox1_csr_mbox_execute(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::MboxExecute::Register,
     > {
@@ -879,7 +945,7 @@ impl MciPeripheral for Mci {
 
     fn write_mcu_mbox1_csr_mbox_execute(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::MboxExecute::Register,
         >,
@@ -895,7 +961,7 @@ impl MciPeripheral for Mci {
 
     fn read_mcu_mbox1_csr_mbox_target_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::MboxTargetStatus::Register,
     > {
@@ -910,7 +976,7 @@ impl MciPeripheral for Mci {
 
     fn write_mcu_mbox1_csr_mbox_target_status(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::MboxTargetStatus::Register,
         >,
@@ -926,7 +992,7 @@ impl MciPeripheral for Mci {
 
     fn read_mcu_mbox1_csr_mbox_cmd_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::MboxCmdStatus::Register,
     > {
@@ -941,7 +1007,7 @@ impl MciPeripheral for Mci {
 
     fn write_mcu_mbox1_csr_mbox_cmd_status(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::MboxCmdStatus::Register,
         >,
@@ -957,7 +1023,7 @@ impl MciPeripheral for Mci {
 
     fn read_mcu_mbox1_csr_mbox_hw_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::MboxHwStatus::Register,
     > {
@@ -972,24 +1038,34 @@ impl MciPeripheral for Mci {
 
     fn read_mci_reg_hw_rev_id(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::mci::bits::HwRevId::Register>
-    {
-        caliptra_emu_bus::ReadWriteRegister::new(0x1000)
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::mci::bits::HwRevId::Register,
+    > {
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0x1000)
     }
 
-    fn read_mci_reg_fw_error_fatal(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_fw_error_fatal(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         self.ext_mci_regs.regs.borrow().fw_error_fatal
     }
 
-    fn write_mci_reg_fw_error_fatal(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mci_reg_fw_error_fatal(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         self.ext_mci_regs.regs.borrow_mut().fw_error_fatal = val;
     }
 
-    fn read_mci_reg_fw_error_non_fatal(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_fw_error_non_fatal(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         self.ext_mci_regs.regs.borrow().fw_error_non_fatal
     }
 
-    fn write_mci_reg_fw_error_non_fatal(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mci_reg_fw_error_non_fatal(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         self.ext_mci_regs.regs.borrow_mut().fw_error_non_fatal = val;
     }
 
@@ -1164,8 +1240,8 @@ impl MciPeripheral for Mci {
 mod tests {
     use super::*;
     use crate::mcu_mbox0::IrqEventToMcu;
-    use caliptra_emu_bus::Bus;
-    use caliptra_emu_types::RvSize;
+    use caliptra_core_tools::caliptra_emu_bus::Bus;
+    use caliptra_core_tools::caliptra_emu_types::RvSize;
     use emulator_registers_generated::mci::MciBus;
     use tock_registers::registers::InMemoryRegister;
 
@@ -1188,8 +1264,8 @@ mod tests {
     #[test]
     fn test_wdt() {
         let clock = Clock::new();
-        let ext_mci_regs = caliptra_emu_periph::mci::Mci::new(vec![]);
-        let pic = caliptra_emu_cpu::Pic::new();
+        let ext_mci_regs = caliptra_core_tools::caliptra_emu_periph::mci::Mci::new(vec![]);
+        let pic = caliptra_core_tools::caliptra_emu_cpu::Pic::new();
         let irq = pic.register_irq(1);
         let mci_reg: Mci = Mci::new(
             &clock,
@@ -1283,8 +1359,8 @@ mod tests {
     #[test]
     fn test_mailbox_interrupt_handling() {
         let clock = Clock::new();
-        let ext_mci_regs = caliptra_emu_periph::mci::Mci::new(vec![]);
-        let pic = caliptra_emu_cpu::Pic::new();
+        let ext_mci_regs = caliptra_core_tools::caliptra_emu_periph::mci::Mci::new(vec![]);
+        let pic = caliptra_core_tools::caliptra_emu_cpu::Pic::new();
         let irq = pic.register_irq(1);
         let mci_reg = Mci::new(
             &clock,
@@ -1322,8 +1398,8 @@ mod tests {
     #[test]
     fn test_mtimecmp_write_high_then_low() {
         let clock = Clock::new();
-        let ext_mci_regs = caliptra_emu_periph::mci::Mci::new(vec![]);
-        let pic = caliptra_emu_cpu::Pic::new();
+        let ext_mci_regs = caliptra_core_tools::caliptra_emu_periph::mci::Mci::new(vec![]);
+        let pic = caliptra_core_tools::caliptra_emu_cpu::Pic::new();
         let irq = pic.register_irq(1);
         let mut mci = Mci::new(
             &clock,
@@ -1352,8 +1428,8 @@ mod tests {
     #[test]
     fn test_mtimecmp_write_low_then_high() {
         let clock = Clock::new();
-        let ext_mci_regs = caliptra_emu_periph::mci::Mci::new(vec![]);
-        let pic = caliptra_emu_cpu::Pic::new();
+        let ext_mci_regs = caliptra_core_tools::caliptra_emu_periph::mci::Mci::new(vec![]);
+        let pic = caliptra_core_tools::caliptra_emu_cpu::Pic::new();
         let irq = pic.register_irq(1);
         let mut mci = Mci::new(
             &clock,
@@ -1382,8 +1458,8 @@ mod tests {
     #[test]
     fn test_mtimecmp_write_low_multiple_times() {
         let clock = Clock::new();
-        let ext_mci_regs = caliptra_emu_periph::mci::Mci::new(vec![]);
-        let pic = caliptra_emu_cpu::Pic::new();
+        let ext_mci_regs = caliptra_core_tools::caliptra_emu_periph::mci::Mci::new(vec![]);
+        let pic = caliptra_core_tools::caliptra_emu_cpu::Pic::new();
         let irq = pic.register_irq(1);
         let mut mci = Mci::new(
             &clock,
@@ -1410,8 +1486,8 @@ mod tests {
 
     fn test_mtimecmp_write_high_multiple_times() {
         let clock = Clock::new();
-        let ext_mci_regs = caliptra_emu_periph::mci::Mci::new(vec![]);
-        let pic = caliptra_emu_cpu::Pic::new();
+        let ext_mci_regs = caliptra_core_tools::caliptra_emu_periph::mci::Mci::new(vec![]);
+        let pic = caliptra_core_tools::caliptra_emu_cpu::Pic::new();
         let irq = pic.register_irq(1);
         let mut mci = Mci::new(
             &clock,
@@ -1454,8 +1530,8 @@ mod tests {
     #[test]
     fn test_reset_reason_fw_boot_then_warm() {
         let clock = Clock::new();
-        let ext_mci_regs = caliptra_emu_periph::mci::Mci::new(vec![]);
-        let pic = caliptra_emu_cpu::Pic::new();
+        let ext_mci_regs = caliptra_core_tools::caliptra_emu_periph::mci::Mci::new(vec![]);
+        let pic = caliptra_core_tools::caliptra_emu_cpu::Pic::new();
         let irq = pic.register_irq(1);
         let mut mci = Mci::new(
             &clock,
@@ -1513,8 +1589,8 @@ mod tests {
     #[test]
     fn test_reset_reason_plain_warm_reset() {
         let clock = Clock::new();
-        let ext_mci_regs = caliptra_emu_periph::mci::Mci::new(vec![]);
-        let pic = caliptra_emu_cpu::Pic::new();
+        let ext_mci_regs = caliptra_core_tools::caliptra_emu_periph::mci::Mci::new(vec![]);
+        let pic = caliptra_core_tools::caliptra_emu_cpu::Pic::new();
         let irq = pic.register_irq(1);
         let mut mci = Mci::new(
             &clock,
@@ -1544,8 +1620,8 @@ mod tests {
     #[test]
     fn test_mtime_reads() {
         let clock = Clock::new();
-        let ext_mci_regs = caliptra_emu_periph::mci::Mci::new(vec![]);
-        let pic = caliptra_emu_cpu::Pic::new();
+        let ext_mci_regs = caliptra_core_tools::caliptra_emu_periph::mci::Mci::new(vec![]);
+        let pic = caliptra_core_tools::caliptra_emu_cpu::Pic::new();
         let irq = pic.register_irq(1);
         let mut mci = Mci::new(
             &clock,
@@ -1571,8 +1647,8 @@ mod tests {
     #[test]
     fn test_mtime_writes() {
         let clock = Clock::new();
-        let ext_mci_regs = caliptra_emu_periph::mci::Mci::new(vec![]);
-        let pic = caliptra_emu_cpu::Pic::new();
+        let ext_mci_regs = caliptra_core_tools::caliptra_emu_periph::mci::Mci::new(vec![]);
+        let pic = caliptra_core_tools::caliptra_emu_cpu::Pic::new();
         let irq = pic.register_irq(1);
         let mut mci = Mci::new(
             &clock,
@@ -1607,8 +1683,8 @@ mod tests {
     #[test]
     fn test_mtime_after_clock_advance_32bit() {
         let clock = Clock::new();
-        let ext_mci_regs = caliptra_emu_periph::mci::Mci::new(vec![]);
-        let pic = caliptra_emu_cpu::Pic::new();
+        let ext_mci_regs = caliptra_core_tools::caliptra_emu_periph::mci::Mci::new(vec![]);
+        let pic = caliptra_core_tools::caliptra_emu_cpu::Pic::new();
         let irq = pic.register_irq(1);
         let mut mci = Mci::new(
             &clock,

--- a/emulator/periph/src/mcu_mbox0.rs
+++ b/emulator/periph/src/mcu_mbox0.rs
@@ -1,8 +1,10 @@
 // Licensed under the Apache-2.0 license
 
-use caliptra_emu_bus::BusError;
-use caliptra_emu_bus::{Bus, Clock, Ram, ReadOnlyRegister, ReadWriteRegister, Timer};
-use caliptra_emu_types::{RvAddr, RvSize};
+use caliptra_core_tools::caliptra_emu_bus::BusError;
+use caliptra_core_tools::caliptra_emu_bus::{
+    Bus, Clock, Ram, ReadOnlyRegister, ReadWriteRegister, Timer,
+};
+use caliptra_core_tools::caliptra_emu_types::{RvAddr, RvSize};
 use emulator_consts::MCU_MAILBOX0_SRAM_SIZE;
 use registers_generated::mci::bits::MboxExecute;
 use std::sync::{Arc, Mutex};
@@ -202,9 +204,11 @@ impl MciMailboxImpl {
         self.read_mcu_mbox0_csr_mbox_lock();
         assert!(self.is_locked(), "MCU can't acquire MCU mailbox lock");
         self.write_mcu_mbox0_csr_mbox_dlen(MCU_MAILBOX0_SRAM_SIZE);
-        self.write_mcu_mbox0_csr_mbox_execute(caliptra_emu_bus::ReadWriteRegister::new(
-            MboxExecute::Execute::CLEAR.value,
-        ));
+        self.write_mcu_mbox0_csr_mbox_execute(
+            caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+                MboxExecute::Execute::CLEAR.value,
+            ),
+        );
     }
 
     pub fn set_requester(&mut self, requester: MciMailboxRequester) {
@@ -243,7 +247,10 @@ impl MciMailboxImpl {
         self.lock.reg.set(0); // Release lock after clearing
     }
 
-    pub fn read_mcu_mbox0_csr_mbox_sram(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    pub fn read_mcu_mbox0_csr_mbox_sram(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if index >= (MCU_MAILBOX0_SRAM_SIZE as usize / 4) {
             panic!("Index out of bounds for mcu_mbox0 SRAM: {index}");
         }
@@ -263,7 +270,11 @@ impl MciMailboxImpl {
             })
     }
 
-    pub fn write_mcu_mbox0_csr_mbox_sram(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    pub fn write_mcu_mbox0_csr_mbox_sram(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+        index: usize,
+    ) {
         if !self.is_locked() {
             panic!("Cannot write to mcu_mbox0 SRAM when mailbox is unlocked");
         }
@@ -284,8 +295,10 @@ impl MciMailboxImpl {
 
     pub fn read_mcu_mbox0_csr_mbox_lock(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::mci::bits::MboxLock::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::mci::bits::MboxLock::Register,
+    > {
         // If the lock is not held, we can grant it to the current requester
         if self.lock.reg.get() == 0 {
             // Grant lock to current requester
@@ -296,27 +309,34 @@ impl MciMailboxImpl {
             self.max_dlen_in_lock_session = 0;
 
             // Return 0 to indicate lock is now held
-            caliptra_emu_bus::ReadWriteRegister::<
+            caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::<
                 u32,
                 registers_generated::mci::bits::MboxLock::Register,
             >::new(0)
         } else {
-            caliptra_emu_bus::ReadWriteRegister::<
+            caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::<
                 u32,
                 registers_generated::mci::bits::MboxLock::Register,
             >::new(self.lock.reg.get())
         }
     }
 
-    pub fn read_mcu_mbox0_csr_mbox_user(&mut self) -> caliptra_emu_types::RvData {
+    pub fn read_mcu_mbox0_csr_mbox_user(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         self.user.reg.get()
     }
 
-    pub fn read_mcu_mbox0_csr_mbox_target_user(&mut self) -> caliptra_emu_types::RvData {
+    pub fn read_mcu_mbox0_csr_mbox_target_user(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         self.target_user.reg.get()
     }
 
-    pub fn write_mcu_mbox0_csr_mbox_target_user(&mut self, val: caliptra_emu_types::RvData) {
+    pub fn write_mcu_mbox0_csr_mbox_target_user(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if !self.is_locked() {
             panic!("Cannot write mcu_mbox0 target user when mailbox is unlocked");
         }
@@ -325,16 +345,18 @@ impl MciMailboxImpl {
 
     pub fn read_mcu_mbox0_csr_mbox_target_user_valid(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::MboxTargetUserValid::Register,
     > {
-        caliptra_emu_bus::ReadWriteRegister::new(self.target_user_valid.reg.get())
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.target_user_valid.reg.get(),
+        )
     }
 
     pub fn write_mcu_mbox0_csr_mbox_target_user_valid(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::MboxTargetUserValid::Register,
         >,
@@ -345,19 +367,29 @@ impl MciMailboxImpl {
         self.target_user_valid.reg.set(val.reg.get());
     }
 
-    pub fn read_mcu_mbox0_csr_mbox_cmd(&mut self) -> caliptra_emu_types::RvData {
+    pub fn read_mcu_mbox0_csr_mbox_cmd(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         self.cmd.reg.get()
     }
 
-    pub fn write_mcu_mbox0_csr_mbox_cmd(&mut self, val: caliptra_emu_types::RvData) {
+    pub fn write_mcu_mbox0_csr_mbox_cmd(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         self.cmd.reg.set(val);
     }
 
-    pub fn read_mcu_mbox0_csr_mbox_dlen(&mut self) -> caliptra_emu_types::RvData {
+    pub fn read_mcu_mbox0_csr_mbox_dlen(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         self.dlen.reg.get()
     }
 
-    pub fn write_mcu_mbox0_csr_mbox_dlen(&mut self, val: caliptra_emu_types::RvData) {
+    pub fn write_mcu_mbox0_csr_mbox_dlen(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if val > MCU_MAILBOX0_SRAM_SIZE {
             panic!("DLEN value {val} exceeds mcu_mbox0 SRAM size");
         }
@@ -371,15 +403,15 @@ impl MciMailboxImpl {
 
     pub fn read_mcu_mbox0_csr_mbox_execute(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::MboxExecute::Register,
     > {
-        caliptra_emu_bus::ReadWriteRegister::new(self.execute.reg.get())
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.execute.reg.get())
     }
     pub fn write_mcu_mbox0_csr_mbox_execute(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::MboxExecute::Register,
         >,
@@ -405,16 +437,16 @@ impl MciMailboxImpl {
 
     pub fn read_mcu_mbox0_csr_mbox_target_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::MboxTargetStatus::Register,
     > {
-        caliptra_emu_bus::ReadWriteRegister::new(self.target_status.reg.get())
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.target_status.reg.get())
     }
 
     pub fn write_mcu_mbox0_csr_mbox_target_status(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::MboxTargetStatus::Register,
         >,
@@ -434,16 +466,16 @@ impl MciMailboxImpl {
 
     pub fn read_mcu_mbox0_csr_mbox_cmd_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::MboxCmdStatus::Register,
     > {
-        caliptra_emu_bus::ReadWriteRegister::new(self.cmd_status.reg.get())
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.cmd_status.reg.get())
     }
 
     pub fn write_mcu_mbox0_csr_mbox_cmd_status(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::MboxCmdStatus::Register,
         >,
@@ -453,11 +485,11 @@ impl MciMailboxImpl {
 
     pub fn read_mcu_mbox0_csr_mbox_hw_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::MboxHwStatus::Register,
     > {
-        caliptra_emu_bus::ReadWriteRegister::new(self.hw_status.reg.get())
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.hw_status.reg.get())
     }
 }
 
@@ -468,9 +500,9 @@ mod tests {
     use super::*;
     use crate::mci::Mci;
     use crate::McuRootBus;
-    use caliptra_emu_bus::{Bus, Clock};
-    use caliptra_emu_cpu::Pic;
-    use caliptra_emu_types::RvSize;
+    use caliptra_core_tools::caliptra_emu_bus::{Bus, Clock};
+    use caliptra_core_tools::caliptra_emu_cpu::Pic;
+    use caliptra_core_tools::caliptra_emu_types::RvSize;
     use emulator_registers_generated::root_bus::AutoRootBus;
     use registers_generated::mci::bits::{
         MboxCmdStatus, MboxExecute, MboxTargetStatus, Notif0IntrEnT, Notif0IntrT,
@@ -496,7 +528,7 @@ mod tests {
 
     fn test_helper_setup_autobus(clock: &Clock, mcu_mailbox0: &McuMailbox0Internal) -> AutoRootBus {
         let pic = Pic::new();
-        let ext_mci_regs = caliptra_emu_periph::mci::Mci::new(vec![]);
+        let ext_mci_regs = caliptra_core_tools::caliptra_emu_periph::mci::Mci::new(vec![]);
         let mci_irq = pic.register_irq(McuRootBus::MCI_IRQ);
         let mci = Mci::new(
             clock,
@@ -782,7 +814,9 @@ mod tests {
             .write_mcu_mbox0_csr_mbox_cmd(test_cmd);
         // SoC writes 1 to EXECUTE
         soc.regs.lock().unwrap().write_mcu_mbox0_csr_mbox_execute(
-            caliptra_emu_bus::ReadWriteRegister::new(MboxExecute::Execute::SET.value),
+            caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+                MboxExecute::Execute::SET.value,
+            ),
         );
 
         for _ in 0..1000 {
@@ -853,7 +887,9 @@ mod tests {
 
         // SoC writes 0 to EXECUTE to release the mailbox
         soc.regs.lock().unwrap().write_mcu_mbox0_csr_mbox_execute(
-            caliptra_emu_bus::ReadWriteRegister::new(MboxExecute::Execute::CLEAR.value),
+            caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+                MboxExecute::Execute::CLEAR.value,
+            ),
         );
 
         test_mailbox_zeroization(test_dlen, &mcu_mailbox0);
@@ -958,9 +994,9 @@ mod tests {
         soc.regs
             .lock()
             .unwrap()
-            .write_mcu_mbox0_csr_mbox_target_status(caliptra_emu_bus::ReadWriteRegister::new(
-                response_status,
-            ));
+            .write_mcu_mbox0_csr_mbox_target_status(
+                caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(response_status),
+            );
 
         // Poll to process the interrupt
         for _ in 0..1000 {

--- a/emulator/periph/src/otp.rs
+++ b/emulator/periph/src/otp.rs
@@ -14,9 +14,9 @@ Abstract:
 
 --*/
 use crate::ecc_ram::EccRam;
-use caliptra_emu_bus::{Clock, ReadWriteRegister, Timer};
-use caliptra_emu_types::{RvAddr, RvData};
-use caliptra_image_types::FwVerificationPqcKeyType;
+use caliptra_core_tools::caliptra_emu_bus::{Clock, ReadWriteRegister, Timer};
+use caliptra_core_tools::caliptra_emu_types::{RvAddr, RvData};
+use caliptra_core_tools::caliptra_image_types::FwVerificationPqcKeyType;
 use emulator_registers_generated::otp::OtpGenerated;
 use registers_generated::fuses::{self};
 use registers_generated::otp_ctrl::bits::{DirectAccessCmd, OtpStatus};
@@ -464,7 +464,9 @@ impl emulator_registers_generated::otp::OtpPeripheral for Otp {
         Some(&mut self.generated)
     }
 
-    fn read_otp_status(&mut self) -> caliptra_emu_bus::ReadWriteRegister<u32, OtpStatus::Register> {
+    fn read_otp_status(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<u32, OtpStatus::Register> {
         ReadWriteRegister::new(self.status.reg.get())
     }
 
@@ -511,147 +513,147 @@ impl emulator_registers_generated::otp::OtpPeripheral for Otp {
 
     fn read_err_code_rf_err_code_0(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
     > {
-        caliptra_emu_bus::ReadWriteRegister::new(self.err_codes[0])
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.err_codes[0])
     }
     fn read_err_code_rf_err_code_1(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
     > {
-        caliptra_emu_bus::ReadWriteRegister::new(self.err_codes[1])
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.err_codes[1])
     }
     fn read_err_code_rf_err_code_2(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
     > {
-        caliptra_emu_bus::ReadWriteRegister::new(self.err_codes[2])
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.err_codes[2])
     }
     fn read_err_code_rf_err_code_3(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
     > {
-        caliptra_emu_bus::ReadWriteRegister::new(self.err_codes[3])
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.err_codes[3])
     }
     fn read_err_code_rf_err_code_4(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
     > {
-        caliptra_emu_bus::ReadWriteRegister::new(self.err_codes[4])
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.err_codes[4])
     }
     fn read_err_code_rf_err_code_5(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
     > {
-        caliptra_emu_bus::ReadWriteRegister::new(self.err_codes[5])
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.err_codes[5])
     }
     fn read_err_code_rf_err_code_6(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
     > {
-        caliptra_emu_bus::ReadWriteRegister::new(self.err_codes[6])
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.err_codes[6])
     }
     fn read_err_code_rf_err_code_7(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
     > {
-        caliptra_emu_bus::ReadWriteRegister::new(self.err_codes[7])
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.err_codes[7])
     }
     fn read_err_code_rf_err_code_8(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
     > {
-        caliptra_emu_bus::ReadWriteRegister::new(self.err_codes[8])
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.err_codes[8])
     }
     fn read_err_code_rf_err_code_9(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
     > {
-        caliptra_emu_bus::ReadWriteRegister::new(self.err_codes[9])
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.err_codes[9])
     }
     fn read_err_code_rf_err_code_10(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
     > {
-        caliptra_emu_bus::ReadWriteRegister::new(self.err_codes[10])
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.err_codes[10])
     }
     fn read_err_code_rf_err_code_11(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
     > {
-        caliptra_emu_bus::ReadWriteRegister::new(self.err_codes[11])
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.err_codes[11])
     }
     fn read_err_code_rf_err_code_12(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
     > {
-        caliptra_emu_bus::ReadWriteRegister::new(self.err_codes[12])
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.err_codes[12])
     }
     fn read_err_code_rf_err_code_13(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
     > {
-        caliptra_emu_bus::ReadWriteRegister::new(self.err_codes[13])
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.err_codes[13])
     }
     fn read_err_code_rf_err_code_14(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
     > {
-        caliptra_emu_bus::ReadWriteRegister::new(self.err_codes[14])
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.err_codes[14])
     }
     fn read_err_code_rf_err_code_15(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
     > {
-        caliptra_emu_bus::ReadWriteRegister::new(self.err_codes[15])
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.err_codes[15])
     }
     fn read_err_code_rf_err_code_16(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
     > {
-        caliptra_emu_bus::ReadWriteRegister::new(self.err_codes[16])
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.err_codes[16])
     }
     fn read_err_code_rf_err_code_17(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
     > {
-        caliptra_emu_bus::ReadWriteRegister::new(self.err_codes[17])
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.err_codes[17])
     }
 
     fn read_dai_wdata_rf_direct_access_wdata_0(&mut self) -> RvData {

--- a/emulator/periph/src/reset_reason.rs
+++ b/emulator/periph/src/reset_reason.rs
@@ -34,14 +34,14 @@
 //! 3. If mci_pwrgood remains high, MCI hardware sets WARM_RESET bit
 //! 4. MCU comes out of reset and reads RESET_REASON to determine boot flow
 
-use caliptra_emu_bus::ReadWriteRegister;
+use caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister;
 use registers_generated::mci::bits::ResetReason;
 use tock_registers::interfaces::{ReadWriteable, Readable};
 
 /// Emulates the MCI RESET_REASON register behavior
 pub struct ResetReasonEmulator {
     /// Reference to the MCI peripheral registers in caliptra-sw
-    ext_mci_regs: caliptra_emu_periph::mci::Mci,
+    ext_mci_regs: caliptra_core_tools::caliptra_emu_periph::mci::Mci,
 
     /// Track power state to properly handle warm reset
     pwrgood: bool,
@@ -49,7 +49,7 @@ pub struct ResetReasonEmulator {
 
 impl ResetReasonEmulator {
     /// Create a new reset reason emulator
-    pub fn new(ext_mci_regs: caliptra_emu_periph::mci::Mci) -> Self {
+    pub fn new(ext_mci_regs: caliptra_core_tools::caliptra_emu_periph::mci::Mci) -> Self {
         Self {
             ext_mci_regs,
             pwrgood: true,
@@ -102,7 +102,7 @@ impl ResetReasonEmulator {
 
 impl Default for ResetReasonEmulator {
     fn default() -> Self {
-        let ext_mci_regs = caliptra_emu_periph::mci::Mci::new(vec![]);
+        let ext_mci_regs = caliptra_core_tools::caliptra_emu_periph::mci::Mci::new(vec![]);
         Self::new(ext_mci_regs)
     }
 }

--- a/emulator/periph/src/root_bus.rs
+++ b/emulator/periph/src/root_bus.rs
@@ -14,10 +14,10 @@ Abstract:
 
 use crate::McuMailbox0Internal;
 use crate::{EmuCtrl, Uart};
-use caliptra_emu_bus::{Bus, BusError, Clock, Ram, Rom};
-use caliptra_emu_bus::{Device, Event, EventData};
-use caliptra_emu_cpu::{Irq, Pic, PicMmioRegisters};
-use caliptra_emu_types::{RvAddr, RvData, RvSize};
+use caliptra_core_tools::caliptra_emu_bus::{Bus, BusError, Clock, Ram, Rom};
+use caliptra_core_tools::caliptra_emu_bus::{Device, Event, EventData};
+use caliptra_core_tools::caliptra_emu_cpu::{Irq, Pic, PicMmioRegisters};
+use caliptra_core_tools::caliptra_emu_types::{RvAddr, RvData, RvSize};
 use emulator_consts::{
     DIRECT_READ_FLASH_ORG, DIRECT_READ_FLASH_SIZE, DOT_FLASH_SIZE, EXTERNAL_TEST_SRAM_SIZE,
     MCU_MAILBOX0_SRAM_SIZE, MCU_MAILBOX1_SRAM_SIZE, RAM_SIZE, ROM_DEDICATED_RAM_ORG,

--- a/emulator/periph/src/uart.rs
+++ b/emulator/periph/src/uart.rs
@@ -12,9 +12,9 @@ Abstract:
 
 --*/
 
-use caliptra_emu_bus::{Bus, BusError, Clock, Timer};
-use caliptra_emu_cpu::Irq;
-use caliptra_emu_types::{RvAddr, RvData, RvSize};
+use caliptra_core_tools::caliptra_emu_bus::{Bus, BusError, Clock, Timer};
+use caliptra_core_tools::caliptra_emu_cpu::Irq;
+use caliptra_core_tools::caliptra_emu_types::{RvAddr, RvData, RvSize};
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};

--- a/hw/model/Cargo.toml
+++ b/hw/model/Cargo.toml
@@ -10,23 +10,14 @@ default = []
 fpga_realtime = [
     "dep:uio",
     "dep:mcu-config-fpga",
-    "caliptra-hw-model/fpga_subsystem",
+    "caliptra-core-tools/hw-model-fpga_subsystem",
 ]
 itrng = []
 
 [dependencies]
+caliptra-core-tools.workspace = true
 anyhow.workspace = true
 bitfield.workspace = true
-caliptra-api-types.workspace = true
-caliptra-api.workspace = true
-caliptra-emu-bus.workspace = true
-caliptra-emu-cpu.workspace = true
-caliptra-emu-periph.workspace = true
-caliptra-emu-types.workspace = true
-caliptra-hw-model-types.workspace = true
-caliptra-hw-model.workspace = true
-caliptra-image-types.workspace = true
-caliptra-registers.workspace = true
 ecdsa.workspace = true
 emulator-bmc.workspace = true
 emulator-caliptra.workspace = true
@@ -52,11 +43,7 @@ sha3.workspace = true
 thiserror.workspace = true
 tock-registers.workspace = true
 uio = { workspace = true, optional = true }
-ureg.workspace = true
 zerocopy.workspace = true
 
 [dev-dependencies]
-caliptra-builder.workspace = true
-caliptra-registers.workspace = true
-caliptra-test-harness-types.workspace = true
 nix.workspace = true

--- a/hw/model/src/bus_logger.rs
+++ b/hw/model/src/bus_logger.rs
@@ -8,8 +8,8 @@ use std::{
     rc::Rc,
 };
 
-use caliptra_emu_bus::{Bus, BusError};
-use caliptra_emu_types::{RvAddr, RvData, RvSize};
+use caliptra_core_tools::caliptra_emu_bus::{Bus, BusError};
+use caliptra_core_tools::caliptra_emu_types::{RvAddr, RvData, RvSize};
 
 #[derive(Clone)]
 pub struct LogFile(Rc<RefCell<BufWriter<File>>>);
@@ -32,7 +32,11 @@ impl Write for LogFile {
 
 pub struct NullBus();
 impl Bus for NullBus {
-    fn read(&mut self, _size: RvSize, _addr: RvAddr) -> Result<RvData, caliptra_emu_bus::BusError> {
+    fn read(
+        &mut self,
+        _size: RvSize,
+        _addr: RvAddr,
+    ) -> Result<RvData, caliptra_core_tools::caliptra_emu_bus::BusError> {
         Err(BusError::LoadAccessFault)
     }
 
@@ -41,7 +45,7 @@ impl Bus for NullBus {
         _size: RvSize,
         _addr: RvAddr,
         _val: RvData,
-    ) -> Result<(), caliptra_emu_bus::BusError> {
+    ) -> Result<(), caliptra_core_tools::caliptra_emu_bus::BusError> {
         Err(BusError::StoreAccessFault)
     }
 }
@@ -59,7 +63,7 @@ impl<TBus: Bus> BusLogger<TBus> {
         bus_name: &str,
         size: RvSize,
         addr: RvAddr,
-        result: Result<RvData, caliptra_emu_bus::BusError>,
+        result: Result<RvData, caliptra_core_tools::caliptra_emu_bus::BusError>,
     ) {
         if let Some(log) = &mut self.log {
             let size = usize::from(size);
@@ -79,7 +83,7 @@ impl<TBus: Bus> BusLogger<TBus> {
         size: RvSize,
         addr: RvAddr,
         val: RvData,
-        result: Result<(), caliptra_emu_bus::BusError>,
+        result: Result<(), caliptra_core_tools::caliptra_emu_bus::BusError>,
     ) {
         if addr < 0x1000_0000 {
             // Don't care about memory
@@ -101,7 +105,11 @@ impl<TBus: Bus> BusLogger<TBus> {
     }
 }
 impl<TBus: Bus> Bus for BusLogger<TBus> {
-    fn read(&mut self, size: RvSize, addr: RvAddr) -> Result<RvData, caliptra_emu_bus::BusError> {
+    fn read(
+        &mut self,
+        size: RvSize,
+        addr: RvAddr,
+    ) -> Result<RvData, caliptra_core_tools::caliptra_emu_bus::BusError> {
         let result = self.bus.read(size, addr);
         self.log_read("UC", size, addr, result);
         result
@@ -112,7 +120,7 @@ impl<TBus: Bus> Bus for BusLogger<TBus> {
         size: RvSize,
         addr: RvAddr,
         val: RvData,
-    ) -> Result<(), caliptra_emu_bus::BusError> {
+    ) -> Result<(), caliptra_core_tools::caliptra_emu_bus::BusError> {
         let result = self.bus.write(size, addr, val);
         self.log_write("UC", size, addr, val, result);
         result
@@ -130,13 +138,13 @@ impl<TBus: Bus> Bus for BusLogger<TBus> {
         self.bus.update_reset();
     }
 
-    fn incoming_event(&mut self, event: Rc<caliptra_emu_bus::Event>) {
+    fn incoming_event(&mut self, event: Rc<caliptra_core_tools::caliptra_emu_bus::Event>) {
         self.bus.incoming_event(event);
     }
 
     fn register_outgoing_events(
         &mut self,
-        sender: std::sync::mpsc::Sender<caliptra_emu_bus::Event>,
+        sender: std::sync::mpsc::Sender<caliptra_core_tools::caliptra_emu_bus::Event>,
     ) {
         self.bus.register_outgoing_events(sender);
     }

--- a/hw/model/src/debug_unlock.rs
+++ b/hw/model/src/debug_unlock.rs
@@ -6,12 +6,12 @@ use std::time::Duration;
 use crate::jtag::{jtag_get_caliptra_mailbox_resp, jtag_send_caliptra_mailbox_cmd};
 use crate::DefaultHwModel;
 
-use caliptra_api::mailbox::{
+use caliptra_core_tools::caliptra_api::mailbox::{
     CommandId, ProductionAuthDebugUnlockChallenge, ProductionAuthDebugUnlockToken,
 };
-use caliptra_hw_model::jtag::CaliptraCoreReg;
-use caliptra_hw_model::openocd::openocd_jtag_tap::OpenOcdJtagTap;
-use caliptra_hw_model::HwModel;
+use caliptra_core_tools::caliptra_hw_model::jtag::CaliptraCoreReg;
+use caliptra_core_tools::caliptra_hw_model::openocd::openocd_jtag_tap::OpenOcdJtagTap;
+use caliptra_core_tools::caliptra_hw_model::HwModel;
 
 use anyhow::{Context, Result};
 use ecdsa::signature::hazmat::PrehashSigner;

--- a/hw/model/src/jtag.rs
+++ b/hw/model/src/jtag.rs
@@ -3,10 +3,10 @@
 use std::thread;
 use std::time::{Duration, SystemTime};
 
-use caliptra_api::checksum::calc_checksum;
-use caliptra_api::mailbox::CommandId;
-use caliptra_hw_model::jtag::CaliptraCoreReg;
-use caliptra_hw_model::openocd::openocd_jtag_tap::OpenOcdJtagTap;
+use caliptra_core_tools::caliptra_api::checksum::calc_checksum;
+use caliptra_core_tools::caliptra_api::mailbox::CommandId;
+use caliptra_core_tools::caliptra_hw_model::jtag::CaliptraCoreReg;
+use caliptra_core_tools::caliptra_hw_model::openocd::openocd_jtag_tap::OpenOcdJtagTap;
 
 use anyhow::{anyhow, Context, Result};
 use int_enum::IntEnum;

--- a/hw/model/src/lcc.rs
+++ b/hw/model/src/lcc.rs
@@ -12,8 +12,8 @@ use std::time::Duration;
 use anyhow::{bail, Context, Result};
 use thiserror::Error;
 
-use caliptra_hw_model::lcc::{LcCtrlReg, LcCtrlStatus, LcCtrlTransitionCmd};
-use caliptra_hw_model::openocd::openocd_jtag_tap::{JtagTap, OpenOcdJtagTap};
+use caliptra_core_tools::caliptra_hw_model::lcc::{LcCtrlReg, LcCtrlStatus, LcCtrlTransitionCmd};
+use caliptra_core_tools::caliptra_hw_model::openocd::openocd_jtag_tap::{JtagTap, OpenOcdJtagTap};
 use mcu_rom_common::{Lifecycle, LifecycleControllerState};
 use poll_common::poll_until;
 

--- a/hw/model/src/lib.rs
+++ b/hw/model/src/lib.rs
@@ -3,16 +3,17 @@
 use anyhow::{bail, Result};
 pub use api::mailbox::mbox_write_fifo;
 pub use api_types::{DbgManufServiceRegReq, DeviceLifecycle, Fuses, U4};
-use caliptra_api::{self as api, SocManager};
-use caliptra_api_types as api_types;
-use caliptra_emu_bus::Event;
-pub use caliptra_emu_cpu::{CodeRange, ImageInfo, StackInfo, StackRange};
-use caliptra_hw_model::{ExitStatus, ModelError, Output};
-use caliptra_hw_model_types::{
+use caliptra_core_tools::caliptra_api::{self as api, SocManager};
+use caliptra_core_tools::caliptra_api_types as api_types;
+use caliptra_core_tools::caliptra_emu_bus::Event;
+pub use caliptra_core_tools::caliptra_emu_cpu::{CodeRange, ImageInfo, StackInfo, StackRange};
+use caliptra_core_tools::caliptra_hw_model::{ExitStatus, ModelError, Output};
+use caliptra_core_tools::caliptra_hw_model_types::{
     EtrngResponse, HexBytes, HexSlice, RandomEtrngResponses, RandomNibbles, DEFAULT_CPTRA_OBF_KEY,
 };
-use caliptra_image_types::FwVerificationPqcKeyType;
-use caliptra_registers::mcu_mbox0::enums::MboxStatusE;
+use caliptra_core_tools::caliptra_image_types::FwVerificationPqcKeyType;
+use caliptra_core_tools::caliptra_registers::mcu_mbox0::enums::MboxStatusE;
+use caliptra_core_tools::ureg::MmioMut;
 pub use mcu_mgr::McuManager;
 use mcu_rom_common::{
     LifecycleControllerState, LifecycleRawTokens, LifecycleToken, McuBootMilestones,
@@ -27,7 +28,6 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::atomic::Ordering;
 use std::sync::mpsc;
-use ureg::MmioMut;
 pub use vmem::read_otp_vmem_data;
 
 // Re-export flash image builder for creating flash images from firmware bytes
@@ -793,10 +793,12 @@ pub trait McuHwModel {
     }
 }
 
-fn mbox_read_fifo(mbox: caliptra_registers::mbox::RegisterBlock<impl MmioMut>) -> Vec<u8> {
+fn mbox_read_fifo(
+    mbox: caliptra_core_tools::caliptra_registers::mbox::RegisterBlock<impl MmioMut>,
+) -> Vec<u8> {
     let dlen = mbox.dlen().read() as usize;
     let mut buf = vec![0; dlen];
-    let _ = caliptra_api::mailbox::mbox_read_fifo(mbox, buf.as_mut_slice());
+    let _ = caliptra_core_tools::caliptra_api::mailbox::mbox_read_fifo(mbox, buf.as_mut_slice());
     buf
 }
 

--- a/hw/model/src/mcu_mgr.rs
+++ b/hw/model/src/mcu_mgr.rs
@@ -1,6 +1,6 @@
 // Licensed under the Apache-2.0 license
 
-use ureg::MmioMut;
+use caliptra_core_tools::ureg::MmioMut;
 
 pub trait McuManager {
     const I3C_ADDR: u32;
@@ -19,9 +19,11 @@ pub trait McuManager {
     fn mmio_mut(&mut self) -> Self::TMmio<'_>;
 
     /// A register block that can be used to manipulate the i3c peripheral
-    fn i3c(&mut self) -> caliptra_registers::i3ccsr::RegisterBlock<Self::TMmio<'_>> {
+    fn i3c(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_registers::i3ccsr::RegisterBlock<Self::TMmio<'_>> {
         unsafe {
-            caliptra_registers::i3ccsr::RegisterBlock::new_with_mmio(
+            caliptra_core_tools::caliptra_registers::i3ccsr::RegisterBlock::new_with_mmio(
                 Self::I3C_ADDR as *mut u32,
                 self.mmio_mut(),
             )
@@ -29,9 +31,11 @@ pub trait McuManager {
     }
 
     /// A register block that can be used to manipulate the mci peripheral
-    fn mci(&mut self) -> caliptra_registers::mci::RegisterBlock<Self::TMmio<'_>> {
+    fn mci(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_registers::mci::RegisterBlock<Self::TMmio<'_>> {
         unsafe {
-            caliptra_registers::mci::RegisterBlock::new_with_mmio(
+            caliptra_core_tools::caliptra_registers::mci::RegisterBlock::new_with_mmio(
                 Self::MCI_ADDR as *mut u32,
                 self.mmio_mut(),
             )
@@ -41,9 +45,10 @@ pub trait McuManager {
     /// A register block that can be used to manipulate the mcu_trace_buffer peripheral
     fn trace_buffer(
         &mut self,
-    ) -> caliptra_registers::mcu_trace_buffer::RegisterBlock<Self::TMmio<'_>> {
+    ) -> caliptra_core_tools::caliptra_registers::mcu_trace_buffer::RegisterBlock<Self::TMmio<'_>>
+    {
         unsafe {
-            caliptra_registers::mcu_trace_buffer::RegisterBlock::new_with_mmio(
+            caliptra_core_tools::caliptra_registers::mcu_trace_buffer::RegisterBlock::new_with_mmio(
                 Self::TRACE_BUFFER_ADDR as *mut u32,
                 self.mmio_mut(),
             )
@@ -51,9 +56,11 @@ pub trait McuManager {
     }
 
     /// A register block that can be used to manipulate the mcu_mbox0 peripheral
-    fn mbox0(&mut self) -> caliptra_registers::mcu_mbox0::RegisterBlock<Self::TMmio<'_>> {
+    fn mbox0(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_registers::mcu_mbox0::RegisterBlock<Self::TMmio<'_>> {
         unsafe {
-            caliptra_registers::mcu_mbox0::RegisterBlock::new_with_mmio(
+            caliptra_core_tools::caliptra_registers::mcu_mbox0::RegisterBlock::new_with_mmio(
                 Self::MBOX_0_ADDR as *mut u32,
                 self.mmio_mut(),
             )
@@ -61,9 +68,11 @@ pub trait McuManager {
     }
 
     /// A register block that can be used to manipulate the mcu_mbox1 peripheral
-    fn mbox1(&mut self) -> caliptra_registers::mcu_mbox1::RegisterBlock<Self::TMmio<'_>> {
+    fn mbox1(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_registers::mcu_mbox1::RegisterBlock<Self::TMmio<'_>> {
         unsafe {
-            caliptra_registers::mcu_mbox1::RegisterBlock::new_with_mmio(
+            caliptra_core_tools::caliptra_registers::mcu_mbox1::RegisterBlock::new_with_mmio(
                 Self::MBOX_1_ADDR as *mut u32,
                 self.mmio_mut(),
             )
@@ -71,9 +80,11 @@ pub trait McuManager {
     }
 
     /// A register block that can be used to manipulate the mcu_sram peripheral
-    fn mcu_sram(&mut self) -> caliptra_registers::mcu_sram::RegisterBlock<Self::TMmio<'_>> {
+    fn mcu_sram(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_registers::mcu_sram::RegisterBlock<Self::TMmio<'_>> {
         unsafe {
-            caliptra_registers::mcu_sram::RegisterBlock::new_with_mmio(
+            caliptra_core_tools::caliptra_registers::mcu_sram::RegisterBlock::new_with_mmio(
                 Self::MCU_SRAM_ADDR as *mut u32,
                 self.mmio_mut(),
             )
@@ -81,9 +92,11 @@ pub trait McuManager {
     }
 
     /// A register block that can be used to manipulate the otp_ctrl peripheral
-    fn otp_ctrl(&mut self) -> caliptra_registers::otp_ctrl::RegisterBlock<Self::TMmio<'_>> {
+    fn otp_ctrl(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_registers::otp_ctrl::RegisterBlock<Self::TMmio<'_>> {
         unsafe {
-            caliptra_registers::otp_ctrl::RegisterBlock::new_with_mmio(
+            caliptra_core_tools::caliptra_registers::otp_ctrl::RegisterBlock::new_with_mmio(
                 Self::OTP_CTRL_ADDR as *mut u32,
                 self.mmio_mut(),
             )
@@ -91,9 +104,11 @@ pub trait McuManager {
     }
 
     /// A register block that can be used to manipulate the lc_ctrl peripheral
-    fn lc_ctrl(&mut self) -> caliptra_registers::lc_ctrl::RegisterBlock<Self::TMmio<'_>> {
+    fn lc_ctrl(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_registers::lc_ctrl::RegisterBlock<Self::TMmio<'_>> {
         unsafe {
-            caliptra_registers::lc_ctrl::RegisterBlock::new_with_mmio(
+            caliptra_core_tools::caliptra_registers::lc_ctrl::RegisterBlock::new_with_mmio(
                 Self::LC_CTRL_ADDR as *mut u32,
                 self.mmio_mut(),
             )
@@ -109,56 +124,74 @@ pub trait McuManager {
 
     fn with_i3c<T, F>(&mut self, f: F) -> T
     where
-        F: FnOnce(caliptra_registers::i3ccsr::RegisterBlock<Self::TMmio<'_>>) -> T,
+        F: FnOnce(
+            caliptra_core_tools::caliptra_registers::i3ccsr::RegisterBlock<Self::TMmio<'_>>,
+        ) -> T,
     {
         f(self.i3c())
     }
 
     fn with_mci<T, F>(&mut self, f: F) -> T
     where
-        F: FnOnce(caliptra_registers::mci::RegisterBlock<Self::TMmio<'_>>) -> T,
+        F: FnOnce(
+            caliptra_core_tools::caliptra_registers::mci::RegisterBlock<Self::TMmio<'_>>,
+        ) -> T,
     {
         f(self.mci())
     }
 
     fn with_trace_buffer<T, F>(&mut self, f: F) -> T
     where
-        F: FnOnce(caliptra_registers::mcu_trace_buffer::RegisterBlock<Self::TMmio<'_>>) -> T,
+        F: FnOnce(
+            caliptra_core_tools::caliptra_registers::mcu_trace_buffer::RegisterBlock<
+                Self::TMmio<'_>,
+            >,
+        ) -> T,
     {
         f(self.trace_buffer())
     }
 
     fn with_mbox0<T, F>(&mut self, f: F) -> T
     where
-        F: FnOnce(caliptra_registers::mcu_mbox0::RegisterBlock<Self::TMmio<'_>>) -> T,
+        F: FnOnce(
+            caliptra_core_tools::caliptra_registers::mcu_mbox0::RegisterBlock<Self::TMmio<'_>>,
+        ) -> T,
     {
         f(self.mbox0())
     }
 
     fn with_mbox1<T, F>(&mut self, f: F) -> T
     where
-        F: FnOnce(caliptra_registers::mcu_mbox1::RegisterBlock<Self::TMmio<'_>>) -> T,
+        F: FnOnce(
+            caliptra_core_tools::caliptra_registers::mcu_mbox1::RegisterBlock<Self::TMmio<'_>>,
+        ) -> T,
     {
         f(self.mbox1())
     }
 
     fn with_mcu_sram<T, F>(&mut self, f: F) -> T
     where
-        F: FnOnce(caliptra_registers::mcu_sram::RegisterBlock<Self::TMmio<'_>>) -> T,
+        F: FnOnce(
+            caliptra_core_tools::caliptra_registers::mcu_sram::RegisterBlock<Self::TMmio<'_>>,
+        ) -> T,
     {
         f(self.mcu_sram())
     }
 
     fn with_otp<T, F>(&mut self, f: F) -> T
     where
-        F: FnOnce(caliptra_registers::otp_ctrl::RegisterBlock<Self::TMmio<'_>>) -> T,
+        F: FnOnce(
+            caliptra_core_tools::caliptra_registers::otp_ctrl::RegisterBlock<Self::TMmio<'_>>,
+        ) -> T,
     {
         f(self.otp_ctrl())
     }
 
     fn with_lc<T, F>(&mut self, f: F) -> T
     where
-        F: FnOnce(caliptra_registers::lc_ctrl::RegisterBlock<Self::TMmio<'_>>) -> T,
+        F: FnOnce(
+            caliptra_core_tools::caliptra_registers::lc_ctrl::RegisterBlock<Self::TMmio<'_>>,
+        ) -> T,
     {
         f(self.lc_ctrl())
     }

--- a/hw/model/src/model_emulated.rs
+++ b/hw/model/src/model_emulated.rs
@@ -11,22 +11,22 @@ use crate::McuManager;
 use crate::DEFAULT_LIFECYCLE_RAW_TOKENS;
 use anyhow::bail;
 use anyhow::Result;
-use caliptra_api::SocManager;
-use caliptra_emu_bus::Bus;
-use caliptra_emu_bus::BusError;
-use caliptra_emu_bus::BusMmio;
-use caliptra_emu_bus::Ram;
-use caliptra_emu_bus::{Clock, Event};
-use caliptra_emu_cpu::CpuOrgArgs;
-use caliptra_emu_cpu::{Cpu, CpuArgs, InstrTracer, Pic};
-use caliptra_emu_periph::CaliptraRootBus as CaliptraMainRootBus;
-use caliptra_emu_periph::SocToCaliptraBus;
-use caliptra_emu_types::RvAddr;
-use caliptra_emu_types::RvData;
-use caliptra_emu_types::RvSize;
-use caliptra_hw_model::Output;
-use caliptra_image_types::FwVerificationPqcKeyType;
-use caliptra_image_types::IMAGE_MANIFEST_BYTE_SIZE;
+use caliptra_core_tools::caliptra_api::SocManager;
+use caliptra_core_tools::caliptra_emu_bus::Bus;
+use caliptra_core_tools::caliptra_emu_bus::BusError;
+use caliptra_core_tools::caliptra_emu_bus::BusMmio;
+use caliptra_core_tools::caliptra_emu_bus::Ram;
+use caliptra_core_tools::caliptra_emu_bus::{Clock, Event};
+use caliptra_core_tools::caliptra_emu_cpu::CpuOrgArgs;
+use caliptra_core_tools::caliptra_emu_cpu::{Cpu, CpuArgs, InstrTracer, Pic};
+use caliptra_core_tools::caliptra_emu_periph::CaliptraRootBus as CaliptraMainRootBus;
+use caliptra_core_tools::caliptra_emu_periph::SocToCaliptraBus;
+use caliptra_core_tools::caliptra_emu_types::RvAddr;
+use caliptra_core_tools::caliptra_emu_types::RvData;
+use caliptra_core_tools::caliptra_emu_types::RvSize;
+use caliptra_core_tools::caliptra_hw_model::Output;
+use caliptra_core_tools::caliptra_image_types::FwVerificationPqcKeyType;
+use caliptra_core_tools::caliptra_image_types::IMAGE_MANIFEST_BYTE_SIZE;
 use emulator_bmc::Bmc;
 use emulator_caliptra::start_caliptra;
 use emulator_caliptra::BytesOrPath;
@@ -87,7 +87,7 @@ pub struct ModelEmulated {
     i3c_controller_join_handle: Option<JoinHandle<()>>,
     dot_flash: Rc<RefCell<Ram>>,
     otp_partitions: Rc<RefCell<Vec<u8>>>,
-    mci_regs: Rc<RefCell<caliptra_emu_periph::mci::MciRegs>>,
+    mci_regs: Rc<RefCell<caliptra_core_tools::caliptra_emu_periph::mci::MciRegs>>,
     check_booted_to_runtime: bool,
     // Synchronises cross-thread timer scheduling (I3C controller thread)
     // with the CPU step that advances the clock.
@@ -238,25 +238,26 @@ impl McuHwModel for ModelEmulated {
         let mut lc = lc;
         lc.set_otp_partitions(otp_partitions.clone());
 
-        let create_flash_controller =
-            |default_path: &str,
-             error_irq: u8,
-             event_irq: u8,
-             initial_content: Option<&[u8]>,
-             direct_read_region: Option<Rc<RefCell<caliptra_emu_bus::Ram>>>| {
-                // Use a temporary file for flash storage if we're running a test
-                let flash_file = Some(PathBuf::from(default_path));
+        let create_flash_controller = |default_path: &str,
+                                       error_irq: u8,
+                                       event_irq: u8,
+                                       initial_content: Option<&[u8]>,
+                                       direct_read_region: Option<
+            Rc<RefCell<caliptra_core_tools::caliptra_emu_bus::Ram>>,
+        >| {
+            // Use a temporary file for flash storage if we're running a test
+            let flash_file = Some(PathBuf::from(default_path));
 
-                DummyFlashCtrl::new(
-                    &clock.clone(),
-                    direct_read_region,
-                    flash_file,
-                    pic.register_irq(error_irq),
-                    pic.register_irq(event_irq),
-                    initial_content,
-                )
-                .unwrap()
-            };
+            DummyFlashCtrl::new(
+                &clock.clone(),
+                direct_read_region,
+                flash_file,
+                pic.register_irq(error_irq),
+                pic.register_irq(event_irq),
+                initial_content,
+            )
+            .unwrap()
+        };
 
         let mut primary_flash_controller = create_flash_controller(
             "primary_flash",
@@ -347,7 +348,7 @@ impl McuHwModel for ModelEmulated {
             mci_generic_input_wires,
         );
 
-        let delegates: Vec<Box<dyn caliptra_emu_bus::Bus>> =
+        let delegates: Vec<Box<dyn caliptra_core_tools::caliptra_emu_bus::Bus>> =
             vec![Box::new(mcu_root_bus), Box::new(soc_to_caliptra)];
 
         let auto_root_bus = AutoRootBus::new(
@@ -607,7 +608,7 @@ impl McuHwModel for ModelEmulated {
         self
     }
 
-    fn caliptra_soc_manager(&mut self) -> impl caliptra_api::SocManager {
+    fn caliptra_soc_manager(&mut self) -> impl caliptra_core_tools::caliptra_api::SocManager {
         self
     }
 

--- a/hw/model/src/model_fpga_realtime.rs
+++ b/hw/model/src/model_fpga_realtime.rs
@@ -4,16 +4,18 @@
 
 use crate::{InitParams, McuHwModel, McuManager};
 use anyhow::{bail, Result};
-use caliptra_api::SocManager;
-use caliptra_emu_bus::{Bus, BusError, BusMmio, Event};
-use caliptra_emu_periph::MailboxRequester;
-use caliptra_emu_types::{RvAddr, RvData, RvSize};
-use caliptra_hw_model::openocd::openocd_jtag_tap::{JtagParams, JtagTap, OpenOcdJtagTap};
-use caliptra_hw_model::{
+use caliptra_core_tools::caliptra_api::SocManager;
+use caliptra_core_tools::caliptra_emu_bus::{Bus, BusError, BusMmio, Event};
+use caliptra_core_tools::caliptra_emu_periph::MailboxRequester;
+use caliptra_core_tools::caliptra_emu_types::{RvAddr, RvData, RvSize};
+use caliptra_core_tools::caliptra_hw_model::openocd::openocd_jtag_tap::{
+    JtagParams, JtagTap, OpenOcdJtagTap,
+};
+use caliptra_core_tools::caliptra_hw_model::{
     DeviceLifecycle, HwModel, InitParams as CaliptraInitParams, ModelFpgaSubsystem, Output,
     SecurityState, SubsystemInitParams, XI3CWrapper,
 };
-use caliptra_registers::i3ccsr::regs::StbyCrDeviceAddrWriteVal;
+use caliptra_core_tools::caliptra_registers::i3ccsr::regs::StbyCrDeviceAddrWriteVal;
 use mcu_rom_common::{LifecycleControllerState, McuBootMilestones};
 use mcu_testing_common::i3c::{
     I3cBusCommand, I3cBusResponse, I3cTcriCommand, I3cTcriResponseXfer, ResponseDescriptor,
@@ -304,7 +306,7 @@ impl McuHwModel for ModelFpgaRealtime {
             csr_hmac_key: params.csr_hmac_key,
             itrng_nibbles: params.itrng_nibbles,
             etrng_responses: params.etrng_responses,
-            trng_mode: Some(caliptra_hw_model::TrngMode::Internal),
+            trng_mode: Some(caliptra_core_tools::caliptra_hw_model::TrngMode::Internal),
             random_sram_puf: params.random_sram_puf,
             trace_path: params.trace_path,
             stack_info: params.stack_info,
@@ -317,9 +319,11 @@ impl McuHwModel for ModelFpgaRealtime {
                 num_prod_dbg_unlock_pk_hashes: params.num_prod_dbg_unlock_pk_hashes,
                 prod_dbg_unlock_pk_hashes_offset: params.prod_dbg_unlock_pk_hashes_offset,
                 primary_flash_initial_contents: params.primary_flash_initial_contents.as_deref(),
-                lc_state: params
-                    .lifecycle_controller_state
-                    .map(|s| caliptra_hw_model::LifecycleControllerState::from(u8::from(s))),
+                lc_state: params.lifecycle_controller_state.map(|s| {
+                    caliptra_core_tools::caliptra_hw_model::LifecycleControllerState::from(
+                        u8::from(s),
+                    )
+                }),
                 ..Default::default()
             },
         };

--- a/platforms/emulator/runtime/userspace/apps/example/Cargo.toml
+++ b/platforms/emulator/runtime/userspace/apps/example/Cargo.toml
@@ -7,9 +7,7 @@ authors.workspace = true
 edition.workspace = true
 
 [dependencies]
-caliptra-api.workspace = true
-caliptra-error.workspace = true
-caliptra-auth-man-types.workspace = true
+caliptra-core-firmware = { workspace = true, default-features = false, features = ["2_0"] }
 critical-section.workspace = true
 embassy-executor.workspace = true
 libapi-caliptra.workspace = true

--- a/platforms/emulator/runtime/userspace/apps/example/src/test_caliptra_crypto.rs
+++ b/platforms/emulator/runtime/userspace/apps/example/src/test_caliptra_crypto.rs
@@ -1,7 +1,7 @@
 // Licensed under the Apache-2.0 license
 
-use caliptra_api::mailbox::CmKeyUsage;
-use caliptra_api::mailbox::Cmk;
+use caliptra_core_firmware::caliptra_api::mailbox::CmKeyUsage;
+use caliptra_core_firmware::caliptra_api::mailbox::Cmk;
 use libapi_caliptra::certificate::{CertContext, KEY_LABEL_SIZE};
 use libapi_caliptra::crypto::aes_gcm::AesGcm;
 use libapi_caliptra::crypto::asym::{

--- a/platforms/emulator/runtime/userspace/apps/example/src/test_caliptra_mailbox.rs
+++ b/platforms/emulator/runtime/userspace/apps/example/src/test_caliptra_mailbox.rs
@@ -1,6 +1,8 @@
 // Licensed under the Apache-2.0 license
 
-use caliptra_api::mailbox::{MailboxReqHeader, QuotePcrsEcc384Req, QuotePcrsEcc384Resp, Request};
+use caliptra_core_firmware::caliptra_api::mailbox::{
+    MailboxReqHeader, QuotePcrsEcc384Req, QuotePcrsEcc384Resp, Request,
+};
 use core::fmt::Write;
 use libsyscall_caliptra::mailbox::{Mailbox, MailboxError};
 use romtime::{println, test_exit};
@@ -80,7 +82,10 @@ pub(crate) async fn test_caliptra_mailbox_bad_command() {
         .await
     {
         Err(MailboxError::MailboxError(err))
-            if err == u32::from(caliptra_error::CaliptraError::RUNTIME_UNIMPLEMENTED_COMMAND) =>
+            if err
+                == u32::from(
+                    caliptra_core_firmware::caliptra_error::CaliptraError::RUNTIME_UNIMPLEMENTED_COMMAND,
+                ) =>
         {
             println!("Test passed");
         }
@@ -118,7 +123,10 @@ pub(crate) async fn test_caliptra_mailbox_fail() {
         .await
     {
         Err(MailboxError::MailboxError(err))
-            if err == u32::from(caliptra_error::CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS) =>
+            if err
+                == u32::from(
+                    caliptra_core_firmware::caliptra_error::CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS,
+                ) =>
         {
             println!("Test passed");
         }

--- a/platforms/emulator/runtime/userspace/apps/example/src/test_get_device_state.rs
+++ b/platforms/emulator/runtime/userspace/apps/example/src/test_get_device_state.rs
@@ -1,5 +1,5 @@
 // Licensed under the Apache-2.0 license
-use caliptra_api::mailbox::{FwInfoResp, GetImageInfoResp};
+use caliptra_core_firmware::caliptra_api::mailbox::{FwInfoResp, GetImageInfoResp};
 use core::fmt::Write;
 use libapi_caliptra::crypto::hash::SHA384_HASH_SIZE;
 use libapi_caliptra::evidence::device_state::*;

--- a/platforms/emulator/runtime/userspace/apps/user/Cargo.toml
+++ b/platforms/emulator/runtime/userspace/apps/user/Cargo.toml
@@ -7,9 +7,9 @@ authors.workspace = true
 edition.workspace = true
 
 [dependencies]
+caliptra-core-firmware = { workspace = true, default-features = false, features = ["2_0"] }
 arrayvec.workspace = true
 async-trait.workspace = true
-caliptra-api.workspace = true
 critical-section.workspace = true
 embassy-executor.workspace = true
 embassy-sync.workspace = true
@@ -30,7 +30,6 @@ mcu-mbox-lib.workspace = true
 mcu-mbox-common.workspace = true
 mctp-vdm-common.workspace = true
 mctp-vdm-lib.workspace = true
-ocp-eat.workspace = true
 portable-atomic.workspace = true
 pldm-common.workspace = true
 pldm-lib.workspace = true

--- a/platforms/emulator/runtime/userspace/apps/user/src/image_loader/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/image_loader/mod.rs
@@ -9,7 +9,7 @@ mod pldm_fdops_mock;
 
 mod config;
 
-use caliptra_api::mailbox::{
+use caliptra_core_firmware::caliptra_api::mailbox::{
     ActivateFirmwareReq, ActivateFirmwareResp, CommandId, MailboxReqHeader,
 };
 use core::fmt::Write;

--- a/platforms/emulator/runtime/userspace/apps/user/src/spdm/device_measurements/ocp_eat/claims.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/spdm/device_measurements/ocp_eat/claims.rs
@@ -3,6 +3,13 @@
 use crate::soc_env::*;
 use arrayvec::ArrayString;
 use arrayvec::ArrayVec;
+use caliptra_core_firmware::ocp_eat::ocp_profile::{
+    IntegrityRegisterEntry, IntegrityRegisterIdChoice, TaggedConciseEvidence,
+};
+use caliptra_core_firmware::ocp_eat::{
+    ClassIdTypeChoice, ClassMap, ConciseEvidence, ConciseEvidenceMap, DigestEntry, EnvironmentMap,
+    EvTriplesMap, EvidenceTripleRecord, MeasurementMap, MeasurementValue, TaggedBytes, VersionMap,
+};
 use core::fmt::Write;
 use core::mem::MaybeUninit;
 use core::sync::atomic::{AtomicBool, Ordering};
@@ -10,13 +17,6 @@ use libapi_caliptra::crypto::hash::SHA384_HASH_SIZE;
 use libapi_caliptra::evidence::device_state::DeviceState;
 use libapi_caliptra::evidence::ocp_eat_claims::generate_eat_claims;
 use libapi_caliptra::evidence::pcr_quote::PcrQuote;
-use ocp_eat::ocp_profile::{
-    IntegrityRegisterEntry, IntegrityRegisterIdChoice, TaggedConciseEvidence,
-};
-use ocp_eat::{
-    ClassIdTypeChoice, ClassMap, ConciseEvidence, ConciseEvidenceMap, DigestEntry, EnvironmentMap,
-    EvTriplesMap, EvidenceTripleRecord, MeasurementMap, MeasurementValue, TaggedBytes, VersionMap,
-};
 use spdm_lib::measurements::{MeasurementsError, MeasurementsResult};
 
 const NUM_FW_TARGET_ENV: usize = NUM_DEFAULT_FW_COMPONENTS + NUM_SOC_FW_COMPONENTS;

--- a/platforms/test_harness/Cargo.toml
+++ b/platforms/test_harness/Cargo.toml
@@ -10,8 +10,7 @@ default = []
 fpga_realtime = []
 
 [dependencies]
-caliptra-api.workspace = true
-caliptra-registers.workspace = true
+caliptra-core-tools.workspace = true
 mcu-config.workspace = true
 mcu-config-emulator.workspace = true
 mcu-config-fpga.workspace = true

--- a/registers/generated-emulator/Cargo.toml
+++ b/registers/generated-emulator/Cargo.toml
@@ -7,7 +7,6 @@ edition.workspace = true
 authors.workspace = true
 
 [dependencies]
-caliptra-emu-bus.workspace = true
-caliptra-emu-types.workspace = true
+caliptra-core-tools = { workspace = true, features = ["2_0"] }
 registers-generated.workspace = true
 tock-registers.workspace = true

--- a/registers/generated-emulator/src/axicdma.rs
+++ b/registers/generated-emulator/src/axicdma.rs
@@ -5,14 +5,24 @@
 #[allow(unused_imports)]
 use tock_registers::interfaces::{Readable, Writeable};
 pub trait AxicdmaPeripheral {
-    fn set_dma_ram(&mut self, _ram: std::rc::Rc<std::cell::RefCell<caliptra_emu_bus::Ram>>) {}
-    fn set_dma_rom_sram(&mut self, _ram: std::rc::Rc<std::cell::RefCell<caliptra_emu_bus::Ram>>) {}
+    fn set_dma_ram(
+        &mut self,
+        _ram: std::rc::Rc<std::cell::RefCell<caliptra_core_tools::caliptra_emu_bus::Ram>>,
+    ) {
+    }
+    fn set_dma_rom_sram(
+        &mut self,
+        _ram: std::rc::Rc<std::cell::RefCell<caliptra_core_tools::caliptra_emu_bus::Ram>>,
+    ) {
+    }
     fn register_event_channels(
         &mut self,
-        _events_to_caliptra: std::sync::mpsc::Sender<caliptra_emu_bus::Event>,
-        _events_from_caliptra: std::sync::mpsc::Receiver<caliptra_emu_bus::Event>,
-        _events_to_mcu: std::sync::mpsc::Sender<caliptra_emu_bus::Event>,
-        _events_from_mcu: std::sync::mpsc::Receiver<caliptra_emu_bus::Event>,
+        _events_to_caliptra: std::sync::mpsc::Sender<caliptra_core_tools::caliptra_emu_bus::Event>,
+        _events_from_caliptra: std::sync::mpsc::Receiver<
+            caliptra_core_tools::caliptra_emu_bus::Event,
+        >,
+        _events_to_mcu: std::sync::mpsc::Sender<caliptra_core_tools::caliptra_emu_bus::Event>,
+        _events_from_mcu: std::sync::mpsc::Receiver<caliptra_core_tools::caliptra_emu_bus::Event>,
     ) {
     }
     fn poll(&mut self) {}
@@ -23,7 +33,7 @@ pub trait AxicdmaPeripheral {
     }
     fn read_axicdma_control(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::axicdma::bits::AxicdmaControl::Register,
     > {
@@ -33,11 +43,11 @@ pub trait AxicdmaPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_axicdma_control();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_axicdma_control(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::axicdma::bits::AxicdmaControl::Register,
         >,
@@ -54,7 +64,7 @@ pub trait AxicdmaPeripheral {
     }
     fn read_axicdma_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::axicdma::bits::AxicdmaStatus::Register,
     > {
@@ -64,11 +74,11 @@ pub trait AxicdmaPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_axicdma_status();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_axicdma_status(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::axicdma::bits::AxicdmaStatus::Register,
         >,
@@ -83,7 +93,7 @@ pub trait AxicdmaPeripheral {
             generated.write_axicdma_status(val);
         }
     }
-    fn read_axicdma_src_addr(&mut self) -> caliptra_emu_types::RvData {
+    fn read_axicdma_src_addr(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read axicdma::axicdma_src_addr");
         }
@@ -92,7 +102,7 @@ pub trait AxicdmaPeripheral {
         }
         0
     }
-    fn write_axicdma_src_addr(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_axicdma_src_addr(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write axicdma::axicdma_src_addr = 0x{:08x}",
@@ -103,7 +113,7 @@ pub trait AxicdmaPeripheral {
             generated.write_axicdma_src_addr(val);
         }
     }
-    fn read_axicdma_src_addr_msb(&mut self) -> caliptra_emu_types::RvData {
+    fn read_axicdma_src_addr_msb(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read axicdma::axicdma_src_addr_msb");
         }
@@ -112,7 +122,7 @@ pub trait AxicdmaPeripheral {
         }
         0
     }
-    fn write_axicdma_src_addr_msb(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_axicdma_src_addr_msb(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write axicdma::axicdma_src_addr_msb = 0x{:08x}" , val);
         }
@@ -120,7 +130,7 @@ pub trait AxicdmaPeripheral {
             generated.write_axicdma_src_addr_msb(val);
         }
     }
-    fn read_axicdma_dst_addr(&mut self) -> caliptra_emu_types::RvData {
+    fn read_axicdma_dst_addr(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read axicdma::axicdma_dst_addr");
         }
@@ -129,7 +139,7 @@ pub trait AxicdmaPeripheral {
         }
         0
     }
-    fn write_axicdma_dst_addr(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_axicdma_dst_addr(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write axicdma::axicdma_dst_addr = 0x{:08x}",
@@ -140,7 +150,7 @@ pub trait AxicdmaPeripheral {
             generated.write_axicdma_dst_addr(val);
         }
     }
-    fn read_axicdma_dst_addr_msb(&mut self) -> caliptra_emu_types::RvData {
+    fn read_axicdma_dst_addr_msb(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read axicdma::axicdma_dst_addr_msb");
         }
@@ -149,7 +159,7 @@ pub trait AxicdmaPeripheral {
         }
         0
     }
-    fn write_axicdma_dst_addr_msb(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_axicdma_dst_addr_msb(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write axicdma::axicdma_dst_addr_msb = 0x{:08x}" , val);
         }
@@ -159,7 +169,7 @@ pub trait AxicdmaPeripheral {
     }
     fn read_axicdma_bytes_to_transfer(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::axicdma::bits::AxicdmaBytesToTransfer::Register,
     > {
@@ -171,11 +181,11 @@ pub trait AxicdmaPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_axicdma_bytes_to_transfer();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_axicdma_bytes_to_transfer(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::axicdma::bits::AxicdmaBytesToTransfer::Register,
         >,
@@ -190,24 +200,24 @@ pub trait AxicdmaPeripheral {
 }
 #[derive(Clone, Debug)]
 pub struct AxicdmaGenerated {
-    axicdma_control: caliptra_emu_types::RvData,
-    axicdma_status: caliptra_emu_types::RvData,
-    axicdma_src_addr: caliptra_emu_types::RvData,
-    axicdma_src_addr_msb: caliptra_emu_types::RvData,
-    axicdma_dst_addr: caliptra_emu_types::RvData,
-    axicdma_dst_addr_msb: caliptra_emu_types::RvData,
-    axicdma_bytes_to_transfer: caliptra_emu_types::RvData,
+    axicdma_control: caliptra_core_tools::caliptra_emu_types::RvData,
+    axicdma_status: caliptra_core_tools::caliptra_emu_types::RvData,
+    axicdma_src_addr: caliptra_core_tools::caliptra_emu_types::RvData,
+    axicdma_src_addr_msb: caliptra_core_tools::caliptra_emu_types::RvData,
+    axicdma_dst_addr: caliptra_core_tools::caliptra_emu_types::RvData,
+    axicdma_dst_addr_msb: caliptra_core_tools::caliptra_emu_types::RvData,
+    axicdma_bytes_to_transfer: caliptra_core_tools::caliptra_emu_types::RvData,
 }
 impl Default for AxicdmaGenerated {
     fn default() -> Self {
         Self {
-            axicdma_control: 0 as caliptra_emu_types::RvData,
-            axicdma_status: 0 as caliptra_emu_types::RvData,
-            axicdma_src_addr: 0 as caliptra_emu_types::RvData,
-            axicdma_src_addr_msb: 0 as caliptra_emu_types::RvData,
-            axicdma_dst_addr: 0 as caliptra_emu_types::RvData,
-            axicdma_dst_addr_msb: 0 as caliptra_emu_types::RvData,
-            axicdma_bytes_to_transfer: 0 as caliptra_emu_types::RvData,
+            axicdma_control: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            axicdma_status: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            axicdma_src_addr: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            axicdma_src_addr_msb: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            axicdma_dst_addr: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            axicdma_dst_addr_msb: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            axicdma_bytes_to_transfer: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
         }
     }
 }
@@ -231,18 +241,18 @@ impl AxicdmaPeripheral for AxicdmaGenerated {
     }
     fn read_axicdma_control(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::axicdma::bits::AxicdmaControl::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read axicdma::axicdma_control");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.axicdma_control)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.axicdma_control)
     }
     fn write_axicdma_control(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::axicdma::bits::AxicdmaControl::Register,
         >,
@@ -250,37 +260,37 @@ impl AxicdmaPeripheral for AxicdmaGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write axicdma::axicdma_control = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.axicdma_control;
         let mut new_val = current_val;
-        new_val = (new_val & !(4 as caliptra_emu_types::RvData))
-            | (write_val & (4 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(8 as caliptra_emu_types::RvData))
-            | (write_val & (8 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x10 as caliptra_emu_types::RvData))
-            | (write_val & (0x10 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x20 as caliptra_emu_types::RvData))
-            | (write_val & (0x20 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x1000 as caliptra_emu_types::RvData))
-            | (write_val & (0x1000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x4000 as caliptra_emu_types::RvData))
-            | (write_val & (0x4000 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(4 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (4 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(8 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (8 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x10 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x10 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x20 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x20 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x1000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x1000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x4000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x4000 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.axicdma_control = new_val;
     }
     fn read_axicdma_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::axicdma::bits::AxicdmaStatus::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read axicdma::axicdma_status");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.axicdma_status)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.axicdma_status)
     }
     fn write_axicdma_status(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::axicdma::bits::AxicdmaStatus::Register,
         >,
@@ -288,33 +298,33 @@ impl AxicdmaPeripheral for AxicdmaGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write axicdma::axicdma_status = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.axicdma_status;
         let mut new_val = current_val;
-        new_val = (new_val & !(0x1000 as caliptra_emu_types::RvData))
-            | (write_val & (0x1000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x4000 as caliptra_emu_types::RvData))
-            | (write_val & (0x4000 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x1000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x1000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x4000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x4000 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.axicdma_status = new_val;
     }
-    fn read_axicdma_src_addr(&mut self) -> caliptra_emu_types::RvData {
+    fn read_axicdma_src_addr(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read axicdma::axicdma_src_addr");
         }
         self.axicdma_src_addr
     }
-    fn write_axicdma_src_addr(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_axicdma_src_addr(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write axicdma::axicdma_src_addr = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.axicdma_src_addr;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.axicdma_src_addr = new_val;
     }
-    fn read_axicdma_src_addr_msb(&mut self) -> caliptra_emu_types::RvData {
+    fn read_axicdma_src_addr_msb(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read axicdma::axicdma_src_addr_msb"
@@ -322,35 +332,35 @@ impl AxicdmaPeripheral for AxicdmaGenerated {
         }
         self.axicdma_src_addr_msb
     }
-    fn write_axicdma_src_addr_msb(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_axicdma_src_addr_msb(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write axicdma::axicdma_src_addr_msb = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.axicdma_src_addr_msb;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.axicdma_src_addr_msb = new_val;
     }
-    fn read_axicdma_dst_addr(&mut self) -> caliptra_emu_types::RvData {
+    fn read_axicdma_dst_addr(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read axicdma::axicdma_dst_addr");
         }
         self.axicdma_dst_addr
     }
-    fn write_axicdma_dst_addr(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_axicdma_dst_addr(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write axicdma::axicdma_dst_addr = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.axicdma_dst_addr;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.axicdma_dst_addr = new_val;
     }
-    fn read_axicdma_dst_addr_msb(&mut self) -> caliptra_emu_types::RvData {
+    fn read_axicdma_dst_addr_msb(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read axicdma::axicdma_dst_addr_msb"
@@ -358,20 +368,20 @@ impl AxicdmaPeripheral for AxicdmaGenerated {
         }
         self.axicdma_dst_addr_msb
     }
-    fn write_axicdma_dst_addr_msb(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_axicdma_dst_addr_msb(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write axicdma::axicdma_dst_addr_msb = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.axicdma_dst_addr_msb;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.axicdma_dst_addr_msb = new_val;
     }
     fn read_axicdma_bytes_to_transfer(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::axicdma::bits::AxicdmaBytesToTransfer::Register,
     > {
@@ -380,11 +390,13 @@ impl AxicdmaPeripheral for AxicdmaGenerated {
                 "[EMU] Generated default register handler: read axicdma::axicdma_bytes_to_transfer"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.axicdma_bytes_to_transfer)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.axicdma_bytes_to_transfer,
+        )
     }
     fn write_axicdma_bytes_to_transfer(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::axicdma::bits::AxicdmaBytesToTransfer::Register,
         >,
@@ -392,61 +404,66 @@ impl AxicdmaPeripheral for AxicdmaGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write axicdma::axicdma_bytes_to_transfer = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.axicdma_bytes_to_transfer;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.axicdma_bytes_to_transfer = new_val;
     }
 }
 pub struct AxicdmaBus {
     pub periph: Box<dyn AxicdmaPeripheral>,
 }
-impl caliptra_emu_bus::Bus for AxicdmaBus {
+impl caliptra_core_tools::caliptra_emu_bus::Bus for AxicdmaBus {
     fn read(
         &mut self,
-        size: caliptra_emu_types::RvSize,
-        addr: caliptra_emu_types::RvAddr,
-    ) -> Result<caliptra_emu_types::RvData, caliptra_emu_bus::BusError> {
-        if addr & 0x3 != 0 || size != caliptra_emu_types::RvSize::Word {
-            return Err(caliptra_emu_bus::BusError::LoadAddrMisaligned);
+        size: caliptra_core_tools::caliptra_emu_types::RvSize,
+        addr: caliptra_core_tools::caliptra_emu_types::RvAddr,
+    ) -> Result<
+        caliptra_core_tools::caliptra_emu_types::RvData,
+        caliptra_core_tools::caliptra_emu_bus::BusError,
+    > {
+        if addr & 0x3 != 0 || size != caliptra_core_tools::caliptra_emu_types::RvSize::Word {
+            return Err(caliptra_core_tools::caliptra_emu_bus::BusError::LoadAddrMisaligned);
         }
         match addr {
-            0..4 => Ok(caliptra_emu_types::RvData::from(
+            0..4 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_axicdma_control().reg.get(),
             )),
-            4..8 => Ok(caliptra_emu_types::RvData::from(
+            4..8 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_axicdma_status().reg.get(),
             )),
             0x18..0x1c => Ok(self.periph.read_axicdma_src_addr()),
             0x1c..0x20 => Ok(self.periph.read_axicdma_src_addr_msb()),
             0x20..0x24 => Ok(self.periph.read_axicdma_dst_addr()),
             0x24..0x28 => Ok(self.periph.read_axicdma_dst_addr_msb()),
-            0x28..0x2c => Ok(caliptra_emu_types::RvData::from(
+            0x28..0x2c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_axicdma_bytes_to_transfer().reg.get(),
             )),
-            _ => Err(caliptra_emu_bus::BusError::LoadAccessFault),
+            _ => Err(caliptra_core_tools::caliptra_emu_bus::BusError::LoadAccessFault),
         }
     }
     fn write(
         &mut self,
-        size: caliptra_emu_types::RvSize,
-        addr: caliptra_emu_types::RvAddr,
-        val: caliptra_emu_types::RvData,
-    ) -> Result<(), caliptra_emu_bus::BusError> {
-        if addr & 0x3 != 0 || size != caliptra_emu_types::RvSize::Word {
-            return Err(caliptra_emu_bus::BusError::StoreAddrMisaligned);
+        size: caliptra_core_tools::caliptra_emu_types::RvSize,
+        addr: caliptra_core_tools::caliptra_emu_types::RvAddr,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) -> Result<(), caliptra_core_tools::caliptra_emu_bus::BusError> {
+        if addr & 0x3 != 0 || size != caliptra_core_tools::caliptra_emu_types::RvSize::Word {
+            return Err(caliptra_core_tools::caliptra_emu_bus::BusError::StoreAddrMisaligned);
         }
         match addr {
             0..4 => {
-                self.periph
-                    .write_axicdma_control(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_axicdma_control(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             4..8 => {
-                self.periph
-                    .write_axicdma_status(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_axicdma_status(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0x18..0x1c => {
@@ -466,11 +483,12 @@ impl caliptra_emu_bus::Bus for AxicdmaBus {
                 Ok(())
             }
             0x28..0x2c => {
-                self.periph
-                    .write_axicdma_bytes_to_transfer(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_axicdma_bytes_to_transfer(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
-            _ => Err(caliptra_emu_bus::BusError::StoreAccessFault),
+            _ => Err(caliptra_core_tools::caliptra_emu_bus::BusError::StoreAccessFault),
         }
     }
     fn poll(&mut self) {

--- a/registers/generated-emulator/src/doe_mbox.rs
+++ b/registers/generated-emulator/src/doe_mbox.rs
@@ -5,14 +5,24 @@
 #[allow(unused_imports)]
 use tock_registers::interfaces::{Readable, Writeable};
 pub trait DoeMboxPeripheral {
-    fn set_dma_ram(&mut self, _ram: std::rc::Rc<std::cell::RefCell<caliptra_emu_bus::Ram>>) {}
-    fn set_dma_rom_sram(&mut self, _ram: std::rc::Rc<std::cell::RefCell<caliptra_emu_bus::Ram>>) {}
+    fn set_dma_ram(
+        &mut self,
+        _ram: std::rc::Rc<std::cell::RefCell<caliptra_core_tools::caliptra_emu_bus::Ram>>,
+    ) {
+    }
+    fn set_dma_rom_sram(
+        &mut self,
+        _ram: std::rc::Rc<std::cell::RefCell<caliptra_core_tools::caliptra_emu_bus::Ram>>,
+    ) {
+    }
     fn register_event_channels(
         &mut self,
-        _events_to_caliptra: std::sync::mpsc::Sender<caliptra_emu_bus::Event>,
-        _events_from_caliptra: std::sync::mpsc::Receiver<caliptra_emu_bus::Event>,
-        _events_to_mcu: std::sync::mpsc::Sender<caliptra_emu_bus::Event>,
-        _events_from_mcu: std::sync::mpsc::Receiver<caliptra_emu_bus::Event>,
+        _events_to_caliptra: std::sync::mpsc::Sender<caliptra_core_tools::caliptra_emu_bus::Event>,
+        _events_from_caliptra: std::sync::mpsc::Receiver<
+            caliptra_core_tools::caliptra_emu_bus::Event,
+        >,
+        _events_to_mcu: std::sync::mpsc::Sender<caliptra_core_tools::caliptra_emu_bus::Event>,
+        _events_from_mcu: std::sync::mpsc::Receiver<caliptra_core_tools::caliptra_emu_bus::Event>,
     ) {
     }
     fn poll(&mut self) {}
@@ -23,7 +33,7 @@ pub trait DoeMboxPeripheral {
     }
     fn read_doe_mbox_lock(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::doe_mbox::bits::DoeMboxLock::Register,
     > {
@@ -33,9 +43,9 @@ pub trait DoeMboxPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_doe_mbox_lock();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
-    fn read_doe_mbox_dlen(&mut self) -> caliptra_emu_types::RvData {
+    fn read_doe_mbox_dlen(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read doe_mbox::doe_mbox_dlen");
         }
@@ -44,7 +54,7 @@ pub trait DoeMboxPeripheral {
         }
         0
     }
-    fn write_doe_mbox_dlen(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_doe_mbox_dlen(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write doe_mbox::doe_mbox_dlen = 0x{:08x}",
@@ -57,7 +67,7 @@ pub trait DoeMboxPeripheral {
     }
     fn read_doe_mbox_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::doe_mbox::bits::DoeMboxStatus::Register,
     > {
@@ -67,11 +77,11 @@ pub trait DoeMboxPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_doe_mbox_status();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_doe_mbox_status(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::doe_mbox::bits::DoeMboxStatus::Register,
         >,
@@ -88,7 +98,7 @@ pub trait DoeMboxPeripheral {
     }
     fn read_doe_mbox_event(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::doe_mbox::bits::DoeMboxEvent::Register,
     > {
@@ -98,11 +108,11 @@ pub trait DoeMboxPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_doe_mbox_event();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_doe_mbox_event(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::doe_mbox::bits::DoeMboxEvent::Register,
         >,
@@ -117,7 +127,10 @@ pub trait DoeMboxPeripheral {
             generated.write_doe_mbox_event(val);
         }
     }
-    fn read_doe_mbox_sram(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_doe_mbox_sram(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read doe_mbox::doe_mbox_sram[{}]",
@@ -129,7 +142,11 @@ pub trait DoeMboxPeripheral {
         }
         0
     }
-    fn write_doe_mbox_sram(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    fn write_doe_mbox_sram(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+        index: usize,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write doe_mbox::doe_mbox_sram[{}] = 0x{:08x}",
@@ -143,20 +160,20 @@ pub trait DoeMboxPeripheral {
 }
 #[derive(Clone, Debug)]
 pub struct DoeMboxGenerated {
-    doe_mbox_lock: caliptra_emu_types::RvData,
-    doe_mbox_dlen: caliptra_emu_types::RvData,
-    doe_mbox_status: caliptra_emu_types::RvData,
-    doe_mbox_event: caliptra_emu_types::RvData,
-    doe_mbox_sram: Vec<caliptra_emu_types::RvData>,
+    doe_mbox_lock: caliptra_core_tools::caliptra_emu_types::RvData,
+    doe_mbox_dlen: caliptra_core_tools::caliptra_emu_types::RvData,
+    doe_mbox_status: caliptra_core_tools::caliptra_emu_types::RvData,
+    doe_mbox_event: caliptra_core_tools::caliptra_emu_types::RvData,
+    doe_mbox_sram: Vec<caliptra_core_tools::caliptra_emu_types::RvData>,
 }
 impl Default for DoeMboxGenerated {
     fn default() -> Self {
         Self {
-            doe_mbox_lock: 0 as caliptra_emu_types::RvData,
-            doe_mbox_dlen: 0 as caliptra_emu_types::RvData,
-            doe_mbox_status: 0 as caliptra_emu_types::RvData,
-            doe_mbox_event: 0 as caliptra_emu_types::RvData,
-            doe_mbox_sram: vec![0 as caliptra_emu_types::RvData; 262144],
+            doe_mbox_lock: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            doe_mbox_dlen: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            doe_mbox_status: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            doe_mbox_event: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            doe_mbox_sram: vec![0 as caliptra_core_tools::caliptra_emu_types::RvData; 262144],
         }
     }
 }
@@ -180,46 +197,46 @@ impl DoeMboxPeripheral for DoeMboxGenerated {
     }
     fn read_doe_mbox_lock(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::doe_mbox::bits::DoeMboxLock::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read doe_mbox::doe_mbox_lock");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.doe_mbox_lock)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.doe_mbox_lock)
     }
-    fn read_doe_mbox_dlen(&mut self) -> caliptra_emu_types::RvData {
+    fn read_doe_mbox_dlen(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read doe_mbox::doe_mbox_dlen");
         }
         self.doe_mbox_dlen
     }
-    fn write_doe_mbox_dlen(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_doe_mbox_dlen(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write doe_mbox::doe_mbox_dlen = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.doe_mbox_dlen;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.doe_mbox_dlen = new_val;
     }
     fn read_doe_mbox_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::doe_mbox::bits::DoeMboxStatus::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read doe_mbox::doe_mbox_status");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.doe_mbox_status)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.doe_mbox_status)
     }
     fn write_doe_mbox_status(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::doe_mbox::bits::DoeMboxStatus::Register,
         >,
@@ -227,31 +244,31 @@ impl DoeMboxPeripheral for DoeMboxGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write doe_mbox::doe_mbox_status = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.doe_mbox_status;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(2 as caliptra_emu_types::RvData))
-            | (write_val & (2 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(4 as caliptra_emu_types::RvData))
-            | (write_val & (4 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(2 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(4 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (4 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.doe_mbox_status = new_val;
     }
     fn read_doe_mbox_event(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::doe_mbox::bits::DoeMboxEvent::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read doe_mbox::doe_mbox_event");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.doe_mbox_event)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.doe_mbox_event)
     }
     fn write_doe_mbox_event(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::doe_mbox::bits::DoeMboxEvent::Register,
         >,
@@ -259,16 +276,19 @@ impl DoeMboxPeripheral for DoeMboxGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write doe_mbox::doe_mbox_event = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.doe_mbox_event;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(2 as caliptra_emu_types::RvData))
-            | (write_val & (2 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(2 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.doe_mbox_event = new_val;
     }
-    fn read_doe_mbox_sram(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_doe_mbox_sram(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read doe_mbox::doe_mbox_sram[{}]",
@@ -277,53 +297,60 @@ impl DoeMboxPeripheral for DoeMboxGenerated {
         }
         self.doe_mbox_sram[index]
     }
-    fn write_doe_mbox_sram(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    fn write_doe_mbox_sram(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+        index: usize,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write doe_mbox::doe_mbox_sram[{}] = 0x{:08x}" , index , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.doe_mbox_sram[index];
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.doe_mbox_sram[index] = new_val;
     }
 }
 pub struct DoeMboxBus {
     pub periph: Box<dyn DoeMboxPeripheral>,
 }
-impl caliptra_emu_bus::Bus for DoeMboxBus {
+impl caliptra_core_tools::caliptra_emu_bus::Bus for DoeMboxBus {
     fn read(
         &mut self,
-        size: caliptra_emu_types::RvSize,
-        addr: caliptra_emu_types::RvAddr,
-    ) -> Result<caliptra_emu_types::RvData, caliptra_emu_bus::BusError> {
-        if addr & 0x3 != 0 || size != caliptra_emu_types::RvSize::Word {
-            return Err(caliptra_emu_bus::BusError::LoadAddrMisaligned);
+        size: caliptra_core_tools::caliptra_emu_types::RvSize,
+        addr: caliptra_core_tools::caliptra_emu_types::RvAddr,
+    ) -> Result<
+        caliptra_core_tools::caliptra_emu_types::RvData,
+        caliptra_core_tools::caliptra_emu_bus::BusError,
+    > {
+        if addr & 0x3 != 0 || size != caliptra_core_tools::caliptra_emu_types::RvSize::Word {
+            return Err(caliptra_core_tools::caliptra_emu_bus::BusError::LoadAddrMisaligned);
         }
         match addr {
-            0..4 => Ok(caliptra_emu_types::RvData::from(
+            0..4 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_doe_mbox_lock().reg.get(),
             )),
             4..8 => Ok(self.periph.read_doe_mbox_dlen()),
-            8..0xc => Ok(caliptra_emu_types::RvData::from(
+            8..0xc => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_doe_mbox_status().reg.get(),
             )),
-            0xc..0x10 => Ok(caliptra_emu_types::RvData::from(
+            0xc..0x10 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_doe_mbox_event().reg.get(),
             )),
             0x1000..0x10_1000 => Ok(self.periph.read_doe_mbox_sram((addr as usize - 0x1000) / 4)),
-            _ => Err(caliptra_emu_bus::BusError::LoadAccessFault),
+            _ => Err(caliptra_core_tools::caliptra_emu_bus::BusError::LoadAccessFault),
         }
     }
     fn write(
         &mut self,
-        size: caliptra_emu_types::RvSize,
-        addr: caliptra_emu_types::RvAddr,
-        val: caliptra_emu_types::RvData,
-    ) -> Result<(), caliptra_emu_bus::BusError> {
-        if addr & 0x3 != 0 || size != caliptra_emu_types::RvSize::Word {
-            return Err(caliptra_emu_bus::BusError::StoreAddrMisaligned);
+        size: caliptra_core_tools::caliptra_emu_types::RvSize,
+        addr: caliptra_core_tools::caliptra_emu_types::RvAddr,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) -> Result<(), caliptra_core_tools::caliptra_emu_bus::BusError> {
+        if addr & 0x3 != 0 || size != caliptra_core_tools::caliptra_emu_types::RvSize::Word {
+            return Err(caliptra_core_tools::caliptra_emu_bus::BusError::StoreAddrMisaligned);
         }
         match addr {
             0..4 => Ok(()),
@@ -332,13 +359,15 @@ impl caliptra_emu_bus::Bus for DoeMboxBus {
                 Ok(())
             }
             8..0xc => {
-                self.periph
-                    .write_doe_mbox_status(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_doe_mbox_status(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0xc..0x10 => {
-                self.periph
-                    .write_doe_mbox_event(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_doe_mbox_event(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0x1000..0x10_1000 => {
@@ -346,7 +375,7 @@ impl caliptra_emu_bus::Bus for DoeMboxBus {
                     .write_doe_mbox_sram(val, (addr as usize - 0x1000) / 4);
                 Ok(())
             }
-            _ => Err(caliptra_emu_bus::BusError::StoreAccessFault),
+            _ => Err(caliptra_core_tools::caliptra_emu_bus::BusError::StoreAccessFault),
         }
     }
     fn poll(&mut self) {

--- a/registers/generated-emulator/src/el2_pic.rs
+++ b/registers/generated-emulator/src/el2_pic.rs
@@ -5,14 +5,24 @@
 #[allow(unused_imports)]
 use tock_registers::interfaces::{Readable, Writeable};
 pub trait El2PicPeripheral {
-    fn set_dma_ram(&mut self, _ram: std::rc::Rc<std::cell::RefCell<caliptra_emu_bus::Ram>>) {}
-    fn set_dma_rom_sram(&mut self, _ram: std::rc::Rc<std::cell::RefCell<caliptra_emu_bus::Ram>>) {}
+    fn set_dma_ram(
+        &mut self,
+        _ram: std::rc::Rc<std::cell::RefCell<caliptra_core_tools::caliptra_emu_bus::Ram>>,
+    ) {
+    }
+    fn set_dma_rom_sram(
+        &mut self,
+        _ram: std::rc::Rc<std::cell::RefCell<caliptra_core_tools::caliptra_emu_bus::Ram>>,
+    ) {
+    }
     fn register_event_channels(
         &mut self,
-        _events_to_caliptra: std::sync::mpsc::Sender<caliptra_emu_bus::Event>,
-        _events_from_caliptra: std::sync::mpsc::Receiver<caliptra_emu_bus::Event>,
-        _events_to_mcu: std::sync::mpsc::Sender<caliptra_emu_bus::Event>,
-        _events_from_mcu: std::sync::mpsc::Receiver<caliptra_emu_bus::Event>,
+        _events_to_caliptra: std::sync::mpsc::Sender<caliptra_core_tools::caliptra_emu_bus::Event>,
+        _events_from_caliptra: std::sync::mpsc::Receiver<
+            caliptra_core_tools::caliptra_emu_bus::Event,
+        >,
+        _events_to_mcu: std::sync::mpsc::Sender<caliptra_core_tools::caliptra_emu_bus::Event>,
+        _events_from_mcu: std::sync::mpsc::Receiver<caliptra_core_tools::caliptra_emu_bus::Event>,
     ) {
     }
     fn poll(&mut self) {}
@@ -24,7 +34,7 @@ pub trait El2PicPeripheral {
     fn read_meipl(
         &mut self,
         index: usize,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::el2_pic_ctrl::bits::Meipl::Register,
     > {
@@ -37,11 +47,11 @@ pub trait El2PicPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_meipl(index);
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_meipl(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::el2_pic_ctrl::bits::Meipl::Register,
         >,
@@ -61,7 +71,7 @@ pub trait El2PicPeripheral {
     fn read_meip(
         &mut self,
         index: usize,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::el2_pic_ctrl::bits::Meip::Register,
     > {
@@ -74,12 +84,12 @@ pub trait El2PicPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_meip(index);
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_meie(
         &mut self,
         index: usize,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::el2_pic_ctrl::bits::Meie::Register,
     > {
@@ -92,11 +102,11 @@ pub trait El2PicPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_meie(index);
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_meie(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::el2_pic_ctrl::bits::Meie::Register,
         >,
@@ -115,7 +125,7 @@ pub trait El2PicPeripheral {
     }
     fn read_mpiccfg(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::el2_pic_ctrl::bits::Mpiccfg::Register,
     > {
@@ -125,11 +135,11 @@ pub trait El2PicPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mpiccfg();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_mpiccfg(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::el2_pic_ctrl::bits::Mpiccfg::Register,
         >,
@@ -147,7 +157,7 @@ pub trait El2PicPeripheral {
     fn read_meigwctrl(
         &mut self,
         index: usize,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::el2_pic_ctrl::bits::Meigwctrl::Register,
     > {
@@ -160,11 +170,11 @@ pub trait El2PicPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_meigwctrl(index);
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_meigwctrl(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::el2_pic_ctrl::bits::Meigwctrl::Register,
         >,
@@ -181,7 +191,7 @@ pub trait El2PicPeripheral {
             generated.write_meigwctrl(val, index);
         }
     }
-    fn read_meigwclr(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_meigwclr(&mut self, index: usize) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read el2_pic::meigwclr[{}]",
@@ -193,7 +203,11 @@ pub trait El2PicPeripheral {
         }
         0
     }
-    fn write_meigwclr(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    fn write_meigwclr(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+        index: usize,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write el2_pic::meigwclr[{}] = 0x{:08x}",
@@ -207,22 +221,22 @@ pub trait El2PicPeripheral {
 }
 #[derive(Clone, Debug)]
 pub struct El2PicGenerated {
-    meipl: Vec<caliptra_emu_types::RvData>,
-    meip: Vec<caliptra_emu_types::RvData>,
-    meie: Vec<caliptra_emu_types::RvData>,
-    mpiccfg: caliptra_emu_types::RvData,
-    meigwctrl: Vec<caliptra_emu_types::RvData>,
-    meigwclr: Vec<caliptra_emu_types::RvData>,
+    meipl: Vec<caliptra_core_tools::caliptra_emu_types::RvData>,
+    meip: Vec<caliptra_core_tools::caliptra_emu_types::RvData>,
+    meie: Vec<caliptra_core_tools::caliptra_emu_types::RvData>,
+    mpiccfg: caliptra_core_tools::caliptra_emu_types::RvData,
+    meigwctrl: Vec<caliptra_core_tools::caliptra_emu_types::RvData>,
+    meigwclr: Vec<caliptra_core_tools::caliptra_emu_types::RvData>,
 }
 impl Default for El2PicGenerated {
     fn default() -> Self {
         Self {
-            meipl: vec![0 as caliptra_emu_types::RvData; 256],
-            meip: vec![0 as caliptra_emu_types::RvData; 256],
-            meie: vec![0 as caliptra_emu_types::RvData; 256],
-            mpiccfg: 0 as caliptra_emu_types::RvData,
-            meigwctrl: vec![0 as caliptra_emu_types::RvData; 256],
-            meigwclr: vec![0 as caliptra_emu_types::RvData; 256],
+            meipl: vec![0 as caliptra_core_tools::caliptra_emu_types::RvData; 256],
+            meip: vec![0 as caliptra_core_tools::caliptra_emu_types::RvData; 256],
+            meie: vec![0 as caliptra_core_tools::caliptra_emu_types::RvData; 256],
+            mpiccfg: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            meigwctrl: vec![0 as caliptra_core_tools::caliptra_emu_types::RvData; 256],
+            meigwclr: vec![0 as caliptra_core_tools::caliptra_emu_types::RvData; 256],
         }
     }
 }
@@ -247,7 +261,7 @@ impl El2PicPeripheral for El2PicGenerated {
     fn read_meipl(
         &mut self,
         index: usize,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::el2_pic_ctrl::bits::Meipl::Register,
     > {
@@ -257,11 +271,11 @@ impl El2PicPeripheral for El2PicGenerated {
                 index
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.meipl[index])
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.meipl[index])
     }
     fn write_meipl(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::el2_pic_ctrl::bits::Meipl::Register,
         >,
@@ -274,17 +288,17 @@ impl El2PicPeripheral for El2PicGenerated {
                 val.reg.get()
             );
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.meipl[index];
         let mut new_val = current_val;
-        new_val = (new_val & !(0xf as caliptra_emu_types::RvData))
-            | (write_val & (0xf as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xf as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xf as caliptra_core_tools::caliptra_emu_types::RvData));
         self.meipl[index] = new_val;
     }
     fn read_meip(
         &mut self,
         index: usize,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::el2_pic_ctrl::bits::Meip::Register,
     > {
@@ -294,12 +308,12 @@ impl El2PicPeripheral for El2PicGenerated {
                 index
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.meip[index])
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.meip[index])
     }
     fn read_meie(
         &mut self,
         index: usize,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::el2_pic_ctrl::bits::Meie::Register,
     > {
@@ -309,11 +323,11 @@ impl El2PicPeripheral for El2PicGenerated {
                 index
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.meie[index])
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.meie[index])
     }
     fn write_meie(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::el2_pic_ctrl::bits::Meie::Register,
         >,
@@ -326,27 +340,27 @@ impl El2PicPeripheral for El2PicGenerated {
                 val.reg.get()
             );
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.meie[index];
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.meie[index] = new_val;
     }
     fn read_mpiccfg(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::el2_pic_ctrl::bits::Mpiccfg::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read el2_pic::mpiccfg");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.mpiccfg)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.mpiccfg)
     }
     fn write_mpiccfg(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::el2_pic_ctrl::bits::Mpiccfg::Register,
         >,
@@ -357,17 +371,17 @@ impl El2PicPeripheral for El2PicGenerated {
                 val.reg.get()
             );
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mpiccfg;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mpiccfg = new_val;
     }
     fn read_meigwctrl(
         &mut self,
         index: usize,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::el2_pic_ctrl::bits::Meigwctrl::Register,
     > {
@@ -377,11 +391,11 @@ impl El2PicPeripheral for El2PicGenerated {
                 index
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.meigwctrl[index])
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.meigwctrl[index])
     }
     fn write_meigwctrl(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::el2_pic_ctrl::bits::Meigwctrl::Register,
         >,
@@ -394,16 +408,16 @@ impl El2PicPeripheral for El2PicGenerated {
                 val.reg.get()
             );
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.meigwctrl[index];
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(2 as caliptra_emu_types::RvData))
-            | (write_val & (2 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(2 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.meigwctrl[index] = new_val;
     }
-    fn read_meigwclr(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_meigwclr(&mut self, index: usize) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read el2_pic::meigwclr[{}]",
@@ -412,75 +426,82 @@ impl El2PicPeripheral for El2PicGenerated {
         }
         self.meigwclr[index]
     }
-    fn write_meigwclr(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    fn write_meigwclr(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+        index: usize,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: write el2_pic::meigwclr[{}] = 0x{:08x}",
                 index, val
             );
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.meigwclr[index];
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.meigwclr[index] = new_val;
     }
 }
 pub struct El2PicBus {
     pub periph: Box<dyn El2PicPeripheral>,
 }
-impl caliptra_emu_bus::Bus for El2PicBus {
+impl caliptra_core_tools::caliptra_emu_bus::Bus for El2PicBus {
     fn read(
         &mut self,
-        size: caliptra_emu_types::RvSize,
-        addr: caliptra_emu_types::RvAddr,
-    ) -> Result<caliptra_emu_types::RvData, caliptra_emu_bus::BusError> {
-        if addr & 0x3 != 0 || size != caliptra_emu_types::RvSize::Word {
-            return Err(caliptra_emu_bus::BusError::LoadAddrMisaligned);
+        size: caliptra_core_tools::caliptra_emu_types::RvSize,
+        addr: caliptra_core_tools::caliptra_emu_types::RvAddr,
+    ) -> Result<
+        caliptra_core_tools::caliptra_emu_types::RvData,
+        caliptra_core_tools::caliptra_emu_bus::BusError,
+    > {
+        if addr & 0x3 != 0 || size != caliptra_core_tools::caliptra_emu_types::RvSize::Word {
+            return Err(caliptra_core_tools::caliptra_emu_bus::BusError::LoadAddrMisaligned);
         }
         match addr {
-            0..0x400 => Ok(caliptra_emu_types::RvData::from(
+            0..0x400 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_meipl(addr as usize / 4).reg.get(),
             )),
-            0x1000..0x1400 => Ok(caliptra_emu_types::RvData::from(
+            0x1000..0x1400 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_meip((addr as usize - 0x1000) / 4)
                     .reg
                     .get(),
             )),
-            0x2000..0x2400 => Ok(caliptra_emu_types::RvData::from(
+            0x2000..0x2400 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_meie((addr as usize - 0x2000) / 4)
                     .reg
                     .get(),
             )),
-            0x3000..0x3004 => Ok(caliptra_emu_types::RvData::from(
+            0x3000..0x3004 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_mpiccfg().reg.get(),
             )),
-            0x4000..0x4400 => Ok(caliptra_emu_types::RvData::from(
+            0x4000..0x4400 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_meigwctrl((addr as usize - 0x4000) / 4)
                     .reg
                     .get(),
             )),
             0x5000..0x5400 => Ok(self.periph.read_meigwclr((addr as usize - 0x5000) / 4)),
-            _ => Err(caliptra_emu_bus::BusError::LoadAccessFault),
+            _ => Err(caliptra_core_tools::caliptra_emu_bus::BusError::LoadAccessFault),
         }
     }
     fn write(
         &mut self,
-        size: caliptra_emu_types::RvSize,
-        addr: caliptra_emu_types::RvAddr,
-        val: caliptra_emu_types::RvData,
-    ) -> Result<(), caliptra_emu_bus::BusError> {
-        if addr & 0x3 != 0 || size != caliptra_emu_types::RvSize::Word {
-            return Err(caliptra_emu_bus::BusError::StoreAddrMisaligned);
+        size: caliptra_core_tools::caliptra_emu_types::RvSize,
+        addr: caliptra_core_tools::caliptra_emu_types::RvAddr,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) -> Result<(), caliptra_core_tools::caliptra_emu_bus::BusError> {
+        if addr & 0x3 != 0 || size != caliptra_core_tools::caliptra_emu_types::RvSize::Word {
+            return Err(caliptra_core_tools::caliptra_emu_bus::BusError::StoreAddrMisaligned);
         }
         match addr {
             0..0x400 => {
                 self.periph.write_meipl(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                     addr as usize / 4,
                 );
                 Ok(())
@@ -488,19 +509,20 @@ impl caliptra_emu_bus::Bus for El2PicBus {
             0x1000..0x1400 => Ok(()),
             0x2000..0x2400 => {
                 self.periph.write_meie(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                     (addr as usize - 0x2000) / 4,
                 );
                 Ok(())
             }
             0x3000..0x3004 => {
-                self.periph
-                    .write_mpiccfg(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_mpiccfg(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0x4000..0x4400 => {
                 self.periph.write_meigwctrl(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                     (addr as usize - 0x4000) / 4,
                 );
                 Ok(())
@@ -510,7 +532,7 @@ impl caliptra_emu_bus::Bus for El2PicBus {
                     .write_meigwclr(val, (addr as usize - 0x5000) / 4);
                 Ok(())
             }
-            _ => Err(caliptra_emu_bus::BusError::StoreAccessFault),
+            _ => Err(caliptra_core_tools::caliptra_emu_bus::BusError::StoreAccessFault),
         }
     }
     fn poll(&mut self) {

--- a/registers/generated-emulator/src/i3c.rs
+++ b/registers/generated-emulator/src/i3c.rs
@@ -5,14 +5,24 @@
 #[allow(unused_imports)]
 use tock_registers::interfaces::{Readable, Writeable};
 pub trait I3cPeripheral {
-    fn set_dma_ram(&mut self, _ram: std::rc::Rc<std::cell::RefCell<caliptra_emu_bus::Ram>>) {}
-    fn set_dma_rom_sram(&mut self, _ram: std::rc::Rc<std::cell::RefCell<caliptra_emu_bus::Ram>>) {}
+    fn set_dma_ram(
+        &mut self,
+        _ram: std::rc::Rc<std::cell::RefCell<caliptra_core_tools::caliptra_emu_bus::Ram>>,
+    ) {
+    }
+    fn set_dma_rom_sram(
+        &mut self,
+        _ram: std::rc::Rc<std::cell::RefCell<caliptra_core_tools::caliptra_emu_bus::Ram>>,
+    ) {
+    }
     fn register_event_channels(
         &mut self,
-        _events_to_caliptra: std::sync::mpsc::Sender<caliptra_emu_bus::Event>,
-        _events_from_caliptra: std::sync::mpsc::Receiver<caliptra_emu_bus::Event>,
-        _events_to_mcu: std::sync::mpsc::Sender<caliptra_emu_bus::Event>,
-        _events_from_mcu: std::sync::mpsc::Receiver<caliptra_emu_bus::Event>,
+        _events_to_caliptra: std::sync::mpsc::Sender<caliptra_core_tools::caliptra_emu_bus::Event>,
+        _events_from_caliptra: std::sync::mpsc::Receiver<
+            caliptra_core_tools::caliptra_emu_bus::Event,
+        >,
+        _events_to_mcu: std::sync::mpsc::Sender<caliptra_core_tools::caliptra_emu_bus::Event>,
+        _events_from_mcu: std::sync::mpsc::Receiver<caliptra_core_tools::caliptra_emu_bus::Event>,
     ) {
     }
     fn poll(&mut self) {}
@@ -21,7 +31,7 @@ pub trait I3cPeripheral {
     fn generated(&mut self) -> Option<&mut I3cGenerated> {
         None
     }
-    fn read_dat(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_dat(&mut self, index: usize) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read i3c::dat[{}]",
@@ -33,7 +43,7 @@ pub trait I3cPeripheral {
         }
         0
     }
-    fn write_dat(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    fn write_dat(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData, index: usize) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write i3c::dat[{}] = 0x{:08x}",
@@ -44,7 +54,7 @@ pub trait I3cPeripheral {
             generated.write_dat(val, index);
         }
     }
-    fn read_dct(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_dct(&mut self, index: usize) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read i3c::dct[{}]",
@@ -56,7 +66,7 @@ pub trait I3cPeripheral {
         }
         0
     }
-    fn write_dct(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    fn write_dct(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData, index: usize) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write i3c::dct[{}] = 0x{:08x}",
@@ -67,7 +77,7 @@ pub trait I3cPeripheral {
             generated.write_dct(val, index);
         }
     }
-    fn read_i3c_base_hci_version(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_base_hci_version(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read i3c::i3c_base_hci_version");
         }
@@ -78,19 +88,21 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_base_hc_control(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::HcControl::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::HcControl::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read i3c::i3c_base_hc_control");
         }
         if let Some(generated) = self.generated() {
             return generated.read_i3c_base_hc_control();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_base_hc_control(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::HcControl::Register,
         >,
@@ -107,7 +119,7 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_base_controller_device_addr(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::ControllerDeviceAddr::Register,
     > {
@@ -119,11 +131,11 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_base_controller_device_addr();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_base_controller_device_addr(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::ControllerDeviceAddr::Register,
         >,
@@ -137,7 +149,7 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_base_hc_capabilities(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::HcCapabilities::Register,
     > {
@@ -147,11 +159,11 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_base_hc_capabilities();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_i3c_base_reset_control(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::ResetControl::Register,
     > {
@@ -161,11 +173,11 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_base_reset_control();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_base_reset_control(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::ResetControl::Register,
         >,
@@ -182,7 +194,7 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_base_present_state(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::PresentState::Register,
     > {
@@ -192,11 +204,11 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_base_present_state();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_i3c_base_intr_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::IntrStatus::Register,
     > {
@@ -206,11 +218,11 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_base_intr_status();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_base_intr_status(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::IntrStatus::Register,
         >,
@@ -227,7 +239,7 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_base_intr_status_enable(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::IntrStatusEnable::Register,
     > {
@@ -237,11 +249,11 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_base_intr_status_enable();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_base_intr_status_enable(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::IntrStatusEnable::Register,
         >,
@@ -255,7 +267,7 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_base_intr_signal_enable(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::IntrSignalEnable::Register,
     > {
@@ -265,11 +277,11 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_base_intr_signal_enable();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_base_intr_signal_enable(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::IntrSignalEnable::Register,
         >,
@@ -283,7 +295,7 @@ pub trait I3cPeripheral {
     }
     fn write_i3c_base_intr_force(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::IntrForce::Register,
         >,
@@ -300,7 +312,7 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_base_dat_section_offset(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::DatSectionOffset::Register,
     > {
@@ -310,11 +322,11 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_base_dat_section_offset();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_i3c_base_dct_section_offset(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::DctSectionOffset::Register,
     > {
@@ -324,11 +336,11 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_base_dct_section_offset();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_base_dct_section_offset(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::DctSectionOffset::Register,
         >,
@@ -342,7 +354,7 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_base_ring_headers_section_offset(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::RingHeadersSectionOffset::Register,
     > {
@@ -352,11 +364,11 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_base_ring_headers_section_offset();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_i3c_base_pio_section_offset(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::PioSectionOffset::Register,
     > {
@@ -366,11 +378,11 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_base_pio_section_offset();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_i3c_base_ext_caps_section_offset(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::ExtCapsSectionOffset::Register,
     > {
@@ -382,11 +394,11 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_base_ext_caps_section_offset();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_i3c_base_int_ctrl_cmds_en(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::IntCtrlCmdsEn::Register,
     > {
@@ -396,11 +408,11 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_base_int_ctrl_cmds_en();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_i3c_base_ibi_notify_ctrl(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::IbiNotifyCtrl::Register,
     > {
@@ -410,11 +422,11 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_base_ibi_notify_ctrl();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_base_ibi_notify_ctrl(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::IbiNotifyCtrl::Register,
         >,
@@ -428,7 +440,7 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_base_ibi_data_abort_ctrl(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::IbiDataAbortCtrl::Register,
     > {
@@ -438,11 +450,11 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_base_ibi_data_abort_ctrl();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_base_ibi_data_abort_ctrl(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::IbiDataAbortCtrl::Register,
         >,
@@ -456,7 +468,7 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_base_dev_ctx_base_lo(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::DevCtxBaseLo::Register,
     > {
@@ -466,11 +478,11 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_base_dev_ctx_base_lo();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_base_dev_ctx_base_lo(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::DevCtxBaseLo::Register,
         >,
@@ -484,7 +496,7 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_base_dev_ctx_base_hi(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::DevCtxBaseHi::Register,
     > {
@@ -494,11 +506,11 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_base_dev_ctx_base_hi();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_base_dev_ctx_base_hi(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::DevCtxBaseHi::Register,
         >,
@@ -512,17 +524,22 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_base_dev_ctx_sg(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::DevCtxSg::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::DevCtxSg::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read i3c::i3c_base_dev_ctx_sg");
         }
         if let Some(generated) = self.generated() {
             return generated.read_i3c_base_dev_ctx_sg();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
-    fn write_piocontrol_command_port(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_piocontrol_command_port(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write i3c::piocontrol_command_port = 0x{:08x}",
@@ -533,7 +550,7 @@ pub trait I3cPeripheral {
             generated.write_piocontrol_command_port(val);
         }
     }
-    fn read_piocontrol_response_port(&mut self) -> caliptra_emu_types::RvData {
+    fn read_piocontrol_response_port(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read i3c::piocontrol_response_port");
         }
@@ -542,7 +559,10 @@ pub trait I3cPeripheral {
         }
         0
     }
-    fn write_piocontrol_tx_data_port(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_piocontrol_tx_data_port(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write i3c::piocontrol_tx_data_port = 0x{:08x}",
@@ -553,7 +573,7 @@ pub trait I3cPeripheral {
             generated.write_piocontrol_tx_data_port(val);
         }
     }
-    fn read_piocontrol_rx_data_port(&mut self) -> caliptra_emu_types::RvData {
+    fn read_piocontrol_rx_data_port(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read i3c::piocontrol_rx_data_port");
         }
@@ -562,7 +582,7 @@ pub trait I3cPeripheral {
         }
         0
     }
-    fn read_piocontrol_ibi_port(&mut self) -> caliptra_emu_types::RvData {
+    fn read_piocontrol_ibi_port(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read i3c::piocontrol_ibi_port");
         }
@@ -573,7 +593,7 @@ pub trait I3cPeripheral {
     }
     fn read_piocontrol_queue_thld_ctrl(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::QueueThldCtrl::Register,
     > {
@@ -583,11 +603,11 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_piocontrol_queue_thld_ctrl();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_piocontrol_queue_thld_ctrl(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::QueueThldCtrl::Register,
         >,
@@ -601,7 +621,7 @@ pub trait I3cPeripheral {
     }
     fn read_piocontrol_data_buffer_thld_ctrl(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::DataBufferThldCtrl::Register,
     > {
@@ -613,11 +633,11 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_piocontrol_data_buffer_thld_ctrl();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_piocontrol_data_buffer_thld_ctrl(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::DataBufferThldCtrl::Register,
         >,
@@ -631,19 +651,21 @@ pub trait I3cPeripheral {
     }
     fn read_piocontrol_queue_size(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::QueueSize::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::QueueSize::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read i3c::piocontrol_queue_size");
         }
         if let Some(generated) = self.generated() {
             return generated.read_piocontrol_queue_size();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_piocontrol_alt_queue_size(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::AltQueueSize::Register,
     > {
@@ -653,11 +675,11 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_piocontrol_alt_queue_size();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_piocontrol_pio_intr_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::PioIntrStatus::Register,
     > {
@@ -667,11 +689,11 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_piocontrol_pio_intr_status();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_piocontrol_pio_intr_status(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::PioIntrStatus::Register,
         >,
@@ -685,7 +707,7 @@ pub trait I3cPeripheral {
     }
     fn read_piocontrol_pio_intr_status_enable(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::PioIntrStatusEnable::Register,
     > {
@@ -697,11 +719,11 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_piocontrol_pio_intr_status_enable();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_piocontrol_pio_intr_status_enable(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::PioIntrStatusEnable::Register,
         >,
@@ -715,7 +737,7 @@ pub trait I3cPeripheral {
     }
     fn read_piocontrol_pio_intr_signal_enable(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::PioIntrSignalEnable::Register,
     > {
@@ -727,11 +749,11 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_piocontrol_pio_intr_signal_enable();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_piocontrol_pio_intr_signal_enable(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::PioIntrSignalEnable::Register,
         >,
@@ -745,7 +767,7 @@ pub trait I3cPeripheral {
     }
     fn write_piocontrol_pio_intr_force(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::PioIntrForce::Register,
         >,
@@ -759,7 +781,7 @@ pub trait I3cPeripheral {
     }
     fn read_piocontrol_pio_control(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::PioControl::Register,
     > {
@@ -769,11 +791,11 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_piocontrol_pio_control();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_piocontrol_pio_control(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::PioControl::Register,
         >,
@@ -790,7 +812,7 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_sec_fw_recovery_if_extcap_header(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::ExtcapHeader::Register,
     > {
@@ -800,9 +822,11 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_sec_fw_recovery_if_extcap_header();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
-    fn read_i3c_ec_sec_fw_recovery_if_prot_cap_0(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_sec_fw_recovery_if_prot_cap_0(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read i3c::i3c_ec_sec_fw_recovery_if_prot_cap_0");
         }
@@ -811,7 +835,9 @@ pub trait I3cPeripheral {
         }
         0
     }
-    fn read_i3c_ec_sec_fw_recovery_if_prot_cap_1(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_sec_fw_recovery_if_prot_cap_1(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read i3c::i3c_ec_sec_fw_recovery_if_prot_cap_1");
         }
@@ -822,19 +848,21 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_sec_fw_recovery_if_prot_cap_2(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::ProtCap2::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::ProtCap2::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read i3c::i3c_ec_sec_fw_recovery_if_prot_cap_2");
         }
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_sec_fw_recovery_if_prot_cap_2();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_sec_fw_recovery_if_prot_cap_2(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::ProtCap2::Register,
         >,
@@ -848,19 +876,21 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_sec_fw_recovery_if_prot_cap_3(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::ProtCap3::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::ProtCap3::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read i3c::i3c_ec_sec_fw_recovery_if_prot_cap_3");
         }
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_sec_fw_recovery_if_prot_cap_3();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_sec_fw_recovery_if_prot_cap_3(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::ProtCap3::Register,
         >,
@@ -874,19 +904,21 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_sec_fw_recovery_if_device_id_0(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::DeviceId0::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::DeviceId0::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read i3c::i3c_ec_sec_fw_recovery_if_device_id_0");
         }
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_sec_fw_recovery_if_device_id_0();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_sec_fw_recovery_if_device_id_0(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::DeviceId0::Register,
         >,
@@ -898,7 +930,9 @@ pub trait I3cPeripheral {
             generated.write_i3c_ec_sec_fw_recovery_if_device_id_0(val);
         }
     }
-    fn read_i3c_ec_sec_fw_recovery_if_device_id_1(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_sec_fw_recovery_if_device_id_1(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read i3c::i3c_ec_sec_fw_recovery_if_device_id_1");
         }
@@ -907,7 +941,10 @@ pub trait I3cPeripheral {
         }
         0
     }
-    fn write_i3c_ec_sec_fw_recovery_if_device_id_1(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_sec_fw_recovery_if_device_id_1(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write i3c::i3c_ec_sec_fw_recovery_if_device_id_1 = 0x{:08x}" , val);
         }
@@ -915,7 +952,9 @@ pub trait I3cPeripheral {
             generated.write_i3c_ec_sec_fw_recovery_if_device_id_1(val);
         }
     }
-    fn read_i3c_ec_sec_fw_recovery_if_device_id_2(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_sec_fw_recovery_if_device_id_2(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read i3c::i3c_ec_sec_fw_recovery_if_device_id_2");
         }
@@ -924,7 +963,10 @@ pub trait I3cPeripheral {
         }
         0
     }
-    fn write_i3c_ec_sec_fw_recovery_if_device_id_2(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_sec_fw_recovery_if_device_id_2(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write i3c::i3c_ec_sec_fw_recovery_if_device_id_2 = 0x{:08x}" , val);
         }
@@ -932,7 +974,9 @@ pub trait I3cPeripheral {
             generated.write_i3c_ec_sec_fw_recovery_if_device_id_2(val);
         }
     }
-    fn read_i3c_ec_sec_fw_recovery_if_device_id_3(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_sec_fw_recovery_if_device_id_3(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read i3c::i3c_ec_sec_fw_recovery_if_device_id_3");
         }
@@ -941,7 +985,10 @@ pub trait I3cPeripheral {
         }
         0
     }
-    fn write_i3c_ec_sec_fw_recovery_if_device_id_3(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_sec_fw_recovery_if_device_id_3(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write i3c::i3c_ec_sec_fw_recovery_if_device_id_3 = 0x{:08x}" , val);
         }
@@ -949,7 +996,9 @@ pub trait I3cPeripheral {
             generated.write_i3c_ec_sec_fw_recovery_if_device_id_3(val);
         }
     }
-    fn read_i3c_ec_sec_fw_recovery_if_device_id_4(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_sec_fw_recovery_if_device_id_4(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read i3c::i3c_ec_sec_fw_recovery_if_device_id_4");
         }
@@ -958,7 +1007,10 @@ pub trait I3cPeripheral {
         }
         0
     }
-    fn write_i3c_ec_sec_fw_recovery_if_device_id_4(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_sec_fw_recovery_if_device_id_4(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write i3c::i3c_ec_sec_fw_recovery_if_device_id_4 = 0x{:08x}" , val);
         }
@@ -966,7 +1018,9 @@ pub trait I3cPeripheral {
             generated.write_i3c_ec_sec_fw_recovery_if_device_id_4(val);
         }
     }
-    fn read_i3c_ec_sec_fw_recovery_if_device_id_5(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_sec_fw_recovery_if_device_id_5(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read i3c::i3c_ec_sec_fw_recovery_if_device_id_5");
         }
@@ -975,7 +1029,10 @@ pub trait I3cPeripheral {
         }
         0
     }
-    fn write_i3c_ec_sec_fw_recovery_if_device_id_5(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_sec_fw_recovery_if_device_id_5(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write i3c::i3c_ec_sec_fw_recovery_if_device_id_5 = 0x{:08x}" , val);
         }
@@ -983,7 +1040,9 @@ pub trait I3cPeripheral {
             generated.write_i3c_ec_sec_fw_recovery_if_device_id_5(val);
         }
     }
-    fn read_i3c_ec_sec_fw_recovery_if_device_id_reserved(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_sec_fw_recovery_if_device_id_reserved(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read i3c::i3c_ec_sec_fw_recovery_if_device_id_reserved");
         }
@@ -994,7 +1053,7 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_sec_fw_recovery_if_device_status_0(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::DeviceStatus0::Register,
     > {
@@ -1004,11 +1063,11 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_sec_fw_recovery_if_device_status_0();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_sec_fw_recovery_if_device_status_0(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::DeviceStatus0::Register,
         >,
@@ -1022,7 +1081,7 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_sec_fw_recovery_if_device_status_1(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::DeviceStatus1::Register,
     > {
@@ -1032,11 +1091,11 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_sec_fw_recovery_if_device_status_1();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_sec_fw_recovery_if_device_status_1(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::DeviceStatus1::Register,
         >,
@@ -1050,7 +1109,7 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_sec_fw_recovery_if_device_reset(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::DeviceReset::Register,
     > {
@@ -1060,11 +1119,11 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_sec_fw_recovery_if_device_reset();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_sec_fw_recovery_if_device_reset(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::DeviceReset::Register,
         >,
@@ -1078,7 +1137,7 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_sec_fw_recovery_if_recovery_ctrl(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::RecoveryCtrl::Register,
     > {
@@ -1088,11 +1147,11 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_sec_fw_recovery_if_recovery_ctrl();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_sec_fw_recovery_if_recovery_ctrl(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::RecoveryCtrl::Register,
         >,
@@ -1106,7 +1165,7 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_sec_fw_recovery_if_recovery_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::RecoveryStatus::Register,
     > {
@@ -1116,11 +1175,11 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_sec_fw_recovery_if_recovery_status();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_sec_fw_recovery_if_recovery_status(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::RecoveryStatus::Register,
         >,
@@ -1134,8 +1193,10 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_sec_fw_recovery_if_hw_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::HwStatus::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::HwStatus::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read i3c::i3c_ec_sec_fw_recovery_if_hw_status"
@@ -1144,11 +1205,11 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_sec_fw_recovery_if_hw_status();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_sec_fw_recovery_if_hw_status(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::HwStatus::Register,
         >,
@@ -1162,7 +1223,7 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_0(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::IndirectFifoCtrl0::Register,
     > {
@@ -1172,11 +1233,11 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_0();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_0(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::IndirectFifoCtrl0::Register,
         >,
@@ -1190,7 +1251,7 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_1(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read i3c::i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_1");
         }
@@ -1201,7 +1262,7 @@ pub trait I3cPeripheral {
     }
     fn write_i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_1(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write i3c::i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_1 = 0x{:08x}" , val);
@@ -1212,7 +1273,7 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_sec_fw_recovery_if_indirect_fifo_status_0(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::IndirectFifoStatus0::Register,
     > {
@@ -1222,11 +1283,11 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_sec_fw_recovery_if_indirect_fifo_status_0();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_i3c_ec_sec_fw_recovery_if_indirect_fifo_status_1(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read i3c::i3c_ec_sec_fw_recovery_if_indirect_fifo_status_1");
         }
@@ -1237,7 +1298,7 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_sec_fw_recovery_if_indirect_fifo_status_2(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read i3c::i3c_ec_sec_fw_recovery_if_indirect_fifo_status_2");
         }
@@ -1248,7 +1309,7 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_sec_fw_recovery_if_indirect_fifo_status_3(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read i3c::i3c_ec_sec_fw_recovery_if_indirect_fifo_status_3");
         }
@@ -1259,7 +1320,7 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_sec_fw_recovery_if_indirect_fifo_status_4(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read i3c::i3c_ec_sec_fw_recovery_if_indirect_fifo_status_4");
         }
@@ -1270,7 +1331,7 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_sec_fw_recovery_if_indirect_fifo_reserved(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read i3c::i3c_ec_sec_fw_recovery_if_indirect_fifo_reserved");
         }
@@ -1279,7 +1340,9 @@ pub trait I3cPeripheral {
         }
         0
     }
-    fn read_i3c_ec_sec_fw_recovery_if_indirect_fifo_data(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_sec_fw_recovery_if_indirect_fifo_data(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read i3c::i3c_ec_sec_fw_recovery_if_indirect_fifo_data");
         }
@@ -1290,7 +1353,7 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_stdby_ctrl_mode_extcap_header(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::ExtcapHeader::Register,
     > {
@@ -1300,11 +1363,11 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_stdby_ctrl_mode_extcap_header();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_i3c_ec_stdby_ctrl_mode_stby_cr_control(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::StbyCrControl::Register,
     > {
@@ -1314,11 +1377,11 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_stdby_ctrl_mode_stby_cr_control();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_stdby_ctrl_mode_stby_cr_control(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::StbyCrControl::Register,
         >,
@@ -1332,7 +1395,7 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_stdby_ctrl_mode_stby_cr_device_addr(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::StbyCrDeviceAddr::Register,
     > {
@@ -1342,11 +1405,11 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_stdby_ctrl_mode_stby_cr_device_addr();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_stdby_ctrl_mode_stby_cr_device_addr(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::StbyCrDeviceAddr::Register,
         >,
@@ -1360,7 +1423,7 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_stdby_ctrl_mode_stby_cr_capabilities(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::StbyCrCapabilities::Register,
     > {
@@ -1370,11 +1433,11 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_stdby_ctrl_mode_stby_cr_capabilities();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_i3c_ec_stdby_ctrl_mode_stby_cr_virtual_device_char(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::StbyCrVirtualDeviceChar::Register,
     > {
@@ -1384,11 +1447,11 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_stdby_ctrl_mode_stby_cr_virtual_device_char();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_stdby_ctrl_mode_stby_cr_virtual_device_char(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::StbyCrVirtualDeviceChar::Register,
         >,
@@ -1402,7 +1465,7 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_stdby_ctrl_mode_stby_cr_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::StbyCrStatus::Register,
     > {
@@ -1412,11 +1475,11 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_stdby_ctrl_mode_stby_cr_status();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_stdby_ctrl_mode_stby_cr_status(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::StbyCrStatus::Register,
         >,
@@ -1430,7 +1493,7 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_stdby_ctrl_mode_stby_cr_device_char(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::StbyCrDeviceChar::Register,
     > {
@@ -1440,11 +1503,11 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_stdby_ctrl_mode_stby_cr_device_char();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_stdby_ctrl_mode_stby_cr_device_char(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::StbyCrDeviceChar::Register,
         >,
@@ -1456,7 +1519,9 @@ pub trait I3cPeripheral {
             generated.write_i3c_ec_stdby_ctrl_mode_stby_cr_device_char(val);
         }
     }
-    fn read_i3c_ec_stdby_ctrl_mode_stby_cr_device_pid_lo(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_stdby_ctrl_mode_stby_cr_device_pid_lo(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read i3c::i3c_ec_stdby_ctrl_mode_stby_cr_device_pid_lo");
         }
@@ -1467,7 +1532,7 @@ pub trait I3cPeripheral {
     }
     fn write_i3c_ec_stdby_ctrl_mode_stby_cr_device_pid_lo(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write i3c::i3c_ec_stdby_ctrl_mode_stby_cr_device_pid_lo = 0x{:08x}" , val);
@@ -1478,7 +1543,7 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_stdby_ctrl_mode_stby_cr_intr_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::StbyCrIntrStatus::Register,
     > {
@@ -1488,11 +1553,11 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_stdby_ctrl_mode_stby_cr_intr_status();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_stdby_ctrl_mode_stby_cr_intr_status(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::StbyCrIntrStatus::Register,
         >,
@@ -1506,7 +1571,7 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_stdby_ctrl_mode_stby_cr_virtual_device_pid_lo(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read i3c::i3c_ec_stdby_ctrl_mode_stby_cr_virtual_device_pid_lo");
         }
@@ -1517,7 +1582,7 @@ pub trait I3cPeripheral {
     }
     fn write_i3c_ec_stdby_ctrl_mode_stby_cr_virtual_device_pid_lo(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write i3c::i3c_ec_stdby_ctrl_mode_stby_cr_virtual_device_pid_lo = 0x{:08x}" , val);
@@ -1528,7 +1593,7 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_stdby_ctrl_mode_stby_cr_intr_signal_enable(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::StbyCrIntrSignalEnable::Register,
     > {
@@ -1538,11 +1603,11 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_stdby_ctrl_mode_stby_cr_intr_signal_enable();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_stdby_ctrl_mode_stby_cr_intr_signal_enable(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::StbyCrIntrSignalEnable::Register,
         >,
@@ -1556,7 +1621,7 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_stdby_ctrl_mode_stby_cr_intr_force(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::StbyCrIntrForce::Register,
     > {
@@ -1566,11 +1631,11 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_stdby_ctrl_mode_stby_cr_intr_force();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_stdby_ctrl_mode_stby_cr_intr_force(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::StbyCrIntrForce::Register,
         >,
@@ -1584,7 +1649,7 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_getcaps(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::StbyCrCccConfigGetcaps::Register,
     > {
@@ -1594,11 +1659,11 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_getcaps();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_getcaps(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::StbyCrCccConfigGetcaps::Register,
         >,
@@ -1612,7 +1677,7 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_rstact_params(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::StbyCrCccConfigRstactParams::Register,
     > {
@@ -1622,11 +1687,11 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_rstact_params();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_rstact_params(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::StbyCrCccConfigRstactParams::Register,
         >,
@@ -1640,7 +1705,7 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_stdby_ctrl_mode_stby_cr_virt_device_addr(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::StbyCrVirtDeviceAddr::Register,
     > {
@@ -1650,11 +1715,11 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_stdby_ctrl_mode_stby_cr_virt_device_addr();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_stdby_ctrl_mode_stby_cr_virt_device_addr(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::StbyCrVirtDeviceAddr::Register,
         >,
@@ -1666,7 +1731,9 @@ pub trait I3cPeripheral {
             generated.write_i3c_ec_stdby_ctrl_mode_stby_cr_virt_device_addr(val);
         }
     }
-    fn read_i3c_ec_stdby_ctrl_mode_rsvd_3(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_stdby_ctrl_mode_rsvd_3(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read i3c::i3c_ec_stdby_ctrl_mode_rsvd_3"
@@ -1677,7 +1744,10 @@ pub trait I3cPeripheral {
         }
         0
     }
-    fn write_i3c_ec_stdby_ctrl_mode_rsvd_3(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_stdby_ctrl_mode_rsvd_3(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write i3c::i3c_ec_stdby_ctrl_mode_rsvd_3 = 0x{:08x}" , val);
         }
@@ -1687,7 +1757,7 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_tti_extcap_header(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::ExtcapHeader::Register,
     > {
@@ -1697,23 +1767,25 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_tti_extcap_header();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_i3c_ec_tti_control(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::Control::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::Control::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read i3c::i3c_ec_tti_control");
         }
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_tti_control();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_tti_control(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::Control::Register,
         >,
@@ -1730,19 +1802,21 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_tti_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::Status::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::Status::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read i3c::i3c_ec_tti_status");
         }
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_tti_status();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_i3c_ec_tti_tti_reset_control(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::TtiResetControl::Register,
     > {
@@ -1752,11 +1826,11 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_tti_tti_reset_control();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_tti_tti_reset_control(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::TtiResetControl::Register,
         >,
@@ -1770,7 +1844,7 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_tti_interrupt_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::InterruptStatus::Register,
     > {
@@ -1780,11 +1854,11 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_tti_interrupt_status();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_tti_interrupt_status(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::InterruptStatus::Register,
         >,
@@ -1798,7 +1872,7 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_tti_interrupt_enable(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::InterruptEnable::Register,
     > {
@@ -1808,11 +1882,11 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_tti_interrupt_enable();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_tti_interrupt_enable(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::InterruptEnable::Register,
         >,
@@ -1826,7 +1900,7 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_tti_interrupt_force(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::InterruptForce::Register,
     > {
@@ -1836,11 +1910,11 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_tti_interrupt_force();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_tti_interrupt_force(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::InterruptForce::Register,
         >,
@@ -1852,7 +1926,9 @@ pub trait I3cPeripheral {
             generated.write_i3c_ec_tti_interrupt_force(val);
         }
     }
-    fn read_i3c_ec_tti_rx_desc_queue_port(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_tti_rx_desc_queue_port(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read i3c::i3c_ec_tti_rx_desc_queue_port"
@@ -1863,7 +1939,7 @@ pub trait I3cPeripheral {
         }
         0
     }
-    fn read_i3c_ec_tti_rx_data_port(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_tti_rx_data_port(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read i3c::i3c_ec_tti_rx_data_port");
         }
@@ -1872,7 +1948,10 @@ pub trait I3cPeripheral {
         }
         0
     }
-    fn write_i3c_ec_tti_tx_desc_queue_port(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_tti_tx_desc_queue_port(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write i3c::i3c_ec_tti_tx_desc_queue_port = 0x{:08x}" , val);
         }
@@ -1880,7 +1959,10 @@ pub trait I3cPeripheral {
             generated.write_i3c_ec_tti_tx_desc_queue_port(val);
         }
     }
-    fn write_i3c_ec_tti_tx_data_port(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_tti_tx_data_port(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write i3c::i3c_ec_tti_tx_data_port = 0x{:08x}",
@@ -1891,7 +1973,10 @@ pub trait I3cPeripheral {
             generated.write_i3c_ec_tti_tx_data_port(val);
         }
     }
-    fn write_i3c_ec_tti_tti_ibi_port(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_tti_tti_ibi_port(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write i3c::i3c_ec_tti_tti_ibi_port = 0x{:08x}",
@@ -1904,7 +1989,7 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_tti_tti_queue_size(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::TtiQueueSize::Register,
     > {
@@ -1914,11 +1999,11 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_tti_tti_queue_size();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_i3c_ec_tti_ibi_tti_queue_size(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::IbiTtiQueueSize::Register,
     > {
@@ -1930,11 +2015,11 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_tti_ibi_tti_queue_size();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_i3c_ec_tti_tti_queue_thld_ctrl(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::TtiQueueThldCtrl::Register,
     > {
@@ -1946,11 +2031,11 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_tti_tti_queue_thld_ctrl();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_tti_tti_queue_thld_ctrl(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::TtiQueueThldCtrl::Register,
         >,
@@ -1964,7 +2049,7 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_tti_tti_data_buffer_thld_ctrl(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::TtiDataBufferThldCtrl::Register,
     > {
@@ -1974,11 +2059,11 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_tti_tti_data_buffer_thld_ctrl();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_tti_tti_data_buffer_thld_ctrl(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::TtiDataBufferThldCtrl::Register,
         >,
@@ -1992,7 +2077,7 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_soc_mgmt_if_extcap_header(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::ExtcapHeader::Register,
     > {
@@ -2004,9 +2089,11 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_soc_mgmt_if_extcap_header();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
-    fn read_i3c_ec_soc_mgmt_if_soc_mgmt_control(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_soc_mgmt_if_soc_mgmt_control(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read i3c::i3c_ec_soc_mgmt_if_soc_mgmt_control"
@@ -2017,7 +2104,10 @@ pub trait I3cPeripheral {
         }
         0
     }
-    fn write_i3c_ec_soc_mgmt_if_soc_mgmt_control(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_soc_mgmt_if_soc_mgmt_control(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write i3c::i3c_ec_soc_mgmt_if_soc_mgmt_control = 0x{:08x}" , val);
         }
@@ -2025,7 +2115,9 @@ pub trait I3cPeripheral {
             generated.write_i3c_ec_soc_mgmt_if_soc_mgmt_control(val);
         }
     }
-    fn read_i3c_ec_soc_mgmt_if_soc_mgmt_status(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_soc_mgmt_if_soc_mgmt_status(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read i3c::i3c_ec_soc_mgmt_if_soc_mgmt_status"
@@ -2036,7 +2128,10 @@ pub trait I3cPeripheral {
         }
         0
     }
-    fn write_i3c_ec_soc_mgmt_if_soc_mgmt_status(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_soc_mgmt_if_soc_mgmt_status(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write i3c::i3c_ec_soc_mgmt_if_soc_mgmt_status = 0x{:08x}" , val);
         }
@@ -2046,7 +2141,7 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_soc_mgmt_if_rec_intf_cfg(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::RecIntfCfg::Register,
     > {
@@ -2058,11 +2153,11 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_soc_mgmt_if_rec_intf_cfg();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_soc_mgmt_if_rec_intf_cfg(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::RecIntfCfg::Register,
         >,
@@ -2076,7 +2171,7 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_soc_mgmt_if_rec_intf_reg_w1_c_access(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::RecIntfRegW1cAccess::Register,
     > {
@@ -2086,11 +2181,11 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_soc_mgmt_if_rec_intf_reg_w1_c_access();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_soc_mgmt_if_rec_intf_reg_w1_c_access(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::RecIntfRegW1cAccess::Register,
         >,
@@ -2102,7 +2197,9 @@ pub trait I3cPeripheral {
             generated.write_i3c_ec_soc_mgmt_if_rec_intf_reg_w1_c_access(val);
         }
     }
-    fn read_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_2(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_2(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read i3c::i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_2"
@@ -2113,7 +2210,10 @@ pub trait I3cPeripheral {
         }
         0
     }
-    fn write_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_2(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_2(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write i3c::i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_2 = 0x{:08x}" , val);
         }
@@ -2121,7 +2221,9 @@ pub trait I3cPeripheral {
             generated.write_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_2(val);
         }
     }
-    fn read_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_3(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_3(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read i3c::i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_3"
@@ -2132,7 +2234,10 @@ pub trait I3cPeripheral {
         }
         0
     }
-    fn write_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_3(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_3(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write i3c::i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_3 = 0x{:08x}" , val);
         }
@@ -2142,7 +2247,7 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_soc_mgmt_if_soc_pad_conf(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::SocPadConf::Register,
     > {
@@ -2154,11 +2259,11 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_soc_mgmt_if_soc_pad_conf();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_soc_mgmt_if_soc_pad_conf(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::SocPadConf::Register,
         >,
@@ -2172,7 +2277,7 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_soc_mgmt_if_soc_pad_attr(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::SocPadAttr::Register,
     > {
@@ -2184,11 +2289,11 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_soc_mgmt_if_soc_pad_attr();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_soc_mgmt_if_soc_pad_attr(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::SocPadAttr::Register,
         >,
@@ -2200,7 +2305,9 @@ pub trait I3cPeripheral {
             generated.write_i3c_ec_soc_mgmt_if_soc_pad_attr(val);
         }
     }
-    fn read_i3c_ec_soc_mgmt_if_soc_mgmt_feature_2(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_soc_mgmt_if_soc_mgmt_feature_2(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read i3c::i3c_ec_soc_mgmt_if_soc_mgmt_feature_2");
         }
@@ -2209,7 +2316,10 @@ pub trait I3cPeripheral {
         }
         0
     }
-    fn write_i3c_ec_soc_mgmt_if_soc_mgmt_feature_2(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_soc_mgmt_if_soc_mgmt_feature_2(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write i3c::i3c_ec_soc_mgmt_if_soc_mgmt_feature_2 = 0x{:08x}" , val);
         }
@@ -2217,7 +2327,9 @@ pub trait I3cPeripheral {
             generated.write_i3c_ec_soc_mgmt_if_soc_mgmt_feature_2(val);
         }
     }
-    fn read_i3c_ec_soc_mgmt_if_soc_mgmt_feature_3(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_soc_mgmt_if_soc_mgmt_feature_3(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read i3c::i3c_ec_soc_mgmt_if_soc_mgmt_feature_3");
         }
@@ -2226,7 +2338,10 @@ pub trait I3cPeripheral {
         }
         0
     }
-    fn write_i3c_ec_soc_mgmt_if_soc_mgmt_feature_3(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_soc_mgmt_if_soc_mgmt_feature_3(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write i3c::i3c_ec_soc_mgmt_if_soc_mgmt_feature_3 = 0x{:08x}" , val);
         }
@@ -2236,19 +2351,21 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_soc_mgmt_if_t_r_reg(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::TRReg::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::TRReg::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read i3c::i3c_ec_soc_mgmt_if_t_r_reg");
         }
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_soc_mgmt_if_t_r_reg();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_soc_mgmt_if_t_r_reg(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::TRReg::Register,
         >,
@@ -2262,19 +2379,21 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_soc_mgmt_if_t_f_reg(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::TFReg::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::TFReg::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read i3c::i3c_ec_soc_mgmt_if_t_f_reg");
         }
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_soc_mgmt_if_t_f_reg();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_soc_mgmt_if_t_f_reg(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::TFReg::Register,
         >,
@@ -2288,8 +2407,10 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_soc_mgmt_if_t_su_dat_reg(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::TSuDatReg::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::TSuDatReg::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read i3c::i3c_ec_soc_mgmt_if_t_su_dat_reg"
@@ -2298,11 +2419,11 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_soc_mgmt_if_t_su_dat_reg();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_soc_mgmt_if_t_su_dat_reg(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::TSuDatReg::Register,
         >,
@@ -2316,8 +2437,10 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_soc_mgmt_if_t_hd_dat_reg(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::THdDatReg::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::THdDatReg::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read i3c::i3c_ec_soc_mgmt_if_t_hd_dat_reg"
@@ -2326,11 +2449,11 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_soc_mgmt_if_t_hd_dat_reg();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_soc_mgmt_if_t_hd_dat_reg(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::THdDatReg::Register,
         >,
@@ -2344,8 +2467,10 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_soc_mgmt_if_t_high_reg(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::THighReg::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::THighReg::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read i3c::i3c_ec_soc_mgmt_if_t_high_reg"
@@ -2354,11 +2479,11 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_soc_mgmt_if_t_high_reg();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_soc_mgmt_if_t_high_reg(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::THighReg::Register,
         >,
@@ -2372,19 +2497,21 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_soc_mgmt_if_t_low_reg(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::TLowReg::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::TLowReg::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read i3c::i3c_ec_soc_mgmt_if_t_low_reg");
         }
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_soc_mgmt_if_t_low_reg();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_soc_mgmt_if_t_low_reg(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::TLowReg::Register,
         >,
@@ -2398,8 +2525,10 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_soc_mgmt_if_t_hd_sta_reg(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::THdStaReg::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::THdStaReg::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read i3c::i3c_ec_soc_mgmt_if_t_hd_sta_reg"
@@ -2408,11 +2537,11 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_soc_mgmt_if_t_hd_sta_reg();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_soc_mgmt_if_t_hd_sta_reg(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::THdStaReg::Register,
         >,
@@ -2426,8 +2555,10 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_soc_mgmt_if_t_su_sta_reg(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::TSuStaReg::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::TSuStaReg::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read i3c::i3c_ec_soc_mgmt_if_t_su_sta_reg"
@@ -2436,11 +2567,11 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_soc_mgmt_if_t_su_sta_reg();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_soc_mgmt_if_t_su_sta_reg(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::TSuStaReg::Register,
         >,
@@ -2454,8 +2585,10 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_soc_mgmt_if_t_su_sto_reg(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::TSuStoReg::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::TSuStoReg::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read i3c::i3c_ec_soc_mgmt_if_t_su_sto_reg"
@@ -2464,11 +2597,11 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_soc_mgmt_if_t_su_sto_reg();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_soc_mgmt_if_t_su_sto_reg(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::TSuStoReg::Register,
         >,
@@ -2480,7 +2613,9 @@ pub trait I3cPeripheral {
             generated.write_i3c_ec_soc_mgmt_if_t_su_sto_reg(val);
         }
     }
-    fn read_i3c_ec_soc_mgmt_if_t_free_reg(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_soc_mgmt_if_t_free_reg(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read i3c::i3c_ec_soc_mgmt_if_t_free_reg"
@@ -2491,7 +2626,10 @@ pub trait I3cPeripheral {
         }
         0
     }
-    fn write_i3c_ec_soc_mgmt_if_t_free_reg(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_soc_mgmt_if_t_free_reg(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write i3c::i3c_ec_soc_mgmt_if_t_free_reg = 0x{:08x}" , val);
         }
@@ -2499,7 +2637,9 @@ pub trait I3cPeripheral {
             generated.write_i3c_ec_soc_mgmt_if_t_free_reg(val);
         }
     }
-    fn read_i3c_ec_soc_mgmt_if_t_aval_reg(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_soc_mgmt_if_t_aval_reg(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read i3c::i3c_ec_soc_mgmt_if_t_aval_reg"
@@ -2510,7 +2650,10 @@ pub trait I3cPeripheral {
         }
         0
     }
-    fn write_i3c_ec_soc_mgmt_if_t_aval_reg(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_soc_mgmt_if_t_aval_reg(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write i3c::i3c_ec_soc_mgmt_if_t_aval_reg = 0x{:08x}" , val);
         }
@@ -2518,7 +2661,9 @@ pub trait I3cPeripheral {
             generated.write_i3c_ec_soc_mgmt_if_t_aval_reg(val);
         }
     }
-    fn read_i3c_ec_soc_mgmt_if_t_idle_reg(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_soc_mgmt_if_t_idle_reg(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read i3c::i3c_ec_soc_mgmt_if_t_idle_reg"
@@ -2529,7 +2674,10 @@ pub trait I3cPeripheral {
         }
         0
     }
-    fn write_i3c_ec_soc_mgmt_if_t_idle_reg(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_soc_mgmt_if_t_idle_reg(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write i3c::i3c_ec_soc_mgmt_if_t_idle_reg = 0x{:08x}" , val);
         }
@@ -2539,7 +2687,7 @@ pub trait I3cPeripheral {
     }
     fn read_i3c_ec_ctrl_cfg_extcap_header(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::ExtcapHeader::Register,
     > {
@@ -2551,11 +2699,11 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_ctrl_cfg_extcap_header();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_i3c_ec_ctrl_cfg_controller_config(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::ControllerConfig::Register,
     > {
@@ -2567,259 +2715,328 @@ pub trait I3cPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_ctrl_cfg_controller_config();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
 }
 #[derive(Clone, Debug)]
 pub struct I3cGenerated {
-    dat: Vec<caliptra_emu_types::RvData>,
-    dct: Vec<caliptra_emu_types::RvData>,
-    i3c_base_hci_version: caliptra_emu_types::RvData,
-    i3c_base_hc_control: caliptra_emu_types::RvData,
-    i3c_base_controller_device_addr: caliptra_emu_types::RvData,
-    i3c_base_hc_capabilities: caliptra_emu_types::RvData,
-    i3c_base_reset_control: caliptra_emu_types::RvData,
-    i3c_base_present_state: caliptra_emu_types::RvData,
-    i3c_base_intr_status: caliptra_emu_types::RvData,
-    i3c_base_intr_status_enable: caliptra_emu_types::RvData,
-    i3c_base_intr_signal_enable: caliptra_emu_types::RvData,
-    i3c_base_intr_force: caliptra_emu_types::RvData,
-    i3c_base_dat_section_offset: caliptra_emu_types::RvData,
-    i3c_base_dct_section_offset: caliptra_emu_types::RvData,
-    i3c_base_ring_headers_section_offset: caliptra_emu_types::RvData,
-    i3c_base_pio_section_offset: caliptra_emu_types::RvData,
-    i3c_base_ext_caps_section_offset: caliptra_emu_types::RvData,
-    i3c_base_int_ctrl_cmds_en: caliptra_emu_types::RvData,
-    i3c_base_ibi_notify_ctrl: caliptra_emu_types::RvData,
-    i3c_base_ibi_data_abort_ctrl: caliptra_emu_types::RvData,
-    i3c_base_dev_ctx_base_lo: caliptra_emu_types::RvData,
-    i3c_base_dev_ctx_base_hi: caliptra_emu_types::RvData,
-    i3c_base_dev_ctx_sg: caliptra_emu_types::RvData,
-    piocontrol_command_port: caliptra_emu_types::RvData,
-    piocontrol_response_port: caliptra_emu_types::RvData,
-    piocontrol_tx_data_port: caliptra_emu_types::RvData,
-    piocontrol_rx_data_port: caliptra_emu_types::RvData,
-    piocontrol_ibi_port: caliptra_emu_types::RvData,
-    piocontrol_queue_thld_ctrl: caliptra_emu_types::RvData,
-    piocontrol_data_buffer_thld_ctrl: caliptra_emu_types::RvData,
-    piocontrol_queue_size: caliptra_emu_types::RvData,
-    piocontrol_alt_queue_size: caliptra_emu_types::RvData,
-    piocontrol_pio_intr_status: caliptra_emu_types::RvData,
-    piocontrol_pio_intr_status_enable: caliptra_emu_types::RvData,
-    piocontrol_pio_intr_signal_enable: caliptra_emu_types::RvData,
-    piocontrol_pio_intr_force: caliptra_emu_types::RvData,
-    piocontrol_pio_control: caliptra_emu_types::RvData,
-    i3c_ec_sec_fw_recovery_if_extcap_header: caliptra_emu_types::RvData,
-    i3c_ec_sec_fw_recovery_if_prot_cap_0: caliptra_emu_types::RvData,
-    i3c_ec_sec_fw_recovery_if_prot_cap_1: caliptra_emu_types::RvData,
-    i3c_ec_sec_fw_recovery_if_prot_cap_2: caliptra_emu_types::RvData,
-    i3c_ec_sec_fw_recovery_if_prot_cap_3: caliptra_emu_types::RvData,
-    i3c_ec_sec_fw_recovery_if_device_id_0: caliptra_emu_types::RvData,
-    i3c_ec_sec_fw_recovery_if_device_id_1: caliptra_emu_types::RvData,
-    i3c_ec_sec_fw_recovery_if_device_id_2: caliptra_emu_types::RvData,
-    i3c_ec_sec_fw_recovery_if_device_id_3: caliptra_emu_types::RvData,
-    i3c_ec_sec_fw_recovery_if_device_id_4: caliptra_emu_types::RvData,
-    i3c_ec_sec_fw_recovery_if_device_id_5: caliptra_emu_types::RvData,
-    i3c_ec_sec_fw_recovery_if_device_id_reserved: caliptra_emu_types::RvData,
-    i3c_ec_sec_fw_recovery_if_device_status_0: caliptra_emu_types::RvData,
-    i3c_ec_sec_fw_recovery_if_device_status_1: caliptra_emu_types::RvData,
-    i3c_ec_sec_fw_recovery_if_device_reset: caliptra_emu_types::RvData,
-    i3c_ec_sec_fw_recovery_if_recovery_ctrl: caliptra_emu_types::RvData,
-    i3c_ec_sec_fw_recovery_if_recovery_status: caliptra_emu_types::RvData,
-    i3c_ec_sec_fw_recovery_if_hw_status: caliptra_emu_types::RvData,
-    i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_0: caliptra_emu_types::RvData,
-    i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_1: caliptra_emu_types::RvData,
-    i3c_ec_sec_fw_recovery_if_indirect_fifo_status_0: caliptra_emu_types::RvData,
-    i3c_ec_sec_fw_recovery_if_indirect_fifo_status_1: caliptra_emu_types::RvData,
-    i3c_ec_sec_fw_recovery_if_indirect_fifo_status_2: caliptra_emu_types::RvData,
-    i3c_ec_sec_fw_recovery_if_indirect_fifo_status_3: caliptra_emu_types::RvData,
-    i3c_ec_sec_fw_recovery_if_indirect_fifo_status_4: caliptra_emu_types::RvData,
-    i3c_ec_sec_fw_recovery_if_indirect_fifo_reserved: caliptra_emu_types::RvData,
-    i3c_ec_sec_fw_recovery_if_indirect_fifo_data: caliptra_emu_types::RvData,
-    i3c_ec_stdby_ctrl_mode_extcap_header: caliptra_emu_types::RvData,
-    i3c_ec_stdby_ctrl_mode_stby_cr_control: caliptra_emu_types::RvData,
-    i3c_ec_stdby_ctrl_mode_stby_cr_device_addr: caliptra_emu_types::RvData,
-    i3c_ec_stdby_ctrl_mode_stby_cr_capabilities: caliptra_emu_types::RvData,
-    i3c_ec_stdby_ctrl_mode_stby_cr_virtual_device_char: caliptra_emu_types::RvData,
-    i3c_ec_stdby_ctrl_mode_stby_cr_status: caliptra_emu_types::RvData,
-    i3c_ec_stdby_ctrl_mode_stby_cr_device_char: caliptra_emu_types::RvData,
-    i3c_ec_stdby_ctrl_mode_stby_cr_device_pid_lo: caliptra_emu_types::RvData,
-    i3c_ec_stdby_ctrl_mode_stby_cr_intr_status: caliptra_emu_types::RvData,
-    i3c_ec_stdby_ctrl_mode_stby_cr_virtual_device_pid_lo: caliptra_emu_types::RvData,
-    i3c_ec_stdby_ctrl_mode_stby_cr_intr_signal_enable: caliptra_emu_types::RvData,
-    i3c_ec_stdby_ctrl_mode_stby_cr_intr_force: caliptra_emu_types::RvData,
-    i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_getcaps: caliptra_emu_types::RvData,
-    i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_rstact_params: caliptra_emu_types::RvData,
-    i3c_ec_stdby_ctrl_mode_stby_cr_virt_device_addr: caliptra_emu_types::RvData,
-    i3c_ec_stdby_ctrl_mode_rsvd_3: caliptra_emu_types::RvData,
-    i3c_ec_tti_extcap_header: caliptra_emu_types::RvData,
-    i3c_ec_tti_control: caliptra_emu_types::RvData,
-    i3c_ec_tti_status: caliptra_emu_types::RvData,
-    i3c_ec_tti_tti_reset_control: caliptra_emu_types::RvData,
-    i3c_ec_tti_interrupt_status: caliptra_emu_types::RvData,
-    i3c_ec_tti_interrupt_enable: caliptra_emu_types::RvData,
-    i3c_ec_tti_interrupt_force: caliptra_emu_types::RvData,
-    i3c_ec_tti_rx_desc_queue_port: caliptra_emu_types::RvData,
-    i3c_ec_tti_rx_data_port: caliptra_emu_types::RvData,
-    i3c_ec_tti_tx_desc_queue_port: caliptra_emu_types::RvData,
-    i3c_ec_tti_tx_data_port: caliptra_emu_types::RvData,
-    i3c_ec_tti_tti_ibi_port: caliptra_emu_types::RvData,
-    i3c_ec_tti_tti_queue_size: caliptra_emu_types::RvData,
-    i3c_ec_tti_ibi_tti_queue_size: caliptra_emu_types::RvData,
-    i3c_ec_tti_tti_queue_thld_ctrl: caliptra_emu_types::RvData,
-    i3c_ec_tti_tti_data_buffer_thld_ctrl: caliptra_emu_types::RvData,
-    i3c_ec_soc_mgmt_if_extcap_header: caliptra_emu_types::RvData,
-    i3c_ec_soc_mgmt_if_soc_mgmt_control: caliptra_emu_types::RvData,
-    i3c_ec_soc_mgmt_if_soc_mgmt_status: caliptra_emu_types::RvData,
-    i3c_ec_soc_mgmt_if_rec_intf_cfg: caliptra_emu_types::RvData,
-    i3c_ec_soc_mgmt_if_rec_intf_reg_w1_c_access: caliptra_emu_types::RvData,
-    i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_2: caliptra_emu_types::RvData,
-    i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_3: caliptra_emu_types::RvData,
-    i3c_ec_soc_mgmt_if_soc_pad_conf: caliptra_emu_types::RvData,
-    i3c_ec_soc_mgmt_if_soc_pad_attr: caliptra_emu_types::RvData,
-    i3c_ec_soc_mgmt_if_soc_mgmt_feature_2: caliptra_emu_types::RvData,
-    i3c_ec_soc_mgmt_if_soc_mgmt_feature_3: caliptra_emu_types::RvData,
-    i3c_ec_soc_mgmt_if_t_r_reg: caliptra_emu_types::RvData,
-    i3c_ec_soc_mgmt_if_t_f_reg: caliptra_emu_types::RvData,
-    i3c_ec_soc_mgmt_if_t_su_dat_reg: caliptra_emu_types::RvData,
-    i3c_ec_soc_mgmt_if_t_hd_dat_reg: caliptra_emu_types::RvData,
-    i3c_ec_soc_mgmt_if_t_high_reg: caliptra_emu_types::RvData,
-    i3c_ec_soc_mgmt_if_t_low_reg: caliptra_emu_types::RvData,
-    i3c_ec_soc_mgmt_if_t_hd_sta_reg: caliptra_emu_types::RvData,
-    i3c_ec_soc_mgmt_if_t_su_sta_reg: caliptra_emu_types::RvData,
-    i3c_ec_soc_mgmt_if_t_su_sto_reg: caliptra_emu_types::RvData,
-    i3c_ec_soc_mgmt_if_t_free_reg: caliptra_emu_types::RvData,
-    i3c_ec_soc_mgmt_if_t_aval_reg: caliptra_emu_types::RvData,
-    i3c_ec_soc_mgmt_if_t_idle_reg: caliptra_emu_types::RvData,
-    i3c_ec_ctrl_cfg_extcap_header: caliptra_emu_types::RvData,
-    i3c_ec_ctrl_cfg_controller_config: caliptra_emu_types::RvData,
+    dat: Vec<caliptra_core_tools::caliptra_emu_types::RvData>,
+    dct: Vec<caliptra_core_tools::caliptra_emu_types::RvData>,
+    i3c_base_hci_version: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_base_hc_control: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_base_controller_device_addr: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_base_hc_capabilities: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_base_reset_control: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_base_present_state: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_base_intr_status: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_base_intr_status_enable: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_base_intr_signal_enable: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_base_intr_force: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_base_dat_section_offset: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_base_dct_section_offset: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_base_ring_headers_section_offset: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_base_pio_section_offset: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_base_ext_caps_section_offset: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_base_int_ctrl_cmds_en: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_base_ibi_notify_ctrl: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_base_ibi_data_abort_ctrl: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_base_dev_ctx_base_lo: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_base_dev_ctx_base_hi: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_base_dev_ctx_sg: caliptra_core_tools::caliptra_emu_types::RvData,
+    piocontrol_command_port: caliptra_core_tools::caliptra_emu_types::RvData,
+    piocontrol_response_port: caliptra_core_tools::caliptra_emu_types::RvData,
+    piocontrol_tx_data_port: caliptra_core_tools::caliptra_emu_types::RvData,
+    piocontrol_rx_data_port: caliptra_core_tools::caliptra_emu_types::RvData,
+    piocontrol_ibi_port: caliptra_core_tools::caliptra_emu_types::RvData,
+    piocontrol_queue_thld_ctrl: caliptra_core_tools::caliptra_emu_types::RvData,
+    piocontrol_data_buffer_thld_ctrl: caliptra_core_tools::caliptra_emu_types::RvData,
+    piocontrol_queue_size: caliptra_core_tools::caliptra_emu_types::RvData,
+    piocontrol_alt_queue_size: caliptra_core_tools::caliptra_emu_types::RvData,
+    piocontrol_pio_intr_status: caliptra_core_tools::caliptra_emu_types::RvData,
+    piocontrol_pio_intr_status_enable: caliptra_core_tools::caliptra_emu_types::RvData,
+    piocontrol_pio_intr_signal_enable: caliptra_core_tools::caliptra_emu_types::RvData,
+    piocontrol_pio_intr_force: caliptra_core_tools::caliptra_emu_types::RvData,
+    piocontrol_pio_control: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_sec_fw_recovery_if_extcap_header: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_sec_fw_recovery_if_prot_cap_0: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_sec_fw_recovery_if_prot_cap_1: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_sec_fw_recovery_if_prot_cap_2: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_sec_fw_recovery_if_prot_cap_3: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_sec_fw_recovery_if_device_id_0: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_sec_fw_recovery_if_device_id_1: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_sec_fw_recovery_if_device_id_2: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_sec_fw_recovery_if_device_id_3: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_sec_fw_recovery_if_device_id_4: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_sec_fw_recovery_if_device_id_5: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_sec_fw_recovery_if_device_id_reserved: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_sec_fw_recovery_if_device_status_0: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_sec_fw_recovery_if_device_status_1: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_sec_fw_recovery_if_device_reset: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_sec_fw_recovery_if_recovery_ctrl: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_sec_fw_recovery_if_recovery_status: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_sec_fw_recovery_if_hw_status: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_0: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_1: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_sec_fw_recovery_if_indirect_fifo_status_0:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_sec_fw_recovery_if_indirect_fifo_status_1:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_sec_fw_recovery_if_indirect_fifo_status_2:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_sec_fw_recovery_if_indirect_fifo_status_3:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_sec_fw_recovery_if_indirect_fifo_status_4:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_sec_fw_recovery_if_indirect_fifo_reserved:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_sec_fw_recovery_if_indirect_fifo_data: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_stdby_ctrl_mode_extcap_header: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_stdby_ctrl_mode_stby_cr_control: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_stdby_ctrl_mode_stby_cr_device_addr: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_stdby_ctrl_mode_stby_cr_capabilities: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_stdby_ctrl_mode_stby_cr_virtual_device_char:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_stdby_ctrl_mode_stby_cr_status: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_stdby_ctrl_mode_stby_cr_device_char: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_stdby_ctrl_mode_stby_cr_device_pid_lo: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_stdby_ctrl_mode_stby_cr_intr_status: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_stdby_ctrl_mode_stby_cr_virtual_device_pid_lo:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_stdby_ctrl_mode_stby_cr_intr_signal_enable:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_stdby_ctrl_mode_stby_cr_intr_force: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_getcaps:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_rstact_params:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_stdby_ctrl_mode_stby_cr_virt_device_addr:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_stdby_ctrl_mode_rsvd_3: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_tti_extcap_header: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_tti_control: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_tti_status: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_tti_tti_reset_control: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_tti_interrupt_status: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_tti_interrupt_enable: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_tti_interrupt_force: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_tti_rx_desc_queue_port: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_tti_rx_data_port: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_tti_tx_desc_queue_port: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_tti_tx_data_port: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_tti_tti_ibi_port: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_tti_tti_queue_size: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_tti_ibi_tti_queue_size: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_tti_tti_queue_thld_ctrl: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_tti_tti_data_buffer_thld_ctrl: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_soc_mgmt_if_extcap_header: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_soc_mgmt_if_soc_mgmt_control: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_soc_mgmt_if_soc_mgmt_status: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_soc_mgmt_if_rec_intf_cfg: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_soc_mgmt_if_rec_intf_reg_w1_c_access: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_2: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_3: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_soc_mgmt_if_soc_pad_conf: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_soc_mgmt_if_soc_pad_attr: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_soc_mgmt_if_soc_mgmt_feature_2: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_soc_mgmt_if_soc_mgmt_feature_3: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_soc_mgmt_if_t_r_reg: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_soc_mgmt_if_t_f_reg: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_soc_mgmt_if_t_su_dat_reg: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_soc_mgmt_if_t_hd_dat_reg: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_soc_mgmt_if_t_high_reg: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_soc_mgmt_if_t_low_reg: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_soc_mgmt_if_t_hd_sta_reg: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_soc_mgmt_if_t_su_sta_reg: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_soc_mgmt_if_t_su_sto_reg: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_soc_mgmt_if_t_free_reg: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_soc_mgmt_if_t_aval_reg: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_soc_mgmt_if_t_idle_reg: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_ctrl_cfg_extcap_header: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_ctrl_cfg_controller_config: caliptra_core_tools::caliptra_emu_types::RvData,
 }
 impl Default for I3cGenerated {
     fn default() -> Self {
         Self {
-            dat: vec![0 as caliptra_emu_types::RvData; 256],
-            dct: vec![0 as caliptra_emu_types::RvData; 512],
-            i3c_base_hci_version: 0x120 as caliptra_emu_types::RvData,
-            i3c_base_hc_control: 0x40 as caliptra_emu_types::RvData,
-            i3c_base_controller_device_addr: 0 as caliptra_emu_types::RvData,
-            i3c_base_hc_capabilities: 0x400 as caliptra_emu_types::RvData,
-            i3c_base_reset_control: 0 as caliptra_emu_types::RvData,
-            i3c_base_present_state: 0 as caliptra_emu_types::RvData,
-            i3c_base_intr_status: 0 as caliptra_emu_types::RvData,
-            i3c_base_intr_status_enable: 0 as caliptra_emu_types::RvData,
-            i3c_base_intr_signal_enable: 0 as caliptra_emu_types::RvData,
-            i3c_base_intr_force: 0 as caliptra_emu_types::RvData,
-            i3c_base_dat_section_offset: 0x400 as caliptra_emu_types::RvData,
-            i3c_base_dct_section_offset: 0 as caliptra_emu_types::RvData,
-            i3c_base_ring_headers_section_offset: 0 as caliptra_emu_types::RvData,
-            i3c_base_pio_section_offset: 0 as caliptra_emu_types::RvData,
-            i3c_base_ext_caps_section_offset: 0 as caliptra_emu_types::RvData,
-            i3c_base_int_ctrl_cmds_en: 1 as caliptra_emu_types::RvData,
-            i3c_base_ibi_notify_ctrl: 0 as caliptra_emu_types::RvData,
-            i3c_base_ibi_data_abort_ctrl: 0 as caliptra_emu_types::RvData,
-            i3c_base_dev_ctx_base_lo: 0 as caliptra_emu_types::RvData,
-            i3c_base_dev_ctx_base_hi: 0 as caliptra_emu_types::RvData,
-            i3c_base_dev_ctx_sg: 0 as caliptra_emu_types::RvData,
-            piocontrol_command_port: 0 as caliptra_emu_types::RvData,
-            piocontrol_response_port: 0 as caliptra_emu_types::RvData,
-            piocontrol_tx_data_port: 0 as caliptra_emu_types::RvData,
-            piocontrol_rx_data_port: 0 as caliptra_emu_types::RvData,
-            piocontrol_ibi_port: 0 as caliptra_emu_types::RvData,
-            piocontrol_queue_thld_ctrl: 0x101_0101 as caliptra_emu_types::RvData,
-            piocontrol_data_buffer_thld_ctrl: 0x101_0101 as caliptra_emu_types::RvData,
-            piocontrol_queue_size: 0 as caliptra_emu_types::RvData,
-            piocontrol_alt_queue_size: 0 as caliptra_emu_types::RvData,
-            piocontrol_pio_intr_status: 0 as caliptra_emu_types::RvData,
-            piocontrol_pio_intr_status_enable: 0 as caliptra_emu_types::RvData,
-            piocontrol_pio_intr_signal_enable: 0 as caliptra_emu_types::RvData,
-            piocontrol_pio_intr_force: 0 as caliptra_emu_types::RvData,
-            piocontrol_pio_control: 1 as caliptra_emu_types::RvData,
-            i3c_ec_sec_fw_recovery_if_extcap_header: 0x20c0 as caliptra_emu_types::RvData,
-            i3c_ec_sec_fw_recovery_if_prot_cap_0: 0x2050_434f as caliptra_emu_types::RvData,
-            i3c_ec_sec_fw_recovery_if_prot_cap_1: 0x5643_4552 as caliptra_emu_types::RvData,
-            i3c_ec_sec_fw_recovery_if_prot_cap_2: 0 as caliptra_emu_types::RvData,
-            i3c_ec_sec_fw_recovery_if_prot_cap_3: 0 as caliptra_emu_types::RvData,
-            i3c_ec_sec_fw_recovery_if_device_id_0: 0 as caliptra_emu_types::RvData,
-            i3c_ec_sec_fw_recovery_if_device_id_1: 0 as caliptra_emu_types::RvData,
-            i3c_ec_sec_fw_recovery_if_device_id_2: 0 as caliptra_emu_types::RvData,
-            i3c_ec_sec_fw_recovery_if_device_id_3: 0 as caliptra_emu_types::RvData,
-            i3c_ec_sec_fw_recovery_if_device_id_4: 0 as caliptra_emu_types::RvData,
-            i3c_ec_sec_fw_recovery_if_device_id_5: 0 as caliptra_emu_types::RvData,
-            i3c_ec_sec_fw_recovery_if_device_id_reserved: 0 as caliptra_emu_types::RvData,
-            i3c_ec_sec_fw_recovery_if_device_status_0: 0 as caliptra_emu_types::RvData,
-            i3c_ec_sec_fw_recovery_if_device_status_1: 0 as caliptra_emu_types::RvData,
-            i3c_ec_sec_fw_recovery_if_device_reset: 0 as caliptra_emu_types::RvData,
-            i3c_ec_sec_fw_recovery_if_recovery_ctrl: 0 as caliptra_emu_types::RvData,
-            i3c_ec_sec_fw_recovery_if_recovery_status: 0 as caliptra_emu_types::RvData,
-            i3c_ec_sec_fw_recovery_if_hw_status: 0 as caliptra_emu_types::RvData,
-            i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_0: 0 as caliptra_emu_types::RvData,
-            i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_1: 0 as caliptra_emu_types::RvData,
-            i3c_ec_sec_fw_recovery_if_indirect_fifo_status_0: 1 as caliptra_emu_types::RvData,
-            i3c_ec_sec_fw_recovery_if_indirect_fifo_status_1: 0 as caliptra_emu_types::RvData,
-            i3c_ec_sec_fw_recovery_if_indirect_fifo_status_2: 0 as caliptra_emu_types::RvData,
-            i3c_ec_sec_fw_recovery_if_indirect_fifo_status_3: 0x40 as caliptra_emu_types::RvData,
-            i3c_ec_sec_fw_recovery_if_indirect_fifo_status_4: 0x40 as caliptra_emu_types::RvData,
-            i3c_ec_sec_fw_recovery_if_indirect_fifo_reserved: 0 as caliptra_emu_types::RvData,
-            i3c_ec_sec_fw_recovery_if_indirect_fifo_data: 0 as caliptra_emu_types::RvData,
-            i3c_ec_stdby_ctrl_mode_extcap_header: 0x1012 as caliptra_emu_types::RvData,
-            i3c_ec_stdby_ctrl_mode_stby_cr_control: 0x1000 as caliptra_emu_types::RvData,
-            i3c_ec_stdby_ctrl_mode_stby_cr_device_addr: 0 as caliptra_emu_types::RvData,
-            i3c_ec_stdby_ctrl_mode_stby_cr_capabilities: 0x7000 as caliptra_emu_types::RvData,
+            dat: vec![0 as caliptra_core_tools::caliptra_emu_types::RvData; 256],
+            dct: vec![0 as caliptra_core_tools::caliptra_emu_types::RvData; 512],
+            i3c_base_hci_version: 0x120 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_base_hc_control: 0x40 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_base_controller_device_addr: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_base_hc_capabilities: 0x400 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_base_reset_control: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_base_present_state: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_base_intr_status: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_base_intr_status_enable: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_base_intr_signal_enable: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_base_intr_force: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_base_dat_section_offset: 0x400 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_base_dct_section_offset: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_base_ring_headers_section_offset: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_base_pio_section_offset: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_base_ext_caps_section_offset: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_base_int_ctrl_cmds_en: 1 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_base_ibi_notify_ctrl: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_base_ibi_data_abort_ctrl: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_base_dev_ctx_base_lo: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_base_dev_ctx_base_hi: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_base_dev_ctx_sg: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            piocontrol_command_port: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            piocontrol_response_port: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            piocontrol_tx_data_port: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            piocontrol_rx_data_port: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            piocontrol_ibi_port: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            piocontrol_queue_thld_ctrl: 0x101_0101
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            piocontrol_data_buffer_thld_ctrl: 0x101_0101
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            piocontrol_queue_size: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            piocontrol_alt_queue_size: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            piocontrol_pio_intr_status: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            piocontrol_pio_intr_status_enable: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            piocontrol_pio_intr_signal_enable: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            piocontrol_pio_intr_force: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            piocontrol_pio_control: 1 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_sec_fw_recovery_if_extcap_header: 0x20c0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_sec_fw_recovery_if_prot_cap_0: 0x2050_434f
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_sec_fw_recovery_if_prot_cap_1: 0x5643_4552
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_sec_fw_recovery_if_prot_cap_2: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_sec_fw_recovery_if_prot_cap_3: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_sec_fw_recovery_if_device_id_0: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_sec_fw_recovery_if_device_id_1: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_sec_fw_recovery_if_device_id_2: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_sec_fw_recovery_if_device_id_3: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_sec_fw_recovery_if_device_id_4: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_sec_fw_recovery_if_device_id_5: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_sec_fw_recovery_if_device_id_reserved: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_sec_fw_recovery_if_device_status_0: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_sec_fw_recovery_if_device_status_1: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_sec_fw_recovery_if_device_reset: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_sec_fw_recovery_if_recovery_ctrl: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_sec_fw_recovery_if_recovery_status: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_sec_fw_recovery_if_hw_status: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_0: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_1: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_sec_fw_recovery_if_indirect_fifo_status_0: 1
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_sec_fw_recovery_if_indirect_fifo_status_1: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_sec_fw_recovery_if_indirect_fifo_status_2: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_sec_fw_recovery_if_indirect_fifo_status_3: 0x40
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_sec_fw_recovery_if_indirect_fifo_status_4: 0x40
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_sec_fw_recovery_if_indirect_fifo_reserved: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_sec_fw_recovery_if_indirect_fifo_data: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_stdby_ctrl_mode_extcap_header: 0x1012
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_stdby_ctrl_mode_stby_cr_control: 0x1000
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_stdby_ctrl_mode_stby_cr_device_addr: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_stdby_ctrl_mode_stby_cr_capabilities: 0x7000
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             i3c_ec_stdby_ctrl_mode_stby_cr_virtual_device_char: 0x36bd_0000
-                as caliptra_emu_types::RvData,
-            i3c_ec_stdby_ctrl_mode_stby_cr_status: 0 as caliptra_emu_types::RvData,
-            i3c_ec_stdby_ctrl_mode_stby_cr_device_char: 0x26bd_0000 as caliptra_emu_types::RvData,
-            i3c_ec_stdby_ctrl_mode_stby_cr_device_pid_lo: 0 as caliptra_emu_types::RvData,
-            i3c_ec_stdby_ctrl_mode_stby_cr_intr_status: 0 as caliptra_emu_types::RvData,
-            i3c_ec_stdby_ctrl_mode_stby_cr_virtual_device_pid_lo: 0 as caliptra_emu_types::RvData,
-            i3c_ec_stdby_ctrl_mode_stby_cr_intr_signal_enable: 0 as caliptra_emu_types::RvData,
-            i3c_ec_stdby_ctrl_mode_stby_cr_intr_force: 0 as caliptra_emu_types::RvData,
-            i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_getcaps: 0 as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_stdby_ctrl_mode_stby_cr_status: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_stdby_ctrl_mode_stby_cr_device_char: 0x26bd_0000
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_stdby_ctrl_mode_stby_cr_device_pid_lo: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_stdby_ctrl_mode_stby_cr_intr_status: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_stdby_ctrl_mode_stby_cr_virtual_device_pid_lo: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_stdby_ctrl_mode_stby_cr_intr_signal_enable: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_stdby_ctrl_mode_stby_cr_intr_force: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_getcaps: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_rstact_params: 0x8000_0000
-                as caliptra_emu_types::RvData,
-            i3c_ec_stdby_ctrl_mode_stby_cr_virt_device_addr: 0 as caliptra_emu_types::RvData,
-            i3c_ec_stdby_ctrl_mode_rsvd_3: 0 as caliptra_emu_types::RvData,
-            i3c_ec_tti_extcap_header: 0x10c4 as caliptra_emu_types::RvData,
-            i3c_ec_tti_control: 0x1400 as caliptra_emu_types::RvData,
-            i3c_ec_tti_status: 0 as caliptra_emu_types::RvData,
-            i3c_ec_tti_tti_reset_control: 0 as caliptra_emu_types::RvData,
-            i3c_ec_tti_interrupt_status: 0 as caliptra_emu_types::RvData,
-            i3c_ec_tti_interrupt_enable: 0 as caliptra_emu_types::RvData,
-            i3c_ec_tti_interrupt_force: 0 as caliptra_emu_types::RvData,
-            i3c_ec_tti_rx_desc_queue_port: 0 as caliptra_emu_types::RvData,
-            i3c_ec_tti_rx_data_port: 0 as caliptra_emu_types::RvData,
-            i3c_ec_tti_tx_desc_queue_port: 0 as caliptra_emu_types::RvData,
-            i3c_ec_tti_tx_data_port: 0 as caliptra_emu_types::RvData,
-            i3c_ec_tti_tti_ibi_port: 0 as caliptra_emu_types::RvData,
-            i3c_ec_tti_tti_queue_size: 0 as caliptra_emu_types::RvData,
-            i3c_ec_tti_ibi_tti_queue_size: 0 as caliptra_emu_types::RvData,
-            i3c_ec_tti_tti_queue_thld_ctrl: 0x100_0101 as caliptra_emu_types::RvData,
-            i3c_ec_tti_tti_data_buffer_thld_ctrl: 0x101_0101 as caliptra_emu_types::RvData,
-            i3c_ec_soc_mgmt_if_extcap_header: 0x18c1 as caliptra_emu_types::RvData,
-            i3c_ec_soc_mgmt_if_soc_mgmt_control: 0 as caliptra_emu_types::RvData,
-            i3c_ec_soc_mgmt_if_soc_mgmt_status: 0 as caliptra_emu_types::RvData,
-            i3c_ec_soc_mgmt_if_rec_intf_cfg: 0 as caliptra_emu_types::RvData,
-            i3c_ec_soc_mgmt_if_rec_intf_reg_w1_c_access: 0 as caliptra_emu_types::RvData,
-            i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_2: 0 as caliptra_emu_types::RvData,
-            i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_3: 0 as caliptra_emu_types::RvData,
-            i3c_ec_soc_mgmt_if_soc_pad_conf: 0x100_0001 as caliptra_emu_types::RvData,
-            i3c_ec_soc_mgmt_if_soc_pad_attr: 0xf00_0f00 as caliptra_emu_types::RvData,
-            i3c_ec_soc_mgmt_if_soc_mgmt_feature_2: 0 as caliptra_emu_types::RvData,
-            i3c_ec_soc_mgmt_if_soc_mgmt_feature_3: 0 as caliptra_emu_types::RvData,
-            i3c_ec_soc_mgmt_if_t_r_reg: 0 as caliptra_emu_types::RvData,
-            i3c_ec_soc_mgmt_if_t_f_reg: 0 as caliptra_emu_types::RvData,
-            i3c_ec_soc_mgmt_if_t_su_dat_reg: 0 as caliptra_emu_types::RvData,
-            i3c_ec_soc_mgmt_if_t_hd_dat_reg: 0 as caliptra_emu_types::RvData,
-            i3c_ec_soc_mgmt_if_t_high_reg: 0 as caliptra_emu_types::RvData,
-            i3c_ec_soc_mgmt_if_t_low_reg: 0 as caliptra_emu_types::RvData,
-            i3c_ec_soc_mgmt_if_t_hd_sta_reg: 0 as caliptra_emu_types::RvData,
-            i3c_ec_soc_mgmt_if_t_su_sta_reg: 0 as caliptra_emu_types::RvData,
-            i3c_ec_soc_mgmt_if_t_su_sto_reg: 0 as caliptra_emu_types::RvData,
-            i3c_ec_soc_mgmt_if_t_free_reg: 0xc as caliptra_emu_types::RvData,
-            i3c_ec_soc_mgmt_if_t_aval_reg: 0x12c as caliptra_emu_types::RvData,
-            i3c_ec_soc_mgmt_if_t_idle_reg: 0xea60 as caliptra_emu_types::RvData,
-            i3c_ec_ctrl_cfg_extcap_header: 0x202 as caliptra_emu_types::RvData,
-            i3c_ec_ctrl_cfg_controller_config: 0x10 as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_stdby_ctrl_mode_stby_cr_virt_device_addr: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_stdby_ctrl_mode_rsvd_3: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_tti_extcap_header: 0x10c4 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_tti_control: 0x1400 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_tti_status: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_tti_tti_reset_control: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_tti_interrupt_status: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_tti_interrupt_enable: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_tti_interrupt_force: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_tti_rx_desc_queue_port: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_tti_rx_data_port: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_tti_tx_desc_queue_port: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_tti_tx_data_port: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_tti_tti_ibi_port: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_tti_tti_queue_size: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_tti_ibi_tti_queue_size: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_tti_tti_queue_thld_ctrl: 0x100_0101
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_tti_tti_data_buffer_thld_ctrl: 0x101_0101
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_soc_mgmt_if_extcap_header: 0x18c1
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_soc_mgmt_if_soc_mgmt_control: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_soc_mgmt_if_soc_mgmt_status: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_soc_mgmt_if_rec_intf_cfg: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_soc_mgmt_if_rec_intf_reg_w1_c_access: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_2: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_3: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_soc_mgmt_if_soc_pad_conf: 0x100_0001
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_soc_mgmt_if_soc_pad_attr: 0xf00_0f00
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_soc_mgmt_if_soc_mgmt_feature_2: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_soc_mgmt_if_soc_mgmt_feature_3: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_soc_mgmt_if_t_r_reg: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_soc_mgmt_if_t_f_reg: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_soc_mgmt_if_t_su_dat_reg: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_soc_mgmt_if_t_hd_dat_reg: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_soc_mgmt_if_t_high_reg: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_soc_mgmt_if_t_low_reg: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_soc_mgmt_if_t_hd_sta_reg: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_soc_mgmt_if_t_su_sta_reg: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_soc_mgmt_if_t_su_sto_reg: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_soc_mgmt_if_t_free_reg: 0xc as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_soc_mgmt_if_t_aval_reg: 0x12c as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_soc_mgmt_if_t_idle_reg: 0xea60
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_ctrl_cfg_extcap_header: 0x202 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_ctrl_cfg_controller_config: 0x10
+                as caliptra_core_tools::caliptra_emu_types::RvData,
         }
     }
 }
@@ -2841,7 +3058,7 @@ impl I3cPeripheral for I3cGenerated {
     fn update_reset(&mut self) {
         self.reset_state();
     }
-    fn read_dat(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_dat(&mut self, index: usize) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read i3c::dat[{}]",
@@ -2850,21 +3067,21 @@ impl I3cPeripheral for I3cGenerated {
         }
         self.dat[index]
     }
-    fn write_dat(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    fn write_dat(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData, index: usize) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: write i3c::dat[{}] = 0x{:08x}",
                 index, val
             );
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.dat[index];
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.dat[index] = new_val;
     }
-    fn read_dct(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_dct(&mut self, index: usize) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read i3c::dct[{}]",
@@ -2873,21 +3090,21 @@ impl I3cPeripheral for I3cGenerated {
         }
         self.dct[index]
     }
-    fn write_dct(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    fn write_dct(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData, index: usize) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: write i3c::dct[{}] = 0x{:08x}",
                 index, val
             );
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.dct[index];
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.dct[index] = new_val;
     }
-    fn read_i3c_base_hci_version(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_base_hci_version(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read i3c::i3c_base_hci_version");
         }
@@ -2895,16 +3112,18 @@ impl I3cPeripheral for I3cGenerated {
     }
     fn read_i3c_base_hc_control(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::HcControl::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::HcControl::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read i3c::i3c_base_hc_control");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_base_hc_control)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.i3c_base_hc_control)
     }
     fn write_i3c_base_hc_control(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::HcControl::Register,
         >,
@@ -2912,39 +3131,41 @@ impl I3cPeripheral for I3cGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_base_hc_control = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_base_hc_control;
         let mut new_val = current_val;
-        new_val = (new_val & !(0x8000_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x8000_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x4000_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x4000_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x2000_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x2000_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x1000 as caliptra_emu_types::RvData))
-            | (write_val & (0x1000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x100 as caliptra_emu_types::RvData))
-            | (write_val & (0x100 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x80 as caliptra_emu_types::RvData))
-            | (write_val & (0x80 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x8000_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x8000_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x4000_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x4000_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x2000_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x2000_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x1000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x1000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x100 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x100 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x80 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x80 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_base_hc_control = new_val;
     }
     fn read_i3c_base_controller_device_addr(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::ControllerDeviceAddr::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::i3c_base_controller_device_addr");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_base_controller_device_addr)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_base_controller_device_addr,
+        )
     }
     fn write_i3c_base_controller_device_addr(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::ControllerDeviceAddr::Register,
         >,
@@ -2952,18 +3173,18 @@ impl I3cPeripheral for I3cGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_base_controller_device_addr = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_base_controller_device_addr;
         let mut new_val = current_val;
-        new_val = (new_val & !(0x8000_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x8000_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x7f_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x7f_0000 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x8000_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x8000_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x7f_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x7f_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_base_controller_device_addr = new_val;
     }
     fn read_i3c_base_hc_capabilities(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::HcCapabilities::Register,
     > {
@@ -2972,22 +3193,22 @@ impl I3cPeripheral for I3cGenerated {
                 "[EMU] Generated default register handler: read i3c::i3c_base_hc_capabilities"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_base_hc_capabilities)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.i3c_base_hc_capabilities)
     }
     fn read_i3c_base_reset_control(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::ResetControl::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read i3c::i3c_base_reset_control");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_base_reset_control)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.i3c_base_reset_control)
     }
     fn write_i3c_base_reset_control(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::ResetControl::Register,
         >,
@@ -2995,48 +3216,48 @@ impl I3cPeripheral for I3cGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_base_reset_control = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_base_reset_control;
         let mut new_val = current_val;
-        new_val = (new_val & !(0x20 as caliptra_emu_types::RvData))
-            | (write_val & (0x20 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x10 as caliptra_emu_types::RvData))
-            | (write_val & (0x10 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(8 as caliptra_emu_types::RvData))
-            | (write_val & (8 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(4 as caliptra_emu_types::RvData))
-            | (write_val & (4 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(2 as caliptra_emu_types::RvData))
-            | (write_val & (2 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x20 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x20 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x10 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x10 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(8 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (8 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(4 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (4 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(2 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_base_reset_control = new_val;
     }
     fn read_i3c_base_present_state(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::PresentState::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read i3c::i3c_base_present_state");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_base_present_state)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.i3c_base_present_state)
     }
     fn read_i3c_base_intr_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::IntrStatus::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read i3c::i3c_base_intr_status");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_base_intr_status)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.i3c_base_intr_status)
     }
     fn write_i3c_base_intr_status(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::IntrStatus::Register,
         >,
@@ -3044,24 +3265,24 @@ impl I3cPeripheral for I3cGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_base_intr_status = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_base_intr_status;
         let mut new_val = current_val;
-        new_val = (new_val & !(0x4000 as caliptra_emu_types::RvData))
-            | (write_val & (0x4000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x2000 as caliptra_emu_types::RvData))
-            | (write_val & (0x2000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x1000 as caliptra_emu_types::RvData))
-            | (write_val & (0x1000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x800 as caliptra_emu_types::RvData))
-            | (write_val & (0x800 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x400 as caliptra_emu_types::RvData))
-            | (write_val & (0x400 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x4000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x4000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x2000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x2000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x1000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x1000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x800 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x800 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x400 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x400 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_base_intr_status = new_val;
     }
     fn read_i3c_base_intr_status_enable(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::IntrStatusEnable::Register,
     > {
@@ -3070,11 +3291,13 @@ impl I3cPeripheral for I3cGenerated {
                 "[EMU] Generated default register handler: read i3c::i3c_base_intr_status_enable"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_base_intr_status_enable)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_base_intr_status_enable,
+        )
     }
     fn write_i3c_base_intr_status_enable(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::IntrStatusEnable::Register,
         >,
@@ -3082,24 +3305,24 @@ impl I3cPeripheral for I3cGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_base_intr_status_enable = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_base_intr_status_enable;
         let mut new_val = current_val;
-        new_val = (new_val & !(0x4000 as caliptra_emu_types::RvData))
-            | (write_val & (0x4000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x2000 as caliptra_emu_types::RvData))
-            | (write_val & (0x2000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x1000 as caliptra_emu_types::RvData))
-            | (write_val & (0x1000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x800 as caliptra_emu_types::RvData))
-            | (write_val & (0x800 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x400 as caliptra_emu_types::RvData))
-            | (write_val & (0x400 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x4000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x4000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x2000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x2000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x1000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x1000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x800 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x800 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x400 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x400 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_base_intr_status_enable = new_val;
     }
     fn read_i3c_base_intr_signal_enable(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::IntrSignalEnable::Register,
     > {
@@ -3108,11 +3331,13 @@ impl I3cPeripheral for I3cGenerated {
                 "[EMU] Generated default register handler: read i3c::i3c_base_intr_signal_enable"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_base_intr_signal_enable)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_base_intr_signal_enable,
+        )
     }
     fn write_i3c_base_intr_signal_enable(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::IntrSignalEnable::Register,
         >,
@@ -3120,24 +3345,24 @@ impl I3cPeripheral for I3cGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_base_intr_signal_enable = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_base_intr_signal_enable;
         let mut new_val = current_val;
-        new_val = (new_val & !(0x4000 as caliptra_emu_types::RvData))
-            | (write_val & (0x4000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x2000 as caliptra_emu_types::RvData))
-            | (write_val & (0x2000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x1000 as caliptra_emu_types::RvData))
-            | (write_val & (0x1000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x800 as caliptra_emu_types::RvData))
-            | (write_val & (0x800 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x400 as caliptra_emu_types::RvData))
-            | (write_val & (0x400 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x4000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x4000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x2000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x2000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x1000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x1000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x800 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x800 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x400 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x400 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_base_intr_signal_enable = new_val;
     }
     fn write_i3c_base_intr_force(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::IntrForce::Register,
         >,
@@ -3145,24 +3370,24 @@ impl I3cPeripheral for I3cGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_base_intr_force = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_base_intr_force;
         let mut new_val = current_val;
-        new_val = (new_val & !(0x4000 as caliptra_emu_types::RvData))
-            | (write_val & (0x4000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x2000 as caliptra_emu_types::RvData))
-            | (write_val & (0x2000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x1000 as caliptra_emu_types::RvData))
-            | (write_val & (0x1000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x800 as caliptra_emu_types::RvData))
-            | (write_val & (0x800 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x400 as caliptra_emu_types::RvData))
-            | (write_val & (0x400 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x4000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x4000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x2000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x2000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x1000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x1000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x800 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x800 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x400 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x400 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_base_intr_force = new_val;
     }
     fn read_i3c_base_dat_section_offset(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::DatSectionOffset::Register,
     > {
@@ -3171,11 +3396,13 @@ impl I3cPeripheral for I3cGenerated {
                 "[EMU] Generated default register handler: read i3c::i3c_base_dat_section_offset"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_base_dat_section_offset)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_base_dat_section_offset,
+        )
     }
     fn read_i3c_base_dct_section_offset(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::DctSectionOffset::Register,
     > {
@@ -3184,11 +3411,13 @@ impl I3cPeripheral for I3cGenerated {
                 "[EMU] Generated default register handler: read i3c::i3c_base_dct_section_offset"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_base_dct_section_offset)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_base_dct_section_offset,
+        )
     }
     fn write_i3c_base_dct_section_offset(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::DctSectionOffset::Register,
         >,
@@ -3196,27 +3425,29 @@ impl I3cPeripheral for I3cGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_base_dct_section_offset = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_base_dct_section_offset;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xf8_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0xf8_0000 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xf8_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xf8_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_base_dct_section_offset = new_val;
     }
     fn read_i3c_base_ring_headers_section_offset(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::RingHeadersSectionOffset::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::i3c_base_ring_headers_section_offset");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_base_ring_headers_section_offset)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_base_ring_headers_section_offset,
+        )
     }
     fn read_i3c_base_pio_section_offset(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::PioSectionOffset::Register,
     > {
@@ -3225,22 +3456,26 @@ impl I3cPeripheral for I3cGenerated {
                 "[EMU] Generated default register handler: read i3c::i3c_base_pio_section_offset"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_base_pio_section_offset)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_base_pio_section_offset,
+        )
     }
     fn read_i3c_base_ext_caps_section_offset(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::ExtCapsSectionOffset::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::i3c_base_ext_caps_section_offset");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_base_ext_caps_section_offset)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_base_ext_caps_section_offset,
+        )
     }
     fn read_i3c_base_int_ctrl_cmds_en(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::IntCtrlCmdsEn::Register,
     > {
@@ -3249,11 +3484,13 @@ impl I3cPeripheral for I3cGenerated {
                 "[EMU] Generated default register handler: read i3c::i3c_base_int_ctrl_cmds_en"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_base_int_ctrl_cmds_en)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_base_int_ctrl_cmds_en,
+        )
     }
     fn read_i3c_base_ibi_notify_ctrl(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::IbiNotifyCtrl::Register,
     > {
@@ -3262,11 +3499,11 @@ impl I3cPeripheral for I3cGenerated {
                 "[EMU] Generated default register handler: read i3c::i3c_base_ibi_notify_ctrl"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_base_ibi_notify_ctrl)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.i3c_base_ibi_notify_ctrl)
     }
     fn write_i3c_base_ibi_notify_ctrl(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::IbiNotifyCtrl::Register,
         >,
@@ -3274,20 +3511,20 @@ impl I3cPeripheral for I3cGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_base_ibi_notify_ctrl = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_base_ibi_notify_ctrl;
         let mut new_val = current_val;
-        new_val = (new_val & !(8 as caliptra_emu_types::RvData))
-            | (write_val & (8 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(2 as caliptra_emu_types::RvData))
-            | (write_val & (2 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(8 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (8 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(2 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_base_ibi_notify_ctrl = new_val;
     }
     fn read_i3c_base_ibi_data_abort_ctrl(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::IbiDataAbortCtrl::Register,
     > {
@@ -3296,11 +3533,13 @@ impl I3cPeripheral for I3cGenerated {
                 "[EMU] Generated default register handler: read i3c::i3c_base_ibi_data_abort_ctrl"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_base_ibi_data_abort_ctrl)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_base_ibi_data_abort_ctrl,
+        )
     }
     fn write_i3c_base_ibi_data_abort_ctrl(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::IbiDataAbortCtrl::Register,
         >,
@@ -3308,22 +3547,22 @@ impl I3cPeripheral for I3cGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_base_ibi_data_abort_ctrl = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_base_ibi_data_abort_ctrl;
         let mut new_val = current_val;
-        new_val = (new_val & !(0x8000_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x8000_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x1c_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x1c_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x3_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x3_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xff00 as caliptra_emu_types::RvData))
-            | (write_val & (0xff00 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x8000_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x8000_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x1c_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x1c_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x3_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x3_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff00 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff00 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_base_ibi_data_abort_ctrl = new_val;
     }
     fn read_i3c_base_dev_ctx_base_lo(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::DevCtxBaseLo::Register,
     > {
@@ -3332,11 +3571,11 @@ impl I3cPeripheral for I3cGenerated {
                 "[EMU] Generated default register handler: read i3c::i3c_base_dev_ctx_base_lo"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_base_dev_ctx_base_lo)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.i3c_base_dev_ctx_base_lo)
     }
     fn write_i3c_base_dev_ctx_base_lo(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::DevCtxBaseLo::Register,
         >,
@@ -3344,16 +3583,16 @@ impl I3cPeripheral for I3cGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_base_dev_ctx_base_lo = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_base_dev_ctx_base_lo;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_base_dev_ctx_base_lo = new_val;
     }
     fn read_i3c_base_dev_ctx_base_hi(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::DevCtxBaseHi::Register,
     > {
@@ -3362,11 +3601,11 @@ impl I3cPeripheral for I3cGenerated {
                 "[EMU] Generated default register handler: read i3c::i3c_base_dev_ctx_base_hi"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_base_dev_ctx_base_hi)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.i3c_base_dev_ctx_base_hi)
     }
     fn write_i3c_base_dev_ctx_base_hi(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::DevCtxBaseHi::Register,
         >,
@@ -3374,34 +3613,39 @@ impl I3cPeripheral for I3cGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_base_dev_ctx_base_hi = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_base_dev_ctx_base_hi;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_base_dev_ctx_base_hi = new_val;
     }
     fn read_i3c_base_dev_ctx_sg(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::DevCtxSg::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::DevCtxSg::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read i3c::i3c_base_dev_ctx_sg");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_base_dev_ctx_sg)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.i3c_base_dev_ctx_sg)
     }
-    fn write_piocontrol_command_port(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_piocontrol_command_port(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::piocontrol_command_port = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.piocontrol_command_port;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.piocontrol_command_port = new_val;
     }
-    fn read_piocontrol_response_port(&mut self) -> caliptra_emu_types::RvData {
+    fn read_piocontrol_response_port(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read i3c::piocontrol_response_port"
@@ -3409,18 +3653,21 @@ impl I3cPeripheral for I3cGenerated {
         }
         self.piocontrol_response_port
     }
-    fn write_piocontrol_tx_data_port(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_piocontrol_tx_data_port(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::piocontrol_tx_data_port = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.piocontrol_tx_data_port;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.piocontrol_tx_data_port = new_val;
     }
-    fn read_piocontrol_rx_data_port(&mut self) -> caliptra_emu_types::RvData {
+    fn read_piocontrol_rx_data_port(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read i3c::piocontrol_rx_data_port"
@@ -3428,7 +3675,7 @@ impl I3cPeripheral for I3cGenerated {
         }
         self.piocontrol_rx_data_port
     }
-    fn read_piocontrol_ibi_port(&mut self) -> caliptra_emu_types::RvData {
+    fn read_piocontrol_ibi_port(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read i3c::piocontrol_ibi_port");
         }
@@ -3436,7 +3683,7 @@ impl I3cPeripheral for I3cGenerated {
     }
     fn read_piocontrol_queue_thld_ctrl(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::QueueThldCtrl::Register,
     > {
@@ -3445,11 +3692,13 @@ impl I3cPeripheral for I3cGenerated {
                 "[EMU] Generated default register handler: read i3c::piocontrol_queue_thld_ctrl"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.piocontrol_queue_thld_ctrl)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.piocontrol_queue_thld_ctrl,
+        )
     }
     fn write_piocontrol_queue_thld_ctrl(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::QueueThldCtrl::Register,
         >,
@@ -3457,33 +3706,35 @@ impl I3cPeripheral for I3cGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::piocontrol_queue_thld_ctrl = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.piocontrol_queue_thld_ctrl;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xff00_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0xff00_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xff_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0xff_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xff00 as caliptra_emu_types::RvData))
-            | (write_val & (0xff00 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xff as caliptra_emu_types::RvData))
-            | (write_val & (0xff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff00_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff00_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff00 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff00 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.piocontrol_queue_thld_ctrl = new_val;
     }
     fn read_piocontrol_data_buffer_thld_ctrl(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::DataBufferThldCtrl::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::piocontrol_data_buffer_thld_ctrl");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.piocontrol_data_buffer_thld_ctrl)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.piocontrol_data_buffer_thld_ctrl,
+        )
     }
     fn write_piocontrol_data_buffer_thld_ctrl(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::DataBufferThldCtrl::Register,
         >,
@@ -3491,31 +3742,33 @@ impl I3cPeripheral for I3cGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::piocontrol_data_buffer_thld_ctrl = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.piocontrol_data_buffer_thld_ctrl;
         let mut new_val = current_val;
-        new_val = (new_val & !(0x700_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x700_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x7_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x7_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x700 as caliptra_emu_types::RvData))
-            | (write_val & (0x700 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(7 as caliptra_emu_types::RvData))
-            | (write_val & (7 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x700_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x700_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x7_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x7_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x700 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x700 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(7 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (7 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.piocontrol_data_buffer_thld_ctrl = new_val;
     }
     fn read_piocontrol_queue_size(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::QueueSize::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::QueueSize::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read i3c::piocontrol_queue_size");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.piocontrol_queue_size)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.piocontrol_queue_size)
     }
     fn read_piocontrol_alt_queue_size(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::AltQueueSize::Register,
     > {
@@ -3524,11 +3777,13 @@ impl I3cPeripheral for I3cGenerated {
                 "[EMU] Generated default register handler: read i3c::piocontrol_alt_queue_size"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.piocontrol_alt_queue_size)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.piocontrol_alt_queue_size,
+        )
     }
     fn read_piocontrol_pio_intr_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::PioIntrStatus::Register,
     > {
@@ -3537,11 +3792,13 @@ impl I3cPeripheral for I3cGenerated {
                 "[EMU] Generated default register handler: read i3c::piocontrol_pio_intr_status"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.piocontrol_pio_intr_status)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.piocontrol_pio_intr_status,
+        )
     }
     fn write_piocontrol_pio_intr_status(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::PioIntrStatus::Register,
         >,
@@ -3549,29 +3806,31 @@ impl I3cPeripheral for I3cGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::piocontrol_pio_intr_status = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.piocontrol_pio_intr_status;
         let mut new_val = current_val;
-        new_val = (new_val & !(0x200 as caliptra_emu_types::RvData))
-            | (write_val & (0x200 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x20 as caliptra_emu_types::RvData))
-            | (write_val & (0x20 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x200 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x200 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x20 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x20 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.piocontrol_pio_intr_status = new_val;
     }
     fn read_piocontrol_pio_intr_status_enable(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::PioIntrStatusEnable::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::piocontrol_pio_intr_status_enable");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.piocontrol_pio_intr_status_enable)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.piocontrol_pio_intr_status_enable,
+        )
     }
     fn write_piocontrol_pio_intr_status_enable(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::PioIntrStatusEnable::Register,
         >,
@@ -3579,39 +3838,41 @@ impl I3cPeripheral for I3cGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::piocontrol_pio_intr_status_enable = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.piocontrol_pio_intr_status_enable;
         let mut new_val = current_val;
-        new_val = (new_val & !(0x200 as caliptra_emu_types::RvData))
-            | (write_val & (0x200 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x20 as caliptra_emu_types::RvData))
-            | (write_val & (0x20 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x10 as caliptra_emu_types::RvData))
-            | (write_val & (0x10 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(8 as caliptra_emu_types::RvData))
-            | (write_val & (8 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(4 as caliptra_emu_types::RvData))
-            | (write_val & (4 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(2 as caliptra_emu_types::RvData))
-            | (write_val & (2 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x200 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x200 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x20 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x20 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x10 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x10 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(8 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (8 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(4 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (4 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(2 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.piocontrol_pio_intr_status_enable = new_val;
     }
     fn read_piocontrol_pio_intr_signal_enable(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::PioIntrSignalEnable::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::piocontrol_pio_intr_signal_enable");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.piocontrol_pio_intr_signal_enable)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.piocontrol_pio_intr_signal_enable,
+        )
     }
     fn write_piocontrol_pio_intr_signal_enable(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::PioIntrSignalEnable::Register,
         >,
@@ -3619,28 +3880,28 @@ impl I3cPeripheral for I3cGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::piocontrol_pio_intr_signal_enable = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.piocontrol_pio_intr_signal_enable;
         let mut new_val = current_val;
-        new_val = (new_val & !(0x200 as caliptra_emu_types::RvData))
-            | (write_val & (0x200 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x20 as caliptra_emu_types::RvData))
-            | (write_val & (0x20 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x10 as caliptra_emu_types::RvData))
-            | (write_val & (0x10 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(8 as caliptra_emu_types::RvData))
-            | (write_val & (8 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(4 as caliptra_emu_types::RvData))
-            | (write_val & (4 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(2 as caliptra_emu_types::RvData))
-            | (write_val & (2 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x200 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x200 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x20 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x20 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x10 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x10 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(8 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (8 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(4 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (4 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(2 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.piocontrol_pio_intr_signal_enable = new_val;
     }
     fn write_piocontrol_pio_intr_force(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::PioIntrForce::Register,
         >,
@@ -3648,39 +3909,39 @@ impl I3cPeripheral for I3cGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::piocontrol_pio_intr_force = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.piocontrol_pio_intr_force;
         let mut new_val = current_val;
-        new_val = (new_val & !(0x200 as caliptra_emu_types::RvData))
-            | (write_val & (0x200 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x20 as caliptra_emu_types::RvData))
-            | (write_val & (0x20 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x10 as caliptra_emu_types::RvData))
-            | (write_val & (0x10 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(8 as caliptra_emu_types::RvData))
-            | (write_val & (8 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(4 as caliptra_emu_types::RvData))
-            | (write_val & (4 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(2 as caliptra_emu_types::RvData))
-            | (write_val & (2 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x200 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x200 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x20 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x20 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x10 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x10 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(8 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (8 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(4 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (4 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(2 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.piocontrol_pio_intr_force = new_val;
     }
     fn read_piocontrol_pio_control(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::PioControl::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read i3c::piocontrol_pio_control");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.piocontrol_pio_control)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.piocontrol_pio_control)
     }
     fn write_piocontrol_pio_control(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::PioControl::Register,
         >,
@@ -3688,35 +3949,41 @@ impl I3cPeripheral for I3cGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::piocontrol_pio_control = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.piocontrol_pio_control;
         let mut new_val = current_val;
-        new_val = (new_val & !(4 as caliptra_emu_types::RvData))
-            | (write_val & (4 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(2 as caliptra_emu_types::RvData))
-            | (write_val & (2 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(4 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (4 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(2 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.piocontrol_pio_control = new_val;
     }
     fn read_i3c_ec_sec_fw_recovery_if_extcap_header(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::ExtcapHeader::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::i3c_ec_sec_fw_recovery_if_extcap_header");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_sec_fw_recovery_if_extcap_header)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_sec_fw_recovery_if_extcap_header,
+        )
     }
-    fn read_i3c_ec_sec_fw_recovery_if_prot_cap_0(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_sec_fw_recovery_if_prot_cap_0(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::i3c_ec_sec_fw_recovery_if_prot_cap_0");
         }
         self.i3c_ec_sec_fw_recovery_if_prot_cap_0
     }
-    fn read_i3c_ec_sec_fw_recovery_if_prot_cap_1(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_sec_fw_recovery_if_prot_cap_1(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::i3c_ec_sec_fw_recovery_if_prot_cap_1");
         }
@@ -3724,16 +3991,20 @@ impl I3cPeripheral for I3cGenerated {
     }
     fn read_i3c_ec_sec_fw_recovery_if_prot_cap_2(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::ProtCap2::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::ProtCap2::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::i3c_ec_sec_fw_recovery_if_prot_cap_2");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_sec_fw_recovery_if_prot_cap_2)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_sec_fw_recovery_if_prot_cap_2,
+        )
     }
     fn write_i3c_ec_sec_fw_recovery_if_prot_cap_2(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::ProtCap2::Register,
         >,
@@ -3741,27 +4012,31 @@ impl I3cPeripheral for I3cGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_ec_sec_fw_recovery_if_prot_cap_2 = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_sec_fw_recovery_if_prot_cap_2;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xffff_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_0000 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_sec_fw_recovery_if_prot_cap_2 = new_val;
     }
     fn read_i3c_ec_sec_fw_recovery_if_prot_cap_3(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::ProtCap3::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::ProtCap3::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::i3c_ec_sec_fw_recovery_if_prot_cap_3");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_sec_fw_recovery_if_prot_cap_3)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_sec_fw_recovery_if_prot_cap_3,
+        )
     }
     fn write_i3c_ec_sec_fw_recovery_if_prot_cap_3(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::ProtCap3::Register,
         >,
@@ -3769,29 +4044,33 @@ impl I3cPeripheral for I3cGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_ec_sec_fw_recovery_if_prot_cap_3 = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_sec_fw_recovery_if_prot_cap_3;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xff as caliptra_emu_types::RvData))
-            | (write_val & (0xff as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xff00 as caliptra_emu_types::RvData))
-            | (write_val & (0xff00 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xff_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0xff_0000 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff00 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff00 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_sec_fw_recovery_if_prot_cap_3 = new_val;
     }
     fn read_i3c_ec_sec_fw_recovery_if_device_id_0(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::DeviceId0::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::DeviceId0::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::i3c_ec_sec_fw_recovery_if_device_id_0");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_sec_fw_recovery_if_device_id_0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_sec_fw_recovery_if_device_id_0,
+        )
     }
     fn write_i3c_ec_sec_fw_recovery_if_device_id_0(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::DeviceId0::Register,
         >,
@@ -3799,103 +4078,130 @@ impl I3cPeripheral for I3cGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_ec_sec_fw_recovery_if_device_id_0 = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_sec_fw_recovery_if_device_id_0;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xff as caliptra_emu_types::RvData))
-            | (write_val & (0xff as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xff00 as caliptra_emu_types::RvData))
-            | (write_val & (0xff00 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xffff_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_0000 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff00 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff00 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_sec_fw_recovery_if_device_id_0 = new_val;
     }
-    fn read_i3c_ec_sec_fw_recovery_if_device_id_1(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_sec_fw_recovery_if_device_id_1(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::i3c_ec_sec_fw_recovery_if_device_id_1");
         }
         self.i3c_ec_sec_fw_recovery_if_device_id_1
     }
-    fn write_i3c_ec_sec_fw_recovery_if_device_id_1(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_sec_fw_recovery_if_device_id_1(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_ec_sec_fw_recovery_if_device_id_1 = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_sec_fw_recovery_if_device_id_1;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_sec_fw_recovery_if_device_id_1 = new_val;
     }
-    fn read_i3c_ec_sec_fw_recovery_if_device_id_2(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_sec_fw_recovery_if_device_id_2(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::i3c_ec_sec_fw_recovery_if_device_id_2");
         }
         self.i3c_ec_sec_fw_recovery_if_device_id_2
     }
-    fn write_i3c_ec_sec_fw_recovery_if_device_id_2(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_sec_fw_recovery_if_device_id_2(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_ec_sec_fw_recovery_if_device_id_2 = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_sec_fw_recovery_if_device_id_2;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_sec_fw_recovery_if_device_id_2 = new_val;
     }
-    fn read_i3c_ec_sec_fw_recovery_if_device_id_3(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_sec_fw_recovery_if_device_id_3(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::i3c_ec_sec_fw_recovery_if_device_id_3");
         }
         self.i3c_ec_sec_fw_recovery_if_device_id_3
     }
-    fn write_i3c_ec_sec_fw_recovery_if_device_id_3(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_sec_fw_recovery_if_device_id_3(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_ec_sec_fw_recovery_if_device_id_3 = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_sec_fw_recovery_if_device_id_3;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_sec_fw_recovery_if_device_id_3 = new_val;
     }
-    fn read_i3c_ec_sec_fw_recovery_if_device_id_4(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_sec_fw_recovery_if_device_id_4(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::i3c_ec_sec_fw_recovery_if_device_id_4");
         }
         self.i3c_ec_sec_fw_recovery_if_device_id_4
     }
-    fn write_i3c_ec_sec_fw_recovery_if_device_id_4(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_sec_fw_recovery_if_device_id_4(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_ec_sec_fw_recovery_if_device_id_4 = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_sec_fw_recovery_if_device_id_4;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_sec_fw_recovery_if_device_id_4 = new_val;
     }
-    fn read_i3c_ec_sec_fw_recovery_if_device_id_5(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_sec_fw_recovery_if_device_id_5(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::i3c_ec_sec_fw_recovery_if_device_id_5");
         }
         self.i3c_ec_sec_fw_recovery_if_device_id_5
     }
-    fn write_i3c_ec_sec_fw_recovery_if_device_id_5(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_sec_fw_recovery_if_device_id_5(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_ec_sec_fw_recovery_if_device_id_5 = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_sec_fw_recovery_if_device_id_5;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_sec_fw_recovery_if_device_id_5 = new_val;
     }
-    fn read_i3c_ec_sec_fw_recovery_if_device_id_reserved(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_sec_fw_recovery_if_device_id_reserved(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::i3c_ec_sec_fw_recovery_if_device_id_reserved");
         }
@@ -3903,18 +4209,20 @@ impl I3cPeripheral for I3cGenerated {
     }
     fn read_i3c_ec_sec_fw_recovery_if_device_status_0(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::DeviceStatus0::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::i3c_ec_sec_fw_recovery_if_device_status_0");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_sec_fw_recovery_if_device_status_0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_sec_fw_recovery_if_device_status_0,
+        )
     }
     fn write_i3c_ec_sec_fw_recovery_if_device_status_0(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::DeviceStatus0::Register,
         >,
@@ -3922,31 +4230,33 @@ impl I3cPeripheral for I3cGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_ec_sec_fw_recovery_if_device_status_0 = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_sec_fw_recovery_if_device_status_0;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xff as caliptra_emu_types::RvData))
-            | (write_val & (0xff as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xff00 as caliptra_emu_types::RvData))
-            | (write_val & (0xff00 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xffff_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_0000 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff00 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff00 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_sec_fw_recovery_if_device_status_0 = new_val;
     }
     fn read_i3c_ec_sec_fw_recovery_if_device_status_1(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::DeviceStatus1::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::i3c_ec_sec_fw_recovery_if_device_status_1");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_sec_fw_recovery_if_device_status_1)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_sec_fw_recovery_if_device_status_1,
+        )
     }
     fn write_i3c_ec_sec_fw_recovery_if_device_status_1(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::DeviceStatus1::Register,
         >,
@@ -3954,31 +4264,33 @@ impl I3cPeripheral for I3cGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_ec_sec_fw_recovery_if_device_status_1 = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_sec_fw_recovery_if_device_status_1;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x1ff_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x1ff_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xfe00_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0xfe00_0000 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x1ff_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x1ff_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xfe00_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xfe00_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_sec_fw_recovery_if_device_status_1 = new_val;
     }
     fn read_i3c_ec_sec_fw_recovery_if_device_reset(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::DeviceReset::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::i3c_ec_sec_fw_recovery_if_device_reset");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_sec_fw_recovery_if_device_reset)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_sec_fw_recovery_if_device_reset,
+        )
     }
     fn write_i3c_ec_sec_fw_recovery_if_device_reset(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::DeviceReset::Register,
         >,
@@ -3986,31 +4298,33 @@ impl I3cPeripheral for I3cGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_ec_sec_fw_recovery_if_device_reset = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_sec_fw_recovery_if_device_reset;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xff as caliptra_emu_types::RvData))
-            | (write_val & (0xff as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xff00 as caliptra_emu_types::RvData))
-            | (write_val & (0xff00 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xff_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0xff_0000 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff00 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff00 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_sec_fw_recovery_if_device_reset = new_val;
     }
     fn read_i3c_ec_sec_fw_recovery_if_recovery_ctrl(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::RecoveryCtrl::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::i3c_ec_sec_fw_recovery_if_recovery_ctrl");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_sec_fw_recovery_if_recovery_ctrl)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_sec_fw_recovery_if_recovery_ctrl,
+        )
     }
     fn write_i3c_ec_sec_fw_recovery_if_recovery_ctrl(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::RecoveryCtrl::Register,
         >,
@@ -4018,31 +4332,33 @@ impl I3cPeripheral for I3cGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_ec_sec_fw_recovery_if_recovery_ctrl = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_sec_fw_recovery_if_recovery_ctrl;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xff as caliptra_emu_types::RvData))
-            | (write_val & (0xff as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xff00 as caliptra_emu_types::RvData))
-            | (write_val & (0xff00 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xff_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0xff_0000 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff00 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff00 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_sec_fw_recovery_if_recovery_ctrl = new_val;
     }
     fn read_i3c_ec_sec_fw_recovery_if_recovery_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::RecoveryStatus::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::i3c_ec_sec_fw_recovery_if_recovery_status");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_sec_fw_recovery_if_recovery_status)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_sec_fw_recovery_if_recovery_status,
+        )
     }
     fn write_i3c_ec_sec_fw_recovery_if_recovery_status(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::RecoveryStatus::Register,
         >,
@@ -4050,29 +4366,33 @@ impl I3cPeripheral for I3cGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_ec_sec_fw_recovery_if_recovery_status = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_sec_fw_recovery_if_recovery_status;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xf as caliptra_emu_types::RvData))
-            | (write_val & (0xf as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xf0 as caliptra_emu_types::RvData))
-            | (write_val & (0xf0 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xff00 as caliptra_emu_types::RvData))
-            | (write_val & (0xff00 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xf as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xf as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xf0 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xf0 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff00 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff00 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_sec_fw_recovery_if_recovery_status = new_val;
     }
     fn read_i3c_ec_sec_fw_recovery_if_hw_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::HwStatus::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::HwStatus::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::i3c_ec_sec_fw_recovery_if_hw_status");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_sec_fw_recovery_if_hw_status)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_sec_fw_recovery_if_hw_status,
+        )
     }
     fn write_i3c_ec_sec_fw_recovery_if_hw_status(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::HwStatus::Register,
         >,
@@ -4080,41 +4400,41 @@ impl I3cPeripheral for I3cGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_ec_sec_fw_recovery_if_hw_status = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_sec_fw_recovery_if_hw_status;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(2 as caliptra_emu_types::RvData))
-            | (write_val & (2 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(4 as caliptra_emu_types::RvData))
-            | (write_val & (4 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xf8 as caliptra_emu_types::RvData))
-            | (write_val & (0xf8 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xff00 as caliptra_emu_types::RvData))
-            | (write_val & (0xff00 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xff_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0xff_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xff00_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0xff00_0000 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(2 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(4 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (4 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xf8 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xf8 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff00 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff00 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff00_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff00_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_sec_fw_recovery_if_hw_status = new_val;
     }
     fn read_i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_0(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::IndirectFifoCtrl0::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_0");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_0,
         )
     }
     fn write_i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_0(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::IndirectFifoCtrl0::Register,
         >,
@@ -4122,18 +4442,18 @@ impl I3cPeripheral for I3cGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_0 = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_0;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xff as caliptra_emu_types::RvData))
-            | (write_val & (0xff as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xff00 as caliptra_emu_types::RvData))
-            | (write_val & (0xff00 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff00 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff00 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_0 = new_val;
     }
     fn read_i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_1(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_1");
         }
@@ -4141,34 +4461,34 @@ impl I3cPeripheral for I3cGenerated {
     }
     fn write_i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_1(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_1 = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_1;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_1 = new_val;
     }
     fn read_i3c_ec_sec_fw_recovery_if_indirect_fifo_status_0(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::IndirectFifoStatus0::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::i3c_ec_sec_fw_recovery_if_indirect_fifo_status_0");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.i3c_ec_sec_fw_recovery_if_indirect_fifo_status_0,
         )
     }
     fn read_i3c_ec_sec_fw_recovery_if_indirect_fifo_status_1(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::i3c_ec_sec_fw_recovery_if_indirect_fifo_status_1");
         }
@@ -4176,7 +4496,7 @@ impl I3cPeripheral for I3cGenerated {
     }
     fn read_i3c_ec_sec_fw_recovery_if_indirect_fifo_status_2(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::i3c_ec_sec_fw_recovery_if_indirect_fifo_status_2");
         }
@@ -4184,7 +4504,7 @@ impl I3cPeripheral for I3cGenerated {
     }
     fn read_i3c_ec_sec_fw_recovery_if_indirect_fifo_status_3(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::i3c_ec_sec_fw_recovery_if_indirect_fifo_status_3");
         }
@@ -4192,7 +4512,7 @@ impl I3cPeripheral for I3cGenerated {
     }
     fn read_i3c_ec_sec_fw_recovery_if_indirect_fifo_status_4(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::i3c_ec_sec_fw_recovery_if_indirect_fifo_status_4");
         }
@@ -4200,13 +4520,15 @@ impl I3cPeripheral for I3cGenerated {
     }
     fn read_i3c_ec_sec_fw_recovery_if_indirect_fifo_reserved(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::i3c_ec_sec_fw_recovery_if_indirect_fifo_reserved");
         }
         self.i3c_ec_sec_fw_recovery_if_indirect_fifo_reserved
     }
-    fn read_i3c_ec_sec_fw_recovery_if_indirect_fifo_data(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_sec_fw_recovery_if_indirect_fifo_data(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::i3c_ec_sec_fw_recovery_if_indirect_fifo_data");
         }
@@ -4214,29 +4536,33 @@ impl I3cPeripheral for I3cGenerated {
     }
     fn read_i3c_ec_stdby_ctrl_mode_extcap_header(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::ExtcapHeader::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::i3c_ec_stdby_ctrl_mode_extcap_header");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_stdby_ctrl_mode_extcap_header)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_stdby_ctrl_mode_extcap_header,
+        )
     }
     fn read_i3c_ec_stdby_ctrl_mode_stby_cr_control(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::StbyCrControl::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::i3c_ec_stdby_ctrl_mode_stby_cr_control");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_stdby_ctrl_mode_stby_cr_control)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_stdby_ctrl_mode_stby_cr_control,
+        )
     }
     fn write_i3c_ec_stdby_ctrl_mode_stby_cr_control(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::StbyCrControl::Register,
         >,
@@ -4244,51 +4570,53 @@ impl I3cPeripheral for I3cGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_ec_stdby_ctrl_mode_stby_cr_control = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_stdby_ctrl_mode_stby_cr_control;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xc000_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0xc000_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x10_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x10_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x8000 as caliptra_emu_types::RvData))
-            | (write_val & (0x8000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x4000 as caliptra_emu_types::RvData))
-            | (write_val & (0x4000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x2000 as caliptra_emu_types::RvData))
-            | (write_val & (0x2000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x1000 as caliptra_emu_types::RvData))
-            | (write_val & (0x1000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x700 as caliptra_emu_types::RvData))
-            | (write_val & (0x700 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x20 as caliptra_emu_types::RvData))
-            | (write_val & (0x20 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x10 as caliptra_emu_types::RvData))
-            | (write_val & (0x10 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(8 as caliptra_emu_types::RvData))
-            | (write_val & (8 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(4 as caliptra_emu_types::RvData))
-            | (write_val & (4 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(2 as caliptra_emu_types::RvData))
-            | (write_val & (2 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xc000_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xc000_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x10_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x10_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x8000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x8000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x4000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x4000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x2000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x2000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x1000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x1000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x700 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x700 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x20 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x20 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x10 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x10 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(8 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (8 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(4 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (4 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(2 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_stdby_ctrl_mode_stby_cr_control = new_val;
     }
     fn read_i3c_ec_stdby_ctrl_mode_stby_cr_device_addr(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::StbyCrDeviceAddr::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::i3c_ec_stdby_ctrl_mode_stby_cr_device_addr");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_stdby_ctrl_mode_stby_cr_device_addr)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_stdby_ctrl_mode_stby_cr_device_addr,
+        )
     }
     fn write_i3c_ec_stdby_ctrl_mode_stby_cr_device_addr(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::StbyCrDeviceAddr::Register,
         >,
@@ -4296,46 +4624,48 @@ impl I3cPeripheral for I3cGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_ec_stdby_ctrl_mode_stby_cr_device_addr = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_stdby_ctrl_mode_stby_cr_device_addr;
         let mut new_val = current_val;
-        new_val = (new_val & !(0x8000_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x8000_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x7f_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x7f_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x8000 as caliptra_emu_types::RvData))
-            | (write_val & (0x8000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x7f as caliptra_emu_types::RvData))
-            | (write_val & (0x7f as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x8000_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x8000_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x7f_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x7f_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x8000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x8000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x7f as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x7f as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_stdby_ctrl_mode_stby_cr_device_addr = new_val;
     }
     fn read_i3c_ec_stdby_ctrl_mode_stby_cr_capabilities(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::StbyCrCapabilities::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::i3c_ec_stdby_ctrl_mode_stby_cr_capabilities");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_stdby_ctrl_mode_stby_cr_capabilities)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_stdby_ctrl_mode_stby_cr_capabilities,
+        )
     }
     fn read_i3c_ec_stdby_ctrl_mode_stby_cr_virtual_device_char(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::StbyCrVirtualDeviceChar::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::i3c_ec_stdby_ctrl_mode_stby_cr_virtual_device_char");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.i3c_ec_stdby_ctrl_mode_stby_cr_virtual_device_char,
         )
     }
     fn write_i3c_ec_stdby_ctrl_mode_stby_cr_virtual_device_char(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::StbyCrVirtualDeviceChar::Register,
         >,
@@ -4343,33 +4673,35 @@ impl I3cPeripheral for I3cGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_ec_stdby_ctrl_mode_stby_cr_virtual_device_char = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_stdby_ctrl_mode_stby_cr_virtual_device_char;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xe000_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0xe000_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x1f00_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x1f00_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xff_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0xff_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xfffe as caliptra_emu_types::RvData))
-            | (write_val & (0xfffe as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xe000_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xe000_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x1f00_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x1f00_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xfffe as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xfffe as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_stdby_ctrl_mode_stby_cr_virtual_device_char = new_val;
     }
     fn read_i3c_ec_stdby_ctrl_mode_stby_cr_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::StbyCrStatus::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::i3c_ec_stdby_ctrl_mode_stby_cr_status");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_stdby_ctrl_mode_stby_cr_status)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_stdby_ctrl_mode_stby_cr_status,
+        )
     }
     fn write_i3c_ec_stdby_ctrl_mode_stby_cr_status(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::StbyCrStatus::Register,
         >,
@@ -4377,31 +4709,33 @@ impl I3cPeripheral for I3cGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_ec_stdby_ctrl_mode_stby_cr_status = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_stdby_ctrl_mode_stby_cr_status;
         let mut new_val = current_val;
-        new_val = (new_val & !(0x100 as caliptra_emu_types::RvData))
-            | (write_val & (0x100 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xe0 as caliptra_emu_types::RvData))
-            | (write_val & (0xe0 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(4 as caliptra_emu_types::RvData))
-            | (write_val & (4 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x100 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x100 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xe0 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xe0 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(4 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (4 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_stdby_ctrl_mode_stby_cr_status = new_val;
     }
     fn read_i3c_ec_stdby_ctrl_mode_stby_cr_device_char(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::StbyCrDeviceChar::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::i3c_ec_stdby_ctrl_mode_stby_cr_device_char");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_stdby_ctrl_mode_stby_cr_device_char)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_stdby_ctrl_mode_stby_cr_device_char,
+        )
     }
     fn write_i3c_ec_stdby_ctrl_mode_stby_cr_device_char(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::StbyCrDeviceChar::Register,
         >,
@@ -4409,20 +4743,22 @@ impl I3cPeripheral for I3cGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_ec_stdby_ctrl_mode_stby_cr_device_char = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_stdby_ctrl_mode_stby_cr_device_char;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xe000_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0xe000_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x1f00_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x1f00_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xff_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0xff_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xfffe as caliptra_emu_types::RvData))
-            | (write_val & (0xfffe as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xe000_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xe000_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x1f00_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x1f00_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xfffe as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xfffe as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_stdby_ctrl_mode_stby_cr_device_char = new_val;
     }
-    fn read_i3c_ec_stdby_ctrl_mode_stby_cr_device_pid_lo(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_stdby_ctrl_mode_stby_cr_device_pid_lo(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::i3c_ec_stdby_ctrl_mode_stby_cr_device_pid_lo");
         }
@@ -4430,32 +4766,34 @@ impl I3cPeripheral for I3cGenerated {
     }
     fn write_i3c_ec_stdby_ctrl_mode_stby_cr_device_pid_lo(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_ec_stdby_ctrl_mode_stby_cr_device_pid_lo = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_stdby_ctrl_mode_stby_cr_device_pid_lo;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_stdby_ctrl_mode_stby_cr_device_pid_lo = new_val;
     }
     fn read_i3c_ec_stdby_ctrl_mode_stby_cr_intr_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::StbyCrIntrStatus::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::i3c_ec_stdby_ctrl_mode_stby_cr_intr_status");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_stdby_ctrl_mode_stby_cr_intr_status)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_stdby_ctrl_mode_stby_cr_intr_status,
+        )
     }
     fn write_i3c_ec_stdby_ctrl_mode_stby_cr_intr_status(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::StbyCrIntrStatus::Register,
         >,
@@ -4463,40 +4801,40 @@ impl I3cPeripheral for I3cGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_ec_stdby_ctrl_mode_stby_cr_intr_status = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_stdby_ctrl_mode_stby_cr_intr_status;
         let mut new_val = current_val;
-        new_val = (new_val & !(0x8_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x8_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x4_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x4_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x2_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x2_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x1_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x1_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x4000 as caliptra_emu_types::RvData))
-            | (write_val & (0x4000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x2000 as caliptra_emu_types::RvData))
-            | (write_val & (0x2000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x1000 as caliptra_emu_types::RvData))
-            | (write_val & (0x1000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x800 as caliptra_emu_types::RvData))
-            | (write_val & (0x800 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x400 as caliptra_emu_types::RvData))
-            | (write_val & (0x400 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(8 as caliptra_emu_types::RvData))
-            | (write_val & (8 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(4 as caliptra_emu_types::RvData))
-            | (write_val & (4 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(2 as caliptra_emu_types::RvData))
-            | (write_val & (2 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x8_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x8_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x4_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x4_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x2_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x2_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x1_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x1_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x4000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x4000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x2000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x2000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x1000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x1000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x800 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x800 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x400 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x400 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(8 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (8 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(4 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (4 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(2 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_stdby_ctrl_mode_stby_cr_intr_status = new_val;
     }
     fn read_i3c_ec_stdby_ctrl_mode_stby_cr_virtual_device_pid_lo(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::i3c_ec_stdby_ctrl_mode_stby_cr_virtual_device_pid_lo");
         }
@@ -4504,34 +4842,34 @@ impl I3cPeripheral for I3cGenerated {
     }
     fn write_i3c_ec_stdby_ctrl_mode_stby_cr_virtual_device_pid_lo(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_ec_stdby_ctrl_mode_stby_cr_virtual_device_pid_lo = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_stdby_ctrl_mode_stby_cr_virtual_device_pid_lo;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_stdby_ctrl_mode_stby_cr_virtual_device_pid_lo = new_val;
     }
     fn read_i3c_ec_stdby_ctrl_mode_stby_cr_intr_signal_enable(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::StbyCrIntrSignalEnable::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::i3c_ec_stdby_ctrl_mode_stby_cr_intr_signal_enable");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.i3c_ec_stdby_ctrl_mode_stby_cr_intr_signal_enable,
         )
     }
     fn write_i3c_ec_stdby_ctrl_mode_stby_cr_intr_signal_enable(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::StbyCrIntrSignalEnable::Register,
         >,
@@ -4539,51 +4877,53 @@ impl I3cPeripheral for I3cGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_ec_stdby_ctrl_mode_stby_cr_intr_signal_enable = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_stdby_ctrl_mode_stby_cr_intr_signal_enable;
         let mut new_val = current_val;
-        new_val = (new_val & !(0x8_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x8_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x4_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x4_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x2_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x2_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x1_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x1_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x4000 as caliptra_emu_types::RvData))
-            | (write_val & (0x4000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x2000 as caliptra_emu_types::RvData))
-            | (write_val & (0x2000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x1000 as caliptra_emu_types::RvData))
-            | (write_val & (0x1000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x800 as caliptra_emu_types::RvData))
-            | (write_val & (0x800 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x400 as caliptra_emu_types::RvData))
-            | (write_val & (0x400 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(8 as caliptra_emu_types::RvData))
-            | (write_val & (8 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(4 as caliptra_emu_types::RvData))
-            | (write_val & (4 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(2 as caliptra_emu_types::RvData))
-            | (write_val & (2 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x8_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x8_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x4_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x4_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x2_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x2_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x1_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x1_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x4000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x4000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x2000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x2000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x1000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x1000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x800 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x800 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x400 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x400 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(8 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (8 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(4 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (4 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(2 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_stdby_ctrl_mode_stby_cr_intr_signal_enable = new_val;
     }
     fn read_i3c_ec_stdby_ctrl_mode_stby_cr_intr_force(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::StbyCrIntrForce::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::i3c_ec_stdby_ctrl_mode_stby_cr_intr_force");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_stdby_ctrl_mode_stby_cr_intr_force)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_stdby_ctrl_mode_stby_cr_intr_force,
+        )
     }
     fn write_i3c_ec_stdby_ctrl_mode_stby_cr_intr_force(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::StbyCrIntrForce::Register,
         >,
@@ -4591,45 +4931,45 @@ impl I3cPeripheral for I3cGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_ec_stdby_ctrl_mode_stby_cr_intr_force = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_stdby_ctrl_mode_stby_cr_intr_force;
         let mut new_val = current_val;
-        new_val = (new_val & !(0x8_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x8_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x4_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x4_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x2_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x2_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x1_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x1_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x4000 as caliptra_emu_types::RvData))
-            | (write_val & (0x4000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x2000 as caliptra_emu_types::RvData))
-            | (write_val & (0x2000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x1000 as caliptra_emu_types::RvData))
-            | (write_val & (0x1000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x800 as caliptra_emu_types::RvData))
-            | (write_val & (0x800 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x400 as caliptra_emu_types::RvData))
-            | (write_val & (0x400 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x8_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x8_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x4_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x4_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x2_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x2_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x1_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x1_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x4000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x4000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x2000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x2000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x1000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x1000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x800 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x800 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x400 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x400 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_stdby_ctrl_mode_stby_cr_intr_force = new_val;
     }
     fn read_i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_getcaps(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::StbyCrCccConfigGetcaps::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_getcaps");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_getcaps,
         )
     }
     fn write_i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_getcaps(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::StbyCrCccConfigGetcaps::Register,
         >,
@@ -4637,31 +4977,31 @@ impl I3cPeripheral for I3cGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_getcaps = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_getcaps;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xf00 as caliptra_emu_types::RvData))
-            | (write_val & (0xf00 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(7 as caliptra_emu_types::RvData))
-            | (write_val & (7 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xf00 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xf00 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(7 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (7 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_getcaps = new_val;
     }
     fn read_i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_rstact_params(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::StbyCrCccConfigRstactParams::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_rstact_params");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_rstact_params,
         )
     }
     fn write_i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_rstact_params(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::StbyCrCccConfigRstactParams::Register,
         >,
@@ -4669,33 +5009,33 @@ impl I3cPeripheral for I3cGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_rstact_params = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_rstact_params;
         let mut new_val = current_val;
-        new_val = (new_val & !(0x8000_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x8000_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xff_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0xff_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xff00 as caliptra_emu_types::RvData))
-            | (write_val & (0xff00 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x8000_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x8000_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff00 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff00 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_rstact_params = new_val;
     }
     fn read_i3c_ec_stdby_ctrl_mode_stby_cr_virt_device_addr(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::StbyCrVirtDeviceAddr::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::i3c_ec_stdby_ctrl_mode_stby_cr_virt_device_addr");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.i3c_ec_stdby_ctrl_mode_stby_cr_virt_device_addr,
         )
     }
     fn write_i3c_ec_stdby_ctrl_mode_stby_cr_virt_device_addr(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::StbyCrVirtDeviceAddr::Register,
         >,
@@ -4703,20 +5043,22 @@ impl I3cPeripheral for I3cGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_ec_stdby_ctrl_mode_stby_cr_virt_device_addr = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_stdby_ctrl_mode_stby_cr_virt_device_addr;
         let mut new_val = current_val;
-        new_val = (new_val & !(0x8000_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x8000_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x7f_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x7f_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x8000 as caliptra_emu_types::RvData))
-            | (write_val & (0x8000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x7f as caliptra_emu_types::RvData))
-            | (write_val & (0x7f as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x8000_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x8000_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x7f_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x7f_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x8000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x8000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x7f as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x7f as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_stdby_ctrl_mode_stby_cr_virt_device_addr = new_val;
     }
-    fn read_i3c_ec_stdby_ctrl_mode_rsvd_3(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_stdby_ctrl_mode_rsvd_3(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read i3c::i3c_ec_stdby_ctrl_mode_rsvd_3"
@@ -4724,20 +5066,23 @@ impl I3cPeripheral for I3cGenerated {
         }
         self.i3c_ec_stdby_ctrl_mode_rsvd_3
     }
-    fn write_i3c_ec_stdby_ctrl_mode_rsvd_3(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_stdby_ctrl_mode_rsvd_3(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_ec_stdby_ctrl_mode_rsvd_3 = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_stdby_ctrl_mode_rsvd_3;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_stdby_ctrl_mode_rsvd_3 = new_val;
     }
     fn read_i3c_ec_tti_extcap_header(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::ExtcapHeader::Register,
     > {
@@ -4746,20 +5091,22 @@ impl I3cPeripheral for I3cGenerated {
                 "[EMU] Generated default register handler: read i3c::i3c_ec_tti_extcap_header"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_tti_extcap_header)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_tti_extcap_header)
     }
     fn read_i3c_ec_tti_control(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::Control::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::Control::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read i3c::i3c_ec_tti_control");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_tti_control)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_tti_control)
     }
     fn write_i3c_ec_tti_control(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::Control::Register,
         >,
@@ -4767,31 +5114,33 @@ impl I3cPeripheral for I3cGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_ec_tti_control = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_tti_control;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xe000 as caliptra_emu_types::RvData))
-            | (write_val & (0xe000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x1000 as caliptra_emu_types::RvData))
-            | (write_val & (0x1000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x800 as caliptra_emu_types::RvData))
-            | (write_val & (0x800 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x400 as caliptra_emu_types::RvData))
-            | (write_val & (0x400 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xe000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xe000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x1000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x1000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x800 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x800 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x400 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x400 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_tti_control = new_val;
     }
     fn read_i3c_ec_tti_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::Status::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::Status::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read i3c::i3c_ec_tti_status");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_tti_status)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_tti_status)
     }
     fn read_i3c_ec_tti_tti_reset_control(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::TtiResetControl::Register,
     > {
@@ -4800,11 +5149,13 @@ impl I3cPeripheral for I3cGenerated {
                 "[EMU] Generated default register handler: read i3c::i3c_ec_tti_tti_reset_control"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_tti_tti_reset_control)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_tti_tti_reset_control,
+        )
     }
     fn write_i3c_ec_tti_tti_reset_control(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::TtiResetControl::Register,
         >,
@@ -4812,26 +5163,26 @@ impl I3cPeripheral for I3cGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_ec_tti_tti_reset_control = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_tti_tti_reset_control;
         let mut new_val = current_val;
-        new_val = (new_val & !(0x20 as caliptra_emu_types::RvData))
-            | (write_val & (0x20 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x10 as caliptra_emu_types::RvData))
-            | (write_val & (0x10 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(8 as caliptra_emu_types::RvData))
-            | (write_val & (8 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(4 as caliptra_emu_types::RvData))
-            | (write_val & (4 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(2 as caliptra_emu_types::RvData))
-            | (write_val & (2 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x20 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x20 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x10 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x10 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(8 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (8 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(4 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (4 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(2 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_tti_tti_reset_control = new_val;
     }
     fn read_i3c_ec_tti_interrupt_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::InterruptStatus::Register,
     > {
@@ -4840,11 +5191,13 @@ impl I3cPeripheral for I3cGenerated {
                 "[EMU] Generated default register handler: read i3c::i3c_ec_tti_interrupt_status"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_tti_interrupt_status)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_tti_interrupt_status,
+        )
     }
     fn write_i3c_ec_tti_interrupt_status(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::InterruptStatus::Register,
         >,
@@ -4852,42 +5205,51 @@ impl I3cPeripheral for I3cGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_ec_tti_interrupt_status = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_tti_interrupt_status;
         let mut new_val = current_val;
-        let bits_to_clear_0 = write_val & (0x8000_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_0 =
+            write_val & (0x8000_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_0;
-        let bits_to_clear_1 = write_val & (0x400_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_1 =
+            write_val & (0x400_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_1;
-        let bits_to_clear_2 = write_val & (0x200_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_2 =
+            write_val & (0x200_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_2;
-        new_val = (new_val & !(0x7_8000 as caliptra_emu_types::RvData))
-            | (write_val & (0x7_8000 as caliptra_emu_types::RvData));
-        let bits_to_clear_4 = write_val & (0x2000 as caliptra_emu_types::RvData);
+        new_val = (new_val & !(0x7_8000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x7_8000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        let bits_to_clear_4 =
+            write_val & (0x2000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_4;
-        let bits_to_clear_5 = write_val & (0x1000 as caliptra_emu_types::RvData);
+        let bits_to_clear_5 =
+            write_val & (0x1000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_5;
-        let bits_to_clear_6 = write_val & (0x800 as caliptra_emu_types::RvData);
+        let bits_to_clear_6 =
+            write_val & (0x800 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_6;
-        let bits_to_clear_7 = write_val & (0x400 as caliptra_emu_types::RvData);
+        let bits_to_clear_7 =
+            write_val & (0x400 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_7;
-        let bits_to_clear_8 = write_val & (0x200 as caliptra_emu_types::RvData);
+        let bits_to_clear_8 =
+            write_val & (0x200 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_8;
-        let bits_to_clear_9 = write_val & (0x100 as caliptra_emu_types::RvData);
+        let bits_to_clear_9 =
+            write_val & (0x100 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_9;
-        let bits_to_clear_10 = write_val & (8 as caliptra_emu_types::RvData);
+        let bits_to_clear_10 = write_val & (8 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_10;
-        let bits_to_clear_11 = write_val & (4 as caliptra_emu_types::RvData);
+        let bits_to_clear_11 = write_val & (4 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_11;
-        let bits_to_clear_12 = write_val & (2 as caliptra_emu_types::RvData);
+        let bits_to_clear_12 = write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_12;
-        let bits_to_clear_13 = write_val & (1 as caliptra_emu_types::RvData);
+        let bits_to_clear_13 = write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_13;
         self.i3c_ec_tti_interrupt_status = new_val;
     }
     fn read_i3c_ec_tti_interrupt_enable(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::InterruptEnable::Register,
     > {
@@ -4896,11 +5258,13 @@ impl I3cPeripheral for I3cGenerated {
                 "[EMU] Generated default register handler: read i3c::i3c_ec_tti_interrupt_enable"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_tti_interrupt_enable)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_tti_interrupt_enable,
+        )
     }
     fn write_i3c_ec_tti_interrupt_enable(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::InterruptEnable::Register,
         >,
@@ -4908,40 +5272,40 @@ impl I3cPeripheral for I3cGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_ec_tti_interrupt_enable = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_tti_interrupt_enable;
         let mut new_val = current_val;
-        new_val = (new_val & !(0x8000_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x8000_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x400_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x400_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x200_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x200_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x2000 as caliptra_emu_types::RvData))
-            | (write_val & (0x2000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x1000 as caliptra_emu_types::RvData))
-            | (write_val & (0x1000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x800 as caliptra_emu_types::RvData))
-            | (write_val & (0x800 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x400 as caliptra_emu_types::RvData))
-            | (write_val & (0x400 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x200 as caliptra_emu_types::RvData))
-            | (write_val & (0x200 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x100 as caliptra_emu_types::RvData))
-            | (write_val & (0x100 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(8 as caliptra_emu_types::RvData))
-            | (write_val & (8 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(4 as caliptra_emu_types::RvData))
-            | (write_val & (4 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(2 as caliptra_emu_types::RvData))
-            | (write_val & (2 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x8000_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x8000_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x400_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x400_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x200_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x200_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x2000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x2000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x1000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x1000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x800 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x800 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x400 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x400 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x200 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x200 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x100 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x100 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(8 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (8 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(4 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (4 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(2 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_tti_interrupt_enable = new_val;
     }
     fn read_i3c_ec_tti_interrupt_force(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::InterruptForce::Register,
     > {
@@ -4950,11 +5314,13 @@ impl I3cPeripheral for I3cGenerated {
                 "[EMU] Generated default register handler: read i3c::i3c_ec_tti_interrupt_force"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_tti_interrupt_force)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_tti_interrupt_force,
+        )
     }
     fn write_i3c_ec_tti_interrupt_force(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::InterruptForce::Register,
         >,
@@ -4962,38 +5328,40 @@ impl I3cPeripheral for I3cGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_ec_tti_interrupt_force = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_tti_interrupt_force;
         let mut new_val = current_val;
-        new_val = (new_val & !(0x8000_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x8000_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x400_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x400_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x200_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x200_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x2000 as caliptra_emu_types::RvData))
-            | (write_val & (0x2000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x1000 as caliptra_emu_types::RvData))
-            | (write_val & (0x1000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x800 as caliptra_emu_types::RvData))
-            | (write_val & (0x800 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x400 as caliptra_emu_types::RvData))
-            | (write_val & (0x400 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x200 as caliptra_emu_types::RvData))
-            | (write_val & (0x200 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x100 as caliptra_emu_types::RvData))
-            | (write_val & (0x100 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(8 as caliptra_emu_types::RvData))
-            | (write_val & (8 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(4 as caliptra_emu_types::RvData))
-            | (write_val & (4 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(2 as caliptra_emu_types::RvData))
-            | (write_val & (2 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x8000_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x8000_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x400_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x400_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x200_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x200_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x2000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x2000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x1000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x1000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x800 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x800 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x400 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x400 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x200 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x200 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x100 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x100 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(8 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (8 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(4 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (4 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(2 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_tti_interrupt_force = new_val;
     }
-    fn read_i3c_ec_tti_rx_desc_queue_port(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_tti_rx_desc_queue_port(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read i3c::i3c_ec_tti_rx_desc_queue_port"
@@ -5001,7 +5369,7 @@ impl I3cPeripheral for I3cGenerated {
         }
         self.i3c_ec_tti_rx_desc_queue_port
     }
-    fn read_i3c_ec_tti_rx_data_port(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_tti_rx_data_port(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read i3c::i3c_ec_tti_rx_data_port"
@@ -5009,42 +5377,51 @@ impl I3cPeripheral for I3cGenerated {
         }
         self.i3c_ec_tti_rx_data_port
     }
-    fn write_i3c_ec_tti_tx_desc_queue_port(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_tti_tx_desc_queue_port(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_ec_tti_tx_desc_queue_port = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_tti_tx_desc_queue_port;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_tti_tx_desc_queue_port = new_val;
     }
-    fn write_i3c_ec_tti_tx_data_port(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_tti_tx_data_port(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_ec_tti_tx_data_port = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_tti_tx_data_port;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_tti_tx_data_port = new_val;
     }
-    fn write_i3c_ec_tti_tti_ibi_port(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_tti_tti_ibi_port(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_ec_tti_tti_ibi_port = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_tti_tti_ibi_port;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_tti_tti_ibi_port = new_val;
     }
     fn read_i3c_ec_tti_tti_queue_size(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::TtiQueueSize::Register,
     > {
@@ -5053,11 +5430,13 @@ impl I3cPeripheral for I3cGenerated {
                 "[EMU] Generated default register handler: read i3c::i3c_ec_tti_tti_queue_size"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_tti_tti_queue_size)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_tti_tti_queue_size,
+        )
     }
     fn read_i3c_ec_tti_ibi_tti_queue_size(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::IbiTtiQueueSize::Register,
     > {
@@ -5066,22 +5445,26 @@ impl I3cPeripheral for I3cGenerated {
                 "[EMU] Generated default register handler: read i3c::i3c_ec_tti_ibi_tti_queue_size"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_tti_ibi_tti_queue_size)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_tti_ibi_tti_queue_size,
+        )
     }
     fn read_i3c_ec_tti_tti_queue_thld_ctrl(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::TtiQueueThldCtrl::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::i3c_ec_tti_tti_queue_thld_ctrl");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_tti_tti_queue_thld_ctrl)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_tti_tti_queue_thld_ctrl,
+        )
     }
     fn write_i3c_ec_tti_tti_queue_thld_ctrl(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::TtiQueueThldCtrl::Register,
         >,
@@ -5089,31 +5472,33 @@ impl I3cPeripheral for I3cGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_ec_tti_tti_queue_thld_ctrl = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_tti_tti_queue_thld_ctrl;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xff00_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0xff00_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xff00 as caliptra_emu_types::RvData))
-            | (write_val & (0xff00 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xff as caliptra_emu_types::RvData))
-            | (write_val & (0xff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff00_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff00_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff00 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff00 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_tti_tti_queue_thld_ctrl = new_val;
     }
     fn read_i3c_ec_tti_tti_data_buffer_thld_ctrl(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::TtiDataBufferThldCtrl::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::i3c_ec_tti_tti_data_buffer_thld_ctrl");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_tti_tti_data_buffer_thld_ctrl)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_tti_tti_data_buffer_thld_ctrl,
+        )
     }
     fn write_i3c_ec_tti_tti_data_buffer_thld_ctrl(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::TtiDataBufferThldCtrl::Register,
         >,
@@ -5121,78 +5506,92 @@ impl I3cPeripheral for I3cGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_ec_tti_tti_data_buffer_thld_ctrl = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_tti_tti_data_buffer_thld_ctrl;
         let mut new_val = current_val;
-        new_val = (new_val & !(0x700_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x700_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x7_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x7_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x700 as caliptra_emu_types::RvData))
-            | (write_val & (0x700 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(7 as caliptra_emu_types::RvData))
-            | (write_val & (7 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x700_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x700_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x7_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x7_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x700 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x700 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(7 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (7 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_tti_tti_data_buffer_thld_ctrl = new_val;
     }
     fn read_i3c_ec_soc_mgmt_if_extcap_header(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::ExtcapHeader::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::i3c_ec_soc_mgmt_if_extcap_header");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_soc_mgmt_if_extcap_header)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_soc_mgmt_if_extcap_header,
+        )
     }
-    fn read_i3c_ec_soc_mgmt_if_soc_mgmt_control(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_soc_mgmt_if_soc_mgmt_control(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::i3c_ec_soc_mgmt_if_soc_mgmt_control");
         }
         self.i3c_ec_soc_mgmt_if_soc_mgmt_control
     }
-    fn write_i3c_ec_soc_mgmt_if_soc_mgmt_control(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_soc_mgmt_if_soc_mgmt_control(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_ec_soc_mgmt_if_soc_mgmt_control = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_soc_mgmt_if_soc_mgmt_control;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_soc_mgmt_if_soc_mgmt_control = new_val;
     }
-    fn read_i3c_ec_soc_mgmt_if_soc_mgmt_status(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_soc_mgmt_if_soc_mgmt_status(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::i3c_ec_soc_mgmt_if_soc_mgmt_status");
         }
         self.i3c_ec_soc_mgmt_if_soc_mgmt_status
     }
-    fn write_i3c_ec_soc_mgmt_if_soc_mgmt_status(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_soc_mgmt_if_soc_mgmt_status(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_ec_soc_mgmt_if_soc_mgmt_status = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_soc_mgmt_if_soc_mgmt_status;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_soc_mgmt_if_soc_mgmt_status = new_val;
     }
     fn read_i3c_ec_soc_mgmt_if_rec_intf_cfg(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::RecIntfCfg::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::i3c_ec_soc_mgmt_if_rec_intf_cfg");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_soc_mgmt_if_rec_intf_cfg)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_soc_mgmt_if_rec_intf_cfg,
+        )
     }
     fn write_i3c_ec_soc_mgmt_if_rec_intf_cfg(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::RecIntfCfg::Register,
         >,
@@ -5200,29 +5599,31 @@ impl I3cPeripheral for I3cGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_ec_soc_mgmt_if_rec_intf_cfg = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_soc_mgmt_if_rec_intf_cfg;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(2 as caliptra_emu_types::RvData))
-            | (write_val & (2 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(2 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_soc_mgmt_if_rec_intf_cfg = new_val;
     }
     fn read_i3c_ec_soc_mgmt_if_rec_intf_reg_w1_c_access(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::RecIntfRegW1cAccess::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::i3c_ec_soc_mgmt_if_rec_intf_reg_w1_c_access");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_soc_mgmt_if_rec_intf_reg_w1_c_access)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_soc_mgmt_if_rec_intf_reg_w1_c_access,
+        )
     }
     fn write_i3c_ec_soc_mgmt_if_rec_intf_reg_w1_c_access(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::RecIntfRegW1cAccess::Register,
         >,
@@ -5230,65 +5631,77 @@ impl I3cPeripheral for I3cGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_ec_soc_mgmt_if_rec_intf_reg_w1_c_access = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_soc_mgmt_if_rec_intf_reg_w1_c_access;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xff as caliptra_emu_types::RvData))
-            | (write_val & (0xff as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xff00 as caliptra_emu_types::RvData))
-            | (write_val & (0xff00 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xff_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0xff_0000 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff00 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff00 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_soc_mgmt_if_rec_intf_reg_w1_c_access = new_val;
     }
-    fn read_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_2(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_2(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_2");
         }
         self.i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_2
     }
-    fn write_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_2(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_2(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_2 = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_2;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_2 = new_val;
     }
-    fn read_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_3(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_3(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_3");
         }
         self.i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_3
     }
-    fn write_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_3(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_3(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_3 = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_3;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_3 = new_val;
     }
     fn read_i3c_ec_soc_mgmt_if_soc_pad_conf(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::SocPadConf::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::i3c_ec_soc_mgmt_if_soc_pad_conf");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_soc_mgmt_if_soc_pad_conf)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_soc_mgmt_if_soc_pad_conf,
+        )
     }
     fn write_i3c_ec_soc_mgmt_if_soc_pad_conf(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::SocPadConf::Register,
         >,
@@ -5296,43 +5709,45 @@ impl I3cPeripheral for I3cGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_ec_soc_mgmt_if_soc_pad_conf = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_soc_mgmt_if_soc_pad_conf;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xff00_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0xff00_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x80 as caliptra_emu_types::RvData))
-            | (write_val & (0x80 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x40 as caliptra_emu_types::RvData))
-            | (write_val & (0x40 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x20 as caliptra_emu_types::RvData))
-            | (write_val & (0x20 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x10 as caliptra_emu_types::RvData))
-            | (write_val & (0x10 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(8 as caliptra_emu_types::RvData))
-            | (write_val & (8 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(4 as caliptra_emu_types::RvData))
-            | (write_val & (4 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(2 as caliptra_emu_types::RvData))
-            | (write_val & (2 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff00_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff00_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x80 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x80 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x40 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x40 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x20 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x20 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x10 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x10 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(8 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (8 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(4 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (4 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(2 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_soc_mgmt_if_soc_pad_conf = new_val;
     }
     fn read_i3c_ec_soc_mgmt_if_soc_pad_attr(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::SocPadAttr::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::i3c_ec_soc_mgmt_if_soc_pad_attr");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_soc_mgmt_if_soc_pad_attr)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_soc_mgmt_if_soc_pad_attr,
+        )
     }
     fn write_i3c_ec_soc_mgmt_if_soc_pad_attr(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::SocPadAttr::Register,
         >,
@@ -5340,63 +5755,77 @@ impl I3cPeripheral for I3cGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_ec_soc_mgmt_if_soc_pad_attr = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_soc_mgmt_if_soc_pad_attr;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xff00_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0xff00_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xff00 as caliptra_emu_types::RvData))
-            | (write_val & (0xff00 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff00_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff00_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff00 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff00 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_soc_mgmt_if_soc_pad_attr = new_val;
     }
-    fn read_i3c_ec_soc_mgmt_if_soc_mgmt_feature_2(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_soc_mgmt_if_soc_mgmt_feature_2(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::i3c_ec_soc_mgmt_if_soc_mgmt_feature_2");
         }
         self.i3c_ec_soc_mgmt_if_soc_mgmt_feature_2
     }
-    fn write_i3c_ec_soc_mgmt_if_soc_mgmt_feature_2(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_soc_mgmt_if_soc_mgmt_feature_2(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_ec_soc_mgmt_if_soc_mgmt_feature_2 = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_soc_mgmt_if_soc_mgmt_feature_2;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_soc_mgmt_if_soc_mgmt_feature_2 = new_val;
     }
-    fn read_i3c_ec_soc_mgmt_if_soc_mgmt_feature_3(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_soc_mgmt_if_soc_mgmt_feature_3(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::i3c_ec_soc_mgmt_if_soc_mgmt_feature_3");
         }
         self.i3c_ec_soc_mgmt_if_soc_mgmt_feature_3
     }
-    fn write_i3c_ec_soc_mgmt_if_soc_mgmt_feature_3(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_soc_mgmt_if_soc_mgmt_feature_3(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_ec_soc_mgmt_if_soc_mgmt_feature_3 = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_soc_mgmt_if_soc_mgmt_feature_3;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_soc_mgmt_if_soc_mgmt_feature_3 = new_val;
     }
     fn read_i3c_ec_soc_mgmt_if_t_r_reg(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::TRReg::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::TRReg::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read i3c::i3c_ec_soc_mgmt_if_t_r_reg"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_soc_mgmt_if_t_r_reg)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_soc_mgmt_if_t_r_reg,
+        )
     }
     fn write_i3c_ec_soc_mgmt_if_t_r_reg(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::TRReg::Register,
         >,
@@ -5404,27 +5833,31 @@ impl I3cPeripheral for I3cGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_ec_soc_mgmt_if_t_r_reg = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_soc_mgmt_if_t_r_reg;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xf_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xf_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xf_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xf_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_soc_mgmt_if_t_r_reg = new_val;
     }
     fn read_i3c_ec_soc_mgmt_if_t_f_reg(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::TFReg::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::TFReg::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read i3c::i3c_ec_soc_mgmt_if_t_f_reg"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_soc_mgmt_if_t_f_reg)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_soc_mgmt_if_t_f_reg,
+        )
     }
     fn write_i3c_ec_soc_mgmt_if_t_f_reg(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::TFReg::Register,
         >,
@@ -5432,25 +5865,29 @@ impl I3cPeripheral for I3cGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_ec_soc_mgmt_if_t_f_reg = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_soc_mgmt_if_t_f_reg;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xf_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xf_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xf_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xf_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_soc_mgmt_if_t_f_reg = new_val;
     }
     fn read_i3c_ec_soc_mgmt_if_t_su_dat_reg(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::TSuDatReg::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::TSuDatReg::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::i3c_ec_soc_mgmt_if_t_su_dat_reg");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_soc_mgmt_if_t_su_dat_reg)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_soc_mgmt_if_t_su_dat_reg,
+        )
     }
     fn write_i3c_ec_soc_mgmt_if_t_su_dat_reg(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::TSuDatReg::Register,
         >,
@@ -5458,25 +5895,29 @@ impl I3cPeripheral for I3cGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_ec_soc_mgmt_if_t_su_dat_reg = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_soc_mgmt_if_t_su_dat_reg;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xf_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xf_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xf_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xf_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_soc_mgmt_if_t_su_dat_reg = new_val;
     }
     fn read_i3c_ec_soc_mgmt_if_t_hd_dat_reg(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::THdDatReg::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::THdDatReg::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::i3c_ec_soc_mgmt_if_t_hd_dat_reg");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_soc_mgmt_if_t_hd_dat_reg)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_soc_mgmt_if_t_hd_dat_reg,
+        )
     }
     fn write_i3c_ec_soc_mgmt_if_t_hd_dat_reg(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::THdDatReg::Register,
         >,
@@ -5484,27 +5925,31 @@ impl I3cPeripheral for I3cGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_ec_soc_mgmt_if_t_hd_dat_reg = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_soc_mgmt_if_t_hd_dat_reg;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xf_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xf_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xf_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xf_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_soc_mgmt_if_t_hd_dat_reg = new_val;
     }
     fn read_i3c_ec_soc_mgmt_if_t_high_reg(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::THighReg::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::THighReg::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read i3c::i3c_ec_soc_mgmt_if_t_high_reg"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_soc_mgmt_if_t_high_reg)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_soc_mgmt_if_t_high_reg,
+        )
     }
     fn write_i3c_ec_soc_mgmt_if_t_high_reg(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::THighReg::Register,
         >,
@@ -5512,27 +5957,31 @@ impl I3cPeripheral for I3cGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_ec_soc_mgmt_if_t_high_reg = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_soc_mgmt_if_t_high_reg;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xf_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xf_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xf_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xf_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_soc_mgmt_if_t_high_reg = new_val;
     }
     fn read_i3c_ec_soc_mgmt_if_t_low_reg(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::TLowReg::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::TLowReg::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read i3c::i3c_ec_soc_mgmt_if_t_low_reg"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_soc_mgmt_if_t_low_reg)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_soc_mgmt_if_t_low_reg,
+        )
     }
     fn write_i3c_ec_soc_mgmt_if_t_low_reg(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::TLowReg::Register,
         >,
@@ -5540,25 +5989,29 @@ impl I3cPeripheral for I3cGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_ec_soc_mgmt_if_t_low_reg = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_soc_mgmt_if_t_low_reg;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xf_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xf_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xf_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xf_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_soc_mgmt_if_t_low_reg = new_val;
     }
     fn read_i3c_ec_soc_mgmt_if_t_hd_sta_reg(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::THdStaReg::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::THdStaReg::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::i3c_ec_soc_mgmt_if_t_hd_sta_reg");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_soc_mgmt_if_t_hd_sta_reg)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_soc_mgmt_if_t_hd_sta_reg,
+        )
     }
     fn write_i3c_ec_soc_mgmt_if_t_hd_sta_reg(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::THdStaReg::Register,
         >,
@@ -5566,25 +6019,29 @@ impl I3cPeripheral for I3cGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_ec_soc_mgmt_if_t_hd_sta_reg = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_soc_mgmt_if_t_hd_sta_reg;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xf_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xf_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xf_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xf_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_soc_mgmt_if_t_hd_sta_reg = new_val;
     }
     fn read_i3c_ec_soc_mgmt_if_t_su_sta_reg(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::TSuStaReg::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::TSuStaReg::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::i3c_ec_soc_mgmt_if_t_su_sta_reg");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_soc_mgmt_if_t_su_sta_reg)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_soc_mgmt_if_t_su_sta_reg,
+        )
     }
     fn write_i3c_ec_soc_mgmt_if_t_su_sta_reg(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::TSuStaReg::Register,
         >,
@@ -5592,25 +6049,29 @@ impl I3cPeripheral for I3cGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_ec_soc_mgmt_if_t_su_sta_reg = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_soc_mgmt_if_t_su_sta_reg;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xf_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xf_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xf_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xf_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_soc_mgmt_if_t_su_sta_reg = new_val;
     }
     fn read_i3c_ec_soc_mgmt_if_t_su_sto_reg(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::TSuStoReg::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::TSuStoReg::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::i3c_ec_soc_mgmt_if_t_su_sto_reg");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_soc_mgmt_if_t_su_sto_reg)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_soc_mgmt_if_t_su_sto_reg,
+        )
     }
     fn write_i3c_ec_soc_mgmt_if_t_su_sto_reg(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::TSuStoReg::Register,
         >,
@@ -5618,14 +6079,16 @@ impl I3cPeripheral for I3cGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_ec_soc_mgmt_if_t_su_sto_reg = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_soc_mgmt_if_t_su_sto_reg;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xf_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xf_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xf_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xf_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_soc_mgmt_if_t_su_sto_reg = new_val;
     }
-    fn read_i3c_ec_soc_mgmt_if_t_free_reg(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_soc_mgmt_if_t_free_reg(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read i3c::i3c_ec_soc_mgmt_if_t_free_reg"
@@ -5633,18 +6096,23 @@ impl I3cPeripheral for I3cGenerated {
         }
         self.i3c_ec_soc_mgmt_if_t_free_reg
     }
-    fn write_i3c_ec_soc_mgmt_if_t_free_reg(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_soc_mgmt_if_t_free_reg(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_ec_soc_mgmt_if_t_free_reg = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_soc_mgmt_if_t_free_reg;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_soc_mgmt_if_t_free_reg = new_val;
     }
-    fn read_i3c_ec_soc_mgmt_if_t_aval_reg(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_soc_mgmt_if_t_aval_reg(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read i3c::i3c_ec_soc_mgmt_if_t_aval_reg"
@@ -5652,18 +6120,23 @@ impl I3cPeripheral for I3cGenerated {
         }
         self.i3c_ec_soc_mgmt_if_t_aval_reg
     }
-    fn write_i3c_ec_soc_mgmt_if_t_aval_reg(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_soc_mgmt_if_t_aval_reg(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_ec_soc_mgmt_if_t_aval_reg = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_soc_mgmt_if_t_aval_reg;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_soc_mgmt_if_t_aval_reg = new_val;
     }
-    fn read_i3c_ec_soc_mgmt_if_t_idle_reg(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_soc_mgmt_if_t_idle_reg(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read i3c::i3c_ec_soc_mgmt_if_t_idle_reg"
@@ -5671,20 +6144,23 @@ impl I3cPeripheral for I3cGenerated {
         }
         self.i3c_ec_soc_mgmt_if_t_idle_reg
     }
-    fn write_i3c_ec_soc_mgmt_if_t_idle_reg(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_soc_mgmt_if_t_idle_reg(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c::i3c_ec_soc_mgmt_if_t_idle_reg = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_soc_mgmt_if_t_idle_reg;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_soc_mgmt_if_t_idle_reg = new_val;
     }
     fn read_i3c_ec_ctrl_cfg_extcap_header(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::ExtcapHeader::Register,
     > {
@@ -5693,136 +6169,143 @@ impl I3cPeripheral for I3cGenerated {
                 "[EMU] Generated default register handler: read i3c::i3c_ec_ctrl_cfg_extcap_header"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_ctrl_cfg_extcap_header)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_ctrl_cfg_extcap_header,
+        )
     }
     fn read_i3c_ec_ctrl_cfg_controller_config(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::ControllerConfig::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c::i3c_ec_ctrl_cfg_controller_config");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_ctrl_cfg_controller_config)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_ctrl_cfg_controller_config,
+        )
     }
 }
 pub struct I3cBus {
     pub periph: Box<dyn I3cPeripheral>,
 }
-impl caliptra_emu_bus::Bus for I3cBus {
+impl caliptra_core_tools::caliptra_emu_bus::Bus for I3cBus {
     fn read(
         &mut self,
-        size: caliptra_emu_types::RvSize,
-        addr: caliptra_emu_types::RvAddr,
-    ) -> Result<caliptra_emu_types::RvData, caliptra_emu_bus::BusError> {
-        if addr & 0x3 != 0 || size != caliptra_emu_types::RvSize::Word {
-            return Err(caliptra_emu_bus::BusError::LoadAddrMisaligned);
+        size: caliptra_core_tools::caliptra_emu_types::RvSize,
+        addr: caliptra_core_tools::caliptra_emu_types::RvAddr,
+    ) -> Result<
+        caliptra_core_tools::caliptra_emu_types::RvData,
+        caliptra_core_tools::caliptra_emu_bus::BusError,
+    > {
+        if addr & 0x3 != 0 || size != caliptra_core_tools::caliptra_emu_types::RvSize::Word {
+            return Err(caliptra_core_tools::caliptra_emu_bus::BusError::LoadAddrMisaligned);
         }
         match addr {
             0x400..0x800 => Ok(self.periph.read_dat((addr as usize - 0x400) / 4)),
             0x800..0x1000 => Ok(self.periph.read_dct((addr as usize - 0x800) / 4)),
             0..4 => Ok(self.periph.read_i3c_base_hci_version()),
-            4..8 => Ok(caliptra_emu_types::RvData::from(
+            4..8 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_base_hc_control().reg.get(),
             )),
-            8..0xc => Ok(caliptra_emu_types::RvData::from(
+            8..0xc => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_base_controller_device_addr().reg.get(),
             )),
-            0xc..0x10 => Ok(caliptra_emu_types::RvData::from(
+            0xc..0x10 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_base_hc_capabilities().reg.get(),
             )),
-            0x10..0x14 => Ok(caliptra_emu_types::RvData::from(
+            0x10..0x14 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_base_reset_control().reg.get(),
             )),
-            0x14..0x18 => Ok(caliptra_emu_types::RvData::from(
+            0x14..0x18 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_base_present_state().reg.get(),
             )),
-            0x20..0x24 => Ok(caliptra_emu_types::RvData::from(
+            0x20..0x24 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_base_intr_status().reg.get(),
             )),
-            0x24..0x28 => Ok(caliptra_emu_types::RvData::from(
+            0x24..0x28 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_base_intr_status_enable().reg.get(),
             )),
-            0x28..0x2c => Ok(caliptra_emu_types::RvData::from(
+            0x28..0x2c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_base_intr_signal_enable().reg.get(),
             )),
-            0x30..0x34 => Ok(caliptra_emu_types::RvData::from(
+            0x30..0x34 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_base_dat_section_offset().reg.get(),
             )),
-            0x34..0x38 => Ok(caliptra_emu_types::RvData::from(
+            0x34..0x38 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_base_dct_section_offset().reg.get(),
             )),
-            0x38..0x3c => Ok(caliptra_emu_types::RvData::from(
+            0x38..0x3c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_i3c_base_ring_headers_section_offset()
                     .reg
                     .get(),
             )),
-            0x3c..0x40 => Ok(caliptra_emu_types::RvData::from(
+            0x3c..0x40 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_base_pio_section_offset().reg.get(),
             )),
-            0x40..0x44 => Ok(caliptra_emu_types::RvData::from(
+            0x40..0x44 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_i3c_base_ext_caps_section_offset()
                     .reg
                     .get(),
             )),
-            0x4c..0x50 => Ok(caliptra_emu_types::RvData::from(
+            0x4c..0x50 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_base_int_ctrl_cmds_en().reg.get(),
             )),
-            0x58..0x5c => Ok(caliptra_emu_types::RvData::from(
+            0x58..0x5c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_base_ibi_notify_ctrl().reg.get(),
             )),
-            0x5c..0x60 => Ok(caliptra_emu_types::RvData::from(
+            0x5c..0x60 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_base_ibi_data_abort_ctrl().reg.get(),
             )),
-            0x60..0x64 => Ok(caliptra_emu_types::RvData::from(
+            0x60..0x64 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_base_dev_ctx_base_lo().reg.get(),
             )),
-            0x64..0x68 => Ok(caliptra_emu_types::RvData::from(
+            0x64..0x68 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_base_dev_ctx_base_hi().reg.get(),
             )),
-            0x68..0x6c => Ok(caliptra_emu_types::RvData::from(
+            0x68..0x6c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_base_dev_ctx_sg().reg.get(),
             )),
             0x84..0x88 => Ok(self.periph.read_piocontrol_response_port()),
             0x88..0x8c => Ok(self.periph.read_piocontrol_rx_data_port()),
             0x8c..0x90 => Ok(self.periph.read_piocontrol_ibi_port()),
-            0x90..0x94 => Ok(caliptra_emu_types::RvData::from(
+            0x90..0x94 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_piocontrol_queue_thld_ctrl().reg.get(),
             )),
-            0x94..0x98 => Ok(caliptra_emu_types::RvData::from(
+            0x94..0x98 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_piocontrol_data_buffer_thld_ctrl()
                     .reg
                     .get(),
             )),
-            0x98..0x9c => Ok(caliptra_emu_types::RvData::from(
+            0x98..0x9c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_piocontrol_queue_size().reg.get(),
             )),
-            0x9c..0xa0 => Ok(caliptra_emu_types::RvData::from(
+            0x9c..0xa0 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_piocontrol_alt_queue_size().reg.get(),
             )),
-            0xa0..0xa4 => Ok(caliptra_emu_types::RvData::from(
+            0xa0..0xa4 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_piocontrol_pio_intr_status().reg.get(),
             )),
-            0xa4..0xa8 => Ok(caliptra_emu_types::RvData::from(
+            0xa4..0xa8 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_piocontrol_pio_intr_status_enable()
                     .reg
                     .get(),
             )),
-            0xa8..0xac => Ok(caliptra_emu_types::RvData::from(
+            0xa8..0xac => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_piocontrol_pio_intr_signal_enable()
                     .reg
                     .get(),
             )),
-            0xb0..0xb4 => Ok(caliptra_emu_types::RvData::from(
+            0xb0..0xb4 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_piocontrol_pio_control().reg.get(),
             )),
-            0x100..0x104 => Ok(caliptra_emu_types::RvData::from(
+            0x100..0x104 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_i3c_ec_sec_fw_recovery_if_extcap_header()
                     .reg
@@ -5830,19 +6313,19 @@ impl caliptra_emu_bus::Bus for I3cBus {
             )),
             0x104..0x108 => Ok(self.periph.read_i3c_ec_sec_fw_recovery_if_prot_cap_0()),
             0x108..0x10c => Ok(self.periph.read_i3c_ec_sec_fw_recovery_if_prot_cap_1()),
-            0x10c..0x110 => Ok(caliptra_emu_types::RvData::from(
+            0x10c..0x110 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_i3c_ec_sec_fw_recovery_if_prot_cap_2()
                     .reg
                     .get(),
             )),
-            0x110..0x114 => Ok(caliptra_emu_types::RvData::from(
+            0x110..0x114 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_i3c_ec_sec_fw_recovery_if_prot_cap_3()
                     .reg
                     .get(),
             )),
-            0x114..0x118 => Ok(caliptra_emu_types::RvData::from(
+            0x114..0x118 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_i3c_ec_sec_fw_recovery_if_device_id_0()
                     .reg
@@ -5856,43 +6339,43 @@ impl caliptra_emu_bus::Bus for I3cBus {
             0x12c..0x130 => Ok(self
                 .periph
                 .read_i3c_ec_sec_fw_recovery_if_device_id_reserved()),
-            0x130..0x134 => Ok(caliptra_emu_types::RvData::from(
+            0x130..0x134 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_i3c_ec_sec_fw_recovery_if_device_status_0()
                     .reg
                     .get(),
             )),
-            0x134..0x138 => Ok(caliptra_emu_types::RvData::from(
+            0x134..0x138 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_i3c_ec_sec_fw_recovery_if_device_status_1()
                     .reg
                     .get(),
             )),
-            0x138..0x13c => Ok(caliptra_emu_types::RvData::from(
+            0x138..0x13c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_i3c_ec_sec_fw_recovery_if_device_reset()
                     .reg
                     .get(),
             )),
-            0x13c..0x140 => Ok(caliptra_emu_types::RvData::from(
+            0x13c..0x140 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_i3c_ec_sec_fw_recovery_if_recovery_ctrl()
                     .reg
                     .get(),
             )),
-            0x140..0x144 => Ok(caliptra_emu_types::RvData::from(
+            0x140..0x144 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_i3c_ec_sec_fw_recovery_if_recovery_status()
                     .reg
                     .get(),
             )),
-            0x144..0x148 => Ok(caliptra_emu_types::RvData::from(
+            0x144..0x148 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_i3c_ec_sec_fw_recovery_if_hw_status()
                     .reg
                     .get(),
             )),
-            0x148..0x14c => Ok(caliptra_emu_types::RvData::from(
+            0x148..0x14c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_0()
                     .reg
@@ -5901,7 +6384,7 @@ impl caliptra_emu_bus::Bus for I3cBus {
             0x14c..0x150 => Ok(self
                 .periph
                 .read_i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_1()),
-            0x150..0x154 => Ok(caliptra_emu_types::RvData::from(
+            0x150..0x154 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_i3c_ec_sec_fw_recovery_if_indirect_fifo_status_0()
                     .reg
@@ -5925,43 +6408,43 @@ impl caliptra_emu_bus::Bus for I3cBus {
             0x168..0x16c => Ok(self
                 .periph
                 .read_i3c_ec_sec_fw_recovery_if_indirect_fifo_data()),
-            0x180..0x184 => Ok(caliptra_emu_types::RvData::from(
+            0x180..0x184 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_i3c_ec_stdby_ctrl_mode_extcap_header()
                     .reg
                     .get(),
             )),
-            0x184..0x188 => Ok(caliptra_emu_types::RvData::from(
+            0x184..0x188 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_i3c_ec_stdby_ctrl_mode_stby_cr_control()
                     .reg
                     .get(),
             )),
-            0x188..0x18c => Ok(caliptra_emu_types::RvData::from(
+            0x188..0x18c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_i3c_ec_stdby_ctrl_mode_stby_cr_device_addr()
                     .reg
                     .get(),
             )),
-            0x18c..0x190 => Ok(caliptra_emu_types::RvData::from(
+            0x18c..0x190 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_i3c_ec_stdby_ctrl_mode_stby_cr_capabilities()
                     .reg
                     .get(),
             )),
-            0x190..0x194 => Ok(caliptra_emu_types::RvData::from(
+            0x190..0x194 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_i3c_ec_stdby_ctrl_mode_stby_cr_virtual_device_char()
                     .reg
                     .get(),
             )),
-            0x194..0x198 => Ok(caliptra_emu_types::RvData::from(
+            0x194..0x198 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_i3c_ec_stdby_ctrl_mode_stby_cr_status()
                     .reg
                     .get(),
             )),
-            0x198..0x19c => Ok(caliptra_emu_types::RvData::from(
+            0x198..0x19c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_i3c_ec_stdby_ctrl_mode_stby_cr_device_char()
                     .reg
@@ -5970,7 +6453,7 @@ impl caliptra_emu_bus::Bus for I3cBus {
             0x19c..0x1a0 => Ok(self
                 .periph
                 .read_i3c_ec_stdby_ctrl_mode_stby_cr_device_pid_lo()),
-            0x1a0..0x1a4 => Ok(caliptra_emu_types::RvData::from(
+            0x1a0..0x1a4 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_i3c_ec_stdby_ctrl_mode_stby_cr_intr_status()
                     .reg
@@ -5979,76 +6462,76 @@ impl caliptra_emu_bus::Bus for I3cBus {
             0x1a4..0x1a8 => Ok(self
                 .periph
                 .read_i3c_ec_stdby_ctrl_mode_stby_cr_virtual_device_pid_lo()),
-            0x1a8..0x1ac => Ok(caliptra_emu_types::RvData::from(
+            0x1a8..0x1ac => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_i3c_ec_stdby_ctrl_mode_stby_cr_intr_signal_enable()
                     .reg
                     .get(),
             )),
-            0x1ac..0x1b0 => Ok(caliptra_emu_types::RvData::from(
+            0x1ac..0x1b0 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_i3c_ec_stdby_ctrl_mode_stby_cr_intr_force()
                     .reg
                     .get(),
             )),
-            0x1b0..0x1b4 => Ok(caliptra_emu_types::RvData::from(
+            0x1b0..0x1b4 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_getcaps()
                     .reg
                     .get(),
             )),
-            0x1b4..0x1b8 => Ok(caliptra_emu_types::RvData::from(
+            0x1b4..0x1b8 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_rstact_params()
                     .reg
                     .get(),
             )),
-            0x1b8..0x1bc => Ok(caliptra_emu_types::RvData::from(
+            0x1b8..0x1bc => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_i3c_ec_stdby_ctrl_mode_stby_cr_virt_device_addr()
                     .reg
                     .get(),
             )),
             0x1bc..0x1c0 => Ok(self.periph.read_i3c_ec_stdby_ctrl_mode_rsvd_3()),
-            0x1c0..0x1c4 => Ok(caliptra_emu_types::RvData::from(
+            0x1c0..0x1c4 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_ec_tti_extcap_header().reg.get(),
             )),
-            0x1c4..0x1c8 => Ok(caliptra_emu_types::RvData::from(
+            0x1c4..0x1c8 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_ec_tti_control().reg.get(),
             )),
-            0x1c8..0x1cc => Ok(caliptra_emu_types::RvData::from(
+            0x1c8..0x1cc => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_ec_tti_status().reg.get(),
             )),
-            0x1cc..0x1d0 => Ok(caliptra_emu_types::RvData::from(
+            0x1cc..0x1d0 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_ec_tti_tti_reset_control().reg.get(),
             )),
-            0x1d0..0x1d4 => Ok(caliptra_emu_types::RvData::from(
+            0x1d0..0x1d4 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_ec_tti_interrupt_status().reg.get(),
             )),
-            0x1d4..0x1d8 => Ok(caliptra_emu_types::RvData::from(
+            0x1d4..0x1d8 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_ec_tti_interrupt_enable().reg.get(),
             )),
-            0x1d8..0x1dc => Ok(caliptra_emu_types::RvData::from(
+            0x1d8..0x1dc => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_ec_tti_interrupt_force().reg.get(),
             )),
             0x1dc..0x1e0 => Ok(self.periph.read_i3c_ec_tti_rx_desc_queue_port()),
             0x1e0..0x1e4 => Ok(self.periph.read_i3c_ec_tti_rx_data_port()),
-            0x1f0..0x1f4 => Ok(caliptra_emu_types::RvData::from(
+            0x1f0..0x1f4 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_ec_tti_tti_queue_size().reg.get(),
             )),
-            0x1f4..0x1f8 => Ok(caliptra_emu_types::RvData::from(
+            0x1f4..0x1f8 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_ec_tti_ibi_tti_queue_size().reg.get(),
             )),
-            0x1f8..0x1fc => Ok(caliptra_emu_types::RvData::from(
+            0x1f8..0x1fc => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_ec_tti_tti_queue_thld_ctrl().reg.get(),
             )),
-            0x1fc..0x200 => Ok(caliptra_emu_types::RvData::from(
+            0x1fc..0x200 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_i3c_ec_tti_tti_data_buffer_thld_ctrl()
                     .reg
                     .get(),
             )),
-            0x200..0x204 => Ok(caliptra_emu_types::RvData::from(
+            0x200..0x204 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_i3c_ec_soc_mgmt_if_extcap_header()
                     .reg
@@ -6056,10 +6539,10 @@ impl caliptra_emu_bus::Bus for I3cBus {
             )),
             0x204..0x208 => Ok(self.periph.read_i3c_ec_soc_mgmt_if_soc_mgmt_control()),
             0x208..0x20c => Ok(self.periph.read_i3c_ec_soc_mgmt_if_soc_mgmt_status()),
-            0x20c..0x210 => Ok(caliptra_emu_types::RvData::from(
+            0x20c..0x210 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_ec_soc_mgmt_if_rec_intf_cfg().reg.get(),
             )),
-            0x210..0x214 => Ok(caliptra_emu_types::RvData::from(
+            0x210..0x214 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_i3c_ec_soc_mgmt_if_rec_intf_reg_w1_c_access()
                     .reg
@@ -6067,64 +6550,64 @@ impl caliptra_emu_bus::Bus for I3cBus {
             )),
             0x214..0x218 => Ok(self.periph.read_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_2()),
             0x218..0x21c => Ok(self.periph.read_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_3()),
-            0x21c..0x220 => Ok(caliptra_emu_types::RvData::from(
+            0x21c..0x220 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_ec_soc_mgmt_if_soc_pad_conf().reg.get(),
             )),
-            0x220..0x224 => Ok(caliptra_emu_types::RvData::from(
+            0x220..0x224 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_ec_soc_mgmt_if_soc_pad_attr().reg.get(),
             )),
             0x224..0x228 => Ok(self.periph.read_i3c_ec_soc_mgmt_if_soc_mgmt_feature_2()),
             0x228..0x22c => Ok(self.periph.read_i3c_ec_soc_mgmt_if_soc_mgmt_feature_3()),
-            0x22c..0x230 => Ok(caliptra_emu_types::RvData::from(
+            0x22c..0x230 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_ec_soc_mgmt_if_t_r_reg().reg.get(),
             )),
-            0x230..0x234 => Ok(caliptra_emu_types::RvData::from(
+            0x230..0x234 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_ec_soc_mgmt_if_t_f_reg().reg.get(),
             )),
-            0x234..0x238 => Ok(caliptra_emu_types::RvData::from(
+            0x234..0x238 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_ec_soc_mgmt_if_t_su_dat_reg().reg.get(),
             )),
-            0x238..0x23c => Ok(caliptra_emu_types::RvData::from(
+            0x238..0x23c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_ec_soc_mgmt_if_t_hd_dat_reg().reg.get(),
             )),
-            0x23c..0x240 => Ok(caliptra_emu_types::RvData::from(
+            0x23c..0x240 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_ec_soc_mgmt_if_t_high_reg().reg.get(),
             )),
-            0x240..0x244 => Ok(caliptra_emu_types::RvData::from(
+            0x240..0x244 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_ec_soc_mgmt_if_t_low_reg().reg.get(),
             )),
-            0x244..0x248 => Ok(caliptra_emu_types::RvData::from(
+            0x244..0x248 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_ec_soc_mgmt_if_t_hd_sta_reg().reg.get(),
             )),
-            0x248..0x24c => Ok(caliptra_emu_types::RvData::from(
+            0x248..0x24c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_ec_soc_mgmt_if_t_su_sta_reg().reg.get(),
             )),
-            0x24c..0x250 => Ok(caliptra_emu_types::RvData::from(
+            0x24c..0x250 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_ec_soc_mgmt_if_t_su_sto_reg().reg.get(),
             )),
             0x250..0x254 => Ok(self.periph.read_i3c_ec_soc_mgmt_if_t_free_reg()),
             0x254..0x258 => Ok(self.periph.read_i3c_ec_soc_mgmt_if_t_aval_reg()),
             0x258..0x25c => Ok(self.periph.read_i3c_ec_soc_mgmt_if_t_idle_reg()),
-            0x260..0x264 => Ok(caliptra_emu_types::RvData::from(
+            0x260..0x264 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_ec_ctrl_cfg_extcap_header().reg.get(),
             )),
-            0x264..0x268 => Ok(caliptra_emu_types::RvData::from(
+            0x264..0x268 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_i3c_ec_ctrl_cfg_controller_config()
                     .reg
                     .get(),
             )),
-            _ => Err(caliptra_emu_bus::BusError::LoadAccessFault),
+            _ => Err(caliptra_core_tools::caliptra_emu_bus::BusError::LoadAccessFault),
         }
     }
     fn write(
         &mut self,
-        size: caliptra_emu_types::RvSize,
-        addr: caliptra_emu_types::RvAddr,
-        val: caliptra_emu_types::RvData,
-    ) -> Result<(), caliptra_emu_bus::BusError> {
-        if addr & 0x3 != 0 || size != caliptra_emu_types::RvSize::Word {
-            return Err(caliptra_emu_bus::BusError::StoreAddrMisaligned);
+        size: caliptra_core_tools::caliptra_emu_types::RvSize,
+        addr: caliptra_core_tools::caliptra_emu_types::RvAddr,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) -> Result<(), caliptra_core_tools::caliptra_emu_bus::BusError> {
+        if addr & 0x3 != 0 || size != caliptra_core_tools::caliptra_emu_types::RvSize::Word {
+            return Err(caliptra_core_tools::caliptra_emu_bus::BusError::StoreAddrMisaligned);
         }
         match addr {
             0x400..0x800 => {
@@ -6137,49 +6620,53 @@ impl caliptra_emu_bus::Bus for I3cBus {
             }
             0..4 => Ok(()),
             4..8 => {
-                self.periph
-                    .write_i3c_base_hc_control(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_i3c_base_hc_control(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             8..0xc => {
                 self.periph.write_i3c_base_controller_device_addr(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0xc..0x10 => Ok(()),
             0x10..0x14 => {
-                self.periph
-                    .write_i3c_base_reset_control(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_i3c_base_reset_control(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0x14..0x18 => Ok(()),
             0x20..0x24 => {
-                self.periph
-                    .write_i3c_base_intr_status(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_i3c_base_intr_status(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0x24..0x28 => {
                 self.periph.write_i3c_base_intr_status_enable(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x28..0x2c => {
                 self.periph.write_i3c_base_intr_signal_enable(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x2c..0x30 => {
-                self.periph
-                    .write_i3c_base_intr_force(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_i3c_base_intr_force(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0x30..0x34 => Ok(()),
             0x34..0x38 => {
                 self.periph.write_i3c_base_dct_section_offset(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
@@ -6188,24 +6675,27 @@ impl caliptra_emu_bus::Bus for I3cBus {
             0x40..0x44 => Ok(()),
             0x4c..0x50 => Ok(()),
             0x58..0x5c => {
-                self.periph
-                    .write_i3c_base_ibi_notify_ctrl(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_i3c_base_ibi_notify_ctrl(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0x5c..0x60 => {
                 self.periph.write_i3c_base_ibi_data_abort_ctrl(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x60..0x64 => {
-                self.periph
-                    .write_i3c_base_dev_ctx_base_lo(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_i3c_base_dev_ctx_base_lo(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0x64..0x68 => {
-                self.periph
-                    .write_i3c_base_dev_ctx_base_hi(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_i3c_base_dev_ctx_base_hi(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0x68..0x6c => Ok(()),
@@ -6221,13 +6711,13 @@ impl caliptra_emu_bus::Bus for I3cBus {
             0x8c..0x90 => Ok(()),
             0x90..0x94 => {
                 self.periph.write_piocontrol_queue_thld_ctrl(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x94..0x98 => {
                 self.periph.write_piocontrol_data_buffer_thld_ctrl(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
@@ -6235,30 +6725,32 @@ impl caliptra_emu_bus::Bus for I3cBus {
             0x9c..0xa0 => Ok(()),
             0xa0..0xa4 => {
                 self.periph.write_piocontrol_pio_intr_status(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0xa4..0xa8 => {
                 self.periph.write_piocontrol_pio_intr_status_enable(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0xa8..0xac => {
                 self.periph.write_piocontrol_pio_intr_signal_enable(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0xac..0xb0 => {
-                self.periph
-                    .write_piocontrol_pio_intr_force(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_piocontrol_pio_intr_force(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0xb0..0xb4 => {
-                self.periph
-                    .write_piocontrol_pio_control(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_piocontrol_pio_control(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0x100..0x104 => Ok(()),
@@ -6266,19 +6758,19 @@ impl caliptra_emu_bus::Bus for I3cBus {
             0x108..0x10c => Ok(()),
             0x10c..0x110 => {
                 self.periph.write_i3c_ec_sec_fw_recovery_if_prot_cap_2(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x110..0x114 => {
                 self.periph.write_i3c_ec_sec_fw_recovery_if_prot_cap_3(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x114..0x118 => {
                 self.periph.write_i3c_ec_sec_fw_recovery_if_device_id_0(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
@@ -6305,44 +6797,44 @@ impl caliptra_emu_bus::Bus for I3cBus {
             0x12c..0x130 => Ok(()),
             0x130..0x134 => {
                 self.periph.write_i3c_ec_sec_fw_recovery_if_device_status_0(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x134..0x138 => {
                 self.periph.write_i3c_ec_sec_fw_recovery_if_device_status_1(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x138..0x13c => {
                 self.periph.write_i3c_ec_sec_fw_recovery_if_device_reset(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x13c..0x140 => {
                 self.periph.write_i3c_ec_sec_fw_recovery_if_recovery_ctrl(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x140..0x144 => {
                 self.periph.write_i3c_ec_sec_fw_recovery_if_recovery_status(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x144..0x148 => {
                 self.periph.write_i3c_ec_sec_fw_recovery_if_hw_status(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x148..0x14c => {
                 self.periph
                     .write_i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_0(
-                        caliptra_emu_bus::ReadWriteRegister::new(val),
+                        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                     );
                 Ok(())
             }
@@ -6361,14 +6853,14 @@ impl caliptra_emu_bus::Bus for I3cBus {
             0x180..0x184 => Ok(()),
             0x184..0x188 => {
                 self.periph.write_i3c_ec_stdby_ctrl_mode_stby_cr_control(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x188..0x18c => {
                 self.periph
                     .write_i3c_ec_stdby_ctrl_mode_stby_cr_device_addr(
-                        caliptra_emu_bus::ReadWriteRegister::new(val),
+                        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                     );
                 Ok(())
             }
@@ -6376,20 +6868,20 @@ impl caliptra_emu_bus::Bus for I3cBus {
             0x190..0x194 => {
                 self.periph
                     .write_i3c_ec_stdby_ctrl_mode_stby_cr_virtual_device_char(
-                        caliptra_emu_bus::ReadWriteRegister::new(val),
+                        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                     );
                 Ok(())
             }
             0x194..0x198 => {
                 self.periph.write_i3c_ec_stdby_ctrl_mode_stby_cr_status(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x198..0x19c => {
                 self.periph
                     .write_i3c_ec_stdby_ctrl_mode_stby_cr_device_char(
-                        caliptra_emu_bus::ReadWriteRegister::new(val),
+                        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                     );
                 Ok(())
             }
@@ -6401,7 +6893,7 @@ impl caliptra_emu_bus::Bus for I3cBus {
             0x1a0..0x1a4 => {
                 self.periph
                     .write_i3c_ec_stdby_ctrl_mode_stby_cr_intr_status(
-                        caliptra_emu_bus::ReadWriteRegister::new(val),
+                        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                     );
                 Ok(())
             }
@@ -6413,34 +6905,34 @@ impl caliptra_emu_bus::Bus for I3cBus {
             0x1a8..0x1ac => {
                 self.periph
                     .write_i3c_ec_stdby_ctrl_mode_stby_cr_intr_signal_enable(
-                        caliptra_emu_bus::ReadWriteRegister::new(val),
+                        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                     );
                 Ok(())
             }
             0x1ac..0x1b0 => {
                 self.periph.write_i3c_ec_stdby_ctrl_mode_stby_cr_intr_force(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x1b0..0x1b4 => {
                 self.periph
                     .write_i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_getcaps(
-                        caliptra_emu_bus::ReadWriteRegister::new(val),
+                        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                     );
                 Ok(())
             }
             0x1b4..0x1b8 => {
                 self.periph
                     .write_i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_rstact_params(
-                        caliptra_emu_bus::ReadWriteRegister::new(val),
+                        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                     );
                 Ok(())
             }
             0x1b8..0x1bc => {
                 self.periph
                     .write_i3c_ec_stdby_ctrl_mode_stby_cr_virt_device_addr(
-                        caliptra_emu_bus::ReadWriteRegister::new(val),
+                        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                     );
                 Ok(())
             }
@@ -6450,32 +6942,33 @@ impl caliptra_emu_bus::Bus for I3cBus {
             }
             0x1c0..0x1c4 => Ok(()),
             0x1c4..0x1c8 => {
-                self.periph
-                    .write_i3c_ec_tti_control(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_i3c_ec_tti_control(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0x1c8..0x1cc => Ok(()),
             0x1cc..0x1d0 => {
                 self.periph.write_i3c_ec_tti_tti_reset_control(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x1d0..0x1d4 => {
                 self.periph.write_i3c_ec_tti_interrupt_status(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x1d4..0x1d8 => {
                 self.periph.write_i3c_ec_tti_interrupt_enable(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x1d8..0x1dc => {
                 self.periph.write_i3c_ec_tti_interrupt_force(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
@@ -6497,13 +6990,13 @@ impl caliptra_emu_bus::Bus for I3cBus {
             0x1f4..0x1f8 => Ok(()),
             0x1f8..0x1fc => {
                 self.periph.write_i3c_ec_tti_tti_queue_thld_ctrl(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x1fc..0x200 => {
                 self.periph.write_i3c_ec_tti_tti_data_buffer_thld_ctrl(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
@@ -6518,14 +7011,14 @@ impl caliptra_emu_bus::Bus for I3cBus {
             }
             0x20c..0x210 => {
                 self.periph.write_i3c_ec_soc_mgmt_if_rec_intf_cfg(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x210..0x214 => {
                 self.periph
                     .write_i3c_ec_soc_mgmt_if_rec_intf_reg_w1_c_access(
-                        caliptra_emu_bus::ReadWriteRegister::new(val),
+                        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                     );
                 Ok(())
             }
@@ -6539,13 +7032,13 @@ impl caliptra_emu_bus::Bus for I3cBus {
             }
             0x21c..0x220 => {
                 self.periph.write_i3c_ec_soc_mgmt_if_soc_pad_conf(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x220..0x224 => {
                 self.periph.write_i3c_ec_soc_mgmt_if_soc_pad_attr(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
@@ -6559,55 +7052,55 @@ impl caliptra_emu_bus::Bus for I3cBus {
             }
             0x22c..0x230 => {
                 self.periph.write_i3c_ec_soc_mgmt_if_t_r_reg(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x230..0x234 => {
                 self.periph.write_i3c_ec_soc_mgmt_if_t_f_reg(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x234..0x238 => {
                 self.periph.write_i3c_ec_soc_mgmt_if_t_su_dat_reg(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x238..0x23c => {
                 self.periph.write_i3c_ec_soc_mgmt_if_t_hd_dat_reg(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x23c..0x240 => {
                 self.periph.write_i3c_ec_soc_mgmt_if_t_high_reg(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x240..0x244 => {
                 self.periph.write_i3c_ec_soc_mgmt_if_t_low_reg(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x244..0x248 => {
                 self.periph.write_i3c_ec_soc_mgmt_if_t_hd_sta_reg(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x248..0x24c => {
                 self.periph.write_i3c_ec_soc_mgmt_if_t_su_sta_reg(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x24c..0x250 => {
                 self.periph.write_i3c_ec_soc_mgmt_if_t_su_sto_reg(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
@@ -6625,7 +7118,7 @@ impl caliptra_emu_bus::Bus for I3cBus {
             }
             0x260..0x264 => Ok(()),
             0x264..0x268 => Ok(()),
-            _ => Err(caliptra_emu_bus::BusError::StoreAccessFault),
+            _ => Err(caliptra_core_tools::caliptra_emu_bus::BusError::StoreAccessFault),
         }
     }
     fn poll(&mut self) {

--- a/registers/generated-emulator/src/i3c1.rs
+++ b/registers/generated-emulator/src/i3c1.rs
@@ -5,14 +5,24 @@
 #[allow(unused_imports)]
 use tock_registers::interfaces::{Readable, Writeable};
 pub trait I3c1Peripheral {
-    fn set_dma_ram(&mut self, _ram: std::rc::Rc<std::cell::RefCell<caliptra_emu_bus::Ram>>) {}
-    fn set_dma_rom_sram(&mut self, _ram: std::rc::Rc<std::cell::RefCell<caliptra_emu_bus::Ram>>) {}
+    fn set_dma_ram(
+        &mut self,
+        _ram: std::rc::Rc<std::cell::RefCell<caliptra_core_tools::caliptra_emu_bus::Ram>>,
+    ) {
+    }
+    fn set_dma_rom_sram(
+        &mut self,
+        _ram: std::rc::Rc<std::cell::RefCell<caliptra_core_tools::caliptra_emu_bus::Ram>>,
+    ) {
+    }
     fn register_event_channels(
         &mut self,
-        _events_to_caliptra: std::sync::mpsc::Sender<caliptra_emu_bus::Event>,
-        _events_from_caliptra: std::sync::mpsc::Receiver<caliptra_emu_bus::Event>,
-        _events_to_mcu: std::sync::mpsc::Sender<caliptra_emu_bus::Event>,
-        _events_from_mcu: std::sync::mpsc::Receiver<caliptra_emu_bus::Event>,
+        _events_to_caliptra: std::sync::mpsc::Sender<caliptra_core_tools::caliptra_emu_bus::Event>,
+        _events_from_caliptra: std::sync::mpsc::Receiver<
+            caliptra_core_tools::caliptra_emu_bus::Event,
+        >,
+        _events_to_mcu: std::sync::mpsc::Sender<caliptra_core_tools::caliptra_emu_bus::Event>,
+        _events_from_mcu: std::sync::mpsc::Receiver<caliptra_core_tools::caliptra_emu_bus::Event>,
     ) {
     }
     fn poll(&mut self) {}
@@ -21,7 +31,7 @@ pub trait I3c1Peripheral {
     fn generated(&mut self) -> Option<&mut I3c1Generated> {
         None
     }
-    fn read_dat(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_dat(&mut self, index: usize) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read i3c1::dat[{}]",
@@ -33,7 +43,7 @@ pub trait I3c1Peripheral {
         }
         0
     }
-    fn write_dat(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    fn write_dat(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData, index: usize) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write i3c1::dat[{}] = 0x{:08x}",
@@ -44,7 +54,7 @@ pub trait I3c1Peripheral {
             generated.write_dat(val, index);
         }
     }
-    fn read_dct(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_dct(&mut self, index: usize) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read i3c1::dct[{}]",
@@ -56,7 +66,7 @@ pub trait I3c1Peripheral {
         }
         0
     }
-    fn write_dct(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    fn write_dct(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData, index: usize) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write i3c1::dct[{}] = 0x{:08x}",
@@ -67,7 +77,7 @@ pub trait I3c1Peripheral {
             generated.write_dct(val, index);
         }
     }
-    fn read_i3c_base_hci_version(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_base_hci_version(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read i3c1::i3c_base_hci_version");
         }
@@ -78,19 +88,21 @@ pub trait I3c1Peripheral {
     }
     fn read_i3c_base_hc_control(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::HcControl::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::HcControl::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read i3c1::i3c_base_hc_control");
         }
         if let Some(generated) = self.generated() {
             return generated.read_i3c_base_hc_control();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_base_hc_control(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::HcControl::Register,
         >,
@@ -107,7 +119,7 @@ pub trait I3c1Peripheral {
     }
     fn read_i3c_base_controller_device_addr(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::ControllerDeviceAddr::Register,
     > {
@@ -119,11 +131,11 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_base_controller_device_addr();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_base_controller_device_addr(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::ControllerDeviceAddr::Register,
         >,
@@ -137,7 +149,7 @@ pub trait I3c1Peripheral {
     }
     fn read_i3c_base_hc_capabilities(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::HcCapabilities::Register,
     > {
@@ -147,11 +159,11 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_base_hc_capabilities();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_i3c_base_reset_control(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::ResetControl::Register,
     > {
@@ -161,11 +173,11 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_base_reset_control();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_base_reset_control(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::ResetControl::Register,
         >,
@@ -182,7 +194,7 @@ pub trait I3c1Peripheral {
     }
     fn read_i3c_base_present_state(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::PresentState::Register,
     > {
@@ -192,11 +204,11 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_base_present_state();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_i3c_base_intr_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::IntrStatus::Register,
     > {
@@ -206,11 +218,11 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_base_intr_status();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_base_intr_status(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::IntrStatus::Register,
         >,
@@ -227,7 +239,7 @@ pub trait I3c1Peripheral {
     }
     fn read_i3c_base_intr_status_enable(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::IntrStatusEnable::Register,
     > {
@@ -237,11 +249,11 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_base_intr_status_enable();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_base_intr_status_enable(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::IntrStatusEnable::Register,
         >,
@@ -255,7 +267,7 @@ pub trait I3c1Peripheral {
     }
     fn read_i3c_base_intr_signal_enable(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::IntrSignalEnable::Register,
     > {
@@ -265,11 +277,11 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_base_intr_signal_enable();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_base_intr_signal_enable(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::IntrSignalEnable::Register,
         >,
@@ -283,7 +295,7 @@ pub trait I3c1Peripheral {
     }
     fn write_i3c_base_intr_force(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::IntrForce::Register,
         >,
@@ -300,7 +312,7 @@ pub trait I3c1Peripheral {
     }
     fn read_i3c_base_dat_section_offset(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::DatSectionOffset::Register,
     > {
@@ -310,11 +322,11 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_base_dat_section_offset();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_i3c_base_dct_section_offset(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::DctSectionOffset::Register,
     > {
@@ -324,11 +336,11 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_base_dct_section_offset();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_base_dct_section_offset(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::DctSectionOffset::Register,
         >,
@@ -342,7 +354,7 @@ pub trait I3c1Peripheral {
     }
     fn read_i3c_base_ring_headers_section_offset(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::RingHeadersSectionOffset::Register,
     > {
@@ -352,11 +364,11 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_base_ring_headers_section_offset();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_i3c_base_pio_section_offset(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::PioSectionOffset::Register,
     > {
@@ -366,11 +378,11 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_base_pio_section_offset();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_i3c_base_ext_caps_section_offset(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::ExtCapsSectionOffset::Register,
     > {
@@ -382,11 +394,11 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_base_ext_caps_section_offset();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_i3c_base_int_ctrl_cmds_en(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::IntCtrlCmdsEn::Register,
     > {
@@ -396,11 +408,11 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_base_int_ctrl_cmds_en();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_i3c_base_ibi_notify_ctrl(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::IbiNotifyCtrl::Register,
     > {
@@ -410,11 +422,11 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_base_ibi_notify_ctrl();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_base_ibi_notify_ctrl(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::IbiNotifyCtrl::Register,
         >,
@@ -428,7 +440,7 @@ pub trait I3c1Peripheral {
     }
     fn read_i3c_base_ibi_data_abort_ctrl(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::IbiDataAbortCtrl::Register,
     > {
@@ -440,11 +452,11 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_base_ibi_data_abort_ctrl();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_base_ibi_data_abort_ctrl(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::IbiDataAbortCtrl::Register,
         >,
@@ -458,7 +470,7 @@ pub trait I3c1Peripheral {
     }
     fn read_i3c_base_dev_ctx_base_lo(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::DevCtxBaseLo::Register,
     > {
@@ -468,11 +480,11 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_base_dev_ctx_base_lo();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_base_dev_ctx_base_lo(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::DevCtxBaseLo::Register,
         >,
@@ -486,7 +498,7 @@ pub trait I3c1Peripheral {
     }
     fn read_i3c_base_dev_ctx_base_hi(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::DevCtxBaseHi::Register,
     > {
@@ -496,11 +508,11 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_base_dev_ctx_base_hi();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_base_dev_ctx_base_hi(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::DevCtxBaseHi::Register,
         >,
@@ -514,17 +526,22 @@ pub trait I3c1Peripheral {
     }
     fn read_i3c_base_dev_ctx_sg(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::DevCtxSg::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::DevCtxSg::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read i3c1::i3c_base_dev_ctx_sg");
         }
         if let Some(generated) = self.generated() {
             return generated.read_i3c_base_dev_ctx_sg();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
-    fn write_piocontrol_command_port(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_piocontrol_command_port(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write i3c1::piocontrol_command_port = 0x{:08x}" , val);
         }
@@ -532,7 +549,7 @@ pub trait I3c1Peripheral {
             generated.write_piocontrol_command_port(val);
         }
     }
-    fn read_piocontrol_response_port(&mut self) -> caliptra_emu_types::RvData {
+    fn read_piocontrol_response_port(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read i3c1::piocontrol_response_port");
         }
@@ -541,7 +558,10 @@ pub trait I3c1Peripheral {
         }
         0
     }
-    fn write_piocontrol_tx_data_port(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_piocontrol_tx_data_port(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write i3c1::piocontrol_tx_data_port = 0x{:08x}" , val);
         }
@@ -549,7 +569,7 @@ pub trait I3c1Peripheral {
             generated.write_piocontrol_tx_data_port(val);
         }
     }
-    fn read_piocontrol_rx_data_port(&mut self) -> caliptra_emu_types::RvData {
+    fn read_piocontrol_rx_data_port(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read i3c1::piocontrol_rx_data_port");
         }
@@ -558,7 +578,7 @@ pub trait I3c1Peripheral {
         }
         0
     }
-    fn read_piocontrol_ibi_port(&mut self) -> caliptra_emu_types::RvData {
+    fn read_piocontrol_ibi_port(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read i3c1::piocontrol_ibi_port");
         }
@@ -569,7 +589,7 @@ pub trait I3c1Peripheral {
     }
     fn read_piocontrol_queue_thld_ctrl(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::QueueThldCtrl::Register,
     > {
@@ -579,11 +599,11 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_piocontrol_queue_thld_ctrl();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_piocontrol_queue_thld_ctrl(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::QueueThldCtrl::Register,
         >,
@@ -597,7 +617,7 @@ pub trait I3c1Peripheral {
     }
     fn read_piocontrol_data_buffer_thld_ctrl(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::DataBufferThldCtrl::Register,
     > {
@@ -609,11 +629,11 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_piocontrol_data_buffer_thld_ctrl();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_piocontrol_data_buffer_thld_ctrl(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::DataBufferThldCtrl::Register,
         >,
@@ -627,19 +647,21 @@ pub trait I3c1Peripheral {
     }
     fn read_piocontrol_queue_size(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::QueueSize::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::QueueSize::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read i3c1::piocontrol_queue_size");
         }
         if let Some(generated) = self.generated() {
             return generated.read_piocontrol_queue_size();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_piocontrol_alt_queue_size(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::AltQueueSize::Register,
     > {
@@ -649,11 +671,11 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_piocontrol_alt_queue_size();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_piocontrol_pio_intr_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::PioIntrStatus::Register,
     > {
@@ -663,11 +685,11 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_piocontrol_pio_intr_status();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_piocontrol_pio_intr_status(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::PioIntrStatus::Register,
         >,
@@ -681,7 +703,7 @@ pub trait I3c1Peripheral {
     }
     fn read_piocontrol_pio_intr_status_enable(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::PioIntrStatusEnable::Register,
     > {
@@ -693,11 +715,11 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_piocontrol_pio_intr_status_enable();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_piocontrol_pio_intr_status_enable(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::PioIntrStatusEnable::Register,
         >,
@@ -711,7 +733,7 @@ pub trait I3c1Peripheral {
     }
     fn read_piocontrol_pio_intr_signal_enable(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::PioIntrSignalEnable::Register,
     > {
@@ -723,11 +745,11 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_piocontrol_pio_intr_signal_enable();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_piocontrol_pio_intr_signal_enable(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::PioIntrSignalEnable::Register,
         >,
@@ -741,7 +763,7 @@ pub trait I3c1Peripheral {
     }
     fn write_piocontrol_pio_intr_force(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::PioIntrForce::Register,
         >,
@@ -755,7 +777,7 @@ pub trait I3c1Peripheral {
     }
     fn read_piocontrol_pio_control(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::PioControl::Register,
     > {
@@ -765,11 +787,11 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_piocontrol_pio_control();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_piocontrol_pio_control(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::PioControl::Register,
         >,
@@ -786,7 +808,7 @@ pub trait I3c1Peripheral {
     }
     fn read_i3c_ec_sec_fw_recovery_if_extcap_header(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::ExtcapHeader::Register,
     > {
@@ -796,9 +818,11 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_sec_fw_recovery_if_extcap_header();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
-    fn read_i3c_ec_sec_fw_recovery_if_prot_cap_0(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_sec_fw_recovery_if_prot_cap_0(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read i3c1::i3c_ec_sec_fw_recovery_if_prot_cap_0");
         }
@@ -807,7 +831,9 @@ pub trait I3c1Peripheral {
         }
         0
     }
-    fn read_i3c_ec_sec_fw_recovery_if_prot_cap_1(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_sec_fw_recovery_if_prot_cap_1(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read i3c1::i3c_ec_sec_fw_recovery_if_prot_cap_1");
         }
@@ -818,19 +844,21 @@ pub trait I3c1Peripheral {
     }
     fn read_i3c_ec_sec_fw_recovery_if_prot_cap_2(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::ProtCap2::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::ProtCap2::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read i3c1::i3c_ec_sec_fw_recovery_if_prot_cap_2");
         }
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_sec_fw_recovery_if_prot_cap_2();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_sec_fw_recovery_if_prot_cap_2(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::ProtCap2::Register,
         >,
@@ -844,19 +872,21 @@ pub trait I3c1Peripheral {
     }
     fn read_i3c_ec_sec_fw_recovery_if_prot_cap_3(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::ProtCap3::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::ProtCap3::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read i3c1::i3c_ec_sec_fw_recovery_if_prot_cap_3");
         }
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_sec_fw_recovery_if_prot_cap_3();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_sec_fw_recovery_if_prot_cap_3(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::ProtCap3::Register,
         >,
@@ -870,19 +900,21 @@ pub trait I3c1Peripheral {
     }
     fn read_i3c_ec_sec_fw_recovery_if_device_id_0(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::DeviceId0::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::DeviceId0::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read i3c1::i3c_ec_sec_fw_recovery_if_device_id_0");
         }
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_sec_fw_recovery_if_device_id_0();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_sec_fw_recovery_if_device_id_0(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::DeviceId0::Register,
         >,
@@ -894,7 +926,9 @@ pub trait I3c1Peripheral {
             generated.write_i3c_ec_sec_fw_recovery_if_device_id_0(val);
         }
     }
-    fn read_i3c_ec_sec_fw_recovery_if_device_id_1(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_sec_fw_recovery_if_device_id_1(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read i3c1::i3c_ec_sec_fw_recovery_if_device_id_1");
         }
@@ -903,7 +937,10 @@ pub trait I3c1Peripheral {
         }
         0
     }
-    fn write_i3c_ec_sec_fw_recovery_if_device_id_1(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_sec_fw_recovery_if_device_id_1(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write i3c1::i3c_ec_sec_fw_recovery_if_device_id_1 = 0x{:08x}" , val);
         }
@@ -911,7 +948,9 @@ pub trait I3c1Peripheral {
             generated.write_i3c_ec_sec_fw_recovery_if_device_id_1(val);
         }
     }
-    fn read_i3c_ec_sec_fw_recovery_if_device_id_2(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_sec_fw_recovery_if_device_id_2(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read i3c1::i3c_ec_sec_fw_recovery_if_device_id_2");
         }
@@ -920,7 +959,10 @@ pub trait I3c1Peripheral {
         }
         0
     }
-    fn write_i3c_ec_sec_fw_recovery_if_device_id_2(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_sec_fw_recovery_if_device_id_2(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write i3c1::i3c_ec_sec_fw_recovery_if_device_id_2 = 0x{:08x}" , val);
         }
@@ -928,7 +970,9 @@ pub trait I3c1Peripheral {
             generated.write_i3c_ec_sec_fw_recovery_if_device_id_2(val);
         }
     }
-    fn read_i3c_ec_sec_fw_recovery_if_device_id_3(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_sec_fw_recovery_if_device_id_3(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read i3c1::i3c_ec_sec_fw_recovery_if_device_id_3");
         }
@@ -937,7 +981,10 @@ pub trait I3c1Peripheral {
         }
         0
     }
-    fn write_i3c_ec_sec_fw_recovery_if_device_id_3(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_sec_fw_recovery_if_device_id_3(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write i3c1::i3c_ec_sec_fw_recovery_if_device_id_3 = 0x{:08x}" , val);
         }
@@ -945,7 +992,9 @@ pub trait I3c1Peripheral {
             generated.write_i3c_ec_sec_fw_recovery_if_device_id_3(val);
         }
     }
-    fn read_i3c_ec_sec_fw_recovery_if_device_id_4(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_sec_fw_recovery_if_device_id_4(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read i3c1::i3c_ec_sec_fw_recovery_if_device_id_4");
         }
@@ -954,7 +1003,10 @@ pub trait I3c1Peripheral {
         }
         0
     }
-    fn write_i3c_ec_sec_fw_recovery_if_device_id_4(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_sec_fw_recovery_if_device_id_4(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write i3c1::i3c_ec_sec_fw_recovery_if_device_id_4 = 0x{:08x}" , val);
         }
@@ -962,7 +1014,9 @@ pub trait I3c1Peripheral {
             generated.write_i3c_ec_sec_fw_recovery_if_device_id_4(val);
         }
     }
-    fn read_i3c_ec_sec_fw_recovery_if_device_id_5(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_sec_fw_recovery_if_device_id_5(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read i3c1::i3c_ec_sec_fw_recovery_if_device_id_5");
         }
@@ -971,7 +1025,10 @@ pub trait I3c1Peripheral {
         }
         0
     }
-    fn write_i3c_ec_sec_fw_recovery_if_device_id_5(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_sec_fw_recovery_if_device_id_5(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write i3c1::i3c_ec_sec_fw_recovery_if_device_id_5 = 0x{:08x}" , val);
         }
@@ -979,7 +1036,9 @@ pub trait I3c1Peripheral {
             generated.write_i3c_ec_sec_fw_recovery_if_device_id_5(val);
         }
     }
-    fn read_i3c_ec_sec_fw_recovery_if_device_id_reserved(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_sec_fw_recovery_if_device_id_reserved(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read i3c1::i3c_ec_sec_fw_recovery_if_device_id_reserved");
         }
@@ -990,7 +1049,7 @@ pub trait I3c1Peripheral {
     }
     fn read_i3c_ec_sec_fw_recovery_if_device_status_0(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::DeviceStatus0::Register,
     > {
@@ -1000,11 +1059,11 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_sec_fw_recovery_if_device_status_0();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_sec_fw_recovery_if_device_status_0(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::DeviceStatus0::Register,
         >,
@@ -1018,7 +1077,7 @@ pub trait I3c1Peripheral {
     }
     fn read_i3c_ec_sec_fw_recovery_if_device_status_1(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::DeviceStatus1::Register,
     > {
@@ -1028,11 +1087,11 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_sec_fw_recovery_if_device_status_1();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_sec_fw_recovery_if_device_status_1(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::DeviceStatus1::Register,
         >,
@@ -1046,7 +1105,7 @@ pub trait I3c1Peripheral {
     }
     fn read_i3c_ec_sec_fw_recovery_if_device_reset(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::DeviceReset::Register,
     > {
@@ -1056,11 +1115,11 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_sec_fw_recovery_if_device_reset();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_sec_fw_recovery_if_device_reset(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::DeviceReset::Register,
         >,
@@ -1074,7 +1133,7 @@ pub trait I3c1Peripheral {
     }
     fn read_i3c_ec_sec_fw_recovery_if_recovery_ctrl(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::RecoveryCtrl::Register,
     > {
@@ -1084,11 +1143,11 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_sec_fw_recovery_if_recovery_ctrl();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_sec_fw_recovery_if_recovery_ctrl(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::RecoveryCtrl::Register,
         >,
@@ -1102,7 +1161,7 @@ pub trait I3c1Peripheral {
     }
     fn read_i3c_ec_sec_fw_recovery_if_recovery_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::RecoveryStatus::Register,
     > {
@@ -1112,11 +1171,11 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_sec_fw_recovery_if_recovery_status();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_sec_fw_recovery_if_recovery_status(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::RecoveryStatus::Register,
         >,
@@ -1130,19 +1189,21 @@ pub trait I3c1Peripheral {
     }
     fn read_i3c_ec_sec_fw_recovery_if_hw_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::HwStatus::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::HwStatus::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read i3c1::i3c_ec_sec_fw_recovery_if_hw_status");
         }
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_sec_fw_recovery_if_hw_status();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_sec_fw_recovery_if_hw_status(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::HwStatus::Register,
         >,
@@ -1156,7 +1217,7 @@ pub trait I3c1Peripheral {
     }
     fn read_i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_0(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::IndirectFifoCtrl0::Register,
     > {
@@ -1166,11 +1227,11 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_0();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_0(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::IndirectFifoCtrl0::Register,
         >,
@@ -1184,7 +1245,7 @@ pub trait I3c1Peripheral {
     }
     fn read_i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_1(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read i3c1::i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_1");
         }
@@ -1195,7 +1256,7 @@ pub trait I3c1Peripheral {
     }
     fn write_i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_1(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write i3c1::i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_1 = 0x{:08x}" , val);
@@ -1206,7 +1267,7 @@ pub trait I3c1Peripheral {
     }
     fn read_i3c_ec_sec_fw_recovery_if_indirect_fifo_status_0(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::IndirectFifoStatus0::Register,
     > {
@@ -1216,11 +1277,11 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_sec_fw_recovery_if_indirect_fifo_status_0();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_i3c_ec_sec_fw_recovery_if_indirect_fifo_status_1(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read i3c1::i3c_ec_sec_fw_recovery_if_indirect_fifo_status_1");
         }
@@ -1231,7 +1292,7 @@ pub trait I3c1Peripheral {
     }
     fn read_i3c_ec_sec_fw_recovery_if_indirect_fifo_status_2(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read i3c1::i3c_ec_sec_fw_recovery_if_indirect_fifo_status_2");
         }
@@ -1242,7 +1303,7 @@ pub trait I3c1Peripheral {
     }
     fn read_i3c_ec_sec_fw_recovery_if_indirect_fifo_status_3(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read i3c1::i3c_ec_sec_fw_recovery_if_indirect_fifo_status_3");
         }
@@ -1253,7 +1314,7 @@ pub trait I3c1Peripheral {
     }
     fn read_i3c_ec_sec_fw_recovery_if_indirect_fifo_status_4(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read i3c1::i3c_ec_sec_fw_recovery_if_indirect_fifo_status_4");
         }
@@ -1264,7 +1325,7 @@ pub trait I3c1Peripheral {
     }
     fn read_i3c_ec_sec_fw_recovery_if_indirect_fifo_reserved(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read i3c1::i3c_ec_sec_fw_recovery_if_indirect_fifo_reserved");
         }
@@ -1273,7 +1334,9 @@ pub trait I3c1Peripheral {
         }
         0
     }
-    fn read_i3c_ec_sec_fw_recovery_if_indirect_fifo_data(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_sec_fw_recovery_if_indirect_fifo_data(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read i3c1::i3c_ec_sec_fw_recovery_if_indirect_fifo_data");
         }
@@ -1284,7 +1347,7 @@ pub trait I3c1Peripheral {
     }
     fn read_i3c_ec_stdby_ctrl_mode_extcap_header(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::ExtcapHeader::Register,
     > {
@@ -1294,11 +1357,11 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_stdby_ctrl_mode_extcap_header();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_i3c_ec_stdby_ctrl_mode_stby_cr_control(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::StbyCrControl::Register,
     > {
@@ -1308,11 +1371,11 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_stdby_ctrl_mode_stby_cr_control();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_stdby_ctrl_mode_stby_cr_control(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::StbyCrControl::Register,
         >,
@@ -1326,7 +1389,7 @@ pub trait I3c1Peripheral {
     }
     fn read_i3c_ec_stdby_ctrl_mode_stby_cr_device_addr(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::StbyCrDeviceAddr::Register,
     > {
@@ -1336,11 +1399,11 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_stdby_ctrl_mode_stby_cr_device_addr();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_stdby_ctrl_mode_stby_cr_device_addr(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::StbyCrDeviceAddr::Register,
         >,
@@ -1354,7 +1417,7 @@ pub trait I3c1Peripheral {
     }
     fn read_i3c_ec_stdby_ctrl_mode_stby_cr_capabilities(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::StbyCrCapabilities::Register,
     > {
@@ -1364,11 +1427,11 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_stdby_ctrl_mode_stby_cr_capabilities();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_i3c_ec_stdby_ctrl_mode_stby_cr_virtual_device_char(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::StbyCrVirtualDeviceChar::Register,
     > {
@@ -1378,11 +1441,11 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_stdby_ctrl_mode_stby_cr_virtual_device_char();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_stdby_ctrl_mode_stby_cr_virtual_device_char(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::StbyCrVirtualDeviceChar::Register,
         >,
@@ -1396,7 +1459,7 @@ pub trait I3c1Peripheral {
     }
     fn read_i3c_ec_stdby_ctrl_mode_stby_cr_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::StbyCrStatus::Register,
     > {
@@ -1406,11 +1469,11 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_stdby_ctrl_mode_stby_cr_status();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_stdby_ctrl_mode_stby_cr_status(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::StbyCrStatus::Register,
         >,
@@ -1424,7 +1487,7 @@ pub trait I3c1Peripheral {
     }
     fn read_i3c_ec_stdby_ctrl_mode_stby_cr_device_char(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::StbyCrDeviceChar::Register,
     > {
@@ -1434,11 +1497,11 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_stdby_ctrl_mode_stby_cr_device_char();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_stdby_ctrl_mode_stby_cr_device_char(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::StbyCrDeviceChar::Register,
         >,
@@ -1450,7 +1513,9 @@ pub trait I3c1Peripheral {
             generated.write_i3c_ec_stdby_ctrl_mode_stby_cr_device_char(val);
         }
     }
-    fn read_i3c_ec_stdby_ctrl_mode_stby_cr_device_pid_lo(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_stdby_ctrl_mode_stby_cr_device_pid_lo(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read i3c1::i3c_ec_stdby_ctrl_mode_stby_cr_device_pid_lo");
         }
@@ -1461,7 +1526,7 @@ pub trait I3c1Peripheral {
     }
     fn write_i3c_ec_stdby_ctrl_mode_stby_cr_device_pid_lo(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write i3c1::i3c_ec_stdby_ctrl_mode_stby_cr_device_pid_lo = 0x{:08x}" , val);
@@ -1472,7 +1537,7 @@ pub trait I3c1Peripheral {
     }
     fn read_i3c_ec_stdby_ctrl_mode_stby_cr_intr_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::StbyCrIntrStatus::Register,
     > {
@@ -1482,11 +1547,11 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_stdby_ctrl_mode_stby_cr_intr_status();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_stdby_ctrl_mode_stby_cr_intr_status(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::StbyCrIntrStatus::Register,
         >,
@@ -1500,7 +1565,7 @@ pub trait I3c1Peripheral {
     }
     fn read_i3c_ec_stdby_ctrl_mode_stby_cr_virtual_device_pid_lo(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read i3c1::i3c_ec_stdby_ctrl_mode_stby_cr_virtual_device_pid_lo");
         }
@@ -1511,7 +1576,7 @@ pub trait I3c1Peripheral {
     }
     fn write_i3c_ec_stdby_ctrl_mode_stby_cr_virtual_device_pid_lo(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write i3c1::i3c_ec_stdby_ctrl_mode_stby_cr_virtual_device_pid_lo = 0x{:08x}" , val);
@@ -1522,7 +1587,7 @@ pub trait I3c1Peripheral {
     }
     fn read_i3c_ec_stdby_ctrl_mode_stby_cr_intr_signal_enable(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::StbyCrIntrSignalEnable::Register,
     > {
@@ -1532,11 +1597,11 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_stdby_ctrl_mode_stby_cr_intr_signal_enable();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_stdby_ctrl_mode_stby_cr_intr_signal_enable(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::StbyCrIntrSignalEnable::Register,
         >,
@@ -1550,7 +1615,7 @@ pub trait I3c1Peripheral {
     }
     fn read_i3c_ec_stdby_ctrl_mode_stby_cr_intr_force(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::StbyCrIntrForce::Register,
     > {
@@ -1560,11 +1625,11 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_stdby_ctrl_mode_stby_cr_intr_force();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_stdby_ctrl_mode_stby_cr_intr_force(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::StbyCrIntrForce::Register,
         >,
@@ -1578,7 +1643,7 @@ pub trait I3c1Peripheral {
     }
     fn read_i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_getcaps(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::StbyCrCccConfigGetcaps::Register,
     > {
@@ -1588,11 +1653,11 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_getcaps();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_getcaps(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::StbyCrCccConfigGetcaps::Register,
         >,
@@ -1606,7 +1671,7 @@ pub trait I3c1Peripheral {
     }
     fn read_i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_rstact_params(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::StbyCrCccConfigRstactParams::Register,
     > {
@@ -1616,11 +1681,11 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_rstact_params();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_rstact_params(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::StbyCrCccConfigRstactParams::Register,
         >,
@@ -1634,7 +1699,7 @@ pub trait I3c1Peripheral {
     }
     fn read_i3c_ec_stdby_ctrl_mode_stby_cr_virt_device_addr(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::StbyCrVirtDeviceAddr::Register,
     > {
@@ -1644,11 +1709,11 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_stdby_ctrl_mode_stby_cr_virt_device_addr();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_stdby_ctrl_mode_stby_cr_virt_device_addr(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::StbyCrVirtDeviceAddr::Register,
         >,
@@ -1660,7 +1725,9 @@ pub trait I3c1Peripheral {
             generated.write_i3c_ec_stdby_ctrl_mode_stby_cr_virt_device_addr(val);
         }
     }
-    fn read_i3c_ec_stdby_ctrl_mode_rsvd_3(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_stdby_ctrl_mode_rsvd_3(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read i3c1::i3c_ec_stdby_ctrl_mode_rsvd_3"
@@ -1671,7 +1738,10 @@ pub trait I3c1Peripheral {
         }
         0
     }
-    fn write_i3c_ec_stdby_ctrl_mode_rsvd_3(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_stdby_ctrl_mode_rsvd_3(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write i3c1::i3c_ec_stdby_ctrl_mode_rsvd_3 = 0x{:08x}" , val);
         }
@@ -1681,7 +1751,7 @@ pub trait I3c1Peripheral {
     }
     fn read_i3c_ec_tti_extcap_header(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::ExtcapHeader::Register,
     > {
@@ -1691,23 +1761,25 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_tti_extcap_header();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_i3c_ec_tti_control(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::Control::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::Control::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read i3c1::i3c_ec_tti_control");
         }
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_tti_control();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_tti_control(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::Control::Register,
         >,
@@ -1724,19 +1796,21 @@ pub trait I3c1Peripheral {
     }
     fn read_i3c_ec_tti_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::Status::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::Status::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read i3c1::i3c_ec_tti_status");
         }
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_tti_status();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_i3c_ec_tti_tti_reset_control(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::TtiResetControl::Register,
     > {
@@ -1748,11 +1822,11 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_tti_tti_reset_control();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_tti_tti_reset_control(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::TtiResetControl::Register,
         >,
@@ -1766,7 +1840,7 @@ pub trait I3c1Peripheral {
     }
     fn read_i3c_ec_tti_interrupt_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::InterruptStatus::Register,
     > {
@@ -1776,11 +1850,11 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_tti_interrupt_status();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_tti_interrupt_status(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::InterruptStatus::Register,
         >,
@@ -1794,7 +1868,7 @@ pub trait I3c1Peripheral {
     }
     fn read_i3c_ec_tti_interrupt_enable(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::InterruptEnable::Register,
     > {
@@ -1804,11 +1878,11 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_tti_interrupt_enable();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_tti_interrupt_enable(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::InterruptEnable::Register,
         >,
@@ -1822,7 +1896,7 @@ pub trait I3c1Peripheral {
     }
     fn read_i3c_ec_tti_interrupt_force(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::InterruptForce::Register,
     > {
@@ -1832,11 +1906,11 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_tti_interrupt_force();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_tti_interrupt_force(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::InterruptForce::Register,
         >,
@@ -1848,7 +1922,9 @@ pub trait I3c1Peripheral {
             generated.write_i3c_ec_tti_interrupt_force(val);
         }
     }
-    fn read_i3c_ec_tti_rx_desc_queue_port(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_tti_rx_desc_queue_port(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read i3c1::i3c_ec_tti_rx_desc_queue_port"
@@ -1859,7 +1935,7 @@ pub trait I3c1Peripheral {
         }
         0
     }
-    fn read_i3c_ec_tti_rx_data_port(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_tti_rx_data_port(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read i3c1::i3c_ec_tti_rx_data_port");
         }
@@ -1868,7 +1944,10 @@ pub trait I3c1Peripheral {
         }
         0
     }
-    fn write_i3c_ec_tti_tx_desc_queue_port(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_tti_tx_desc_queue_port(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write i3c1::i3c_ec_tti_tx_desc_queue_port = 0x{:08x}" , val);
         }
@@ -1876,7 +1955,10 @@ pub trait I3c1Peripheral {
             generated.write_i3c_ec_tti_tx_desc_queue_port(val);
         }
     }
-    fn write_i3c_ec_tti_tx_data_port(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_tti_tx_data_port(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write i3c1::i3c_ec_tti_tx_data_port = 0x{:08x}" , val);
         }
@@ -1884,7 +1966,10 @@ pub trait I3c1Peripheral {
             generated.write_i3c_ec_tti_tx_data_port(val);
         }
     }
-    fn write_i3c_ec_tti_tti_ibi_port(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_tti_tti_ibi_port(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write i3c1::i3c_ec_tti_tti_ibi_port = 0x{:08x}" , val);
         }
@@ -1894,7 +1979,7 @@ pub trait I3c1Peripheral {
     }
     fn read_i3c_ec_tti_tti_queue_size(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::TtiQueueSize::Register,
     > {
@@ -1904,11 +1989,11 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_tti_tti_queue_size();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_i3c_ec_tti_ibi_tti_queue_size(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::IbiTtiQueueSize::Register,
     > {
@@ -1920,11 +2005,11 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_tti_ibi_tti_queue_size();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_i3c_ec_tti_tti_queue_thld_ctrl(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::TtiQueueThldCtrl::Register,
     > {
@@ -1936,11 +2021,11 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_tti_tti_queue_thld_ctrl();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_tti_tti_queue_thld_ctrl(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::TtiQueueThldCtrl::Register,
         >,
@@ -1954,7 +2039,7 @@ pub trait I3c1Peripheral {
     }
     fn read_i3c_ec_tti_tti_data_buffer_thld_ctrl(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::TtiDataBufferThldCtrl::Register,
     > {
@@ -1964,11 +2049,11 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_tti_tti_data_buffer_thld_ctrl();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_tti_tti_data_buffer_thld_ctrl(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::TtiDataBufferThldCtrl::Register,
         >,
@@ -1982,7 +2067,7 @@ pub trait I3c1Peripheral {
     }
     fn read_i3c_ec_soc_mgmt_if_extcap_header(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::ExtcapHeader::Register,
     > {
@@ -1994,9 +2079,11 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_soc_mgmt_if_extcap_header();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
-    fn read_i3c_ec_soc_mgmt_if_soc_mgmt_control(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_soc_mgmt_if_soc_mgmt_control(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read i3c1::i3c_ec_soc_mgmt_if_soc_mgmt_control");
         }
@@ -2005,7 +2092,10 @@ pub trait I3c1Peripheral {
         }
         0
     }
-    fn write_i3c_ec_soc_mgmt_if_soc_mgmt_control(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_soc_mgmt_if_soc_mgmt_control(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write i3c1::i3c_ec_soc_mgmt_if_soc_mgmt_control = 0x{:08x}" , val);
         }
@@ -2013,7 +2103,9 @@ pub trait I3c1Peripheral {
             generated.write_i3c_ec_soc_mgmt_if_soc_mgmt_control(val);
         }
     }
-    fn read_i3c_ec_soc_mgmt_if_soc_mgmt_status(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_soc_mgmt_if_soc_mgmt_status(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read i3c1::i3c_ec_soc_mgmt_if_soc_mgmt_status"
@@ -2024,7 +2116,10 @@ pub trait I3c1Peripheral {
         }
         0
     }
-    fn write_i3c_ec_soc_mgmt_if_soc_mgmt_status(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_soc_mgmt_if_soc_mgmt_status(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write i3c1::i3c_ec_soc_mgmt_if_soc_mgmt_status = 0x{:08x}" , val);
         }
@@ -2034,7 +2129,7 @@ pub trait I3c1Peripheral {
     }
     fn read_i3c_ec_soc_mgmt_if_rec_intf_cfg(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::RecIntfCfg::Register,
     > {
@@ -2046,11 +2141,11 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_soc_mgmt_if_rec_intf_cfg();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_soc_mgmt_if_rec_intf_cfg(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::RecIntfCfg::Register,
         >,
@@ -2064,7 +2159,7 @@ pub trait I3c1Peripheral {
     }
     fn read_i3c_ec_soc_mgmt_if_rec_intf_reg_w1_c_access(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::RecIntfRegW1cAccess::Register,
     > {
@@ -2074,11 +2169,11 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_soc_mgmt_if_rec_intf_reg_w1_c_access();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_soc_mgmt_if_rec_intf_reg_w1_c_access(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::RecIntfRegW1cAccess::Register,
         >,
@@ -2090,7 +2185,9 @@ pub trait I3c1Peripheral {
             generated.write_i3c_ec_soc_mgmt_if_rec_intf_reg_w1_c_access(val);
         }
     }
-    fn read_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_2(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_2(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read i3c1::i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_2"
@@ -2101,7 +2198,10 @@ pub trait I3c1Peripheral {
         }
         0
     }
-    fn write_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_2(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_2(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write i3c1::i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_2 = 0x{:08x}" , val);
         }
@@ -2109,7 +2209,9 @@ pub trait I3c1Peripheral {
             generated.write_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_2(val);
         }
     }
-    fn read_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_3(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_3(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read i3c1::i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_3"
@@ -2120,7 +2222,10 @@ pub trait I3c1Peripheral {
         }
         0
     }
-    fn write_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_3(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_3(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write i3c1::i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_3 = 0x{:08x}" , val);
         }
@@ -2130,7 +2235,7 @@ pub trait I3c1Peripheral {
     }
     fn read_i3c_ec_soc_mgmt_if_soc_pad_conf(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::SocPadConf::Register,
     > {
@@ -2142,11 +2247,11 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_soc_mgmt_if_soc_pad_conf();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_soc_mgmt_if_soc_pad_conf(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::SocPadConf::Register,
         >,
@@ -2160,7 +2265,7 @@ pub trait I3c1Peripheral {
     }
     fn read_i3c_ec_soc_mgmt_if_soc_pad_attr(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::SocPadAttr::Register,
     > {
@@ -2172,11 +2277,11 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_soc_mgmt_if_soc_pad_attr();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_soc_mgmt_if_soc_pad_attr(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::SocPadAttr::Register,
         >,
@@ -2188,7 +2293,9 @@ pub trait I3c1Peripheral {
             generated.write_i3c_ec_soc_mgmt_if_soc_pad_attr(val);
         }
     }
-    fn read_i3c_ec_soc_mgmt_if_soc_mgmt_feature_2(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_soc_mgmt_if_soc_mgmt_feature_2(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read i3c1::i3c_ec_soc_mgmt_if_soc_mgmt_feature_2");
         }
@@ -2197,7 +2304,10 @@ pub trait I3c1Peripheral {
         }
         0
     }
-    fn write_i3c_ec_soc_mgmt_if_soc_mgmt_feature_2(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_soc_mgmt_if_soc_mgmt_feature_2(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write i3c1::i3c_ec_soc_mgmt_if_soc_mgmt_feature_2 = 0x{:08x}" , val);
         }
@@ -2205,7 +2315,9 @@ pub trait I3c1Peripheral {
             generated.write_i3c_ec_soc_mgmt_if_soc_mgmt_feature_2(val);
         }
     }
-    fn read_i3c_ec_soc_mgmt_if_soc_mgmt_feature_3(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_soc_mgmt_if_soc_mgmt_feature_3(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read i3c1::i3c_ec_soc_mgmt_if_soc_mgmt_feature_3");
         }
@@ -2214,7 +2326,10 @@ pub trait I3c1Peripheral {
         }
         0
     }
-    fn write_i3c_ec_soc_mgmt_if_soc_mgmt_feature_3(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_soc_mgmt_if_soc_mgmt_feature_3(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write i3c1::i3c_ec_soc_mgmt_if_soc_mgmt_feature_3 = 0x{:08x}" , val);
         }
@@ -2224,19 +2339,21 @@ pub trait I3c1Peripheral {
     }
     fn read_i3c_ec_soc_mgmt_if_t_r_reg(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::TRReg::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::TRReg::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read i3c1::i3c_ec_soc_mgmt_if_t_r_reg");
         }
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_soc_mgmt_if_t_r_reg();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_soc_mgmt_if_t_r_reg(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::TRReg::Register,
         >,
@@ -2250,19 +2367,21 @@ pub trait I3c1Peripheral {
     }
     fn read_i3c_ec_soc_mgmt_if_t_f_reg(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::TFReg::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::TFReg::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read i3c1::i3c_ec_soc_mgmt_if_t_f_reg");
         }
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_soc_mgmt_if_t_f_reg();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_soc_mgmt_if_t_f_reg(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::TFReg::Register,
         >,
@@ -2276,8 +2395,10 @@ pub trait I3c1Peripheral {
     }
     fn read_i3c_ec_soc_mgmt_if_t_su_dat_reg(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::TSuDatReg::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::TSuDatReg::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read i3c1::i3c_ec_soc_mgmt_if_t_su_dat_reg"
@@ -2286,11 +2407,11 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_soc_mgmt_if_t_su_dat_reg();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_soc_mgmt_if_t_su_dat_reg(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::TSuDatReg::Register,
         >,
@@ -2304,8 +2425,10 @@ pub trait I3c1Peripheral {
     }
     fn read_i3c_ec_soc_mgmt_if_t_hd_dat_reg(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::THdDatReg::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::THdDatReg::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read i3c1::i3c_ec_soc_mgmt_if_t_hd_dat_reg"
@@ -2314,11 +2437,11 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_soc_mgmt_if_t_hd_dat_reg();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_soc_mgmt_if_t_hd_dat_reg(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::THdDatReg::Register,
         >,
@@ -2332,8 +2455,10 @@ pub trait I3c1Peripheral {
     }
     fn read_i3c_ec_soc_mgmt_if_t_high_reg(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::THighReg::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::THighReg::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read i3c1::i3c_ec_soc_mgmt_if_t_high_reg"
@@ -2342,11 +2467,11 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_soc_mgmt_if_t_high_reg();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_soc_mgmt_if_t_high_reg(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::THighReg::Register,
         >,
@@ -2360,8 +2485,10 @@ pub trait I3c1Peripheral {
     }
     fn read_i3c_ec_soc_mgmt_if_t_low_reg(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::TLowReg::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::TLowReg::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read i3c1::i3c_ec_soc_mgmt_if_t_low_reg"
@@ -2370,11 +2497,11 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_soc_mgmt_if_t_low_reg();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_soc_mgmt_if_t_low_reg(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::TLowReg::Register,
         >,
@@ -2388,8 +2515,10 @@ pub trait I3c1Peripheral {
     }
     fn read_i3c_ec_soc_mgmt_if_t_hd_sta_reg(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::THdStaReg::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::THdStaReg::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read i3c1::i3c_ec_soc_mgmt_if_t_hd_sta_reg"
@@ -2398,11 +2527,11 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_soc_mgmt_if_t_hd_sta_reg();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_soc_mgmt_if_t_hd_sta_reg(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::THdStaReg::Register,
         >,
@@ -2416,8 +2545,10 @@ pub trait I3c1Peripheral {
     }
     fn read_i3c_ec_soc_mgmt_if_t_su_sta_reg(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::TSuStaReg::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::TSuStaReg::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read i3c1::i3c_ec_soc_mgmt_if_t_su_sta_reg"
@@ -2426,11 +2557,11 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_soc_mgmt_if_t_su_sta_reg();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_soc_mgmt_if_t_su_sta_reg(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::TSuStaReg::Register,
         >,
@@ -2444,8 +2575,10 @@ pub trait I3c1Peripheral {
     }
     fn read_i3c_ec_soc_mgmt_if_t_su_sto_reg(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::TSuStoReg::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::TSuStoReg::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read i3c1::i3c_ec_soc_mgmt_if_t_su_sto_reg"
@@ -2454,11 +2587,11 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_soc_mgmt_if_t_su_sto_reg();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_i3c_ec_soc_mgmt_if_t_su_sto_reg(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::TSuStoReg::Register,
         >,
@@ -2470,7 +2603,9 @@ pub trait I3c1Peripheral {
             generated.write_i3c_ec_soc_mgmt_if_t_su_sto_reg(val);
         }
     }
-    fn read_i3c_ec_soc_mgmt_if_t_free_reg(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_soc_mgmt_if_t_free_reg(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read i3c1::i3c_ec_soc_mgmt_if_t_free_reg"
@@ -2481,7 +2616,10 @@ pub trait I3c1Peripheral {
         }
         0
     }
-    fn write_i3c_ec_soc_mgmt_if_t_free_reg(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_soc_mgmt_if_t_free_reg(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write i3c1::i3c_ec_soc_mgmt_if_t_free_reg = 0x{:08x}" , val);
         }
@@ -2489,7 +2627,9 @@ pub trait I3c1Peripheral {
             generated.write_i3c_ec_soc_mgmt_if_t_free_reg(val);
         }
     }
-    fn read_i3c_ec_soc_mgmt_if_t_aval_reg(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_soc_mgmt_if_t_aval_reg(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read i3c1::i3c_ec_soc_mgmt_if_t_aval_reg"
@@ -2500,7 +2640,10 @@ pub trait I3c1Peripheral {
         }
         0
     }
-    fn write_i3c_ec_soc_mgmt_if_t_aval_reg(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_soc_mgmt_if_t_aval_reg(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write i3c1::i3c_ec_soc_mgmt_if_t_aval_reg = 0x{:08x}" , val);
         }
@@ -2508,7 +2651,9 @@ pub trait I3c1Peripheral {
             generated.write_i3c_ec_soc_mgmt_if_t_aval_reg(val);
         }
     }
-    fn read_i3c_ec_soc_mgmt_if_t_idle_reg(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_soc_mgmt_if_t_idle_reg(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read i3c1::i3c_ec_soc_mgmt_if_t_idle_reg"
@@ -2519,7 +2664,10 @@ pub trait I3c1Peripheral {
         }
         0
     }
-    fn write_i3c_ec_soc_mgmt_if_t_idle_reg(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_soc_mgmt_if_t_idle_reg(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write i3c1::i3c_ec_soc_mgmt_if_t_idle_reg = 0x{:08x}" , val);
         }
@@ -2529,7 +2677,7 @@ pub trait I3c1Peripheral {
     }
     fn read_i3c_ec_ctrl_cfg_extcap_header(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::ExtcapHeader::Register,
     > {
@@ -2541,11 +2689,11 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_ctrl_cfg_extcap_header();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_i3c_ec_ctrl_cfg_controller_config(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::ControllerConfig::Register,
     > {
@@ -2557,259 +2705,328 @@ pub trait I3c1Peripheral {
         if let Some(generated) = self.generated() {
             return generated.read_i3c_ec_ctrl_cfg_controller_config();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
 }
 #[derive(Clone, Debug)]
 pub struct I3c1Generated {
-    dat: Vec<caliptra_emu_types::RvData>,
-    dct: Vec<caliptra_emu_types::RvData>,
-    i3c_base_hci_version: caliptra_emu_types::RvData,
-    i3c_base_hc_control: caliptra_emu_types::RvData,
-    i3c_base_controller_device_addr: caliptra_emu_types::RvData,
-    i3c_base_hc_capabilities: caliptra_emu_types::RvData,
-    i3c_base_reset_control: caliptra_emu_types::RvData,
-    i3c_base_present_state: caliptra_emu_types::RvData,
-    i3c_base_intr_status: caliptra_emu_types::RvData,
-    i3c_base_intr_status_enable: caliptra_emu_types::RvData,
-    i3c_base_intr_signal_enable: caliptra_emu_types::RvData,
-    i3c_base_intr_force: caliptra_emu_types::RvData,
-    i3c_base_dat_section_offset: caliptra_emu_types::RvData,
-    i3c_base_dct_section_offset: caliptra_emu_types::RvData,
-    i3c_base_ring_headers_section_offset: caliptra_emu_types::RvData,
-    i3c_base_pio_section_offset: caliptra_emu_types::RvData,
-    i3c_base_ext_caps_section_offset: caliptra_emu_types::RvData,
-    i3c_base_int_ctrl_cmds_en: caliptra_emu_types::RvData,
-    i3c_base_ibi_notify_ctrl: caliptra_emu_types::RvData,
-    i3c_base_ibi_data_abort_ctrl: caliptra_emu_types::RvData,
-    i3c_base_dev_ctx_base_lo: caliptra_emu_types::RvData,
-    i3c_base_dev_ctx_base_hi: caliptra_emu_types::RvData,
-    i3c_base_dev_ctx_sg: caliptra_emu_types::RvData,
-    piocontrol_command_port: caliptra_emu_types::RvData,
-    piocontrol_response_port: caliptra_emu_types::RvData,
-    piocontrol_tx_data_port: caliptra_emu_types::RvData,
-    piocontrol_rx_data_port: caliptra_emu_types::RvData,
-    piocontrol_ibi_port: caliptra_emu_types::RvData,
-    piocontrol_queue_thld_ctrl: caliptra_emu_types::RvData,
-    piocontrol_data_buffer_thld_ctrl: caliptra_emu_types::RvData,
-    piocontrol_queue_size: caliptra_emu_types::RvData,
-    piocontrol_alt_queue_size: caliptra_emu_types::RvData,
-    piocontrol_pio_intr_status: caliptra_emu_types::RvData,
-    piocontrol_pio_intr_status_enable: caliptra_emu_types::RvData,
-    piocontrol_pio_intr_signal_enable: caliptra_emu_types::RvData,
-    piocontrol_pio_intr_force: caliptra_emu_types::RvData,
-    piocontrol_pio_control: caliptra_emu_types::RvData,
-    i3c_ec_sec_fw_recovery_if_extcap_header: caliptra_emu_types::RvData,
-    i3c_ec_sec_fw_recovery_if_prot_cap_0: caliptra_emu_types::RvData,
-    i3c_ec_sec_fw_recovery_if_prot_cap_1: caliptra_emu_types::RvData,
-    i3c_ec_sec_fw_recovery_if_prot_cap_2: caliptra_emu_types::RvData,
-    i3c_ec_sec_fw_recovery_if_prot_cap_3: caliptra_emu_types::RvData,
-    i3c_ec_sec_fw_recovery_if_device_id_0: caliptra_emu_types::RvData,
-    i3c_ec_sec_fw_recovery_if_device_id_1: caliptra_emu_types::RvData,
-    i3c_ec_sec_fw_recovery_if_device_id_2: caliptra_emu_types::RvData,
-    i3c_ec_sec_fw_recovery_if_device_id_3: caliptra_emu_types::RvData,
-    i3c_ec_sec_fw_recovery_if_device_id_4: caliptra_emu_types::RvData,
-    i3c_ec_sec_fw_recovery_if_device_id_5: caliptra_emu_types::RvData,
-    i3c_ec_sec_fw_recovery_if_device_id_reserved: caliptra_emu_types::RvData,
-    i3c_ec_sec_fw_recovery_if_device_status_0: caliptra_emu_types::RvData,
-    i3c_ec_sec_fw_recovery_if_device_status_1: caliptra_emu_types::RvData,
-    i3c_ec_sec_fw_recovery_if_device_reset: caliptra_emu_types::RvData,
-    i3c_ec_sec_fw_recovery_if_recovery_ctrl: caliptra_emu_types::RvData,
-    i3c_ec_sec_fw_recovery_if_recovery_status: caliptra_emu_types::RvData,
-    i3c_ec_sec_fw_recovery_if_hw_status: caliptra_emu_types::RvData,
-    i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_0: caliptra_emu_types::RvData,
-    i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_1: caliptra_emu_types::RvData,
-    i3c_ec_sec_fw_recovery_if_indirect_fifo_status_0: caliptra_emu_types::RvData,
-    i3c_ec_sec_fw_recovery_if_indirect_fifo_status_1: caliptra_emu_types::RvData,
-    i3c_ec_sec_fw_recovery_if_indirect_fifo_status_2: caliptra_emu_types::RvData,
-    i3c_ec_sec_fw_recovery_if_indirect_fifo_status_3: caliptra_emu_types::RvData,
-    i3c_ec_sec_fw_recovery_if_indirect_fifo_status_4: caliptra_emu_types::RvData,
-    i3c_ec_sec_fw_recovery_if_indirect_fifo_reserved: caliptra_emu_types::RvData,
-    i3c_ec_sec_fw_recovery_if_indirect_fifo_data: caliptra_emu_types::RvData,
-    i3c_ec_stdby_ctrl_mode_extcap_header: caliptra_emu_types::RvData,
-    i3c_ec_stdby_ctrl_mode_stby_cr_control: caliptra_emu_types::RvData,
-    i3c_ec_stdby_ctrl_mode_stby_cr_device_addr: caliptra_emu_types::RvData,
-    i3c_ec_stdby_ctrl_mode_stby_cr_capabilities: caliptra_emu_types::RvData,
-    i3c_ec_stdby_ctrl_mode_stby_cr_virtual_device_char: caliptra_emu_types::RvData,
-    i3c_ec_stdby_ctrl_mode_stby_cr_status: caliptra_emu_types::RvData,
-    i3c_ec_stdby_ctrl_mode_stby_cr_device_char: caliptra_emu_types::RvData,
-    i3c_ec_stdby_ctrl_mode_stby_cr_device_pid_lo: caliptra_emu_types::RvData,
-    i3c_ec_stdby_ctrl_mode_stby_cr_intr_status: caliptra_emu_types::RvData,
-    i3c_ec_stdby_ctrl_mode_stby_cr_virtual_device_pid_lo: caliptra_emu_types::RvData,
-    i3c_ec_stdby_ctrl_mode_stby_cr_intr_signal_enable: caliptra_emu_types::RvData,
-    i3c_ec_stdby_ctrl_mode_stby_cr_intr_force: caliptra_emu_types::RvData,
-    i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_getcaps: caliptra_emu_types::RvData,
-    i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_rstact_params: caliptra_emu_types::RvData,
-    i3c_ec_stdby_ctrl_mode_stby_cr_virt_device_addr: caliptra_emu_types::RvData,
-    i3c_ec_stdby_ctrl_mode_rsvd_3: caliptra_emu_types::RvData,
-    i3c_ec_tti_extcap_header: caliptra_emu_types::RvData,
-    i3c_ec_tti_control: caliptra_emu_types::RvData,
-    i3c_ec_tti_status: caliptra_emu_types::RvData,
-    i3c_ec_tti_tti_reset_control: caliptra_emu_types::RvData,
-    i3c_ec_tti_interrupt_status: caliptra_emu_types::RvData,
-    i3c_ec_tti_interrupt_enable: caliptra_emu_types::RvData,
-    i3c_ec_tti_interrupt_force: caliptra_emu_types::RvData,
-    i3c_ec_tti_rx_desc_queue_port: caliptra_emu_types::RvData,
-    i3c_ec_tti_rx_data_port: caliptra_emu_types::RvData,
-    i3c_ec_tti_tx_desc_queue_port: caliptra_emu_types::RvData,
-    i3c_ec_tti_tx_data_port: caliptra_emu_types::RvData,
-    i3c_ec_tti_tti_ibi_port: caliptra_emu_types::RvData,
-    i3c_ec_tti_tti_queue_size: caliptra_emu_types::RvData,
-    i3c_ec_tti_ibi_tti_queue_size: caliptra_emu_types::RvData,
-    i3c_ec_tti_tti_queue_thld_ctrl: caliptra_emu_types::RvData,
-    i3c_ec_tti_tti_data_buffer_thld_ctrl: caliptra_emu_types::RvData,
-    i3c_ec_soc_mgmt_if_extcap_header: caliptra_emu_types::RvData,
-    i3c_ec_soc_mgmt_if_soc_mgmt_control: caliptra_emu_types::RvData,
-    i3c_ec_soc_mgmt_if_soc_mgmt_status: caliptra_emu_types::RvData,
-    i3c_ec_soc_mgmt_if_rec_intf_cfg: caliptra_emu_types::RvData,
-    i3c_ec_soc_mgmt_if_rec_intf_reg_w1_c_access: caliptra_emu_types::RvData,
-    i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_2: caliptra_emu_types::RvData,
-    i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_3: caliptra_emu_types::RvData,
-    i3c_ec_soc_mgmt_if_soc_pad_conf: caliptra_emu_types::RvData,
-    i3c_ec_soc_mgmt_if_soc_pad_attr: caliptra_emu_types::RvData,
-    i3c_ec_soc_mgmt_if_soc_mgmt_feature_2: caliptra_emu_types::RvData,
-    i3c_ec_soc_mgmt_if_soc_mgmt_feature_3: caliptra_emu_types::RvData,
-    i3c_ec_soc_mgmt_if_t_r_reg: caliptra_emu_types::RvData,
-    i3c_ec_soc_mgmt_if_t_f_reg: caliptra_emu_types::RvData,
-    i3c_ec_soc_mgmt_if_t_su_dat_reg: caliptra_emu_types::RvData,
-    i3c_ec_soc_mgmt_if_t_hd_dat_reg: caliptra_emu_types::RvData,
-    i3c_ec_soc_mgmt_if_t_high_reg: caliptra_emu_types::RvData,
-    i3c_ec_soc_mgmt_if_t_low_reg: caliptra_emu_types::RvData,
-    i3c_ec_soc_mgmt_if_t_hd_sta_reg: caliptra_emu_types::RvData,
-    i3c_ec_soc_mgmt_if_t_su_sta_reg: caliptra_emu_types::RvData,
-    i3c_ec_soc_mgmt_if_t_su_sto_reg: caliptra_emu_types::RvData,
-    i3c_ec_soc_mgmt_if_t_free_reg: caliptra_emu_types::RvData,
-    i3c_ec_soc_mgmt_if_t_aval_reg: caliptra_emu_types::RvData,
-    i3c_ec_soc_mgmt_if_t_idle_reg: caliptra_emu_types::RvData,
-    i3c_ec_ctrl_cfg_extcap_header: caliptra_emu_types::RvData,
-    i3c_ec_ctrl_cfg_controller_config: caliptra_emu_types::RvData,
+    dat: Vec<caliptra_core_tools::caliptra_emu_types::RvData>,
+    dct: Vec<caliptra_core_tools::caliptra_emu_types::RvData>,
+    i3c_base_hci_version: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_base_hc_control: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_base_controller_device_addr: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_base_hc_capabilities: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_base_reset_control: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_base_present_state: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_base_intr_status: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_base_intr_status_enable: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_base_intr_signal_enable: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_base_intr_force: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_base_dat_section_offset: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_base_dct_section_offset: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_base_ring_headers_section_offset: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_base_pio_section_offset: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_base_ext_caps_section_offset: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_base_int_ctrl_cmds_en: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_base_ibi_notify_ctrl: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_base_ibi_data_abort_ctrl: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_base_dev_ctx_base_lo: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_base_dev_ctx_base_hi: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_base_dev_ctx_sg: caliptra_core_tools::caliptra_emu_types::RvData,
+    piocontrol_command_port: caliptra_core_tools::caliptra_emu_types::RvData,
+    piocontrol_response_port: caliptra_core_tools::caliptra_emu_types::RvData,
+    piocontrol_tx_data_port: caliptra_core_tools::caliptra_emu_types::RvData,
+    piocontrol_rx_data_port: caliptra_core_tools::caliptra_emu_types::RvData,
+    piocontrol_ibi_port: caliptra_core_tools::caliptra_emu_types::RvData,
+    piocontrol_queue_thld_ctrl: caliptra_core_tools::caliptra_emu_types::RvData,
+    piocontrol_data_buffer_thld_ctrl: caliptra_core_tools::caliptra_emu_types::RvData,
+    piocontrol_queue_size: caliptra_core_tools::caliptra_emu_types::RvData,
+    piocontrol_alt_queue_size: caliptra_core_tools::caliptra_emu_types::RvData,
+    piocontrol_pio_intr_status: caliptra_core_tools::caliptra_emu_types::RvData,
+    piocontrol_pio_intr_status_enable: caliptra_core_tools::caliptra_emu_types::RvData,
+    piocontrol_pio_intr_signal_enable: caliptra_core_tools::caliptra_emu_types::RvData,
+    piocontrol_pio_intr_force: caliptra_core_tools::caliptra_emu_types::RvData,
+    piocontrol_pio_control: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_sec_fw_recovery_if_extcap_header: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_sec_fw_recovery_if_prot_cap_0: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_sec_fw_recovery_if_prot_cap_1: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_sec_fw_recovery_if_prot_cap_2: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_sec_fw_recovery_if_prot_cap_3: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_sec_fw_recovery_if_device_id_0: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_sec_fw_recovery_if_device_id_1: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_sec_fw_recovery_if_device_id_2: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_sec_fw_recovery_if_device_id_3: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_sec_fw_recovery_if_device_id_4: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_sec_fw_recovery_if_device_id_5: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_sec_fw_recovery_if_device_id_reserved: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_sec_fw_recovery_if_device_status_0: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_sec_fw_recovery_if_device_status_1: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_sec_fw_recovery_if_device_reset: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_sec_fw_recovery_if_recovery_ctrl: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_sec_fw_recovery_if_recovery_status: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_sec_fw_recovery_if_hw_status: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_0: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_1: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_sec_fw_recovery_if_indirect_fifo_status_0:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_sec_fw_recovery_if_indirect_fifo_status_1:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_sec_fw_recovery_if_indirect_fifo_status_2:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_sec_fw_recovery_if_indirect_fifo_status_3:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_sec_fw_recovery_if_indirect_fifo_status_4:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_sec_fw_recovery_if_indirect_fifo_reserved:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_sec_fw_recovery_if_indirect_fifo_data: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_stdby_ctrl_mode_extcap_header: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_stdby_ctrl_mode_stby_cr_control: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_stdby_ctrl_mode_stby_cr_device_addr: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_stdby_ctrl_mode_stby_cr_capabilities: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_stdby_ctrl_mode_stby_cr_virtual_device_char:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_stdby_ctrl_mode_stby_cr_status: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_stdby_ctrl_mode_stby_cr_device_char: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_stdby_ctrl_mode_stby_cr_device_pid_lo: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_stdby_ctrl_mode_stby_cr_intr_status: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_stdby_ctrl_mode_stby_cr_virtual_device_pid_lo:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_stdby_ctrl_mode_stby_cr_intr_signal_enable:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_stdby_ctrl_mode_stby_cr_intr_force: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_getcaps:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_rstact_params:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_stdby_ctrl_mode_stby_cr_virt_device_addr:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_stdby_ctrl_mode_rsvd_3: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_tti_extcap_header: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_tti_control: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_tti_status: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_tti_tti_reset_control: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_tti_interrupt_status: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_tti_interrupt_enable: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_tti_interrupt_force: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_tti_rx_desc_queue_port: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_tti_rx_data_port: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_tti_tx_desc_queue_port: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_tti_tx_data_port: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_tti_tti_ibi_port: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_tti_tti_queue_size: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_tti_ibi_tti_queue_size: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_tti_tti_queue_thld_ctrl: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_tti_tti_data_buffer_thld_ctrl: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_soc_mgmt_if_extcap_header: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_soc_mgmt_if_soc_mgmt_control: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_soc_mgmt_if_soc_mgmt_status: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_soc_mgmt_if_rec_intf_cfg: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_soc_mgmt_if_rec_intf_reg_w1_c_access: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_2: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_3: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_soc_mgmt_if_soc_pad_conf: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_soc_mgmt_if_soc_pad_attr: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_soc_mgmt_if_soc_mgmt_feature_2: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_soc_mgmt_if_soc_mgmt_feature_3: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_soc_mgmt_if_t_r_reg: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_soc_mgmt_if_t_f_reg: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_soc_mgmt_if_t_su_dat_reg: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_soc_mgmt_if_t_hd_dat_reg: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_soc_mgmt_if_t_high_reg: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_soc_mgmt_if_t_low_reg: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_soc_mgmt_if_t_hd_sta_reg: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_soc_mgmt_if_t_su_sta_reg: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_soc_mgmt_if_t_su_sto_reg: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_soc_mgmt_if_t_free_reg: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_soc_mgmt_if_t_aval_reg: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_soc_mgmt_if_t_idle_reg: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_ctrl_cfg_extcap_header: caliptra_core_tools::caliptra_emu_types::RvData,
+    i3c_ec_ctrl_cfg_controller_config: caliptra_core_tools::caliptra_emu_types::RvData,
 }
 impl Default for I3c1Generated {
     fn default() -> Self {
         Self {
-            dat: vec![0 as caliptra_emu_types::RvData; 256],
-            dct: vec![0 as caliptra_emu_types::RvData; 512],
-            i3c_base_hci_version: 0x120 as caliptra_emu_types::RvData,
-            i3c_base_hc_control: 0x40 as caliptra_emu_types::RvData,
-            i3c_base_controller_device_addr: 0 as caliptra_emu_types::RvData,
-            i3c_base_hc_capabilities: 0x400 as caliptra_emu_types::RvData,
-            i3c_base_reset_control: 0 as caliptra_emu_types::RvData,
-            i3c_base_present_state: 0 as caliptra_emu_types::RvData,
-            i3c_base_intr_status: 0 as caliptra_emu_types::RvData,
-            i3c_base_intr_status_enable: 0 as caliptra_emu_types::RvData,
-            i3c_base_intr_signal_enable: 0 as caliptra_emu_types::RvData,
-            i3c_base_intr_force: 0 as caliptra_emu_types::RvData,
-            i3c_base_dat_section_offset: 0x400 as caliptra_emu_types::RvData,
-            i3c_base_dct_section_offset: 0 as caliptra_emu_types::RvData,
-            i3c_base_ring_headers_section_offset: 0 as caliptra_emu_types::RvData,
-            i3c_base_pio_section_offset: 0 as caliptra_emu_types::RvData,
-            i3c_base_ext_caps_section_offset: 0 as caliptra_emu_types::RvData,
-            i3c_base_int_ctrl_cmds_en: 1 as caliptra_emu_types::RvData,
-            i3c_base_ibi_notify_ctrl: 0 as caliptra_emu_types::RvData,
-            i3c_base_ibi_data_abort_ctrl: 0 as caliptra_emu_types::RvData,
-            i3c_base_dev_ctx_base_lo: 0 as caliptra_emu_types::RvData,
-            i3c_base_dev_ctx_base_hi: 0 as caliptra_emu_types::RvData,
-            i3c_base_dev_ctx_sg: 0 as caliptra_emu_types::RvData,
-            piocontrol_command_port: 0 as caliptra_emu_types::RvData,
-            piocontrol_response_port: 0 as caliptra_emu_types::RvData,
-            piocontrol_tx_data_port: 0 as caliptra_emu_types::RvData,
-            piocontrol_rx_data_port: 0 as caliptra_emu_types::RvData,
-            piocontrol_ibi_port: 0 as caliptra_emu_types::RvData,
-            piocontrol_queue_thld_ctrl: 0x101_0101 as caliptra_emu_types::RvData,
-            piocontrol_data_buffer_thld_ctrl: 0x101_0101 as caliptra_emu_types::RvData,
-            piocontrol_queue_size: 0 as caliptra_emu_types::RvData,
-            piocontrol_alt_queue_size: 0 as caliptra_emu_types::RvData,
-            piocontrol_pio_intr_status: 0 as caliptra_emu_types::RvData,
-            piocontrol_pio_intr_status_enable: 0 as caliptra_emu_types::RvData,
-            piocontrol_pio_intr_signal_enable: 0 as caliptra_emu_types::RvData,
-            piocontrol_pio_intr_force: 0 as caliptra_emu_types::RvData,
-            piocontrol_pio_control: 1 as caliptra_emu_types::RvData,
-            i3c_ec_sec_fw_recovery_if_extcap_header: 0x20c0 as caliptra_emu_types::RvData,
-            i3c_ec_sec_fw_recovery_if_prot_cap_0: 0x2050_434f as caliptra_emu_types::RvData,
-            i3c_ec_sec_fw_recovery_if_prot_cap_1: 0x5643_4552 as caliptra_emu_types::RvData,
-            i3c_ec_sec_fw_recovery_if_prot_cap_2: 0 as caliptra_emu_types::RvData,
-            i3c_ec_sec_fw_recovery_if_prot_cap_3: 0 as caliptra_emu_types::RvData,
-            i3c_ec_sec_fw_recovery_if_device_id_0: 0 as caliptra_emu_types::RvData,
-            i3c_ec_sec_fw_recovery_if_device_id_1: 0 as caliptra_emu_types::RvData,
-            i3c_ec_sec_fw_recovery_if_device_id_2: 0 as caliptra_emu_types::RvData,
-            i3c_ec_sec_fw_recovery_if_device_id_3: 0 as caliptra_emu_types::RvData,
-            i3c_ec_sec_fw_recovery_if_device_id_4: 0 as caliptra_emu_types::RvData,
-            i3c_ec_sec_fw_recovery_if_device_id_5: 0 as caliptra_emu_types::RvData,
-            i3c_ec_sec_fw_recovery_if_device_id_reserved: 0 as caliptra_emu_types::RvData,
-            i3c_ec_sec_fw_recovery_if_device_status_0: 0 as caliptra_emu_types::RvData,
-            i3c_ec_sec_fw_recovery_if_device_status_1: 0 as caliptra_emu_types::RvData,
-            i3c_ec_sec_fw_recovery_if_device_reset: 0 as caliptra_emu_types::RvData,
-            i3c_ec_sec_fw_recovery_if_recovery_ctrl: 0 as caliptra_emu_types::RvData,
-            i3c_ec_sec_fw_recovery_if_recovery_status: 0 as caliptra_emu_types::RvData,
-            i3c_ec_sec_fw_recovery_if_hw_status: 0 as caliptra_emu_types::RvData,
-            i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_0: 0 as caliptra_emu_types::RvData,
-            i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_1: 0 as caliptra_emu_types::RvData,
-            i3c_ec_sec_fw_recovery_if_indirect_fifo_status_0: 1 as caliptra_emu_types::RvData,
-            i3c_ec_sec_fw_recovery_if_indirect_fifo_status_1: 0 as caliptra_emu_types::RvData,
-            i3c_ec_sec_fw_recovery_if_indirect_fifo_status_2: 0 as caliptra_emu_types::RvData,
-            i3c_ec_sec_fw_recovery_if_indirect_fifo_status_3: 0x40 as caliptra_emu_types::RvData,
-            i3c_ec_sec_fw_recovery_if_indirect_fifo_status_4: 0x40 as caliptra_emu_types::RvData,
-            i3c_ec_sec_fw_recovery_if_indirect_fifo_reserved: 0 as caliptra_emu_types::RvData,
-            i3c_ec_sec_fw_recovery_if_indirect_fifo_data: 0 as caliptra_emu_types::RvData,
-            i3c_ec_stdby_ctrl_mode_extcap_header: 0x1012 as caliptra_emu_types::RvData,
-            i3c_ec_stdby_ctrl_mode_stby_cr_control: 0x1000 as caliptra_emu_types::RvData,
-            i3c_ec_stdby_ctrl_mode_stby_cr_device_addr: 0 as caliptra_emu_types::RvData,
-            i3c_ec_stdby_ctrl_mode_stby_cr_capabilities: 0x7000 as caliptra_emu_types::RvData,
+            dat: vec![0 as caliptra_core_tools::caliptra_emu_types::RvData; 256],
+            dct: vec![0 as caliptra_core_tools::caliptra_emu_types::RvData; 512],
+            i3c_base_hci_version: 0x120 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_base_hc_control: 0x40 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_base_controller_device_addr: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_base_hc_capabilities: 0x400 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_base_reset_control: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_base_present_state: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_base_intr_status: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_base_intr_status_enable: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_base_intr_signal_enable: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_base_intr_force: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_base_dat_section_offset: 0x400 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_base_dct_section_offset: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_base_ring_headers_section_offset: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_base_pio_section_offset: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_base_ext_caps_section_offset: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_base_int_ctrl_cmds_en: 1 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_base_ibi_notify_ctrl: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_base_ibi_data_abort_ctrl: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_base_dev_ctx_base_lo: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_base_dev_ctx_base_hi: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_base_dev_ctx_sg: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            piocontrol_command_port: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            piocontrol_response_port: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            piocontrol_tx_data_port: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            piocontrol_rx_data_port: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            piocontrol_ibi_port: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            piocontrol_queue_thld_ctrl: 0x101_0101
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            piocontrol_data_buffer_thld_ctrl: 0x101_0101
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            piocontrol_queue_size: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            piocontrol_alt_queue_size: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            piocontrol_pio_intr_status: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            piocontrol_pio_intr_status_enable: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            piocontrol_pio_intr_signal_enable: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            piocontrol_pio_intr_force: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            piocontrol_pio_control: 1 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_sec_fw_recovery_if_extcap_header: 0x20c0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_sec_fw_recovery_if_prot_cap_0: 0x2050_434f
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_sec_fw_recovery_if_prot_cap_1: 0x5643_4552
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_sec_fw_recovery_if_prot_cap_2: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_sec_fw_recovery_if_prot_cap_3: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_sec_fw_recovery_if_device_id_0: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_sec_fw_recovery_if_device_id_1: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_sec_fw_recovery_if_device_id_2: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_sec_fw_recovery_if_device_id_3: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_sec_fw_recovery_if_device_id_4: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_sec_fw_recovery_if_device_id_5: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_sec_fw_recovery_if_device_id_reserved: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_sec_fw_recovery_if_device_status_0: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_sec_fw_recovery_if_device_status_1: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_sec_fw_recovery_if_device_reset: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_sec_fw_recovery_if_recovery_ctrl: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_sec_fw_recovery_if_recovery_status: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_sec_fw_recovery_if_hw_status: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_0: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_1: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_sec_fw_recovery_if_indirect_fifo_status_0: 1
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_sec_fw_recovery_if_indirect_fifo_status_1: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_sec_fw_recovery_if_indirect_fifo_status_2: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_sec_fw_recovery_if_indirect_fifo_status_3: 0x40
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_sec_fw_recovery_if_indirect_fifo_status_4: 0x40
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_sec_fw_recovery_if_indirect_fifo_reserved: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_sec_fw_recovery_if_indirect_fifo_data: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_stdby_ctrl_mode_extcap_header: 0x1012
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_stdby_ctrl_mode_stby_cr_control: 0x1000
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_stdby_ctrl_mode_stby_cr_device_addr: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_stdby_ctrl_mode_stby_cr_capabilities: 0x7000
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             i3c_ec_stdby_ctrl_mode_stby_cr_virtual_device_char: 0x36bd_0000
-                as caliptra_emu_types::RvData,
-            i3c_ec_stdby_ctrl_mode_stby_cr_status: 0 as caliptra_emu_types::RvData,
-            i3c_ec_stdby_ctrl_mode_stby_cr_device_char: 0x26bd_0000 as caliptra_emu_types::RvData,
-            i3c_ec_stdby_ctrl_mode_stby_cr_device_pid_lo: 0 as caliptra_emu_types::RvData,
-            i3c_ec_stdby_ctrl_mode_stby_cr_intr_status: 0 as caliptra_emu_types::RvData,
-            i3c_ec_stdby_ctrl_mode_stby_cr_virtual_device_pid_lo: 0 as caliptra_emu_types::RvData,
-            i3c_ec_stdby_ctrl_mode_stby_cr_intr_signal_enable: 0 as caliptra_emu_types::RvData,
-            i3c_ec_stdby_ctrl_mode_stby_cr_intr_force: 0 as caliptra_emu_types::RvData,
-            i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_getcaps: 0 as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_stdby_ctrl_mode_stby_cr_status: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_stdby_ctrl_mode_stby_cr_device_char: 0x26bd_0000
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_stdby_ctrl_mode_stby_cr_device_pid_lo: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_stdby_ctrl_mode_stby_cr_intr_status: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_stdby_ctrl_mode_stby_cr_virtual_device_pid_lo: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_stdby_ctrl_mode_stby_cr_intr_signal_enable: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_stdby_ctrl_mode_stby_cr_intr_force: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_getcaps: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_rstact_params: 0x8000_0000
-                as caliptra_emu_types::RvData,
-            i3c_ec_stdby_ctrl_mode_stby_cr_virt_device_addr: 0 as caliptra_emu_types::RvData,
-            i3c_ec_stdby_ctrl_mode_rsvd_3: 0 as caliptra_emu_types::RvData,
-            i3c_ec_tti_extcap_header: 0x10c4 as caliptra_emu_types::RvData,
-            i3c_ec_tti_control: 0x1400 as caliptra_emu_types::RvData,
-            i3c_ec_tti_status: 0 as caliptra_emu_types::RvData,
-            i3c_ec_tti_tti_reset_control: 0 as caliptra_emu_types::RvData,
-            i3c_ec_tti_interrupt_status: 0 as caliptra_emu_types::RvData,
-            i3c_ec_tti_interrupt_enable: 0 as caliptra_emu_types::RvData,
-            i3c_ec_tti_interrupt_force: 0 as caliptra_emu_types::RvData,
-            i3c_ec_tti_rx_desc_queue_port: 0 as caliptra_emu_types::RvData,
-            i3c_ec_tti_rx_data_port: 0 as caliptra_emu_types::RvData,
-            i3c_ec_tti_tx_desc_queue_port: 0 as caliptra_emu_types::RvData,
-            i3c_ec_tti_tx_data_port: 0 as caliptra_emu_types::RvData,
-            i3c_ec_tti_tti_ibi_port: 0 as caliptra_emu_types::RvData,
-            i3c_ec_tti_tti_queue_size: 0 as caliptra_emu_types::RvData,
-            i3c_ec_tti_ibi_tti_queue_size: 0 as caliptra_emu_types::RvData,
-            i3c_ec_tti_tti_queue_thld_ctrl: 0x100_0101 as caliptra_emu_types::RvData,
-            i3c_ec_tti_tti_data_buffer_thld_ctrl: 0x101_0101 as caliptra_emu_types::RvData,
-            i3c_ec_soc_mgmt_if_extcap_header: 0x18c1 as caliptra_emu_types::RvData,
-            i3c_ec_soc_mgmt_if_soc_mgmt_control: 0 as caliptra_emu_types::RvData,
-            i3c_ec_soc_mgmt_if_soc_mgmt_status: 0 as caliptra_emu_types::RvData,
-            i3c_ec_soc_mgmt_if_rec_intf_cfg: 0 as caliptra_emu_types::RvData,
-            i3c_ec_soc_mgmt_if_rec_intf_reg_w1_c_access: 0 as caliptra_emu_types::RvData,
-            i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_2: 0 as caliptra_emu_types::RvData,
-            i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_3: 0 as caliptra_emu_types::RvData,
-            i3c_ec_soc_mgmt_if_soc_pad_conf: 0x100_0001 as caliptra_emu_types::RvData,
-            i3c_ec_soc_mgmt_if_soc_pad_attr: 0xf00_0f00 as caliptra_emu_types::RvData,
-            i3c_ec_soc_mgmt_if_soc_mgmt_feature_2: 0 as caliptra_emu_types::RvData,
-            i3c_ec_soc_mgmt_if_soc_mgmt_feature_3: 0 as caliptra_emu_types::RvData,
-            i3c_ec_soc_mgmt_if_t_r_reg: 0 as caliptra_emu_types::RvData,
-            i3c_ec_soc_mgmt_if_t_f_reg: 0 as caliptra_emu_types::RvData,
-            i3c_ec_soc_mgmt_if_t_su_dat_reg: 0 as caliptra_emu_types::RvData,
-            i3c_ec_soc_mgmt_if_t_hd_dat_reg: 0 as caliptra_emu_types::RvData,
-            i3c_ec_soc_mgmt_if_t_high_reg: 0 as caliptra_emu_types::RvData,
-            i3c_ec_soc_mgmt_if_t_low_reg: 0 as caliptra_emu_types::RvData,
-            i3c_ec_soc_mgmt_if_t_hd_sta_reg: 0 as caliptra_emu_types::RvData,
-            i3c_ec_soc_mgmt_if_t_su_sta_reg: 0 as caliptra_emu_types::RvData,
-            i3c_ec_soc_mgmt_if_t_su_sto_reg: 0 as caliptra_emu_types::RvData,
-            i3c_ec_soc_mgmt_if_t_free_reg: 0xc as caliptra_emu_types::RvData,
-            i3c_ec_soc_mgmt_if_t_aval_reg: 0x12c as caliptra_emu_types::RvData,
-            i3c_ec_soc_mgmt_if_t_idle_reg: 0xea60 as caliptra_emu_types::RvData,
-            i3c_ec_ctrl_cfg_extcap_header: 0x202 as caliptra_emu_types::RvData,
-            i3c_ec_ctrl_cfg_controller_config: 0x10 as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_stdby_ctrl_mode_stby_cr_virt_device_addr: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_stdby_ctrl_mode_rsvd_3: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_tti_extcap_header: 0x10c4 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_tti_control: 0x1400 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_tti_status: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_tti_tti_reset_control: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_tti_interrupt_status: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_tti_interrupt_enable: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_tti_interrupt_force: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_tti_rx_desc_queue_port: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_tti_rx_data_port: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_tti_tx_desc_queue_port: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_tti_tx_data_port: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_tti_tti_ibi_port: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_tti_tti_queue_size: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_tti_ibi_tti_queue_size: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_tti_tti_queue_thld_ctrl: 0x100_0101
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_tti_tti_data_buffer_thld_ctrl: 0x101_0101
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_soc_mgmt_if_extcap_header: 0x18c1
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_soc_mgmt_if_soc_mgmt_control: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_soc_mgmt_if_soc_mgmt_status: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_soc_mgmt_if_rec_intf_cfg: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_soc_mgmt_if_rec_intf_reg_w1_c_access: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_2: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_3: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_soc_mgmt_if_soc_pad_conf: 0x100_0001
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_soc_mgmt_if_soc_pad_attr: 0xf00_0f00
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_soc_mgmt_if_soc_mgmt_feature_2: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_soc_mgmt_if_soc_mgmt_feature_3: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_soc_mgmt_if_t_r_reg: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_soc_mgmt_if_t_f_reg: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_soc_mgmt_if_t_su_dat_reg: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_soc_mgmt_if_t_hd_dat_reg: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_soc_mgmt_if_t_high_reg: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_soc_mgmt_if_t_low_reg: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_soc_mgmt_if_t_hd_sta_reg: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_soc_mgmt_if_t_su_sta_reg: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_soc_mgmt_if_t_su_sto_reg: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_soc_mgmt_if_t_free_reg: 0xc as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_soc_mgmt_if_t_aval_reg: 0x12c as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_soc_mgmt_if_t_idle_reg: 0xea60
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_ctrl_cfg_extcap_header: 0x202 as caliptra_core_tools::caliptra_emu_types::RvData,
+            i3c_ec_ctrl_cfg_controller_config: 0x10
+                as caliptra_core_tools::caliptra_emu_types::RvData,
         }
     }
 }
@@ -2831,7 +3048,7 @@ impl I3c1Peripheral for I3c1Generated {
     fn update_reset(&mut self) {
         self.reset_state();
     }
-    fn read_dat(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_dat(&mut self, index: usize) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read i3c1::dat[{}]",
@@ -2840,21 +3057,21 @@ impl I3c1Peripheral for I3c1Generated {
         }
         self.dat[index]
     }
-    fn write_dat(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    fn write_dat(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData, index: usize) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: write i3c1::dat[{}] = 0x{:08x}",
                 index, val
             );
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.dat[index];
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.dat[index] = new_val;
     }
-    fn read_dct(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_dct(&mut self, index: usize) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read i3c1::dct[{}]",
@@ -2863,21 +3080,21 @@ impl I3c1Peripheral for I3c1Generated {
         }
         self.dct[index]
     }
-    fn write_dct(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    fn write_dct(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData, index: usize) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: write i3c1::dct[{}] = 0x{:08x}",
                 index, val
             );
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.dct[index];
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.dct[index] = new_val;
     }
-    fn read_i3c_base_hci_version(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_base_hci_version(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read i3c1::i3c_base_hci_version");
         }
@@ -2885,16 +3102,18 @@ impl I3c1Peripheral for I3c1Generated {
     }
     fn read_i3c_base_hc_control(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::HcControl::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::HcControl::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read i3c1::i3c_base_hc_control");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_base_hc_control)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.i3c_base_hc_control)
     }
     fn write_i3c_base_hc_control(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::HcControl::Register,
         >,
@@ -2902,39 +3121,41 @@ impl I3c1Peripheral for I3c1Generated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_base_hc_control = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_base_hc_control;
         let mut new_val = current_val;
-        new_val = (new_val & !(0x8000_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x8000_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x4000_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x4000_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x2000_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x2000_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x1000 as caliptra_emu_types::RvData))
-            | (write_val & (0x1000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x100 as caliptra_emu_types::RvData))
-            | (write_val & (0x100 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x80 as caliptra_emu_types::RvData))
-            | (write_val & (0x80 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x8000_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x8000_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x4000_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x4000_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x2000_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x2000_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x1000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x1000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x100 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x100 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x80 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x80 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_base_hc_control = new_val;
     }
     fn read_i3c_base_controller_device_addr(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::ControllerDeviceAddr::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_base_controller_device_addr");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_base_controller_device_addr)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_base_controller_device_addr,
+        )
     }
     fn write_i3c_base_controller_device_addr(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::ControllerDeviceAddr::Register,
         >,
@@ -2942,18 +3163,18 @@ impl I3c1Peripheral for I3c1Generated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_base_controller_device_addr = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_base_controller_device_addr;
         let mut new_val = current_val;
-        new_val = (new_val & !(0x8000_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x8000_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x7f_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x7f_0000 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x8000_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x8000_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x7f_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x7f_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_base_controller_device_addr = new_val;
     }
     fn read_i3c_base_hc_capabilities(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::HcCapabilities::Register,
     > {
@@ -2962,11 +3183,11 @@ impl I3c1Peripheral for I3c1Generated {
                 "[EMU] Generated default register handler: read i3c1::i3c_base_hc_capabilities"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_base_hc_capabilities)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.i3c_base_hc_capabilities)
     }
     fn read_i3c_base_reset_control(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::ResetControl::Register,
     > {
@@ -2975,11 +3196,11 @@ impl I3c1Peripheral for I3c1Generated {
                 "[EMU] Generated default register handler: read i3c1::i3c_base_reset_control"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_base_reset_control)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.i3c_base_reset_control)
     }
     fn write_i3c_base_reset_control(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::ResetControl::Register,
         >,
@@ -2987,26 +3208,26 @@ impl I3c1Peripheral for I3c1Generated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_base_reset_control = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_base_reset_control;
         let mut new_val = current_val;
-        new_val = (new_val & !(0x20 as caliptra_emu_types::RvData))
-            | (write_val & (0x20 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x10 as caliptra_emu_types::RvData))
-            | (write_val & (0x10 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(8 as caliptra_emu_types::RvData))
-            | (write_val & (8 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(4 as caliptra_emu_types::RvData))
-            | (write_val & (4 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(2 as caliptra_emu_types::RvData))
-            | (write_val & (2 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x20 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x20 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x10 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x10 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(8 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (8 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(4 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (4 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(2 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_base_reset_control = new_val;
     }
     fn read_i3c_base_present_state(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::PresentState::Register,
     > {
@@ -3015,22 +3236,22 @@ impl I3c1Peripheral for I3c1Generated {
                 "[EMU] Generated default register handler: read i3c1::i3c_base_present_state"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_base_present_state)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.i3c_base_present_state)
     }
     fn read_i3c_base_intr_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::IntrStatus::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read i3c1::i3c_base_intr_status");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_base_intr_status)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.i3c_base_intr_status)
     }
     fn write_i3c_base_intr_status(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::IntrStatus::Register,
         >,
@@ -3038,24 +3259,24 @@ impl I3c1Peripheral for I3c1Generated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_base_intr_status = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_base_intr_status;
         let mut new_val = current_val;
-        new_val = (new_val & !(0x4000 as caliptra_emu_types::RvData))
-            | (write_val & (0x4000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x2000 as caliptra_emu_types::RvData))
-            | (write_val & (0x2000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x1000 as caliptra_emu_types::RvData))
-            | (write_val & (0x1000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x800 as caliptra_emu_types::RvData))
-            | (write_val & (0x800 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x400 as caliptra_emu_types::RvData))
-            | (write_val & (0x400 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x4000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x4000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x2000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x2000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x1000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x1000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x800 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x800 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x400 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x400 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_base_intr_status = new_val;
     }
     fn read_i3c_base_intr_status_enable(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::IntrStatusEnable::Register,
     > {
@@ -3064,11 +3285,13 @@ impl I3c1Peripheral for I3c1Generated {
                 "[EMU] Generated default register handler: read i3c1::i3c_base_intr_status_enable"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_base_intr_status_enable)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_base_intr_status_enable,
+        )
     }
     fn write_i3c_base_intr_status_enable(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::IntrStatusEnable::Register,
         >,
@@ -3076,24 +3299,24 @@ impl I3c1Peripheral for I3c1Generated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_base_intr_status_enable = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_base_intr_status_enable;
         let mut new_val = current_val;
-        new_val = (new_val & !(0x4000 as caliptra_emu_types::RvData))
-            | (write_val & (0x4000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x2000 as caliptra_emu_types::RvData))
-            | (write_val & (0x2000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x1000 as caliptra_emu_types::RvData))
-            | (write_val & (0x1000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x800 as caliptra_emu_types::RvData))
-            | (write_val & (0x800 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x400 as caliptra_emu_types::RvData))
-            | (write_val & (0x400 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x4000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x4000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x2000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x2000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x1000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x1000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x800 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x800 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x400 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x400 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_base_intr_status_enable = new_val;
     }
     fn read_i3c_base_intr_signal_enable(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::IntrSignalEnable::Register,
     > {
@@ -3102,11 +3325,13 @@ impl I3c1Peripheral for I3c1Generated {
                 "[EMU] Generated default register handler: read i3c1::i3c_base_intr_signal_enable"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_base_intr_signal_enable)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_base_intr_signal_enable,
+        )
     }
     fn write_i3c_base_intr_signal_enable(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::IntrSignalEnable::Register,
         >,
@@ -3114,24 +3339,24 @@ impl I3c1Peripheral for I3c1Generated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_base_intr_signal_enable = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_base_intr_signal_enable;
         let mut new_val = current_val;
-        new_val = (new_val & !(0x4000 as caliptra_emu_types::RvData))
-            | (write_val & (0x4000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x2000 as caliptra_emu_types::RvData))
-            | (write_val & (0x2000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x1000 as caliptra_emu_types::RvData))
-            | (write_val & (0x1000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x800 as caliptra_emu_types::RvData))
-            | (write_val & (0x800 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x400 as caliptra_emu_types::RvData))
-            | (write_val & (0x400 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x4000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x4000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x2000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x2000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x1000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x1000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x800 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x800 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x400 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x400 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_base_intr_signal_enable = new_val;
     }
     fn write_i3c_base_intr_force(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::IntrForce::Register,
         >,
@@ -3139,24 +3364,24 @@ impl I3c1Peripheral for I3c1Generated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_base_intr_force = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_base_intr_force;
         let mut new_val = current_val;
-        new_val = (new_val & !(0x4000 as caliptra_emu_types::RvData))
-            | (write_val & (0x4000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x2000 as caliptra_emu_types::RvData))
-            | (write_val & (0x2000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x1000 as caliptra_emu_types::RvData))
-            | (write_val & (0x1000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x800 as caliptra_emu_types::RvData))
-            | (write_val & (0x800 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x400 as caliptra_emu_types::RvData))
-            | (write_val & (0x400 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x4000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x4000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x2000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x2000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x1000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x1000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x800 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x800 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x400 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x400 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_base_intr_force = new_val;
     }
     fn read_i3c_base_dat_section_offset(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::DatSectionOffset::Register,
     > {
@@ -3165,11 +3390,13 @@ impl I3c1Peripheral for I3c1Generated {
                 "[EMU] Generated default register handler: read i3c1::i3c_base_dat_section_offset"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_base_dat_section_offset)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_base_dat_section_offset,
+        )
     }
     fn read_i3c_base_dct_section_offset(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::DctSectionOffset::Register,
     > {
@@ -3178,11 +3405,13 @@ impl I3c1Peripheral for I3c1Generated {
                 "[EMU] Generated default register handler: read i3c1::i3c_base_dct_section_offset"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_base_dct_section_offset)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_base_dct_section_offset,
+        )
     }
     fn write_i3c_base_dct_section_offset(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::DctSectionOffset::Register,
         >,
@@ -3190,27 +3419,29 @@ impl I3c1Peripheral for I3c1Generated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_base_dct_section_offset = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_base_dct_section_offset;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xf8_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0xf8_0000 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xf8_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xf8_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_base_dct_section_offset = new_val;
     }
     fn read_i3c_base_ring_headers_section_offset(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::RingHeadersSectionOffset::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_base_ring_headers_section_offset");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_base_ring_headers_section_offset)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_base_ring_headers_section_offset,
+        )
     }
     fn read_i3c_base_pio_section_offset(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::PioSectionOffset::Register,
     > {
@@ -3219,22 +3450,26 @@ impl I3c1Peripheral for I3c1Generated {
                 "[EMU] Generated default register handler: read i3c1::i3c_base_pio_section_offset"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_base_pio_section_offset)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_base_pio_section_offset,
+        )
     }
     fn read_i3c_base_ext_caps_section_offset(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::ExtCapsSectionOffset::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_base_ext_caps_section_offset");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_base_ext_caps_section_offset)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_base_ext_caps_section_offset,
+        )
     }
     fn read_i3c_base_int_ctrl_cmds_en(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::IntCtrlCmdsEn::Register,
     > {
@@ -3243,11 +3478,13 @@ impl I3c1Peripheral for I3c1Generated {
                 "[EMU] Generated default register handler: read i3c1::i3c_base_int_ctrl_cmds_en"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_base_int_ctrl_cmds_en)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_base_int_ctrl_cmds_en,
+        )
     }
     fn read_i3c_base_ibi_notify_ctrl(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::IbiNotifyCtrl::Register,
     > {
@@ -3256,11 +3493,11 @@ impl I3c1Peripheral for I3c1Generated {
                 "[EMU] Generated default register handler: read i3c1::i3c_base_ibi_notify_ctrl"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_base_ibi_notify_ctrl)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.i3c_base_ibi_notify_ctrl)
     }
     fn write_i3c_base_ibi_notify_ctrl(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::IbiNotifyCtrl::Register,
         >,
@@ -3268,20 +3505,20 @@ impl I3c1Peripheral for I3c1Generated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_base_ibi_notify_ctrl = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_base_ibi_notify_ctrl;
         let mut new_val = current_val;
-        new_val = (new_val & !(8 as caliptra_emu_types::RvData))
-            | (write_val & (8 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(2 as caliptra_emu_types::RvData))
-            | (write_val & (2 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(8 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (8 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(2 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_base_ibi_notify_ctrl = new_val;
     }
     fn read_i3c_base_ibi_data_abort_ctrl(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::IbiDataAbortCtrl::Register,
     > {
@@ -3290,11 +3527,13 @@ impl I3c1Peripheral for I3c1Generated {
                 "[EMU] Generated default register handler: read i3c1::i3c_base_ibi_data_abort_ctrl"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_base_ibi_data_abort_ctrl)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_base_ibi_data_abort_ctrl,
+        )
     }
     fn write_i3c_base_ibi_data_abort_ctrl(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::IbiDataAbortCtrl::Register,
         >,
@@ -3302,22 +3541,22 @@ impl I3c1Peripheral for I3c1Generated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_base_ibi_data_abort_ctrl = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_base_ibi_data_abort_ctrl;
         let mut new_val = current_val;
-        new_val = (new_val & !(0x8000_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x8000_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x1c_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x1c_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x3_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x3_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xff00 as caliptra_emu_types::RvData))
-            | (write_val & (0xff00 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x8000_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x8000_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x1c_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x1c_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x3_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x3_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff00 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff00 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_base_ibi_data_abort_ctrl = new_val;
     }
     fn read_i3c_base_dev_ctx_base_lo(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::DevCtxBaseLo::Register,
     > {
@@ -3326,11 +3565,11 @@ impl I3c1Peripheral for I3c1Generated {
                 "[EMU] Generated default register handler: read i3c1::i3c_base_dev_ctx_base_lo"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_base_dev_ctx_base_lo)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.i3c_base_dev_ctx_base_lo)
     }
     fn write_i3c_base_dev_ctx_base_lo(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::DevCtxBaseLo::Register,
         >,
@@ -3338,16 +3577,16 @@ impl I3c1Peripheral for I3c1Generated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_base_dev_ctx_base_lo = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_base_dev_ctx_base_lo;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_base_dev_ctx_base_lo = new_val;
     }
     fn read_i3c_base_dev_ctx_base_hi(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::DevCtxBaseHi::Register,
     > {
@@ -3356,11 +3595,11 @@ impl I3c1Peripheral for I3c1Generated {
                 "[EMU] Generated default register handler: read i3c1::i3c_base_dev_ctx_base_hi"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_base_dev_ctx_base_hi)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.i3c_base_dev_ctx_base_hi)
     }
     fn write_i3c_base_dev_ctx_base_hi(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::DevCtxBaseHi::Register,
         >,
@@ -3368,34 +3607,39 @@ impl I3c1Peripheral for I3c1Generated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_base_dev_ctx_base_hi = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_base_dev_ctx_base_hi;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_base_dev_ctx_base_hi = new_val;
     }
     fn read_i3c_base_dev_ctx_sg(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::DevCtxSg::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::DevCtxSg::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read i3c1::i3c_base_dev_ctx_sg");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_base_dev_ctx_sg)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.i3c_base_dev_ctx_sg)
     }
-    fn write_piocontrol_command_port(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_piocontrol_command_port(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::piocontrol_command_port = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.piocontrol_command_port;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.piocontrol_command_port = new_val;
     }
-    fn read_piocontrol_response_port(&mut self) -> caliptra_emu_types::RvData {
+    fn read_piocontrol_response_port(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read i3c1::piocontrol_response_port"
@@ -3403,18 +3647,21 @@ impl I3c1Peripheral for I3c1Generated {
         }
         self.piocontrol_response_port
     }
-    fn write_piocontrol_tx_data_port(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_piocontrol_tx_data_port(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::piocontrol_tx_data_port = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.piocontrol_tx_data_port;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.piocontrol_tx_data_port = new_val;
     }
-    fn read_piocontrol_rx_data_port(&mut self) -> caliptra_emu_types::RvData {
+    fn read_piocontrol_rx_data_port(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read i3c1::piocontrol_rx_data_port"
@@ -3422,7 +3669,7 @@ impl I3c1Peripheral for I3c1Generated {
         }
         self.piocontrol_rx_data_port
     }
-    fn read_piocontrol_ibi_port(&mut self) -> caliptra_emu_types::RvData {
+    fn read_piocontrol_ibi_port(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read i3c1::piocontrol_ibi_port");
         }
@@ -3430,7 +3677,7 @@ impl I3c1Peripheral for I3c1Generated {
     }
     fn read_piocontrol_queue_thld_ctrl(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::QueueThldCtrl::Register,
     > {
@@ -3439,11 +3686,13 @@ impl I3c1Peripheral for I3c1Generated {
                 "[EMU] Generated default register handler: read i3c1::piocontrol_queue_thld_ctrl"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.piocontrol_queue_thld_ctrl)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.piocontrol_queue_thld_ctrl,
+        )
     }
     fn write_piocontrol_queue_thld_ctrl(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::QueueThldCtrl::Register,
         >,
@@ -3451,33 +3700,35 @@ impl I3c1Peripheral for I3c1Generated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::piocontrol_queue_thld_ctrl = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.piocontrol_queue_thld_ctrl;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xff00_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0xff00_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xff_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0xff_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xff00 as caliptra_emu_types::RvData))
-            | (write_val & (0xff00 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xff as caliptra_emu_types::RvData))
-            | (write_val & (0xff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff00_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff00_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff00 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff00 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.piocontrol_queue_thld_ctrl = new_val;
     }
     fn read_piocontrol_data_buffer_thld_ctrl(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::DataBufferThldCtrl::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::piocontrol_data_buffer_thld_ctrl");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.piocontrol_data_buffer_thld_ctrl)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.piocontrol_data_buffer_thld_ctrl,
+        )
     }
     fn write_piocontrol_data_buffer_thld_ctrl(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::DataBufferThldCtrl::Register,
         >,
@@ -3485,31 +3736,33 @@ impl I3c1Peripheral for I3c1Generated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::piocontrol_data_buffer_thld_ctrl = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.piocontrol_data_buffer_thld_ctrl;
         let mut new_val = current_val;
-        new_val = (new_val & !(0x700_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x700_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x7_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x7_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x700 as caliptra_emu_types::RvData))
-            | (write_val & (0x700 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(7 as caliptra_emu_types::RvData))
-            | (write_val & (7 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x700_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x700_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x7_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x7_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x700 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x700 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(7 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (7 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.piocontrol_data_buffer_thld_ctrl = new_val;
     }
     fn read_piocontrol_queue_size(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::QueueSize::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::QueueSize::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read i3c1::piocontrol_queue_size");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.piocontrol_queue_size)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.piocontrol_queue_size)
     }
     fn read_piocontrol_alt_queue_size(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::AltQueueSize::Register,
     > {
@@ -3518,11 +3771,13 @@ impl I3c1Peripheral for I3c1Generated {
                 "[EMU] Generated default register handler: read i3c1::piocontrol_alt_queue_size"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.piocontrol_alt_queue_size)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.piocontrol_alt_queue_size,
+        )
     }
     fn read_piocontrol_pio_intr_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::PioIntrStatus::Register,
     > {
@@ -3531,11 +3786,13 @@ impl I3c1Peripheral for I3c1Generated {
                 "[EMU] Generated default register handler: read i3c1::piocontrol_pio_intr_status"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.piocontrol_pio_intr_status)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.piocontrol_pio_intr_status,
+        )
     }
     fn write_piocontrol_pio_intr_status(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::PioIntrStatus::Register,
         >,
@@ -3543,29 +3800,31 @@ impl I3c1Peripheral for I3c1Generated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::piocontrol_pio_intr_status = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.piocontrol_pio_intr_status;
         let mut new_val = current_val;
-        new_val = (new_val & !(0x200 as caliptra_emu_types::RvData))
-            | (write_val & (0x200 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x20 as caliptra_emu_types::RvData))
-            | (write_val & (0x20 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x200 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x200 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x20 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x20 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.piocontrol_pio_intr_status = new_val;
     }
     fn read_piocontrol_pio_intr_status_enable(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::PioIntrStatusEnable::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::piocontrol_pio_intr_status_enable");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.piocontrol_pio_intr_status_enable)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.piocontrol_pio_intr_status_enable,
+        )
     }
     fn write_piocontrol_pio_intr_status_enable(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::PioIntrStatusEnable::Register,
         >,
@@ -3573,39 +3832,41 @@ impl I3c1Peripheral for I3c1Generated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::piocontrol_pio_intr_status_enable = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.piocontrol_pio_intr_status_enable;
         let mut new_val = current_val;
-        new_val = (new_val & !(0x200 as caliptra_emu_types::RvData))
-            | (write_val & (0x200 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x20 as caliptra_emu_types::RvData))
-            | (write_val & (0x20 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x10 as caliptra_emu_types::RvData))
-            | (write_val & (0x10 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(8 as caliptra_emu_types::RvData))
-            | (write_val & (8 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(4 as caliptra_emu_types::RvData))
-            | (write_val & (4 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(2 as caliptra_emu_types::RvData))
-            | (write_val & (2 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x200 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x200 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x20 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x20 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x10 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x10 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(8 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (8 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(4 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (4 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(2 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.piocontrol_pio_intr_status_enable = new_val;
     }
     fn read_piocontrol_pio_intr_signal_enable(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::PioIntrSignalEnable::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::piocontrol_pio_intr_signal_enable");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.piocontrol_pio_intr_signal_enable)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.piocontrol_pio_intr_signal_enable,
+        )
     }
     fn write_piocontrol_pio_intr_signal_enable(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::PioIntrSignalEnable::Register,
         >,
@@ -3613,28 +3874,28 @@ impl I3c1Peripheral for I3c1Generated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::piocontrol_pio_intr_signal_enable = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.piocontrol_pio_intr_signal_enable;
         let mut new_val = current_val;
-        new_val = (new_val & !(0x200 as caliptra_emu_types::RvData))
-            | (write_val & (0x200 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x20 as caliptra_emu_types::RvData))
-            | (write_val & (0x20 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x10 as caliptra_emu_types::RvData))
-            | (write_val & (0x10 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(8 as caliptra_emu_types::RvData))
-            | (write_val & (8 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(4 as caliptra_emu_types::RvData))
-            | (write_val & (4 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(2 as caliptra_emu_types::RvData))
-            | (write_val & (2 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x200 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x200 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x20 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x20 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x10 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x10 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(8 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (8 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(4 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (4 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(2 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.piocontrol_pio_intr_signal_enable = new_val;
     }
     fn write_piocontrol_pio_intr_force(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::PioIntrForce::Register,
         >,
@@ -3642,28 +3903,28 @@ impl I3c1Peripheral for I3c1Generated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::piocontrol_pio_intr_force = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.piocontrol_pio_intr_force;
         let mut new_val = current_val;
-        new_val = (new_val & !(0x200 as caliptra_emu_types::RvData))
-            | (write_val & (0x200 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x20 as caliptra_emu_types::RvData))
-            | (write_val & (0x20 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x10 as caliptra_emu_types::RvData))
-            | (write_val & (0x10 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(8 as caliptra_emu_types::RvData))
-            | (write_val & (8 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(4 as caliptra_emu_types::RvData))
-            | (write_val & (4 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(2 as caliptra_emu_types::RvData))
-            | (write_val & (2 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x200 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x200 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x20 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x20 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x10 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x10 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(8 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (8 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(4 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (4 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(2 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.piocontrol_pio_intr_force = new_val;
     }
     fn read_piocontrol_pio_control(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::PioControl::Register,
     > {
@@ -3672,11 +3933,11 @@ impl I3c1Peripheral for I3c1Generated {
                 "[EMU] Generated default register handler: read i3c1::piocontrol_pio_control"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.piocontrol_pio_control)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.piocontrol_pio_control)
     }
     fn write_piocontrol_pio_control(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::PioControl::Register,
         >,
@@ -3684,35 +3945,41 @@ impl I3c1Peripheral for I3c1Generated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::piocontrol_pio_control = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.piocontrol_pio_control;
         let mut new_val = current_val;
-        new_val = (new_val & !(4 as caliptra_emu_types::RvData))
-            | (write_val & (4 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(2 as caliptra_emu_types::RvData))
-            | (write_val & (2 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(4 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (4 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(2 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.piocontrol_pio_control = new_val;
     }
     fn read_i3c_ec_sec_fw_recovery_if_extcap_header(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::ExtcapHeader::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_sec_fw_recovery_if_extcap_header");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_sec_fw_recovery_if_extcap_header)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_sec_fw_recovery_if_extcap_header,
+        )
     }
-    fn read_i3c_ec_sec_fw_recovery_if_prot_cap_0(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_sec_fw_recovery_if_prot_cap_0(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_sec_fw_recovery_if_prot_cap_0");
         }
         self.i3c_ec_sec_fw_recovery_if_prot_cap_0
     }
-    fn read_i3c_ec_sec_fw_recovery_if_prot_cap_1(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_sec_fw_recovery_if_prot_cap_1(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_sec_fw_recovery_if_prot_cap_1");
         }
@@ -3720,16 +3987,20 @@ impl I3c1Peripheral for I3c1Generated {
     }
     fn read_i3c_ec_sec_fw_recovery_if_prot_cap_2(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::ProtCap2::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::ProtCap2::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_sec_fw_recovery_if_prot_cap_2");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_sec_fw_recovery_if_prot_cap_2)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_sec_fw_recovery_if_prot_cap_2,
+        )
     }
     fn write_i3c_ec_sec_fw_recovery_if_prot_cap_2(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::ProtCap2::Register,
         >,
@@ -3737,27 +4008,31 @@ impl I3c1Peripheral for I3c1Generated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_ec_sec_fw_recovery_if_prot_cap_2 = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_sec_fw_recovery_if_prot_cap_2;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xffff_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_0000 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_sec_fw_recovery_if_prot_cap_2 = new_val;
     }
     fn read_i3c_ec_sec_fw_recovery_if_prot_cap_3(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::ProtCap3::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::ProtCap3::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_sec_fw_recovery_if_prot_cap_3");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_sec_fw_recovery_if_prot_cap_3)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_sec_fw_recovery_if_prot_cap_3,
+        )
     }
     fn write_i3c_ec_sec_fw_recovery_if_prot_cap_3(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::ProtCap3::Register,
         >,
@@ -3765,29 +4040,33 @@ impl I3c1Peripheral for I3c1Generated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_ec_sec_fw_recovery_if_prot_cap_3 = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_sec_fw_recovery_if_prot_cap_3;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xff as caliptra_emu_types::RvData))
-            | (write_val & (0xff as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xff00 as caliptra_emu_types::RvData))
-            | (write_val & (0xff00 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xff_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0xff_0000 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff00 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff00 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_sec_fw_recovery_if_prot_cap_3 = new_val;
     }
     fn read_i3c_ec_sec_fw_recovery_if_device_id_0(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::DeviceId0::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::DeviceId0::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_sec_fw_recovery_if_device_id_0");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_sec_fw_recovery_if_device_id_0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_sec_fw_recovery_if_device_id_0,
+        )
     }
     fn write_i3c_ec_sec_fw_recovery_if_device_id_0(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::DeviceId0::Register,
         >,
@@ -3795,103 +4074,130 @@ impl I3c1Peripheral for I3c1Generated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_ec_sec_fw_recovery_if_device_id_0 = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_sec_fw_recovery_if_device_id_0;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xff as caliptra_emu_types::RvData))
-            | (write_val & (0xff as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xff00 as caliptra_emu_types::RvData))
-            | (write_val & (0xff00 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xffff_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_0000 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff00 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff00 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_sec_fw_recovery_if_device_id_0 = new_val;
     }
-    fn read_i3c_ec_sec_fw_recovery_if_device_id_1(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_sec_fw_recovery_if_device_id_1(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_sec_fw_recovery_if_device_id_1");
         }
         self.i3c_ec_sec_fw_recovery_if_device_id_1
     }
-    fn write_i3c_ec_sec_fw_recovery_if_device_id_1(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_sec_fw_recovery_if_device_id_1(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_ec_sec_fw_recovery_if_device_id_1 = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_sec_fw_recovery_if_device_id_1;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_sec_fw_recovery_if_device_id_1 = new_val;
     }
-    fn read_i3c_ec_sec_fw_recovery_if_device_id_2(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_sec_fw_recovery_if_device_id_2(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_sec_fw_recovery_if_device_id_2");
         }
         self.i3c_ec_sec_fw_recovery_if_device_id_2
     }
-    fn write_i3c_ec_sec_fw_recovery_if_device_id_2(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_sec_fw_recovery_if_device_id_2(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_ec_sec_fw_recovery_if_device_id_2 = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_sec_fw_recovery_if_device_id_2;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_sec_fw_recovery_if_device_id_2 = new_val;
     }
-    fn read_i3c_ec_sec_fw_recovery_if_device_id_3(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_sec_fw_recovery_if_device_id_3(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_sec_fw_recovery_if_device_id_3");
         }
         self.i3c_ec_sec_fw_recovery_if_device_id_3
     }
-    fn write_i3c_ec_sec_fw_recovery_if_device_id_3(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_sec_fw_recovery_if_device_id_3(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_ec_sec_fw_recovery_if_device_id_3 = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_sec_fw_recovery_if_device_id_3;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_sec_fw_recovery_if_device_id_3 = new_val;
     }
-    fn read_i3c_ec_sec_fw_recovery_if_device_id_4(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_sec_fw_recovery_if_device_id_4(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_sec_fw_recovery_if_device_id_4");
         }
         self.i3c_ec_sec_fw_recovery_if_device_id_4
     }
-    fn write_i3c_ec_sec_fw_recovery_if_device_id_4(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_sec_fw_recovery_if_device_id_4(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_ec_sec_fw_recovery_if_device_id_4 = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_sec_fw_recovery_if_device_id_4;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_sec_fw_recovery_if_device_id_4 = new_val;
     }
-    fn read_i3c_ec_sec_fw_recovery_if_device_id_5(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_sec_fw_recovery_if_device_id_5(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_sec_fw_recovery_if_device_id_5");
         }
         self.i3c_ec_sec_fw_recovery_if_device_id_5
     }
-    fn write_i3c_ec_sec_fw_recovery_if_device_id_5(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_sec_fw_recovery_if_device_id_5(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_ec_sec_fw_recovery_if_device_id_5 = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_sec_fw_recovery_if_device_id_5;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_sec_fw_recovery_if_device_id_5 = new_val;
     }
-    fn read_i3c_ec_sec_fw_recovery_if_device_id_reserved(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_sec_fw_recovery_if_device_id_reserved(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_sec_fw_recovery_if_device_id_reserved");
         }
@@ -3899,18 +4205,20 @@ impl I3c1Peripheral for I3c1Generated {
     }
     fn read_i3c_ec_sec_fw_recovery_if_device_status_0(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::DeviceStatus0::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_sec_fw_recovery_if_device_status_0");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_sec_fw_recovery_if_device_status_0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_sec_fw_recovery_if_device_status_0,
+        )
     }
     fn write_i3c_ec_sec_fw_recovery_if_device_status_0(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::DeviceStatus0::Register,
         >,
@@ -3918,31 +4226,33 @@ impl I3c1Peripheral for I3c1Generated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_ec_sec_fw_recovery_if_device_status_0 = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_sec_fw_recovery_if_device_status_0;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xff as caliptra_emu_types::RvData))
-            | (write_val & (0xff as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xff00 as caliptra_emu_types::RvData))
-            | (write_val & (0xff00 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xffff_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_0000 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff00 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff00 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_sec_fw_recovery_if_device_status_0 = new_val;
     }
     fn read_i3c_ec_sec_fw_recovery_if_device_status_1(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::DeviceStatus1::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_sec_fw_recovery_if_device_status_1");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_sec_fw_recovery_if_device_status_1)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_sec_fw_recovery_if_device_status_1,
+        )
     }
     fn write_i3c_ec_sec_fw_recovery_if_device_status_1(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::DeviceStatus1::Register,
         >,
@@ -3950,31 +4260,33 @@ impl I3c1Peripheral for I3c1Generated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_ec_sec_fw_recovery_if_device_status_1 = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_sec_fw_recovery_if_device_status_1;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x1ff_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x1ff_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xfe00_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0xfe00_0000 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x1ff_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x1ff_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xfe00_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xfe00_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_sec_fw_recovery_if_device_status_1 = new_val;
     }
     fn read_i3c_ec_sec_fw_recovery_if_device_reset(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::DeviceReset::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_sec_fw_recovery_if_device_reset");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_sec_fw_recovery_if_device_reset)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_sec_fw_recovery_if_device_reset,
+        )
     }
     fn write_i3c_ec_sec_fw_recovery_if_device_reset(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::DeviceReset::Register,
         >,
@@ -3982,31 +4294,33 @@ impl I3c1Peripheral for I3c1Generated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_ec_sec_fw_recovery_if_device_reset = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_sec_fw_recovery_if_device_reset;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xff as caliptra_emu_types::RvData))
-            | (write_val & (0xff as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xff00 as caliptra_emu_types::RvData))
-            | (write_val & (0xff00 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xff_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0xff_0000 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff00 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff00 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_sec_fw_recovery_if_device_reset = new_val;
     }
     fn read_i3c_ec_sec_fw_recovery_if_recovery_ctrl(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::RecoveryCtrl::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_sec_fw_recovery_if_recovery_ctrl");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_sec_fw_recovery_if_recovery_ctrl)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_sec_fw_recovery_if_recovery_ctrl,
+        )
     }
     fn write_i3c_ec_sec_fw_recovery_if_recovery_ctrl(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::RecoveryCtrl::Register,
         >,
@@ -4014,31 +4328,33 @@ impl I3c1Peripheral for I3c1Generated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_ec_sec_fw_recovery_if_recovery_ctrl = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_sec_fw_recovery_if_recovery_ctrl;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xff as caliptra_emu_types::RvData))
-            | (write_val & (0xff as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xff00 as caliptra_emu_types::RvData))
-            | (write_val & (0xff00 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xff_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0xff_0000 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff00 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff00 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_sec_fw_recovery_if_recovery_ctrl = new_val;
     }
     fn read_i3c_ec_sec_fw_recovery_if_recovery_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::RecoveryStatus::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_sec_fw_recovery_if_recovery_status");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_sec_fw_recovery_if_recovery_status)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_sec_fw_recovery_if_recovery_status,
+        )
     }
     fn write_i3c_ec_sec_fw_recovery_if_recovery_status(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::RecoveryStatus::Register,
         >,
@@ -4046,29 +4362,33 @@ impl I3c1Peripheral for I3c1Generated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_ec_sec_fw_recovery_if_recovery_status = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_sec_fw_recovery_if_recovery_status;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xf as caliptra_emu_types::RvData))
-            | (write_val & (0xf as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xf0 as caliptra_emu_types::RvData))
-            | (write_val & (0xf0 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xff00 as caliptra_emu_types::RvData))
-            | (write_val & (0xff00 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xf as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xf as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xf0 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xf0 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff00 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff00 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_sec_fw_recovery_if_recovery_status = new_val;
     }
     fn read_i3c_ec_sec_fw_recovery_if_hw_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::HwStatus::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::HwStatus::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_sec_fw_recovery_if_hw_status");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_sec_fw_recovery_if_hw_status)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_sec_fw_recovery_if_hw_status,
+        )
     }
     fn write_i3c_ec_sec_fw_recovery_if_hw_status(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::HwStatus::Register,
         >,
@@ -4076,41 +4396,41 @@ impl I3c1Peripheral for I3c1Generated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_ec_sec_fw_recovery_if_hw_status = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_sec_fw_recovery_if_hw_status;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(2 as caliptra_emu_types::RvData))
-            | (write_val & (2 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(4 as caliptra_emu_types::RvData))
-            | (write_val & (4 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xf8 as caliptra_emu_types::RvData))
-            | (write_val & (0xf8 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xff00 as caliptra_emu_types::RvData))
-            | (write_val & (0xff00 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xff_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0xff_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xff00_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0xff00_0000 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(2 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(4 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (4 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xf8 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xf8 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff00 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff00 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff00_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff00_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_sec_fw_recovery_if_hw_status = new_val;
     }
     fn read_i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_0(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::IndirectFifoCtrl0::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_0");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_0,
         )
     }
     fn write_i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_0(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::IndirectFifoCtrl0::Register,
         >,
@@ -4118,18 +4438,18 @@ impl I3c1Peripheral for I3c1Generated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_0 = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_0;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xff as caliptra_emu_types::RvData))
-            | (write_val & (0xff as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xff00 as caliptra_emu_types::RvData))
-            | (write_val & (0xff00 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff00 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff00 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_0 = new_val;
     }
     fn read_i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_1(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_1");
         }
@@ -4137,34 +4457,34 @@ impl I3c1Peripheral for I3c1Generated {
     }
     fn write_i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_1(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_1 = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_1;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_1 = new_val;
     }
     fn read_i3c_ec_sec_fw_recovery_if_indirect_fifo_status_0(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::IndirectFifoStatus0::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_sec_fw_recovery_if_indirect_fifo_status_0");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.i3c_ec_sec_fw_recovery_if_indirect_fifo_status_0,
         )
     }
     fn read_i3c_ec_sec_fw_recovery_if_indirect_fifo_status_1(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_sec_fw_recovery_if_indirect_fifo_status_1");
         }
@@ -4172,7 +4492,7 @@ impl I3c1Peripheral for I3c1Generated {
     }
     fn read_i3c_ec_sec_fw_recovery_if_indirect_fifo_status_2(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_sec_fw_recovery_if_indirect_fifo_status_2");
         }
@@ -4180,7 +4500,7 @@ impl I3c1Peripheral for I3c1Generated {
     }
     fn read_i3c_ec_sec_fw_recovery_if_indirect_fifo_status_3(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_sec_fw_recovery_if_indirect_fifo_status_3");
         }
@@ -4188,7 +4508,7 @@ impl I3c1Peripheral for I3c1Generated {
     }
     fn read_i3c_ec_sec_fw_recovery_if_indirect_fifo_status_4(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_sec_fw_recovery_if_indirect_fifo_status_4");
         }
@@ -4196,13 +4516,15 @@ impl I3c1Peripheral for I3c1Generated {
     }
     fn read_i3c_ec_sec_fw_recovery_if_indirect_fifo_reserved(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_sec_fw_recovery_if_indirect_fifo_reserved");
         }
         self.i3c_ec_sec_fw_recovery_if_indirect_fifo_reserved
     }
-    fn read_i3c_ec_sec_fw_recovery_if_indirect_fifo_data(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_sec_fw_recovery_if_indirect_fifo_data(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_sec_fw_recovery_if_indirect_fifo_data");
         }
@@ -4210,29 +4532,33 @@ impl I3c1Peripheral for I3c1Generated {
     }
     fn read_i3c_ec_stdby_ctrl_mode_extcap_header(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::ExtcapHeader::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_stdby_ctrl_mode_extcap_header");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_stdby_ctrl_mode_extcap_header)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_stdby_ctrl_mode_extcap_header,
+        )
     }
     fn read_i3c_ec_stdby_ctrl_mode_stby_cr_control(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::StbyCrControl::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_stdby_ctrl_mode_stby_cr_control");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_stdby_ctrl_mode_stby_cr_control)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_stdby_ctrl_mode_stby_cr_control,
+        )
     }
     fn write_i3c_ec_stdby_ctrl_mode_stby_cr_control(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::StbyCrControl::Register,
         >,
@@ -4240,51 +4566,53 @@ impl I3c1Peripheral for I3c1Generated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_ec_stdby_ctrl_mode_stby_cr_control = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_stdby_ctrl_mode_stby_cr_control;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xc000_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0xc000_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x10_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x10_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x8000 as caliptra_emu_types::RvData))
-            | (write_val & (0x8000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x4000 as caliptra_emu_types::RvData))
-            | (write_val & (0x4000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x2000 as caliptra_emu_types::RvData))
-            | (write_val & (0x2000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x1000 as caliptra_emu_types::RvData))
-            | (write_val & (0x1000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x700 as caliptra_emu_types::RvData))
-            | (write_val & (0x700 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x20 as caliptra_emu_types::RvData))
-            | (write_val & (0x20 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x10 as caliptra_emu_types::RvData))
-            | (write_val & (0x10 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(8 as caliptra_emu_types::RvData))
-            | (write_val & (8 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(4 as caliptra_emu_types::RvData))
-            | (write_val & (4 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(2 as caliptra_emu_types::RvData))
-            | (write_val & (2 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xc000_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xc000_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x10_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x10_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x8000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x8000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x4000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x4000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x2000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x2000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x1000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x1000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x700 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x700 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x20 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x20 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x10 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x10 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(8 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (8 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(4 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (4 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(2 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_stdby_ctrl_mode_stby_cr_control = new_val;
     }
     fn read_i3c_ec_stdby_ctrl_mode_stby_cr_device_addr(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::StbyCrDeviceAddr::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_stdby_ctrl_mode_stby_cr_device_addr");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_stdby_ctrl_mode_stby_cr_device_addr)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_stdby_ctrl_mode_stby_cr_device_addr,
+        )
     }
     fn write_i3c_ec_stdby_ctrl_mode_stby_cr_device_addr(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::StbyCrDeviceAddr::Register,
         >,
@@ -4292,46 +4620,48 @@ impl I3c1Peripheral for I3c1Generated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_ec_stdby_ctrl_mode_stby_cr_device_addr = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_stdby_ctrl_mode_stby_cr_device_addr;
         let mut new_val = current_val;
-        new_val = (new_val & !(0x8000_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x8000_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x7f_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x7f_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x8000 as caliptra_emu_types::RvData))
-            | (write_val & (0x8000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x7f as caliptra_emu_types::RvData))
-            | (write_val & (0x7f as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x8000_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x8000_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x7f_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x7f_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x8000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x8000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x7f as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x7f as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_stdby_ctrl_mode_stby_cr_device_addr = new_val;
     }
     fn read_i3c_ec_stdby_ctrl_mode_stby_cr_capabilities(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::StbyCrCapabilities::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_stdby_ctrl_mode_stby_cr_capabilities");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_stdby_ctrl_mode_stby_cr_capabilities)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_stdby_ctrl_mode_stby_cr_capabilities,
+        )
     }
     fn read_i3c_ec_stdby_ctrl_mode_stby_cr_virtual_device_char(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::StbyCrVirtualDeviceChar::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_stdby_ctrl_mode_stby_cr_virtual_device_char");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.i3c_ec_stdby_ctrl_mode_stby_cr_virtual_device_char,
         )
     }
     fn write_i3c_ec_stdby_ctrl_mode_stby_cr_virtual_device_char(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::StbyCrVirtualDeviceChar::Register,
         >,
@@ -4339,33 +4669,35 @@ impl I3c1Peripheral for I3c1Generated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_ec_stdby_ctrl_mode_stby_cr_virtual_device_char = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_stdby_ctrl_mode_stby_cr_virtual_device_char;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xe000_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0xe000_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x1f00_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x1f00_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xff_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0xff_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xfffe as caliptra_emu_types::RvData))
-            | (write_val & (0xfffe as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xe000_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xe000_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x1f00_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x1f00_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xfffe as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xfffe as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_stdby_ctrl_mode_stby_cr_virtual_device_char = new_val;
     }
     fn read_i3c_ec_stdby_ctrl_mode_stby_cr_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::StbyCrStatus::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_stdby_ctrl_mode_stby_cr_status");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_stdby_ctrl_mode_stby_cr_status)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_stdby_ctrl_mode_stby_cr_status,
+        )
     }
     fn write_i3c_ec_stdby_ctrl_mode_stby_cr_status(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::StbyCrStatus::Register,
         >,
@@ -4373,31 +4705,33 @@ impl I3c1Peripheral for I3c1Generated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_ec_stdby_ctrl_mode_stby_cr_status = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_stdby_ctrl_mode_stby_cr_status;
         let mut new_val = current_val;
-        new_val = (new_val & !(0x100 as caliptra_emu_types::RvData))
-            | (write_val & (0x100 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xe0 as caliptra_emu_types::RvData))
-            | (write_val & (0xe0 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(4 as caliptra_emu_types::RvData))
-            | (write_val & (4 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x100 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x100 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xe0 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xe0 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(4 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (4 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_stdby_ctrl_mode_stby_cr_status = new_val;
     }
     fn read_i3c_ec_stdby_ctrl_mode_stby_cr_device_char(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::StbyCrDeviceChar::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_stdby_ctrl_mode_stby_cr_device_char");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_stdby_ctrl_mode_stby_cr_device_char)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_stdby_ctrl_mode_stby_cr_device_char,
+        )
     }
     fn write_i3c_ec_stdby_ctrl_mode_stby_cr_device_char(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::StbyCrDeviceChar::Register,
         >,
@@ -4405,20 +4739,22 @@ impl I3c1Peripheral for I3c1Generated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_ec_stdby_ctrl_mode_stby_cr_device_char = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_stdby_ctrl_mode_stby_cr_device_char;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xe000_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0xe000_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x1f00_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x1f00_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xff_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0xff_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xfffe as caliptra_emu_types::RvData))
-            | (write_val & (0xfffe as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xe000_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xe000_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x1f00_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x1f00_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xfffe as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xfffe as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_stdby_ctrl_mode_stby_cr_device_char = new_val;
     }
-    fn read_i3c_ec_stdby_ctrl_mode_stby_cr_device_pid_lo(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_stdby_ctrl_mode_stby_cr_device_pid_lo(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_stdby_ctrl_mode_stby_cr_device_pid_lo");
         }
@@ -4426,32 +4762,34 @@ impl I3c1Peripheral for I3c1Generated {
     }
     fn write_i3c_ec_stdby_ctrl_mode_stby_cr_device_pid_lo(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_ec_stdby_ctrl_mode_stby_cr_device_pid_lo = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_stdby_ctrl_mode_stby_cr_device_pid_lo;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_stdby_ctrl_mode_stby_cr_device_pid_lo = new_val;
     }
     fn read_i3c_ec_stdby_ctrl_mode_stby_cr_intr_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::StbyCrIntrStatus::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_stdby_ctrl_mode_stby_cr_intr_status");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_stdby_ctrl_mode_stby_cr_intr_status)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_stdby_ctrl_mode_stby_cr_intr_status,
+        )
     }
     fn write_i3c_ec_stdby_ctrl_mode_stby_cr_intr_status(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::StbyCrIntrStatus::Register,
         >,
@@ -4459,40 +4797,40 @@ impl I3c1Peripheral for I3c1Generated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_ec_stdby_ctrl_mode_stby_cr_intr_status = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_stdby_ctrl_mode_stby_cr_intr_status;
         let mut new_val = current_val;
-        new_val = (new_val & !(0x8_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x8_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x4_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x4_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x2_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x2_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x1_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x1_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x4000 as caliptra_emu_types::RvData))
-            | (write_val & (0x4000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x2000 as caliptra_emu_types::RvData))
-            | (write_val & (0x2000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x1000 as caliptra_emu_types::RvData))
-            | (write_val & (0x1000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x800 as caliptra_emu_types::RvData))
-            | (write_val & (0x800 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x400 as caliptra_emu_types::RvData))
-            | (write_val & (0x400 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(8 as caliptra_emu_types::RvData))
-            | (write_val & (8 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(4 as caliptra_emu_types::RvData))
-            | (write_val & (4 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(2 as caliptra_emu_types::RvData))
-            | (write_val & (2 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x8_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x8_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x4_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x4_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x2_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x2_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x1_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x1_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x4000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x4000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x2000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x2000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x1000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x1000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x800 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x800 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x400 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x400 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(8 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (8 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(4 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (4 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(2 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_stdby_ctrl_mode_stby_cr_intr_status = new_val;
     }
     fn read_i3c_ec_stdby_ctrl_mode_stby_cr_virtual_device_pid_lo(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_stdby_ctrl_mode_stby_cr_virtual_device_pid_lo");
         }
@@ -4500,34 +4838,34 @@ impl I3c1Peripheral for I3c1Generated {
     }
     fn write_i3c_ec_stdby_ctrl_mode_stby_cr_virtual_device_pid_lo(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_ec_stdby_ctrl_mode_stby_cr_virtual_device_pid_lo = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_stdby_ctrl_mode_stby_cr_virtual_device_pid_lo;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_stdby_ctrl_mode_stby_cr_virtual_device_pid_lo = new_val;
     }
     fn read_i3c_ec_stdby_ctrl_mode_stby_cr_intr_signal_enable(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::StbyCrIntrSignalEnable::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_stdby_ctrl_mode_stby_cr_intr_signal_enable");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.i3c_ec_stdby_ctrl_mode_stby_cr_intr_signal_enable,
         )
     }
     fn write_i3c_ec_stdby_ctrl_mode_stby_cr_intr_signal_enable(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::StbyCrIntrSignalEnable::Register,
         >,
@@ -4535,51 +4873,53 @@ impl I3c1Peripheral for I3c1Generated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_ec_stdby_ctrl_mode_stby_cr_intr_signal_enable = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_stdby_ctrl_mode_stby_cr_intr_signal_enable;
         let mut new_val = current_val;
-        new_val = (new_val & !(0x8_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x8_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x4_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x4_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x2_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x2_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x1_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x1_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x4000 as caliptra_emu_types::RvData))
-            | (write_val & (0x4000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x2000 as caliptra_emu_types::RvData))
-            | (write_val & (0x2000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x1000 as caliptra_emu_types::RvData))
-            | (write_val & (0x1000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x800 as caliptra_emu_types::RvData))
-            | (write_val & (0x800 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x400 as caliptra_emu_types::RvData))
-            | (write_val & (0x400 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(8 as caliptra_emu_types::RvData))
-            | (write_val & (8 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(4 as caliptra_emu_types::RvData))
-            | (write_val & (4 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(2 as caliptra_emu_types::RvData))
-            | (write_val & (2 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x8_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x8_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x4_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x4_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x2_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x2_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x1_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x1_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x4000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x4000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x2000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x2000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x1000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x1000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x800 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x800 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x400 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x400 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(8 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (8 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(4 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (4 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(2 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_stdby_ctrl_mode_stby_cr_intr_signal_enable = new_val;
     }
     fn read_i3c_ec_stdby_ctrl_mode_stby_cr_intr_force(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::StbyCrIntrForce::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_stdby_ctrl_mode_stby_cr_intr_force");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_stdby_ctrl_mode_stby_cr_intr_force)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_stdby_ctrl_mode_stby_cr_intr_force,
+        )
     }
     fn write_i3c_ec_stdby_ctrl_mode_stby_cr_intr_force(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::StbyCrIntrForce::Register,
         >,
@@ -4587,45 +4927,45 @@ impl I3c1Peripheral for I3c1Generated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_ec_stdby_ctrl_mode_stby_cr_intr_force = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_stdby_ctrl_mode_stby_cr_intr_force;
         let mut new_val = current_val;
-        new_val = (new_val & !(0x8_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x8_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x4_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x4_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x2_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x2_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x1_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x1_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x4000 as caliptra_emu_types::RvData))
-            | (write_val & (0x4000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x2000 as caliptra_emu_types::RvData))
-            | (write_val & (0x2000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x1000 as caliptra_emu_types::RvData))
-            | (write_val & (0x1000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x800 as caliptra_emu_types::RvData))
-            | (write_val & (0x800 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x400 as caliptra_emu_types::RvData))
-            | (write_val & (0x400 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x8_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x8_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x4_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x4_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x2_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x2_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x1_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x1_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x4000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x4000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x2000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x2000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x1000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x1000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x800 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x800 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x400 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x400 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_stdby_ctrl_mode_stby_cr_intr_force = new_val;
     }
     fn read_i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_getcaps(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::StbyCrCccConfigGetcaps::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_getcaps");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_getcaps,
         )
     }
     fn write_i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_getcaps(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::StbyCrCccConfigGetcaps::Register,
         >,
@@ -4633,31 +4973,31 @@ impl I3c1Peripheral for I3c1Generated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_getcaps = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_getcaps;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xf00 as caliptra_emu_types::RvData))
-            | (write_val & (0xf00 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(7 as caliptra_emu_types::RvData))
-            | (write_val & (7 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xf00 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xf00 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(7 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (7 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_getcaps = new_val;
     }
     fn read_i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_rstact_params(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::StbyCrCccConfigRstactParams::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_rstact_params");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_rstact_params,
         )
     }
     fn write_i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_rstact_params(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::StbyCrCccConfigRstactParams::Register,
         >,
@@ -4665,33 +5005,33 @@ impl I3c1Peripheral for I3c1Generated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_rstact_params = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_rstact_params;
         let mut new_val = current_val;
-        new_val = (new_val & !(0x8000_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x8000_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xff_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0xff_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xff00 as caliptra_emu_types::RvData))
-            | (write_val & (0xff00 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x8000_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x8000_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff00 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff00 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_rstact_params = new_val;
     }
     fn read_i3c_ec_stdby_ctrl_mode_stby_cr_virt_device_addr(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::StbyCrVirtDeviceAddr::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_stdby_ctrl_mode_stby_cr_virt_device_addr");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.i3c_ec_stdby_ctrl_mode_stby_cr_virt_device_addr,
         )
     }
     fn write_i3c_ec_stdby_ctrl_mode_stby_cr_virt_device_addr(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::StbyCrVirtDeviceAddr::Register,
         >,
@@ -4699,39 +5039,44 @@ impl I3c1Peripheral for I3c1Generated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_ec_stdby_ctrl_mode_stby_cr_virt_device_addr = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_stdby_ctrl_mode_stby_cr_virt_device_addr;
         let mut new_val = current_val;
-        new_val = (new_val & !(0x8000_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x8000_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x7f_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x7f_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x8000 as caliptra_emu_types::RvData))
-            | (write_val & (0x8000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x7f as caliptra_emu_types::RvData))
-            | (write_val & (0x7f as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x8000_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x8000_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x7f_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x7f_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x8000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x8000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x7f as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x7f as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_stdby_ctrl_mode_stby_cr_virt_device_addr = new_val;
     }
-    fn read_i3c_ec_stdby_ctrl_mode_rsvd_3(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_stdby_ctrl_mode_rsvd_3(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_stdby_ctrl_mode_rsvd_3");
         }
         self.i3c_ec_stdby_ctrl_mode_rsvd_3
     }
-    fn write_i3c_ec_stdby_ctrl_mode_rsvd_3(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_stdby_ctrl_mode_rsvd_3(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_ec_stdby_ctrl_mode_rsvd_3 = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_stdby_ctrl_mode_rsvd_3;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_stdby_ctrl_mode_rsvd_3 = new_val;
     }
     fn read_i3c_ec_tti_extcap_header(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::ExtcapHeader::Register,
     > {
@@ -4740,20 +5085,22 @@ impl I3c1Peripheral for I3c1Generated {
                 "[EMU] Generated default register handler: read i3c1::i3c_ec_tti_extcap_header"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_tti_extcap_header)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_tti_extcap_header)
     }
     fn read_i3c_ec_tti_control(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::Control::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::Control::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read i3c1::i3c_ec_tti_control");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_tti_control)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_tti_control)
     }
     fn write_i3c_ec_tti_control(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::Control::Register,
         >,
@@ -4761,31 +5108,33 @@ impl I3c1Peripheral for I3c1Generated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_ec_tti_control = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_tti_control;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xe000 as caliptra_emu_types::RvData))
-            | (write_val & (0xe000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x1000 as caliptra_emu_types::RvData))
-            | (write_val & (0x1000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x800 as caliptra_emu_types::RvData))
-            | (write_val & (0x800 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x400 as caliptra_emu_types::RvData))
-            | (write_val & (0x400 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xe000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xe000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x1000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x1000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x800 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x800 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x400 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x400 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_tti_control = new_val;
     }
     fn read_i3c_ec_tti_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::Status::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::Status::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read i3c1::i3c_ec_tti_status");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_tti_status)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_tti_status)
     }
     fn read_i3c_ec_tti_tti_reset_control(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::TtiResetControl::Register,
     > {
@@ -4794,11 +5143,13 @@ impl I3c1Peripheral for I3c1Generated {
                 "[EMU] Generated default register handler: read i3c1::i3c_ec_tti_tti_reset_control"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_tti_tti_reset_control)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_tti_tti_reset_control,
+        )
     }
     fn write_i3c_ec_tti_tti_reset_control(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::TtiResetControl::Register,
         >,
@@ -4806,26 +5157,26 @@ impl I3c1Peripheral for I3c1Generated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_ec_tti_tti_reset_control = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_tti_tti_reset_control;
         let mut new_val = current_val;
-        new_val = (new_val & !(0x20 as caliptra_emu_types::RvData))
-            | (write_val & (0x20 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x10 as caliptra_emu_types::RvData))
-            | (write_val & (0x10 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(8 as caliptra_emu_types::RvData))
-            | (write_val & (8 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(4 as caliptra_emu_types::RvData))
-            | (write_val & (4 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(2 as caliptra_emu_types::RvData))
-            | (write_val & (2 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x20 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x20 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x10 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x10 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(8 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (8 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(4 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (4 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(2 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_tti_tti_reset_control = new_val;
     }
     fn read_i3c_ec_tti_interrupt_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::InterruptStatus::Register,
     > {
@@ -4834,11 +5185,13 @@ impl I3c1Peripheral for I3c1Generated {
                 "[EMU] Generated default register handler: read i3c1::i3c_ec_tti_interrupt_status"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_tti_interrupt_status)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_tti_interrupt_status,
+        )
     }
     fn write_i3c_ec_tti_interrupt_status(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::InterruptStatus::Register,
         >,
@@ -4846,42 +5199,51 @@ impl I3c1Peripheral for I3c1Generated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_ec_tti_interrupt_status = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_tti_interrupt_status;
         let mut new_val = current_val;
-        let bits_to_clear_0 = write_val & (0x8000_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_0 =
+            write_val & (0x8000_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_0;
-        let bits_to_clear_1 = write_val & (0x400_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_1 =
+            write_val & (0x400_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_1;
-        let bits_to_clear_2 = write_val & (0x200_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_2 =
+            write_val & (0x200_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_2;
-        new_val = (new_val & !(0x7_8000 as caliptra_emu_types::RvData))
-            | (write_val & (0x7_8000 as caliptra_emu_types::RvData));
-        let bits_to_clear_4 = write_val & (0x2000 as caliptra_emu_types::RvData);
+        new_val = (new_val & !(0x7_8000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x7_8000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        let bits_to_clear_4 =
+            write_val & (0x2000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_4;
-        let bits_to_clear_5 = write_val & (0x1000 as caliptra_emu_types::RvData);
+        let bits_to_clear_5 =
+            write_val & (0x1000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_5;
-        let bits_to_clear_6 = write_val & (0x800 as caliptra_emu_types::RvData);
+        let bits_to_clear_6 =
+            write_val & (0x800 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_6;
-        let bits_to_clear_7 = write_val & (0x400 as caliptra_emu_types::RvData);
+        let bits_to_clear_7 =
+            write_val & (0x400 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_7;
-        let bits_to_clear_8 = write_val & (0x200 as caliptra_emu_types::RvData);
+        let bits_to_clear_8 =
+            write_val & (0x200 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_8;
-        let bits_to_clear_9 = write_val & (0x100 as caliptra_emu_types::RvData);
+        let bits_to_clear_9 =
+            write_val & (0x100 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_9;
-        let bits_to_clear_10 = write_val & (8 as caliptra_emu_types::RvData);
+        let bits_to_clear_10 = write_val & (8 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_10;
-        let bits_to_clear_11 = write_val & (4 as caliptra_emu_types::RvData);
+        let bits_to_clear_11 = write_val & (4 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_11;
-        let bits_to_clear_12 = write_val & (2 as caliptra_emu_types::RvData);
+        let bits_to_clear_12 = write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_12;
-        let bits_to_clear_13 = write_val & (1 as caliptra_emu_types::RvData);
+        let bits_to_clear_13 = write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_13;
         self.i3c_ec_tti_interrupt_status = new_val;
     }
     fn read_i3c_ec_tti_interrupt_enable(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::InterruptEnable::Register,
     > {
@@ -4890,11 +5252,13 @@ impl I3c1Peripheral for I3c1Generated {
                 "[EMU] Generated default register handler: read i3c1::i3c_ec_tti_interrupt_enable"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_tti_interrupt_enable)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_tti_interrupt_enable,
+        )
     }
     fn write_i3c_ec_tti_interrupt_enable(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::InterruptEnable::Register,
         >,
@@ -4902,40 +5266,40 @@ impl I3c1Peripheral for I3c1Generated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_ec_tti_interrupt_enable = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_tti_interrupt_enable;
         let mut new_val = current_val;
-        new_val = (new_val & !(0x8000_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x8000_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x400_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x400_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x200_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x200_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x2000 as caliptra_emu_types::RvData))
-            | (write_val & (0x2000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x1000 as caliptra_emu_types::RvData))
-            | (write_val & (0x1000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x800 as caliptra_emu_types::RvData))
-            | (write_val & (0x800 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x400 as caliptra_emu_types::RvData))
-            | (write_val & (0x400 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x200 as caliptra_emu_types::RvData))
-            | (write_val & (0x200 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x100 as caliptra_emu_types::RvData))
-            | (write_val & (0x100 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(8 as caliptra_emu_types::RvData))
-            | (write_val & (8 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(4 as caliptra_emu_types::RvData))
-            | (write_val & (4 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(2 as caliptra_emu_types::RvData))
-            | (write_val & (2 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x8000_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x8000_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x400_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x400_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x200_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x200_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x2000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x2000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x1000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x1000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x800 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x800 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x400 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x400 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x200 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x200 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x100 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x100 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(8 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (8 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(4 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (4 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(2 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_tti_interrupt_enable = new_val;
     }
     fn read_i3c_ec_tti_interrupt_force(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::InterruptForce::Register,
     > {
@@ -4944,11 +5308,13 @@ impl I3c1Peripheral for I3c1Generated {
                 "[EMU] Generated default register handler: read i3c1::i3c_ec_tti_interrupt_force"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_tti_interrupt_force)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_tti_interrupt_force,
+        )
     }
     fn write_i3c_ec_tti_interrupt_force(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::InterruptForce::Register,
         >,
@@ -4956,44 +5322,46 @@ impl I3c1Peripheral for I3c1Generated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_ec_tti_interrupt_force = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_tti_interrupt_force;
         let mut new_val = current_val;
-        new_val = (new_val & !(0x8000_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x8000_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x400_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x400_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x200_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x200_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x2000 as caliptra_emu_types::RvData))
-            | (write_val & (0x2000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x1000 as caliptra_emu_types::RvData))
-            | (write_val & (0x1000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x800 as caliptra_emu_types::RvData))
-            | (write_val & (0x800 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x400 as caliptra_emu_types::RvData))
-            | (write_val & (0x400 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x200 as caliptra_emu_types::RvData))
-            | (write_val & (0x200 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x100 as caliptra_emu_types::RvData))
-            | (write_val & (0x100 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(8 as caliptra_emu_types::RvData))
-            | (write_val & (8 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(4 as caliptra_emu_types::RvData))
-            | (write_val & (4 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(2 as caliptra_emu_types::RvData))
-            | (write_val & (2 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x8000_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x8000_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x400_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x400_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x200_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x200_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x2000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x2000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x1000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x1000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x800 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x800 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x400 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x400 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x200 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x200 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x100 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x100 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(8 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (8 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(4 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (4 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(2 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_tti_interrupt_force = new_val;
     }
-    fn read_i3c_ec_tti_rx_desc_queue_port(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_tti_rx_desc_queue_port(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_tti_rx_desc_queue_port");
         }
         self.i3c_ec_tti_rx_desc_queue_port
     }
-    fn read_i3c_ec_tti_rx_data_port(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_tti_rx_data_port(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read i3c1::i3c_ec_tti_rx_data_port"
@@ -5001,42 +5369,51 @@ impl I3c1Peripheral for I3c1Generated {
         }
         self.i3c_ec_tti_rx_data_port
     }
-    fn write_i3c_ec_tti_tx_desc_queue_port(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_tti_tx_desc_queue_port(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_ec_tti_tx_desc_queue_port = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_tti_tx_desc_queue_port;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_tti_tx_desc_queue_port = new_val;
     }
-    fn write_i3c_ec_tti_tx_data_port(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_tti_tx_data_port(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_ec_tti_tx_data_port = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_tti_tx_data_port;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_tti_tx_data_port = new_val;
     }
-    fn write_i3c_ec_tti_tti_ibi_port(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_tti_tti_ibi_port(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_ec_tti_tti_ibi_port = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_tti_tti_ibi_port;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_tti_tti_ibi_port = new_val;
     }
     fn read_i3c_ec_tti_tti_queue_size(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::TtiQueueSize::Register,
     > {
@@ -5045,33 +5422,39 @@ impl I3c1Peripheral for I3c1Generated {
                 "[EMU] Generated default register handler: read i3c1::i3c_ec_tti_tti_queue_size"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_tti_tti_queue_size)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_tti_tti_queue_size,
+        )
     }
     fn read_i3c_ec_tti_ibi_tti_queue_size(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::IbiTtiQueueSize::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_tti_ibi_tti_queue_size");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_tti_ibi_tti_queue_size)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_tti_ibi_tti_queue_size,
+        )
     }
     fn read_i3c_ec_tti_tti_queue_thld_ctrl(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::TtiQueueThldCtrl::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_tti_tti_queue_thld_ctrl");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_tti_tti_queue_thld_ctrl)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_tti_tti_queue_thld_ctrl,
+        )
     }
     fn write_i3c_ec_tti_tti_queue_thld_ctrl(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::TtiQueueThldCtrl::Register,
         >,
@@ -5079,31 +5462,33 @@ impl I3c1Peripheral for I3c1Generated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_ec_tti_tti_queue_thld_ctrl = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_tti_tti_queue_thld_ctrl;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xff00_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0xff00_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xff00 as caliptra_emu_types::RvData))
-            | (write_val & (0xff00 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xff as caliptra_emu_types::RvData))
-            | (write_val & (0xff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff00_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff00_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff00 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff00 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_tti_tti_queue_thld_ctrl = new_val;
     }
     fn read_i3c_ec_tti_tti_data_buffer_thld_ctrl(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::TtiDataBufferThldCtrl::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_tti_tti_data_buffer_thld_ctrl");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_tti_tti_data_buffer_thld_ctrl)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_tti_tti_data_buffer_thld_ctrl,
+        )
     }
     fn write_i3c_ec_tti_tti_data_buffer_thld_ctrl(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::TtiDataBufferThldCtrl::Register,
         >,
@@ -5111,78 +5496,92 @@ impl I3c1Peripheral for I3c1Generated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_ec_tti_tti_data_buffer_thld_ctrl = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_tti_tti_data_buffer_thld_ctrl;
         let mut new_val = current_val;
-        new_val = (new_val & !(0x700_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x700_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x7_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x7_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x700 as caliptra_emu_types::RvData))
-            | (write_val & (0x700 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(7 as caliptra_emu_types::RvData))
-            | (write_val & (7 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x700_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x700_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x7_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x7_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x700 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x700 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(7 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (7 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_tti_tti_data_buffer_thld_ctrl = new_val;
     }
     fn read_i3c_ec_soc_mgmt_if_extcap_header(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::ExtcapHeader::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_soc_mgmt_if_extcap_header");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_soc_mgmt_if_extcap_header)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_soc_mgmt_if_extcap_header,
+        )
     }
-    fn read_i3c_ec_soc_mgmt_if_soc_mgmt_control(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_soc_mgmt_if_soc_mgmt_control(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_soc_mgmt_if_soc_mgmt_control");
         }
         self.i3c_ec_soc_mgmt_if_soc_mgmt_control
     }
-    fn write_i3c_ec_soc_mgmt_if_soc_mgmt_control(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_soc_mgmt_if_soc_mgmt_control(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_ec_soc_mgmt_if_soc_mgmt_control = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_soc_mgmt_if_soc_mgmt_control;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_soc_mgmt_if_soc_mgmt_control = new_val;
     }
-    fn read_i3c_ec_soc_mgmt_if_soc_mgmt_status(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_soc_mgmt_if_soc_mgmt_status(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_soc_mgmt_if_soc_mgmt_status");
         }
         self.i3c_ec_soc_mgmt_if_soc_mgmt_status
     }
-    fn write_i3c_ec_soc_mgmt_if_soc_mgmt_status(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_soc_mgmt_if_soc_mgmt_status(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_ec_soc_mgmt_if_soc_mgmt_status = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_soc_mgmt_if_soc_mgmt_status;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_soc_mgmt_if_soc_mgmt_status = new_val;
     }
     fn read_i3c_ec_soc_mgmt_if_rec_intf_cfg(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::RecIntfCfg::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_soc_mgmt_if_rec_intf_cfg");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_soc_mgmt_if_rec_intf_cfg)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_soc_mgmt_if_rec_intf_cfg,
+        )
     }
     fn write_i3c_ec_soc_mgmt_if_rec_intf_cfg(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::RecIntfCfg::Register,
         >,
@@ -5190,29 +5589,31 @@ impl I3c1Peripheral for I3c1Generated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_ec_soc_mgmt_if_rec_intf_cfg = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_soc_mgmt_if_rec_intf_cfg;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(2 as caliptra_emu_types::RvData))
-            | (write_val & (2 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(2 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_soc_mgmt_if_rec_intf_cfg = new_val;
     }
     fn read_i3c_ec_soc_mgmt_if_rec_intf_reg_w1_c_access(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::RecIntfRegW1cAccess::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_soc_mgmt_if_rec_intf_reg_w1_c_access");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_soc_mgmt_if_rec_intf_reg_w1_c_access)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_soc_mgmt_if_rec_intf_reg_w1_c_access,
+        )
     }
     fn write_i3c_ec_soc_mgmt_if_rec_intf_reg_w1_c_access(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::RecIntfRegW1cAccess::Register,
         >,
@@ -5220,65 +5621,77 @@ impl I3c1Peripheral for I3c1Generated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_ec_soc_mgmt_if_rec_intf_reg_w1_c_access = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_soc_mgmt_if_rec_intf_reg_w1_c_access;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xff as caliptra_emu_types::RvData))
-            | (write_val & (0xff as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xff00 as caliptra_emu_types::RvData))
-            | (write_val & (0xff00 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xff_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0xff_0000 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff00 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff00 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_soc_mgmt_if_rec_intf_reg_w1_c_access = new_val;
     }
-    fn read_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_2(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_2(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_2");
         }
         self.i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_2
     }
-    fn write_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_2(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_2(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_2 = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_2;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_2 = new_val;
     }
-    fn read_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_3(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_3(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_3");
         }
         self.i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_3
     }
-    fn write_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_3(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_3(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_3 = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_3;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_3 = new_val;
     }
     fn read_i3c_ec_soc_mgmt_if_soc_pad_conf(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::SocPadConf::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_soc_mgmt_if_soc_pad_conf");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_soc_mgmt_if_soc_pad_conf)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_soc_mgmt_if_soc_pad_conf,
+        )
     }
     fn write_i3c_ec_soc_mgmt_if_soc_pad_conf(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::SocPadConf::Register,
         >,
@@ -5286,43 +5699,45 @@ impl I3c1Peripheral for I3c1Generated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_ec_soc_mgmt_if_soc_pad_conf = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_soc_mgmt_if_soc_pad_conf;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xff00_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0xff00_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x80 as caliptra_emu_types::RvData))
-            | (write_val & (0x80 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x40 as caliptra_emu_types::RvData))
-            | (write_val & (0x40 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x20 as caliptra_emu_types::RvData))
-            | (write_val & (0x20 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x10 as caliptra_emu_types::RvData))
-            | (write_val & (0x10 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(8 as caliptra_emu_types::RvData))
-            | (write_val & (8 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(4 as caliptra_emu_types::RvData))
-            | (write_val & (4 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(2 as caliptra_emu_types::RvData))
-            | (write_val & (2 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff00_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff00_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x80 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x80 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x40 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x40 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x20 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x20 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x10 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x10 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(8 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (8 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(4 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (4 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(2 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_soc_mgmt_if_soc_pad_conf = new_val;
     }
     fn read_i3c_ec_soc_mgmt_if_soc_pad_attr(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::SocPadAttr::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_soc_mgmt_if_soc_pad_attr");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_soc_mgmt_if_soc_pad_attr)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_soc_mgmt_if_soc_pad_attr,
+        )
     }
     fn write_i3c_ec_soc_mgmt_if_soc_pad_attr(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::SocPadAttr::Register,
         >,
@@ -5330,63 +5745,77 @@ impl I3c1Peripheral for I3c1Generated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_ec_soc_mgmt_if_soc_pad_attr = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_soc_mgmt_if_soc_pad_attr;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xff00_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0xff00_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xff00 as caliptra_emu_types::RvData))
-            | (write_val & (0xff00 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff00_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff00_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff00 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff00 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_soc_mgmt_if_soc_pad_attr = new_val;
     }
-    fn read_i3c_ec_soc_mgmt_if_soc_mgmt_feature_2(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_soc_mgmt_if_soc_mgmt_feature_2(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_soc_mgmt_if_soc_mgmt_feature_2");
         }
         self.i3c_ec_soc_mgmt_if_soc_mgmt_feature_2
     }
-    fn write_i3c_ec_soc_mgmt_if_soc_mgmt_feature_2(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_soc_mgmt_if_soc_mgmt_feature_2(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_ec_soc_mgmt_if_soc_mgmt_feature_2 = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_soc_mgmt_if_soc_mgmt_feature_2;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_soc_mgmt_if_soc_mgmt_feature_2 = new_val;
     }
-    fn read_i3c_ec_soc_mgmt_if_soc_mgmt_feature_3(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_soc_mgmt_if_soc_mgmt_feature_3(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_soc_mgmt_if_soc_mgmt_feature_3");
         }
         self.i3c_ec_soc_mgmt_if_soc_mgmt_feature_3
     }
-    fn write_i3c_ec_soc_mgmt_if_soc_mgmt_feature_3(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_soc_mgmt_if_soc_mgmt_feature_3(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_ec_soc_mgmt_if_soc_mgmt_feature_3 = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_soc_mgmt_if_soc_mgmt_feature_3;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_soc_mgmt_if_soc_mgmt_feature_3 = new_val;
     }
     fn read_i3c_ec_soc_mgmt_if_t_r_reg(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::TRReg::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::TRReg::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read i3c1::i3c_ec_soc_mgmt_if_t_r_reg"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_soc_mgmt_if_t_r_reg)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_soc_mgmt_if_t_r_reg,
+        )
     }
     fn write_i3c_ec_soc_mgmt_if_t_r_reg(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::TRReg::Register,
         >,
@@ -5394,27 +5823,31 @@ impl I3c1Peripheral for I3c1Generated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_ec_soc_mgmt_if_t_r_reg = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_soc_mgmt_if_t_r_reg;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xf_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xf_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xf_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xf_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_soc_mgmt_if_t_r_reg = new_val;
     }
     fn read_i3c_ec_soc_mgmt_if_t_f_reg(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::TFReg::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::TFReg::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read i3c1::i3c_ec_soc_mgmt_if_t_f_reg"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_soc_mgmt_if_t_f_reg)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_soc_mgmt_if_t_f_reg,
+        )
     }
     fn write_i3c_ec_soc_mgmt_if_t_f_reg(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::TFReg::Register,
         >,
@@ -5422,25 +5855,29 @@ impl I3c1Peripheral for I3c1Generated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_ec_soc_mgmt_if_t_f_reg = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_soc_mgmt_if_t_f_reg;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xf_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xf_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xf_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xf_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_soc_mgmt_if_t_f_reg = new_val;
     }
     fn read_i3c_ec_soc_mgmt_if_t_su_dat_reg(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::TSuDatReg::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::TSuDatReg::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_soc_mgmt_if_t_su_dat_reg");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_soc_mgmt_if_t_su_dat_reg)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_soc_mgmt_if_t_su_dat_reg,
+        )
     }
     fn write_i3c_ec_soc_mgmt_if_t_su_dat_reg(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::TSuDatReg::Register,
         >,
@@ -5448,25 +5885,29 @@ impl I3c1Peripheral for I3c1Generated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_ec_soc_mgmt_if_t_su_dat_reg = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_soc_mgmt_if_t_su_dat_reg;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xf_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xf_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xf_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xf_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_soc_mgmt_if_t_su_dat_reg = new_val;
     }
     fn read_i3c_ec_soc_mgmt_if_t_hd_dat_reg(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::THdDatReg::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::THdDatReg::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_soc_mgmt_if_t_hd_dat_reg");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_soc_mgmt_if_t_hd_dat_reg)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_soc_mgmt_if_t_hd_dat_reg,
+        )
     }
     fn write_i3c_ec_soc_mgmt_if_t_hd_dat_reg(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::THdDatReg::Register,
         >,
@@ -5474,25 +5915,29 @@ impl I3c1Peripheral for I3c1Generated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_ec_soc_mgmt_if_t_hd_dat_reg = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_soc_mgmt_if_t_hd_dat_reg;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xf_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xf_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xf_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xf_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_soc_mgmt_if_t_hd_dat_reg = new_val;
     }
     fn read_i3c_ec_soc_mgmt_if_t_high_reg(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::THighReg::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::THighReg::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_soc_mgmt_if_t_high_reg");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_soc_mgmt_if_t_high_reg)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_soc_mgmt_if_t_high_reg,
+        )
     }
     fn write_i3c_ec_soc_mgmt_if_t_high_reg(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::THighReg::Register,
         >,
@@ -5500,27 +5945,31 @@ impl I3c1Peripheral for I3c1Generated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_ec_soc_mgmt_if_t_high_reg = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_soc_mgmt_if_t_high_reg;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xf_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xf_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xf_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xf_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_soc_mgmt_if_t_high_reg = new_val;
     }
     fn read_i3c_ec_soc_mgmt_if_t_low_reg(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::TLowReg::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::TLowReg::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read i3c1::i3c_ec_soc_mgmt_if_t_low_reg"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_soc_mgmt_if_t_low_reg)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_soc_mgmt_if_t_low_reg,
+        )
     }
     fn write_i3c_ec_soc_mgmt_if_t_low_reg(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::TLowReg::Register,
         >,
@@ -5528,25 +5977,29 @@ impl I3c1Peripheral for I3c1Generated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_ec_soc_mgmt_if_t_low_reg = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_soc_mgmt_if_t_low_reg;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xf_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xf_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xf_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xf_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_soc_mgmt_if_t_low_reg = new_val;
     }
     fn read_i3c_ec_soc_mgmt_if_t_hd_sta_reg(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::THdStaReg::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::THdStaReg::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_soc_mgmt_if_t_hd_sta_reg");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_soc_mgmt_if_t_hd_sta_reg)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_soc_mgmt_if_t_hd_sta_reg,
+        )
     }
     fn write_i3c_ec_soc_mgmt_if_t_hd_sta_reg(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::THdStaReg::Register,
         >,
@@ -5554,25 +6007,29 @@ impl I3c1Peripheral for I3c1Generated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_ec_soc_mgmt_if_t_hd_sta_reg = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_soc_mgmt_if_t_hd_sta_reg;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xf_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xf_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xf_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xf_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_soc_mgmt_if_t_hd_sta_reg = new_val;
     }
     fn read_i3c_ec_soc_mgmt_if_t_su_sta_reg(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::TSuStaReg::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::TSuStaReg::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_soc_mgmt_if_t_su_sta_reg");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_soc_mgmt_if_t_su_sta_reg)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_soc_mgmt_if_t_su_sta_reg,
+        )
     }
     fn write_i3c_ec_soc_mgmt_if_t_su_sta_reg(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::TSuStaReg::Register,
         >,
@@ -5580,25 +6037,29 @@ impl I3c1Peripheral for I3c1Generated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_ec_soc_mgmt_if_t_su_sta_reg = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_soc_mgmt_if_t_su_sta_reg;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xf_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xf_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xf_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xf_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_soc_mgmt_if_t_su_sta_reg = new_val;
     }
     fn read_i3c_ec_soc_mgmt_if_t_su_sto_reg(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::i3c::bits::TSuStoReg::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::i3c::bits::TSuStoReg::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_soc_mgmt_if_t_su_sto_reg");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_soc_mgmt_if_t_su_sto_reg)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_soc_mgmt_if_t_su_sto_reg,
+        )
     }
     fn write_i3c_ec_soc_mgmt_if_t_su_sto_reg(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::i3c::bits::TSuStoReg::Register,
         >,
@@ -5606,203 +6067,225 @@ impl I3c1Peripheral for I3c1Generated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_ec_soc_mgmt_if_t_su_sto_reg = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_soc_mgmt_if_t_su_sto_reg;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xf_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xf_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xf_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xf_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_soc_mgmt_if_t_su_sto_reg = new_val;
     }
-    fn read_i3c_ec_soc_mgmt_if_t_free_reg(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_soc_mgmt_if_t_free_reg(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_soc_mgmt_if_t_free_reg");
         }
         self.i3c_ec_soc_mgmt_if_t_free_reg
     }
-    fn write_i3c_ec_soc_mgmt_if_t_free_reg(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_soc_mgmt_if_t_free_reg(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_ec_soc_mgmt_if_t_free_reg = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_soc_mgmt_if_t_free_reg;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_soc_mgmt_if_t_free_reg = new_val;
     }
-    fn read_i3c_ec_soc_mgmt_if_t_aval_reg(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_soc_mgmt_if_t_aval_reg(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_soc_mgmt_if_t_aval_reg");
         }
         self.i3c_ec_soc_mgmt_if_t_aval_reg
     }
-    fn write_i3c_ec_soc_mgmt_if_t_aval_reg(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_soc_mgmt_if_t_aval_reg(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_ec_soc_mgmt_if_t_aval_reg = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_soc_mgmt_if_t_aval_reg;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_soc_mgmt_if_t_aval_reg = new_val;
     }
-    fn read_i3c_ec_soc_mgmt_if_t_idle_reg(&mut self) -> caliptra_emu_types::RvData {
+    fn read_i3c_ec_soc_mgmt_if_t_idle_reg(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_soc_mgmt_if_t_idle_reg");
         }
         self.i3c_ec_soc_mgmt_if_t_idle_reg
     }
-    fn write_i3c_ec_soc_mgmt_if_t_idle_reg(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_i3c_ec_soc_mgmt_if_t_idle_reg(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write i3c1::i3c_ec_soc_mgmt_if_t_idle_reg = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.i3c_ec_soc_mgmt_if_t_idle_reg;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.i3c_ec_soc_mgmt_if_t_idle_reg = new_val;
     }
     fn read_i3c_ec_ctrl_cfg_extcap_header(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::ExtcapHeader::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_ctrl_cfg_extcap_header");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_ctrl_cfg_extcap_header)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_ctrl_cfg_extcap_header,
+        )
     }
     fn read_i3c_ec_ctrl_cfg_controller_config(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::i3c::bits::ControllerConfig::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read i3c1::i3c_ec_ctrl_cfg_controller_config");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.i3c_ec_ctrl_cfg_controller_config)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.i3c_ec_ctrl_cfg_controller_config,
+        )
     }
 }
 pub struct I3c1Bus {
     pub periph: Box<dyn I3c1Peripheral>,
 }
-impl caliptra_emu_bus::Bus for I3c1Bus {
+impl caliptra_core_tools::caliptra_emu_bus::Bus for I3c1Bus {
     fn read(
         &mut self,
-        size: caliptra_emu_types::RvSize,
-        addr: caliptra_emu_types::RvAddr,
-    ) -> Result<caliptra_emu_types::RvData, caliptra_emu_bus::BusError> {
-        if addr & 0x3 != 0 || size != caliptra_emu_types::RvSize::Word {
-            return Err(caliptra_emu_bus::BusError::LoadAddrMisaligned);
+        size: caliptra_core_tools::caliptra_emu_types::RvSize,
+        addr: caliptra_core_tools::caliptra_emu_types::RvAddr,
+    ) -> Result<
+        caliptra_core_tools::caliptra_emu_types::RvData,
+        caliptra_core_tools::caliptra_emu_bus::BusError,
+    > {
+        if addr & 0x3 != 0 || size != caliptra_core_tools::caliptra_emu_types::RvSize::Word {
+            return Err(caliptra_core_tools::caliptra_emu_bus::BusError::LoadAddrMisaligned);
         }
         match addr {
             0x400..0x800 => Ok(self.periph.read_dat((addr as usize - 0x400) / 4)),
             0x800..0x1000 => Ok(self.periph.read_dct((addr as usize - 0x800) / 4)),
             0..4 => Ok(self.periph.read_i3c_base_hci_version()),
-            4..8 => Ok(caliptra_emu_types::RvData::from(
+            4..8 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_base_hc_control().reg.get(),
             )),
-            8..0xc => Ok(caliptra_emu_types::RvData::from(
+            8..0xc => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_base_controller_device_addr().reg.get(),
             )),
-            0xc..0x10 => Ok(caliptra_emu_types::RvData::from(
+            0xc..0x10 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_base_hc_capabilities().reg.get(),
             )),
-            0x10..0x14 => Ok(caliptra_emu_types::RvData::from(
+            0x10..0x14 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_base_reset_control().reg.get(),
             )),
-            0x14..0x18 => Ok(caliptra_emu_types::RvData::from(
+            0x14..0x18 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_base_present_state().reg.get(),
             )),
-            0x20..0x24 => Ok(caliptra_emu_types::RvData::from(
+            0x20..0x24 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_base_intr_status().reg.get(),
             )),
-            0x24..0x28 => Ok(caliptra_emu_types::RvData::from(
+            0x24..0x28 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_base_intr_status_enable().reg.get(),
             )),
-            0x28..0x2c => Ok(caliptra_emu_types::RvData::from(
+            0x28..0x2c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_base_intr_signal_enable().reg.get(),
             )),
-            0x30..0x34 => Ok(caliptra_emu_types::RvData::from(
+            0x30..0x34 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_base_dat_section_offset().reg.get(),
             )),
-            0x34..0x38 => Ok(caliptra_emu_types::RvData::from(
+            0x34..0x38 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_base_dct_section_offset().reg.get(),
             )),
-            0x38..0x3c => Ok(caliptra_emu_types::RvData::from(
+            0x38..0x3c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_i3c_base_ring_headers_section_offset()
                     .reg
                     .get(),
             )),
-            0x3c..0x40 => Ok(caliptra_emu_types::RvData::from(
+            0x3c..0x40 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_base_pio_section_offset().reg.get(),
             )),
-            0x40..0x44 => Ok(caliptra_emu_types::RvData::from(
+            0x40..0x44 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_i3c_base_ext_caps_section_offset()
                     .reg
                     .get(),
             )),
-            0x4c..0x50 => Ok(caliptra_emu_types::RvData::from(
+            0x4c..0x50 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_base_int_ctrl_cmds_en().reg.get(),
             )),
-            0x58..0x5c => Ok(caliptra_emu_types::RvData::from(
+            0x58..0x5c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_base_ibi_notify_ctrl().reg.get(),
             )),
-            0x5c..0x60 => Ok(caliptra_emu_types::RvData::from(
+            0x5c..0x60 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_base_ibi_data_abort_ctrl().reg.get(),
             )),
-            0x60..0x64 => Ok(caliptra_emu_types::RvData::from(
+            0x60..0x64 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_base_dev_ctx_base_lo().reg.get(),
             )),
-            0x64..0x68 => Ok(caliptra_emu_types::RvData::from(
+            0x64..0x68 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_base_dev_ctx_base_hi().reg.get(),
             )),
-            0x68..0x6c => Ok(caliptra_emu_types::RvData::from(
+            0x68..0x6c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_base_dev_ctx_sg().reg.get(),
             )),
             0x84..0x88 => Ok(self.periph.read_piocontrol_response_port()),
             0x88..0x8c => Ok(self.periph.read_piocontrol_rx_data_port()),
             0x8c..0x90 => Ok(self.periph.read_piocontrol_ibi_port()),
-            0x90..0x94 => Ok(caliptra_emu_types::RvData::from(
+            0x90..0x94 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_piocontrol_queue_thld_ctrl().reg.get(),
             )),
-            0x94..0x98 => Ok(caliptra_emu_types::RvData::from(
+            0x94..0x98 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_piocontrol_data_buffer_thld_ctrl()
                     .reg
                     .get(),
             )),
-            0x98..0x9c => Ok(caliptra_emu_types::RvData::from(
+            0x98..0x9c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_piocontrol_queue_size().reg.get(),
             )),
-            0x9c..0xa0 => Ok(caliptra_emu_types::RvData::from(
+            0x9c..0xa0 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_piocontrol_alt_queue_size().reg.get(),
             )),
-            0xa0..0xa4 => Ok(caliptra_emu_types::RvData::from(
+            0xa0..0xa4 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_piocontrol_pio_intr_status().reg.get(),
             )),
-            0xa4..0xa8 => Ok(caliptra_emu_types::RvData::from(
+            0xa4..0xa8 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_piocontrol_pio_intr_status_enable()
                     .reg
                     .get(),
             )),
-            0xa8..0xac => Ok(caliptra_emu_types::RvData::from(
+            0xa8..0xac => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_piocontrol_pio_intr_signal_enable()
                     .reg
                     .get(),
             )),
-            0xb0..0xb4 => Ok(caliptra_emu_types::RvData::from(
+            0xb0..0xb4 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_piocontrol_pio_control().reg.get(),
             )),
-            0x100..0x104 => Ok(caliptra_emu_types::RvData::from(
+            0x100..0x104 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_i3c_ec_sec_fw_recovery_if_extcap_header()
                     .reg
@@ -5810,19 +6293,19 @@ impl caliptra_emu_bus::Bus for I3c1Bus {
             )),
             0x104..0x108 => Ok(self.periph.read_i3c_ec_sec_fw_recovery_if_prot_cap_0()),
             0x108..0x10c => Ok(self.periph.read_i3c_ec_sec_fw_recovery_if_prot_cap_1()),
-            0x10c..0x110 => Ok(caliptra_emu_types::RvData::from(
+            0x10c..0x110 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_i3c_ec_sec_fw_recovery_if_prot_cap_2()
                     .reg
                     .get(),
             )),
-            0x110..0x114 => Ok(caliptra_emu_types::RvData::from(
+            0x110..0x114 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_i3c_ec_sec_fw_recovery_if_prot_cap_3()
                     .reg
                     .get(),
             )),
-            0x114..0x118 => Ok(caliptra_emu_types::RvData::from(
+            0x114..0x118 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_i3c_ec_sec_fw_recovery_if_device_id_0()
                     .reg
@@ -5836,43 +6319,43 @@ impl caliptra_emu_bus::Bus for I3c1Bus {
             0x12c..0x130 => Ok(self
                 .periph
                 .read_i3c_ec_sec_fw_recovery_if_device_id_reserved()),
-            0x130..0x134 => Ok(caliptra_emu_types::RvData::from(
+            0x130..0x134 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_i3c_ec_sec_fw_recovery_if_device_status_0()
                     .reg
                     .get(),
             )),
-            0x134..0x138 => Ok(caliptra_emu_types::RvData::from(
+            0x134..0x138 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_i3c_ec_sec_fw_recovery_if_device_status_1()
                     .reg
                     .get(),
             )),
-            0x138..0x13c => Ok(caliptra_emu_types::RvData::from(
+            0x138..0x13c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_i3c_ec_sec_fw_recovery_if_device_reset()
                     .reg
                     .get(),
             )),
-            0x13c..0x140 => Ok(caliptra_emu_types::RvData::from(
+            0x13c..0x140 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_i3c_ec_sec_fw_recovery_if_recovery_ctrl()
                     .reg
                     .get(),
             )),
-            0x140..0x144 => Ok(caliptra_emu_types::RvData::from(
+            0x140..0x144 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_i3c_ec_sec_fw_recovery_if_recovery_status()
                     .reg
                     .get(),
             )),
-            0x144..0x148 => Ok(caliptra_emu_types::RvData::from(
+            0x144..0x148 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_i3c_ec_sec_fw_recovery_if_hw_status()
                     .reg
                     .get(),
             )),
-            0x148..0x14c => Ok(caliptra_emu_types::RvData::from(
+            0x148..0x14c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_0()
                     .reg
@@ -5881,7 +6364,7 @@ impl caliptra_emu_bus::Bus for I3c1Bus {
             0x14c..0x150 => Ok(self
                 .periph
                 .read_i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_1()),
-            0x150..0x154 => Ok(caliptra_emu_types::RvData::from(
+            0x150..0x154 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_i3c_ec_sec_fw_recovery_if_indirect_fifo_status_0()
                     .reg
@@ -5905,43 +6388,43 @@ impl caliptra_emu_bus::Bus for I3c1Bus {
             0x168..0x16c => Ok(self
                 .periph
                 .read_i3c_ec_sec_fw_recovery_if_indirect_fifo_data()),
-            0x180..0x184 => Ok(caliptra_emu_types::RvData::from(
+            0x180..0x184 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_i3c_ec_stdby_ctrl_mode_extcap_header()
                     .reg
                     .get(),
             )),
-            0x184..0x188 => Ok(caliptra_emu_types::RvData::from(
+            0x184..0x188 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_i3c_ec_stdby_ctrl_mode_stby_cr_control()
                     .reg
                     .get(),
             )),
-            0x188..0x18c => Ok(caliptra_emu_types::RvData::from(
+            0x188..0x18c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_i3c_ec_stdby_ctrl_mode_stby_cr_device_addr()
                     .reg
                     .get(),
             )),
-            0x18c..0x190 => Ok(caliptra_emu_types::RvData::from(
+            0x18c..0x190 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_i3c_ec_stdby_ctrl_mode_stby_cr_capabilities()
                     .reg
                     .get(),
             )),
-            0x190..0x194 => Ok(caliptra_emu_types::RvData::from(
+            0x190..0x194 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_i3c_ec_stdby_ctrl_mode_stby_cr_virtual_device_char()
                     .reg
                     .get(),
             )),
-            0x194..0x198 => Ok(caliptra_emu_types::RvData::from(
+            0x194..0x198 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_i3c_ec_stdby_ctrl_mode_stby_cr_status()
                     .reg
                     .get(),
             )),
-            0x198..0x19c => Ok(caliptra_emu_types::RvData::from(
+            0x198..0x19c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_i3c_ec_stdby_ctrl_mode_stby_cr_device_char()
                     .reg
@@ -5950,7 +6433,7 @@ impl caliptra_emu_bus::Bus for I3c1Bus {
             0x19c..0x1a0 => Ok(self
                 .periph
                 .read_i3c_ec_stdby_ctrl_mode_stby_cr_device_pid_lo()),
-            0x1a0..0x1a4 => Ok(caliptra_emu_types::RvData::from(
+            0x1a0..0x1a4 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_i3c_ec_stdby_ctrl_mode_stby_cr_intr_status()
                     .reg
@@ -5959,76 +6442,76 @@ impl caliptra_emu_bus::Bus for I3c1Bus {
             0x1a4..0x1a8 => Ok(self
                 .periph
                 .read_i3c_ec_stdby_ctrl_mode_stby_cr_virtual_device_pid_lo()),
-            0x1a8..0x1ac => Ok(caliptra_emu_types::RvData::from(
+            0x1a8..0x1ac => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_i3c_ec_stdby_ctrl_mode_stby_cr_intr_signal_enable()
                     .reg
                     .get(),
             )),
-            0x1ac..0x1b0 => Ok(caliptra_emu_types::RvData::from(
+            0x1ac..0x1b0 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_i3c_ec_stdby_ctrl_mode_stby_cr_intr_force()
                     .reg
                     .get(),
             )),
-            0x1b0..0x1b4 => Ok(caliptra_emu_types::RvData::from(
+            0x1b0..0x1b4 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_getcaps()
                     .reg
                     .get(),
             )),
-            0x1b4..0x1b8 => Ok(caliptra_emu_types::RvData::from(
+            0x1b4..0x1b8 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_rstact_params()
                     .reg
                     .get(),
             )),
-            0x1b8..0x1bc => Ok(caliptra_emu_types::RvData::from(
+            0x1b8..0x1bc => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_i3c_ec_stdby_ctrl_mode_stby_cr_virt_device_addr()
                     .reg
                     .get(),
             )),
             0x1bc..0x1c0 => Ok(self.periph.read_i3c_ec_stdby_ctrl_mode_rsvd_3()),
-            0x1c0..0x1c4 => Ok(caliptra_emu_types::RvData::from(
+            0x1c0..0x1c4 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_ec_tti_extcap_header().reg.get(),
             )),
-            0x1c4..0x1c8 => Ok(caliptra_emu_types::RvData::from(
+            0x1c4..0x1c8 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_ec_tti_control().reg.get(),
             )),
-            0x1c8..0x1cc => Ok(caliptra_emu_types::RvData::from(
+            0x1c8..0x1cc => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_ec_tti_status().reg.get(),
             )),
-            0x1cc..0x1d0 => Ok(caliptra_emu_types::RvData::from(
+            0x1cc..0x1d0 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_ec_tti_tti_reset_control().reg.get(),
             )),
-            0x1d0..0x1d4 => Ok(caliptra_emu_types::RvData::from(
+            0x1d0..0x1d4 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_ec_tti_interrupt_status().reg.get(),
             )),
-            0x1d4..0x1d8 => Ok(caliptra_emu_types::RvData::from(
+            0x1d4..0x1d8 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_ec_tti_interrupt_enable().reg.get(),
             )),
-            0x1d8..0x1dc => Ok(caliptra_emu_types::RvData::from(
+            0x1d8..0x1dc => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_ec_tti_interrupt_force().reg.get(),
             )),
             0x1dc..0x1e0 => Ok(self.periph.read_i3c_ec_tti_rx_desc_queue_port()),
             0x1e0..0x1e4 => Ok(self.periph.read_i3c_ec_tti_rx_data_port()),
-            0x1f0..0x1f4 => Ok(caliptra_emu_types::RvData::from(
+            0x1f0..0x1f4 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_ec_tti_tti_queue_size().reg.get(),
             )),
-            0x1f4..0x1f8 => Ok(caliptra_emu_types::RvData::from(
+            0x1f4..0x1f8 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_ec_tti_ibi_tti_queue_size().reg.get(),
             )),
-            0x1f8..0x1fc => Ok(caliptra_emu_types::RvData::from(
+            0x1f8..0x1fc => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_ec_tti_tti_queue_thld_ctrl().reg.get(),
             )),
-            0x1fc..0x200 => Ok(caliptra_emu_types::RvData::from(
+            0x1fc..0x200 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_i3c_ec_tti_tti_data_buffer_thld_ctrl()
                     .reg
                     .get(),
             )),
-            0x200..0x204 => Ok(caliptra_emu_types::RvData::from(
+            0x200..0x204 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_i3c_ec_soc_mgmt_if_extcap_header()
                     .reg
@@ -6036,10 +6519,10 @@ impl caliptra_emu_bus::Bus for I3c1Bus {
             )),
             0x204..0x208 => Ok(self.periph.read_i3c_ec_soc_mgmt_if_soc_mgmt_control()),
             0x208..0x20c => Ok(self.periph.read_i3c_ec_soc_mgmt_if_soc_mgmt_status()),
-            0x20c..0x210 => Ok(caliptra_emu_types::RvData::from(
+            0x20c..0x210 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_ec_soc_mgmt_if_rec_intf_cfg().reg.get(),
             )),
-            0x210..0x214 => Ok(caliptra_emu_types::RvData::from(
+            0x210..0x214 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_i3c_ec_soc_mgmt_if_rec_intf_reg_w1_c_access()
                     .reg
@@ -6047,64 +6530,64 @@ impl caliptra_emu_bus::Bus for I3c1Bus {
             )),
             0x214..0x218 => Ok(self.periph.read_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_2()),
             0x218..0x21c => Ok(self.periph.read_i3c_ec_soc_mgmt_if_soc_mgmt_rsvd_3()),
-            0x21c..0x220 => Ok(caliptra_emu_types::RvData::from(
+            0x21c..0x220 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_ec_soc_mgmt_if_soc_pad_conf().reg.get(),
             )),
-            0x220..0x224 => Ok(caliptra_emu_types::RvData::from(
+            0x220..0x224 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_ec_soc_mgmt_if_soc_pad_attr().reg.get(),
             )),
             0x224..0x228 => Ok(self.periph.read_i3c_ec_soc_mgmt_if_soc_mgmt_feature_2()),
             0x228..0x22c => Ok(self.periph.read_i3c_ec_soc_mgmt_if_soc_mgmt_feature_3()),
-            0x22c..0x230 => Ok(caliptra_emu_types::RvData::from(
+            0x22c..0x230 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_ec_soc_mgmt_if_t_r_reg().reg.get(),
             )),
-            0x230..0x234 => Ok(caliptra_emu_types::RvData::from(
+            0x230..0x234 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_ec_soc_mgmt_if_t_f_reg().reg.get(),
             )),
-            0x234..0x238 => Ok(caliptra_emu_types::RvData::from(
+            0x234..0x238 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_ec_soc_mgmt_if_t_su_dat_reg().reg.get(),
             )),
-            0x238..0x23c => Ok(caliptra_emu_types::RvData::from(
+            0x238..0x23c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_ec_soc_mgmt_if_t_hd_dat_reg().reg.get(),
             )),
-            0x23c..0x240 => Ok(caliptra_emu_types::RvData::from(
+            0x23c..0x240 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_ec_soc_mgmt_if_t_high_reg().reg.get(),
             )),
-            0x240..0x244 => Ok(caliptra_emu_types::RvData::from(
+            0x240..0x244 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_ec_soc_mgmt_if_t_low_reg().reg.get(),
             )),
-            0x244..0x248 => Ok(caliptra_emu_types::RvData::from(
+            0x244..0x248 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_ec_soc_mgmt_if_t_hd_sta_reg().reg.get(),
             )),
-            0x248..0x24c => Ok(caliptra_emu_types::RvData::from(
+            0x248..0x24c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_ec_soc_mgmt_if_t_su_sta_reg().reg.get(),
             )),
-            0x24c..0x250 => Ok(caliptra_emu_types::RvData::from(
+            0x24c..0x250 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_ec_soc_mgmt_if_t_su_sto_reg().reg.get(),
             )),
             0x250..0x254 => Ok(self.periph.read_i3c_ec_soc_mgmt_if_t_free_reg()),
             0x254..0x258 => Ok(self.periph.read_i3c_ec_soc_mgmt_if_t_aval_reg()),
             0x258..0x25c => Ok(self.periph.read_i3c_ec_soc_mgmt_if_t_idle_reg()),
-            0x260..0x264 => Ok(caliptra_emu_types::RvData::from(
+            0x260..0x264 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_i3c_ec_ctrl_cfg_extcap_header().reg.get(),
             )),
-            0x264..0x268 => Ok(caliptra_emu_types::RvData::from(
+            0x264..0x268 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_i3c_ec_ctrl_cfg_controller_config()
                     .reg
                     .get(),
             )),
-            _ => Err(caliptra_emu_bus::BusError::LoadAccessFault),
+            _ => Err(caliptra_core_tools::caliptra_emu_bus::BusError::LoadAccessFault),
         }
     }
     fn write(
         &mut self,
-        size: caliptra_emu_types::RvSize,
-        addr: caliptra_emu_types::RvAddr,
-        val: caliptra_emu_types::RvData,
-    ) -> Result<(), caliptra_emu_bus::BusError> {
-        if addr & 0x3 != 0 || size != caliptra_emu_types::RvSize::Word {
-            return Err(caliptra_emu_bus::BusError::StoreAddrMisaligned);
+        size: caliptra_core_tools::caliptra_emu_types::RvSize,
+        addr: caliptra_core_tools::caliptra_emu_types::RvAddr,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) -> Result<(), caliptra_core_tools::caliptra_emu_bus::BusError> {
+        if addr & 0x3 != 0 || size != caliptra_core_tools::caliptra_emu_types::RvSize::Word {
+            return Err(caliptra_core_tools::caliptra_emu_bus::BusError::StoreAddrMisaligned);
         }
         match addr {
             0x400..0x800 => {
@@ -6117,49 +6600,53 @@ impl caliptra_emu_bus::Bus for I3c1Bus {
             }
             0..4 => Ok(()),
             4..8 => {
-                self.periph
-                    .write_i3c_base_hc_control(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_i3c_base_hc_control(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             8..0xc => {
                 self.periph.write_i3c_base_controller_device_addr(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0xc..0x10 => Ok(()),
             0x10..0x14 => {
-                self.periph
-                    .write_i3c_base_reset_control(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_i3c_base_reset_control(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0x14..0x18 => Ok(()),
             0x20..0x24 => {
-                self.periph
-                    .write_i3c_base_intr_status(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_i3c_base_intr_status(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0x24..0x28 => {
                 self.periph.write_i3c_base_intr_status_enable(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x28..0x2c => {
                 self.periph.write_i3c_base_intr_signal_enable(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x2c..0x30 => {
-                self.periph
-                    .write_i3c_base_intr_force(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_i3c_base_intr_force(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0x30..0x34 => Ok(()),
             0x34..0x38 => {
                 self.periph.write_i3c_base_dct_section_offset(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
@@ -6168,24 +6655,27 @@ impl caliptra_emu_bus::Bus for I3c1Bus {
             0x40..0x44 => Ok(()),
             0x4c..0x50 => Ok(()),
             0x58..0x5c => {
-                self.periph
-                    .write_i3c_base_ibi_notify_ctrl(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_i3c_base_ibi_notify_ctrl(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0x5c..0x60 => {
                 self.periph.write_i3c_base_ibi_data_abort_ctrl(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x60..0x64 => {
-                self.periph
-                    .write_i3c_base_dev_ctx_base_lo(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_i3c_base_dev_ctx_base_lo(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0x64..0x68 => {
-                self.periph
-                    .write_i3c_base_dev_ctx_base_hi(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_i3c_base_dev_ctx_base_hi(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0x68..0x6c => Ok(()),
@@ -6201,13 +6691,13 @@ impl caliptra_emu_bus::Bus for I3c1Bus {
             0x8c..0x90 => Ok(()),
             0x90..0x94 => {
                 self.periph.write_piocontrol_queue_thld_ctrl(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x94..0x98 => {
                 self.periph.write_piocontrol_data_buffer_thld_ctrl(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
@@ -6215,30 +6705,32 @@ impl caliptra_emu_bus::Bus for I3c1Bus {
             0x9c..0xa0 => Ok(()),
             0xa0..0xa4 => {
                 self.periph.write_piocontrol_pio_intr_status(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0xa4..0xa8 => {
                 self.periph.write_piocontrol_pio_intr_status_enable(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0xa8..0xac => {
                 self.periph.write_piocontrol_pio_intr_signal_enable(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0xac..0xb0 => {
-                self.periph
-                    .write_piocontrol_pio_intr_force(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_piocontrol_pio_intr_force(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0xb0..0xb4 => {
-                self.periph
-                    .write_piocontrol_pio_control(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_piocontrol_pio_control(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0x100..0x104 => Ok(()),
@@ -6246,19 +6738,19 @@ impl caliptra_emu_bus::Bus for I3c1Bus {
             0x108..0x10c => Ok(()),
             0x10c..0x110 => {
                 self.periph.write_i3c_ec_sec_fw_recovery_if_prot_cap_2(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x110..0x114 => {
                 self.periph.write_i3c_ec_sec_fw_recovery_if_prot_cap_3(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x114..0x118 => {
                 self.periph.write_i3c_ec_sec_fw_recovery_if_device_id_0(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
@@ -6285,44 +6777,44 @@ impl caliptra_emu_bus::Bus for I3c1Bus {
             0x12c..0x130 => Ok(()),
             0x130..0x134 => {
                 self.periph.write_i3c_ec_sec_fw_recovery_if_device_status_0(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x134..0x138 => {
                 self.periph.write_i3c_ec_sec_fw_recovery_if_device_status_1(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x138..0x13c => {
                 self.periph.write_i3c_ec_sec_fw_recovery_if_device_reset(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x13c..0x140 => {
                 self.periph.write_i3c_ec_sec_fw_recovery_if_recovery_ctrl(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x140..0x144 => {
                 self.periph.write_i3c_ec_sec_fw_recovery_if_recovery_status(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x144..0x148 => {
                 self.periph.write_i3c_ec_sec_fw_recovery_if_hw_status(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x148..0x14c => {
                 self.periph
                     .write_i3c_ec_sec_fw_recovery_if_indirect_fifo_ctrl_0(
-                        caliptra_emu_bus::ReadWriteRegister::new(val),
+                        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                     );
                 Ok(())
             }
@@ -6341,14 +6833,14 @@ impl caliptra_emu_bus::Bus for I3c1Bus {
             0x180..0x184 => Ok(()),
             0x184..0x188 => {
                 self.periph.write_i3c_ec_stdby_ctrl_mode_stby_cr_control(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x188..0x18c => {
                 self.periph
                     .write_i3c_ec_stdby_ctrl_mode_stby_cr_device_addr(
-                        caliptra_emu_bus::ReadWriteRegister::new(val),
+                        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                     );
                 Ok(())
             }
@@ -6356,20 +6848,20 @@ impl caliptra_emu_bus::Bus for I3c1Bus {
             0x190..0x194 => {
                 self.periph
                     .write_i3c_ec_stdby_ctrl_mode_stby_cr_virtual_device_char(
-                        caliptra_emu_bus::ReadWriteRegister::new(val),
+                        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                     );
                 Ok(())
             }
             0x194..0x198 => {
                 self.periph.write_i3c_ec_stdby_ctrl_mode_stby_cr_status(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x198..0x19c => {
                 self.periph
                     .write_i3c_ec_stdby_ctrl_mode_stby_cr_device_char(
-                        caliptra_emu_bus::ReadWriteRegister::new(val),
+                        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                     );
                 Ok(())
             }
@@ -6381,7 +6873,7 @@ impl caliptra_emu_bus::Bus for I3c1Bus {
             0x1a0..0x1a4 => {
                 self.periph
                     .write_i3c_ec_stdby_ctrl_mode_stby_cr_intr_status(
-                        caliptra_emu_bus::ReadWriteRegister::new(val),
+                        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                     );
                 Ok(())
             }
@@ -6393,34 +6885,34 @@ impl caliptra_emu_bus::Bus for I3c1Bus {
             0x1a8..0x1ac => {
                 self.periph
                     .write_i3c_ec_stdby_ctrl_mode_stby_cr_intr_signal_enable(
-                        caliptra_emu_bus::ReadWriteRegister::new(val),
+                        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                     );
                 Ok(())
             }
             0x1ac..0x1b0 => {
                 self.periph.write_i3c_ec_stdby_ctrl_mode_stby_cr_intr_force(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x1b0..0x1b4 => {
                 self.periph
                     .write_i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_getcaps(
-                        caliptra_emu_bus::ReadWriteRegister::new(val),
+                        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                     );
                 Ok(())
             }
             0x1b4..0x1b8 => {
                 self.periph
                     .write_i3c_ec_stdby_ctrl_mode_stby_cr_ccc_config_rstact_params(
-                        caliptra_emu_bus::ReadWriteRegister::new(val),
+                        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                     );
                 Ok(())
             }
             0x1b8..0x1bc => {
                 self.periph
                     .write_i3c_ec_stdby_ctrl_mode_stby_cr_virt_device_addr(
-                        caliptra_emu_bus::ReadWriteRegister::new(val),
+                        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                     );
                 Ok(())
             }
@@ -6430,32 +6922,33 @@ impl caliptra_emu_bus::Bus for I3c1Bus {
             }
             0x1c0..0x1c4 => Ok(()),
             0x1c4..0x1c8 => {
-                self.periph
-                    .write_i3c_ec_tti_control(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_i3c_ec_tti_control(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0x1c8..0x1cc => Ok(()),
             0x1cc..0x1d0 => {
                 self.periph.write_i3c_ec_tti_tti_reset_control(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x1d0..0x1d4 => {
                 self.periph.write_i3c_ec_tti_interrupt_status(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x1d4..0x1d8 => {
                 self.periph.write_i3c_ec_tti_interrupt_enable(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x1d8..0x1dc => {
                 self.periph.write_i3c_ec_tti_interrupt_force(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
@@ -6477,13 +6970,13 @@ impl caliptra_emu_bus::Bus for I3c1Bus {
             0x1f4..0x1f8 => Ok(()),
             0x1f8..0x1fc => {
                 self.periph.write_i3c_ec_tti_tti_queue_thld_ctrl(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x1fc..0x200 => {
                 self.periph.write_i3c_ec_tti_tti_data_buffer_thld_ctrl(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
@@ -6498,14 +6991,14 @@ impl caliptra_emu_bus::Bus for I3c1Bus {
             }
             0x20c..0x210 => {
                 self.periph.write_i3c_ec_soc_mgmt_if_rec_intf_cfg(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x210..0x214 => {
                 self.periph
                     .write_i3c_ec_soc_mgmt_if_rec_intf_reg_w1_c_access(
-                        caliptra_emu_bus::ReadWriteRegister::new(val),
+                        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                     );
                 Ok(())
             }
@@ -6519,13 +7012,13 @@ impl caliptra_emu_bus::Bus for I3c1Bus {
             }
             0x21c..0x220 => {
                 self.periph.write_i3c_ec_soc_mgmt_if_soc_pad_conf(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x220..0x224 => {
                 self.periph.write_i3c_ec_soc_mgmt_if_soc_pad_attr(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
@@ -6539,55 +7032,55 @@ impl caliptra_emu_bus::Bus for I3c1Bus {
             }
             0x22c..0x230 => {
                 self.periph.write_i3c_ec_soc_mgmt_if_t_r_reg(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x230..0x234 => {
                 self.periph.write_i3c_ec_soc_mgmt_if_t_f_reg(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x234..0x238 => {
                 self.periph.write_i3c_ec_soc_mgmt_if_t_su_dat_reg(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x238..0x23c => {
                 self.periph.write_i3c_ec_soc_mgmt_if_t_hd_dat_reg(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x23c..0x240 => {
                 self.periph.write_i3c_ec_soc_mgmt_if_t_high_reg(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x240..0x244 => {
                 self.periph.write_i3c_ec_soc_mgmt_if_t_low_reg(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x244..0x248 => {
                 self.periph.write_i3c_ec_soc_mgmt_if_t_hd_sta_reg(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x248..0x24c => {
                 self.periph.write_i3c_ec_soc_mgmt_if_t_su_sta_reg(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x24c..0x250 => {
                 self.periph.write_i3c_ec_soc_mgmt_if_t_su_sto_reg(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
@@ -6605,7 +7098,7 @@ impl caliptra_emu_bus::Bus for I3c1Bus {
             }
             0x260..0x264 => Ok(()),
             0x264..0x268 => Ok(()),
-            _ => Err(caliptra_emu_bus::BusError::StoreAccessFault),
+            _ => Err(caliptra_core_tools::caliptra_emu_bus::BusError::StoreAccessFault),
         }
     }
     fn poll(&mut self) {

--- a/registers/generated-emulator/src/lc.rs
+++ b/registers/generated-emulator/src/lc.rs
@@ -5,14 +5,24 @@
 #[allow(unused_imports)]
 use tock_registers::interfaces::{Readable, Writeable};
 pub trait LcPeripheral {
-    fn set_dma_ram(&mut self, _ram: std::rc::Rc<std::cell::RefCell<caliptra_emu_bus::Ram>>) {}
-    fn set_dma_rom_sram(&mut self, _ram: std::rc::Rc<std::cell::RefCell<caliptra_emu_bus::Ram>>) {}
+    fn set_dma_ram(
+        &mut self,
+        _ram: std::rc::Rc<std::cell::RefCell<caliptra_core_tools::caliptra_emu_bus::Ram>>,
+    ) {
+    }
+    fn set_dma_rom_sram(
+        &mut self,
+        _ram: std::rc::Rc<std::cell::RefCell<caliptra_core_tools::caliptra_emu_bus::Ram>>,
+    ) {
+    }
     fn register_event_channels(
         &mut self,
-        _events_to_caliptra: std::sync::mpsc::Sender<caliptra_emu_bus::Event>,
-        _events_from_caliptra: std::sync::mpsc::Receiver<caliptra_emu_bus::Event>,
-        _events_to_mcu: std::sync::mpsc::Sender<caliptra_emu_bus::Event>,
-        _events_from_mcu: std::sync::mpsc::Receiver<caliptra_emu_bus::Event>,
+        _events_to_caliptra: std::sync::mpsc::Sender<caliptra_core_tools::caliptra_emu_bus::Event>,
+        _events_from_caliptra: std::sync::mpsc::Receiver<
+            caliptra_core_tools::caliptra_emu_bus::Event,
+        >,
+        _events_to_mcu: std::sync::mpsc::Sender<caliptra_core_tools::caliptra_emu_bus::Event>,
+        _events_from_mcu: std::sync::mpsc::Receiver<caliptra_core_tools::caliptra_emu_bus::Event>,
     ) {
     }
     fn poll(&mut self) {}
@@ -23,7 +33,7 @@ pub trait LcPeripheral {
     }
     fn write_alert_test(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::lc_ctrl::bits::AlertTest::Register,
         >,
@@ -40,7 +50,7 @@ pub trait LcPeripheral {
     }
     fn read_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::lc_ctrl::bits::Status::Register,
     > {
@@ -50,11 +60,11 @@ pub trait LcPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_status();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_claim_transition_if_regwen(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::lc_ctrl::bits::ClaimTransitionIfRegwen::Register,
     > {
@@ -64,11 +74,11 @@ pub trait LcPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_claim_transition_if_regwen();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_claim_transition_if_regwen(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::lc_ctrl::bits::ClaimTransitionIfRegwen::Register,
         >,
@@ -82,7 +92,7 @@ pub trait LcPeripheral {
     }
     fn read_claim_transition_if(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::lc_ctrl::bits::ClaimTransitionIf::Register,
     > {
@@ -92,11 +102,11 @@ pub trait LcPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_claim_transition_if();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_claim_transition_if(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::lc_ctrl::bits::ClaimTransitionIf::Register,
         >,
@@ -113,7 +123,7 @@ pub trait LcPeripheral {
     }
     fn read_transition_regwen(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::lc_ctrl::bits::TransitionRegwen::Register,
     > {
@@ -123,11 +133,11 @@ pub trait LcPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_transition_regwen();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_transition_cmd(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::lc_ctrl::bits::TransitionCmd::Register,
     > {
@@ -137,11 +147,11 @@ pub trait LcPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_transition_cmd();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_transition_cmd(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::lc_ctrl::bits::TransitionCmd::Register,
         >,
@@ -158,7 +168,7 @@ pub trait LcPeripheral {
     }
     fn read_transition_ctrl(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::lc_ctrl::bits::TransitionCtrl::Register,
     > {
@@ -168,11 +178,11 @@ pub trait LcPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_transition_ctrl();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_transition_ctrl(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::lc_ctrl::bits::TransitionCtrl::Register,
         >,
@@ -187,7 +197,7 @@ pub trait LcPeripheral {
             generated.write_transition_ctrl(val);
         }
     }
-    fn read_transition_token_0(&mut self) -> caliptra_emu_types::RvData {
+    fn read_transition_token_0(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read lc::transition_token_0");
         }
@@ -196,7 +206,7 @@ pub trait LcPeripheral {
         }
         0
     }
-    fn write_transition_token_0(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_transition_token_0(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write lc::transition_token_0 = 0x{:08x}",
@@ -207,7 +217,7 @@ pub trait LcPeripheral {
             generated.write_transition_token_0(val);
         }
     }
-    fn read_transition_token_1(&mut self) -> caliptra_emu_types::RvData {
+    fn read_transition_token_1(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read lc::transition_token_1");
         }
@@ -216,7 +226,7 @@ pub trait LcPeripheral {
         }
         0
     }
-    fn write_transition_token_1(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_transition_token_1(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write lc::transition_token_1 = 0x{:08x}",
@@ -227,7 +237,7 @@ pub trait LcPeripheral {
             generated.write_transition_token_1(val);
         }
     }
-    fn read_transition_token_2(&mut self) -> caliptra_emu_types::RvData {
+    fn read_transition_token_2(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read lc::transition_token_2");
         }
@@ -236,7 +246,7 @@ pub trait LcPeripheral {
         }
         0
     }
-    fn write_transition_token_2(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_transition_token_2(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write lc::transition_token_2 = 0x{:08x}",
@@ -247,7 +257,7 @@ pub trait LcPeripheral {
             generated.write_transition_token_2(val);
         }
     }
-    fn read_transition_token_3(&mut self) -> caliptra_emu_types::RvData {
+    fn read_transition_token_3(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read lc::transition_token_3");
         }
@@ -256,7 +266,7 @@ pub trait LcPeripheral {
         }
         0
     }
-    fn write_transition_token_3(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_transition_token_3(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write lc::transition_token_3 = 0x{:08x}",
@@ -269,7 +279,7 @@ pub trait LcPeripheral {
     }
     fn read_transition_target(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::lc_ctrl::bits::TransitionTarget::Register,
     > {
@@ -279,11 +289,11 @@ pub trait LcPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_transition_target();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_transition_target(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::lc_ctrl::bits::TransitionTarget::Register,
         >,
@@ -298,7 +308,7 @@ pub trait LcPeripheral {
             generated.write_transition_target(val);
         }
     }
-    fn read_otp_vendor_test_ctrl(&mut self) -> caliptra_emu_types::RvData {
+    fn read_otp_vendor_test_ctrl(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read lc::otp_vendor_test_ctrl");
         }
@@ -307,7 +317,7 @@ pub trait LcPeripheral {
         }
         0
     }
-    fn write_otp_vendor_test_ctrl(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_otp_vendor_test_ctrl(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write lc::otp_vendor_test_ctrl = 0x{:08x}",
@@ -318,7 +328,7 @@ pub trait LcPeripheral {
             generated.write_otp_vendor_test_ctrl(val);
         }
     }
-    fn read_otp_vendor_test_status(&mut self) -> caliptra_emu_types::RvData {
+    fn read_otp_vendor_test_status(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read lc::otp_vendor_test_status");
         }
@@ -329,7 +339,7 @@ pub trait LcPeripheral {
     }
     fn read_lc_state(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::lc_ctrl::bits::LcState::Register,
     > {
@@ -339,11 +349,11 @@ pub trait LcPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_lc_state();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_lc_transition_cnt(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::lc_ctrl::bits::LcTransitionCnt::Register,
     > {
@@ -353,9 +363,9 @@ pub trait LcPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_lc_transition_cnt();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
-    fn read_lc_id_state(&mut self) -> caliptra_emu_types::RvData {
+    fn read_lc_id_state(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read lc::lc_id_state");
         }
@@ -366,7 +376,7 @@ pub trait LcPeripheral {
     }
     fn read_hw_revision0(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::lc_ctrl::bits::HwRevision0::Register,
     > {
@@ -376,11 +386,11 @@ pub trait LcPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_hw_revision0();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_hw_revision1(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::lc_ctrl::bits::HwRevision1::Register,
     > {
@@ -390,9 +400,9 @@ pub trait LcPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_hw_revision1();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
-    fn read_device_id_0(&mut self) -> caliptra_emu_types::RvData {
+    fn read_device_id_0(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read lc::device_id_0");
         }
@@ -401,7 +411,7 @@ pub trait LcPeripheral {
         }
         0
     }
-    fn read_device_id_1(&mut self) -> caliptra_emu_types::RvData {
+    fn read_device_id_1(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read lc::device_id_1");
         }
@@ -410,7 +420,7 @@ pub trait LcPeripheral {
         }
         0
     }
-    fn read_device_id_2(&mut self) -> caliptra_emu_types::RvData {
+    fn read_device_id_2(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read lc::device_id_2");
         }
@@ -419,7 +429,7 @@ pub trait LcPeripheral {
         }
         0
     }
-    fn read_device_id_3(&mut self) -> caliptra_emu_types::RvData {
+    fn read_device_id_3(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read lc::device_id_3");
         }
@@ -428,7 +438,7 @@ pub trait LcPeripheral {
         }
         0
     }
-    fn read_device_id_4(&mut self) -> caliptra_emu_types::RvData {
+    fn read_device_id_4(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read lc::device_id_4");
         }
@@ -437,7 +447,7 @@ pub trait LcPeripheral {
         }
         0
     }
-    fn read_device_id_5(&mut self) -> caliptra_emu_types::RvData {
+    fn read_device_id_5(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read lc::device_id_5");
         }
@@ -446,7 +456,7 @@ pub trait LcPeripheral {
         }
         0
     }
-    fn read_device_id_6(&mut self) -> caliptra_emu_types::RvData {
+    fn read_device_id_6(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read lc::device_id_6");
         }
@@ -455,7 +465,7 @@ pub trait LcPeripheral {
         }
         0
     }
-    fn read_device_id_7(&mut self) -> caliptra_emu_types::RvData {
+    fn read_device_id_7(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read lc::device_id_7");
         }
@@ -464,7 +474,7 @@ pub trait LcPeripheral {
         }
         0
     }
-    fn read_manuf_state_0(&mut self) -> caliptra_emu_types::RvData {
+    fn read_manuf_state_0(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read lc::manuf_state_0");
         }
@@ -473,7 +483,7 @@ pub trait LcPeripheral {
         }
         0
     }
-    fn read_manuf_state_1(&mut self) -> caliptra_emu_types::RvData {
+    fn read_manuf_state_1(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read lc::manuf_state_1");
         }
@@ -482,7 +492,7 @@ pub trait LcPeripheral {
         }
         0
     }
-    fn read_manuf_state_2(&mut self) -> caliptra_emu_types::RvData {
+    fn read_manuf_state_2(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read lc::manuf_state_2");
         }
@@ -491,7 +501,7 @@ pub trait LcPeripheral {
         }
         0
     }
-    fn read_manuf_state_3(&mut self) -> caliptra_emu_types::RvData {
+    fn read_manuf_state_3(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read lc::manuf_state_3");
         }
@@ -500,7 +510,7 @@ pub trait LcPeripheral {
         }
         0
     }
-    fn read_manuf_state_4(&mut self) -> caliptra_emu_types::RvData {
+    fn read_manuf_state_4(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read lc::manuf_state_4");
         }
@@ -509,7 +519,7 @@ pub trait LcPeripheral {
         }
         0
     }
-    fn read_manuf_state_5(&mut self) -> caliptra_emu_types::RvData {
+    fn read_manuf_state_5(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read lc::manuf_state_5");
         }
@@ -518,7 +528,7 @@ pub trait LcPeripheral {
         }
         0
     }
-    fn read_manuf_state_6(&mut self) -> caliptra_emu_types::RvData {
+    fn read_manuf_state_6(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read lc::manuf_state_6");
         }
@@ -527,7 +537,7 @@ pub trait LcPeripheral {
         }
         0
     }
-    fn read_manuf_state_7(&mut self) -> caliptra_emu_types::RvData {
+    fn read_manuf_state_7(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read lc::manuf_state_7");
         }
@@ -539,80 +549,80 @@ pub trait LcPeripheral {
 }
 #[derive(Clone, Debug)]
 pub struct LcGenerated {
-    alert_test: caliptra_emu_types::RvData,
-    status: caliptra_emu_types::RvData,
-    claim_transition_if_regwen: caliptra_emu_types::RvData,
-    claim_transition_if: caliptra_emu_types::RvData,
-    transition_regwen: caliptra_emu_types::RvData,
-    transition_cmd: caliptra_emu_types::RvData,
-    transition_ctrl: caliptra_emu_types::RvData,
-    transition_token_0: caliptra_emu_types::RvData,
-    transition_token_1: caliptra_emu_types::RvData,
-    transition_token_2: caliptra_emu_types::RvData,
-    transition_token_3: caliptra_emu_types::RvData,
-    transition_target: caliptra_emu_types::RvData,
-    otp_vendor_test_ctrl: caliptra_emu_types::RvData,
-    otp_vendor_test_status: caliptra_emu_types::RvData,
-    lc_state: caliptra_emu_types::RvData,
-    lc_transition_cnt: caliptra_emu_types::RvData,
-    lc_id_state: caliptra_emu_types::RvData,
-    hw_revision0: caliptra_emu_types::RvData,
-    hw_revision1: caliptra_emu_types::RvData,
-    device_id_0: caliptra_emu_types::RvData,
-    device_id_1: caliptra_emu_types::RvData,
-    device_id_2: caliptra_emu_types::RvData,
-    device_id_3: caliptra_emu_types::RvData,
-    device_id_4: caliptra_emu_types::RvData,
-    device_id_5: caliptra_emu_types::RvData,
-    device_id_6: caliptra_emu_types::RvData,
-    device_id_7: caliptra_emu_types::RvData,
-    manuf_state_0: caliptra_emu_types::RvData,
-    manuf_state_1: caliptra_emu_types::RvData,
-    manuf_state_2: caliptra_emu_types::RvData,
-    manuf_state_3: caliptra_emu_types::RvData,
-    manuf_state_4: caliptra_emu_types::RvData,
-    manuf_state_5: caliptra_emu_types::RvData,
-    manuf_state_6: caliptra_emu_types::RvData,
-    manuf_state_7: caliptra_emu_types::RvData,
+    alert_test: caliptra_core_tools::caliptra_emu_types::RvData,
+    status: caliptra_core_tools::caliptra_emu_types::RvData,
+    claim_transition_if_regwen: caliptra_core_tools::caliptra_emu_types::RvData,
+    claim_transition_if: caliptra_core_tools::caliptra_emu_types::RvData,
+    transition_regwen: caliptra_core_tools::caliptra_emu_types::RvData,
+    transition_cmd: caliptra_core_tools::caliptra_emu_types::RvData,
+    transition_ctrl: caliptra_core_tools::caliptra_emu_types::RvData,
+    transition_token_0: caliptra_core_tools::caliptra_emu_types::RvData,
+    transition_token_1: caliptra_core_tools::caliptra_emu_types::RvData,
+    transition_token_2: caliptra_core_tools::caliptra_emu_types::RvData,
+    transition_token_3: caliptra_core_tools::caliptra_emu_types::RvData,
+    transition_target: caliptra_core_tools::caliptra_emu_types::RvData,
+    otp_vendor_test_ctrl: caliptra_core_tools::caliptra_emu_types::RvData,
+    otp_vendor_test_status: caliptra_core_tools::caliptra_emu_types::RvData,
+    lc_state: caliptra_core_tools::caliptra_emu_types::RvData,
+    lc_transition_cnt: caliptra_core_tools::caliptra_emu_types::RvData,
+    lc_id_state: caliptra_core_tools::caliptra_emu_types::RvData,
+    hw_revision0: caliptra_core_tools::caliptra_emu_types::RvData,
+    hw_revision1: caliptra_core_tools::caliptra_emu_types::RvData,
+    device_id_0: caliptra_core_tools::caliptra_emu_types::RvData,
+    device_id_1: caliptra_core_tools::caliptra_emu_types::RvData,
+    device_id_2: caliptra_core_tools::caliptra_emu_types::RvData,
+    device_id_3: caliptra_core_tools::caliptra_emu_types::RvData,
+    device_id_4: caliptra_core_tools::caliptra_emu_types::RvData,
+    device_id_5: caliptra_core_tools::caliptra_emu_types::RvData,
+    device_id_6: caliptra_core_tools::caliptra_emu_types::RvData,
+    device_id_7: caliptra_core_tools::caliptra_emu_types::RvData,
+    manuf_state_0: caliptra_core_tools::caliptra_emu_types::RvData,
+    manuf_state_1: caliptra_core_tools::caliptra_emu_types::RvData,
+    manuf_state_2: caliptra_core_tools::caliptra_emu_types::RvData,
+    manuf_state_3: caliptra_core_tools::caliptra_emu_types::RvData,
+    manuf_state_4: caliptra_core_tools::caliptra_emu_types::RvData,
+    manuf_state_5: caliptra_core_tools::caliptra_emu_types::RvData,
+    manuf_state_6: caliptra_core_tools::caliptra_emu_types::RvData,
+    manuf_state_7: caliptra_core_tools::caliptra_emu_types::RvData,
 }
 impl Default for LcGenerated {
     fn default() -> Self {
         Self {
-            alert_test: 0 as caliptra_emu_types::RvData,
-            status: 0 as caliptra_emu_types::RvData,
-            claim_transition_if_regwen: 0 as caliptra_emu_types::RvData,
-            claim_transition_if: 0 as caliptra_emu_types::RvData,
-            transition_regwen: 0 as caliptra_emu_types::RvData,
-            transition_cmd: 0 as caliptra_emu_types::RvData,
-            transition_ctrl: 0 as caliptra_emu_types::RvData,
-            transition_token_0: 0 as caliptra_emu_types::RvData,
-            transition_token_1: 0 as caliptra_emu_types::RvData,
-            transition_token_2: 0 as caliptra_emu_types::RvData,
-            transition_token_3: 0 as caliptra_emu_types::RvData,
-            transition_target: 0 as caliptra_emu_types::RvData,
-            otp_vendor_test_ctrl: 0 as caliptra_emu_types::RvData,
-            otp_vendor_test_status: 0 as caliptra_emu_types::RvData,
-            lc_state: 0 as caliptra_emu_types::RvData,
-            lc_transition_cnt: 0 as caliptra_emu_types::RvData,
-            lc_id_state: 0 as caliptra_emu_types::RvData,
-            hw_revision0: 0 as caliptra_emu_types::RvData,
-            hw_revision1: 0 as caliptra_emu_types::RvData,
-            device_id_0: 0 as caliptra_emu_types::RvData,
-            device_id_1: 0 as caliptra_emu_types::RvData,
-            device_id_2: 0 as caliptra_emu_types::RvData,
-            device_id_3: 0 as caliptra_emu_types::RvData,
-            device_id_4: 0 as caliptra_emu_types::RvData,
-            device_id_5: 0 as caliptra_emu_types::RvData,
-            device_id_6: 0 as caliptra_emu_types::RvData,
-            device_id_7: 0 as caliptra_emu_types::RvData,
-            manuf_state_0: 0 as caliptra_emu_types::RvData,
-            manuf_state_1: 0 as caliptra_emu_types::RvData,
-            manuf_state_2: 0 as caliptra_emu_types::RvData,
-            manuf_state_3: 0 as caliptra_emu_types::RvData,
-            manuf_state_4: 0 as caliptra_emu_types::RvData,
-            manuf_state_5: 0 as caliptra_emu_types::RvData,
-            manuf_state_6: 0 as caliptra_emu_types::RvData,
-            manuf_state_7: 0 as caliptra_emu_types::RvData,
+            alert_test: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            status: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            claim_transition_if_regwen: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            claim_transition_if: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            transition_regwen: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            transition_cmd: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            transition_ctrl: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            transition_token_0: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            transition_token_1: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            transition_token_2: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            transition_token_3: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            transition_target: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            otp_vendor_test_ctrl: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            otp_vendor_test_status: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            lc_state: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            lc_transition_cnt: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            lc_id_state: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            hw_revision0: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            hw_revision1: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            device_id_0: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            device_id_1: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            device_id_2: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            device_id_3: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            device_id_4: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            device_id_5: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            device_id_6: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            device_id_7: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            manuf_state_0: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            manuf_state_1: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            manuf_state_2: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            manuf_state_3: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            manuf_state_4: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            manuf_state_5: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            manuf_state_6: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            manuf_state_7: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
         }
     }
 }
@@ -636,7 +646,7 @@ impl LcPeripheral for LcGenerated {
     }
     fn write_alert_test(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::lc_ctrl::bits::AlertTest::Register,
         >,
@@ -647,31 +657,31 @@ impl LcPeripheral for LcGenerated {
                 val.reg.get()
             );
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.alert_test;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(2 as caliptra_emu_types::RvData))
-            | (write_val & (2 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(4 as caliptra_emu_types::RvData))
-            | (write_val & (4 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(2 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(4 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (4 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.alert_test = new_val;
     }
     fn read_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::lc_ctrl::bits::Status::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read lc::status");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.status)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.status)
     }
     fn read_claim_transition_if_regwen(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::lc_ctrl::bits::ClaimTransitionIfRegwen::Register,
     > {
@@ -680,11 +690,13 @@ impl LcPeripheral for LcGenerated {
                 "[EMU] Generated default register handler: read lc::claim_transition_if_regwen"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.claim_transition_if_regwen)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.claim_transition_if_regwen,
+        )
     }
     fn write_claim_transition_if_regwen(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::lc_ctrl::bits::ClaimTransitionIfRegwen::Register,
         >,
@@ -692,27 +704,27 @@ impl LcPeripheral for LcGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write lc::claim_transition_if_regwen = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.claim_transition_if_regwen;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.claim_transition_if_regwen = new_val;
     }
     fn read_claim_transition_if(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::lc_ctrl::bits::ClaimTransitionIf::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read lc::claim_transition_if");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.claim_transition_if)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.claim_transition_if)
     }
     fn write_claim_transition_if(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::lc_ctrl::bits::ClaimTransitionIf::Register,
         >,
@@ -720,38 +732,38 @@ impl LcPeripheral for LcGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write lc::claim_transition_if = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.claim_transition_if;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xff as caliptra_emu_types::RvData))
-            | (write_val & (0xff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.claim_transition_if = new_val;
     }
     fn read_transition_regwen(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::lc_ctrl::bits::TransitionRegwen::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read lc::transition_regwen");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.transition_regwen)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.transition_regwen)
     }
     fn read_transition_cmd(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::lc_ctrl::bits::TransitionCmd::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read lc::transition_cmd");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.transition_cmd)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.transition_cmd)
     }
     fn write_transition_cmd(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::lc_ctrl::bits::TransitionCmd::Register,
         >,
@@ -762,27 +774,27 @@ impl LcPeripheral for LcGenerated {
                 val.reg.get()
             );
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.transition_cmd;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.transition_cmd = new_val;
     }
     fn read_transition_ctrl(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::lc_ctrl::bits::TransitionCtrl::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read lc::transition_ctrl");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.transition_ctrl)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.transition_ctrl)
     }
     fn write_transition_ctrl(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::lc_ctrl::bits::TransitionCtrl::Register,
         >,
@@ -793,109 +805,109 @@ impl LcPeripheral for LcGenerated {
                 val.reg.get()
             );
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.transition_ctrl;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(2 as caliptra_emu_types::RvData))
-            | (write_val & (2 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(2 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.transition_ctrl = new_val;
     }
-    fn read_transition_token_0(&mut self) -> caliptra_emu_types::RvData {
+    fn read_transition_token_0(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read lc::transition_token_0");
         }
         self.transition_token_0
     }
-    fn write_transition_token_0(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_transition_token_0(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: write lc::transition_token_0 = 0x{:08x}",
                 val
             );
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.transition_token_0;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.transition_token_0 = new_val;
     }
-    fn read_transition_token_1(&mut self) -> caliptra_emu_types::RvData {
+    fn read_transition_token_1(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read lc::transition_token_1");
         }
         self.transition_token_1
     }
-    fn write_transition_token_1(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_transition_token_1(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: write lc::transition_token_1 = 0x{:08x}",
                 val
             );
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.transition_token_1;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.transition_token_1 = new_val;
     }
-    fn read_transition_token_2(&mut self) -> caliptra_emu_types::RvData {
+    fn read_transition_token_2(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read lc::transition_token_2");
         }
         self.transition_token_2
     }
-    fn write_transition_token_2(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_transition_token_2(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: write lc::transition_token_2 = 0x{:08x}",
                 val
             );
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.transition_token_2;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.transition_token_2 = new_val;
     }
-    fn read_transition_token_3(&mut self) -> caliptra_emu_types::RvData {
+    fn read_transition_token_3(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read lc::transition_token_3");
         }
         self.transition_token_3
     }
-    fn write_transition_token_3(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_transition_token_3(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: write lc::transition_token_3 = 0x{:08x}",
                 val
             );
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.transition_token_3;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.transition_token_3 = new_val;
     }
     fn read_transition_target(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::lc_ctrl::bits::TransitionTarget::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read lc::transition_target");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.transition_target)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.transition_target)
     }
     fn write_transition_target(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::lc_ctrl::bits::TransitionTarget::Register,
         >,
@@ -906,31 +918,31 @@ impl LcPeripheral for LcGenerated {
                 val.reg.get()
             );
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.transition_target;
         let mut new_val = current_val;
-        new_val = (new_val & !(0x3fff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0x3fff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x3fff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x3fff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.transition_target = new_val;
     }
-    fn read_otp_vendor_test_ctrl(&mut self) -> caliptra_emu_types::RvData {
+    fn read_otp_vendor_test_ctrl(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read lc::otp_vendor_test_ctrl");
         }
         self.otp_vendor_test_ctrl
     }
-    fn write_otp_vendor_test_ctrl(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_otp_vendor_test_ctrl(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write lc::otp_vendor_test_ctrl = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.otp_vendor_test_ctrl;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.otp_vendor_test_ctrl = new_val;
     }
-    fn read_otp_vendor_test_status(&mut self) -> caliptra_emu_types::RvData {
+    fn read_otp_vendor_test_status(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read lc::otp_vendor_test_status");
         }
@@ -938,27 +950,27 @@ impl LcPeripheral for LcGenerated {
     }
     fn read_lc_state(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::lc_ctrl::bits::LcState::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read lc::lc_state");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.lc_state)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.lc_state)
     }
     fn read_lc_transition_cnt(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::lc_ctrl::bits::LcTransitionCnt::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read lc::lc_transition_cnt");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.lc_transition_cnt)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.lc_transition_cnt)
     }
-    fn read_lc_id_state(&mut self) -> caliptra_emu_types::RvData {
+    fn read_lc_id_state(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read lc::lc_id_state");
         }
@@ -966,117 +978,117 @@ impl LcPeripheral for LcGenerated {
     }
     fn read_hw_revision0(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::lc_ctrl::bits::HwRevision0::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read lc::hw_revision0");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.hw_revision0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.hw_revision0)
     }
     fn read_hw_revision1(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::lc_ctrl::bits::HwRevision1::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read lc::hw_revision1");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.hw_revision1)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.hw_revision1)
     }
-    fn read_device_id_0(&mut self) -> caliptra_emu_types::RvData {
+    fn read_device_id_0(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read lc::device_id_0");
         }
         self.device_id_0
     }
-    fn read_device_id_1(&mut self) -> caliptra_emu_types::RvData {
+    fn read_device_id_1(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read lc::device_id_1");
         }
         self.device_id_1
     }
-    fn read_device_id_2(&mut self) -> caliptra_emu_types::RvData {
+    fn read_device_id_2(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read lc::device_id_2");
         }
         self.device_id_2
     }
-    fn read_device_id_3(&mut self) -> caliptra_emu_types::RvData {
+    fn read_device_id_3(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read lc::device_id_3");
         }
         self.device_id_3
     }
-    fn read_device_id_4(&mut self) -> caliptra_emu_types::RvData {
+    fn read_device_id_4(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read lc::device_id_4");
         }
         self.device_id_4
     }
-    fn read_device_id_5(&mut self) -> caliptra_emu_types::RvData {
+    fn read_device_id_5(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read lc::device_id_5");
         }
         self.device_id_5
     }
-    fn read_device_id_6(&mut self) -> caliptra_emu_types::RvData {
+    fn read_device_id_6(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read lc::device_id_6");
         }
         self.device_id_6
     }
-    fn read_device_id_7(&mut self) -> caliptra_emu_types::RvData {
+    fn read_device_id_7(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read lc::device_id_7");
         }
         self.device_id_7
     }
-    fn read_manuf_state_0(&mut self) -> caliptra_emu_types::RvData {
+    fn read_manuf_state_0(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read lc::manuf_state_0");
         }
         self.manuf_state_0
     }
-    fn read_manuf_state_1(&mut self) -> caliptra_emu_types::RvData {
+    fn read_manuf_state_1(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read lc::manuf_state_1");
         }
         self.manuf_state_1
     }
-    fn read_manuf_state_2(&mut self) -> caliptra_emu_types::RvData {
+    fn read_manuf_state_2(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read lc::manuf_state_2");
         }
         self.manuf_state_2
     }
-    fn read_manuf_state_3(&mut self) -> caliptra_emu_types::RvData {
+    fn read_manuf_state_3(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read lc::manuf_state_3");
         }
         self.manuf_state_3
     }
-    fn read_manuf_state_4(&mut self) -> caliptra_emu_types::RvData {
+    fn read_manuf_state_4(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read lc::manuf_state_4");
         }
         self.manuf_state_4
     }
-    fn read_manuf_state_5(&mut self) -> caliptra_emu_types::RvData {
+    fn read_manuf_state_5(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read lc::manuf_state_5");
         }
         self.manuf_state_5
     }
-    fn read_manuf_state_6(&mut self) -> caliptra_emu_types::RvData {
+    fn read_manuf_state_6(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read lc::manuf_state_6");
         }
         self.manuf_state_6
     }
-    fn read_manuf_state_7(&mut self) -> caliptra_emu_types::RvData {
+    fn read_manuf_state_7(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read lc::manuf_state_7");
         }
@@ -1086,54 +1098,57 @@ impl LcPeripheral for LcGenerated {
 pub struct LcBus {
     pub periph: Box<dyn LcPeripheral>,
 }
-impl caliptra_emu_bus::Bus for LcBus {
+impl caliptra_core_tools::caliptra_emu_bus::Bus for LcBus {
     fn read(
         &mut self,
-        size: caliptra_emu_types::RvSize,
-        addr: caliptra_emu_types::RvAddr,
-    ) -> Result<caliptra_emu_types::RvData, caliptra_emu_bus::BusError> {
-        if addr & 0x3 != 0 || size != caliptra_emu_types::RvSize::Word {
-            return Err(caliptra_emu_bus::BusError::LoadAddrMisaligned);
+        size: caliptra_core_tools::caliptra_emu_types::RvSize,
+        addr: caliptra_core_tools::caliptra_emu_types::RvAddr,
+    ) -> Result<
+        caliptra_core_tools::caliptra_emu_types::RvData,
+        caliptra_core_tools::caliptra_emu_bus::BusError,
+    > {
+        if addr & 0x3 != 0 || size != caliptra_core_tools::caliptra_emu_types::RvSize::Word {
+            return Err(caliptra_core_tools::caliptra_emu_bus::BusError::LoadAddrMisaligned);
         }
         match addr {
-            4..8 => Ok(caliptra_emu_types::RvData::from(
+            4..8 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_status().reg.get(),
             )),
-            8..0xc => Ok(caliptra_emu_types::RvData::from(
+            8..0xc => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_claim_transition_if_regwen().reg.get(),
             )),
-            0xc..0x10 => Ok(caliptra_emu_types::RvData::from(
+            0xc..0x10 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_claim_transition_if().reg.get(),
             )),
-            0x10..0x14 => Ok(caliptra_emu_types::RvData::from(
+            0x10..0x14 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_transition_regwen().reg.get(),
             )),
-            0x14..0x18 => Ok(caliptra_emu_types::RvData::from(
+            0x14..0x18 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_transition_cmd().reg.get(),
             )),
-            0x18..0x1c => Ok(caliptra_emu_types::RvData::from(
+            0x18..0x1c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_transition_ctrl().reg.get(),
             )),
             0x1c..0x20 => Ok(self.periph.read_transition_token_0()),
             0x20..0x24 => Ok(self.periph.read_transition_token_1()),
             0x24..0x28 => Ok(self.periph.read_transition_token_2()),
             0x28..0x2c => Ok(self.periph.read_transition_token_3()),
-            0x2c..0x30 => Ok(caliptra_emu_types::RvData::from(
+            0x2c..0x30 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_transition_target().reg.get(),
             )),
             0x30..0x34 => Ok(self.periph.read_otp_vendor_test_ctrl()),
             0x34..0x38 => Ok(self.periph.read_otp_vendor_test_status()),
-            0x38..0x3c => Ok(caliptra_emu_types::RvData::from(
+            0x38..0x3c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_lc_state().reg.get(),
             )),
-            0x3c..0x40 => Ok(caliptra_emu_types::RvData::from(
+            0x3c..0x40 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_lc_transition_cnt().reg.get(),
             )),
             0x40..0x44 => Ok(self.periph.read_lc_id_state()),
-            0x44..0x48 => Ok(caliptra_emu_types::RvData::from(
+            0x44..0x48 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_hw_revision0().reg.get(),
             )),
-            0x48..0x4c => Ok(caliptra_emu_types::RvData::from(
+            0x48..0x4c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_hw_revision1().reg.get(),
             )),
             0x4c..0x50 => Ok(self.periph.read_device_id_0()),
@@ -1152,45 +1167,49 @@ impl caliptra_emu_bus::Bus for LcBus {
             0x80..0x84 => Ok(self.periph.read_manuf_state_5()),
             0x84..0x88 => Ok(self.periph.read_manuf_state_6()),
             0x88..0x8c => Ok(self.periph.read_manuf_state_7()),
-            _ => Err(caliptra_emu_bus::BusError::LoadAccessFault),
+            _ => Err(caliptra_core_tools::caliptra_emu_bus::BusError::LoadAccessFault),
         }
     }
     fn write(
         &mut self,
-        size: caliptra_emu_types::RvSize,
-        addr: caliptra_emu_types::RvAddr,
-        val: caliptra_emu_types::RvData,
-    ) -> Result<(), caliptra_emu_bus::BusError> {
-        if addr & 0x3 != 0 || size != caliptra_emu_types::RvSize::Word {
-            return Err(caliptra_emu_bus::BusError::StoreAddrMisaligned);
+        size: caliptra_core_tools::caliptra_emu_types::RvSize,
+        addr: caliptra_core_tools::caliptra_emu_types::RvAddr,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) -> Result<(), caliptra_core_tools::caliptra_emu_bus::BusError> {
+        if addr & 0x3 != 0 || size != caliptra_core_tools::caliptra_emu_types::RvSize::Word {
+            return Err(caliptra_core_tools::caliptra_emu_bus::BusError::StoreAddrMisaligned);
         }
         match addr {
             0..4 => {
-                self.periph
-                    .write_alert_test(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_alert_test(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             4..8 => Ok(()),
             8..0xc => {
                 self.periph.write_claim_transition_if_regwen(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0xc..0x10 => {
-                self.periph
-                    .write_claim_transition_if(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_claim_transition_if(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0x10..0x14 => Ok(()),
             0x14..0x18 => {
-                self.periph
-                    .write_transition_cmd(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_transition_cmd(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0x18..0x1c => {
-                self.periph
-                    .write_transition_ctrl(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_transition_ctrl(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0x1c..0x20 => {
@@ -1210,8 +1229,9 @@ impl caliptra_emu_bus::Bus for LcBus {
                 Ok(())
             }
             0x2c..0x30 => {
-                self.periph
-                    .write_transition_target(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_transition_target(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0x30..0x34 => {
@@ -1240,7 +1260,7 @@ impl caliptra_emu_bus::Bus for LcBus {
             0x80..0x84 => Ok(()),
             0x84..0x88 => Ok(()),
             0x88..0x8c => Ok(()),
-            _ => Err(caliptra_emu_bus::BusError::StoreAccessFault),
+            _ => Err(caliptra_core_tools::caliptra_emu_bus::BusError::StoreAccessFault),
         }
     }
     fn poll(&mut self) {

--- a/registers/generated-emulator/src/mbox.rs
+++ b/registers/generated-emulator/src/mbox.rs
@@ -5,14 +5,24 @@
 #[allow(unused_imports)]
 use tock_registers::interfaces::{Readable, Writeable};
 pub trait MboxPeripheral {
-    fn set_dma_ram(&mut self, _ram: std::rc::Rc<std::cell::RefCell<caliptra_emu_bus::Ram>>) {}
-    fn set_dma_rom_sram(&mut self, _ram: std::rc::Rc<std::cell::RefCell<caliptra_emu_bus::Ram>>) {}
+    fn set_dma_ram(
+        &mut self,
+        _ram: std::rc::Rc<std::cell::RefCell<caliptra_core_tools::caliptra_emu_bus::Ram>>,
+    ) {
+    }
+    fn set_dma_rom_sram(
+        &mut self,
+        _ram: std::rc::Rc<std::cell::RefCell<caliptra_core_tools::caliptra_emu_bus::Ram>>,
+    ) {
+    }
     fn register_event_channels(
         &mut self,
-        _events_to_caliptra: std::sync::mpsc::Sender<caliptra_emu_bus::Event>,
-        _events_from_caliptra: std::sync::mpsc::Receiver<caliptra_emu_bus::Event>,
-        _events_to_mcu: std::sync::mpsc::Sender<caliptra_emu_bus::Event>,
-        _events_from_mcu: std::sync::mpsc::Receiver<caliptra_emu_bus::Event>,
+        _events_to_caliptra: std::sync::mpsc::Sender<caliptra_core_tools::caliptra_emu_bus::Event>,
+        _events_from_caliptra: std::sync::mpsc::Receiver<
+            caliptra_core_tools::caliptra_emu_bus::Event,
+        >,
+        _events_to_mcu: std::sync::mpsc::Sender<caliptra_core_tools::caliptra_emu_bus::Event>,
+        _events_from_mcu: std::sync::mpsc::Receiver<caliptra_core_tools::caliptra_emu_bus::Event>,
     ) {
     }
     fn poll(&mut self) {}
@@ -23,17 +33,19 @@ pub trait MboxPeripheral {
     }
     fn read_mbox_lock(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::mbox::bits::MboxLock::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::mbox::bits::MboxLock::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read mbox::mbox_lock");
         }
         if let Some(generated) = self.generated() {
             return generated.read_mbox_lock();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
-    fn read_mbox_user(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mbox_user(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read mbox::mbox_user");
         }
@@ -42,7 +54,7 @@ pub trait MboxPeripheral {
         }
         0
     }
-    fn read_mbox_cmd(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mbox_cmd(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read mbox::mbox_cmd");
         }
@@ -51,7 +63,7 @@ pub trait MboxPeripheral {
         }
         0
     }
-    fn write_mbox_cmd(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mbox_cmd(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write mbox::mbox_cmd = 0x{:08x}",
@@ -62,7 +74,7 @@ pub trait MboxPeripheral {
             generated.write_mbox_cmd(val);
         }
     }
-    fn read_mbox_dlen(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mbox_dlen(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read mbox::mbox_dlen");
         }
@@ -71,7 +83,7 @@ pub trait MboxPeripheral {
         }
         0
     }
-    fn write_mbox_dlen(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mbox_dlen(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write mbox::mbox_dlen = 0x{:08x}",
@@ -82,7 +94,7 @@ pub trait MboxPeripheral {
             generated.write_mbox_dlen(val);
         }
     }
-    fn read_mbox_datain(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mbox_datain(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read mbox::mbox_datain");
         }
@@ -91,7 +103,7 @@ pub trait MboxPeripheral {
         }
         0
     }
-    fn write_mbox_datain(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mbox_datain(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write mbox::mbox_datain = 0x{:08x}",
@@ -102,7 +114,7 @@ pub trait MboxPeripheral {
             generated.write_mbox_datain(val);
         }
     }
-    fn read_mbox_dataout(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mbox_dataout(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read mbox::mbox_dataout");
         }
@@ -111,7 +123,7 @@ pub trait MboxPeripheral {
         }
         0
     }
-    fn write_mbox_dataout(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mbox_dataout(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write mbox::mbox_dataout = 0x{:08x}",
@@ -124,7 +136,7 @@ pub trait MboxPeripheral {
     }
     fn read_mbox_execute(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mbox::bits::MboxExecute::Register,
     > {
@@ -134,11 +146,11 @@ pub trait MboxPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mbox_execute();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_mbox_execute(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mbox::bits::MboxExecute::Register,
         >,
@@ -155,7 +167,7 @@ pub trait MboxPeripheral {
     }
     fn read_mbox_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mbox::bits::MboxStatus::Register,
     > {
@@ -165,11 +177,11 @@ pub trait MboxPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mbox_status();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_mbox_status(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mbox::bits::MboxStatus::Register,
         >,
@@ -186,7 +198,7 @@ pub trait MboxPeripheral {
     }
     fn read_mbox_unlock(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mbox::bits::MboxUnlock::Register,
     > {
@@ -196,11 +208,11 @@ pub trait MboxPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mbox_unlock();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_mbox_unlock(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mbox::bits::MboxUnlock::Register,
         >,
@@ -217,19 +229,21 @@ pub trait MboxPeripheral {
     }
     fn read_tap_mode(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::mbox::bits::TapMode::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::mbox::bits::TapMode::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read mbox::tap_mode");
         }
         if let Some(generated) = self.generated() {
             return generated.read_tap_mode();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_tap_mode(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mbox::bits::TapMode::Register,
         >,
@@ -247,30 +261,30 @@ pub trait MboxPeripheral {
 }
 #[derive(Clone, Debug)]
 pub struct MboxGenerated {
-    mbox_lock: caliptra_emu_types::RvData,
-    mbox_user: caliptra_emu_types::RvData,
-    mbox_cmd: caliptra_emu_types::RvData,
-    mbox_dlen: caliptra_emu_types::RvData,
-    mbox_datain: caliptra_emu_types::RvData,
-    mbox_dataout: caliptra_emu_types::RvData,
-    mbox_execute: caliptra_emu_types::RvData,
-    mbox_status: caliptra_emu_types::RvData,
-    mbox_unlock: caliptra_emu_types::RvData,
-    tap_mode: caliptra_emu_types::RvData,
+    mbox_lock: caliptra_core_tools::caliptra_emu_types::RvData,
+    mbox_user: caliptra_core_tools::caliptra_emu_types::RvData,
+    mbox_cmd: caliptra_core_tools::caliptra_emu_types::RvData,
+    mbox_dlen: caliptra_core_tools::caliptra_emu_types::RvData,
+    mbox_datain: caliptra_core_tools::caliptra_emu_types::RvData,
+    mbox_dataout: caliptra_core_tools::caliptra_emu_types::RvData,
+    mbox_execute: caliptra_core_tools::caliptra_emu_types::RvData,
+    mbox_status: caliptra_core_tools::caliptra_emu_types::RvData,
+    mbox_unlock: caliptra_core_tools::caliptra_emu_types::RvData,
+    tap_mode: caliptra_core_tools::caliptra_emu_types::RvData,
 }
 impl Default for MboxGenerated {
     fn default() -> Self {
         Self {
-            mbox_lock: 0 as caliptra_emu_types::RvData,
-            mbox_user: 0 as caliptra_emu_types::RvData,
-            mbox_cmd: 0 as caliptra_emu_types::RvData,
-            mbox_dlen: 0 as caliptra_emu_types::RvData,
-            mbox_datain: 0 as caliptra_emu_types::RvData,
-            mbox_dataout: 0 as caliptra_emu_types::RvData,
-            mbox_execute: 0 as caliptra_emu_types::RvData,
-            mbox_status: 0 as caliptra_emu_types::RvData,
-            mbox_unlock: 0 as caliptra_emu_types::RvData,
-            tap_mode: 0 as caliptra_emu_types::RvData,
+            mbox_lock: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mbox_user: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mbox_cmd: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mbox_dlen: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mbox_datain: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mbox_dataout: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mbox_execute: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mbox_status: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mbox_unlock: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            tap_mode: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
         }
     }
 }
@@ -294,113 +308,115 @@ impl MboxPeripheral for MboxGenerated {
     }
     fn read_mbox_lock(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::mbox::bits::MboxLock::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::mbox::bits::MboxLock::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read mbox::mbox_lock");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.mbox_lock)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.mbox_lock)
     }
-    fn read_mbox_user(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mbox_user(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read mbox::mbox_user");
         }
         self.mbox_user
     }
-    fn read_mbox_cmd(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mbox_cmd(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read mbox::mbox_cmd");
         }
         self.mbox_cmd
     }
-    fn write_mbox_cmd(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mbox_cmd(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: write mbox::mbox_cmd = 0x{:08x}",
                 val
             );
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mbox_cmd;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mbox_cmd = new_val;
     }
-    fn read_mbox_dlen(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mbox_dlen(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read mbox::mbox_dlen");
         }
         self.mbox_dlen
     }
-    fn write_mbox_dlen(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mbox_dlen(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: write mbox::mbox_dlen = 0x{:08x}",
                 val
             );
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mbox_dlen;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mbox_dlen = new_val;
     }
-    fn read_mbox_datain(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mbox_datain(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read mbox::mbox_datain");
         }
         self.mbox_datain
     }
-    fn write_mbox_datain(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mbox_datain(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: write mbox::mbox_datain = 0x{:08x}",
                 val
             );
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mbox_datain;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mbox_datain = new_val;
     }
-    fn read_mbox_dataout(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mbox_dataout(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read mbox::mbox_dataout");
         }
         self.mbox_dataout
     }
-    fn write_mbox_dataout(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mbox_dataout(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: write mbox::mbox_dataout = 0x{:08x}",
                 val
             );
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mbox_dataout;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mbox_dataout = new_val;
     }
     fn read_mbox_execute(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mbox::bits::MboxExecute::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read mbox::mbox_execute");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.mbox_execute)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.mbox_execute)
     }
     fn write_mbox_execute(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mbox::bits::MboxExecute::Register,
         >,
@@ -411,27 +427,27 @@ impl MboxPeripheral for MboxGenerated {
                 val.reg.get()
             );
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mbox_execute;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mbox_execute = new_val;
     }
     fn read_mbox_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mbox::bits::MboxStatus::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read mbox::mbox_status");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.mbox_status)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.mbox_status)
     }
     fn write_mbox_status(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mbox::bits::MboxStatus::Register,
         >,
@@ -442,27 +458,27 @@ impl MboxPeripheral for MboxGenerated {
                 val.reg.get()
             );
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mbox_status;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xf as caliptra_emu_types::RvData))
-            | (write_val & (0xf as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xf as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xf as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mbox_status = new_val;
     }
     fn read_mbox_unlock(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mbox::bits::MboxUnlock::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read mbox::mbox_unlock");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.mbox_unlock)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.mbox_unlock)
     }
     fn write_mbox_unlock(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mbox::bits::MboxUnlock::Register,
         >,
@@ -473,25 +489,27 @@ impl MboxPeripheral for MboxGenerated {
                 val.reg.get()
             );
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mbox_unlock;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mbox_unlock = new_val;
     }
     fn read_tap_mode(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::mbox::bits::TapMode::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::mbox::bits::TapMode::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read mbox::tap_mode");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.tap_mode)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.tap_mode)
     }
     fn write_tap_mode(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mbox::bits::TapMode::Register,
         >,
@@ -502,28 +520,31 @@ impl MboxPeripheral for MboxGenerated {
                 val.reg.get()
             );
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.tap_mode;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.tap_mode = new_val;
     }
 }
 pub struct MboxBus {
     pub periph: Box<dyn MboxPeripheral>,
 }
-impl caliptra_emu_bus::Bus for MboxBus {
+impl caliptra_core_tools::caliptra_emu_bus::Bus for MboxBus {
     fn read(
         &mut self,
-        size: caliptra_emu_types::RvSize,
-        addr: caliptra_emu_types::RvAddr,
-    ) -> Result<caliptra_emu_types::RvData, caliptra_emu_bus::BusError> {
-        if addr & 0x3 != 0 || size != caliptra_emu_types::RvSize::Word {
-            return Err(caliptra_emu_bus::BusError::LoadAddrMisaligned);
+        size: caliptra_core_tools::caliptra_emu_types::RvSize,
+        addr: caliptra_core_tools::caliptra_emu_types::RvAddr,
+    ) -> Result<
+        caliptra_core_tools::caliptra_emu_types::RvData,
+        caliptra_core_tools::caliptra_emu_bus::BusError,
+    > {
+        if addr & 0x3 != 0 || size != caliptra_core_tools::caliptra_emu_types::RvSize::Word {
+            return Err(caliptra_core_tools::caliptra_emu_bus::BusError::LoadAddrMisaligned);
         }
         match addr {
-            0..4 => Ok(caliptra_emu_types::RvData::from(
+            0..4 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_mbox_lock().reg.get(),
             )),
             4..8 => Ok(self.periph.read_mbox_user()),
@@ -531,29 +552,29 @@ impl caliptra_emu_bus::Bus for MboxBus {
             0xc..0x10 => Ok(self.periph.read_mbox_dlen()),
             0x10..0x14 => Ok(self.periph.read_mbox_datain()),
             0x14..0x18 => Ok(self.periph.read_mbox_dataout()),
-            0x18..0x1c => Ok(caliptra_emu_types::RvData::from(
+            0x18..0x1c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_mbox_execute().reg.get(),
             )),
-            0x1c..0x20 => Ok(caliptra_emu_types::RvData::from(
+            0x1c..0x20 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_mbox_status().reg.get(),
             )),
-            0x20..0x24 => Ok(caliptra_emu_types::RvData::from(
+            0x20..0x24 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_mbox_unlock().reg.get(),
             )),
-            0x24..0x28 => Ok(caliptra_emu_types::RvData::from(
+            0x24..0x28 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_tap_mode().reg.get(),
             )),
-            _ => Err(caliptra_emu_bus::BusError::LoadAccessFault),
+            _ => Err(caliptra_core_tools::caliptra_emu_bus::BusError::LoadAccessFault),
         }
     }
     fn write(
         &mut self,
-        size: caliptra_emu_types::RvSize,
-        addr: caliptra_emu_types::RvAddr,
-        val: caliptra_emu_types::RvData,
-    ) -> Result<(), caliptra_emu_bus::BusError> {
-        if addr & 0x3 != 0 || size != caliptra_emu_types::RvSize::Word {
-            return Err(caliptra_emu_bus::BusError::StoreAddrMisaligned);
+        size: caliptra_core_tools::caliptra_emu_types::RvSize,
+        addr: caliptra_core_tools::caliptra_emu_types::RvAddr,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) -> Result<(), caliptra_core_tools::caliptra_emu_bus::BusError> {
+        if addr & 0x3 != 0 || size != caliptra_core_tools::caliptra_emu_types::RvSize::Word {
+            return Err(caliptra_core_tools::caliptra_emu_bus::BusError::StoreAddrMisaligned);
         }
         match addr {
             0..4 => Ok(()),
@@ -575,26 +596,30 @@ impl caliptra_emu_bus::Bus for MboxBus {
                 Ok(())
             }
             0x18..0x1c => {
-                self.periph
-                    .write_mbox_execute(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_mbox_execute(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0x1c..0x20 => {
-                self.periph
-                    .write_mbox_status(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_mbox_status(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0x20..0x24 => {
-                self.periph
-                    .write_mbox_unlock(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_mbox_unlock(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0x24..0x28 => {
-                self.periph
-                    .write_tap_mode(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_tap_mode(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
-            _ => Err(caliptra_emu_bus::BusError::StoreAccessFault),
+            _ => Err(caliptra_core_tools::caliptra_emu_bus::BusError::StoreAccessFault),
         }
     }
     fn poll(&mut self) {

--- a/registers/generated-emulator/src/mci.rs
+++ b/registers/generated-emulator/src/mci.rs
@@ -5,14 +5,24 @@
 #[allow(unused_imports)]
 use tock_registers::interfaces::{Readable, Writeable};
 pub trait MciPeripheral {
-    fn set_dma_ram(&mut self, _ram: std::rc::Rc<std::cell::RefCell<caliptra_emu_bus::Ram>>) {}
-    fn set_dma_rom_sram(&mut self, _ram: std::rc::Rc<std::cell::RefCell<caliptra_emu_bus::Ram>>) {}
+    fn set_dma_ram(
+        &mut self,
+        _ram: std::rc::Rc<std::cell::RefCell<caliptra_core_tools::caliptra_emu_bus::Ram>>,
+    ) {
+    }
+    fn set_dma_rom_sram(
+        &mut self,
+        _ram: std::rc::Rc<std::cell::RefCell<caliptra_core_tools::caliptra_emu_bus::Ram>>,
+    ) {
+    }
     fn register_event_channels(
         &mut self,
-        _events_to_caliptra: std::sync::mpsc::Sender<caliptra_emu_bus::Event>,
-        _events_from_caliptra: std::sync::mpsc::Receiver<caliptra_emu_bus::Event>,
-        _events_to_mcu: std::sync::mpsc::Sender<caliptra_emu_bus::Event>,
-        _events_from_mcu: std::sync::mpsc::Receiver<caliptra_emu_bus::Event>,
+        _events_to_caliptra: std::sync::mpsc::Sender<caliptra_core_tools::caliptra_emu_bus::Event>,
+        _events_from_caliptra: std::sync::mpsc::Receiver<
+            caliptra_core_tools::caliptra_emu_bus::Event,
+        >,
+        _events_to_mcu: std::sync::mpsc::Sender<caliptra_core_tools::caliptra_emu_bus::Event>,
+        _events_from_mcu: std::sync::mpsc::Receiver<caliptra_core_tools::caliptra_emu_bus::Event>,
     ) {
     }
     fn poll(&mut self) {}
@@ -21,7 +31,7 @@ pub trait MciPeripheral {
     fn generated(&mut self) -> Option<&mut MciGenerated> {
         None
     }
-    fn read_mcu_sram(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_mcu_sram(&mut self, index: usize) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read mci::mcu_sram[{}]",
@@ -33,7 +43,11 @@ pub trait MciPeripheral {
         }
         0
     }
-    fn write_mcu_sram(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    fn write_mcu_sram(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+        index: usize,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write mci::mcu_sram[{}] = 0x{:08x}",
@@ -44,7 +58,7 @@ pub trait MciPeripheral {
             generated.write_mcu_sram(val, index);
         }
     }
-    fn read_mci_reg_hw_capabilities(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_hw_capabilities(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read mci::mci_reg_hw_capabilities");
         }
@@ -53,7 +67,10 @@ pub trait MciPeripheral {
         }
         0
     }
-    fn write_mci_reg_hw_capabilities(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mci_reg_hw_capabilities(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write mci::mci_reg_hw_capabilities = 0x{:08x}",
@@ -64,7 +81,7 @@ pub trait MciPeripheral {
             generated.write_mci_reg_hw_capabilities(val);
         }
     }
-    fn read_mci_reg_fw_capabilities(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_fw_capabilities(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read mci::mci_reg_fw_capabilities");
         }
@@ -73,7 +90,10 @@ pub trait MciPeripheral {
         }
         0
     }
-    fn write_mci_reg_fw_capabilities(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mci_reg_fw_capabilities(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write mci::mci_reg_fw_capabilities = 0x{:08x}",
@@ -86,19 +106,21 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_cap_lock(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::mci::bits::CapLock::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::mci::bits::CapLock::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read mci::mci_reg_cap_lock");
         }
         if let Some(generated) = self.generated() {
             return generated.read_mci_reg_cap_lock();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_mci_reg_cap_lock(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::CapLock::Register,
         >,
@@ -115,17 +137,22 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_hw_rev_id(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::mci::bits::HwRevId::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::mci::bits::HwRevId::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read mci::mci_reg_hw_rev_id");
         }
         if let Some(generated) = self.generated() {
             return generated.read_mci_reg_hw_rev_id();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
-    fn read_mci_reg_fw_rev_id(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_fw_rev_id(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read mci::mci_reg_fw_rev_id[{}]",
@@ -137,7 +164,11 @@ pub trait MciPeripheral {
         }
         0
     }
-    fn write_mci_reg_fw_rev_id(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    fn write_mci_reg_fw_rev_id(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+        index: usize,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write mci::mci_reg_fw_rev_id[{}] = 0x{:08x}",
@@ -150,29 +181,33 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_hw_config0(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::mci::bits::HwConfig0::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::mci::bits::HwConfig0::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read mci::mci_reg_hw_config0");
         }
         if let Some(generated) = self.generated() {
             return generated.read_mci_reg_hw_config0();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_hw_config1(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::mci::bits::HwConfig1::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::mci::bits::HwConfig1::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read mci::mci_reg_hw_config1");
         }
         if let Some(generated) = self.generated() {
             return generated.read_mci_reg_hw_config1();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
-    fn read_mci_reg_mcu_ifu_axi_user(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_mcu_ifu_axi_user(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read mci::mci_reg_mcu_ifu_axi_user");
         }
@@ -181,7 +216,7 @@ pub trait MciPeripheral {
         }
         0
     }
-    fn read_mci_reg_mcu_lsu_axi_user(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_mcu_lsu_axi_user(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read mci::mci_reg_mcu_lsu_axi_user");
         }
@@ -190,7 +225,9 @@ pub trait MciPeripheral {
         }
         0
     }
-    fn read_mci_reg_mcu_sram_config_axi_user(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_mcu_sram_config_axi_user(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read mci::mci_reg_mcu_sram_config_axi_user"
@@ -201,7 +238,9 @@ pub trait MciPeripheral {
         }
         0
     }
-    fn read_mci_reg_mci_soc_config_axi_user(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_mci_soc_config_axi_user(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read mci::mci_reg_mci_soc_config_axi_user"
@@ -212,7 +251,7 @@ pub trait MciPeripheral {
         }
         0
     }
-    fn read_mci_reg_fw_flow_status(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_fw_flow_status(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read mci::mci_reg_fw_flow_status");
         }
@@ -221,7 +260,10 @@ pub trait MciPeripheral {
         }
         0
     }
-    fn write_mci_reg_fw_flow_status(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mci_reg_fw_flow_status(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write mci::mci_reg_fw_flow_status = 0x{:08x}",
@@ -234,7 +276,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_hw_flow_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::HwFlowStatus::Register,
     > {
@@ -244,11 +286,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mci_reg_hw_flow_status();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_reset_reason(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::ResetReason::Register,
     > {
@@ -258,11 +300,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mci_reg_reset_reason();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_mci_reg_reset_reason(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::ResetReason::Register,
         >,
@@ -279,7 +321,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_reset_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::ResetStatus::Register,
     > {
@@ -289,11 +331,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mci_reg_reset_status();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_security_state(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::SecurityState::Register,
     > {
@@ -303,11 +345,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mci_reg_security_state();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_hw_error_fatal(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::HwErrorFatal::Register,
     > {
@@ -317,11 +359,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mci_reg_hw_error_fatal();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_mci_reg_hw_error_fatal(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::HwErrorFatal::Register,
         >,
@@ -338,7 +380,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_agg_error_fatal(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::AggErrorFatal::Register,
     > {
@@ -348,11 +390,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mci_reg_agg_error_fatal();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_mci_reg_agg_error_fatal(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::AggErrorFatal::Register,
         >,
@@ -369,7 +411,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_hw_error_non_fatal(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::HwErrorNonFatal::Register,
     > {
@@ -379,11 +421,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mci_reg_hw_error_non_fatal();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_mci_reg_hw_error_non_fatal(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::HwErrorNonFatal::Register,
         >,
@@ -397,7 +439,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_agg_error_non_fatal(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::AggErrorNonFatal::Register,
     > {
@@ -407,11 +449,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mci_reg_agg_error_non_fatal();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_mci_reg_agg_error_non_fatal(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::AggErrorNonFatal::Register,
         >,
@@ -423,7 +465,7 @@ pub trait MciPeripheral {
             generated.write_mci_reg_agg_error_non_fatal(val);
         }
     }
-    fn read_mci_reg_fw_error_fatal(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_fw_error_fatal(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read mci::mci_reg_fw_error_fatal");
         }
@@ -432,7 +474,10 @@ pub trait MciPeripheral {
         }
         0
     }
-    fn write_mci_reg_fw_error_fatal(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mci_reg_fw_error_fatal(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write mci::mci_reg_fw_error_fatal = 0x{:08x}",
@@ -443,7 +488,9 @@ pub trait MciPeripheral {
             generated.write_mci_reg_fw_error_fatal(val);
         }
     }
-    fn read_mci_reg_fw_error_non_fatal(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_fw_error_non_fatal(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read mci::mci_reg_fw_error_non_fatal");
         }
@@ -452,7 +499,10 @@ pub trait MciPeripheral {
         }
         0
     }
-    fn write_mci_reg_fw_error_non_fatal(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mci_reg_fw_error_non_fatal(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_fw_error_non_fatal = 0x{:08x}" , val);
         }
@@ -460,7 +510,7 @@ pub trait MciPeripheral {
             generated.write_mci_reg_fw_error_non_fatal(val);
         }
     }
-    fn read_mci_reg_hw_error_enc(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_hw_error_enc(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read mci::mci_reg_hw_error_enc");
         }
@@ -469,7 +519,7 @@ pub trait MciPeripheral {
         }
         0
     }
-    fn write_mci_reg_hw_error_enc(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mci_reg_hw_error_enc(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write mci::mci_reg_hw_error_enc = 0x{:08x}",
@@ -480,7 +530,7 @@ pub trait MciPeripheral {
             generated.write_mci_reg_hw_error_enc(val);
         }
     }
-    fn read_mci_reg_fw_error_enc(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_fw_error_enc(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read mci::mci_reg_fw_error_enc");
         }
@@ -489,7 +539,7 @@ pub trait MciPeripheral {
         }
         0
     }
-    fn write_mci_reg_fw_error_enc(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mci_reg_fw_error_enc(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write mci::mci_reg_fw_error_enc = 0x{:08x}",
@@ -500,7 +550,10 @@ pub trait MciPeripheral {
             generated.write_mci_reg_fw_error_enc(val);
         }
     }
-    fn read_mci_reg_fw_extended_error_info(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_fw_extended_error_info(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read mci::mci_reg_fw_extended_error_info[{}]",
@@ -514,7 +567,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_fw_extended_error_info(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
         index: usize,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
@@ -526,7 +579,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_internal_hw_error_fatal_mask(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::InternalHwErrorFatalMask::Register,
     > {
@@ -536,11 +589,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mci_reg_internal_hw_error_fatal_mask();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_mci_reg_internal_hw_error_fatal_mask(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::InternalHwErrorFatalMask::Register,
         >,
@@ -554,7 +607,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_internal_hw_error_non_fatal_mask(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::InternalHwErrorNonFatalMask::Register,
     > {
@@ -564,11 +617,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mci_reg_internal_hw_error_non_fatal_mask();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_mci_reg_internal_hw_error_non_fatal_mask(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::InternalHwErrorNonFatalMask::Register,
         >,
@@ -582,7 +635,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_internal_agg_error_fatal_mask(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::InternalAggErrorFatalMask::Register,
     > {
@@ -592,11 +645,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mci_reg_internal_agg_error_fatal_mask();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_mci_reg_internal_agg_error_fatal_mask(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::InternalAggErrorFatalMask::Register,
         >,
@@ -610,7 +663,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_internal_agg_error_non_fatal_mask(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::InternalAggErrorNonFatalMask::Register,
     > {
@@ -620,11 +673,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mci_reg_internal_agg_error_non_fatal_mask();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_mci_reg_internal_agg_error_non_fatal_mask(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::InternalAggErrorNonFatalMask::Register,
         >,
@@ -636,7 +689,9 @@ pub trait MciPeripheral {
             generated.write_mci_reg_internal_agg_error_non_fatal_mask(val);
         }
     }
-    fn read_mci_reg_internal_fw_error_fatal_mask(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_internal_fw_error_fatal_mask(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_internal_fw_error_fatal_mask");
         }
@@ -645,7 +700,10 @@ pub trait MciPeripheral {
         }
         0
     }
-    fn write_mci_reg_internal_fw_error_fatal_mask(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mci_reg_internal_fw_error_fatal_mask(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_internal_fw_error_fatal_mask = 0x{:08x}" , val);
         }
@@ -653,7 +711,9 @@ pub trait MciPeripheral {
             generated.write_mci_reg_internal_fw_error_fatal_mask(val);
         }
     }
-    fn read_mci_reg_internal_fw_error_non_fatal_mask(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_internal_fw_error_non_fatal_mask(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_internal_fw_error_non_fatal_mask");
         }
@@ -662,7 +722,10 @@ pub trait MciPeripheral {
         }
         0
     }
-    fn write_mci_reg_internal_fw_error_non_fatal_mask(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mci_reg_internal_fw_error_non_fatal_mask(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_internal_fw_error_non_fatal_mask = 0x{:08x}" , val);
         }
@@ -672,7 +735,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_wdt_timer1_en(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::WdtTimer1En::Register,
     > {
@@ -682,11 +745,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mci_reg_wdt_timer1_en();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_mci_reg_wdt_timer1_en(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::WdtTimer1En::Register,
         >,
@@ -703,7 +766,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_wdt_timer1_ctrl(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::WdtTimer1Ctrl::Register,
     > {
@@ -713,11 +776,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mci_reg_wdt_timer1_ctrl();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_mci_reg_wdt_timer1_ctrl(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::WdtTimer1Ctrl::Register,
         >,
@@ -735,7 +798,7 @@ pub trait MciPeripheral {
     fn read_mci_reg_wdt_timer1_timeout_period(
         &mut self,
         index: usize,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_wdt_timer1_timeout_period[{}]" , index);
         }
@@ -746,7 +809,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_wdt_timer1_timeout_period(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
         index: usize,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
@@ -758,7 +821,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_wdt_timer2_en(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::WdtTimer2En::Register,
     > {
@@ -768,11 +831,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mci_reg_wdt_timer2_en();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_mci_reg_wdt_timer2_en(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::WdtTimer2En::Register,
         >,
@@ -789,7 +852,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_wdt_timer2_ctrl(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::WdtTimer2Ctrl::Register,
     > {
@@ -799,11 +862,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mci_reg_wdt_timer2_ctrl();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_mci_reg_wdt_timer2_ctrl(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::WdtTimer2Ctrl::Register,
         >,
@@ -821,7 +884,7 @@ pub trait MciPeripheral {
     fn read_mci_reg_wdt_timer2_timeout_period(
         &mut self,
         index: usize,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_wdt_timer2_timeout_period[{}]" , index);
         }
@@ -832,7 +895,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_wdt_timer2_timeout_period(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
         index: usize,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
@@ -844,17 +907,22 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_wdt_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::mci::bits::WdtStatus::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::mci::bits::WdtStatus::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read mci::mci_reg_wdt_status");
         }
         if let Some(generated) = self.generated() {
             return generated.read_mci_reg_wdt_status();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
-    fn read_mci_reg_wdt_cfg(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_wdt_cfg(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read mci::mci_reg_wdt_cfg[{}]",
@@ -866,7 +934,11 @@ pub trait MciPeripheral {
         }
         0
     }
-    fn write_mci_reg_wdt_cfg(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    fn write_mci_reg_wdt_cfg(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+        index: usize,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write mci::mci_reg_wdt_cfg[{}] = 0x{:08x}",
@@ -877,7 +949,7 @@ pub trait MciPeripheral {
             generated.write_mci_reg_wdt_cfg(val, index);
         }
     }
-    fn read_mci_reg_mcu_timer_config(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_mcu_timer_config(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read mci::mci_reg_mcu_timer_config");
         }
@@ -886,7 +958,10 @@ pub trait MciPeripheral {
         }
         0
     }
-    fn write_mci_reg_mcu_timer_config(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mci_reg_mcu_timer_config(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_mcu_timer_config = 0x{:08x}" , val);
         }
@@ -894,7 +969,7 @@ pub trait MciPeripheral {
             generated.write_mci_reg_mcu_timer_config(val);
         }
     }
-    fn read_mci_reg_mcu_rv_mtime_l(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_mcu_rv_mtime_l(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read mci::mci_reg_mcu_rv_mtime_l");
         }
@@ -903,7 +978,10 @@ pub trait MciPeripheral {
         }
         0
     }
-    fn write_mci_reg_mcu_rv_mtime_l(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mci_reg_mcu_rv_mtime_l(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write mci::mci_reg_mcu_rv_mtime_l = 0x{:08x}",
@@ -914,7 +992,7 @@ pub trait MciPeripheral {
             generated.write_mci_reg_mcu_rv_mtime_l(val);
         }
     }
-    fn read_mci_reg_mcu_rv_mtime_h(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_mcu_rv_mtime_h(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read mci::mci_reg_mcu_rv_mtime_h");
         }
@@ -923,7 +1001,10 @@ pub trait MciPeripheral {
         }
         0
     }
-    fn write_mci_reg_mcu_rv_mtime_h(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mci_reg_mcu_rv_mtime_h(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write mci::mci_reg_mcu_rv_mtime_h = 0x{:08x}",
@@ -934,7 +1015,9 @@ pub trait MciPeripheral {
             generated.write_mci_reg_mcu_rv_mtime_h(val);
         }
     }
-    fn read_mci_reg_mcu_rv_mtimecmp_l(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_mcu_rv_mtimecmp_l(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read mci::mci_reg_mcu_rv_mtimecmp_l");
         }
@@ -943,7 +1026,10 @@ pub trait MciPeripheral {
         }
         0
     }
-    fn write_mci_reg_mcu_rv_mtimecmp_l(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mci_reg_mcu_rv_mtimecmp_l(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_mcu_rv_mtimecmp_l = 0x{:08x}" , val);
         }
@@ -951,7 +1037,9 @@ pub trait MciPeripheral {
             generated.write_mci_reg_mcu_rv_mtimecmp_l(val);
         }
     }
-    fn read_mci_reg_mcu_rv_mtimecmp_h(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_mcu_rv_mtimecmp_h(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read mci::mci_reg_mcu_rv_mtimecmp_h");
         }
@@ -960,7 +1048,10 @@ pub trait MciPeripheral {
         }
         0
     }
-    fn write_mci_reg_mcu_rv_mtimecmp_h(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mci_reg_mcu_rv_mtimecmp_h(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_mcu_rv_mtimecmp_h = 0x{:08x}" , val);
         }
@@ -970,7 +1061,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_reset_request(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::ResetRequest::Register,
     > {
@@ -980,11 +1071,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mci_reg_reset_request();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_mci_reg_reset_request(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::ResetRequest::Register,
         >,
@@ -1001,19 +1092,24 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_mci_bootfsm_go(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::mci::bits::Go::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::mci::bits::Go::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read mci::mci_reg_mci_bootfsm_go");
         }
         if let Some(generated) = self.generated() {
             return generated.read_mci_reg_mci_bootfsm_go();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_mci_reg_mci_bootfsm_go(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::mci::bits::Go::Register>,
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+            u32,
+            registers_generated::mci::bits::Go::Register,
+        >,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
@@ -1027,19 +1123,24 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_cptra_boot_go(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::mci::bits::Go::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::mci::bits::Go::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read mci::mci_reg_cptra_boot_go");
         }
         if let Some(generated) = self.generated() {
             return generated.read_mci_reg_cptra_boot_go();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_mci_reg_cptra_boot_go(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::mci::bits::Go::Register>,
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+            u32,
+            registers_generated::mci::bits::Go::Register,
+        >,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
@@ -1053,7 +1154,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_fw_sram_exec_region_size(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::FwSramExecRegionSize::Register,
     > {
@@ -1065,11 +1166,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mci_reg_fw_sram_exec_region_size();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_mci_reg_fw_sram_exec_region_size(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::FwSramExecRegionSize::Register,
         >,
@@ -1081,7 +1182,7 @@ pub trait MciPeripheral {
             generated.write_mci_reg_fw_sram_exec_region_size(val);
         }
     }
-    fn read_mci_reg_mcu_nmi_vector(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_mcu_nmi_vector(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read mci::mci_reg_mcu_nmi_vector");
         }
@@ -1090,7 +1191,10 @@ pub trait MciPeripheral {
         }
         0
     }
-    fn write_mci_reg_mcu_nmi_vector(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mci_reg_mcu_nmi_vector(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write mci::mci_reg_mcu_nmi_vector = 0x{:08x}",
@@ -1101,7 +1205,7 @@ pub trait MciPeripheral {
             generated.write_mci_reg_mcu_nmi_vector(val);
         }
     }
-    fn read_mci_reg_mcu_reset_vector(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_mcu_reset_vector(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read mci::mci_reg_mcu_reset_vector");
         }
@@ -1110,7 +1214,10 @@ pub trait MciPeripheral {
         }
         0
     }
-    fn write_mci_reg_mcu_reset_vector(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mci_reg_mcu_reset_vector(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_mcu_reset_vector = 0x{:08x}" , val);
         }
@@ -1118,7 +1225,10 @@ pub trait MciPeripheral {
             generated.write_mci_reg_mcu_reset_vector(val);
         }
     }
-    fn read_mci_reg_mbox0_valid_axi_user(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_mbox0_valid_axi_user(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read mci::mci_reg_mbox0_valid_axi_user[{}]",
@@ -1132,7 +1242,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_mbox0_valid_axi_user(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
         index: usize,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
@@ -1145,7 +1255,7 @@ pub trait MciPeripheral {
     fn read_mci_reg_mbox0_axi_user_lock(
         &mut self,
         index: usize,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::MboxxAxiUserLock::Register,
     > {
@@ -1158,11 +1268,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mci_reg_mbox0_axi_user_lock(index);
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_mci_reg_mbox0_axi_user_lock(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::MboxxAxiUserLock::Register,
         >,
@@ -1175,7 +1285,10 @@ pub trait MciPeripheral {
             generated.write_mci_reg_mbox0_axi_user_lock(val, index);
         }
     }
-    fn read_mci_reg_mbox1_valid_axi_user(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_mbox1_valid_axi_user(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read mci::mci_reg_mbox1_valid_axi_user[{}]",
@@ -1189,7 +1302,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_mbox1_valid_axi_user(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
         index: usize,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
@@ -1202,7 +1315,7 @@ pub trait MciPeripheral {
     fn read_mci_reg_mbox1_axi_user_lock(
         &mut self,
         index: usize,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::MboxxAxiUserLock::Register,
     > {
@@ -1215,11 +1328,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mci_reg_mbox1_axi_user_lock(index);
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_mci_reg_mbox1_axi_user_lock(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::MboxxAxiUserLock::Register,
         >,
@@ -1232,7 +1345,10 @@ pub trait MciPeripheral {
             generated.write_mci_reg_mbox1_axi_user_lock(val, index);
         }
     }
-    fn read_mci_reg_soc_dft_en(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_soc_dft_en(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read mci::mci_reg_soc_dft_en[{}]",
@@ -1244,7 +1360,11 @@ pub trait MciPeripheral {
         }
         0
     }
-    fn write_mci_reg_soc_dft_en(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    fn write_mci_reg_soc_dft_en(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+        index: usize,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write mci::mci_reg_soc_dft_en[{}] = 0x{:08x}",
@@ -1255,7 +1375,10 @@ pub trait MciPeripheral {
             generated.write_mci_reg_soc_dft_en(val, index);
         }
     }
-    fn read_mci_reg_soc_hw_debug_en(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_soc_hw_debug_en(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read mci::mci_reg_soc_hw_debug_en[{}]",
@@ -1267,7 +1390,11 @@ pub trait MciPeripheral {
         }
         0
     }
-    fn write_mci_reg_soc_hw_debug_en(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    fn write_mci_reg_soc_hw_debug_en(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+        index: usize,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_soc_hw_debug_en[{}] = 0x{:08x}" , index , val);
         }
@@ -1275,7 +1402,10 @@ pub trait MciPeripheral {
             generated.write_mci_reg_soc_hw_debug_en(val, index);
         }
     }
-    fn read_mci_reg_soc_prod_debug_state(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_soc_prod_debug_state(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read mci::mci_reg_soc_prod_debug_state[{}]",
@@ -1289,7 +1419,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_soc_prod_debug_state(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
         index: usize,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
@@ -1299,7 +1429,9 @@ pub trait MciPeripheral {
             generated.write_mci_reg_soc_prod_debug_state(val, index);
         }
     }
-    fn read_mci_reg_fc_fips_zerozation(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_fc_fips_zerozation(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read mci::mci_reg_fc_fips_zerozation");
         }
@@ -1308,7 +1440,10 @@ pub trait MciPeripheral {
         }
         0
     }
-    fn write_mci_reg_fc_fips_zerozation(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mci_reg_fc_fips_zerozation(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_fc_fips_zerozation = 0x{:08x}" , val);
         }
@@ -1316,7 +1451,10 @@ pub trait MciPeripheral {
             generated.write_mci_reg_fc_fips_zerozation(val);
         }
     }
-    fn read_mci_reg_generic_input_wires(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_generic_input_wires(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read mci::mci_reg_generic_input_wires[{}]",
@@ -1328,7 +1466,10 @@ pub trait MciPeripheral {
         }
         0
     }
-    fn read_mci_reg_generic_output_wires(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_generic_output_wires(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read mci::mci_reg_generic_output_wires[{}]",
@@ -1342,7 +1483,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_generic_output_wires(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
         index: usize,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
@@ -1352,7 +1493,7 @@ pub trait MciPeripheral {
             generated.write_mci_reg_generic_output_wires(val, index);
         }
     }
-    fn read_mci_reg_debug_in(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_debug_in(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read mci::mci_reg_debug_in");
         }
@@ -1361,7 +1502,7 @@ pub trait MciPeripheral {
         }
         0
     }
-    fn write_mci_reg_debug_in(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mci_reg_debug_in(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write mci::mci_reg_debug_in = 0x{:08x}",
@@ -1372,7 +1513,7 @@ pub trait MciPeripheral {
             generated.write_mci_reg_debug_in(val);
         }
     }
-    fn read_mci_reg_debug_out(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_debug_out(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read mci::mci_reg_debug_out");
         }
@@ -1381,7 +1522,7 @@ pub trait MciPeripheral {
         }
         0
     }
-    fn write_mci_reg_debug_out(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mci_reg_debug_out(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write mci::mci_reg_debug_out = 0x{:08x}",
@@ -1394,7 +1535,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_ss_debug_intent(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::SsDebugIntent::Register,
     > {
@@ -1404,11 +1545,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mci_reg_ss_debug_intent();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_ss_config_done_sticky(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::SsConfigDone::Register,
     > {
@@ -1420,11 +1561,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mci_reg_ss_config_done_sticky();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_mci_reg_ss_config_done_sticky(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::SsConfigDone::Register,
         >,
@@ -1438,7 +1579,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_ss_config_done(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::SsConfigDone::Register,
     > {
@@ -1448,11 +1589,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mci_reg_ss_config_done();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_mci_reg_ss_config_done(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::SsConfigDone::Register,
         >,
@@ -1470,7 +1611,7 @@ pub trait MciPeripheral {
     fn read_mci_reg_prod_debug_unlock_pk_hash_reg(
         &mut self,
         index: usize,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_prod_debug_unlock_pk_hash_reg[{}]" , index);
         }
@@ -1481,7 +1622,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_prod_debug_unlock_pk_hash_reg(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
         index: usize,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
@@ -1493,7 +1634,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_global_intr_en_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::GlobalIntrEnT::Register,
     > {
@@ -1503,11 +1644,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mci_reg_intr_block_rf_global_intr_en_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_mci_reg_intr_block_rf_global_intr_en_r(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::GlobalIntrEnT::Register,
         >,
@@ -1521,7 +1662,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_error0_intr_en_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::Error0IntrEnT::Register,
     > {
@@ -1531,11 +1672,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mci_reg_intr_block_rf_error0_intr_en_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_mci_reg_intr_block_rf_error0_intr_en_r(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::Error0IntrEnT::Register,
         >,
@@ -1549,7 +1690,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_error1_intr_en_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::Error1IntrEnT::Register,
     > {
@@ -1559,11 +1700,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mci_reg_intr_block_rf_error1_intr_en_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_mci_reg_intr_block_rf_error1_intr_en_r(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::Error1IntrEnT::Register,
         >,
@@ -1577,7 +1718,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_notif0_intr_en_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::Notif0IntrEnT::Register,
     > {
@@ -1587,11 +1728,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mci_reg_intr_block_rf_notif0_intr_en_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_mci_reg_intr_block_rf_notif0_intr_en_r(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::Notif0IntrEnT::Register,
         >,
@@ -1605,7 +1746,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_notif1_intr_en_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::Notif1IntrEnT::Register,
     > {
@@ -1615,11 +1756,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mci_reg_intr_block_rf_notif1_intr_en_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_mci_reg_intr_block_rf_notif1_intr_en_r(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::Notif1IntrEnT::Register,
         >,
@@ -1633,7 +1774,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_error_global_intr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::GlobalIntrT::Register,
     > {
@@ -1643,11 +1784,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mci_reg_intr_block_rf_error_global_intr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_notif_global_intr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::GlobalIntrT::Register,
     > {
@@ -1657,11 +1798,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mci_reg_intr_block_rf_notif_global_intr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_error0_internal_intr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::Error0IntrT::Register,
     > {
@@ -1671,11 +1812,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mci_reg_intr_block_rf_error0_internal_intr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_mci_reg_intr_block_rf_error0_internal_intr_r(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::Error0IntrT::Register,
         >,
@@ -1689,7 +1830,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_error1_internal_intr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::Error1IntrT::Register,
     > {
@@ -1699,11 +1840,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mci_reg_intr_block_rf_error1_internal_intr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_mci_reg_intr_block_rf_error1_internal_intr_r(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::Error1IntrT::Register,
         >,
@@ -1717,7 +1858,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_notif0_internal_intr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::Notif0IntrT::Register,
     > {
@@ -1727,11 +1868,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mci_reg_intr_block_rf_notif0_internal_intr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_mci_reg_intr_block_rf_notif0_internal_intr_r(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::Notif0IntrT::Register,
         >,
@@ -1745,7 +1886,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_notif1_internal_intr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::Notif1IntrT::Register,
     > {
@@ -1755,11 +1896,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mci_reg_intr_block_rf_notif1_internal_intr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_mci_reg_intr_block_rf_notif1_internal_intr_r(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::Notif1IntrT::Register,
         >,
@@ -1773,7 +1914,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_error0_intr_trig_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::Error0IntrTrigT::Register,
     > {
@@ -1783,11 +1924,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mci_reg_intr_block_rf_error0_intr_trig_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_mci_reg_intr_block_rf_error0_intr_trig_r(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::Error0IntrTrigT::Register,
         >,
@@ -1801,7 +1942,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_error1_intr_trig_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::Error1IntrTrigT::Register,
     > {
@@ -1811,11 +1952,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mci_reg_intr_block_rf_error1_intr_trig_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_mci_reg_intr_block_rf_error1_intr_trig_r(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::Error1IntrTrigT::Register,
         >,
@@ -1829,7 +1970,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_notif0_intr_trig_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::Notif0IntrTrigT::Register,
     > {
@@ -1839,11 +1980,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mci_reg_intr_block_rf_notif0_intr_trig_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_mci_reg_intr_block_rf_notif0_intr_trig_r(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::Notif0IntrTrigT::Register,
         >,
@@ -1857,7 +1998,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_notif1_intr_trig_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::Notif1IntrTrigT::Register,
     > {
@@ -1867,11 +2008,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mci_reg_intr_block_rf_notif1_intr_trig_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_mci_reg_intr_block_rf_notif1_intr_trig_r(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::Notif1IntrTrigT::Register,
         >,
@@ -1885,7 +2026,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_error_internal_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_error_internal_intr_count_r");
         }
@@ -1896,7 +2037,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_error_internal_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_error_internal_intr_count_r = 0x{:08x}" , val);
@@ -1907,7 +2048,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_error_mbox0_ecc_unc_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_error_mbox0_ecc_unc_intr_count_r");
         }
@@ -1918,7 +2059,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_error_mbox0_ecc_unc_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_error_mbox0_ecc_unc_intr_count_r = 0x{:08x}" , val);
@@ -1929,7 +2070,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_error_mbox1_ecc_unc_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_error_mbox1_ecc_unc_intr_count_r");
         }
@@ -1940,7 +2081,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_error_mbox1_ecc_unc_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_error_mbox1_ecc_unc_intr_count_r = 0x{:08x}" , val);
@@ -1951,7 +2092,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_error_mcu_sram_dmi_axi_collision_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_error_mcu_sram_dmi_axi_collision_intr_count_r");
         }
@@ -1963,7 +2104,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_error_mcu_sram_dmi_axi_collision_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_error_mcu_sram_dmi_axi_collision_intr_count_r = 0x{:08x}" , val);
@@ -1975,7 +2116,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_error_wdt_timer1_timeout_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_error_wdt_timer1_timeout_intr_count_r");
         }
@@ -1986,7 +2127,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_error_wdt_timer1_timeout_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_error_wdt_timer1_timeout_intr_count_r = 0x{:08x}" , val);
@@ -1997,7 +2138,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_error_wdt_timer2_timeout_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_error_wdt_timer2_timeout_intr_count_r");
         }
@@ -2008,7 +2149,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_error_wdt_timer2_timeout_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_error_wdt_timer2_timeout_intr_count_r = 0x{:08x}" , val);
@@ -2019,7 +2160,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal0_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_error_agg_error_fatal0_intr_count_r");
         }
@@ -2030,7 +2171,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_error_agg_error_fatal0_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_error_agg_error_fatal0_intr_count_r = 0x{:08x}" , val);
@@ -2041,7 +2182,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal1_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_error_agg_error_fatal1_intr_count_r");
         }
@@ -2052,7 +2193,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_error_agg_error_fatal1_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_error_agg_error_fatal1_intr_count_r = 0x{:08x}" , val);
@@ -2063,7 +2204,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal2_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_error_agg_error_fatal2_intr_count_r");
         }
@@ -2074,7 +2215,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_error_agg_error_fatal2_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_error_agg_error_fatal2_intr_count_r = 0x{:08x}" , val);
@@ -2085,7 +2226,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal3_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_error_agg_error_fatal3_intr_count_r");
         }
@@ -2096,7 +2237,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_error_agg_error_fatal3_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_error_agg_error_fatal3_intr_count_r = 0x{:08x}" , val);
@@ -2107,7 +2248,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal4_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_error_agg_error_fatal4_intr_count_r");
         }
@@ -2118,7 +2259,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_error_agg_error_fatal4_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_error_agg_error_fatal4_intr_count_r = 0x{:08x}" , val);
@@ -2129,7 +2270,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal5_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_error_agg_error_fatal5_intr_count_r");
         }
@@ -2140,7 +2281,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_error_agg_error_fatal5_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_error_agg_error_fatal5_intr_count_r = 0x{:08x}" , val);
@@ -2151,7 +2292,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal6_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_error_agg_error_fatal6_intr_count_r");
         }
@@ -2162,7 +2303,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_error_agg_error_fatal6_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_error_agg_error_fatal6_intr_count_r = 0x{:08x}" , val);
@@ -2173,7 +2314,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal7_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_error_agg_error_fatal7_intr_count_r");
         }
@@ -2184,7 +2325,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_error_agg_error_fatal7_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_error_agg_error_fatal7_intr_count_r = 0x{:08x}" , val);
@@ -2195,7 +2336,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal8_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_error_agg_error_fatal8_intr_count_r");
         }
@@ -2206,7 +2347,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_error_agg_error_fatal8_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_error_agg_error_fatal8_intr_count_r = 0x{:08x}" , val);
@@ -2217,7 +2358,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal9_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_error_agg_error_fatal9_intr_count_r");
         }
@@ -2228,7 +2369,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_error_agg_error_fatal9_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_error_agg_error_fatal9_intr_count_r = 0x{:08x}" , val);
@@ -2239,7 +2380,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal10_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_error_agg_error_fatal10_intr_count_r");
         }
@@ -2250,7 +2391,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_error_agg_error_fatal10_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_error_agg_error_fatal10_intr_count_r = 0x{:08x}" , val);
@@ -2261,7 +2402,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal11_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_error_agg_error_fatal11_intr_count_r");
         }
@@ -2272,7 +2413,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_error_agg_error_fatal11_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_error_agg_error_fatal11_intr_count_r = 0x{:08x}" , val);
@@ -2283,7 +2424,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal12_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_error_agg_error_fatal12_intr_count_r");
         }
@@ -2294,7 +2435,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_error_agg_error_fatal12_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_error_agg_error_fatal12_intr_count_r = 0x{:08x}" , val);
@@ -2305,7 +2446,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal13_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_error_agg_error_fatal13_intr_count_r");
         }
@@ -2316,7 +2457,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_error_agg_error_fatal13_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_error_agg_error_fatal13_intr_count_r = 0x{:08x}" , val);
@@ -2327,7 +2468,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal14_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_error_agg_error_fatal14_intr_count_r");
         }
@@ -2338,7 +2479,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_error_agg_error_fatal14_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_error_agg_error_fatal14_intr_count_r = 0x{:08x}" , val);
@@ -2349,7 +2490,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal15_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_error_agg_error_fatal15_intr_count_r");
         }
@@ -2360,7 +2501,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_error_agg_error_fatal15_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_error_agg_error_fatal15_intr_count_r = 0x{:08x}" , val);
@@ -2371,7 +2512,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal16_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_error_agg_error_fatal16_intr_count_r");
         }
@@ -2382,7 +2523,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_error_agg_error_fatal16_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_error_agg_error_fatal16_intr_count_r = 0x{:08x}" , val);
@@ -2393,7 +2534,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal17_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_error_agg_error_fatal17_intr_count_r");
         }
@@ -2404,7 +2545,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_error_agg_error_fatal17_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_error_agg_error_fatal17_intr_count_r = 0x{:08x}" , val);
@@ -2415,7 +2556,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal18_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_error_agg_error_fatal18_intr_count_r");
         }
@@ -2426,7 +2567,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_error_agg_error_fatal18_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_error_agg_error_fatal18_intr_count_r = 0x{:08x}" , val);
@@ -2437,7 +2578,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal19_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_error_agg_error_fatal19_intr_count_r");
         }
@@ -2448,7 +2589,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_error_agg_error_fatal19_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_error_agg_error_fatal19_intr_count_r = 0x{:08x}" , val);
@@ -2459,7 +2600,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal20_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_error_agg_error_fatal20_intr_count_r");
         }
@@ -2470,7 +2611,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_error_agg_error_fatal20_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_error_agg_error_fatal20_intr_count_r = 0x{:08x}" , val);
@@ -2481,7 +2622,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal21_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_error_agg_error_fatal21_intr_count_r");
         }
@@ -2492,7 +2633,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_error_agg_error_fatal21_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_error_agg_error_fatal21_intr_count_r = 0x{:08x}" , val);
@@ -2503,7 +2644,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal22_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_error_agg_error_fatal22_intr_count_r");
         }
@@ -2514,7 +2655,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_error_agg_error_fatal22_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_error_agg_error_fatal22_intr_count_r = 0x{:08x}" , val);
@@ -2525,7 +2666,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal23_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_error_agg_error_fatal23_intr_count_r");
         }
@@ -2536,7 +2677,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_error_agg_error_fatal23_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_error_agg_error_fatal23_intr_count_r = 0x{:08x}" , val);
@@ -2547,7 +2688,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal24_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_error_agg_error_fatal24_intr_count_r");
         }
@@ -2558,7 +2699,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_error_agg_error_fatal24_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_error_agg_error_fatal24_intr_count_r = 0x{:08x}" , val);
@@ -2569,7 +2710,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal25_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_error_agg_error_fatal25_intr_count_r");
         }
@@ -2580,7 +2721,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_error_agg_error_fatal25_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_error_agg_error_fatal25_intr_count_r = 0x{:08x}" , val);
@@ -2591,7 +2732,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal26_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_error_agg_error_fatal26_intr_count_r");
         }
@@ -2602,7 +2743,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_error_agg_error_fatal26_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_error_agg_error_fatal26_intr_count_r = 0x{:08x}" , val);
@@ -2613,7 +2754,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal27_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_error_agg_error_fatal27_intr_count_r");
         }
@@ -2624,7 +2765,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_error_agg_error_fatal27_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_error_agg_error_fatal27_intr_count_r = 0x{:08x}" , val);
@@ -2635,7 +2776,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal28_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_error_agg_error_fatal28_intr_count_r");
         }
@@ -2646,7 +2787,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_error_agg_error_fatal28_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_error_agg_error_fatal28_intr_count_r = 0x{:08x}" , val);
@@ -2657,7 +2798,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal29_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_error_agg_error_fatal29_intr_count_r");
         }
@@ -2668,7 +2809,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_error_agg_error_fatal29_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_error_agg_error_fatal29_intr_count_r = 0x{:08x}" , val);
@@ -2679,7 +2820,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal30_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_error_agg_error_fatal30_intr_count_r");
         }
@@ -2690,7 +2831,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_error_agg_error_fatal30_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_error_agg_error_fatal30_intr_count_r = 0x{:08x}" , val);
@@ -2701,7 +2842,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal31_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_error_agg_error_fatal31_intr_count_r");
         }
@@ -2712,7 +2853,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_error_agg_error_fatal31_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_error_agg_error_fatal31_intr_count_r = 0x{:08x}" , val);
@@ -2723,7 +2864,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_notif_mcu_sram_ecc_cor_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_notif_mcu_sram_ecc_cor_intr_count_r");
         }
@@ -2734,7 +2875,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_notif_mcu_sram_ecc_cor_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_notif_mcu_sram_ecc_cor_intr_count_r = 0x{:08x}" , val);
@@ -2745,7 +2886,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_notif_cptra_mcu_reset_req_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_notif_cptra_mcu_reset_req_intr_count_r");
         }
@@ -2756,7 +2897,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_notif_cptra_mcu_reset_req_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_notif_cptra_mcu_reset_req_intr_count_r = 0x{:08x}" , val);
@@ -2767,7 +2908,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_notif_gen_in_toggle_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_notif_gen_in_toggle_intr_count_r");
         }
@@ -2778,7 +2919,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_notif_gen_in_toggle_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_notif_gen_in_toggle_intr_count_r = 0x{:08x}" , val);
@@ -2789,7 +2930,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal0_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal0_intr_count_r");
         }
@@ -2800,7 +2941,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_notif_agg_error_non_fatal0_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal0_intr_count_r = 0x{:08x}" , val);
@@ -2811,7 +2952,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal1_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal1_intr_count_r");
         }
@@ -2822,7 +2963,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_notif_agg_error_non_fatal1_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal1_intr_count_r = 0x{:08x}" , val);
@@ -2833,7 +2974,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal2_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal2_intr_count_r");
         }
@@ -2844,7 +2985,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_notif_agg_error_non_fatal2_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal2_intr_count_r = 0x{:08x}" , val);
@@ -2855,7 +2996,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal3_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal3_intr_count_r");
         }
@@ -2866,7 +3007,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_notif_agg_error_non_fatal3_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal3_intr_count_r = 0x{:08x}" , val);
@@ -2877,7 +3018,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal4_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal4_intr_count_r");
         }
@@ -2888,7 +3029,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_notif_agg_error_non_fatal4_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal4_intr_count_r = 0x{:08x}" , val);
@@ -2899,7 +3040,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal5_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal5_intr_count_r");
         }
@@ -2910,7 +3051,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_notif_agg_error_non_fatal5_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal5_intr_count_r = 0x{:08x}" , val);
@@ -2921,7 +3062,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal6_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal6_intr_count_r");
         }
@@ -2932,7 +3073,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_notif_agg_error_non_fatal6_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal6_intr_count_r = 0x{:08x}" , val);
@@ -2943,7 +3084,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal7_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal7_intr_count_r");
         }
@@ -2954,7 +3095,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_notif_agg_error_non_fatal7_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal7_intr_count_r = 0x{:08x}" , val);
@@ -2965,7 +3106,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal8_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal8_intr_count_r");
         }
@@ -2976,7 +3117,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_notif_agg_error_non_fatal8_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal8_intr_count_r = 0x{:08x}" , val);
@@ -2987,7 +3128,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal9_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal9_intr_count_r");
         }
@@ -2998,7 +3139,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_notif_agg_error_non_fatal9_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal9_intr_count_r = 0x{:08x}" , val);
@@ -3009,7 +3150,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal10_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal10_intr_count_r");
         }
@@ -3020,7 +3161,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_notif_agg_error_non_fatal10_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal10_intr_count_r = 0x{:08x}" , val);
@@ -3031,7 +3172,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal11_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal11_intr_count_r");
         }
@@ -3042,7 +3183,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_notif_agg_error_non_fatal11_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal11_intr_count_r = 0x{:08x}" , val);
@@ -3053,7 +3194,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal12_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal12_intr_count_r");
         }
@@ -3064,7 +3205,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_notif_agg_error_non_fatal12_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal12_intr_count_r = 0x{:08x}" , val);
@@ -3075,7 +3216,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal13_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal13_intr_count_r");
         }
@@ -3086,7 +3227,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_notif_agg_error_non_fatal13_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal13_intr_count_r = 0x{:08x}" , val);
@@ -3097,7 +3238,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal14_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal14_intr_count_r");
         }
@@ -3108,7 +3249,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_notif_agg_error_non_fatal14_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal14_intr_count_r = 0x{:08x}" , val);
@@ -3119,7 +3260,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal15_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal15_intr_count_r");
         }
@@ -3130,7 +3271,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_notif_agg_error_non_fatal15_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal15_intr_count_r = 0x{:08x}" , val);
@@ -3141,7 +3282,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal16_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal16_intr_count_r");
         }
@@ -3152,7 +3293,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_notif_agg_error_non_fatal16_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal16_intr_count_r = 0x{:08x}" , val);
@@ -3163,7 +3304,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal17_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal17_intr_count_r");
         }
@@ -3174,7 +3315,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_notif_agg_error_non_fatal17_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal17_intr_count_r = 0x{:08x}" , val);
@@ -3185,7 +3326,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal18_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal18_intr_count_r");
         }
@@ -3196,7 +3337,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_notif_agg_error_non_fatal18_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal18_intr_count_r = 0x{:08x}" , val);
@@ -3207,7 +3348,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal19_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal19_intr_count_r");
         }
@@ -3218,7 +3359,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_notif_agg_error_non_fatal19_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal19_intr_count_r = 0x{:08x}" , val);
@@ -3229,7 +3370,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal20_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal20_intr_count_r");
         }
@@ -3240,7 +3381,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_notif_agg_error_non_fatal20_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal20_intr_count_r = 0x{:08x}" , val);
@@ -3251,7 +3392,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal21_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal21_intr_count_r");
         }
@@ -3262,7 +3403,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_notif_agg_error_non_fatal21_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal21_intr_count_r = 0x{:08x}" , val);
@@ -3273,7 +3414,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal22_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal22_intr_count_r");
         }
@@ -3284,7 +3425,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_notif_agg_error_non_fatal22_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal22_intr_count_r = 0x{:08x}" , val);
@@ -3295,7 +3436,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal23_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal23_intr_count_r");
         }
@@ -3306,7 +3447,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_notif_agg_error_non_fatal23_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal23_intr_count_r = 0x{:08x}" , val);
@@ -3317,7 +3458,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal24_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal24_intr_count_r");
         }
@@ -3328,7 +3469,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_notif_agg_error_non_fatal24_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal24_intr_count_r = 0x{:08x}" , val);
@@ -3339,7 +3480,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal25_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal25_intr_count_r");
         }
@@ -3350,7 +3491,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_notif_agg_error_non_fatal25_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal25_intr_count_r = 0x{:08x}" , val);
@@ -3361,7 +3502,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal26_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal26_intr_count_r");
         }
@@ -3372,7 +3513,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_notif_agg_error_non_fatal26_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal26_intr_count_r = 0x{:08x}" , val);
@@ -3383,7 +3524,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal27_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal27_intr_count_r");
         }
@@ -3394,7 +3535,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_notif_agg_error_non_fatal27_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal27_intr_count_r = 0x{:08x}" , val);
@@ -3405,7 +3546,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal28_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal28_intr_count_r");
         }
@@ -3416,7 +3557,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_notif_agg_error_non_fatal28_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal28_intr_count_r = 0x{:08x}" , val);
@@ -3427,7 +3568,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal29_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal29_intr_count_r");
         }
@@ -3438,7 +3579,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_notif_agg_error_non_fatal29_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal29_intr_count_r = 0x{:08x}" , val);
@@ -3449,7 +3590,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal30_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal30_intr_count_r");
         }
@@ -3460,7 +3601,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_notif_agg_error_non_fatal30_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal30_intr_count_r = 0x{:08x}" , val);
@@ -3471,7 +3612,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal31_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal31_intr_count_r");
         }
@@ -3482,7 +3623,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_notif_agg_error_non_fatal31_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal31_intr_count_r = 0x{:08x}" , val);
@@ -3493,7 +3634,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_notif_mbox0_target_done_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_notif_mbox0_target_done_intr_count_r");
         }
@@ -3504,7 +3645,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_notif_mbox0_target_done_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_notif_mbox0_target_done_intr_count_r = 0x{:08x}" , val);
@@ -3515,7 +3656,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_notif_mbox1_target_done_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_notif_mbox1_target_done_intr_count_r");
         }
@@ -3526,7 +3667,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_notif_mbox1_target_done_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_notif_mbox1_target_done_intr_count_r = 0x{:08x}" , val);
@@ -3537,7 +3678,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_notif_mbox0_cmd_avail_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_notif_mbox0_cmd_avail_intr_count_r");
         }
@@ -3548,7 +3689,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_notif_mbox0_cmd_avail_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_notif_mbox0_cmd_avail_intr_count_r = 0x{:08x}" , val);
@@ -3559,7 +3700,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_notif_mbox1_cmd_avail_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_notif_mbox1_cmd_avail_intr_count_r");
         }
@@ -3570,7 +3711,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_notif_mbox1_cmd_avail_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_notif_mbox1_cmd_avail_intr_count_r = 0x{:08x}" , val);
@@ -3581,7 +3722,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_notif_cptra_mbox_cmd_avail_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_notif_cptra_mbox_cmd_avail_intr_count_r");
         }
@@ -3592,7 +3733,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_notif_cptra_mbox_cmd_avail_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_notif_cptra_mbox_cmd_avail_intr_count_r = 0x{:08x}" , val);
@@ -3603,7 +3744,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_notif_mbox0_ecc_cor_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_notif_mbox0_ecc_cor_intr_count_r");
         }
@@ -3614,7 +3755,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_notif_mbox0_ecc_cor_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_notif_mbox0_ecc_cor_intr_count_r = 0x{:08x}" , val);
@@ -3625,7 +3766,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_notif_mbox1_ecc_cor_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_notif_mbox1_ecc_cor_intr_count_r");
         }
@@ -3636,7 +3777,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_notif_mbox1_ecc_cor_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_notif_mbox1_ecc_cor_intr_count_r = 0x{:08x}" , val);
@@ -3647,7 +3788,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_notif_debug_locked_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_notif_debug_locked_intr_count_r");
         }
@@ -3658,7 +3799,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_notif_debug_locked_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_notif_debug_locked_intr_count_r = 0x{:08x}" , val);
@@ -3669,7 +3810,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_notif_scan_mode_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_notif_scan_mode_intr_count_r");
         }
@@ -3680,7 +3821,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_notif_scan_mode_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_notif_scan_mode_intr_count_r = 0x{:08x}" , val);
@@ -3691,7 +3832,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_notif_mbox0_soc_req_lock_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_notif_mbox0_soc_req_lock_intr_count_r");
         }
@@ -3702,7 +3843,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_notif_mbox0_soc_req_lock_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_notif_mbox0_soc_req_lock_intr_count_r = 0x{:08x}" , val);
@@ -3713,7 +3854,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_notif_mbox1_soc_req_lock_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_notif_mbox1_soc_req_lock_intr_count_r");
         }
@@ -3724,7 +3865,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_notif_mbox1_soc_req_lock_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_notif_mbox1_soc_req_lock_intr_count_r = 0x{:08x}" , val);
@@ -3735,7 +3876,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_notif_otp_operation_done_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read mci::mci_reg_intr_block_rf_notif_otp_operation_done_intr_count_r");
         }
@@ -3746,7 +3887,7 @@ pub trait MciPeripheral {
     }
     fn write_mci_reg_intr_block_rf_notif_otp_operation_done_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mci_reg_intr_block_rf_notif_otp_operation_done_intr_count_r = 0x{:08x}" , val);
@@ -3757,7 +3898,7 @@ pub trait MciPeripheral {
     }
     fn read_mci_reg_intr_block_rf_error_internal_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -3767,11 +3908,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mci_reg_intr_block_rf_error_internal_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_error_mbox0_ecc_unc_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -3781,11 +3922,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mci_reg_intr_block_rf_error_mbox0_ecc_unc_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_error_mbox1_ecc_unc_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -3795,11 +3936,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mci_reg_intr_block_rf_error_mbox1_ecc_unc_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_error_wdt_timer1_timeout_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -3810,11 +3951,11 @@ pub trait MciPeripheral {
             return generated
                 .read_mci_reg_intr_block_rf_error_wdt_timer1_timeout_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_error_wdt_timer2_timeout_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -3825,11 +3966,11 @@ pub trait MciPeripheral {
             return generated
                 .read_mci_reg_intr_block_rf_error_wdt_timer2_timeout_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_error_mcu_sram_dmi_axi_collision_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -3840,11 +3981,11 @@ pub trait MciPeripheral {
             return generated
                 .read_mci_reg_intr_block_rf_error_mcu_sram_dmi_axi_collision_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal0_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -3854,11 +3995,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mci_reg_intr_block_rf_error_agg_error_fatal0_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal1_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -3868,11 +4009,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mci_reg_intr_block_rf_error_agg_error_fatal1_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal2_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -3882,11 +4023,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mci_reg_intr_block_rf_error_agg_error_fatal2_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal3_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -3896,11 +4037,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mci_reg_intr_block_rf_error_agg_error_fatal3_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal4_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -3910,11 +4051,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mci_reg_intr_block_rf_error_agg_error_fatal4_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal5_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -3924,11 +4065,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mci_reg_intr_block_rf_error_agg_error_fatal5_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal6_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -3938,11 +4079,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mci_reg_intr_block_rf_error_agg_error_fatal6_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal7_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -3952,11 +4093,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mci_reg_intr_block_rf_error_agg_error_fatal7_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal8_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -3966,11 +4107,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mci_reg_intr_block_rf_error_agg_error_fatal8_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal9_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -3980,11 +4121,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mci_reg_intr_block_rf_error_agg_error_fatal9_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal10_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -3995,11 +4136,11 @@ pub trait MciPeripheral {
             return generated
                 .read_mci_reg_intr_block_rf_error_agg_error_fatal10_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal11_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4010,11 +4151,11 @@ pub trait MciPeripheral {
             return generated
                 .read_mci_reg_intr_block_rf_error_agg_error_fatal11_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal12_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4025,11 +4166,11 @@ pub trait MciPeripheral {
             return generated
                 .read_mci_reg_intr_block_rf_error_agg_error_fatal12_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal13_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4040,11 +4181,11 @@ pub trait MciPeripheral {
             return generated
                 .read_mci_reg_intr_block_rf_error_agg_error_fatal13_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal14_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4055,11 +4196,11 @@ pub trait MciPeripheral {
             return generated
                 .read_mci_reg_intr_block_rf_error_agg_error_fatal14_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal15_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4070,11 +4211,11 @@ pub trait MciPeripheral {
             return generated
                 .read_mci_reg_intr_block_rf_error_agg_error_fatal15_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal16_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4085,11 +4226,11 @@ pub trait MciPeripheral {
             return generated
                 .read_mci_reg_intr_block_rf_error_agg_error_fatal16_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal17_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4100,11 +4241,11 @@ pub trait MciPeripheral {
             return generated
                 .read_mci_reg_intr_block_rf_error_agg_error_fatal17_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal18_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4115,11 +4256,11 @@ pub trait MciPeripheral {
             return generated
                 .read_mci_reg_intr_block_rf_error_agg_error_fatal18_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal19_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4130,11 +4271,11 @@ pub trait MciPeripheral {
             return generated
                 .read_mci_reg_intr_block_rf_error_agg_error_fatal19_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal20_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4145,11 +4286,11 @@ pub trait MciPeripheral {
             return generated
                 .read_mci_reg_intr_block_rf_error_agg_error_fatal20_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal21_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4160,11 +4301,11 @@ pub trait MciPeripheral {
             return generated
                 .read_mci_reg_intr_block_rf_error_agg_error_fatal21_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal22_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4175,11 +4316,11 @@ pub trait MciPeripheral {
             return generated
                 .read_mci_reg_intr_block_rf_error_agg_error_fatal22_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal23_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4190,11 +4331,11 @@ pub trait MciPeripheral {
             return generated
                 .read_mci_reg_intr_block_rf_error_agg_error_fatal23_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal24_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4205,11 +4346,11 @@ pub trait MciPeripheral {
             return generated
                 .read_mci_reg_intr_block_rf_error_agg_error_fatal24_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal25_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4220,11 +4361,11 @@ pub trait MciPeripheral {
             return generated
                 .read_mci_reg_intr_block_rf_error_agg_error_fatal25_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal26_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4235,11 +4376,11 @@ pub trait MciPeripheral {
             return generated
                 .read_mci_reg_intr_block_rf_error_agg_error_fatal26_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal27_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4250,11 +4391,11 @@ pub trait MciPeripheral {
             return generated
                 .read_mci_reg_intr_block_rf_error_agg_error_fatal27_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal28_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4265,11 +4406,11 @@ pub trait MciPeripheral {
             return generated
                 .read_mci_reg_intr_block_rf_error_agg_error_fatal28_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal29_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4280,11 +4421,11 @@ pub trait MciPeripheral {
             return generated
                 .read_mci_reg_intr_block_rf_error_agg_error_fatal29_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal30_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4295,11 +4436,11 @@ pub trait MciPeripheral {
             return generated
                 .read_mci_reg_intr_block_rf_error_agg_error_fatal30_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal31_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4310,11 +4451,11 @@ pub trait MciPeripheral {
             return generated
                 .read_mci_reg_intr_block_rf_error_agg_error_fatal31_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_notif_mcu_sram_ecc_cor_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4324,11 +4465,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mci_reg_intr_block_rf_notif_mcu_sram_ecc_cor_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_notif_cptra_mcu_reset_req_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4339,11 +4480,11 @@ pub trait MciPeripheral {
             return generated
                 .read_mci_reg_intr_block_rf_notif_cptra_mcu_reset_req_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_notif_gen_in_toggle_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4353,11 +4494,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mci_reg_intr_block_rf_notif_gen_in_toggle_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal0_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4368,11 +4509,11 @@ pub trait MciPeripheral {
             return generated
                 .read_mci_reg_intr_block_rf_notif_agg_error_non_fatal0_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal1_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4383,11 +4524,11 @@ pub trait MciPeripheral {
             return generated
                 .read_mci_reg_intr_block_rf_notif_agg_error_non_fatal1_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal2_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4398,11 +4539,11 @@ pub trait MciPeripheral {
             return generated
                 .read_mci_reg_intr_block_rf_notif_agg_error_non_fatal2_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal3_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4413,11 +4554,11 @@ pub trait MciPeripheral {
             return generated
                 .read_mci_reg_intr_block_rf_notif_agg_error_non_fatal3_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal4_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4428,11 +4569,11 @@ pub trait MciPeripheral {
             return generated
                 .read_mci_reg_intr_block_rf_notif_agg_error_non_fatal4_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal5_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4443,11 +4584,11 @@ pub trait MciPeripheral {
             return generated
                 .read_mci_reg_intr_block_rf_notif_agg_error_non_fatal5_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal6_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4458,11 +4599,11 @@ pub trait MciPeripheral {
             return generated
                 .read_mci_reg_intr_block_rf_notif_agg_error_non_fatal6_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal7_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4473,11 +4614,11 @@ pub trait MciPeripheral {
             return generated
                 .read_mci_reg_intr_block_rf_notif_agg_error_non_fatal7_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal8_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4488,11 +4629,11 @@ pub trait MciPeripheral {
             return generated
                 .read_mci_reg_intr_block_rf_notif_agg_error_non_fatal8_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal9_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4503,11 +4644,11 @@ pub trait MciPeripheral {
             return generated
                 .read_mci_reg_intr_block_rf_notif_agg_error_non_fatal9_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal10_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4518,11 +4659,11 @@ pub trait MciPeripheral {
             return generated
                 .read_mci_reg_intr_block_rf_notif_agg_error_non_fatal10_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal11_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4533,11 +4674,11 @@ pub trait MciPeripheral {
             return generated
                 .read_mci_reg_intr_block_rf_notif_agg_error_non_fatal11_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal12_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4548,11 +4689,11 @@ pub trait MciPeripheral {
             return generated
                 .read_mci_reg_intr_block_rf_notif_agg_error_non_fatal12_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal13_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4563,11 +4704,11 @@ pub trait MciPeripheral {
             return generated
                 .read_mci_reg_intr_block_rf_notif_agg_error_non_fatal13_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal14_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4578,11 +4719,11 @@ pub trait MciPeripheral {
             return generated
                 .read_mci_reg_intr_block_rf_notif_agg_error_non_fatal14_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal15_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4593,11 +4734,11 @@ pub trait MciPeripheral {
             return generated
                 .read_mci_reg_intr_block_rf_notif_agg_error_non_fatal15_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal16_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4608,11 +4749,11 @@ pub trait MciPeripheral {
             return generated
                 .read_mci_reg_intr_block_rf_notif_agg_error_non_fatal16_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal17_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4623,11 +4764,11 @@ pub trait MciPeripheral {
             return generated
                 .read_mci_reg_intr_block_rf_notif_agg_error_non_fatal17_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal18_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4638,11 +4779,11 @@ pub trait MciPeripheral {
             return generated
                 .read_mci_reg_intr_block_rf_notif_agg_error_non_fatal18_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal19_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4653,11 +4794,11 @@ pub trait MciPeripheral {
             return generated
                 .read_mci_reg_intr_block_rf_notif_agg_error_non_fatal19_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal20_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4668,11 +4809,11 @@ pub trait MciPeripheral {
             return generated
                 .read_mci_reg_intr_block_rf_notif_agg_error_non_fatal20_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal21_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4683,11 +4824,11 @@ pub trait MciPeripheral {
             return generated
                 .read_mci_reg_intr_block_rf_notif_agg_error_non_fatal21_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal22_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4698,11 +4839,11 @@ pub trait MciPeripheral {
             return generated
                 .read_mci_reg_intr_block_rf_notif_agg_error_non_fatal22_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal23_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4713,11 +4854,11 @@ pub trait MciPeripheral {
             return generated
                 .read_mci_reg_intr_block_rf_notif_agg_error_non_fatal23_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal24_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4728,11 +4869,11 @@ pub trait MciPeripheral {
             return generated
                 .read_mci_reg_intr_block_rf_notif_agg_error_non_fatal24_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal25_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4743,11 +4884,11 @@ pub trait MciPeripheral {
             return generated
                 .read_mci_reg_intr_block_rf_notif_agg_error_non_fatal25_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal26_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4758,11 +4899,11 @@ pub trait MciPeripheral {
             return generated
                 .read_mci_reg_intr_block_rf_notif_agg_error_non_fatal26_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal27_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4773,11 +4914,11 @@ pub trait MciPeripheral {
             return generated
                 .read_mci_reg_intr_block_rf_notif_agg_error_non_fatal27_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal28_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4788,11 +4929,11 @@ pub trait MciPeripheral {
             return generated
                 .read_mci_reg_intr_block_rf_notif_agg_error_non_fatal28_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal29_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4803,11 +4944,11 @@ pub trait MciPeripheral {
             return generated
                 .read_mci_reg_intr_block_rf_notif_agg_error_non_fatal29_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal30_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4818,11 +4959,11 @@ pub trait MciPeripheral {
             return generated
                 .read_mci_reg_intr_block_rf_notif_agg_error_non_fatal30_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal31_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4833,11 +4974,11 @@ pub trait MciPeripheral {
             return generated
                 .read_mci_reg_intr_block_rf_notif_agg_error_non_fatal31_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_notif_mbox0_target_done_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4848,11 +4989,11 @@ pub trait MciPeripheral {
             return generated
                 .read_mci_reg_intr_block_rf_notif_mbox0_target_done_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_notif_mbox1_target_done_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4863,11 +5004,11 @@ pub trait MciPeripheral {
             return generated
                 .read_mci_reg_intr_block_rf_notif_mbox1_target_done_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_notif_mbox0_cmd_avail_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4877,11 +5018,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mci_reg_intr_block_rf_notif_mbox0_cmd_avail_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_notif_mbox1_cmd_avail_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4891,11 +5032,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mci_reg_intr_block_rf_notif_mbox1_cmd_avail_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_notif_cptra_mbox_cmd_avail_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4906,11 +5047,11 @@ pub trait MciPeripheral {
             return generated
                 .read_mci_reg_intr_block_rf_notif_cptra_mbox_cmd_avail_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_notif_mbox0_ecc_cor_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4920,11 +5061,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mci_reg_intr_block_rf_notif_mbox0_ecc_cor_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_notif_mbox1_ecc_cor_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4934,11 +5075,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mci_reg_intr_block_rf_notif_mbox1_ecc_cor_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_notif_debug_locked_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4948,11 +5089,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mci_reg_intr_block_rf_notif_debug_locked_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_notif_scan_mode_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4962,11 +5103,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mci_reg_intr_block_rf_notif_scan_mode_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_notif_mbox0_soc_req_lock_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4977,11 +5118,11 @@ pub trait MciPeripheral {
             return generated
                 .read_mci_reg_intr_block_rf_notif_mbox0_soc_req_lock_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_notif_mbox1_soc_req_lock_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -4992,11 +5133,11 @@ pub trait MciPeripheral {
             return generated
                 .read_mci_reg_intr_block_rf_notif_mbox1_soc_req_lock_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mci_reg_intr_block_rf_notif_otp_operation_done_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
@@ -5007,21 +5148,25 @@ pub trait MciPeripheral {
             return generated
                 .read_mci_reg_intr_block_rf_notif_otp_operation_done_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_mcu_trace_buffer_csr_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::mci::bits::Status::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::mci::bits::Status::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read mci::mcu_trace_buffer_csr_status");
         }
         if let Some(generated) = self.generated() {
             return generated.read_mcu_trace_buffer_csr_status();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
-    fn read_mcu_trace_buffer_csr_config(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mcu_trace_buffer_csr_config(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read mci::mcu_trace_buffer_csr_config");
         }
@@ -5030,7 +5175,9 @@ pub trait MciPeripheral {
         }
         0
     }
-    fn read_mcu_trace_buffer_csr_data(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mcu_trace_buffer_csr_data(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read mci::mcu_trace_buffer_csr_data");
         }
@@ -5039,7 +5186,9 @@ pub trait MciPeripheral {
         }
         0
     }
-    fn read_mcu_trace_buffer_csr_write_ptr(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mcu_trace_buffer_csr_write_ptr(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read mci::mcu_trace_buffer_csr_write_ptr"
@@ -5050,7 +5199,9 @@ pub trait MciPeripheral {
         }
         0
     }
-    fn read_mcu_trace_buffer_csr_read_ptr(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mcu_trace_buffer_csr_read_ptr(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read mci::mcu_trace_buffer_csr_read_ptr"
@@ -5061,7 +5212,10 @@ pub trait MciPeripheral {
         }
         0
     }
-    fn write_mcu_trace_buffer_csr_read_ptr(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mcu_trace_buffer_csr_read_ptr(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mcu_trace_buffer_csr_read_ptr = 0x{:08x}" , val);
         }
@@ -5069,7 +5223,10 @@ pub trait MciPeripheral {
             generated.write_mcu_trace_buffer_csr_read_ptr(val);
         }
     }
-    fn read_mcu_mbox0_csr_mbox_sram(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_mcu_mbox0_csr_mbox_sram(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read mci::mcu_mbox0_csr_mbox_sram[{}]",
@@ -5081,7 +5238,11 @@ pub trait MciPeripheral {
         }
         0
     }
-    fn write_mcu_mbox0_csr_mbox_sram(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    fn write_mcu_mbox0_csr_mbox_sram(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+        index: usize,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mcu_mbox0_csr_mbox_sram[{}] = 0x{:08x}" , index , val);
         }
@@ -5091,17 +5252,19 @@ pub trait MciPeripheral {
     }
     fn read_mcu_mbox0_csr_mbox_lock(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::mci::bits::MboxLock::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::mci::bits::MboxLock::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read mci::mcu_mbox0_csr_mbox_lock");
         }
         if let Some(generated) = self.generated() {
             return generated.read_mcu_mbox0_csr_mbox_lock();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
-    fn read_mcu_mbox0_csr_mbox_user(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mcu_mbox0_csr_mbox_user(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read mci::mcu_mbox0_csr_mbox_user");
         }
@@ -5110,7 +5273,9 @@ pub trait MciPeripheral {
         }
         0
     }
-    fn read_mcu_mbox0_csr_mbox_target_user(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mcu_mbox0_csr_mbox_target_user(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read mci::mcu_mbox0_csr_mbox_target_user"
@@ -5121,7 +5286,10 @@ pub trait MciPeripheral {
         }
         0
     }
-    fn write_mcu_mbox0_csr_mbox_target_user(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mcu_mbox0_csr_mbox_target_user(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mcu_mbox0_csr_mbox_target_user = 0x{:08x}" , val);
         }
@@ -5131,7 +5299,7 @@ pub trait MciPeripheral {
     }
     fn read_mcu_mbox0_csr_mbox_target_user_valid(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::MboxTargetUserValid::Register,
     > {
@@ -5141,11 +5309,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mcu_mbox0_csr_mbox_target_user_valid();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_mcu_mbox0_csr_mbox_target_user_valid(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::MboxTargetUserValid::Register,
         >,
@@ -5157,7 +5325,7 @@ pub trait MciPeripheral {
             generated.write_mcu_mbox0_csr_mbox_target_user_valid(val);
         }
     }
-    fn read_mcu_mbox0_csr_mbox_cmd(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mcu_mbox0_csr_mbox_cmd(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read mci::mcu_mbox0_csr_mbox_cmd");
         }
@@ -5166,7 +5334,10 @@ pub trait MciPeripheral {
         }
         0
     }
-    fn write_mcu_mbox0_csr_mbox_cmd(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mcu_mbox0_csr_mbox_cmd(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write mci::mcu_mbox0_csr_mbox_cmd = 0x{:08x}",
@@ -5177,7 +5348,7 @@ pub trait MciPeripheral {
             generated.write_mcu_mbox0_csr_mbox_cmd(val);
         }
     }
-    fn read_mcu_mbox0_csr_mbox_dlen(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mcu_mbox0_csr_mbox_dlen(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read mci::mcu_mbox0_csr_mbox_dlen");
         }
@@ -5186,7 +5357,10 @@ pub trait MciPeripheral {
         }
         0
     }
-    fn write_mcu_mbox0_csr_mbox_dlen(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mcu_mbox0_csr_mbox_dlen(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write mci::mcu_mbox0_csr_mbox_dlen = 0x{:08x}",
@@ -5199,7 +5373,7 @@ pub trait MciPeripheral {
     }
     fn read_mcu_mbox0_csr_mbox_execute(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::MboxExecute::Register,
     > {
@@ -5209,11 +5383,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mcu_mbox0_csr_mbox_execute();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_mcu_mbox0_csr_mbox_execute(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::MboxExecute::Register,
         >,
@@ -5227,7 +5401,7 @@ pub trait MciPeripheral {
     }
     fn read_mcu_mbox0_csr_mbox_target_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::MboxTargetStatus::Register,
     > {
@@ -5239,11 +5413,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mcu_mbox0_csr_mbox_target_status();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_mcu_mbox0_csr_mbox_target_status(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::MboxTargetStatus::Register,
         >,
@@ -5257,7 +5431,7 @@ pub trait MciPeripheral {
     }
     fn read_mcu_mbox0_csr_mbox_cmd_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::MboxCmdStatus::Register,
     > {
@@ -5269,11 +5443,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mcu_mbox0_csr_mbox_cmd_status();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_mcu_mbox0_csr_mbox_cmd_status(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::MboxCmdStatus::Register,
         >,
@@ -5287,7 +5461,7 @@ pub trait MciPeripheral {
     }
     fn read_mcu_mbox0_csr_mbox_hw_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::MboxHwStatus::Register,
     > {
@@ -5297,9 +5471,12 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mcu_mbox0_csr_mbox_hw_status();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
-    fn read_mcu_mbox1_csr_mbox_sram(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_mcu_mbox1_csr_mbox_sram(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read mci::mcu_mbox1_csr_mbox_sram[{}]",
@@ -5311,7 +5488,11 @@ pub trait MciPeripheral {
         }
         0
     }
-    fn write_mcu_mbox1_csr_mbox_sram(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    fn write_mcu_mbox1_csr_mbox_sram(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+        index: usize,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mcu_mbox1_csr_mbox_sram[{}] = 0x{:08x}" , index , val);
         }
@@ -5321,17 +5502,19 @@ pub trait MciPeripheral {
     }
     fn read_mcu_mbox1_csr_mbox_lock(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::mci::bits::MboxLock::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::mci::bits::MboxLock::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read mci::mcu_mbox1_csr_mbox_lock");
         }
         if let Some(generated) = self.generated() {
             return generated.read_mcu_mbox1_csr_mbox_lock();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
-    fn read_mcu_mbox1_csr_mbox_user(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mcu_mbox1_csr_mbox_user(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read mci::mcu_mbox1_csr_mbox_user");
         }
@@ -5340,7 +5523,9 @@ pub trait MciPeripheral {
         }
         0
     }
-    fn read_mcu_mbox1_csr_mbox_target_user(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mcu_mbox1_csr_mbox_target_user(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read mci::mcu_mbox1_csr_mbox_target_user"
@@ -5351,7 +5536,10 @@ pub trait MciPeripheral {
         }
         0
     }
-    fn write_mcu_mbox1_csr_mbox_target_user(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mcu_mbox1_csr_mbox_target_user(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write mci::mcu_mbox1_csr_mbox_target_user = 0x{:08x}" , val);
         }
@@ -5361,7 +5549,7 @@ pub trait MciPeripheral {
     }
     fn read_mcu_mbox1_csr_mbox_target_user_valid(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::MboxTargetUserValid::Register,
     > {
@@ -5371,11 +5559,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mcu_mbox1_csr_mbox_target_user_valid();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_mcu_mbox1_csr_mbox_target_user_valid(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::MboxTargetUserValid::Register,
         >,
@@ -5387,7 +5575,7 @@ pub trait MciPeripheral {
             generated.write_mcu_mbox1_csr_mbox_target_user_valid(val);
         }
     }
-    fn read_mcu_mbox1_csr_mbox_cmd(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mcu_mbox1_csr_mbox_cmd(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read mci::mcu_mbox1_csr_mbox_cmd");
         }
@@ -5396,7 +5584,10 @@ pub trait MciPeripheral {
         }
         0
     }
-    fn write_mcu_mbox1_csr_mbox_cmd(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mcu_mbox1_csr_mbox_cmd(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write mci::mcu_mbox1_csr_mbox_cmd = 0x{:08x}",
@@ -5407,7 +5598,7 @@ pub trait MciPeripheral {
             generated.write_mcu_mbox1_csr_mbox_cmd(val);
         }
     }
-    fn read_mcu_mbox1_csr_mbox_dlen(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mcu_mbox1_csr_mbox_dlen(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read mci::mcu_mbox1_csr_mbox_dlen");
         }
@@ -5416,7 +5607,10 @@ pub trait MciPeripheral {
         }
         0
     }
-    fn write_mcu_mbox1_csr_mbox_dlen(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mcu_mbox1_csr_mbox_dlen(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write mci::mcu_mbox1_csr_mbox_dlen = 0x{:08x}",
@@ -5429,7 +5623,7 @@ pub trait MciPeripheral {
     }
     fn read_mcu_mbox1_csr_mbox_execute(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::MboxExecute::Register,
     > {
@@ -5439,11 +5633,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mcu_mbox1_csr_mbox_execute();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_mcu_mbox1_csr_mbox_execute(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::MboxExecute::Register,
         >,
@@ -5457,7 +5651,7 @@ pub trait MciPeripheral {
     }
     fn read_mcu_mbox1_csr_mbox_target_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::MboxTargetStatus::Register,
     > {
@@ -5469,11 +5663,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mcu_mbox1_csr_mbox_target_status();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_mcu_mbox1_csr_mbox_target_status(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::MboxTargetStatus::Register,
         >,
@@ -5487,7 +5681,7 @@ pub trait MciPeripheral {
     }
     fn read_mcu_mbox1_csr_mbox_cmd_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::MboxCmdStatus::Register,
     > {
@@ -5499,11 +5693,11 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mcu_mbox1_csr_mbox_cmd_status();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_mcu_mbox1_csr_mbox_cmd_status(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::MboxCmdStatus::Register,
         >,
@@ -5517,7 +5711,7 @@ pub trait MciPeripheral {
     }
     fn read_mcu_mbox1_csr_mbox_hw_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::MboxHwStatus::Register,
     > {
@@ -5527,735 +5721,963 @@ pub trait MciPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mcu_mbox1_csr_mbox_hw_status();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
 }
 #[derive(Clone, Debug)]
 pub struct MciGenerated {
-    mcu_sram: Vec<caliptra_emu_types::RvData>,
-    mci_reg_hw_capabilities: caliptra_emu_types::RvData,
-    mci_reg_fw_capabilities: caliptra_emu_types::RvData,
-    mci_reg_cap_lock: caliptra_emu_types::RvData,
-    mci_reg_hw_rev_id: caliptra_emu_types::RvData,
-    mci_reg_fw_rev_id: Vec<caliptra_emu_types::RvData>,
-    mci_reg_hw_config0: caliptra_emu_types::RvData,
-    mci_reg_hw_config1: caliptra_emu_types::RvData,
-    mci_reg_mcu_ifu_axi_user: caliptra_emu_types::RvData,
-    mci_reg_mcu_lsu_axi_user: caliptra_emu_types::RvData,
-    mci_reg_mcu_sram_config_axi_user: caliptra_emu_types::RvData,
-    mci_reg_mci_soc_config_axi_user: caliptra_emu_types::RvData,
-    mci_reg_fw_flow_status: caliptra_emu_types::RvData,
-    mci_reg_hw_flow_status: caliptra_emu_types::RvData,
-    mci_reg_reset_reason: caliptra_emu_types::RvData,
-    mci_reg_reset_status: caliptra_emu_types::RvData,
-    mci_reg_security_state: caliptra_emu_types::RvData,
-    mci_reg_hw_error_fatal: caliptra_emu_types::RvData,
-    mci_reg_agg_error_fatal: caliptra_emu_types::RvData,
-    mci_reg_hw_error_non_fatal: caliptra_emu_types::RvData,
-    mci_reg_agg_error_non_fatal: caliptra_emu_types::RvData,
-    mci_reg_fw_error_fatal: caliptra_emu_types::RvData,
-    mci_reg_fw_error_non_fatal: caliptra_emu_types::RvData,
-    mci_reg_hw_error_enc: caliptra_emu_types::RvData,
-    mci_reg_fw_error_enc: caliptra_emu_types::RvData,
-    mci_reg_fw_extended_error_info: Vec<caliptra_emu_types::RvData>,
-    mci_reg_internal_hw_error_fatal_mask: caliptra_emu_types::RvData,
-    mci_reg_internal_hw_error_non_fatal_mask: caliptra_emu_types::RvData,
-    mci_reg_internal_agg_error_fatal_mask: caliptra_emu_types::RvData,
-    mci_reg_internal_agg_error_non_fatal_mask: caliptra_emu_types::RvData,
-    mci_reg_internal_fw_error_fatal_mask: caliptra_emu_types::RvData,
-    mci_reg_internal_fw_error_non_fatal_mask: caliptra_emu_types::RvData,
-    mci_reg_wdt_timer1_en: caliptra_emu_types::RvData,
-    mci_reg_wdt_timer1_ctrl: caliptra_emu_types::RvData,
-    mci_reg_wdt_timer1_timeout_period: Vec<caliptra_emu_types::RvData>,
-    mci_reg_wdt_timer2_en: caliptra_emu_types::RvData,
-    mci_reg_wdt_timer2_ctrl: caliptra_emu_types::RvData,
-    mci_reg_wdt_timer2_timeout_period: Vec<caliptra_emu_types::RvData>,
-    mci_reg_wdt_status: caliptra_emu_types::RvData,
-    mci_reg_wdt_cfg: Vec<caliptra_emu_types::RvData>,
-    mci_reg_mcu_timer_config: caliptra_emu_types::RvData,
-    mci_reg_mcu_rv_mtime_l: caliptra_emu_types::RvData,
-    mci_reg_mcu_rv_mtime_h: caliptra_emu_types::RvData,
-    mci_reg_mcu_rv_mtimecmp_l: caliptra_emu_types::RvData,
-    mci_reg_mcu_rv_mtimecmp_h: caliptra_emu_types::RvData,
-    mci_reg_reset_request: caliptra_emu_types::RvData,
-    mci_reg_mci_bootfsm_go: caliptra_emu_types::RvData,
-    mci_reg_cptra_boot_go: caliptra_emu_types::RvData,
-    mci_reg_fw_sram_exec_region_size: caliptra_emu_types::RvData,
-    mci_reg_mcu_nmi_vector: caliptra_emu_types::RvData,
-    mci_reg_mcu_reset_vector: caliptra_emu_types::RvData,
-    mci_reg_mbox0_valid_axi_user: Vec<caliptra_emu_types::RvData>,
-    mci_reg_mbox0_axi_user_lock: Vec<caliptra_emu_types::RvData>,
-    mci_reg_mbox1_valid_axi_user: Vec<caliptra_emu_types::RvData>,
-    mci_reg_mbox1_axi_user_lock: Vec<caliptra_emu_types::RvData>,
-    mci_reg_soc_dft_en: Vec<caliptra_emu_types::RvData>,
-    mci_reg_soc_hw_debug_en: Vec<caliptra_emu_types::RvData>,
-    mci_reg_soc_prod_debug_state: Vec<caliptra_emu_types::RvData>,
-    mci_reg_fc_fips_zerozation: caliptra_emu_types::RvData,
-    mci_reg_generic_input_wires: Vec<caliptra_emu_types::RvData>,
-    mci_reg_generic_output_wires: Vec<caliptra_emu_types::RvData>,
-    mci_reg_debug_in: caliptra_emu_types::RvData,
-    mci_reg_debug_out: caliptra_emu_types::RvData,
-    mci_reg_ss_debug_intent: caliptra_emu_types::RvData,
-    mci_reg_ss_config_done_sticky: caliptra_emu_types::RvData,
-    mci_reg_ss_config_done: caliptra_emu_types::RvData,
-    mci_reg_prod_debug_unlock_pk_hash_reg: Vec<caliptra_emu_types::RvData>,
-    mci_reg_intr_block_rf_global_intr_en_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error0_intr_en_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error1_intr_en_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif0_intr_en_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif1_intr_en_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_global_intr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_global_intr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error0_internal_intr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error1_internal_intr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif0_internal_intr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif1_internal_intr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error0_intr_trig_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error1_intr_trig_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif0_intr_trig_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif1_intr_trig_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_internal_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_mbox0_ecc_unc_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_mbox1_ecc_unc_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_mcu_sram_dmi_axi_collision_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_wdt_timer1_timeout_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_wdt_timer2_timeout_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_agg_error_fatal0_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_agg_error_fatal1_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_agg_error_fatal2_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_agg_error_fatal3_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_agg_error_fatal4_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_agg_error_fatal5_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_agg_error_fatal6_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_agg_error_fatal7_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_agg_error_fatal8_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_agg_error_fatal9_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_agg_error_fatal10_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_agg_error_fatal11_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_agg_error_fatal12_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_agg_error_fatal13_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_agg_error_fatal14_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_agg_error_fatal15_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_agg_error_fatal16_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_agg_error_fatal17_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_agg_error_fatal18_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_agg_error_fatal19_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_agg_error_fatal20_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_agg_error_fatal21_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_agg_error_fatal22_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_agg_error_fatal23_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_agg_error_fatal24_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_agg_error_fatal25_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_agg_error_fatal26_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_agg_error_fatal27_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_agg_error_fatal28_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_agg_error_fatal29_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_agg_error_fatal30_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_agg_error_fatal31_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_mcu_sram_ecc_cor_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_cptra_mcu_reset_req_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_gen_in_toggle_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_agg_error_non_fatal0_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_agg_error_non_fatal1_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_agg_error_non_fatal2_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_agg_error_non_fatal3_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_agg_error_non_fatal4_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_agg_error_non_fatal5_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_agg_error_non_fatal6_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_agg_error_non_fatal7_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_agg_error_non_fatal8_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_agg_error_non_fatal9_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_agg_error_non_fatal10_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_agg_error_non_fatal11_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_agg_error_non_fatal12_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_agg_error_non_fatal13_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_agg_error_non_fatal14_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_agg_error_non_fatal15_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_agg_error_non_fatal16_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_agg_error_non_fatal17_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_agg_error_non_fatal18_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_agg_error_non_fatal19_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_agg_error_non_fatal20_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_agg_error_non_fatal21_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_agg_error_non_fatal22_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_agg_error_non_fatal23_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_agg_error_non_fatal24_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_agg_error_non_fatal25_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_agg_error_non_fatal26_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_agg_error_non_fatal27_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_agg_error_non_fatal28_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_agg_error_non_fatal29_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_agg_error_non_fatal30_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_agg_error_non_fatal31_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_mbox0_target_done_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_mbox1_target_done_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_mbox0_cmd_avail_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_mbox1_cmd_avail_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_cptra_mbox_cmd_avail_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_mbox0_ecc_cor_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_mbox1_ecc_cor_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_debug_locked_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_scan_mode_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_mbox0_soc_req_lock_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_mbox1_soc_req_lock_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_otp_operation_done_intr_count_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_internal_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_mbox0_ecc_unc_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_mbox1_ecc_unc_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_wdt_timer1_timeout_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_wdt_timer2_timeout_intr_count_incr_r: caliptra_emu_types::RvData,
+    mcu_sram: Vec<caliptra_core_tools::caliptra_emu_types::RvData>,
+    mci_reg_hw_capabilities: caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_fw_capabilities: caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_cap_lock: caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_hw_rev_id: caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_fw_rev_id: Vec<caliptra_core_tools::caliptra_emu_types::RvData>,
+    mci_reg_hw_config0: caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_hw_config1: caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_mcu_ifu_axi_user: caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_mcu_lsu_axi_user: caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_mcu_sram_config_axi_user: caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_mci_soc_config_axi_user: caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_fw_flow_status: caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_hw_flow_status: caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_reset_reason: caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_reset_status: caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_security_state: caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_hw_error_fatal: caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_agg_error_fatal: caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_hw_error_non_fatal: caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_agg_error_non_fatal: caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_fw_error_fatal: caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_fw_error_non_fatal: caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_hw_error_enc: caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_fw_error_enc: caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_fw_extended_error_info: Vec<caliptra_core_tools::caliptra_emu_types::RvData>,
+    mci_reg_internal_hw_error_fatal_mask: caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_internal_hw_error_non_fatal_mask: caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_internal_agg_error_fatal_mask: caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_internal_agg_error_non_fatal_mask: caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_internal_fw_error_fatal_mask: caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_internal_fw_error_non_fatal_mask: caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_wdt_timer1_en: caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_wdt_timer1_ctrl: caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_wdt_timer1_timeout_period: Vec<caliptra_core_tools::caliptra_emu_types::RvData>,
+    mci_reg_wdt_timer2_en: caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_wdt_timer2_ctrl: caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_wdt_timer2_timeout_period: Vec<caliptra_core_tools::caliptra_emu_types::RvData>,
+    mci_reg_wdt_status: caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_wdt_cfg: Vec<caliptra_core_tools::caliptra_emu_types::RvData>,
+    mci_reg_mcu_timer_config: caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_mcu_rv_mtime_l: caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_mcu_rv_mtime_h: caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_mcu_rv_mtimecmp_l: caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_mcu_rv_mtimecmp_h: caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_reset_request: caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_mci_bootfsm_go: caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_cptra_boot_go: caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_fw_sram_exec_region_size: caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_mcu_nmi_vector: caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_mcu_reset_vector: caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_mbox0_valid_axi_user: Vec<caliptra_core_tools::caliptra_emu_types::RvData>,
+    mci_reg_mbox0_axi_user_lock: Vec<caliptra_core_tools::caliptra_emu_types::RvData>,
+    mci_reg_mbox1_valid_axi_user: Vec<caliptra_core_tools::caliptra_emu_types::RvData>,
+    mci_reg_mbox1_axi_user_lock: Vec<caliptra_core_tools::caliptra_emu_types::RvData>,
+    mci_reg_soc_dft_en: Vec<caliptra_core_tools::caliptra_emu_types::RvData>,
+    mci_reg_soc_hw_debug_en: Vec<caliptra_core_tools::caliptra_emu_types::RvData>,
+    mci_reg_soc_prod_debug_state: Vec<caliptra_core_tools::caliptra_emu_types::RvData>,
+    mci_reg_fc_fips_zerozation: caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_generic_input_wires: Vec<caliptra_core_tools::caliptra_emu_types::RvData>,
+    mci_reg_generic_output_wires: Vec<caliptra_core_tools::caliptra_emu_types::RvData>,
+    mci_reg_debug_in: caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_debug_out: caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_ss_debug_intent: caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_ss_config_done_sticky: caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_ss_config_done: caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_prod_debug_unlock_pk_hash_reg: Vec<caliptra_core_tools::caliptra_emu_types::RvData>,
+    mci_reg_intr_block_rf_global_intr_en_r: caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error0_intr_en_r: caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error1_intr_en_r: caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif0_intr_en_r: caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif1_intr_en_r: caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_global_intr_r: caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_global_intr_r: caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error0_internal_intr_r: caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error1_internal_intr_r: caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif0_internal_intr_r: caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif1_internal_intr_r: caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error0_intr_trig_r: caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error1_intr_trig_r: caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif0_intr_trig_r: caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif1_intr_trig_r: caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_internal_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_mbox0_ecc_unc_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_mbox1_ecc_unc_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_mcu_sram_dmi_axi_collision_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_wdt_timer1_timeout_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_wdt_timer2_timeout_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_agg_error_fatal0_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_agg_error_fatal1_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_agg_error_fatal2_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_agg_error_fatal3_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_agg_error_fatal4_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_agg_error_fatal5_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_agg_error_fatal6_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_agg_error_fatal7_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_agg_error_fatal8_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_agg_error_fatal9_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_agg_error_fatal10_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_agg_error_fatal11_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_agg_error_fatal12_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_agg_error_fatal13_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_agg_error_fatal14_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_agg_error_fatal15_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_agg_error_fatal16_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_agg_error_fatal17_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_agg_error_fatal18_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_agg_error_fatal19_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_agg_error_fatal20_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_agg_error_fatal21_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_agg_error_fatal22_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_agg_error_fatal23_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_agg_error_fatal24_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_agg_error_fatal25_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_agg_error_fatal26_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_agg_error_fatal27_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_agg_error_fatal28_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_agg_error_fatal29_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_agg_error_fatal30_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_agg_error_fatal31_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_mcu_sram_ecc_cor_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_cptra_mcu_reset_req_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_gen_in_toggle_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_agg_error_non_fatal0_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_agg_error_non_fatal1_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_agg_error_non_fatal2_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_agg_error_non_fatal3_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_agg_error_non_fatal4_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_agg_error_non_fatal5_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_agg_error_non_fatal6_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_agg_error_non_fatal7_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_agg_error_non_fatal8_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_agg_error_non_fatal9_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_agg_error_non_fatal10_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_agg_error_non_fatal11_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_agg_error_non_fatal12_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_agg_error_non_fatal13_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_agg_error_non_fatal14_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_agg_error_non_fatal15_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_agg_error_non_fatal16_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_agg_error_non_fatal17_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_agg_error_non_fatal18_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_agg_error_non_fatal19_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_agg_error_non_fatal20_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_agg_error_non_fatal21_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_agg_error_non_fatal22_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_agg_error_non_fatal23_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_agg_error_non_fatal24_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_agg_error_non_fatal25_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_agg_error_non_fatal26_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_agg_error_non_fatal27_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_agg_error_non_fatal28_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_agg_error_non_fatal29_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_agg_error_non_fatal30_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_agg_error_non_fatal31_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_mbox0_target_done_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_mbox1_target_done_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_mbox0_cmd_avail_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_mbox1_cmd_avail_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_cptra_mbox_cmd_avail_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_mbox0_ecc_cor_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_mbox1_ecc_cor_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_debug_locked_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_scan_mode_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_mbox0_soc_req_lock_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_mbox1_soc_req_lock_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_otp_operation_done_intr_count_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_internal_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_mbox0_ecc_unc_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_mbox1_ecc_unc_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_wdt_timer1_timeout_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_wdt_timer2_timeout_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
     mci_reg_intr_block_rf_error_mcu_sram_dmi_axi_collision_intr_count_incr_r:
-        caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_agg_error_fatal0_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_agg_error_fatal1_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_agg_error_fatal2_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_agg_error_fatal3_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_agg_error_fatal4_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_agg_error_fatal5_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_agg_error_fatal6_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_agg_error_fatal7_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_agg_error_fatal8_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_agg_error_fatal9_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_agg_error_fatal10_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_agg_error_fatal11_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_agg_error_fatal12_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_agg_error_fatal13_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_agg_error_fatal14_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_agg_error_fatal15_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_agg_error_fatal16_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_agg_error_fatal17_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_agg_error_fatal18_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_agg_error_fatal19_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_agg_error_fatal20_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_agg_error_fatal21_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_agg_error_fatal22_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_agg_error_fatal23_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_agg_error_fatal24_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_agg_error_fatal25_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_agg_error_fatal26_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_agg_error_fatal27_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_agg_error_fatal28_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_agg_error_fatal29_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_agg_error_fatal30_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_error_agg_error_fatal31_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_mcu_sram_ecc_cor_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_cptra_mcu_reset_req_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_gen_in_toggle_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_agg_error_non_fatal0_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_agg_error_non_fatal1_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_agg_error_non_fatal2_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_agg_error_non_fatal3_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_agg_error_non_fatal4_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_agg_error_non_fatal5_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_agg_error_non_fatal6_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_agg_error_non_fatal7_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_agg_error_non_fatal8_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_agg_error_non_fatal9_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_agg_error_non_fatal10_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_agg_error_non_fatal11_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_agg_error_non_fatal12_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_agg_error_non_fatal13_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_agg_error_non_fatal14_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_agg_error_non_fatal15_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_agg_error_non_fatal16_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_agg_error_non_fatal17_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_agg_error_non_fatal18_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_agg_error_non_fatal19_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_agg_error_non_fatal20_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_agg_error_non_fatal21_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_agg_error_non_fatal22_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_agg_error_non_fatal23_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_agg_error_non_fatal24_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_agg_error_non_fatal25_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_agg_error_non_fatal26_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_agg_error_non_fatal27_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_agg_error_non_fatal28_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_agg_error_non_fatal29_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_agg_error_non_fatal30_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_agg_error_non_fatal31_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_mbox0_target_done_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_mbox1_target_done_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_mbox0_cmd_avail_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_mbox1_cmd_avail_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_cptra_mbox_cmd_avail_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_mbox0_ecc_cor_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_mbox1_ecc_cor_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_debug_locked_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_scan_mode_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_mbox0_soc_req_lock_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_mbox1_soc_req_lock_intr_count_incr_r: caliptra_emu_types::RvData,
-    mci_reg_intr_block_rf_notif_otp_operation_done_intr_count_incr_r: caliptra_emu_types::RvData,
-    mcu_trace_buffer_csr_status: caliptra_emu_types::RvData,
-    mcu_trace_buffer_csr_config: caliptra_emu_types::RvData,
-    mcu_trace_buffer_csr_data: caliptra_emu_types::RvData,
-    mcu_trace_buffer_csr_write_ptr: caliptra_emu_types::RvData,
-    mcu_trace_buffer_csr_read_ptr: caliptra_emu_types::RvData,
-    mcu_mbox0_csr_mbox_sram: Vec<caliptra_emu_types::RvData>,
-    mcu_mbox0_csr_mbox_lock: caliptra_emu_types::RvData,
-    mcu_mbox0_csr_mbox_user: caliptra_emu_types::RvData,
-    mcu_mbox0_csr_mbox_target_user: caliptra_emu_types::RvData,
-    mcu_mbox0_csr_mbox_target_user_valid: caliptra_emu_types::RvData,
-    mcu_mbox0_csr_mbox_cmd: caliptra_emu_types::RvData,
-    mcu_mbox0_csr_mbox_dlen: caliptra_emu_types::RvData,
-    mcu_mbox0_csr_mbox_execute: caliptra_emu_types::RvData,
-    mcu_mbox0_csr_mbox_target_status: caliptra_emu_types::RvData,
-    mcu_mbox0_csr_mbox_cmd_status: caliptra_emu_types::RvData,
-    mcu_mbox0_csr_mbox_hw_status: caliptra_emu_types::RvData,
-    mcu_mbox1_csr_mbox_sram: Vec<caliptra_emu_types::RvData>,
-    mcu_mbox1_csr_mbox_lock: caliptra_emu_types::RvData,
-    mcu_mbox1_csr_mbox_user: caliptra_emu_types::RvData,
-    mcu_mbox1_csr_mbox_target_user: caliptra_emu_types::RvData,
-    mcu_mbox1_csr_mbox_target_user_valid: caliptra_emu_types::RvData,
-    mcu_mbox1_csr_mbox_cmd: caliptra_emu_types::RvData,
-    mcu_mbox1_csr_mbox_dlen: caliptra_emu_types::RvData,
-    mcu_mbox1_csr_mbox_execute: caliptra_emu_types::RvData,
-    mcu_mbox1_csr_mbox_target_status: caliptra_emu_types::RvData,
-    mcu_mbox1_csr_mbox_cmd_status: caliptra_emu_types::RvData,
-    mcu_mbox1_csr_mbox_hw_status: caliptra_emu_types::RvData,
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_agg_error_fatal0_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_agg_error_fatal1_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_agg_error_fatal2_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_agg_error_fatal3_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_agg_error_fatal4_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_agg_error_fatal5_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_agg_error_fatal6_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_agg_error_fatal7_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_agg_error_fatal8_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_agg_error_fatal9_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_agg_error_fatal10_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_agg_error_fatal11_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_agg_error_fatal12_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_agg_error_fatal13_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_agg_error_fatal14_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_agg_error_fatal15_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_agg_error_fatal16_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_agg_error_fatal17_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_agg_error_fatal18_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_agg_error_fatal19_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_agg_error_fatal20_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_agg_error_fatal21_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_agg_error_fatal22_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_agg_error_fatal23_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_agg_error_fatal24_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_agg_error_fatal25_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_agg_error_fatal26_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_agg_error_fatal27_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_agg_error_fatal28_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_agg_error_fatal29_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_agg_error_fatal30_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_error_agg_error_fatal31_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_mcu_sram_ecc_cor_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_cptra_mcu_reset_req_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_gen_in_toggle_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_agg_error_non_fatal0_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_agg_error_non_fatal1_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_agg_error_non_fatal2_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_agg_error_non_fatal3_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_agg_error_non_fatal4_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_agg_error_non_fatal5_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_agg_error_non_fatal6_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_agg_error_non_fatal7_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_agg_error_non_fatal8_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_agg_error_non_fatal9_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_agg_error_non_fatal10_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_agg_error_non_fatal11_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_agg_error_non_fatal12_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_agg_error_non_fatal13_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_agg_error_non_fatal14_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_agg_error_non_fatal15_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_agg_error_non_fatal16_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_agg_error_non_fatal17_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_agg_error_non_fatal18_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_agg_error_non_fatal19_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_agg_error_non_fatal20_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_agg_error_non_fatal21_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_agg_error_non_fatal22_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_agg_error_non_fatal23_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_agg_error_non_fatal24_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_agg_error_non_fatal25_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_agg_error_non_fatal26_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_agg_error_non_fatal27_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_agg_error_non_fatal28_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_agg_error_non_fatal29_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_agg_error_non_fatal30_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_agg_error_non_fatal31_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_mbox0_target_done_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_mbox1_target_done_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_mbox0_cmd_avail_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_mbox1_cmd_avail_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_cptra_mbox_cmd_avail_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_mbox0_ecc_cor_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_mbox1_ecc_cor_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_debug_locked_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_scan_mode_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_mbox0_soc_req_lock_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_mbox1_soc_req_lock_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mci_reg_intr_block_rf_notif_otp_operation_done_intr_count_incr_r:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    mcu_trace_buffer_csr_status: caliptra_core_tools::caliptra_emu_types::RvData,
+    mcu_trace_buffer_csr_config: caliptra_core_tools::caliptra_emu_types::RvData,
+    mcu_trace_buffer_csr_data: caliptra_core_tools::caliptra_emu_types::RvData,
+    mcu_trace_buffer_csr_write_ptr: caliptra_core_tools::caliptra_emu_types::RvData,
+    mcu_trace_buffer_csr_read_ptr: caliptra_core_tools::caliptra_emu_types::RvData,
+    mcu_mbox0_csr_mbox_sram: Vec<caliptra_core_tools::caliptra_emu_types::RvData>,
+    mcu_mbox0_csr_mbox_lock: caliptra_core_tools::caliptra_emu_types::RvData,
+    mcu_mbox0_csr_mbox_user: caliptra_core_tools::caliptra_emu_types::RvData,
+    mcu_mbox0_csr_mbox_target_user: caliptra_core_tools::caliptra_emu_types::RvData,
+    mcu_mbox0_csr_mbox_target_user_valid: caliptra_core_tools::caliptra_emu_types::RvData,
+    mcu_mbox0_csr_mbox_cmd: caliptra_core_tools::caliptra_emu_types::RvData,
+    mcu_mbox0_csr_mbox_dlen: caliptra_core_tools::caliptra_emu_types::RvData,
+    mcu_mbox0_csr_mbox_execute: caliptra_core_tools::caliptra_emu_types::RvData,
+    mcu_mbox0_csr_mbox_target_status: caliptra_core_tools::caliptra_emu_types::RvData,
+    mcu_mbox0_csr_mbox_cmd_status: caliptra_core_tools::caliptra_emu_types::RvData,
+    mcu_mbox0_csr_mbox_hw_status: caliptra_core_tools::caliptra_emu_types::RvData,
+    mcu_mbox1_csr_mbox_sram: Vec<caliptra_core_tools::caliptra_emu_types::RvData>,
+    mcu_mbox1_csr_mbox_lock: caliptra_core_tools::caliptra_emu_types::RvData,
+    mcu_mbox1_csr_mbox_user: caliptra_core_tools::caliptra_emu_types::RvData,
+    mcu_mbox1_csr_mbox_target_user: caliptra_core_tools::caliptra_emu_types::RvData,
+    mcu_mbox1_csr_mbox_target_user_valid: caliptra_core_tools::caliptra_emu_types::RvData,
+    mcu_mbox1_csr_mbox_cmd: caliptra_core_tools::caliptra_emu_types::RvData,
+    mcu_mbox1_csr_mbox_dlen: caliptra_core_tools::caliptra_emu_types::RvData,
+    mcu_mbox1_csr_mbox_execute: caliptra_core_tools::caliptra_emu_types::RvData,
+    mcu_mbox1_csr_mbox_target_status: caliptra_core_tools::caliptra_emu_types::RvData,
+    mcu_mbox1_csr_mbox_cmd_status: caliptra_core_tools::caliptra_emu_types::RvData,
+    mcu_mbox1_csr_mbox_hw_status: caliptra_core_tools::caliptra_emu_types::RvData,
 }
 impl Default for MciGenerated {
     fn default() -> Self {
         Self {
-            mcu_sram: vec![0 as caliptra_emu_types::RvData; 524288],
-            mci_reg_hw_capabilities: 0 as caliptra_emu_types::RvData,
-            mci_reg_fw_capabilities: 0 as caliptra_emu_types::RvData,
-            mci_reg_cap_lock: 0 as caliptra_emu_types::RvData,
-            mci_reg_hw_rev_id: 0x2001 as caliptra_emu_types::RvData,
-            mci_reg_fw_rev_id: vec![0 as caliptra_emu_types::RvData; 2],
-            mci_reg_hw_config0: 0 as caliptra_emu_types::RvData,
-            mci_reg_hw_config1: 0 as caliptra_emu_types::RvData,
-            mci_reg_mcu_ifu_axi_user: 0 as caliptra_emu_types::RvData,
-            mci_reg_mcu_lsu_axi_user: 0 as caliptra_emu_types::RvData,
-            mci_reg_mcu_sram_config_axi_user: 0 as caliptra_emu_types::RvData,
-            mci_reg_mci_soc_config_axi_user: 0 as caliptra_emu_types::RvData,
-            mci_reg_fw_flow_status: 0 as caliptra_emu_types::RvData,
-            mci_reg_hw_flow_status: 0 as caliptra_emu_types::RvData,
-            mci_reg_reset_reason: 0 as caliptra_emu_types::RvData,
-            mci_reg_reset_status: 0 as caliptra_emu_types::RvData,
-            mci_reg_security_state: 0 as caliptra_emu_types::RvData,
-            mci_reg_hw_error_fatal: 0 as caliptra_emu_types::RvData,
-            mci_reg_agg_error_fatal: 0 as caliptra_emu_types::RvData,
-            mci_reg_hw_error_non_fatal: 0 as caliptra_emu_types::RvData,
-            mci_reg_agg_error_non_fatal: 0 as caliptra_emu_types::RvData,
-            mci_reg_fw_error_fatal: 0 as caliptra_emu_types::RvData,
-            mci_reg_fw_error_non_fatal: 0 as caliptra_emu_types::RvData,
-            mci_reg_hw_error_enc: 0 as caliptra_emu_types::RvData,
-            mci_reg_fw_error_enc: 0 as caliptra_emu_types::RvData,
-            mci_reg_fw_extended_error_info: vec![0 as caliptra_emu_types::RvData; 8],
-            mci_reg_internal_hw_error_fatal_mask: 0 as caliptra_emu_types::RvData,
-            mci_reg_internal_hw_error_non_fatal_mask: 0 as caliptra_emu_types::RvData,
-            mci_reg_internal_agg_error_fatal_mask: 0x3fff_f000 as caliptra_emu_types::RvData,
-            mci_reg_internal_agg_error_non_fatal_mask: 0 as caliptra_emu_types::RvData,
-            mci_reg_internal_fw_error_fatal_mask: 0 as caliptra_emu_types::RvData,
-            mci_reg_internal_fw_error_non_fatal_mask: 0 as caliptra_emu_types::RvData,
-            mci_reg_wdt_timer1_en: 0 as caliptra_emu_types::RvData,
-            mci_reg_wdt_timer1_ctrl: 0 as caliptra_emu_types::RvData,
-            mci_reg_wdt_timer1_timeout_period: vec![0xffff_ffff as caliptra_emu_types::RvData; 2],
-            mci_reg_wdt_timer2_en: 0 as caliptra_emu_types::RvData,
-            mci_reg_wdt_timer2_ctrl: 0 as caliptra_emu_types::RvData,
-            mci_reg_wdt_timer2_timeout_period: vec![0xffff_ffff as caliptra_emu_types::RvData; 2],
-            mci_reg_wdt_status: 0 as caliptra_emu_types::RvData,
-            mci_reg_wdt_cfg: vec![0 as caliptra_emu_types::RvData; 2],
-            mci_reg_mcu_timer_config: 0 as caliptra_emu_types::RvData,
-            mci_reg_mcu_rv_mtime_l: 0 as caliptra_emu_types::RvData,
-            mci_reg_mcu_rv_mtime_h: 0 as caliptra_emu_types::RvData,
-            mci_reg_mcu_rv_mtimecmp_l: 0 as caliptra_emu_types::RvData,
-            mci_reg_mcu_rv_mtimecmp_h: 0 as caliptra_emu_types::RvData,
-            mci_reg_reset_request: 0 as caliptra_emu_types::RvData,
-            mci_reg_mci_bootfsm_go: 0 as caliptra_emu_types::RvData,
-            mci_reg_cptra_boot_go: 0 as caliptra_emu_types::RvData,
-            mci_reg_fw_sram_exec_region_size: 0 as caliptra_emu_types::RvData,
-            mci_reg_mcu_nmi_vector: 0 as caliptra_emu_types::RvData,
-            mci_reg_mcu_reset_vector: 0 as caliptra_emu_types::RvData,
-            mci_reg_mbox0_valid_axi_user: vec![0xffff_ffff as caliptra_emu_types::RvData; 5],
-            mci_reg_mbox0_axi_user_lock: vec![0 as caliptra_emu_types::RvData; 5],
-            mci_reg_mbox1_valid_axi_user: vec![0xffff_ffff as caliptra_emu_types::RvData; 5],
-            mci_reg_mbox1_axi_user_lock: vec![0 as caliptra_emu_types::RvData; 5],
-            mci_reg_soc_dft_en: vec![0 as caliptra_emu_types::RvData; 2],
-            mci_reg_soc_hw_debug_en: vec![0 as caliptra_emu_types::RvData; 2],
-            mci_reg_soc_prod_debug_state: vec![0 as caliptra_emu_types::RvData; 2],
-            mci_reg_fc_fips_zerozation: 0 as caliptra_emu_types::RvData,
-            mci_reg_generic_input_wires: vec![0 as caliptra_emu_types::RvData; 2],
-            mci_reg_generic_output_wires: vec![0 as caliptra_emu_types::RvData; 2],
-            mci_reg_debug_in: 0 as caliptra_emu_types::RvData,
-            mci_reg_debug_out: 0 as caliptra_emu_types::RvData,
-            mci_reg_ss_debug_intent: 0 as caliptra_emu_types::RvData,
-            mci_reg_ss_config_done_sticky: 0 as caliptra_emu_types::RvData,
-            mci_reg_ss_config_done: 0 as caliptra_emu_types::RvData,
-            mci_reg_prod_debug_unlock_pk_hash_reg: vec![0 as caliptra_emu_types::RvData; 96],
-            mci_reg_intr_block_rf_global_intr_en_r: 0 as caliptra_emu_types::RvData,
-            mci_reg_intr_block_rf_error0_intr_en_r: 0 as caliptra_emu_types::RvData,
-            mci_reg_intr_block_rf_error1_intr_en_r: 0 as caliptra_emu_types::RvData,
-            mci_reg_intr_block_rf_notif0_intr_en_r: 0 as caliptra_emu_types::RvData,
-            mci_reg_intr_block_rf_notif1_intr_en_r: 0 as caliptra_emu_types::RvData,
-            mci_reg_intr_block_rf_error_global_intr_r: 0 as caliptra_emu_types::RvData,
-            mci_reg_intr_block_rf_notif_global_intr_r: 0 as caliptra_emu_types::RvData,
-            mci_reg_intr_block_rf_error0_internal_intr_r: 0 as caliptra_emu_types::RvData,
-            mci_reg_intr_block_rf_error1_internal_intr_r: 0 as caliptra_emu_types::RvData,
-            mci_reg_intr_block_rf_notif0_internal_intr_r: 0 as caliptra_emu_types::RvData,
-            mci_reg_intr_block_rf_notif1_internal_intr_r: 0 as caliptra_emu_types::RvData,
-            mci_reg_intr_block_rf_error0_intr_trig_r: 0 as caliptra_emu_types::RvData,
-            mci_reg_intr_block_rf_error1_intr_trig_r: 0 as caliptra_emu_types::RvData,
-            mci_reg_intr_block_rf_notif0_intr_trig_r: 0 as caliptra_emu_types::RvData,
-            mci_reg_intr_block_rf_notif1_intr_trig_r: 0 as caliptra_emu_types::RvData,
-            mci_reg_intr_block_rf_error_internal_intr_count_r: 0 as caliptra_emu_types::RvData,
-            mci_reg_intr_block_rf_error_mbox0_ecc_unc_intr_count_r: 0 as caliptra_emu_types::RvData,
-            mci_reg_intr_block_rf_error_mbox1_ecc_unc_intr_count_r: 0 as caliptra_emu_types::RvData,
+            mcu_sram: vec![0 as caliptra_core_tools::caliptra_emu_types::RvData; 524288],
+            mci_reg_hw_capabilities: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_fw_capabilities: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_cap_lock: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_hw_rev_id: 0x2001 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_fw_rev_id: vec![0 as caliptra_core_tools::caliptra_emu_types::RvData; 2],
+            mci_reg_hw_config0: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_hw_config1: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_mcu_ifu_axi_user: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_mcu_lsu_axi_user: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_mcu_sram_config_axi_user: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_mci_soc_config_axi_user: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_fw_flow_status: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_hw_flow_status: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_reset_reason: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_reset_status: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_security_state: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_hw_error_fatal: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_agg_error_fatal: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_hw_error_non_fatal: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_agg_error_non_fatal: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_fw_error_fatal: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_fw_error_non_fatal: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_hw_error_enc: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_fw_error_enc: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_fw_extended_error_info:
+                vec![0 as caliptra_core_tools::caliptra_emu_types::RvData; 8],
+            mci_reg_internal_hw_error_fatal_mask: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_internal_hw_error_non_fatal_mask: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_internal_agg_error_fatal_mask: 0x3fff_f000
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_internal_agg_error_non_fatal_mask: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_internal_fw_error_fatal_mask: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_internal_fw_error_non_fatal_mask: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_wdt_timer1_en: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_wdt_timer1_ctrl: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_wdt_timer1_timeout_period:
+                vec![0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData; 2],
+            mci_reg_wdt_timer2_en: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_wdt_timer2_ctrl: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_wdt_timer2_timeout_period:
+                vec![0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData; 2],
+            mci_reg_wdt_status: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_wdt_cfg: vec![0 as caliptra_core_tools::caliptra_emu_types::RvData; 2],
+            mci_reg_mcu_timer_config: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_mcu_rv_mtime_l: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_mcu_rv_mtime_h: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_mcu_rv_mtimecmp_l: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_mcu_rv_mtimecmp_h: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_reset_request: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_mci_bootfsm_go: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_cptra_boot_go: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_fw_sram_exec_region_size: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_mcu_nmi_vector: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_mcu_reset_vector: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_mbox0_valid_axi_user:
+                vec![0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData; 5],
+            mci_reg_mbox0_axi_user_lock: vec![
+                0 as caliptra_core_tools::caliptra_emu_types::RvData;
+                5
+            ],
+            mci_reg_mbox1_valid_axi_user:
+                vec![0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData; 5],
+            mci_reg_mbox1_axi_user_lock: vec![
+                0 as caliptra_core_tools::caliptra_emu_types::RvData;
+                5
+            ],
+            mci_reg_soc_dft_en: vec![0 as caliptra_core_tools::caliptra_emu_types::RvData; 2],
+            mci_reg_soc_hw_debug_en: vec![0 as caliptra_core_tools::caliptra_emu_types::RvData; 2],
+            mci_reg_soc_prod_debug_state: vec![
+                0 as caliptra_core_tools::caliptra_emu_types::RvData;
+                2
+            ],
+            mci_reg_fc_fips_zerozation: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_generic_input_wires: vec![
+                0 as caliptra_core_tools::caliptra_emu_types::RvData;
+                2
+            ],
+            mci_reg_generic_output_wires: vec![
+                0 as caliptra_core_tools::caliptra_emu_types::RvData;
+                2
+            ],
+            mci_reg_debug_in: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_debug_out: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_ss_debug_intent: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_ss_config_done_sticky: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_ss_config_done: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_prod_debug_unlock_pk_hash_reg:
+                vec![0 as caliptra_core_tools::caliptra_emu_types::RvData; 96],
+            mci_reg_intr_block_rf_global_intr_en_r: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_intr_block_rf_error0_intr_en_r: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_intr_block_rf_error1_intr_en_r: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_intr_block_rf_notif0_intr_en_r: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_intr_block_rf_notif1_intr_en_r: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_intr_block_rf_error_global_intr_r: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_intr_block_rf_notif_global_intr_r: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_intr_block_rf_error0_internal_intr_r: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_intr_block_rf_error1_internal_intr_r: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_intr_block_rf_notif0_internal_intr_r: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_intr_block_rf_notif1_internal_intr_r: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_intr_block_rf_error0_intr_trig_r: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_intr_block_rf_error1_intr_trig_r: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_intr_block_rf_notif0_intr_trig_r: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_intr_block_rf_notif1_intr_trig_r: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_intr_block_rf_error_internal_intr_count_r: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_intr_block_rf_error_mbox0_ecc_unc_intr_count_r: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_intr_block_rf_error_mbox1_ecc_unc_intr_count_r: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_mcu_sram_dmi_axi_collision_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_wdt_timer1_timeout_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_wdt_timer2_timeout_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_agg_error_fatal0_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_agg_error_fatal1_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_agg_error_fatal2_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_agg_error_fatal3_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_agg_error_fatal4_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_agg_error_fatal5_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_agg_error_fatal6_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_agg_error_fatal7_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_agg_error_fatal8_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_agg_error_fatal9_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_agg_error_fatal10_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_agg_error_fatal11_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_agg_error_fatal12_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_agg_error_fatal13_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_agg_error_fatal14_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_agg_error_fatal15_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_agg_error_fatal16_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_agg_error_fatal17_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_agg_error_fatal18_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_agg_error_fatal19_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_agg_error_fatal20_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_agg_error_fatal21_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_agg_error_fatal22_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_agg_error_fatal23_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_agg_error_fatal24_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_agg_error_fatal25_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_agg_error_fatal26_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_agg_error_fatal27_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_agg_error_fatal28_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_agg_error_fatal29_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_agg_error_fatal30_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_agg_error_fatal31_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_mcu_sram_ecc_cor_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_cptra_mcu_reset_req_intr_count_r: 0
-                as caliptra_emu_types::RvData,
-            mci_reg_intr_block_rf_notif_gen_in_toggle_intr_count_r: 0 as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_intr_block_rf_notif_gen_in_toggle_intr_count_r: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_agg_error_non_fatal0_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_agg_error_non_fatal1_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_agg_error_non_fatal2_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_agg_error_non_fatal3_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_agg_error_non_fatal4_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_agg_error_non_fatal5_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_agg_error_non_fatal6_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_agg_error_non_fatal7_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_agg_error_non_fatal8_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_agg_error_non_fatal9_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_agg_error_non_fatal10_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_agg_error_non_fatal11_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_agg_error_non_fatal12_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_agg_error_non_fatal13_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_agg_error_non_fatal14_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_agg_error_non_fatal15_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_agg_error_non_fatal16_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_agg_error_non_fatal17_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_agg_error_non_fatal18_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_agg_error_non_fatal19_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_agg_error_non_fatal20_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_agg_error_non_fatal21_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_agg_error_non_fatal22_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_agg_error_non_fatal23_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_agg_error_non_fatal24_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_agg_error_non_fatal25_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_agg_error_non_fatal26_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_agg_error_non_fatal27_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_agg_error_non_fatal28_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_agg_error_non_fatal29_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_agg_error_non_fatal30_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_agg_error_non_fatal31_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_mbox0_target_done_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_mbox1_target_done_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_mbox0_cmd_avail_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_mbox1_cmd_avail_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_cptra_mbox_cmd_avail_intr_count_r: 0
-                as caliptra_emu_types::RvData,
-            mci_reg_intr_block_rf_notif_mbox0_ecc_cor_intr_count_r: 0 as caliptra_emu_types::RvData,
-            mci_reg_intr_block_rf_notif_mbox1_ecc_cor_intr_count_r: 0 as caliptra_emu_types::RvData,
-            mci_reg_intr_block_rf_notif_debug_locked_intr_count_r: 0 as caliptra_emu_types::RvData,
-            mci_reg_intr_block_rf_notif_scan_mode_intr_count_r: 0 as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_intr_block_rf_notif_mbox0_ecc_cor_intr_count_r: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_intr_block_rf_notif_mbox1_ecc_cor_intr_count_r: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_intr_block_rf_notif_debug_locked_intr_count_r: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_intr_block_rf_notif_scan_mode_intr_count_r: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_mbox0_soc_req_lock_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_mbox1_soc_req_lock_intr_count_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_otp_operation_done_intr_count_r: 0
-                as caliptra_emu_types::RvData,
-            mci_reg_intr_block_rf_error_internal_intr_count_incr_r: 0 as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            mci_reg_intr_block_rf_error_internal_intr_count_incr_r: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_mbox0_ecc_unc_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_mbox1_ecc_unc_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_wdt_timer1_timeout_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_wdt_timer2_timeout_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_mcu_sram_dmi_axi_collision_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_agg_error_fatal0_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_agg_error_fatal1_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_agg_error_fatal2_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_agg_error_fatal3_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_agg_error_fatal4_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_agg_error_fatal5_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_agg_error_fatal6_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_agg_error_fatal7_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_agg_error_fatal8_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_agg_error_fatal9_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_agg_error_fatal10_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_agg_error_fatal11_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_agg_error_fatal12_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_agg_error_fatal13_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_agg_error_fatal14_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_agg_error_fatal15_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_agg_error_fatal16_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_agg_error_fatal17_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_agg_error_fatal18_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_agg_error_fatal19_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_agg_error_fatal20_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_agg_error_fatal21_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_agg_error_fatal22_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_agg_error_fatal23_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_agg_error_fatal24_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_agg_error_fatal25_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_agg_error_fatal26_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_agg_error_fatal27_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_agg_error_fatal28_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_agg_error_fatal29_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_agg_error_fatal30_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_error_agg_error_fatal31_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_mcu_sram_ecc_cor_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_cptra_mcu_reset_req_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_gen_in_toggle_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_agg_error_non_fatal0_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_agg_error_non_fatal1_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_agg_error_non_fatal2_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_agg_error_non_fatal3_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_agg_error_non_fatal4_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_agg_error_non_fatal5_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_agg_error_non_fatal6_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_agg_error_non_fatal7_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_agg_error_non_fatal8_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_agg_error_non_fatal9_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_agg_error_non_fatal10_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_agg_error_non_fatal11_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_agg_error_non_fatal12_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_agg_error_non_fatal13_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_agg_error_non_fatal14_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_agg_error_non_fatal15_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_agg_error_non_fatal16_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_agg_error_non_fatal17_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_agg_error_non_fatal18_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_agg_error_non_fatal19_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_agg_error_non_fatal20_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_agg_error_non_fatal21_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_agg_error_non_fatal22_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_agg_error_non_fatal23_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_agg_error_non_fatal24_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_agg_error_non_fatal25_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_agg_error_non_fatal26_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_agg_error_non_fatal27_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_agg_error_non_fatal28_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_agg_error_non_fatal29_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_agg_error_non_fatal30_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_agg_error_non_fatal31_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_mbox0_target_done_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_mbox1_target_done_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_mbox0_cmd_avail_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_mbox1_cmd_avail_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_cptra_mbox_cmd_avail_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_mbox0_ecc_cor_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_mbox1_ecc_cor_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_debug_locked_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_scan_mode_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_mbox0_soc_req_lock_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_mbox1_soc_req_lock_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
             mci_reg_intr_block_rf_notif_otp_operation_done_intr_count_incr_r: 0
-                as caliptra_emu_types::RvData,
-            mcu_trace_buffer_csr_status: 0 as caliptra_emu_types::RvData,
-            mcu_trace_buffer_csr_config: 0 as caliptra_emu_types::RvData,
-            mcu_trace_buffer_csr_data: 0 as caliptra_emu_types::RvData,
-            mcu_trace_buffer_csr_write_ptr: 0 as caliptra_emu_types::RvData,
-            mcu_trace_buffer_csr_read_ptr: 0 as caliptra_emu_types::RvData,
-            mcu_mbox0_csr_mbox_sram: vec![0 as caliptra_emu_types::RvData; 524288],
-            mcu_mbox0_csr_mbox_lock: 0 as caliptra_emu_types::RvData,
-            mcu_mbox0_csr_mbox_user: 0 as caliptra_emu_types::RvData,
-            mcu_mbox0_csr_mbox_target_user: 0 as caliptra_emu_types::RvData,
-            mcu_mbox0_csr_mbox_target_user_valid: 0 as caliptra_emu_types::RvData,
-            mcu_mbox0_csr_mbox_cmd: 0 as caliptra_emu_types::RvData,
-            mcu_mbox0_csr_mbox_dlen: 0 as caliptra_emu_types::RvData,
-            mcu_mbox0_csr_mbox_execute: 0 as caliptra_emu_types::RvData,
-            mcu_mbox0_csr_mbox_target_status: 0 as caliptra_emu_types::RvData,
-            mcu_mbox0_csr_mbox_cmd_status: 0 as caliptra_emu_types::RvData,
-            mcu_mbox0_csr_mbox_hw_status: 0 as caliptra_emu_types::RvData,
-            mcu_mbox1_csr_mbox_sram: vec![0 as caliptra_emu_types::RvData; 524288],
-            mcu_mbox1_csr_mbox_lock: 0 as caliptra_emu_types::RvData,
-            mcu_mbox1_csr_mbox_user: 0 as caliptra_emu_types::RvData,
-            mcu_mbox1_csr_mbox_target_user: 0 as caliptra_emu_types::RvData,
-            mcu_mbox1_csr_mbox_target_user_valid: 0 as caliptra_emu_types::RvData,
-            mcu_mbox1_csr_mbox_cmd: 0 as caliptra_emu_types::RvData,
-            mcu_mbox1_csr_mbox_dlen: 0 as caliptra_emu_types::RvData,
-            mcu_mbox1_csr_mbox_execute: 0 as caliptra_emu_types::RvData,
-            mcu_mbox1_csr_mbox_target_status: 0 as caliptra_emu_types::RvData,
-            mcu_mbox1_csr_mbox_cmd_status: 0 as caliptra_emu_types::RvData,
-            mcu_mbox1_csr_mbox_hw_status: 0 as caliptra_emu_types::RvData,
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            mcu_trace_buffer_csr_status: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mcu_trace_buffer_csr_config: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mcu_trace_buffer_csr_data: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mcu_trace_buffer_csr_write_ptr: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mcu_trace_buffer_csr_read_ptr: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mcu_mbox0_csr_mbox_sram: vec![
+                0 as caliptra_core_tools::caliptra_emu_types::RvData;
+                524288
+            ],
+            mcu_mbox0_csr_mbox_lock: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mcu_mbox0_csr_mbox_user: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mcu_mbox0_csr_mbox_target_user: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mcu_mbox0_csr_mbox_target_user_valid: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            mcu_mbox0_csr_mbox_cmd: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mcu_mbox0_csr_mbox_dlen: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mcu_mbox0_csr_mbox_execute: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mcu_mbox0_csr_mbox_target_status: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mcu_mbox0_csr_mbox_cmd_status: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mcu_mbox0_csr_mbox_hw_status: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mcu_mbox1_csr_mbox_sram: vec![
+                0 as caliptra_core_tools::caliptra_emu_types::RvData;
+                524288
+            ],
+            mcu_mbox1_csr_mbox_lock: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mcu_mbox1_csr_mbox_user: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mcu_mbox1_csr_mbox_target_user: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mcu_mbox1_csr_mbox_target_user_valid: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            mcu_mbox1_csr_mbox_cmd: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mcu_mbox1_csr_mbox_dlen: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mcu_mbox1_csr_mbox_execute: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mcu_mbox1_csr_mbox_target_status: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mcu_mbox1_csr_mbox_cmd_status: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mcu_mbox1_csr_mbox_hw_status: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
         }
     }
 }
@@ -6277,7 +6699,7 @@ impl MciPeripheral for MciGenerated {
     fn update_reset(&mut self) {
         self.reset_state();
     }
-    fn read_mcu_sram(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_mcu_sram(&mut self, index: usize) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read mci::mcu_sram[{}]",
@@ -6286,21 +6708,25 @@ impl MciPeripheral for MciGenerated {
         }
         self.mcu_sram[index]
     }
-    fn write_mcu_sram(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    fn write_mcu_sram(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+        index: usize,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: write mci::mcu_sram[{}] = 0x{:08x}",
                 index, val
             );
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mcu_sram[index];
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mcu_sram[index] = new_val;
     }
-    fn read_mci_reg_hw_capabilities(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_hw_capabilities(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read mci::mci_reg_hw_capabilities"
@@ -6308,18 +6734,21 @@ impl MciPeripheral for MciGenerated {
         }
         self.mci_reg_hw_capabilities
     }
-    fn write_mci_reg_hw_capabilities(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mci_reg_hw_capabilities(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_hw_capabilities = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_hw_capabilities;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_hw_capabilities = new_val;
     }
-    fn read_mci_reg_fw_capabilities(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_fw_capabilities(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read mci::mci_reg_fw_capabilities"
@@ -6327,29 +6756,34 @@ impl MciPeripheral for MciGenerated {
         }
         self.mci_reg_fw_capabilities
     }
-    fn write_mci_reg_fw_capabilities(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mci_reg_fw_capabilities(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_fw_capabilities = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_fw_capabilities;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_fw_capabilities = new_val;
     }
     fn read_mci_reg_cap_lock(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::mci::bits::CapLock::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::mci::bits::CapLock::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read mci::mci_reg_cap_lock");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.mci_reg_cap_lock)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.mci_reg_cap_lock)
     }
     fn write_mci_reg_cap_lock(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::CapLock::Register,
         >,
@@ -6360,23 +6794,28 @@ impl MciPeripheral for MciGenerated {
                 val.reg.get()
             );
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_cap_lock;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_cap_lock = new_val;
     }
     fn read_mci_reg_hw_rev_id(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::mci::bits::HwRevId::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::mci::bits::HwRevId::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read mci::mci_reg_hw_rev_id");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.mci_reg_hw_rev_id)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.mci_reg_hw_rev_id)
     }
-    fn read_mci_reg_fw_rev_id(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_fw_rev_id(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read mci::mci_reg_fw_rev_id[{}]",
@@ -6385,36 +6824,44 @@ impl MciPeripheral for MciGenerated {
         }
         self.mci_reg_fw_rev_id[index]
     }
-    fn write_mci_reg_fw_rev_id(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    fn write_mci_reg_fw_rev_id(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+        index: usize,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_fw_rev_id[{}] = 0x{:08x}" , index , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_fw_rev_id[index];
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_fw_rev_id[index] = new_val;
     }
     fn read_mci_reg_hw_config0(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::mci::bits::HwConfig0::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::mci::bits::HwConfig0::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read mci::mci_reg_hw_config0");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.mci_reg_hw_config0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.mci_reg_hw_config0)
     }
     fn read_mci_reg_hw_config1(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::mci::bits::HwConfig1::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::mci::bits::HwConfig1::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read mci::mci_reg_hw_config1");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.mci_reg_hw_config1)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.mci_reg_hw_config1)
     }
-    fn read_mci_reg_mcu_ifu_axi_user(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_mcu_ifu_axi_user(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read mci::mci_reg_mcu_ifu_axi_user"
@@ -6422,7 +6869,7 @@ impl MciPeripheral for MciGenerated {
         }
         self.mci_reg_mcu_ifu_axi_user
     }
-    fn read_mci_reg_mcu_lsu_axi_user(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_mcu_lsu_axi_user(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read mci::mci_reg_mcu_lsu_axi_user"
@@ -6430,60 +6877,67 @@ impl MciPeripheral for MciGenerated {
         }
         self.mci_reg_mcu_lsu_axi_user
     }
-    fn read_mci_reg_mcu_sram_config_axi_user(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_mcu_sram_config_axi_user(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_mcu_sram_config_axi_user");
         }
         self.mci_reg_mcu_sram_config_axi_user
     }
-    fn read_mci_reg_mci_soc_config_axi_user(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_mci_soc_config_axi_user(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_mci_soc_config_axi_user");
         }
         self.mci_reg_mci_soc_config_axi_user
     }
-    fn read_mci_reg_fw_flow_status(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_fw_flow_status(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read mci::mci_reg_fw_flow_status");
         }
         self.mci_reg_fw_flow_status
     }
-    fn write_mci_reg_fw_flow_status(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mci_reg_fw_flow_status(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_fw_flow_status = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_fw_flow_status;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_fw_flow_status = new_val;
     }
     fn read_mci_reg_hw_flow_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::HwFlowStatus::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read mci::mci_reg_hw_flow_status");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.mci_reg_hw_flow_status)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.mci_reg_hw_flow_status)
     }
     fn read_mci_reg_reset_reason(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::ResetReason::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read mci::mci_reg_reset_reason");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.mci_reg_reset_reason)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.mci_reg_reset_reason)
     }
     fn write_mci_reg_reset_reason(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::ResetReason::Register,
         >,
@@ -6491,53 +6945,53 @@ impl MciPeripheral for MciGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_reset_reason = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_reset_reason;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(2 as caliptra_emu_types::RvData))
-            | (write_val & (2 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(4 as caliptra_emu_types::RvData))
-            | (write_val & (4 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(2 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(4 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (4 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_reset_reason = new_val;
     }
     fn read_mci_reg_reset_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::ResetStatus::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read mci::mci_reg_reset_status");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.mci_reg_reset_status)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.mci_reg_reset_status)
     }
     fn read_mci_reg_security_state(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::SecurityState::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read mci::mci_reg_security_state");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.mci_reg_security_state)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.mci_reg_security_state)
     }
     fn read_mci_reg_hw_error_fatal(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::HwErrorFatal::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read mci::mci_reg_hw_error_fatal");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.mci_reg_hw_error_fatal)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.mci_reg_hw_error_fatal)
     }
     fn write_mci_reg_hw_error_fatal(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::HwErrorFatal::Register,
         >,
@@ -6545,20 +6999,20 @@ impl MciPeripheral for MciGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_hw_error_fatal = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_hw_error_fatal;
         let mut new_val = current_val;
-        let bits_to_clear_0 = write_val & (1 as caliptra_emu_types::RvData);
+        let bits_to_clear_0 = write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_0;
-        let bits_to_clear_1 = write_val & (2 as caliptra_emu_types::RvData);
+        let bits_to_clear_1 = write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_1;
-        let bits_to_clear_2 = write_val & (4 as caliptra_emu_types::RvData);
+        let bits_to_clear_2 = write_val & (4 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_2;
         self.mci_reg_hw_error_fatal = new_val;
     }
     fn read_mci_reg_agg_error_fatal(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::AggErrorFatal::Register,
     > {
@@ -6567,11 +7021,11 @@ impl MciPeripheral for MciGenerated {
                 "[EMU] Generated default register handler: read mci::mci_reg_agg_error_fatal"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.mci_reg_agg_error_fatal)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.mci_reg_agg_error_fatal)
     }
     fn write_mci_reg_agg_error_fatal(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::AggErrorFatal::Register,
         >,
@@ -6579,78 +7033,102 @@ impl MciPeripheral for MciGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_agg_error_fatal = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_agg_error_fatal;
         let mut new_val = current_val;
-        let bits_to_clear_0 = write_val & (1 as caliptra_emu_types::RvData);
+        let bits_to_clear_0 = write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_0;
-        let bits_to_clear_1 = write_val & (2 as caliptra_emu_types::RvData);
+        let bits_to_clear_1 = write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_1;
-        let bits_to_clear_2 = write_val & (4 as caliptra_emu_types::RvData);
+        let bits_to_clear_2 = write_val & (4 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_2;
-        let bits_to_clear_3 = write_val & (8 as caliptra_emu_types::RvData);
+        let bits_to_clear_3 = write_val & (8 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_3;
-        let bits_to_clear_4 = write_val & (0x10 as caliptra_emu_types::RvData);
+        let bits_to_clear_4 = write_val & (0x10 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_4;
-        let bits_to_clear_5 = write_val & (0x20 as caliptra_emu_types::RvData);
+        let bits_to_clear_5 = write_val & (0x20 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_5;
-        let bits_to_clear_6 = write_val & (0x40 as caliptra_emu_types::RvData);
+        let bits_to_clear_6 = write_val & (0x40 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_6;
-        let bits_to_clear_7 = write_val & (0x80 as caliptra_emu_types::RvData);
+        let bits_to_clear_7 = write_val & (0x80 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_7;
-        let bits_to_clear_8 = write_val & (0x100 as caliptra_emu_types::RvData);
+        let bits_to_clear_8 =
+            write_val & (0x100 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_8;
-        let bits_to_clear_9 = write_val & (0x200 as caliptra_emu_types::RvData);
+        let bits_to_clear_9 =
+            write_val & (0x200 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_9;
-        let bits_to_clear_10 = write_val & (0x400 as caliptra_emu_types::RvData);
+        let bits_to_clear_10 =
+            write_val & (0x400 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_10;
-        let bits_to_clear_11 = write_val & (0x800 as caliptra_emu_types::RvData);
+        let bits_to_clear_11 =
+            write_val & (0x800 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_11;
-        let bits_to_clear_12 = write_val & (0x1000 as caliptra_emu_types::RvData);
+        let bits_to_clear_12 =
+            write_val & (0x1000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_12;
-        let bits_to_clear_13 = write_val & (0x2000 as caliptra_emu_types::RvData);
+        let bits_to_clear_13 =
+            write_val & (0x2000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_13;
-        let bits_to_clear_14 = write_val & (0x4000 as caliptra_emu_types::RvData);
+        let bits_to_clear_14 =
+            write_val & (0x4000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_14;
-        let bits_to_clear_15 = write_val & (0x8000 as caliptra_emu_types::RvData);
+        let bits_to_clear_15 =
+            write_val & (0x8000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_15;
-        let bits_to_clear_16 = write_val & (0x1_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_16 =
+            write_val & (0x1_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_16;
-        let bits_to_clear_17 = write_val & (0x2_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_17 =
+            write_val & (0x2_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_17;
-        let bits_to_clear_18 = write_val & (0x4_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_18 =
+            write_val & (0x4_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_18;
-        let bits_to_clear_19 = write_val & (0x8_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_19 =
+            write_val & (0x8_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_19;
-        let bits_to_clear_20 = write_val & (0x10_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_20 =
+            write_val & (0x10_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_20;
-        let bits_to_clear_21 = write_val & (0x20_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_21 =
+            write_val & (0x20_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_21;
-        let bits_to_clear_22 = write_val & (0x40_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_22 =
+            write_val & (0x40_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_22;
-        let bits_to_clear_23 = write_val & (0x80_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_23 =
+            write_val & (0x80_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_23;
-        let bits_to_clear_24 = write_val & (0x100_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_24 =
+            write_val & (0x100_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_24;
-        let bits_to_clear_25 = write_val & (0x200_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_25 =
+            write_val & (0x200_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_25;
-        let bits_to_clear_26 = write_val & (0x400_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_26 =
+            write_val & (0x400_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_26;
-        let bits_to_clear_27 = write_val & (0x800_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_27 =
+            write_val & (0x800_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_27;
-        let bits_to_clear_28 = write_val & (0x1000_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_28 =
+            write_val & (0x1000_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_28;
-        let bits_to_clear_29 = write_val & (0x2000_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_29 =
+            write_val & (0x2000_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_29;
-        let bits_to_clear_30 = write_val & (0x4000_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_30 =
+            write_val & (0x4000_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_30;
-        let bits_to_clear_31 = write_val & (0x8000_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_31 =
+            write_val & (0x8000_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_31;
         self.mci_reg_agg_error_fatal = new_val;
     }
     fn read_mci_reg_hw_error_non_fatal(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::HwErrorNonFatal::Register,
     > {
@@ -6659,11 +7137,13 @@ impl MciPeripheral for MciGenerated {
                 "[EMU] Generated default register handler: read mci::mci_reg_hw_error_non_fatal"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.mci_reg_hw_error_non_fatal)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.mci_reg_hw_error_non_fatal,
+        )
     }
     fn write_mci_reg_hw_error_non_fatal(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::HwErrorNonFatal::Register,
         >,
@@ -6671,18 +7151,18 @@ impl MciPeripheral for MciGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_hw_error_non_fatal = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_hw_error_non_fatal;
         let mut new_val = current_val;
-        let bits_to_clear_0 = write_val & (1 as caliptra_emu_types::RvData);
+        let bits_to_clear_0 = write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_0;
-        let bits_to_clear_1 = write_val & (2 as caliptra_emu_types::RvData);
+        let bits_to_clear_1 = write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_1;
         self.mci_reg_hw_error_non_fatal = new_val;
     }
     fn read_mci_reg_agg_error_non_fatal(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::AggErrorNonFatal::Register,
     > {
@@ -6691,11 +7171,13 @@ impl MciPeripheral for MciGenerated {
                 "[EMU] Generated default register handler: read mci::mci_reg_agg_error_non_fatal"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.mci_reg_agg_error_non_fatal)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.mci_reg_agg_error_non_fatal,
+        )
     }
     fn write_mci_reg_agg_error_non_fatal(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::AggErrorNonFatal::Register,
         >,
@@ -6703,93 +7185,122 @@ impl MciPeripheral for MciGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_agg_error_non_fatal = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_agg_error_non_fatal;
         let mut new_val = current_val;
-        let bits_to_clear_0 = write_val & (1 as caliptra_emu_types::RvData);
+        let bits_to_clear_0 = write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_0;
-        let bits_to_clear_1 = write_val & (2 as caliptra_emu_types::RvData);
+        let bits_to_clear_1 = write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_1;
-        let bits_to_clear_2 = write_val & (4 as caliptra_emu_types::RvData);
+        let bits_to_clear_2 = write_val & (4 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_2;
-        let bits_to_clear_3 = write_val & (8 as caliptra_emu_types::RvData);
+        let bits_to_clear_3 = write_val & (8 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_3;
-        let bits_to_clear_4 = write_val & (0x10 as caliptra_emu_types::RvData);
+        let bits_to_clear_4 = write_val & (0x10 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_4;
-        let bits_to_clear_5 = write_val & (0x20 as caliptra_emu_types::RvData);
+        let bits_to_clear_5 = write_val & (0x20 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_5;
-        let bits_to_clear_6 = write_val & (0x40 as caliptra_emu_types::RvData);
+        let bits_to_clear_6 = write_val & (0x40 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_6;
-        let bits_to_clear_7 = write_val & (0x80 as caliptra_emu_types::RvData);
+        let bits_to_clear_7 = write_val & (0x80 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_7;
-        let bits_to_clear_8 = write_val & (0x100 as caliptra_emu_types::RvData);
+        let bits_to_clear_8 =
+            write_val & (0x100 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_8;
-        let bits_to_clear_9 = write_val & (0x200 as caliptra_emu_types::RvData);
+        let bits_to_clear_9 =
+            write_val & (0x200 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_9;
-        let bits_to_clear_10 = write_val & (0x400 as caliptra_emu_types::RvData);
+        let bits_to_clear_10 =
+            write_val & (0x400 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_10;
-        let bits_to_clear_11 = write_val & (0x800 as caliptra_emu_types::RvData);
+        let bits_to_clear_11 =
+            write_val & (0x800 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_11;
-        let bits_to_clear_12 = write_val & (0x1000 as caliptra_emu_types::RvData);
+        let bits_to_clear_12 =
+            write_val & (0x1000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_12;
-        let bits_to_clear_13 = write_val & (0x2000 as caliptra_emu_types::RvData);
+        let bits_to_clear_13 =
+            write_val & (0x2000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_13;
-        let bits_to_clear_14 = write_val & (0x4000 as caliptra_emu_types::RvData);
+        let bits_to_clear_14 =
+            write_val & (0x4000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_14;
-        let bits_to_clear_15 = write_val & (0x8000 as caliptra_emu_types::RvData);
+        let bits_to_clear_15 =
+            write_val & (0x8000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_15;
-        let bits_to_clear_16 = write_val & (0x1_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_16 =
+            write_val & (0x1_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_16;
-        let bits_to_clear_17 = write_val & (0x2_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_17 =
+            write_val & (0x2_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_17;
-        let bits_to_clear_18 = write_val & (0x4_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_18 =
+            write_val & (0x4_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_18;
-        let bits_to_clear_19 = write_val & (0x8_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_19 =
+            write_val & (0x8_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_19;
-        let bits_to_clear_20 = write_val & (0x10_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_20 =
+            write_val & (0x10_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_20;
-        let bits_to_clear_21 = write_val & (0x20_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_21 =
+            write_val & (0x20_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_21;
-        let bits_to_clear_22 = write_val & (0x40_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_22 =
+            write_val & (0x40_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_22;
-        let bits_to_clear_23 = write_val & (0x80_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_23 =
+            write_val & (0x80_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_23;
-        let bits_to_clear_24 = write_val & (0x100_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_24 =
+            write_val & (0x100_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_24;
-        let bits_to_clear_25 = write_val & (0x200_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_25 =
+            write_val & (0x200_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_25;
-        let bits_to_clear_26 = write_val & (0x400_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_26 =
+            write_val & (0x400_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_26;
-        let bits_to_clear_27 = write_val & (0x800_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_27 =
+            write_val & (0x800_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_27;
-        let bits_to_clear_28 = write_val & (0x1000_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_28 =
+            write_val & (0x1000_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_28;
-        let bits_to_clear_29 = write_val & (0x2000_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_29 =
+            write_val & (0x2000_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_29;
-        let bits_to_clear_30 = write_val & (0x4000_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_30 =
+            write_val & (0x4000_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_30;
-        let bits_to_clear_31 = write_val & (0x8000_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_31 =
+            write_val & (0x8000_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_31;
         self.mci_reg_agg_error_non_fatal = new_val;
     }
-    fn read_mci_reg_fw_error_fatal(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_fw_error_fatal(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read mci::mci_reg_fw_error_fatal");
         }
         self.mci_reg_fw_error_fatal
     }
-    fn write_mci_reg_fw_error_fatal(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mci_reg_fw_error_fatal(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_fw_error_fatal = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_fw_error_fatal;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_fw_error_fatal = new_val;
     }
-    fn read_mci_reg_fw_error_non_fatal(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_fw_error_non_fatal(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read mci::mci_reg_fw_error_non_fatal"
@@ -6797,52 +7308,58 @@ impl MciPeripheral for MciGenerated {
         }
         self.mci_reg_fw_error_non_fatal
     }
-    fn write_mci_reg_fw_error_non_fatal(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mci_reg_fw_error_non_fatal(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_fw_error_non_fatal = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_fw_error_non_fatal;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_fw_error_non_fatal = new_val;
     }
-    fn read_mci_reg_hw_error_enc(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_hw_error_enc(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read mci::mci_reg_hw_error_enc");
         }
         self.mci_reg_hw_error_enc
     }
-    fn write_mci_reg_hw_error_enc(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mci_reg_hw_error_enc(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_hw_error_enc = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_hw_error_enc;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_hw_error_enc = new_val;
     }
-    fn read_mci_reg_fw_error_enc(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_fw_error_enc(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read mci::mci_reg_fw_error_enc");
         }
         self.mci_reg_fw_error_enc
     }
-    fn write_mci_reg_fw_error_enc(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mci_reg_fw_error_enc(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_fw_error_enc = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_fw_error_enc;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_fw_error_enc = new_val;
     }
-    fn read_mci_reg_fw_extended_error_info(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_fw_extended_error_info(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_fw_extended_error_info[{}]" , index);
         }
@@ -6850,33 +7367,35 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_fw_extended_error_info(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
         index: usize,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_fw_extended_error_info[{}] = 0x{:08x}" , index , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_fw_extended_error_info[index];
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_fw_extended_error_info[index] = new_val;
     }
     fn read_mci_reg_internal_hw_error_fatal_mask(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::InternalHwErrorFatalMask::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_internal_hw_error_fatal_mask");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.mci_reg_internal_hw_error_fatal_mask)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.mci_reg_internal_hw_error_fatal_mask,
+        )
     }
     fn write_mci_reg_internal_hw_error_fatal_mask(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::InternalHwErrorFatalMask::Register,
         >,
@@ -6884,31 +7403,33 @@ impl MciPeripheral for MciGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_internal_hw_error_fatal_mask = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_internal_hw_error_fatal_mask;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(2 as caliptra_emu_types::RvData))
-            | (write_val & (2 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(4 as caliptra_emu_types::RvData))
-            | (write_val & (4 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(2 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(4 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (4 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_internal_hw_error_fatal_mask = new_val;
     }
     fn read_mci_reg_internal_hw_error_non_fatal_mask(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::InternalHwErrorNonFatalMask::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_internal_hw_error_non_fatal_mask");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.mci_reg_internal_hw_error_non_fatal_mask)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.mci_reg_internal_hw_error_non_fatal_mask,
+        )
     }
     fn write_mci_reg_internal_hw_error_non_fatal_mask(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::InternalHwErrorNonFatalMask::Register,
         >,
@@ -6916,29 +7437,31 @@ impl MciPeripheral for MciGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_internal_hw_error_non_fatal_mask = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_internal_hw_error_non_fatal_mask;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(2 as caliptra_emu_types::RvData))
-            | (write_val & (2 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(2 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_internal_hw_error_non_fatal_mask = new_val;
     }
     fn read_mci_reg_internal_agg_error_fatal_mask(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::InternalAggErrorFatalMask::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_internal_agg_error_fatal_mask");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.mci_reg_internal_agg_error_fatal_mask)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.mci_reg_internal_agg_error_fatal_mask,
+        )
     }
     fn write_mci_reg_internal_agg_error_fatal_mask(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::InternalAggErrorFatalMask::Register,
         >,
@@ -6946,89 +7469,91 @@ impl MciPeripheral for MciGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_internal_agg_error_fatal_mask = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_internal_agg_error_fatal_mask;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(2 as caliptra_emu_types::RvData))
-            | (write_val & (2 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(4 as caliptra_emu_types::RvData))
-            | (write_val & (4 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(8 as caliptra_emu_types::RvData))
-            | (write_val & (8 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x10 as caliptra_emu_types::RvData))
-            | (write_val & (0x10 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x20 as caliptra_emu_types::RvData))
-            | (write_val & (0x20 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x40 as caliptra_emu_types::RvData))
-            | (write_val & (0x40 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x80 as caliptra_emu_types::RvData))
-            | (write_val & (0x80 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x100 as caliptra_emu_types::RvData))
-            | (write_val & (0x100 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x200 as caliptra_emu_types::RvData))
-            | (write_val & (0x200 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x400 as caliptra_emu_types::RvData))
-            | (write_val & (0x400 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x800 as caliptra_emu_types::RvData))
-            | (write_val & (0x800 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x1000 as caliptra_emu_types::RvData))
-            | (write_val & (0x1000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x2000 as caliptra_emu_types::RvData))
-            | (write_val & (0x2000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x4000 as caliptra_emu_types::RvData))
-            | (write_val & (0x4000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x8000 as caliptra_emu_types::RvData))
-            | (write_val & (0x8000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x1_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x1_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x2_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x2_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x4_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x4_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x8_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x8_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x10_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x10_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x20_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x20_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x40_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x40_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x80_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x80_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x100_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x100_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x200_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x200_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x400_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x400_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x800_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x800_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x1000_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x1000_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x2000_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x2000_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x4000_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x4000_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x8000_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x8000_0000 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(2 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(4 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (4 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(8 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (8 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x10 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x10 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x20 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x20 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x40 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x40 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x80 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x80 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x100 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x100 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x200 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x200 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x400 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x400 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x800 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x800 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x1000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x1000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x2000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x2000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x4000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x4000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x8000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x8000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x1_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x1_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x2_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x2_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x4_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x4_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x8_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x8_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x10_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x10_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x20_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x20_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x40_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x40_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x80_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x80_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x100_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x100_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x200_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x200_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x400_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x400_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x800_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x800_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x1000_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x1000_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x2000_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x2000_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x4000_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x4000_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x8000_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x8000_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_internal_agg_error_fatal_mask = new_val;
     }
     fn read_mci_reg_internal_agg_error_non_fatal_mask(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::InternalAggErrorNonFatalMask::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_internal_agg_error_non_fatal_mask");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.mci_reg_internal_agg_error_non_fatal_mask)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.mci_reg_internal_agg_error_non_fatal_mask,
+        )
     }
     fn write_mci_reg_internal_agg_error_non_fatal_mask(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::InternalAggErrorNonFatalMask::Register,
         >,
@@ -7036,123 +7561,133 @@ impl MciPeripheral for MciGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_internal_agg_error_non_fatal_mask = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_internal_agg_error_non_fatal_mask;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(2 as caliptra_emu_types::RvData))
-            | (write_val & (2 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(4 as caliptra_emu_types::RvData))
-            | (write_val & (4 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(8 as caliptra_emu_types::RvData))
-            | (write_val & (8 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x10 as caliptra_emu_types::RvData))
-            | (write_val & (0x10 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x20 as caliptra_emu_types::RvData))
-            | (write_val & (0x20 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x40 as caliptra_emu_types::RvData))
-            | (write_val & (0x40 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x80 as caliptra_emu_types::RvData))
-            | (write_val & (0x80 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x100 as caliptra_emu_types::RvData))
-            | (write_val & (0x100 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x200 as caliptra_emu_types::RvData))
-            | (write_val & (0x200 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x400 as caliptra_emu_types::RvData))
-            | (write_val & (0x400 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x800 as caliptra_emu_types::RvData))
-            | (write_val & (0x800 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x1000 as caliptra_emu_types::RvData))
-            | (write_val & (0x1000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x2000 as caliptra_emu_types::RvData))
-            | (write_val & (0x2000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x4000 as caliptra_emu_types::RvData))
-            | (write_val & (0x4000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x8000 as caliptra_emu_types::RvData))
-            | (write_val & (0x8000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x1_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x1_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x2_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x2_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x4_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x4_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x8_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x8_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x10_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x10_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x20_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x20_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x40_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x40_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x80_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x80_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x100_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x100_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x200_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x200_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x400_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x400_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x800_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x800_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x1000_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x1000_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x2000_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x2000_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x4000_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x4000_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x8000_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x8000_0000 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(2 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(4 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (4 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(8 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (8 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x10 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x10 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x20 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x20 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x40 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x40 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x80 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x80 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x100 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x100 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x200 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x200 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x400 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x400 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x800 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x800 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x1000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x1000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x2000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x2000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x4000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x4000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x8000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x8000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x1_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x1_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x2_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x2_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x4_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x4_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x8_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x8_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x10_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x10_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x20_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x20_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x40_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x40_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x80_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x80_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x100_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x100_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x200_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x200_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x400_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x400_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x800_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x800_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x1000_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x1000_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x2000_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x2000_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x4000_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x4000_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x8000_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x8000_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_internal_agg_error_non_fatal_mask = new_val;
     }
-    fn read_mci_reg_internal_fw_error_fatal_mask(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_internal_fw_error_fatal_mask(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_internal_fw_error_fatal_mask");
         }
         self.mci_reg_internal_fw_error_fatal_mask
     }
-    fn write_mci_reg_internal_fw_error_fatal_mask(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mci_reg_internal_fw_error_fatal_mask(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_internal_fw_error_fatal_mask = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_internal_fw_error_fatal_mask;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_internal_fw_error_fatal_mask = new_val;
     }
-    fn read_mci_reg_internal_fw_error_non_fatal_mask(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_internal_fw_error_non_fatal_mask(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_internal_fw_error_non_fatal_mask");
         }
         self.mci_reg_internal_fw_error_non_fatal_mask
     }
-    fn write_mci_reg_internal_fw_error_non_fatal_mask(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mci_reg_internal_fw_error_non_fatal_mask(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_internal_fw_error_non_fatal_mask = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_internal_fw_error_non_fatal_mask;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_internal_fw_error_non_fatal_mask = new_val;
     }
     fn read_mci_reg_wdt_timer1_en(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::WdtTimer1En::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read mci::mci_reg_wdt_timer1_en");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.mci_reg_wdt_timer1_en)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.mci_reg_wdt_timer1_en)
     }
     fn write_mci_reg_wdt_timer1_en(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::WdtTimer1En::Register,
         >,
@@ -7160,16 +7695,16 @@ impl MciPeripheral for MciGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_wdt_timer1_en = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_wdt_timer1_en;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_wdt_timer1_en = new_val;
     }
     fn read_mci_reg_wdt_timer1_ctrl(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::WdtTimer1Ctrl::Register,
     > {
@@ -7178,11 +7713,11 @@ impl MciPeripheral for MciGenerated {
                 "[EMU] Generated default register handler: read mci::mci_reg_wdt_timer1_ctrl"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.mci_reg_wdt_timer1_ctrl)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.mci_reg_wdt_timer1_ctrl)
     }
     fn write_mci_reg_wdt_timer1_ctrl(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::WdtTimer1Ctrl::Register,
         >,
@@ -7190,17 +7725,17 @@ impl MciPeripheral for MciGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_wdt_timer1_ctrl = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_wdt_timer1_ctrl;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_wdt_timer1_ctrl = new_val;
     }
     fn read_mci_reg_wdt_timer1_timeout_period(
         &mut self,
         index: usize,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_wdt_timer1_timeout_period[{}]" , index);
         }
@@ -7208,33 +7743,33 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_wdt_timer1_timeout_period(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
         index: usize,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_wdt_timer1_timeout_period[{}] = 0x{:08x}" , index , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_wdt_timer1_timeout_period[index];
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_wdt_timer1_timeout_period[index] = new_val;
     }
     fn read_mci_reg_wdt_timer2_en(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::WdtTimer2En::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read mci::mci_reg_wdt_timer2_en");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.mci_reg_wdt_timer2_en)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.mci_reg_wdt_timer2_en)
     }
     fn write_mci_reg_wdt_timer2_en(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::WdtTimer2En::Register,
         >,
@@ -7242,16 +7777,16 @@ impl MciPeripheral for MciGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_wdt_timer2_en = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_wdt_timer2_en;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_wdt_timer2_en = new_val;
     }
     fn read_mci_reg_wdt_timer2_ctrl(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::WdtTimer2Ctrl::Register,
     > {
@@ -7260,11 +7795,11 @@ impl MciPeripheral for MciGenerated {
                 "[EMU] Generated default register handler: read mci::mci_reg_wdt_timer2_ctrl"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.mci_reg_wdt_timer2_ctrl)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.mci_reg_wdt_timer2_ctrl)
     }
     fn write_mci_reg_wdt_timer2_ctrl(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::WdtTimer2Ctrl::Register,
         >,
@@ -7272,17 +7807,17 @@ impl MciPeripheral for MciGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_wdt_timer2_ctrl = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_wdt_timer2_ctrl;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_wdt_timer2_ctrl = new_val;
     }
     fn read_mci_reg_wdt_timer2_timeout_period(
         &mut self,
         index: usize,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_wdt_timer2_timeout_period[{}]" , index);
         }
@@ -7290,29 +7825,34 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_wdt_timer2_timeout_period(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
         index: usize,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_wdt_timer2_timeout_period[{}] = 0x{:08x}" , index , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_wdt_timer2_timeout_period[index];
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_wdt_timer2_timeout_period[index] = new_val;
     }
     fn read_mci_reg_wdt_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::mci::bits::WdtStatus::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::mci::bits::WdtStatus::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read mci::mci_reg_wdt_status");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.mci_reg_wdt_status)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.mci_reg_wdt_status)
     }
-    fn read_mci_reg_wdt_cfg(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_wdt_cfg(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read mci::mci_reg_wdt_cfg[{}]",
@@ -7321,18 +7861,22 @@ impl MciPeripheral for MciGenerated {
         }
         self.mci_reg_wdt_cfg[index]
     }
-    fn write_mci_reg_wdt_cfg(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    fn write_mci_reg_wdt_cfg(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+        index: usize,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_wdt_cfg[{}] = 0x{:08x}" , index , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_wdt_cfg[index];
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_wdt_cfg[index] = new_val;
     }
-    fn read_mci_reg_mcu_timer_config(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_mcu_timer_config(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read mci::mci_reg_mcu_timer_config"
@@ -7340,52 +7884,63 @@ impl MciPeripheral for MciGenerated {
         }
         self.mci_reg_mcu_timer_config
     }
-    fn write_mci_reg_mcu_timer_config(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mci_reg_mcu_timer_config(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_mcu_timer_config = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_mcu_timer_config;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_mcu_timer_config = new_val;
     }
-    fn read_mci_reg_mcu_rv_mtime_l(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_mcu_rv_mtime_l(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read mci::mci_reg_mcu_rv_mtime_l");
         }
         self.mci_reg_mcu_rv_mtime_l
     }
-    fn write_mci_reg_mcu_rv_mtime_l(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mci_reg_mcu_rv_mtime_l(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_mcu_rv_mtime_l = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_mcu_rv_mtime_l;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_mcu_rv_mtime_l = new_val;
     }
-    fn read_mci_reg_mcu_rv_mtime_h(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_mcu_rv_mtime_h(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read mci::mci_reg_mcu_rv_mtime_h");
         }
         self.mci_reg_mcu_rv_mtime_h
     }
-    fn write_mci_reg_mcu_rv_mtime_h(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mci_reg_mcu_rv_mtime_h(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_mcu_rv_mtime_h = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_mcu_rv_mtime_h;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_mcu_rv_mtime_h = new_val;
     }
-    fn read_mci_reg_mcu_rv_mtimecmp_l(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_mcu_rv_mtimecmp_l(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read mci::mci_reg_mcu_rv_mtimecmp_l"
@@ -7393,18 +7948,23 @@ impl MciPeripheral for MciGenerated {
         }
         self.mci_reg_mcu_rv_mtimecmp_l
     }
-    fn write_mci_reg_mcu_rv_mtimecmp_l(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mci_reg_mcu_rv_mtimecmp_l(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_mcu_rv_mtimecmp_l = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_mcu_rv_mtimecmp_l;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_mcu_rv_mtimecmp_l = new_val;
     }
-    fn read_mci_reg_mcu_rv_mtimecmp_h(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_mcu_rv_mtimecmp_h(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read mci::mci_reg_mcu_rv_mtimecmp_h"
@@ -7412,31 +7972,34 @@ impl MciPeripheral for MciGenerated {
         }
         self.mci_reg_mcu_rv_mtimecmp_h
     }
-    fn write_mci_reg_mcu_rv_mtimecmp_h(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mci_reg_mcu_rv_mtimecmp_h(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_mcu_rv_mtimecmp_h = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_mcu_rv_mtimecmp_h;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_mcu_rv_mtimecmp_h = new_val;
     }
     fn read_mci_reg_reset_request(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::ResetRequest::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read mci::mci_reg_reset_request");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.mci_reg_reset_request)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.mci_reg_reset_request)
     }
     fn write_mci_reg_reset_request(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::ResetRequest::Register,
         >,
@@ -7444,73 +8007,85 @@ impl MciPeripheral for MciGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_reset_request = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_reset_request;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_reset_request = new_val;
     }
     fn read_mci_reg_mci_bootfsm_go(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::mci::bits::Go::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::mci::bits::Go::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read mci::mci_reg_mci_bootfsm_go");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.mci_reg_mci_bootfsm_go)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.mci_reg_mci_bootfsm_go)
     }
     fn write_mci_reg_mci_bootfsm_go(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::mci::bits::Go::Register>,
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+            u32,
+            registers_generated::mci::bits::Go::Register,
+        >,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_mci_bootfsm_go = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_mci_bootfsm_go;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_mci_bootfsm_go = new_val;
     }
     fn read_mci_reg_cptra_boot_go(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::mci::bits::Go::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::mci::bits::Go::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read mci::mci_reg_cptra_boot_go");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.mci_reg_cptra_boot_go)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.mci_reg_cptra_boot_go)
     }
     fn write_mci_reg_cptra_boot_go(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::mci::bits::Go::Register>,
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+            u32,
+            registers_generated::mci::bits::Go::Register,
+        >,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_cptra_boot_go = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_cptra_boot_go;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_cptra_boot_go = new_val;
     }
     fn read_mci_reg_fw_sram_exec_region_size(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::FwSramExecRegionSize::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_fw_sram_exec_region_size");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.mci_reg_fw_sram_exec_region_size)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.mci_reg_fw_sram_exec_region_size,
+        )
     }
     fn write_mci_reg_fw_sram_exec_region_size(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::FwSramExecRegionSize::Register,
         >,
@@ -7518,31 +8093,34 @@ impl MciPeripheral for MciGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_fw_sram_exec_region_size = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_fw_sram_exec_region_size;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_fw_sram_exec_region_size = new_val;
     }
-    fn read_mci_reg_mcu_nmi_vector(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_mcu_nmi_vector(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read mci::mci_reg_mcu_nmi_vector");
         }
         self.mci_reg_mcu_nmi_vector
     }
-    fn write_mci_reg_mcu_nmi_vector(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mci_reg_mcu_nmi_vector(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_mcu_nmi_vector = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_mcu_nmi_vector;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_mcu_nmi_vector = new_val;
     }
-    fn read_mci_reg_mcu_reset_vector(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_mcu_reset_vector(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read mci::mci_reg_mcu_reset_vector"
@@ -7550,18 +8128,24 @@ impl MciPeripheral for MciGenerated {
         }
         self.mci_reg_mcu_reset_vector
     }
-    fn write_mci_reg_mcu_reset_vector(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mci_reg_mcu_reset_vector(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_mcu_reset_vector = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_mcu_reset_vector;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_mcu_reset_vector = new_val;
     }
-    fn read_mci_reg_mbox0_valid_axi_user(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_mbox0_valid_axi_user(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_mbox0_valid_axi_user[{}]" , index);
         }
@@ -7569,34 +8153,36 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_mbox0_valid_axi_user(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
         index: usize,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_mbox0_valid_axi_user[{}] = 0x{:08x}" , index , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_mbox0_valid_axi_user[index];
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_mbox0_valid_axi_user[index] = new_val;
     }
     fn read_mci_reg_mbox0_axi_user_lock(
         &mut self,
         index: usize,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::MboxxAxiUserLock::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_mbox0_axi_user_lock[{}]" , index);
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.mci_reg_mbox0_axi_user_lock[index])
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.mci_reg_mbox0_axi_user_lock[index],
+        )
     }
     fn write_mci_reg_mbox0_axi_user_lock(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::MboxxAxiUserLock::Register,
         >,
@@ -7605,14 +8191,17 @@ impl MciPeripheral for MciGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_mbox0_axi_user_lock[{}] = 0x{:08x}" , index , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_mbox0_axi_user_lock[index];
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_mbox0_axi_user_lock[index] = new_val;
     }
-    fn read_mci_reg_mbox1_valid_axi_user(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_mbox1_valid_axi_user(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_mbox1_valid_axi_user[{}]" , index);
         }
@@ -7620,34 +8209,36 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_mbox1_valid_axi_user(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
         index: usize,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_mbox1_valid_axi_user[{}] = 0x{:08x}" , index , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_mbox1_valid_axi_user[index];
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_mbox1_valid_axi_user[index] = new_val;
     }
     fn read_mci_reg_mbox1_axi_user_lock(
         &mut self,
         index: usize,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::MboxxAxiUserLock::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_mbox1_axi_user_lock[{}]" , index);
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.mci_reg_mbox1_axi_user_lock[index])
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.mci_reg_mbox1_axi_user_lock[index],
+        )
     }
     fn write_mci_reg_mbox1_axi_user_lock(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::MboxxAxiUserLock::Register,
         >,
@@ -7656,14 +8247,17 @@ impl MciPeripheral for MciGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_mbox1_axi_user_lock[{}] = 0x{:08x}" , index , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_mbox1_axi_user_lock[index];
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_mbox1_axi_user_lock[index] = new_val;
     }
-    fn read_mci_reg_soc_dft_en(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_soc_dft_en(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read mci::mci_reg_soc_dft_en[{}]",
@@ -7672,18 +8266,25 @@ impl MciPeripheral for MciGenerated {
         }
         self.mci_reg_soc_dft_en[index]
     }
-    fn write_mci_reg_soc_dft_en(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    fn write_mci_reg_soc_dft_en(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+        index: usize,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_soc_dft_en[{}] = 0x{:08x}" , index , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_soc_dft_en[index];
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_soc_dft_en[index] = new_val;
     }
-    fn read_mci_reg_soc_hw_debug_en(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_soc_hw_debug_en(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read mci::mci_reg_soc_hw_debug_en[{}]",
@@ -7692,18 +8293,25 @@ impl MciPeripheral for MciGenerated {
         }
         self.mci_reg_soc_hw_debug_en[index]
     }
-    fn write_mci_reg_soc_hw_debug_en(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    fn write_mci_reg_soc_hw_debug_en(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+        index: usize,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_soc_hw_debug_en[{}] = 0x{:08x}" , index , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_soc_hw_debug_en[index];
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_soc_hw_debug_en[index] = new_val;
     }
-    fn read_mci_reg_soc_prod_debug_state(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_soc_prod_debug_state(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_soc_prod_debug_state[{}]" , index);
         }
@@ -7711,20 +8319,22 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_soc_prod_debug_state(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
         index: usize,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_soc_prod_debug_state[{}] = 0x{:08x}" , index , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_soc_prod_debug_state[index];
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_soc_prod_debug_state[index] = new_val;
     }
-    fn read_mci_reg_fc_fips_zerozation(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_fc_fips_zerozation(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read mci::mci_reg_fc_fips_zerozation"
@@ -7732,24 +8342,33 @@ impl MciPeripheral for MciGenerated {
         }
         self.mci_reg_fc_fips_zerozation
     }
-    fn write_mci_reg_fc_fips_zerozation(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mci_reg_fc_fips_zerozation(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_fc_fips_zerozation = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_fc_fips_zerozation;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_fc_fips_zerozation = new_val;
     }
-    fn read_mci_reg_generic_input_wires(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_generic_input_wires(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_generic_input_wires[{}]" , index);
         }
         self.mci_reg_generic_input_wires[index]
     }
-    fn read_mci_reg_generic_output_wires(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_generic_output_wires(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_generic_output_wires[{}]" , index);
         }
@@ -7757,62 +8376,62 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_generic_output_wires(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
         index: usize,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_generic_output_wires[{}] = 0x{:08x}" , index , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_generic_output_wires[index];
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_generic_output_wires[index] = new_val;
     }
-    fn read_mci_reg_debug_in(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_debug_in(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read mci::mci_reg_debug_in");
         }
         self.mci_reg_debug_in
     }
-    fn write_mci_reg_debug_in(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mci_reg_debug_in(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: write mci::mci_reg_debug_in = 0x{:08x}",
                 val
             );
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_debug_in;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_debug_in = new_val;
     }
-    fn read_mci_reg_debug_out(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mci_reg_debug_out(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read mci::mci_reg_debug_out");
         }
         self.mci_reg_debug_out
     }
-    fn write_mci_reg_debug_out(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mci_reg_debug_out(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: write mci::mci_reg_debug_out = 0x{:08x}",
                 val
             );
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_debug_out;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_debug_out = new_val;
     }
     fn read_mci_reg_ss_debug_intent(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::SsDebugIntent::Register,
     > {
@@ -7821,11 +8440,11 @@ impl MciPeripheral for MciGenerated {
                 "[EMU] Generated default register handler: read mci::mci_reg_ss_debug_intent"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.mci_reg_ss_debug_intent)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.mci_reg_ss_debug_intent)
     }
     fn read_mci_reg_ss_config_done_sticky(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::SsConfigDone::Register,
     > {
@@ -7834,11 +8453,13 @@ impl MciPeripheral for MciGenerated {
                 "[EMU] Generated default register handler: read mci::mci_reg_ss_config_done_sticky"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.mci_reg_ss_config_done_sticky)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.mci_reg_ss_config_done_sticky,
+        )
     }
     fn write_mci_reg_ss_config_done_sticky(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::SsConfigDone::Register,
         >,
@@ -7846,27 +8467,27 @@ impl MciPeripheral for MciGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_ss_config_done_sticky = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_ss_config_done_sticky;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_ss_config_done_sticky = new_val;
     }
     fn read_mci_reg_ss_config_done(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::SsConfigDone::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read mci::mci_reg_ss_config_done");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.mci_reg_ss_config_done)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.mci_reg_ss_config_done)
     }
     fn write_mci_reg_ss_config_done(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::SsConfigDone::Register,
         >,
@@ -7874,17 +8495,17 @@ impl MciPeripheral for MciGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_ss_config_done = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_ss_config_done;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_ss_config_done = new_val;
     }
     fn read_mci_reg_prod_debug_unlock_pk_hash_reg(
         &mut self,
         index: usize,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_prod_debug_unlock_pk_hash_reg[{}]" , index);
         }
@@ -7892,33 +8513,35 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_prod_debug_unlock_pk_hash_reg(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
         index: usize,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_prod_debug_unlock_pk_hash_reg[{}] = 0x{:08x}" , index , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_prod_debug_unlock_pk_hash_reg[index];
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_prod_debug_unlock_pk_hash_reg[index] = new_val;
     }
     fn read_mci_reg_intr_block_rf_global_intr_en_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::GlobalIntrEnT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_global_intr_en_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.mci_reg_intr_block_rf_global_intr_en_r)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.mci_reg_intr_block_rf_global_intr_en_r,
+        )
     }
     fn write_mci_reg_intr_block_rf_global_intr_en_r(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::GlobalIntrEnT::Register,
         >,
@@ -7926,29 +8549,31 @@ impl MciPeripheral for MciGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_global_intr_en_r = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_global_intr_en_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(2 as caliptra_emu_types::RvData))
-            | (write_val & (2 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(2 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_global_intr_en_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_error0_intr_en_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::Error0IntrEnT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error0_intr_en_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.mci_reg_intr_block_rf_error0_intr_en_r)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.mci_reg_intr_block_rf_error0_intr_en_r,
+        )
     }
     fn write_mci_reg_intr_block_rf_error0_intr_en_r(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::Error0IntrEnT::Register,
         >,
@@ -7956,37 +8581,39 @@ impl MciPeripheral for MciGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_error0_intr_en_r = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_error0_intr_en_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(2 as caliptra_emu_types::RvData))
-            | (write_val & (2 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(4 as caliptra_emu_types::RvData))
-            | (write_val & (4 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(8 as caliptra_emu_types::RvData))
-            | (write_val & (8 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x10 as caliptra_emu_types::RvData))
-            | (write_val & (0x10 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x20 as caliptra_emu_types::RvData))
-            | (write_val & (0x20 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(2 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(4 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (4 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(8 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (8 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x10 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x10 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x20 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x20 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_error0_intr_en_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_error1_intr_en_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::Error1IntrEnT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error1_intr_en_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.mci_reg_intr_block_rf_error1_intr_en_r)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.mci_reg_intr_block_rf_error1_intr_en_r,
+        )
     }
     fn write_mci_reg_intr_block_rf_error1_intr_en_r(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::Error1IntrEnT::Register,
         >,
@@ -7994,89 +8621,91 @@ impl MciPeripheral for MciGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_error1_intr_en_r = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_error1_intr_en_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(2 as caliptra_emu_types::RvData))
-            | (write_val & (2 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(4 as caliptra_emu_types::RvData))
-            | (write_val & (4 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(8 as caliptra_emu_types::RvData))
-            | (write_val & (8 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x10 as caliptra_emu_types::RvData))
-            | (write_val & (0x10 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x20 as caliptra_emu_types::RvData))
-            | (write_val & (0x20 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x40 as caliptra_emu_types::RvData))
-            | (write_val & (0x40 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x80 as caliptra_emu_types::RvData))
-            | (write_val & (0x80 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x100 as caliptra_emu_types::RvData))
-            | (write_val & (0x100 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x200 as caliptra_emu_types::RvData))
-            | (write_val & (0x200 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x400 as caliptra_emu_types::RvData))
-            | (write_val & (0x400 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x800 as caliptra_emu_types::RvData))
-            | (write_val & (0x800 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x1000 as caliptra_emu_types::RvData))
-            | (write_val & (0x1000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x2000 as caliptra_emu_types::RvData))
-            | (write_val & (0x2000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x4000 as caliptra_emu_types::RvData))
-            | (write_val & (0x4000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x8000 as caliptra_emu_types::RvData))
-            | (write_val & (0x8000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x1_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x1_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x2_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x2_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x4_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x4_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x8_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x8_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x10_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x10_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x20_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x20_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x40_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x40_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x80_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x80_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x100_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x100_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x200_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x200_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x400_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x400_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x800_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x800_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x1000_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x1000_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x2000_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x2000_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x4000_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x4000_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x8000_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x8000_0000 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(2 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(4 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (4 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(8 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (8 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x10 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x10 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x20 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x20 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x40 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x40 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x80 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x80 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x100 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x100 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x200 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x200 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x400 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x400 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x800 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x800 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x1000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x1000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x2000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x2000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x4000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x4000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x8000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x8000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x1_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x1_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x2_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x2_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x4_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x4_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x8_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x8_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x10_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x10_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x20_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x20_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x40_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x40_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x80_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x80_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x100_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x100_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x200_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x200_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x400_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x400_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x800_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x800_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x1000_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x1000_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x2000_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x2000_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x4000_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x4000_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x8000_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x8000_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_error1_intr_en_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_notif0_intr_en_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::Notif0IntrEnT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif0_intr_en_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.mci_reg_intr_block_rf_notif0_intr_en_r)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.mci_reg_intr_block_rf_notif0_intr_en_r,
+        )
     }
     fn write_mci_reg_intr_block_rf_notif0_intr_en_r(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::Notif0IntrEnT::Register,
         >,
@@ -8084,55 +8713,57 @@ impl MciPeripheral for MciGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_notif0_intr_en_r = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_notif0_intr_en_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(2 as caliptra_emu_types::RvData))
-            | (write_val & (2 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(4 as caliptra_emu_types::RvData))
-            | (write_val & (4 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(8 as caliptra_emu_types::RvData))
-            | (write_val & (8 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x10 as caliptra_emu_types::RvData))
-            | (write_val & (0x10 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x20 as caliptra_emu_types::RvData))
-            | (write_val & (0x20 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x40 as caliptra_emu_types::RvData))
-            | (write_val & (0x40 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x80 as caliptra_emu_types::RvData))
-            | (write_val & (0x80 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x100 as caliptra_emu_types::RvData))
-            | (write_val & (0x100 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x200 as caliptra_emu_types::RvData))
-            | (write_val & (0x200 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x400 as caliptra_emu_types::RvData))
-            | (write_val & (0x400 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x800 as caliptra_emu_types::RvData))
-            | (write_val & (0x800 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x1000 as caliptra_emu_types::RvData))
-            | (write_val & (0x1000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x2000 as caliptra_emu_types::RvData))
-            | (write_val & (0x2000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x4000 as caliptra_emu_types::RvData))
-            | (write_val & (0x4000 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(2 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(4 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (4 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(8 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (8 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x10 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x10 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x20 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x20 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x40 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x40 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x80 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x80 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x100 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x100 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x200 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x200 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x400 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x400 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x800 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x800 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x1000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x1000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x2000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x2000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x4000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x4000 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_notif0_intr_en_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_notif1_intr_en_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::Notif1IntrEnT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif1_intr_en_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.mci_reg_intr_block_rf_notif1_intr_en_r)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.mci_reg_intr_block_rf_notif1_intr_en_r,
+        )
     }
     fn write_mci_reg_intr_block_rf_notif1_intr_en_r(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::Notif1IntrEnT::Register,
         >,
@@ -8140,111 +8771,117 @@ impl MciPeripheral for MciGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_notif1_intr_en_r = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_notif1_intr_en_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(2 as caliptra_emu_types::RvData))
-            | (write_val & (2 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(4 as caliptra_emu_types::RvData))
-            | (write_val & (4 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(8 as caliptra_emu_types::RvData))
-            | (write_val & (8 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x10 as caliptra_emu_types::RvData))
-            | (write_val & (0x10 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x20 as caliptra_emu_types::RvData))
-            | (write_val & (0x20 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x40 as caliptra_emu_types::RvData))
-            | (write_val & (0x40 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x80 as caliptra_emu_types::RvData))
-            | (write_val & (0x80 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x100 as caliptra_emu_types::RvData))
-            | (write_val & (0x100 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x200 as caliptra_emu_types::RvData))
-            | (write_val & (0x200 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x400 as caliptra_emu_types::RvData))
-            | (write_val & (0x400 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x800 as caliptra_emu_types::RvData))
-            | (write_val & (0x800 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x1000 as caliptra_emu_types::RvData))
-            | (write_val & (0x1000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x2000 as caliptra_emu_types::RvData))
-            | (write_val & (0x2000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x4000 as caliptra_emu_types::RvData))
-            | (write_val & (0x4000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x8000 as caliptra_emu_types::RvData))
-            | (write_val & (0x8000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x1_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x1_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x2_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x2_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x4_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x4_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x8_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x8_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x10_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x10_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x20_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x20_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x40_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x40_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x80_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x80_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x100_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x100_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x200_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x200_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x400_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x400_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x800_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x800_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x1000_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x1000_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x2000_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x2000_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x4000_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x4000_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x8000_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x8000_0000 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(2 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(4 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (4 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(8 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (8 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x10 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x10 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x20 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x20 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x40 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x40 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x80 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x80 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x100 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x100 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x200 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x200 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x400 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x400 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x800 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x800 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x1000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x1000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x2000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x2000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x4000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x4000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x8000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x8000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x1_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x1_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x2_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x2_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x4_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x4_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x8_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x8_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x10_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x10_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x20_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x20_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x40_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x40_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x80_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x80_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x100_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x100_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x200_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x200_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x400_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x400_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x800_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x800_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x1000_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x1000_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x2000_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x2000_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x4000_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x4000_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x8000_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x8000_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_notif1_intr_en_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_error_global_intr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::GlobalIntrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_global_intr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.mci_reg_intr_block_rf_error_global_intr_r)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.mci_reg_intr_block_rf_error_global_intr_r,
+        )
     }
     fn read_mci_reg_intr_block_rf_notif_global_intr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::GlobalIntrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_global_intr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.mci_reg_intr_block_rf_notif_global_intr_r)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.mci_reg_intr_block_rf_notif_global_intr_r,
+        )
     }
     fn read_mci_reg_intr_block_rf_error0_internal_intr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::Error0IntrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error0_internal_intr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.mci_reg_intr_block_rf_error0_internal_intr_r)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.mci_reg_intr_block_rf_error0_internal_intr_r,
+        )
     }
     fn write_mci_reg_intr_block_rf_error0_internal_intr_r(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::Error0IntrT::Register,
         >,
@@ -8252,37 +8889,39 @@ impl MciPeripheral for MciGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_error0_internal_intr_r = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_error0_internal_intr_r;
         let mut new_val = current_val;
-        let bits_to_clear_0 = write_val & (1 as caliptra_emu_types::RvData);
+        let bits_to_clear_0 = write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_0;
-        let bits_to_clear_1 = write_val & (2 as caliptra_emu_types::RvData);
+        let bits_to_clear_1 = write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_1;
-        let bits_to_clear_2 = write_val & (4 as caliptra_emu_types::RvData);
+        let bits_to_clear_2 = write_val & (4 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_2;
-        let bits_to_clear_3 = write_val & (8 as caliptra_emu_types::RvData);
+        let bits_to_clear_3 = write_val & (8 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_3;
-        let bits_to_clear_4 = write_val & (0x10 as caliptra_emu_types::RvData);
+        let bits_to_clear_4 = write_val & (0x10 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_4;
-        let bits_to_clear_5 = write_val & (0x20 as caliptra_emu_types::RvData);
+        let bits_to_clear_5 = write_val & (0x20 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_5;
         self.mci_reg_intr_block_rf_error0_internal_intr_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_error1_internal_intr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::Error1IntrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error1_internal_intr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.mci_reg_intr_block_rf_error1_internal_intr_r)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.mci_reg_intr_block_rf_error1_internal_intr_r,
+        )
     }
     fn write_mci_reg_intr_block_rf_error1_internal_intr_r(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::Error1IntrT::Register,
         >,
@@ -8290,89 +8929,115 @@ impl MciPeripheral for MciGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_error1_internal_intr_r = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_error1_internal_intr_r;
         let mut new_val = current_val;
-        let bits_to_clear_0 = write_val & (1 as caliptra_emu_types::RvData);
+        let bits_to_clear_0 = write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_0;
-        let bits_to_clear_1 = write_val & (2 as caliptra_emu_types::RvData);
+        let bits_to_clear_1 = write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_1;
-        let bits_to_clear_2 = write_val & (4 as caliptra_emu_types::RvData);
+        let bits_to_clear_2 = write_val & (4 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_2;
-        let bits_to_clear_3 = write_val & (8 as caliptra_emu_types::RvData);
+        let bits_to_clear_3 = write_val & (8 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_3;
-        let bits_to_clear_4 = write_val & (0x10 as caliptra_emu_types::RvData);
+        let bits_to_clear_4 = write_val & (0x10 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_4;
-        let bits_to_clear_5 = write_val & (0x20 as caliptra_emu_types::RvData);
+        let bits_to_clear_5 = write_val & (0x20 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_5;
-        let bits_to_clear_6 = write_val & (0x40 as caliptra_emu_types::RvData);
+        let bits_to_clear_6 = write_val & (0x40 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_6;
-        let bits_to_clear_7 = write_val & (0x80 as caliptra_emu_types::RvData);
+        let bits_to_clear_7 = write_val & (0x80 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_7;
-        let bits_to_clear_8 = write_val & (0x100 as caliptra_emu_types::RvData);
+        let bits_to_clear_8 =
+            write_val & (0x100 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_8;
-        let bits_to_clear_9 = write_val & (0x200 as caliptra_emu_types::RvData);
+        let bits_to_clear_9 =
+            write_val & (0x200 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_9;
-        let bits_to_clear_10 = write_val & (0x400 as caliptra_emu_types::RvData);
+        let bits_to_clear_10 =
+            write_val & (0x400 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_10;
-        let bits_to_clear_11 = write_val & (0x800 as caliptra_emu_types::RvData);
+        let bits_to_clear_11 =
+            write_val & (0x800 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_11;
-        let bits_to_clear_12 = write_val & (0x1000 as caliptra_emu_types::RvData);
+        let bits_to_clear_12 =
+            write_val & (0x1000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_12;
-        let bits_to_clear_13 = write_val & (0x2000 as caliptra_emu_types::RvData);
+        let bits_to_clear_13 =
+            write_val & (0x2000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_13;
-        let bits_to_clear_14 = write_val & (0x4000 as caliptra_emu_types::RvData);
+        let bits_to_clear_14 =
+            write_val & (0x4000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_14;
-        let bits_to_clear_15 = write_val & (0x8000 as caliptra_emu_types::RvData);
+        let bits_to_clear_15 =
+            write_val & (0x8000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_15;
-        let bits_to_clear_16 = write_val & (0x1_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_16 =
+            write_val & (0x1_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_16;
-        let bits_to_clear_17 = write_val & (0x2_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_17 =
+            write_val & (0x2_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_17;
-        let bits_to_clear_18 = write_val & (0x4_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_18 =
+            write_val & (0x4_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_18;
-        let bits_to_clear_19 = write_val & (0x8_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_19 =
+            write_val & (0x8_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_19;
-        let bits_to_clear_20 = write_val & (0x10_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_20 =
+            write_val & (0x10_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_20;
-        let bits_to_clear_21 = write_val & (0x20_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_21 =
+            write_val & (0x20_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_21;
-        let bits_to_clear_22 = write_val & (0x40_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_22 =
+            write_val & (0x40_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_22;
-        let bits_to_clear_23 = write_val & (0x80_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_23 =
+            write_val & (0x80_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_23;
-        let bits_to_clear_24 = write_val & (0x100_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_24 =
+            write_val & (0x100_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_24;
-        let bits_to_clear_25 = write_val & (0x200_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_25 =
+            write_val & (0x200_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_25;
-        let bits_to_clear_26 = write_val & (0x400_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_26 =
+            write_val & (0x400_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_26;
-        let bits_to_clear_27 = write_val & (0x800_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_27 =
+            write_val & (0x800_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_27;
-        let bits_to_clear_28 = write_val & (0x1000_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_28 =
+            write_val & (0x1000_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_28;
-        let bits_to_clear_29 = write_val & (0x2000_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_29 =
+            write_val & (0x2000_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_29;
-        let bits_to_clear_30 = write_val & (0x4000_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_30 =
+            write_val & (0x4000_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_30;
-        let bits_to_clear_31 = write_val & (0x8000_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_31 =
+            write_val & (0x8000_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_31;
         self.mci_reg_intr_block_rf_error1_internal_intr_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_notif0_internal_intr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::Notif0IntrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif0_internal_intr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.mci_reg_intr_block_rf_notif0_internal_intr_r)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.mci_reg_intr_block_rf_notif0_internal_intr_r,
+        )
     }
     fn write_mci_reg_intr_block_rf_notif0_internal_intr_r(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::Notif0IntrT::Register,
         >,
@@ -8380,55 +9045,64 @@ impl MciPeripheral for MciGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_notif0_internal_intr_r = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_notif0_internal_intr_r;
         let mut new_val = current_val;
-        let bits_to_clear_0 = write_val & (1 as caliptra_emu_types::RvData);
+        let bits_to_clear_0 = write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_0;
-        let bits_to_clear_1 = write_val & (2 as caliptra_emu_types::RvData);
+        let bits_to_clear_1 = write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_1;
-        let bits_to_clear_2 = write_val & (4 as caliptra_emu_types::RvData);
+        let bits_to_clear_2 = write_val & (4 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_2;
-        let bits_to_clear_3 = write_val & (8 as caliptra_emu_types::RvData);
+        let bits_to_clear_3 = write_val & (8 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_3;
-        let bits_to_clear_4 = write_val & (0x10 as caliptra_emu_types::RvData);
+        let bits_to_clear_4 = write_val & (0x10 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_4;
-        let bits_to_clear_5 = write_val & (0x20 as caliptra_emu_types::RvData);
+        let bits_to_clear_5 = write_val & (0x20 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_5;
-        let bits_to_clear_6 = write_val & (0x40 as caliptra_emu_types::RvData);
+        let bits_to_clear_6 = write_val & (0x40 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_6;
-        let bits_to_clear_7 = write_val & (0x80 as caliptra_emu_types::RvData);
+        let bits_to_clear_7 = write_val & (0x80 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_7;
-        let bits_to_clear_8 = write_val & (0x100 as caliptra_emu_types::RvData);
+        let bits_to_clear_8 =
+            write_val & (0x100 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_8;
-        let bits_to_clear_9 = write_val & (0x200 as caliptra_emu_types::RvData);
+        let bits_to_clear_9 =
+            write_val & (0x200 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_9;
-        let bits_to_clear_10 = write_val & (0x400 as caliptra_emu_types::RvData);
+        let bits_to_clear_10 =
+            write_val & (0x400 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_10;
-        let bits_to_clear_11 = write_val & (0x800 as caliptra_emu_types::RvData);
+        let bits_to_clear_11 =
+            write_val & (0x800 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_11;
-        let bits_to_clear_12 = write_val & (0x1000 as caliptra_emu_types::RvData);
+        let bits_to_clear_12 =
+            write_val & (0x1000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_12;
-        let bits_to_clear_13 = write_val & (0x2000 as caliptra_emu_types::RvData);
+        let bits_to_clear_13 =
+            write_val & (0x2000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_13;
-        let bits_to_clear_14 = write_val & (0x4000 as caliptra_emu_types::RvData);
+        let bits_to_clear_14 =
+            write_val & (0x4000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_14;
         self.mci_reg_intr_block_rf_notif0_internal_intr_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_notif1_internal_intr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::Notif1IntrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif1_internal_intr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.mci_reg_intr_block_rf_notif1_internal_intr_r)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.mci_reg_intr_block_rf_notif1_internal_intr_r,
+        )
     }
     fn write_mci_reg_intr_block_rf_notif1_internal_intr_r(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::Notif1IntrT::Register,
         >,
@@ -8436,89 +9110,115 @@ impl MciPeripheral for MciGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_notif1_internal_intr_r = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_notif1_internal_intr_r;
         let mut new_val = current_val;
-        let bits_to_clear_0 = write_val & (1 as caliptra_emu_types::RvData);
+        let bits_to_clear_0 = write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_0;
-        let bits_to_clear_1 = write_val & (2 as caliptra_emu_types::RvData);
+        let bits_to_clear_1 = write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_1;
-        let bits_to_clear_2 = write_val & (4 as caliptra_emu_types::RvData);
+        let bits_to_clear_2 = write_val & (4 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_2;
-        let bits_to_clear_3 = write_val & (8 as caliptra_emu_types::RvData);
+        let bits_to_clear_3 = write_val & (8 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_3;
-        let bits_to_clear_4 = write_val & (0x10 as caliptra_emu_types::RvData);
+        let bits_to_clear_4 = write_val & (0x10 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_4;
-        let bits_to_clear_5 = write_val & (0x20 as caliptra_emu_types::RvData);
+        let bits_to_clear_5 = write_val & (0x20 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_5;
-        let bits_to_clear_6 = write_val & (0x40 as caliptra_emu_types::RvData);
+        let bits_to_clear_6 = write_val & (0x40 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_6;
-        let bits_to_clear_7 = write_val & (0x80 as caliptra_emu_types::RvData);
+        let bits_to_clear_7 = write_val & (0x80 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_7;
-        let bits_to_clear_8 = write_val & (0x100 as caliptra_emu_types::RvData);
+        let bits_to_clear_8 =
+            write_val & (0x100 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_8;
-        let bits_to_clear_9 = write_val & (0x200 as caliptra_emu_types::RvData);
+        let bits_to_clear_9 =
+            write_val & (0x200 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_9;
-        let bits_to_clear_10 = write_val & (0x400 as caliptra_emu_types::RvData);
+        let bits_to_clear_10 =
+            write_val & (0x400 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_10;
-        let bits_to_clear_11 = write_val & (0x800 as caliptra_emu_types::RvData);
+        let bits_to_clear_11 =
+            write_val & (0x800 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_11;
-        let bits_to_clear_12 = write_val & (0x1000 as caliptra_emu_types::RvData);
+        let bits_to_clear_12 =
+            write_val & (0x1000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_12;
-        let bits_to_clear_13 = write_val & (0x2000 as caliptra_emu_types::RvData);
+        let bits_to_clear_13 =
+            write_val & (0x2000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_13;
-        let bits_to_clear_14 = write_val & (0x4000 as caliptra_emu_types::RvData);
+        let bits_to_clear_14 =
+            write_val & (0x4000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_14;
-        let bits_to_clear_15 = write_val & (0x8000 as caliptra_emu_types::RvData);
+        let bits_to_clear_15 =
+            write_val & (0x8000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_15;
-        let bits_to_clear_16 = write_val & (0x1_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_16 =
+            write_val & (0x1_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_16;
-        let bits_to_clear_17 = write_val & (0x2_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_17 =
+            write_val & (0x2_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_17;
-        let bits_to_clear_18 = write_val & (0x4_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_18 =
+            write_val & (0x4_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_18;
-        let bits_to_clear_19 = write_val & (0x8_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_19 =
+            write_val & (0x8_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_19;
-        let bits_to_clear_20 = write_val & (0x10_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_20 =
+            write_val & (0x10_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_20;
-        let bits_to_clear_21 = write_val & (0x20_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_21 =
+            write_val & (0x20_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_21;
-        let bits_to_clear_22 = write_val & (0x40_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_22 =
+            write_val & (0x40_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_22;
-        let bits_to_clear_23 = write_val & (0x80_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_23 =
+            write_val & (0x80_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_23;
-        let bits_to_clear_24 = write_val & (0x100_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_24 =
+            write_val & (0x100_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_24;
-        let bits_to_clear_25 = write_val & (0x200_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_25 =
+            write_val & (0x200_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_25;
-        let bits_to_clear_26 = write_val & (0x400_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_26 =
+            write_val & (0x400_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_26;
-        let bits_to_clear_27 = write_val & (0x800_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_27 =
+            write_val & (0x800_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_27;
-        let bits_to_clear_28 = write_val & (0x1000_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_28 =
+            write_val & (0x1000_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_28;
-        let bits_to_clear_29 = write_val & (0x2000_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_29 =
+            write_val & (0x2000_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_29;
-        let bits_to_clear_30 = write_val & (0x4000_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_30 =
+            write_val & (0x4000_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_30;
-        let bits_to_clear_31 = write_val & (0x8000_0000 as caliptra_emu_types::RvData);
+        let bits_to_clear_31 =
+            write_val & (0x8000_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_31;
         self.mci_reg_intr_block_rf_notif1_internal_intr_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_error0_intr_trig_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::Error0IntrTrigT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error0_intr_trig_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.mci_reg_intr_block_rf_error0_intr_trig_r)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.mci_reg_intr_block_rf_error0_intr_trig_r,
+        )
     }
     fn write_mci_reg_intr_block_rf_error0_intr_trig_r(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::Error0IntrTrigT::Register,
         >,
@@ -8526,37 +9226,39 @@ impl MciPeripheral for MciGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_error0_intr_trig_r = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_error0_intr_trig_r;
         let mut new_val = current_val;
-        let bits_to_set_0 = write_val & (1 as caliptra_emu_types::RvData);
+        let bits_to_set_0 = write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_0;
-        let bits_to_set_1 = write_val & (2 as caliptra_emu_types::RvData);
+        let bits_to_set_1 = write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_1;
-        let bits_to_set_2 = write_val & (4 as caliptra_emu_types::RvData);
+        let bits_to_set_2 = write_val & (4 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_2;
-        let bits_to_set_3 = write_val & (8 as caliptra_emu_types::RvData);
+        let bits_to_set_3 = write_val & (8 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_3;
-        let bits_to_set_4 = write_val & (0x10 as caliptra_emu_types::RvData);
+        let bits_to_set_4 = write_val & (0x10 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_4;
-        let bits_to_set_5 = write_val & (0x20 as caliptra_emu_types::RvData);
+        let bits_to_set_5 = write_val & (0x20 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_5;
         self.mci_reg_intr_block_rf_error0_intr_trig_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_error1_intr_trig_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::Error1IntrTrigT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error1_intr_trig_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.mci_reg_intr_block_rf_error1_intr_trig_r)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.mci_reg_intr_block_rf_error1_intr_trig_r,
+        )
     }
     fn write_mci_reg_intr_block_rf_error1_intr_trig_r(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::Error1IntrTrigT::Register,
         >,
@@ -8564,89 +9266,111 @@ impl MciPeripheral for MciGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_error1_intr_trig_r = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_error1_intr_trig_r;
         let mut new_val = current_val;
-        let bits_to_set_0 = write_val & (1 as caliptra_emu_types::RvData);
+        let bits_to_set_0 = write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_0;
-        let bits_to_set_1 = write_val & (2 as caliptra_emu_types::RvData);
+        let bits_to_set_1 = write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_1;
-        let bits_to_set_2 = write_val & (4 as caliptra_emu_types::RvData);
+        let bits_to_set_2 = write_val & (4 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_2;
-        let bits_to_set_3 = write_val & (8 as caliptra_emu_types::RvData);
+        let bits_to_set_3 = write_val & (8 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_3;
-        let bits_to_set_4 = write_val & (0x10 as caliptra_emu_types::RvData);
+        let bits_to_set_4 = write_val & (0x10 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_4;
-        let bits_to_set_5 = write_val & (0x20 as caliptra_emu_types::RvData);
+        let bits_to_set_5 = write_val & (0x20 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_5;
-        let bits_to_set_6 = write_val & (0x40 as caliptra_emu_types::RvData);
+        let bits_to_set_6 = write_val & (0x40 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_6;
-        let bits_to_set_7 = write_val & (0x80 as caliptra_emu_types::RvData);
+        let bits_to_set_7 = write_val & (0x80 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_7;
-        let bits_to_set_8 = write_val & (0x100 as caliptra_emu_types::RvData);
+        let bits_to_set_8 = write_val & (0x100 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_8;
-        let bits_to_set_9 = write_val & (0x200 as caliptra_emu_types::RvData);
+        let bits_to_set_9 = write_val & (0x200 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_9;
-        let bits_to_set_10 = write_val & (0x400 as caliptra_emu_types::RvData);
+        let bits_to_set_10 = write_val & (0x400 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_10;
-        let bits_to_set_11 = write_val & (0x800 as caliptra_emu_types::RvData);
+        let bits_to_set_11 = write_val & (0x800 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_11;
-        let bits_to_set_12 = write_val & (0x1000 as caliptra_emu_types::RvData);
+        let bits_to_set_12 =
+            write_val & (0x1000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_12;
-        let bits_to_set_13 = write_val & (0x2000 as caliptra_emu_types::RvData);
+        let bits_to_set_13 =
+            write_val & (0x2000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_13;
-        let bits_to_set_14 = write_val & (0x4000 as caliptra_emu_types::RvData);
+        let bits_to_set_14 =
+            write_val & (0x4000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_14;
-        let bits_to_set_15 = write_val & (0x8000 as caliptra_emu_types::RvData);
+        let bits_to_set_15 =
+            write_val & (0x8000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_15;
-        let bits_to_set_16 = write_val & (0x1_0000 as caliptra_emu_types::RvData);
+        let bits_to_set_16 =
+            write_val & (0x1_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_16;
-        let bits_to_set_17 = write_val & (0x2_0000 as caliptra_emu_types::RvData);
+        let bits_to_set_17 =
+            write_val & (0x2_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_17;
-        let bits_to_set_18 = write_val & (0x4_0000 as caliptra_emu_types::RvData);
+        let bits_to_set_18 =
+            write_val & (0x4_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_18;
-        let bits_to_set_19 = write_val & (0x8_0000 as caliptra_emu_types::RvData);
+        let bits_to_set_19 =
+            write_val & (0x8_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_19;
-        let bits_to_set_20 = write_val & (0x10_0000 as caliptra_emu_types::RvData);
+        let bits_to_set_20 =
+            write_val & (0x10_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_20;
-        let bits_to_set_21 = write_val & (0x20_0000 as caliptra_emu_types::RvData);
+        let bits_to_set_21 =
+            write_val & (0x20_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_21;
-        let bits_to_set_22 = write_val & (0x40_0000 as caliptra_emu_types::RvData);
+        let bits_to_set_22 =
+            write_val & (0x40_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_22;
-        let bits_to_set_23 = write_val & (0x80_0000 as caliptra_emu_types::RvData);
+        let bits_to_set_23 =
+            write_val & (0x80_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_23;
-        let bits_to_set_24 = write_val & (0x100_0000 as caliptra_emu_types::RvData);
+        let bits_to_set_24 =
+            write_val & (0x100_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_24;
-        let bits_to_set_25 = write_val & (0x200_0000 as caliptra_emu_types::RvData);
+        let bits_to_set_25 =
+            write_val & (0x200_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_25;
-        let bits_to_set_26 = write_val & (0x400_0000 as caliptra_emu_types::RvData);
+        let bits_to_set_26 =
+            write_val & (0x400_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_26;
-        let bits_to_set_27 = write_val & (0x800_0000 as caliptra_emu_types::RvData);
+        let bits_to_set_27 =
+            write_val & (0x800_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_27;
-        let bits_to_set_28 = write_val & (0x1000_0000 as caliptra_emu_types::RvData);
+        let bits_to_set_28 =
+            write_val & (0x1000_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_28;
-        let bits_to_set_29 = write_val & (0x2000_0000 as caliptra_emu_types::RvData);
+        let bits_to_set_29 =
+            write_val & (0x2000_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_29;
-        let bits_to_set_30 = write_val & (0x4000_0000 as caliptra_emu_types::RvData);
+        let bits_to_set_30 =
+            write_val & (0x4000_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_30;
-        let bits_to_set_31 = write_val & (0x8000_0000 as caliptra_emu_types::RvData);
+        let bits_to_set_31 =
+            write_val & (0x8000_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_31;
         self.mci_reg_intr_block_rf_error1_intr_trig_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_notif0_intr_trig_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::Notif0IntrTrigT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif0_intr_trig_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.mci_reg_intr_block_rf_notif0_intr_trig_r)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.mci_reg_intr_block_rf_notif0_intr_trig_r,
+        )
     }
     fn write_mci_reg_intr_block_rf_notif0_intr_trig_r(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::Notif0IntrTrigT::Register,
         >,
@@ -8654,55 +9378,60 @@ impl MciPeripheral for MciGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_notif0_intr_trig_r = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_notif0_intr_trig_r;
         let mut new_val = current_val;
-        let bits_to_set_0 = write_val & (1 as caliptra_emu_types::RvData);
+        let bits_to_set_0 = write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_0;
-        let bits_to_set_1 = write_val & (2 as caliptra_emu_types::RvData);
+        let bits_to_set_1 = write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_1;
-        let bits_to_set_2 = write_val & (4 as caliptra_emu_types::RvData);
+        let bits_to_set_2 = write_val & (4 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_2;
-        let bits_to_set_3 = write_val & (8 as caliptra_emu_types::RvData);
+        let bits_to_set_3 = write_val & (8 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_3;
-        let bits_to_set_4 = write_val & (0x10 as caliptra_emu_types::RvData);
+        let bits_to_set_4 = write_val & (0x10 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_4;
-        let bits_to_set_5 = write_val & (0x20 as caliptra_emu_types::RvData);
+        let bits_to_set_5 = write_val & (0x20 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_5;
-        let bits_to_set_6 = write_val & (0x40 as caliptra_emu_types::RvData);
+        let bits_to_set_6 = write_val & (0x40 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_6;
-        let bits_to_set_7 = write_val & (0x80 as caliptra_emu_types::RvData);
+        let bits_to_set_7 = write_val & (0x80 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_7;
-        let bits_to_set_8 = write_val & (0x100 as caliptra_emu_types::RvData);
+        let bits_to_set_8 = write_val & (0x100 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_8;
-        let bits_to_set_9 = write_val & (0x200 as caliptra_emu_types::RvData);
+        let bits_to_set_9 = write_val & (0x200 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_9;
-        let bits_to_set_10 = write_val & (0x400 as caliptra_emu_types::RvData);
+        let bits_to_set_10 = write_val & (0x400 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_10;
-        let bits_to_set_11 = write_val & (0x800 as caliptra_emu_types::RvData);
+        let bits_to_set_11 = write_val & (0x800 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_11;
-        let bits_to_set_12 = write_val & (0x1000 as caliptra_emu_types::RvData);
+        let bits_to_set_12 =
+            write_val & (0x1000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_12;
-        let bits_to_set_13 = write_val & (0x2000 as caliptra_emu_types::RvData);
+        let bits_to_set_13 =
+            write_val & (0x2000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_13;
-        let bits_to_set_14 = write_val & (0x4000 as caliptra_emu_types::RvData);
+        let bits_to_set_14 =
+            write_val & (0x4000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_14;
         self.mci_reg_intr_block_rf_notif0_intr_trig_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_notif1_intr_trig_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::Notif1IntrTrigT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif1_intr_trig_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.mci_reg_intr_block_rf_notif1_intr_trig_r)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.mci_reg_intr_block_rf_notif1_intr_trig_r,
+        )
     }
     fn write_mci_reg_intr_block_rf_notif1_intr_trig_r(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::Notif1IntrTrigT::Register,
         >,
@@ -8710,78 +9439,98 @@ impl MciPeripheral for MciGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_notif1_intr_trig_r = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_notif1_intr_trig_r;
         let mut new_val = current_val;
-        let bits_to_set_0 = write_val & (1 as caliptra_emu_types::RvData);
+        let bits_to_set_0 = write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_0;
-        let bits_to_set_1 = write_val & (2 as caliptra_emu_types::RvData);
+        let bits_to_set_1 = write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_1;
-        let bits_to_set_2 = write_val & (4 as caliptra_emu_types::RvData);
+        let bits_to_set_2 = write_val & (4 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_2;
-        let bits_to_set_3 = write_val & (8 as caliptra_emu_types::RvData);
+        let bits_to_set_3 = write_val & (8 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_3;
-        let bits_to_set_4 = write_val & (0x10 as caliptra_emu_types::RvData);
+        let bits_to_set_4 = write_val & (0x10 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_4;
-        let bits_to_set_5 = write_val & (0x20 as caliptra_emu_types::RvData);
+        let bits_to_set_5 = write_val & (0x20 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_5;
-        let bits_to_set_6 = write_val & (0x40 as caliptra_emu_types::RvData);
+        let bits_to_set_6 = write_val & (0x40 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_6;
-        let bits_to_set_7 = write_val & (0x80 as caliptra_emu_types::RvData);
+        let bits_to_set_7 = write_val & (0x80 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_7;
-        let bits_to_set_8 = write_val & (0x100 as caliptra_emu_types::RvData);
+        let bits_to_set_8 = write_val & (0x100 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_8;
-        let bits_to_set_9 = write_val & (0x200 as caliptra_emu_types::RvData);
+        let bits_to_set_9 = write_val & (0x200 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_9;
-        let bits_to_set_10 = write_val & (0x400 as caliptra_emu_types::RvData);
+        let bits_to_set_10 = write_val & (0x400 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_10;
-        let bits_to_set_11 = write_val & (0x800 as caliptra_emu_types::RvData);
+        let bits_to_set_11 = write_val & (0x800 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_11;
-        let bits_to_set_12 = write_val & (0x1000 as caliptra_emu_types::RvData);
+        let bits_to_set_12 =
+            write_val & (0x1000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_12;
-        let bits_to_set_13 = write_val & (0x2000 as caliptra_emu_types::RvData);
+        let bits_to_set_13 =
+            write_val & (0x2000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_13;
-        let bits_to_set_14 = write_val & (0x4000 as caliptra_emu_types::RvData);
+        let bits_to_set_14 =
+            write_val & (0x4000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_14;
-        let bits_to_set_15 = write_val & (0x8000 as caliptra_emu_types::RvData);
+        let bits_to_set_15 =
+            write_val & (0x8000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_15;
-        let bits_to_set_16 = write_val & (0x1_0000 as caliptra_emu_types::RvData);
+        let bits_to_set_16 =
+            write_val & (0x1_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_16;
-        let bits_to_set_17 = write_val & (0x2_0000 as caliptra_emu_types::RvData);
+        let bits_to_set_17 =
+            write_val & (0x2_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_17;
-        let bits_to_set_18 = write_val & (0x4_0000 as caliptra_emu_types::RvData);
+        let bits_to_set_18 =
+            write_val & (0x4_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_18;
-        let bits_to_set_19 = write_val & (0x8_0000 as caliptra_emu_types::RvData);
+        let bits_to_set_19 =
+            write_val & (0x8_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_19;
-        let bits_to_set_20 = write_val & (0x10_0000 as caliptra_emu_types::RvData);
+        let bits_to_set_20 =
+            write_val & (0x10_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_20;
-        let bits_to_set_21 = write_val & (0x20_0000 as caliptra_emu_types::RvData);
+        let bits_to_set_21 =
+            write_val & (0x20_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_21;
-        let bits_to_set_22 = write_val & (0x40_0000 as caliptra_emu_types::RvData);
+        let bits_to_set_22 =
+            write_val & (0x40_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_22;
-        let bits_to_set_23 = write_val & (0x80_0000 as caliptra_emu_types::RvData);
+        let bits_to_set_23 =
+            write_val & (0x80_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_23;
-        let bits_to_set_24 = write_val & (0x100_0000 as caliptra_emu_types::RvData);
+        let bits_to_set_24 =
+            write_val & (0x100_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_24;
-        let bits_to_set_25 = write_val & (0x200_0000 as caliptra_emu_types::RvData);
+        let bits_to_set_25 =
+            write_val & (0x200_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_25;
-        let bits_to_set_26 = write_val & (0x400_0000 as caliptra_emu_types::RvData);
+        let bits_to_set_26 =
+            write_val & (0x400_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_26;
-        let bits_to_set_27 = write_val & (0x800_0000 as caliptra_emu_types::RvData);
+        let bits_to_set_27 =
+            write_val & (0x800_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_27;
-        let bits_to_set_28 = write_val & (0x1000_0000 as caliptra_emu_types::RvData);
+        let bits_to_set_28 =
+            write_val & (0x1000_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_28;
-        let bits_to_set_29 = write_val & (0x2000_0000 as caliptra_emu_types::RvData);
+        let bits_to_set_29 =
+            write_val & (0x2000_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_29;
-        let bits_to_set_30 = write_val & (0x4000_0000 as caliptra_emu_types::RvData);
+        let bits_to_set_30 =
+            write_val & (0x4000_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_30;
-        let bits_to_set_31 = write_val & (0x8000_0000 as caliptra_emu_types::RvData);
+        let bits_to_set_31 =
+            write_val & (0x8000_0000 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_31;
         self.mci_reg_intr_block_rf_notif1_intr_trig_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_error_internal_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_internal_intr_count_r");
         }
@@ -8789,21 +9538,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_error_internal_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_error_internal_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_error_internal_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_error_internal_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_error_mbox0_ecc_unc_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_mbox0_ecc_unc_intr_count_r");
         }
@@ -8811,21 +9560,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_error_mbox0_ecc_unc_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_error_mbox0_ecc_unc_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_error_mbox0_ecc_unc_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_error_mbox0_ecc_unc_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_error_mbox1_ecc_unc_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_mbox1_ecc_unc_intr_count_r");
         }
@@ -8833,21 +9582,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_error_mbox1_ecc_unc_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_error_mbox1_ecc_unc_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_error_mbox1_ecc_unc_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_error_mbox1_ecc_unc_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_error_mcu_sram_dmi_axi_collision_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_mcu_sram_dmi_axi_collision_intr_count_r");
         }
@@ -8855,21 +9604,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_error_mcu_sram_dmi_axi_collision_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_error_mcu_sram_dmi_axi_collision_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_error_mcu_sram_dmi_axi_collision_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_error_mcu_sram_dmi_axi_collision_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_error_wdt_timer1_timeout_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_wdt_timer1_timeout_intr_count_r");
         }
@@ -8877,21 +9626,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_error_wdt_timer1_timeout_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_error_wdt_timer1_timeout_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_error_wdt_timer1_timeout_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_error_wdt_timer1_timeout_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_error_wdt_timer2_timeout_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_wdt_timer2_timeout_intr_count_r");
         }
@@ -8899,21 +9648,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_error_wdt_timer2_timeout_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_error_wdt_timer2_timeout_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_error_wdt_timer2_timeout_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_error_wdt_timer2_timeout_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal0_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_agg_error_fatal0_intr_count_r");
         }
@@ -8921,21 +9670,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_error_agg_error_fatal0_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_error_agg_error_fatal0_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_error_agg_error_fatal0_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_error_agg_error_fatal0_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal1_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_agg_error_fatal1_intr_count_r");
         }
@@ -8943,21 +9692,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_error_agg_error_fatal1_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_error_agg_error_fatal1_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_error_agg_error_fatal1_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_error_agg_error_fatal1_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal2_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_agg_error_fatal2_intr_count_r");
         }
@@ -8965,21 +9714,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_error_agg_error_fatal2_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_error_agg_error_fatal2_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_error_agg_error_fatal2_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_error_agg_error_fatal2_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal3_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_agg_error_fatal3_intr_count_r");
         }
@@ -8987,21 +9736,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_error_agg_error_fatal3_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_error_agg_error_fatal3_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_error_agg_error_fatal3_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_error_agg_error_fatal3_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal4_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_agg_error_fatal4_intr_count_r");
         }
@@ -9009,21 +9758,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_error_agg_error_fatal4_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_error_agg_error_fatal4_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_error_agg_error_fatal4_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_error_agg_error_fatal4_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal5_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_agg_error_fatal5_intr_count_r");
         }
@@ -9031,21 +9780,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_error_agg_error_fatal5_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_error_agg_error_fatal5_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_error_agg_error_fatal5_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_error_agg_error_fatal5_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal6_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_agg_error_fatal6_intr_count_r");
         }
@@ -9053,21 +9802,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_error_agg_error_fatal6_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_error_agg_error_fatal6_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_error_agg_error_fatal6_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_error_agg_error_fatal6_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal7_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_agg_error_fatal7_intr_count_r");
         }
@@ -9075,21 +9824,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_error_agg_error_fatal7_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_error_agg_error_fatal7_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_error_agg_error_fatal7_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_error_agg_error_fatal7_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal8_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_agg_error_fatal8_intr_count_r");
         }
@@ -9097,21 +9846,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_error_agg_error_fatal8_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_error_agg_error_fatal8_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_error_agg_error_fatal8_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_error_agg_error_fatal8_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal9_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_agg_error_fatal9_intr_count_r");
         }
@@ -9119,21 +9868,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_error_agg_error_fatal9_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_error_agg_error_fatal9_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_error_agg_error_fatal9_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_error_agg_error_fatal9_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal10_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_agg_error_fatal10_intr_count_r");
         }
@@ -9141,21 +9890,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_error_agg_error_fatal10_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_error_agg_error_fatal10_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_error_agg_error_fatal10_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_error_agg_error_fatal10_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal11_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_agg_error_fatal11_intr_count_r");
         }
@@ -9163,21 +9912,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_error_agg_error_fatal11_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_error_agg_error_fatal11_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_error_agg_error_fatal11_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_error_agg_error_fatal11_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal12_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_agg_error_fatal12_intr_count_r");
         }
@@ -9185,21 +9934,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_error_agg_error_fatal12_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_error_agg_error_fatal12_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_error_agg_error_fatal12_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_error_agg_error_fatal12_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal13_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_agg_error_fatal13_intr_count_r");
         }
@@ -9207,21 +9956,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_error_agg_error_fatal13_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_error_agg_error_fatal13_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_error_agg_error_fatal13_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_error_agg_error_fatal13_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal14_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_agg_error_fatal14_intr_count_r");
         }
@@ -9229,21 +9978,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_error_agg_error_fatal14_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_error_agg_error_fatal14_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_error_agg_error_fatal14_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_error_agg_error_fatal14_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal15_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_agg_error_fatal15_intr_count_r");
         }
@@ -9251,21 +10000,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_error_agg_error_fatal15_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_error_agg_error_fatal15_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_error_agg_error_fatal15_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_error_agg_error_fatal15_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal16_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_agg_error_fatal16_intr_count_r");
         }
@@ -9273,21 +10022,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_error_agg_error_fatal16_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_error_agg_error_fatal16_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_error_agg_error_fatal16_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_error_agg_error_fatal16_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal17_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_agg_error_fatal17_intr_count_r");
         }
@@ -9295,21 +10044,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_error_agg_error_fatal17_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_error_agg_error_fatal17_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_error_agg_error_fatal17_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_error_agg_error_fatal17_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal18_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_agg_error_fatal18_intr_count_r");
         }
@@ -9317,21 +10066,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_error_agg_error_fatal18_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_error_agg_error_fatal18_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_error_agg_error_fatal18_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_error_agg_error_fatal18_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal19_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_agg_error_fatal19_intr_count_r");
         }
@@ -9339,21 +10088,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_error_agg_error_fatal19_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_error_agg_error_fatal19_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_error_agg_error_fatal19_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_error_agg_error_fatal19_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal20_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_agg_error_fatal20_intr_count_r");
         }
@@ -9361,21 +10110,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_error_agg_error_fatal20_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_error_agg_error_fatal20_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_error_agg_error_fatal20_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_error_agg_error_fatal20_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal21_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_agg_error_fatal21_intr_count_r");
         }
@@ -9383,21 +10132,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_error_agg_error_fatal21_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_error_agg_error_fatal21_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_error_agg_error_fatal21_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_error_agg_error_fatal21_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal22_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_agg_error_fatal22_intr_count_r");
         }
@@ -9405,21 +10154,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_error_agg_error_fatal22_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_error_agg_error_fatal22_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_error_agg_error_fatal22_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_error_agg_error_fatal22_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal23_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_agg_error_fatal23_intr_count_r");
         }
@@ -9427,21 +10176,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_error_agg_error_fatal23_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_error_agg_error_fatal23_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_error_agg_error_fatal23_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_error_agg_error_fatal23_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal24_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_agg_error_fatal24_intr_count_r");
         }
@@ -9449,21 +10198,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_error_agg_error_fatal24_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_error_agg_error_fatal24_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_error_agg_error_fatal24_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_error_agg_error_fatal24_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal25_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_agg_error_fatal25_intr_count_r");
         }
@@ -9471,21 +10220,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_error_agg_error_fatal25_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_error_agg_error_fatal25_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_error_agg_error_fatal25_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_error_agg_error_fatal25_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal26_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_agg_error_fatal26_intr_count_r");
         }
@@ -9493,21 +10242,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_error_agg_error_fatal26_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_error_agg_error_fatal26_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_error_agg_error_fatal26_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_error_agg_error_fatal26_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal27_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_agg_error_fatal27_intr_count_r");
         }
@@ -9515,21 +10264,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_error_agg_error_fatal27_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_error_agg_error_fatal27_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_error_agg_error_fatal27_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_error_agg_error_fatal27_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal28_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_agg_error_fatal28_intr_count_r");
         }
@@ -9537,21 +10286,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_error_agg_error_fatal28_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_error_agg_error_fatal28_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_error_agg_error_fatal28_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_error_agg_error_fatal28_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal29_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_agg_error_fatal29_intr_count_r");
         }
@@ -9559,21 +10308,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_error_agg_error_fatal29_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_error_agg_error_fatal29_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_error_agg_error_fatal29_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_error_agg_error_fatal29_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal30_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_agg_error_fatal30_intr_count_r");
         }
@@ -9581,21 +10330,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_error_agg_error_fatal30_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_error_agg_error_fatal30_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_error_agg_error_fatal30_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_error_agg_error_fatal30_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal31_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_agg_error_fatal31_intr_count_r");
         }
@@ -9603,21 +10352,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_error_agg_error_fatal31_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_error_agg_error_fatal31_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_error_agg_error_fatal31_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_error_agg_error_fatal31_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_notif_mcu_sram_ecc_cor_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_mcu_sram_ecc_cor_intr_count_r");
         }
@@ -9625,21 +10374,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_notif_mcu_sram_ecc_cor_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_notif_mcu_sram_ecc_cor_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_notif_mcu_sram_ecc_cor_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_notif_mcu_sram_ecc_cor_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_notif_cptra_mcu_reset_req_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_cptra_mcu_reset_req_intr_count_r");
         }
@@ -9647,21 +10396,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_notif_cptra_mcu_reset_req_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_notif_cptra_mcu_reset_req_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_notif_cptra_mcu_reset_req_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_notif_cptra_mcu_reset_req_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_notif_gen_in_toggle_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_gen_in_toggle_intr_count_r");
         }
@@ -9669,21 +10418,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_notif_gen_in_toggle_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_notif_gen_in_toggle_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_notif_gen_in_toggle_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_notif_gen_in_toggle_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal0_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal0_intr_count_r");
         }
@@ -9691,21 +10440,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_notif_agg_error_non_fatal0_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal0_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_notif_agg_error_non_fatal0_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_notif_agg_error_non_fatal0_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal1_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal1_intr_count_r");
         }
@@ -9713,21 +10462,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_notif_agg_error_non_fatal1_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal1_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_notif_agg_error_non_fatal1_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_notif_agg_error_non_fatal1_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal2_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal2_intr_count_r");
         }
@@ -9735,21 +10484,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_notif_agg_error_non_fatal2_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal2_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_notif_agg_error_non_fatal2_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_notif_agg_error_non_fatal2_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal3_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal3_intr_count_r");
         }
@@ -9757,21 +10506,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_notif_agg_error_non_fatal3_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal3_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_notif_agg_error_non_fatal3_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_notif_agg_error_non_fatal3_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal4_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal4_intr_count_r");
         }
@@ -9779,21 +10528,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_notif_agg_error_non_fatal4_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal4_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_notif_agg_error_non_fatal4_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_notif_agg_error_non_fatal4_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal5_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal5_intr_count_r");
         }
@@ -9801,21 +10550,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_notif_agg_error_non_fatal5_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal5_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_notif_agg_error_non_fatal5_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_notif_agg_error_non_fatal5_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal6_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal6_intr_count_r");
         }
@@ -9823,21 +10572,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_notif_agg_error_non_fatal6_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal6_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_notif_agg_error_non_fatal6_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_notif_agg_error_non_fatal6_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal7_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal7_intr_count_r");
         }
@@ -9845,21 +10594,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_notif_agg_error_non_fatal7_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal7_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_notif_agg_error_non_fatal7_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_notif_agg_error_non_fatal7_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal8_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal8_intr_count_r");
         }
@@ -9867,21 +10616,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_notif_agg_error_non_fatal8_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal8_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_notif_agg_error_non_fatal8_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_notif_agg_error_non_fatal8_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal9_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal9_intr_count_r");
         }
@@ -9889,21 +10638,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_notif_agg_error_non_fatal9_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal9_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_notif_agg_error_non_fatal9_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_notif_agg_error_non_fatal9_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal10_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal10_intr_count_r");
         }
@@ -9911,21 +10660,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_notif_agg_error_non_fatal10_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal10_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_notif_agg_error_non_fatal10_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_notif_agg_error_non_fatal10_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal11_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal11_intr_count_r");
         }
@@ -9933,21 +10682,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_notif_agg_error_non_fatal11_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal11_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_notif_agg_error_non_fatal11_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_notif_agg_error_non_fatal11_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal12_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal12_intr_count_r");
         }
@@ -9955,21 +10704,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_notif_agg_error_non_fatal12_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal12_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_notif_agg_error_non_fatal12_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_notif_agg_error_non_fatal12_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal13_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal13_intr_count_r");
         }
@@ -9977,21 +10726,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_notif_agg_error_non_fatal13_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal13_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_notif_agg_error_non_fatal13_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_notif_agg_error_non_fatal13_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal14_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal14_intr_count_r");
         }
@@ -9999,21 +10748,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_notif_agg_error_non_fatal14_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal14_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_notif_agg_error_non_fatal14_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_notif_agg_error_non_fatal14_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal15_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal15_intr_count_r");
         }
@@ -10021,21 +10770,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_notif_agg_error_non_fatal15_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal15_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_notif_agg_error_non_fatal15_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_notif_agg_error_non_fatal15_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal16_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal16_intr_count_r");
         }
@@ -10043,21 +10792,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_notif_agg_error_non_fatal16_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal16_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_notif_agg_error_non_fatal16_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_notif_agg_error_non_fatal16_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal17_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal17_intr_count_r");
         }
@@ -10065,21 +10814,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_notif_agg_error_non_fatal17_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal17_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_notif_agg_error_non_fatal17_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_notif_agg_error_non_fatal17_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal18_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal18_intr_count_r");
         }
@@ -10087,21 +10836,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_notif_agg_error_non_fatal18_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal18_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_notif_agg_error_non_fatal18_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_notif_agg_error_non_fatal18_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal19_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal19_intr_count_r");
         }
@@ -10109,21 +10858,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_notif_agg_error_non_fatal19_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal19_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_notif_agg_error_non_fatal19_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_notif_agg_error_non_fatal19_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal20_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal20_intr_count_r");
         }
@@ -10131,21 +10880,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_notif_agg_error_non_fatal20_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal20_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_notif_agg_error_non_fatal20_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_notif_agg_error_non_fatal20_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal21_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal21_intr_count_r");
         }
@@ -10153,21 +10902,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_notif_agg_error_non_fatal21_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal21_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_notif_agg_error_non_fatal21_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_notif_agg_error_non_fatal21_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal22_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal22_intr_count_r");
         }
@@ -10175,21 +10924,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_notif_agg_error_non_fatal22_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal22_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_notif_agg_error_non_fatal22_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_notif_agg_error_non_fatal22_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal23_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal23_intr_count_r");
         }
@@ -10197,21 +10946,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_notif_agg_error_non_fatal23_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal23_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_notif_agg_error_non_fatal23_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_notif_agg_error_non_fatal23_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal24_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal24_intr_count_r");
         }
@@ -10219,21 +10968,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_notif_agg_error_non_fatal24_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal24_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_notif_agg_error_non_fatal24_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_notif_agg_error_non_fatal24_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal25_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal25_intr_count_r");
         }
@@ -10241,21 +10990,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_notif_agg_error_non_fatal25_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal25_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_notif_agg_error_non_fatal25_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_notif_agg_error_non_fatal25_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal26_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal26_intr_count_r");
         }
@@ -10263,21 +11012,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_notif_agg_error_non_fatal26_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal26_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_notif_agg_error_non_fatal26_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_notif_agg_error_non_fatal26_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal27_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal27_intr_count_r");
         }
@@ -10285,21 +11034,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_notif_agg_error_non_fatal27_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal27_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_notif_agg_error_non_fatal27_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_notif_agg_error_non_fatal27_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal28_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal28_intr_count_r");
         }
@@ -10307,21 +11056,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_notif_agg_error_non_fatal28_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal28_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_notif_agg_error_non_fatal28_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_notif_agg_error_non_fatal28_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal29_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal29_intr_count_r");
         }
@@ -10329,21 +11078,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_notif_agg_error_non_fatal29_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal29_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_notif_agg_error_non_fatal29_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_notif_agg_error_non_fatal29_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal30_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal30_intr_count_r");
         }
@@ -10351,21 +11100,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_notif_agg_error_non_fatal30_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal30_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_notif_agg_error_non_fatal30_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_notif_agg_error_non_fatal30_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal31_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal31_intr_count_r");
         }
@@ -10373,21 +11122,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_notif_agg_error_non_fatal31_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal31_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_notif_agg_error_non_fatal31_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_notif_agg_error_non_fatal31_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_notif_mbox0_target_done_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_mbox0_target_done_intr_count_r");
         }
@@ -10395,21 +11144,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_notif_mbox0_target_done_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_notif_mbox0_target_done_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_notif_mbox0_target_done_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_notif_mbox0_target_done_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_notif_mbox1_target_done_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_mbox1_target_done_intr_count_r");
         }
@@ -10417,21 +11166,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_notif_mbox1_target_done_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_notif_mbox1_target_done_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_notif_mbox1_target_done_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_notif_mbox1_target_done_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_notif_mbox0_cmd_avail_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_mbox0_cmd_avail_intr_count_r");
         }
@@ -10439,21 +11188,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_notif_mbox0_cmd_avail_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_notif_mbox0_cmd_avail_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_notif_mbox0_cmd_avail_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_notif_mbox0_cmd_avail_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_notif_mbox1_cmd_avail_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_mbox1_cmd_avail_intr_count_r");
         }
@@ -10461,21 +11210,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_notif_mbox1_cmd_avail_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_notif_mbox1_cmd_avail_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_notif_mbox1_cmd_avail_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_notif_mbox1_cmd_avail_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_notif_cptra_mbox_cmd_avail_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_cptra_mbox_cmd_avail_intr_count_r");
         }
@@ -10483,21 +11232,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_notif_cptra_mbox_cmd_avail_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_notif_cptra_mbox_cmd_avail_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_notif_cptra_mbox_cmd_avail_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_notif_cptra_mbox_cmd_avail_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_notif_mbox0_ecc_cor_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_mbox0_ecc_cor_intr_count_r");
         }
@@ -10505,21 +11254,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_notif_mbox0_ecc_cor_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_notif_mbox0_ecc_cor_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_notif_mbox0_ecc_cor_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_notif_mbox0_ecc_cor_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_notif_mbox1_ecc_cor_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_mbox1_ecc_cor_intr_count_r");
         }
@@ -10527,21 +11276,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_notif_mbox1_ecc_cor_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_notif_mbox1_ecc_cor_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_notif_mbox1_ecc_cor_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_notif_mbox1_ecc_cor_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_notif_debug_locked_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_debug_locked_intr_count_r");
         }
@@ -10549,21 +11298,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_notif_debug_locked_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_notif_debug_locked_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_notif_debug_locked_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_notif_debug_locked_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_notif_scan_mode_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_scan_mode_intr_count_r");
         }
@@ -10571,21 +11320,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_notif_scan_mode_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_notif_scan_mode_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_notif_scan_mode_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_notif_scan_mode_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_notif_mbox0_soc_req_lock_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_mbox0_soc_req_lock_intr_count_r");
         }
@@ -10593,21 +11342,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_notif_mbox0_soc_req_lock_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_notif_mbox0_soc_req_lock_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_notif_mbox0_soc_req_lock_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_notif_mbox0_soc_req_lock_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_notif_mbox1_soc_req_lock_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_mbox1_soc_req_lock_intr_count_r");
         }
@@ -10615,21 +11364,21 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_notif_mbox1_soc_req_lock_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_notif_mbox1_soc_req_lock_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_notif_mbox1_soc_req_lock_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_notif_mbox1_soc_req_lock_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_notif_otp_operation_done_intr_count_r(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_otp_operation_done_intr_count_r");
         }
@@ -10637,1135 +11386,1141 @@ impl MciPeripheral for MciGenerated {
     }
     fn write_mci_reg_intr_block_rf_notif_otp_operation_done_intr_count_r(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mci_reg_intr_block_rf_notif_otp_operation_done_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mci_reg_intr_block_rf_notif_otp_operation_done_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mci_reg_intr_block_rf_notif_otp_operation_done_intr_count_r = new_val;
     }
     fn read_mci_reg_intr_block_rf_error_internal_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_internal_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_error_internal_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_error_mbox0_ecc_unc_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_mbox0_ecc_unc_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_error_mbox0_ecc_unc_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_error_mbox1_ecc_unc_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_mbox1_ecc_unc_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_error_mbox1_ecc_unc_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_error_wdt_timer1_timeout_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_wdt_timer1_timeout_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_error_wdt_timer1_timeout_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_error_wdt_timer2_timeout_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_wdt_timer2_timeout_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_error_wdt_timer2_timeout_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_error_mcu_sram_dmi_axi_collision_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_mcu_sram_dmi_axi_collision_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_error_mcu_sram_dmi_axi_collision_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal0_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_agg_error_fatal0_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_error_agg_error_fatal0_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal1_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_agg_error_fatal1_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_error_agg_error_fatal1_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal2_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_agg_error_fatal2_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_error_agg_error_fatal2_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal3_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_agg_error_fatal3_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_error_agg_error_fatal3_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal4_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_agg_error_fatal4_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_error_agg_error_fatal4_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal5_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_agg_error_fatal5_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_error_agg_error_fatal5_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal6_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_agg_error_fatal6_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_error_agg_error_fatal6_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal7_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_agg_error_fatal7_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_error_agg_error_fatal7_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal8_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_agg_error_fatal8_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_error_agg_error_fatal8_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal9_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_agg_error_fatal9_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_error_agg_error_fatal9_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal10_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_agg_error_fatal10_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_error_agg_error_fatal10_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal11_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_agg_error_fatal11_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_error_agg_error_fatal11_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal12_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_agg_error_fatal12_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_error_agg_error_fatal12_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal13_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_agg_error_fatal13_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_error_agg_error_fatal13_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal14_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_agg_error_fatal14_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_error_agg_error_fatal14_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal15_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_agg_error_fatal15_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_error_agg_error_fatal15_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal16_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_agg_error_fatal16_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_error_agg_error_fatal16_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal17_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_agg_error_fatal17_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_error_agg_error_fatal17_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal18_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_agg_error_fatal18_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_error_agg_error_fatal18_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal19_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_agg_error_fatal19_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_error_agg_error_fatal19_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal20_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_agg_error_fatal20_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_error_agg_error_fatal20_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal21_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_agg_error_fatal21_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_error_agg_error_fatal21_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal22_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_agg_error_fatal22_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_error_agg_error_fatal22_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal23_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_agg_error_fatal23_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_error_agg_error_fatal23_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal24_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_agg_error_fatal24_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_error_agg_error_fatal24_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal25_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_agg_error_fatal25_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_error_agg_error_fatal25_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal26_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_agg_error_fatal26_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_error_agg_error_fatal26_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal27_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_agg_error_fatal27_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_error_agg_error_fatal27_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal28_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_agg_error_fatal28_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_error_agg_error_fatal28_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal29_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_agg_error_fatal29_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_error_agg_error_fatal29_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal30_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_agg_error_fatal30_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_error_agg_error_fatal30_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_error_agg_error_fatal31_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_error_agg_error_fatal31_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_error_agg_error_fatal31_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_notif_mcu_sram_ecc_cor_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_mcu_sram_ecc_cor_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_notif_mcu_sram_ecc_cor_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_notif_cptra_mcu_reset_req_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_cptra_mcu_reset_req_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_notif_cptra_mcu_reset_req_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_notif_gen_in_toggle_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_gen_in_toggle_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_notif_gen_in_toggle_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal0_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal0_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_notif_agg_error_non_fatal0_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal1_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal1_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_notif_agg_error_non_fatal1_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal2_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal2_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_notif_agg_error_non_fatal2_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal3_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal3_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_notif_agg_error_non_fatal3_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal4_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal4_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_notif_agg_error_non_fatal4_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal5_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal5_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_notif_agg_error_non_fatal5_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal6_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal6_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_notif_agg_error_non_fatal6_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal7_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal7_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_notif_agg_error_non_fatal7_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal8_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal8_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_notif_agg_error_non_fatal8_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal9_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal9_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_notif_agg_error_non_fatal9_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal10_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal10_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_notif_agg_error_non_fatal10_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal11_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal11_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_notif_agg_error_non_fatal11_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal12_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal12_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_notif_agg_error_non_fatal12_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal13_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal13_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_notif_agg_error_non_fatal13_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal14_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal14_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_notif_agg_error_non_fatal14_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal15_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal15_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_notif_agg_error_non_fatal15_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal16_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal16_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_notif_agg_error_non_fatal16_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal17_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal17_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_notif_agg_error_non_fatal17_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal18_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal18_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_notif_agg_error_non_fatal18_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal19_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal19_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_notif_agg_error_non_fatal19_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal20_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal20_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_notif_agg_error_non_fatal20_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal21_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal21_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_notif_agg_error_non_fatal21_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal22_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal22_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_notif_agg_error_non_fatal22_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal23_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal23_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_notif_agg_error_non_fatal23_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal24_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal24_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_notif_agg_error_non_fatal24_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal25_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal25_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_notif_agg_error_non_fatal25_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal26_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal26_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_notif_agg_error_non_fatal26_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal27_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal27_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_notif_agg_error_non_fatal27_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal28_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal28_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_notif_agg_error_non_fatal28_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal29_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal29_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_notif_agg_error_non_fatal29_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal30_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal30_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_notif_agg_error_non_fatal30_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_notif_agg_error_non_fatal31_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_agg_error_non_fatal31_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_notif_agg_error_non_fatal31_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_notif_mbox0_target_done_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_mbox0_target_done_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_notif_mbox0_target_done_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_notif_mbox1_target_done_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_mbox1_target_done_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_notif_mbox1_target_done_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_notif_mbox0_cmd_avail_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_mbox0_cmd_avail_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_notif_mbox0_cmd_avail_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_notif_mbox1_cmd_avail_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_mbox1_cmd_avail_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_notif_mbox1_cmd_avail_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_notif_cptra_mbox_cmd_avail_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_cptra_mbox_cmd_avail_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_notif_cptra_mbox_cmd_avail_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_notif_mbox0_ecc_cor_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_mbox0_ecc_cor_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_notif_mbox0_ecc_cor_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_notif_mbox1_ecc_cor_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_mbox1_ecc_cor_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_notif_mbox1_ecc_cor_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_notif_debug_locked_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_debug_locked_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_notif_debug_locked_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_notif_scan_mode_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_scan_mode_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_notif_scan_mode_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_notif_mbox0_soc_req_lock_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_mbox0_soc_req_lock_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_notif_mbox0_soc_req_lock_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_notif_mbox1_soc_req_lock_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_mbox1_soc_req_lock_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_notif_mbox1_soc_req_lock_intr_count_incr_r,
         )
     }
     fn read_mci_reg_intr_block_rf_notif_otp_operation_done_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mci_reg_intr_block_rf_notif_otp_operation_done_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.mci_reg_intr_block_rf_notif_otp_operation_done_intr_count_incr_r,
         )
     }
     fn read_mcu_trace_buffer_csr_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::mci::bits::Status::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::mci::bits::Status::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read mci::mcu_trace_buffer_csr_status"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.mcu_trace_buffer_csr_status)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.mcu_trace_buffer_csr_status,
+        )
     }
-    fn read_mcu_trace_buffer_csr_config(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mcu_trace_buffer_csr_config(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read mci::mcu_trace_buffer_csr_config"
@@ -11773,7 +12528,9 @@ impl MciPeripheral for MciGenerated {
         }
         self.mcu_trace_buffer_csr_config
     }
-    fn read_mcu_trace_buffer_csr_data(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mcu_trace_buffer_csr_data(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read mci::mcu_trace_buffer_csr_data"
@@ -11781,13 +12538,17 @@ impl MciPeripheral for MciGenerated {
         }
         self.mcu_trace_buffer_csr_data
     }
-    fn read_mcu_trace_buffer_csr_write_ptr(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mcu_trace_buffer_csr_write_ptr(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mcu_trace_buffer_csr_write_ptr");
         }
         self.mcu_trace_buffer_csr_write_ptr
     }
-    fn read_mcu_trace_buffer_csr_read_ptr(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mcu_trace_buffer_csr_read_ptr(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read mci::mcu_trace_buffer_csr_read_ptr"
@@ -11795,18 +12556,24 @@ impl MciPeripheral for MciGenerated {
         }
         self.mcu_trace_buffer_csr_read_ptr
     }
-    fn write_mcu_trace_buffer_csr_read_ptr(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mcu_trace_buffer_csr_read_ptr(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mcu_trace_buffer_csr_read_ptr = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mcu_trace_buffer_csr_read_ptr;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mcu_trace_buffer_csr_read_ptr = new_val;
     }
-    fn read_mcu_mbox0_csr_mbox_sram(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_mcu_mbox0_csr_mbox_sram(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read mci::mcu_mbox0_csr_mbox_sram[{}]",
@@ -11815,29 +12582,35 @@ impl MciPeripheral for MciGenerated {
         }
         self.mcu_mbox0_csr_mbox_sram[index]
     }
-    fn write_mcu_mbox0_csr_mbox_sram(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    fn write_mcu_mbox0_csr_mbox_sram(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+        index: usize,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mcu_mbox0_csr_mbox_sram[{}] = 0x{:08x}" , index , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mcu_mbox0_csr_mbox_sram[index];
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mcu_mbox0_csr_mbox_sram[index] = new_val;
     }
     fn read_mcu_mbox0_csr_mbox_lock(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::mci::bits::MboxLock::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::mci::bits::MboxLock::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read mci::mcu_mbox0_csr_mbox_lock"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.mcu_mbox0_csr_mbox_lock)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.mcu_mbox0_csr_mbox_lock)
     }
-    fn read_mcu_mbox0_csr_mbox_user(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mcu_mbox0_csr_mbox_user(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read mci::mcu_mbox0_csr_mbox_user"
@@ -11845,37 +12618,44 @@ impl MciPeripheral for MciGenerated {
         }
         self.mcu_mbox0_csr_mbox_user
     }
-    fn read_mcu_mbox0_csr_mbox_target_user(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mcu_mbox0_csr_mbox_target_user(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mcu_mbox0_csr_mbox_target_user");
         }
         self.mcu_mbox0_csr_mbox_target_user
     }
-    fn write_mcu_mbox0_csr_mbox_target_user(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mcu_mbox0_csr_mbox_target_user(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mcu_mbox0_csr_mbox_target_user = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mcu_mbox0_csr_mbox_target_user;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mcu_mbox0_csr_mbox_target_user = new_val;
     }
     fn read_mcu_mbox0_csr_mbox_target_user_valid(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::MboxTargetUserValid::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mcu_mbox0_csr_mbox_target_user_valid");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.mcu_mbox0_csr_mbox_target_user_valid)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.mcu_mbox0_csr_mbox_target_user_valid,
+        )
     }
     fn write_mcu_mbox0_csr_mbox_target_user_valid(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::MboxTargetUserValid::Register,
         >,
@@ -11883,31 +12663,34 @@ impl MciPeripheral for MciGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mcu_mbox0_csr_mbox_target_user_valid = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mcu_mbox0_csr_mbox_target_user_valid;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mcu_mbox0_csr_mbox_target_user_valid = new_val;
     }
-    fn read_mcu_mbox0_csr_mbox_cmd(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mcu_mbox0_csr_mbox_cmd(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read mci::mcu_mbox0_csr_mbox_cmd");
         }
         self.mcu_mbox0_csr_mbox_cmd
     }
-    fn write_mcu_mbox0_csr_mbox_cmd(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mcu_mbox0_csr_mbox_cmd(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mcu_mbox0_csr_mbox_cmd = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mcu_mbox0_csr_mbox_cmd;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mcu_mbox0_csr_mbox_cmd = new_val;
     }
-    fn read_mcu_mbox0_csr_mbox_dlen(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mcu_mbox0_csr_mbox_dlen(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read mci::mcu_mbox0_csr_mbox_dlen"
@@ -11915,20 +12698,23 @@ impl MciPeripheral for MciGenerated {
         }
         self.mcu_mbox0_csr_mbox_dlen
     }
-    fn write_mcu_mbox0_csr_mbox_dlen(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mcu_mbox0_csr_mbox_dlen(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mcu_mbox0_csr_mbox_dlen = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mcu_mbox0_csr_mbox_dlen;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mcu_mbox0_csr_mbox_dlen = new_val;
     }
     fn read_mcu_mbox0_csr_mbox_execute(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::MboxExecute::Register,
     > {
@@ -11937,11 +12723,13 @@ impl MciPeripheral for MciGenerated {
                 "[EMU] Generated default register handler: read mci::mcu_mbox0_csr_mbox_execute"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.mcu_mbox0_csr_mbox_execute)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.mcu_mbox0_csr_mbox_execute,
+        )
     }
     fn write_mcu_mbox0_csr_mbox_execute(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::MboxExecute::Register,
         >,
@@ -11949,27 +12737,29 @@ impl MciPeripheral for MciGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mcu_mbox0_csr_mbox_execute = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mcu_mbox0_csr_mbox_execute;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mcu_mbox0_csr_mbox_execute = new_val;
     }
     fn read_mcu_mbox0_csr_mbox_target_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::MboxTargetStatus::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mcu_mbox0_csr_mbox_target_status");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.mcu_mbox0_csr_mbox_target_status)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.mcu_mbox0_csr_mbox_target_status,
+        )
     }
     fn write_mcu_mbox0_csr_mbox_target_status(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::MboxTargetStatus::Register,
         >,
@@ -11977,18 +12767,18 @@ impl MciPeripheral for MciGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mcu_mbox0_csr_mbox_target_status = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mcu_mbox0_csr_mbox_target_status;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xf as caliptra_emu_types::RvData))
-            | (write_val & (0xf as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x10 as caliptra_emu_types::RvData))
-            | (write_val & (0x10 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xf as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xf as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x10 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x10 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mcu_mbox0_csr_mbox_target_status = new_val;
     }
     fn read_mcu_mbox0_csr_mbox_cmd_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::MboxCmdStatus::Register,
     > {
@@ -11997,11 +12787,13 @@ impl MciPeripheral for MciGenerated {
                 "[EMU] Generated default register handler: read mci::mcu_mbox0_csr_mbox_cmd_status"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.mcu_mbox0_csr_mbox_cmd_status)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.mcu_mbox0_csr_mbox_cmd_status,
+        )
     }
     fn write_mcu_mbox0_csr_mbox_cmd_status(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::MboxCmdStatus::Register,
         >,
@@ -12009,16 +12801,16 @@ impl MciPeripheral for MciGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mcu_mbox0_csr_mbox_cmd_status = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mcu_mbox0_csr_mbox_cmd_status;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xf as caliptra_emu_types::RvData))
-            | (write_val & (0xf as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xf as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xf as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mcu_mbox0_csr_mbox_cmd_status = new_val;
     }
     fn read_mcu_mbox0_csr_mbox_hw_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::MboxHwStatus::Register,
     > {
@@ -12027,9 +12819,14 @@ impl MciPeripheral for MciGenerated {
                 "[EMU] Generated default register handler: read mci::mcu_mbox0_csr_mbox_hw_status"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.mcu_mbox0_csr_mbox_hw_status)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.mcu_mbox0_csr_mbox_hw_status,
+        )
     }
-    fn read_mcu_mbox1_csr_mbox_sram(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_mcu_mbox1_csr_mbox_sram(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read mci::mcu_mbox1_csr_mbox_sram[{}]",
@@ -12038,29 +12835,35 @@ impl MciPeripheral for MciGenerated {
         }
         self.mcu_mbox1_csr_mbox_sram[index]
     }
-    fn write_mcu_mbox1_csr_mbox_sram(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    fn write_mcu_mbox1_csr_mbox_sram(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+        index: usize,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mcu_mbox1_csr_mbox_sram[{}] = 0x{:08x}" , index , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mcu_mbox1_csr_mbox_sram[index];
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mcu_mbox1_csr_mbox_sram[index] = new_val;
     }
     fn read_mcu_mbox1_csr_mbox_lock(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::mci::bits::MboxLock::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::mci::bits::MboxLock::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read mci::mcu_mbox1_csr_mbox_lock"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.mcu_mbox1_csr_mbox_lock)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.mcu_mbox1_csr_mbox_lock)
     }
-    fn read_mcu_mbox1_csr_mbox_user(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mcu_mbox1_csr_mbox_user(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read mci::mcu_mbox1_csr_mbox_user"
@@ -12068,37 +12871,44 @@ impl MciPeripheral for MciGenerated {
         }
         self.mcu_mbox1_csr_mbox_user
     }
-    fn read_mcu_mbox1_csr_mbox_target_user(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mcu_mbox1_csr_mbox_target_user(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mcu_mbox1_csr_mbox_target_user");
         }
         self.mcu_mbox1_csr_mbox_target_user
     }
-    fn write_mcu_mbox1_csr_mbox_target_user(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mcu_mbox1_csr_mbox_target_user(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mcu_mbox1_csr_mbox_target_user = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mcu_mbox1_csr_mbox_target_user;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mcu_mbox1_csr_mbox_target_user = new_val;
     }
     fn read_mcu_mbox1_csr_mbox_target_user_valid(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::MboxTargetUserValid::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mcu_mbox1_csr_mbox_target_user_valid");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.mcu_mbox1_csr_mbox_target_user_valid)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.mcu_mbox1_csr_mbox_target_user_valid,
+        )
     }
     fn write_mcu_mbox1_csr_mbox_target_user_valid(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::MboxTargetUserValid::Register,
         >,
@@ -12106,31 +12916,34 @@ impl MciPeripheral for MciGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mcu_mbox1_csr_mbox_target_user_valid = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mcu_mbox1_csr_mbox_target_user_valid;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mcu_mbox1_csr_mbox_target_user_valid = new_val;
     }
-    fn read_mcu_mbox1_csr_mbox_cmd(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mcu_mbox1_csr_mbox_cmd(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read mci::mcu_mbox1_csr_mbox_cmd");
         }
         self.mcu_mbox1_csr_mbox_cmd
     }
-    fn write_mcu_mbox1_csr_mbox_cmd(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mcu_mbox1_csr_mbox_cmd(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mcu_mbox1_csr_mbox_cmd = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mcu_mbox1_csr_mbox_cmd;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mcu_mbox1_csr_mbox_cmd = new_val;
     }
-    fn read_mcu_mbox1_csr_mbox_dlen(&mut self) -> caliptra_emu_types::RvData {
+    fn read_mcu_mbox1_csr_mbox_dlen(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read mci::mcu_mbox1_csr_mbox_dlen"
@@ -12138,20 +12951,23 @@ impl MciPeripheral for MciGenerated {
         }
         self.mcu_mbox1_csr_mbox_dlen
     }
-    fn write_mcu_mbox1_csr_mbox_dlen(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_mcu_mbox1_csr_mbox_dlen(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mcu_mbox1_csr_mbox_dlen = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mcu_mbox1_csr_mbox_dlen;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mcu_mbox1_csr_mbox_dlen = new_val;
     }
     fn read_mcu_mbox1_csr_mbox_execute(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::MboxExecute::Register,
     > {
@@ -12160,11 +12976,13 @@ impl MciPeripheral for MciGenerated {
                 "[EMU] Generated default register handler: read mci::mcu_mbox1_csr_mbox_execute"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.mcu_mbox1_csr_mbox_execute)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.mcu_mbox1_csr_mbox_execute,
+        )
     }
     fn write_mcu_mbox1_csr_mbox_execute(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::MboxExecute::Register,
         >,
@@ -12172,27 +12990,29 @@ impl MciPeripheral for MciGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mcu_mbox1_csr_mbox_execute = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mcu_mbox1_csr_mbox_execute;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mcu_mbox1_csr_mbox_execute = new_val;
     }
     fn read_mcu_mbox1_csr_mbox_target_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::MboxTargetStatus::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read mci::mcu_mbox1_csr_mbox_target_status");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.mcu_mbox1_csr_mbox_target_status)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.mcu_mbox1_csr_mbox_target_status,
+        )
     }
     fn write_mcu_mbox1_csr_mbox_target_status(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::MboxTargetStatus::Register,
         >,
@@ -12200,18 +13020,18 @@ impl MciPeripheral for MciGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mcu_mbox1_csr_mbox_target_status = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mcu_mbox1_csr_mbox_target_status;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xf as caliptra_emu_types::RvData))
-            | (write_val & (0xf as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x10 as caliptra_emu_types::RvData))
-            | (write_val & (0x10 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xf as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xf as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x10 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x10 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mcu_mbox1_csr_mbox_target_status = new_val;
     }
     fn read_mcu_mbox1_csr_mbox_cmd_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::MboxCmdStatus::Register,
     > {
@@ -12220,11 +13040,13 @@ impl MciPeripheral for MciGenerated {
                 "[EMU] Generated default register handler: read mci::mcu_mbox1_csr_mbox_cmd_status"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.mcu_mbox1_csr_mbox_cmd_status)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.mcu_mbox1_csr_mbox_cmd_status,
+        )
     }
     fn write_mcu_mbox1_csr_mbox_cmd_status(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::mci::bits::MboxCmdStatus::Register,
         >,
@@ -12232,16 +13054,16 @@ impl MciPeripheral for MciGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write mci::mcu_mbox1_csr_mbox_cmd_status = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mcu_mbox1_csr_mbox_cmd_status;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xf as caliptra_emu_types::RvData))
-            | (write_val & (0xf as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xf as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xf as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mcu_mbox1_csr_mbox_cmd_status = new_val;
     }
     fn read_mcu_mbox1_csr_mbox_hw_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::mci::bits::MboxHwStatus::Register,
     > {
@@ -12250,38 +13072,43 @@ impl MciPeripheral for MciGenerated {
                 "[EMU] Generated default register handler: read mci::mcu_mbox1_csr_mbox_hw_status"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.mcu_mbox1_csr_mbox_hw_status)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.mcu_mbox1_csr_mbox_hw_status,
+        )
     }
 }
 pub struct MciBus {
     pub periph: Box<dyn MciPeripheral>,
 }
-impl caliptra_emu_bus::Bus for MciBus {
+impl caliptra_core_tools::caliptra_emu_bus::Bus for MciBus {
     fn read(
         &mut self,
-        size: caliptra_emu_types::RvSize,
-        addr: caliptra_emu_types::RvAddr,
-    ) -> Result<caliptra_emu_types::RvData, caliptra_emu_bus::BusError> {
-        if addr & 0x3 != 0 || size != caliptra_emu_types::RvSize::Word {
-            return Err(caliptra_emu_bus::BusError::LoadAddrMisaligned);
+        size: caliptra_core_tools::caliptra_emu_types::RvSize,
+        addr: caliptra_core_tools::caliptra_emu_types::RvAddr,
+    ) -> Result<
+        caliptra_core_tools::caliptra_emu_types::RvData,
+        caliptra_core_tools::caliptra_emu_bus::BusError,
+    > {
+        if addr & 0x3 != 0 || size != caliptra_core_tools::caliptra_emu_types::RvSize::Word {
+            return Err(caliptra_core_tools::caliptra_emu_bus::BusError::LoadAddrMisaligned);
         }
         match addr {
             0xc0_0000..0xe0_0000 => Ok(self.periph.read_mcu_sram((addr as usize - 0xc0_0000) / 4)),
             0..4 => Ok(self.periph.read_mci_reg_hw_capabilities()),
             4..8 => Ok(self.periph.read_mci_reg_fw_capabilities()),
-            8..0xc => Ok(caliptra_emu_types::RvData::from(
+            8..0xc => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_mci_reg_cap_lock().reg.get(),
             )),
-            0xc..0x10 => Ok(caliptra_emu_types::RvData::from(
+            0xc..0x10 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_mci_reg_hw_rev_id().reg.get(),
             )),
             0x10..0x18 => Ok(self
                 .periph
                 .read_mci_reg_fw_rev_id((addr as usize - 0x10) / 4)),
-            0x18..0x1c => Ok(caliptra_emu_types::RvData::from(
+            0x18..0x1c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_mci_reg_hw_config0().reg.get(),
             )),
-            0x1c..0x20 => Ok(caliptra_emu_types::RvData::from(
+            0x1c..0x20 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_mci_reg_hw_config1().reg.get(),
             )),
             0x20..0x24 => Ok(self.periph.read_mci_reg_mcu_ifu_axi_user()),
@@ -12289,28 +13116,28 @@ impl caliptra_emu_bus::Bus for MciBus {
             0x28..0x2c => Ok(self.periph.read_mci_reg_mcu_sram_config_axi_user()),
             0x2c..0x30 => Ok(self.periph.read_mci_reg_mci_soc_config_axi_user()),
             0x30..0x34 => Ok(self.periph.read_mci_reg_fw_flow_status()),
-            0x34..0x38 => Ok(caliptra_emu_types::RvData::from(
+            0x34..0x38 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_mci_reg_hw_flow_status().reg.get(),
             )),
-            0x38..0x3c => Ok(caliptra_emu_types::RvData::from(
+            0x38..0x3c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_mci_reg_reset_reason().reg.get(),
             )),
-            0x3c..0x40 => Ok(caliptra_emu_types::RvData::from(
+            0x3c..0x40 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_mci_reg_reset_status().reg.get(),
             )),
-            0x40..0x44 => Ok(caliptra_emu_types::RvData::from(
+            0x40..0x44 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_mci_reg_security_state().reg.get(),
             )),
-            0x50..0x54 => Ok(caliptra_emu_types::RvData::from(
+            0x50..0x54 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_mci_reg_hw_error_fatal().reg.get(),
             )),
-            0x54..0x58 => Ok(caliptra_emu_types::RvData::from(
+            0x54..0x58 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_mci_reg_agg_error_fatal().reg.get(),
             )),
-            0x58..0x5c => Ok(caliptra_emu_types::RvData::from(
+            0x58..0x5c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_mci_reg_hw_error_non_fatal().reg.get(),
             )),
-            0x5c..0x60 => Ok(caliptra_emu_types::RvData::from(
+            0x5c..0x60 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_mci_reg_agg_error_non_fatal().reg.get(),
             )),
             0x60..0x64 => Ok(self.periph.read_mci_reg_fw_error_fatal()),
@@ -12320,25 +13147,25 @@ impl caliptra_emu_bus::Bus for MciBus {
             0x70..0x90 => Ok(self
                 .periph
                 .read_mci_reg_fw_extended_error_info((addr as usize - 0x70) / 4)),
-            0x90..0x94 => Ok(caliptra_emu_types::RvData::from(
+            0x90..0x94 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_internal_hw_error_fatal_mask()
                     .reg
                     .get(),
             )),
-            0x94..0x98 => Ok(caliptra_emu_types::RvData::from(
+            0x94..0x98 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_internal_hw_error_non_fatal_mask()
                     .reg
                     .get(),
             )),
-            0x98..0x9c => Ok(caliptra_emu_types::RvData::from(
+            0x98..0x9c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_internal_agg_error_fatal_mask()
                     .reg
                     .get(),
             )),
-            0x9c..0xa0 => Ok(caliptra_emu_types::RvData::from(
+            0x9c..0xa0 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_internal_agg_error_non_fatal_mask()
                     .reg
@@ -12346,25 +13173,25 @@ impl caliptra_emu_bus::Bus for MciBus {
             )),
             0xa0..0xa4 => Ok(self.periph.read_mci_reg_internal_fw_error_fatal_mask()),
             0xa4..0xa8 => Ok(self.periph.read_mci_reg_internal_fw_error_non_fatal_mask()),
-            0xb0..0xb4 => Ok(caliptra_emu_types::RvData::from(
+            0xb0..0xb4 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_mci_reg_wdt_timer1_en().reg.get(),
             )),
-            0xb4..0xb8 => Ok(caliptra_emu_types::RvData::from(
+            0xb4..0xb8 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_mci_reg_wdt_timer1_ctrl().reg.get(),
             )),
             0xb8..0xc0 => Ok(self
                 .periph
                 .read_mci_reg_wdt_timer1_timeout_period((addr as usize - 0xb8) / 4)),
-            0xc0..0xc4 => Ok(caliptra_emu_types::RvData::from(
+            0xc0..0xc4 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_mci_reg_wdt_timer2_en().reg.get(),
             )),
-            0xc4..0xc8 => Ok(caliptra_emu_types::RvData::from(
+            0xc4..0xc8 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_mci_reg_wdt_timer2_ctrl().reg.get(),
             )),
             0xc8..0xd0 => Ok(self
                 .periph
                 .read_mci_reg_wdt_timer2_timeout_period((addr as usize - 0xc8) / 4)),
-            0xd0..0xd4 => Ok(caliptra_emu_types::RvData::from(
+            0xd0..0xd4 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_mci_reg_wdt_status().reg.get(),
             )),
             0xd4..0xdc => Ok(self.periph.read_mci_reg_wdt_cfg((addr as usize - 0xd4) / 4)),
@@ -12373,16 +13200,16 @@ impl caliptra_emu_bus::Bus for MciBus {
             0xe8..0xec => Ok(self.periph.read_mci_reg_mcu_rv_mtime_h()),
             0xec..0xf0 => Ok(self.periph.read_mci_reg_mcu_rv_mtimecmp_l()),
             0xf0..0xf4 => Ok(self.periph.read_mci_reg_mcu_rv_mtimecmp_h()),
-            0x100..0x104 => Ok(caliptra_emu_types::RvData::from(
+            0x100..0x104 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_mci_reg_reset_request().reg.get(),
             )),
-            0x104..0x108 => Ok(caliptra_emu_types::RvData::from(
+            0x104..0x108 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_mci_reg_mci_bootfsm_go().reg.get(),
             )),
-            0x108..0x10c => Ok(caliptra_emu_types::RvData::from(
+            0x108..0x10c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_mci_reg_cptra_boot_go().reg.get(),
             )),
-            0x10c..0x110 => Ok(caliptra_emu_types::RvData::from(
+            0x10c..0x110 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_fw_sram_exec_region_size()
                     .reg
@@ -12393,7 +13220,7 @@ impl caliptra_emu_bus::Bus for MciBus {
             0x180..0x194 => Ok(self
                 .periph
                 .read_mci_reg_mbox0_valid_axi_user((addr as usize - 0x180) / 4)),
-            0x1a0..0x1b4 => Ok(caliptra_emu_types::RvData::from(
+            0x1a0..0x1b4 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_mbox0_axi_user_lock((addr as usize - 0x1a0) / 4)
                     .reg
@@ -12402,7 +13229,7 @@ impl caliptra_emu_bus::Bus for MciBus {
             0x1c0..0x1d4 => Ok(self
                 .periph
                 .read_mci_reg_mbox1_valid_axi_user((addr as usize - 0x1c0) / 4)),
-            0x1e0..0x1f4 => Ok(caliptra_emu_types::RvData::from(
+            0x1e0..0x1f4 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_mbox1_axi_user_lock((addr as usize - 0x1e0) / 4)
                     .reg
@@ -12426,103 +13253,103 @@ impl caliptra_emu_bus::Bus for MciBus {
                 .read_mci_reg_generic_output_wires((addr as usize - 0x408) / 4)),
             0x410..0x414 => Ok(self.periph.read_mci_reg_debug_in()),
             0x414..0x418 => Ok(self.periph.read_mci_reg_debug_out()),
-            0x418..0x41c => Ok(caliptra_emu_types::RvData::from(
+            0x418..0x41c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_mci_reg_ss_debug_intent().reg.get(),
             )),
-            0x440..0x444 => Ok(caliptra_emu_types::RvData::from(
+            0x440..0x444 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_mci_reg_ss_config_done_sticky().reg.get(),
             )),
-            0x444..0x448 => Ok(caliptra_emu_types::RvData::from(
+            0x444..0x448 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_mci_reg_ss_config_done().reg.get(),
             )),
             0x480..0x600 => Ok(self
                 .periph
                 .read_mci_reg_prod_debug_unlock_pk_hash_reg((addr as usize - 0x480) / 4)),
-            0x1000..0x1004 => Ok(caliptra_emu_types::RvData::from(
+            0x1000..0x1004 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_global_intr_en_r()
                     .reg
                     .get(),
             )),
-            0x1004..0x1008 => Ok(caliptra_emu_types::RvData::from(
+            0x1004..0x1008 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_error0_intr_en_r()
                     .reg
                     .get(),
             )),
-            0x1008..0x100c => Ok(caliptra_emu_types::RvData::from(
+            0x1008..0x100c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_error1_intr_en_r()
                     .reg
                     .get(),
             )),
-            0x100c..0x1010 => Ok(caliptra_emu_types::RvData::from(
+            0x100c..0x1010 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_notif0_intr_en_r()
                     .reg
                     .get(),
             )),
-            0x1010..0x1014 => Ok(caliptra_emu_types::RvData::from(
+            0x1010..0x1014 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_notif1_intr_en_r()
                     .reg
                     .get(),
             )),
-            0x1014..0x1018 => Ok(caliptra_emu_types::RvData::from(
+            0x1014..0x1018 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_error_global_intr_r()
                     .reg
                     .get(),
             )),
-            0x1018..0x101c => Ok(caliptra_emu_types::RvData::from(
+            0x1018..0x101c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_notif_global_intr_r()
                     .reg
                     .get(),
             )),
-            0x101c..0x1020 => Ok(caliptra_emu_types::RvData::from(
+            0x101c..0x1020 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_error0_internal_intr_r()
                     .reg
                     .get(),
             )),
-            0x1020..0x1024 => Ok(caliptra_emu_types::RvData::from(
+            0x1020..0x1024 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_error1_internal_intr_r()
                     .reg
                     .get(),
             )),
-            0x1024..0x1028 => Ok(caliptra_emu_types::RvData::from(
+            0x1024..0x1028 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_notif0_internal_intr_r()
                     .reg
                     .get(),
             )),
-            0x1028..0x102c => Ok(caliptra_emu_types::RvData::from(
+            0x1028..0x102c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_notif1_internal_intr_r()
                     .reg
                     .get(),
             )),
-            0x102c..0x1030 => Ok(caliptra_emu_types::RvData::from(
+            0x102c..0x1030 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_error0_intr_trig_r()
                     .reg
                     .get(),
             )),
-            0x1030..0x1034 => Ok(caliptra_emu_types::RvData::from(
+            0x1030..0x1034 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_error1_intr_trig_r()
                     .reg
                     .get(),
             )),
-            0x1034..0x1038 => Ok(caliptra_emu_types::RvData::from(
+            0x1034..0x1038 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_notif0_intr_trig_r()
                     .reg
                     .get(),
             )),
-            0x1038..0x103c => Ok(caliptra_emu_types::RvData::from(
+            0x1038..0x103c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_notif1_intr_trig_r()
                     .reg
@@ -12783,517 +13610,517 @@ impl caliptra_emu_bus::Bus for MciBus {
             0x12b8..0x12bc => Ok(self
                 .periph
                 .read_mci_reg_intr_block_rf_notif_otp_operation_done_intr_count_r()),
-            0x1300..0x1304 => Ok(caliptra_emu_types::RvData::from(
+            0x1300..0x1304 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_error_internal_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x1304..0x1308 => Ok(caliptra_emu_types::RvData::from(
+            0x1304..0x1308 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_error_mbox0_ecc_unc_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x1308..0x130c => Ok(caliptra_emu_types::RvData::from(
+            0x1308..0x130c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_error_mbox1_ecc_unc_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x130c..0x1310 => Ok(caliptra_emu_types::RvData::from(
+            0x130c..0x1310 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_error_wdt_timer1_timeout_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x1310..0x1314 => Ok(caliptra_emu_types::RvData::from(
+            0x1310..0x1314 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_error_wdt_timer2_timeout_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x1314..0x1318 => Ok(caliptra_emu_types::RvData::from(
+            0x1314..0x1318 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_error_mcu_sram_dmi_axi_collision_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x1318..0x131c => Ok(caliptra_emu_types::RvData::from(
+            0x1318..0x131c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_error_agg_error_fatal0_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x131c..0x1320 => Ok(caliptra_emu_types::RvData::from(
+            0x131c..0x1320 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_error_agg_error_fatal1_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x1320..0x1324 => Ok(caliptra_emu_types::RvData::from(
+            0x1320..0x1324 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_error_agg_error_fatal2_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x1324..0x1328 => Ok(caliptra_emu_types::RvData::from(
+            0x1324..0x1328 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_error_agg_error_fatal3_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x1328..0x132c => Ok(caliptra_emu_types::RvData::from(
+            0x1328..0x132c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_error_agg_error_fatal4_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x132c..0x1330 => Ok(caliptra_emu_types::RvData::from(
+            0x132c..0x1330 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_error_agg_error_fatal5_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x1330..0x1334 => Ok(caliptra_emu_types::RvData::from(
+            0x1330..0x1334 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_error_agg_error_fatal6_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x1334..0x1338 => Ok(caliptra_emu_types::RvData::from(
+            0x1334..0x1338 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_error_agg_error_fatal7_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x1338..0x133c => Ok(caliptra_emu_types::RvData::from(
+            0x1338..0x133c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_error_agg_error_fatal8_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x133c..0x1340 => Ok(caliptra_emu_types::RvData::from(
+            0x133c..0x1340 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_error_agg_error_fatal9_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x1340..0x1344 => Ok(caliptra_emu_types::RvData::from(
+            0x1340..0x1344 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_error_agg_error_fatal10_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x1344..0x1348 => Ok(caliptra_emu_types::RvData::from(
+            0x1344..0x1348 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_error_agg_error_fatal11_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x1348..0x134c => Ok(caliptra_emu_types::RvData::from(
+            0x1348..0x134c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_error_agg_error_fatal12_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x134c..0x1350 => Ok(caliptra_emu_types::RvData::from(
+            0x134c..0x1350 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_error_agg_error_fatal13_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x1350..0x1354 => Ok(caliptra_emu_types::RvData::from(
+            0x1350..0x1354 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_error_agg_error_fatal14_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x1354..0x1358 => Ok(caliptra_emu_types::RvData::from(
+            0x1354..0x1358 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_error_agg_error_fatal15_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x1358..0x135c => Ok(caliptra_emu_types::RvData::from(
+            0x1358..0x135c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_error_agg_error_fatal16_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x135c..0x1360 => Ok(caliptra_emu_types::RvData::from(
+            0x135c..0x1360 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_error_agg_error_fatal17_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x1360..0x1364 => Ok(caliptra_emu_types::RvData::from(
+            0x1360..0x1364 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_error_agg_error_fatal18_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x1364..0x1368 => Ok(caliptra_emu_types::RvData::from(
+            0x1364..0x1368 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_error_agg_error_fatal19_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x1368..0x136c => Ok(caliptra_emu_types::RvData::from(
+            0x1368..0x136c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_error_agg_error_fatal20_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x136c..0x1370 => Ok(caliptra_emu_types::RvData::from(
+            0x136c..0x1370 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_error_agg_error_fatal21_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x1370..0x1374 => Ok(caliptra_emu_types::RvData::from(
+            0x1370..0x1374 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_error_agg_error_fatal22_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x1374..0x1378 => Ok(caliptra_emu_types::RvData::from(
+            0x1374..0x1378 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_error_agg_error_fatal23_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x1378..0x137c => Ok(caliptra_emu_types::RvData::from(
+            0x1378..0x137c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_error_agg_error_fatal24_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x137c..0x1380 => Ok(caliptra_emu_types::RvData::from(
+            0x137c..0x1380 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_error_agg_error_fatal25_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x1380..0x1384 => Ok(caliptra_emu_types::RvData::from(
+            0x1380..0x1384 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_error_agg_error_fatal26_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x1384..0x1388 => Ok(caliptra_emu_types::RvData::from(
+            0x1384..0x1388 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_error_agg_error_fatal27_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x1388..0x138c => Ok(caliptra_emu_types::RvData::from(
+            0x1388..0x138c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_error_agg_error_fatal28_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x138c..0x1390 => Ok(caliptra_emu_types::RvData::from(
+            0x138c..0x1390 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_error_agg_error_fatal29_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x1390..0x1394 => Ok(caliptra_emu_types::RvData::from(
+            0x1390..0x1394 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_error_agg_error_fatal30_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x1394..0x1398 => Ok(caliptra_emu_types::RvData::from(
+            0x1394..0x1398 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_error_agg_error_fatal31_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x1398..0x139c => Ok(caliptra_emu_types::RvData::from(
+            0x1398..0x139c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_notif_mcu_sram_ecc_cor_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x139c..0x13a0 => Ok(caliptra_emu_types::RvData::from(
+            0x139c..0x13a0 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_notif_cptra_mcu_reset_req_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x13a0..0x13a4 => Ok(caliptra_emu_types::RvData::from(
+            0x13a0..0x13a4 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_notif_gen_in_toggle_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x13a4..0x13a8 => Ok(caliptra_emu_types::RvData::from(
+            0x13a4..0x13a8 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_notif_agg_error_non_fatal0_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x13a8..0x13ac => Ok(caliptra_emu_types::RvData::from(
+            0x13a8..0x13ac => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_notif_agg_error_non_fatal1_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x13ac..0x13b0 => Ok(caliptra_emu_types::RvData::from(
+            0x13ac..0x13b0 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_notif_agg_error_non_fatal2_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x13b0..0x13b4 => Ok(caliptra_emu_types::RvData::from(
+            0x13b0..0x13b4 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_notif_agg_error_non_fatal3_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x13b4..0x13b8 => Ok(caliptra_emu_types::RvData::from(
+            0x13b4..0x13b8 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_notif_agg_error_non_fatal4_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x13b8..0x13bc => Ok(caliptra_emu_types::RvData::from(
+            0x13b8..0x13bc => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_notif_agg_error_non_fatal5_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x13bc..0x13c0 => Ok(caliptra_emu_types::RvData::from(
+            0x13bc..0x13c0 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_notif_agg_error_non_fatal6_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x13c0..0x13c4 => Ok(caliptra_emu_types::RvData::from(
+            0x13c0..0x13c4 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_notif_agg_error_non_fatal7_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x13c4..0x13c8 => Ok(caliptra_emu_types::RvData::from(
+            0x13c4..0x13c8 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_notif_agg_error_non_fatal8_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x13c8..0x13cc => Ok(caliptra_emu_types::RvData::from(
+            0x13c8..0x13cc => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_notif_agg_error_non_fatal9_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x13cc..0x13d0 => Ok(caliptra_emu_types::RvData::from(
+            0x13cc..0x13d0 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_notif_agg_error_non_fatal10_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x13d0..0x13d4 => Ok(caliptra_emu_types::RvData::from(
+            0x13d0..0x13d4 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_notif_agg_error_non_fatal11_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x13d4..0x13d8 => Ok(caliptra_emu_types::RvData::from(
+            0x13d4..0x13d8 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_notif_agg_error_non_fatal12_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x13d8..0x13dc => Ok(caliptra_emu_types::RvData::from(
+            0x13d8..0x13dc => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_notif_agg_error_non_fatal13_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x13dc..0x13e0 => Ok(caliptra_emu_types::RvData::from(
+            0x13dc..0x13e0 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_notif_agg_error_non_fatal14_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x13e0..0x13e4 => Ok(caliptra_emu_types::RvData::from(
+            0x13e0..0x13e4 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_notif_agg_error_non_fatal15_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x13e4..0x13e8 => Ok(caliptra_emu_types::RvData::from(
+            0x13e4..0x13e8 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_notif_agg_error_non_fatal16_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x13e8..0x13ec => Ok(caliptra_emu_types::RvData::from(
+            0x13e8..0x13ec => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_notif_agg_error_non_fatal17_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x13ec..0x13f0 => Ok(caliptra_emu_types::RvData::from(
+            0x13ec..0x13f0 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_notif_agg_error_non_fatal18_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x13f0..0x13f4 => Ok(caliptra_emu_types::RvData::from(
+            0x13f0..0x13f4 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_notif_agg_error_non_fatal19_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x13f4..0x13f8 => Ok(caliptra_emu_types::RvData::from(
+            0x13f4..0x13f8 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_notif_agg_error_non_fatal20_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x13f8..0x13fc => Ok(caliptra_emu_types::RvData::from(
+            0x13f8..0x13fc => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_notif_agg_error_non_fatal21_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x13fc..0x1400 => Ok(caliptra_emu_types::RvData::from(
+            0x13fc..0x1400 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_notif_agg_error_non_fatal22_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x1400..0x1404 => Ok(caliptra_emu_types::RvData::from(
+            0x1400..0x1404 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_notif_agg_error_non_fatal23_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x1404..0x1408 => Ok(caliptra_emu_types::RvData::from(
+            0x1404..0x1408 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_notif_agg_error_non_fatal24_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x1408..0x140c => Ok(caliptra_emu_types::RvData::from(
+            0x1408..0x140c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_notif_agg_error_non_fatal25_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x140c..0x1410 => Ok(caliptra_emu_types::RvData::from(
+            0x140c..0x1410 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_notif_agg_error_non_fatal26_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x1410..0x1414 => Ok(caliptra_emu_types::RvData::from(
+            0x1410..0x1414 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_notif_agg_error_non_fatal27_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x1414..0x1418 => Ok(caliptra_emu_types::RvData::from(
+            0x1414..0x1418 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_notif_agg_error_non_fatal28_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x1418..0x141c => Ok(caliptra_emu_types::RvData::from(
+            0x1418..0x141c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_notif_agg_error_non_fatal29_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x141c..0x1420 => Ok(caliptra_emu_types::RvData::from(
+            0x141c..0x1420 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_notif_agg_error_non_fatal30_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x1420..0x1424 => Ok(caliptra_emu_types::RvData::from(
+            0x1420..0x1424 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_notif_agg_error_non_fatal31_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x1424..0x1428 => Ok(caliptra_emu_types::RvData::from(
+            0x1424..0x1428 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_notif_mbox0_target_done_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x1428..0x142c => Ok(caliptra_emu_types::RvData::from(
+            0x1428..0x142c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_notif_mbox1_target_done_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x142c..0x1430 => Ok(caliptra_emu_types::RvData::from(
+            0x142c..0x1430 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_notif_mbox0_cmd_avail_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x1430..0x1434 => Ok(caliptra_emu_types::RvData::from(
+            0x1430..0x1434 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_notif_mbox1_cmd_avail_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x1434..0x1438 => Ok(caliptra_emu_types::RvData::from(
+            0x1434..0x1438 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_notif_cptra_mbox_cmd_avail_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x1438..0x143c => Ok(caliptra_emu_types::RvData::from(
+            0x1438..0x143c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_notif_mbox0_ecc_cor_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x143c..0x1440 => Ok(caliptra_emu_types::RvData::from(
+            0x143c..0x1440 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_notif_mbox1_ecc_cor_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x1440..0x1444 => Ok(caliptra_emu_types::RvData::from(
+            0x1440..0x1444 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_notif_debug_locked_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x1444..0x1448 => Ok(caliptra_emu_types::RvData::from(
+            0x1444..0x1448 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_notif_scan_mode_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x1448..0x144c => Ok(caliptra_emu_types::RvData::from(
+            0x1448..0x144c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_notif_mbox0_soc_req_lock_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x144c..0x1450 => Ok(caliptra_emu_types::RvData::from(
+            0x144c..0x1450 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_notif_mbox1_soc_req_lock_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x1450..0x1454 => Ok(caliptra_emu_types::RvData::from(
+            0x1450..0x1454 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mci_reg_intr_block_rf_notif_otp_operation_done_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0x1_0000..0x1_0004 => Ok(caliptra_emu_types::RvData::from(
+            0x1_0000..0x1_0004 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_mcu_trace_buffer_csr_status().reg.get(),
             )),
             0x1_0004..0x1_0008 => Ok(self.periph.read_mcu_trace_buffer_csr_config()),
@@ -13303,12 +14130,12 @@ impl caliptra_emu_bus::Bus for MciBus {
             0x40_0000..0x60_0000 => Ok(self
                 .periph
                 .read_mcu_mbox0_csr_mbox_sram((addr as usize - 0x40_0000) / 4)),
-            0x60_0000..0x60_0004 => Ok(caliptra_emu_types::RvData::from(
+            0x60_0000..0x60_0004 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_mcu_mbox0_csr_mbox_lock().reg.get(),
             )),
             0x60_0004..0x60_0008 => Ok(self.periph.read_mcu_mbox0_csr_mbox_user()),
             0x60_0008..0x60_000c => Ok(self.periph.read_mcu_mbox0_csr_mbox_target_user()),
-            0x60_000c..0x60_0010 => Ok(caliptra_emu_types::RvData::from(
+            0x60_000c..0x60_0010 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mcu_mbox0_csr_mbox_target_user_valid()
                     .reg
@@ -13316,30 +14143,30 @@ impl caliptra_emu_bus::Bus for MciBus {
             )),
             0x60_0010..0x60_0014 => Ok(self.periph.read_mcu_mbox0_csr_mbox_cmd()),
             0x60_0014..0x60_0018 => Ok(self.periph.read_mcu_mbox0_csr_mbox_dlen()),
-            0x60_0018..0x60_001c => Ok(caliptra_emu_types::RvData::from(
+            0x60_0018..0x60_001c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_mcu_mbox0_csr_mbox_execute().reg.get(),
             )),
-            0x60_001c..0x60_0020 => Ok(caliptra_emu_types::RvData::from(
+            0x60_001c..0x60_0020 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mcu_mbox0_csr_mbox_target_status()
                     .reg
                     .get(),
             )),
-            0x60_0020..0x60_0024 => Ok(caliptra_emu_types::RvData::from(
+            0x60_0020..0x60_0024 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_mcu_mbox0_csr_mbox_cmd_status().reg.get(),
             )),
-            0x60_0024..0x60_0028 => Ok(caliptra_emu_types::RvData::from(
+            0x60_0024..0x60_0028 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_mcu_mbox0_csr_mbox_hw_status().reg.get(),
             )),
             0x80_0000..0xa0_0000 => Ok(self
                 .periph
                 .read_mcu_mbox1_csr_mbox_sram((addr as usize - 0x80_0000) / 4)),
-            0xa0_0000..0xa0_0004 => Ok(caliptra_emu_types::RvData::from(
+            0xa0_0000..0xa0_0004 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_mcu_mbox1_csr_mbox_lock().reg.get(),
             )),
             0xa0_0004..0xa0_0008 => Ok(self.periph.read_mcu_mbox1_csr_mbox_user()),
             0xa0_0008..0xa0_000c => Ok(self.periph.read_mcu_mbox1_csr_mbox_target_user()),
-            0xa0_000c..0xa0_0010 => Ok(caliptra_emu_types::RvData::from(
+            0xa0_000c..0xa0_0010 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mcu_mbox1_csr_mbox_target_user_valid()
                     .reg
@@ -13347,32 +14174,32 @@ impl caliptra_emu_bus::Bus for MciBus {
             )),
             0xa0_0010..0xa0_0014 => Ok(self.periph.read_mcu_mbox1_csr_mbox_cmd()),
             0xa0_0014..0xa0_0018 => Ok(self.periph.read_mcu_mbox1_csr_mbox_dlen()),
-            0xa0_0018..0xa0_001c => Ok(caliptra_emu_types::RvData::from(
+            0xa0_0018..0xa0_001c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_mcu_mbox1_csr_mbox_execute().reg.get(),
             )),
-            0xa0_001c..0xa0_0020 => Ok(caliptra_emu_types::RvData::from(
+            0xa0_001c..0xa0_0020 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_mcu_mbox1_csr_mbox_target_status()
                     .reg
                     .get(),
             )),
-            0xa0_0020..0xa0_0024 => Ok(caliptra_emu_types::RvData::from(
+            0xa0_0020..0xa0_0024 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_mcu_mbox1_csr_mbox_cmd_status().reg.get(),
             )),
-            0xa0_0024..0xa0_0028 => Ok(caliptra_emu_types::RvData::from(
+            0xa0_0024..0xa0_0028 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_mcu_mbox1_csr_mbox_hw_status().reg.get(),
             )),
-            _ => Err(caliptra_emu_bus::BusError::LoadAccessFault),
+            _ => Err(caliptra_core_tools::caliptra_emu_bus::BusError::LoadAccessFault),
         }
     }
     fn write(
         &mut self,
-        size: caliptra_emu_types::RvSize,
-        addr: caliptra_emu_types::RvAddr,
-        val: caliptra_emu_types::RvData,
-    ) -> Result<(), caliptra_emu_bus::BusError> {
-        if addr & 0x3 != 0 || size != caliptra_emu_types::RvSize::Word {
-            return Err(caliptra_emu_bus::BusError::StoreAddrMisaligned);
+        size: caliptra_core_tools::caliptra_emu_types::RvSize,
+        addr: caliptra_core_tools::caliptra_emu_types::RvAddr,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) -> Result<(), caliptra_core_tools::caliptra_emu_bus::BusError> {
+        if addr & 0x3 != 0 || size != caliptra_core_tools::caliptra_emu_types::RvSize::Word {
+            return Err(caliptra_core_tools::caliptra_emu_bus::BusError::StoreAddrMisaligned);
         }
         match addr {
             0xc0_0000..0xe0_0000 => {
@@ -13389,8 +14216,9 @@ impl caliptra_emu_bus::Bus for MciBus {
                 Ok(())
             }
             8..0xc => {
-                self.periph
-                    .write_mci_reg_cap_lock(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_mci_reg_cap_lock(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0xc..0x10 => Ok(()),
@@ -13411,31 +14239,34 @@ impl caliptra_emu_bus::Bus for MciBus {
             }
             0x34..0x38 => Ok(()),
             0x38..0x3c => {
-                self.periph
-                    .write_mci_reg_reset_reason(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_mci_reg_reset_reason(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0x3c..0x40 => Ok(()),
             0x40..0x44 => Ok(()),
             0x50..0x54 => {
-                self.periph
-                    .write_mci_reg_hw_error_fatal(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_mci_reg_hw_error_fatal(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0x54..0x58 => {
-                self.periph
-                    .write_mci_reg_agg_error_fatal(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_mci_reg_agg_error_fatal(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0x58..0x5c => {
                 self.periph.write_mci_reg_hw_error_non_fatal(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x5c..0x60 => {
                 self.periph.write_mci_reg_agg_error_non_fatal(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
@@ -13462,25 +14293,25 @@ impl caliptra_emu_bus::Bus for MciBus {
             }
             0x90..0x94 => {
                 self.periph.write_mci_reg_internal_hw_error_fatal_mask(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x94..0x98 => {
                 self.periph.write_mci_reg_internal_hw_error_non_fatal_mask(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x98..0x9c => {
                 self.periph.write_mci_reg_internal_agg_error_fatal_mask(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x9c..0xa0 => {
                 self.periph.write_mci_reg_internal_agg_error_non_fatal_mask(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
@@ -13494,13 +14325,15 @@ impl caliptra_emu_bus::Bus for MciBus {
                 Ok(())
             }
             0xb0..0xb4 => {
-                self.periph
-                    .write_mci_reg_wdt_timer1_en(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_mci_reg_wdt_timer1_en(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0xb4..0xb8 => {
-                self.periph
-                    .write_mci_reg_wdt_timer1_ctrl(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_mci_reg_wdt_timer1_ctrl(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0xb8..0xc0 => {
@@ -13509,13 +14342,15 @@ impl caliptra_emu_bus::Bus for MciBus {
                 Ok(())
             }
             0xc0..0xc4 => {
-                self.periph
-                    .write_mci_reg_wdt_timer2_en(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_mci_reg_wdt_timer2_en(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0xc4..0xc8 => {
-                self.periph
-                    .write_mci_reg_wdt_timer2_ctrl(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_mci_reg_wdt_timer2_ctrl(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0xc8..0xd0 => {
@@ -13550,23 +14385,26 @@ impl caliptra_emu_bus::Bus for MciBus {
                 Ok(())
             }
             0x100..0x104 => {
-                self.periph
-                    .write_mci_reg_reset_request(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_mci_reg_reset_request(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0x104..0x108 => {
-                self.periph
-                    .write_mci_reg_mci_bootfsm_go(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_mci_reg_mci_bootfsm_go(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0x108..0x10c => {
-                self.periph
-                    .write_mci_reg_cptra_boot_go(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_mci_reg_cptra_boot_go(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0x10c..0x110 => {
                 self.periph.write_mci_reg_fw_sram_exec_region_size(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
@@ -13585,7 +14423,7 @@ impl caliptra_emu_bus::Bus for MciBus {
             }
             0x1a0..0x1b4 => {
                 self.periph.write_mci_reg_mbox0_axi_user_lock(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                     (addr as usize - 0x1a0) / 4,
                 );
                 Ok(())
@@ -13597,7 +14435,7 @@ impl caliptra_emu_bus::Bus for MciBus {
             }
             0x1e0..0x1f4 => {
                 self.periph.write_mci_reg_mbox1_axi_user_lock(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                     (addr as usize - 0x1e0) / 4,
                 );
                 Ok(())
@@ -13638,13 +14476,14 @@ impl caliptra_emu_bus::Bus for MciBus {
             0x418..0x41c => Ok(()),
             0x440..0x444 => {
                 self.periph.write_mci_reg_ss_config_done_sticky(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x444..0x448 => {
-                self.periph
-                    .write_mci_reg_ss_config_done(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_mci_reg_ss_config_done(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0x480..0x600 => {
@@ -13654,31 +14493,31 @@ impl caliptra_emu_bus::Bus for MciBus {
             }
             0x1000..0x1004 => {
                 self.periph.write_mci_reg_intr_block_rf_global_intr_en_r(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x1004..0x1008 => {
                 self.periph.write_mci_reg_intr_block_rf_error0_intr_en_r(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x1008..0x100c => {
                 self.periph.write_mci_reg_intr_block_rf_error1_intr_en_r(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x100c..0x1010 => {
                 self.periph.write_mci_reg_intr_block_rf_notif0_intr_en_r(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x1010..0x1014 => {
                 self.periph.write_mci_reg_intr_block_rf_notif1_intr_en_r(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
@@ -13687,52 +14526,52 @@ impl caliptra_emu_bus::Bus for MciBus {
             0x101c..0x1020 => {
                 self.periph
                     .write_mci_reg_intr_block_rf_error0_internal_intr_r(
-                        caliptra_emu_bus::ReadWriteRegister::new(val),
+                        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                     );
                 Ok(())
             }
             0x1020..0x1024 => {
                 self.periph
                     .write_mci_reg_intr_block_rf_error1_internal_intr_r(
-                        caliptra_emu_bus::ReadWriteRegister::new(val),
+                        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                     );
                 Ok(())
             }
             0x1024..0x1028 => {
                 self.periph
                     .write_mci_reg_intr_block_rf_notif0_internal_intr_r(
-                        caliptra_emu_bus::ReadWriteRegister::new(val),
+                        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                     );
                 Ok(())
             }
             0x1028..0x102c => {
                 self.periph
                     .write_mci_reg_intr_block_rf_notif1_internal_intr_r(
-                        caliptra_emu_bus::ReadWriteRegister::new(val),
+                        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                     );
                 Ok(())
             }
             0x102c..0x1030 => {
                 self.periph.write_mci_reg_intr_block_rf_error0_intr_trig_r(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x1030..0x1034 => {
                 self.periph.write_mci_reg_intr_block_rf_error1_intr_trig_r(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x1034..0x1038 => {
                 self.periph.write_mci_reg_intr_block_rf_notif0_intr_trig_r(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x1038..0x103c => {
                 self.periph.write_mci_reg_intr_block_rf_notif1_intr_trig_r(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
@@ -14267,7 +15106,7 @@ impl caliptra_emu_bus::Bus for MciBus {
             }
             0x60_000c..0x60_0010 => {
                 self.periph.write_mcu_mbox0_csr_mbox_target_user_valid(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
@@ -14281,19 +15120,19 @@ impl caliptra_emu_bus::Bus for MciBus {
             }
             0x60_0018..0x60_001c => {
                 self.periph.write_mcu_mbox0_csr_mbox_execute(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x60_001c..0x60_0020 => {
                 self.periph.write_mcu_mbox0_csr_mbox_target_status(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x60_0020..0x60_0024 => {
                 self.periph.write_mcu_mbox0_csr_mbox_cmd_status(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
@@ -14311,7 +15150,7 @@ impl caliptra_emu_bus::Bus for MciBus {
             }
             0xa0_000c..0xa0_0010 => {
                 self.periph.write_mcu_mbox1_csr_mbox_target_user_valid(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
@@ -14325,24 +15164,24 @@ impl caliptra_emu_bus::Bus for MciBus {
             }
             0xa0_0018..0xa0_001c => {
                 self.periph.write_mcu_mbox1_csr_mbox_execute(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0xa0_001c..0xa0_0020 => {
                 self.periph.write_mcu_mbox1_csr_mbox_target_status(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0xa0_0020..0xa0_0024 => {
                 self.periph.write_mcu_mbox1_csr_mbox_cmd_status(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0xa0_0024..0xa0_0028 => Ok(()),
-            _ => Err(caliptra_emu_bus::BusError::StoreAccessFault),
+            _ => Err(caliptra_core_tools::caliptra_emu_bus::BusError::StoreAccessFault),
         }
     }
     fn poll(&mut self) {

--- a/registers/generated-emulator/src/otp.rs
+++ b/registers/generated-emulator/src/otp.rs
@@ -5,14 +5,24 @@
 #[allow(unused_imports)]
 use tock_registers::interfaces::{Readable, Writeable};
 pub trait OtpPeripheral {
-    fn set_dma_ram(&mut self, _ram: std::rc::Rc<std::cell::RefCell<caliptra_emu_bus::Ram>>) {}
-    fn set_dma_rom_sram(&mut self, _ram: std::rc::Rc<std::cell::RefCell<caliptra_emu_bus::Ram>>) {}
+    fn set_dma_ram(
+        &mut self,
+        _ram: std::rc::Rc<std::cell::RefCell<caliptra_core_tools::caliptra_emu_bus::Ram>>,
+    ) {
+    }
+    fn set_dma_rom_sram(
+        &mut self,
+        _ram: std::rc::Rc<std::cell::RefCell<caliptra_core_tools::caliptra_emu_bus::Ram>>,
+    ) {
+    }
     fn register_event_channels(
         &mut self,
-        _events_to_caliptra: std::sync::mpsc::Sender<caliptra_emu_bus::Event>,
-        _events_from_caliptra: std::sync::mpsc::Receiver<caliptra_emu_bus::Event>,
-        _events_to_mcu: std::sync::mpsc::Sender<caliptra_emu_bus::Event>,
-        _events_from_mcu: std::sync::mpsc::Receiver<caliptra_emu_bus::Event>,
+        _events_to_caliptra: std::sync::mpsc::Sender<caliptra_core_tools::caliptra_emu_bus::Event>,
+        _events_from_caliptra: std::sync::mpsc::Receiver<
+            caliptra_core_tools::caliptra_emu_bus::Event,
+        >,
+        _events_to_mcu: std::sync::mpsc::Sender<caliptra_core_tools::caliptra_emu_bus::Event>,
+        _events_from_mcu: std::sync::mpsc::Receiver<caliptra_core_tools::caliptra_emu_bus::Event>,
     ) {
     }
     fn poll(&mut self) {}
@@ -23,7 +33,7 @@ pub trait OtpPeripheral {
     }
     fn read_interrupt_state(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::InterruptState::Register,
     > {
@@ -33,11 +43,11 @@ pub trait OtpPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_interrupt_state();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_interrupt_state(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::otp_ctrl::bits::InterruptState::Register,
         >,
@@ -54,7 +64,7 @@ pub trait OtpPeripheral {
     }
     fn read_otp_interrupt_enable(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::OtpInterruptEnable::Register,
     > {
@@ -64,11 +74,11 @@ pub trait OtpPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_otp_interrupt_enable();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_otp_interrupt_enable(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::otp_ctrl::bits::OtpInterruptEnable::Register,
         >,
@@ -85,7 +95,7 @@ pub trait OtpPeripheral {
     }
     fn write_interrupt_test(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::otp_ctrl::bits::InterruptTest::Register,
         >,
@@ -102,7 +112,7 @@ pub trait OtpPeripheral {
     }
     fn write_alert_test(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::otp_ctrl::bits::AlertTest::Register,
         >,
@@ -119,7 +129,7 @@ pub trait OtpPeripheral {
     }
     fn read_otp_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::OtpStatus::Register,
     > {
@@ -129,11 +139,11 @@ pub trait OtpPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_otp_status();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_direct_access_regwen(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::DirectAccessRegwen::Register,
     > {
@@ -143,11 +153,11 @@ pub trait OtpPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_direct_access_regwen();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_direct_access_regwen(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::otp_ctrl::bits::DirectAccessRegwen::Register,
         >,
@@ -164,7 +174,7 @@ pub trait OtpPeripheral {
     }
     fn write_direct_access_cmd(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::otp_ctrl::bits::DirectAccessCmd::Register,
         >,
@@ -181,7 +191,7 @@ pub trait OtpPeripheral {
     }
     fn read_direct_access_address(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::DirectAccessAddress::Register,
     > {
@@ -191,11 +201,11 @@ pub trait OtpPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_direct_access_address();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_direct_access_address(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::otp_ctrl::bits::DirectAccessAddress::Register,
         >,
@@ -212,7 +222,7 @@ pub trait OtpPeripheral {
     }
     fn read_check_trigger_regwen(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::CheckTriggerRegwen::Register,
     > {
@@ -222,11 +232,11 @@ pub trait OtpPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_check_trigger_regwen();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_check_trigger_regwen(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::otp_ctrl::bits::CheckTriggerRegwen::Register,
         >,
@@ -243,7 +253,7 @@ pub trait OtpPeripheral {
     }
     fn write_check_trigger(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::otp_ctrl::bits::CheckTrigger::Register,
         >,
@@ -260,7 +270,7 @@ pub trait OtpPeripheral {
     }
     fn write_check_regwen(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::otp_ctrl::bits::CheckRegwen::Register,
         >,
@@ -275,7 +285,7 @@ pub trait OtpPeripheral {
             generated.write_check_regwen(val);
         }
     }
-    fn read_check_timeout(&mut self) -> caliptra_emu_types::RvData {
+    fn read_check_timeout(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read otp::check_timeout");
         }
@@ -284,7 +294,7 @@ pub trait OtpPeripheral {
         }
         0
     }
-    fn write_check_timeout(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_check_timeout(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write otp::check_timeout = 0x{:08x}",
@@ -295,7 +305,7 @@ pub trait OtpPeripheral {
             generated.write_check_timeout(val);
         }
     }
-    fn read_integrity_check_period(&mut self) -> caliptra_emu_types::RvData {
+    fn read_integrity_check_period(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read otp::integrity_check_period");
         }
@@ -304,7 +314,10 @@ pub trait OtpPeripheral {
         }
         0
     }
-    fn write_integrity_check_period(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_integrity_check_period(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write otp::integrity_check_period = 0x{:08x}",
@@ -315,7 +328,7 @@ pub trait OtpPeripheral {
             generated.write_integrity_check_period(val);
         }
     }
-    fn read_consistency_check_period(&mut self) -> caliptra_emu_types::RvData {
+    fn read_consistency_check_period(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read otp::consistency_check_period");
         }
@@ -324,7 +337,10 @@ pub trait OtpPeripheral {
         }
         0
     }
-    fn write_consistency_check_period(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_consistency_check_period(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write otp::consistency_check_period = 0x{:08x}" , val);
         }
@@ -334,7 +350,7 @@ pub trait OtpPeripheral {
     }
     fn read_sw_manuf_partition_read_lock(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::SwManufPartitionReadLock::Register,
     > {
@@ -344,11 +360,11 @@ pub trait OtpPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_sw_manuf_partition_read_lock();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_sw_manuf_partition_read_lock(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::otp_ctrl::bits::SwManufPartitionReadLock::Register,
         >,
@@ -362,7 +378,7 @@ pub trait OtpPeripheral {
     }
     fn read_svn_partition_read_lock(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::SvnPartitionReadLock::Register,
     > {
@@ -372,11 +388,11 @@ pub trait OtpPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_svn_partition_read_lock();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_svn_partition_read_lock(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::otp_ctrl::bits::SvnPartitionReadLock::Register,
         >,
@@ -393,7 +409,7 @@ pub trait OtpPeripheral {
     }
     fn read_vendor_test_partition_read_lock(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::VendorTestPartitionReadLock::Register,
     > {
@@ -405,11 +421,11 @@ pub trait OtpPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_vendor_test_partition_read_lock();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_vendor_test_partition_read_lock(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::otp_ctrl::bits::VendorTestPartitionReadLock::Register,
         >,
@@ -423,7 +439,7 @@ pub trait OtpPeripheral {
     }
     fn read_vendor_hashes_manuf_partition_read_lock(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::VendorHashesManufPartitionReadLock::Register,
     > {
@@ -433,11 +449,11 @@ pub trait OtpPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_vendor_hashes_manuf_partition_read_lock();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_vendor_hashes_manuf_partition_read_lock(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::otp_ctrl::bits::VendorHashesManufPartitionReadLock::Register,
         >,
@@ -451,7 +467,7 @@ pub trait OtpPeripheral {
     }
     fn read_vendor_hashes_prod_partition_read_lock(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::VendorHashesProdPartitionReadLock::Register,
     > {
@@ -461,11 +477,11 @@ pub trait OtpPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_vendor_hashes_prod_partition_read_lock();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_vendor_hashes_prod_partition_read_lock(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::otp_ctrl::bits::VendorHashesProdPartitionReadLock::Register,
         >,
@@ -479,7 +495,7 @@ pub trait OtpPeripheral {
     }
     fn read_vendor_revocations_prod_partition_read_lock(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::VendorRevocationsProdPartitionReadLock::Register,
     > {
@@ -489,11 +505,11 @@ pub trait OtpPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_vendor_revocations_prod_partition_read_lock();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_vendor_revocations_prod_partition_read_lock(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::otp_ctrl::bits::VendorRevocationsProdPartitionReadLock::Register,
         >,
@@ -507,7 +523,7 @@ pub trait OtpPeripheral {
     }
     fn read_vendor_non_secret_prod_partition_read_lock(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::VendorNonSecretProdPartitionReadLock::Register,
     > {
@@ -517,11 +533,11 @@ pub trait OtpPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_vendor_non_secret_prod_partition_read_lock();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_vendor_non_secret_prod_partition_read_lock(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::otp_ctrl::bits::VendorNonSecretProdPartitionReadLock::Register,
         >,
@@ -533,7 +549,9 @@ pub trait OtpPeripheral {
             generated.write_vendor_non_secret_prod_partition_read_lock(val);
         }
     }
-    fn read_vendor_pk_hash_volatile_lock(&mut self) -> caliptra_emu_types::RvData {
+    fn read_vendor_pk_hash_volatile_lock(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read otp::vendor_pk_hash_volatile_lock");
         }
@@ -542,7 +560,10 @@ pub trait OtpPeripheral {
         }
         0
     }
-    fn write_vendor_pk_hash_volatile_lock(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_vendor_pk_hash_volatile_lock(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write otp::vendor_pk_hash_volatile_lock = 0x{:08x}" , val);
         }
@@ -552,19 +573,21 @@ pub trait OtpPeripheral {
     }
     fn read_csr0(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::otp_ctrl::bits::Csr0::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::otp_ctrl::bits::Csr0::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read otp::csr0");
         }
         if let Some(generated) = self.generated() {
             return generated.read_csr0();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_csr0(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::otp_ctrl::bits::Csr0::Register,
         >,
@@ -581,19 +604,21 @@ pub trait OtpPeripheral {
     }
     fn read_csr1(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::otp_ctrl::bits::Csr1::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::otp_ctrl::bits::Csr1::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read otp::csr1");
         }
         if let Some(generated) = self.generated() {
             return generated.read_csr1();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_csr1(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::otp_ctrl::bits::Csr1::Register,
         >,
@@ -610,19 +635,21 @@ pub trait OtpPeripheral {
     }
     fn read_csr2(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::otp_ctrl::bits::Csr2::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::otp_ctrl::bits::Csr2::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read otp::csr2");
         }
         if let Some(generated) = self.generated() {
             return generated.read_csr2();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_csr2(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::otp_ctrl::bits::Csr2::Register,
         >,
@@ -639,19 +666,21 @@ pub trait OtpPeripheral {
     }
     fn read_csr3(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::otp_ctrl::bits::Csr3::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::otp_ctrl::bits::Csr3::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read otp::csr3");
         }
         if let Some(generated) = self.generated() {
             return generated.read_csr3();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_csr3(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::otp_ctrl::bits::Csr3::Register,
         >,
@@ -668,19 +697,21 @@ pub trait OtpPeripheral {
     }
     fn read_csr4(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::otp_ctrl::bits::Csr4::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::otp_ctrl::bits::Csr4::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read otp::csr4");
         }
         if let Some(generated) = self.generated() {
             return generated.read_csr4();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_csr4(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::otp_ctrl::bits::Csr4::Register,
         >,
@@ -697,19 +728,21 @@ pub trait OtpPeripheral {
     }
     fn read_csr5(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::otp_ctrl::bits::Csr5::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::otp_ctrl::bits::Csr5::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read otp::csr5");
         }
         if let Some(generated) = self.generated() {
             return generated.read_csr5();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_csr5(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::otp_ctrl::bits::Csr5::Register,
         >,
@@ -726,19 +759,21 @@ pub trait OtpPeripheral {
     }
     fn read_csr6(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::otp_ctrl::bits::Csr6::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::otp_ctrl::bits::Csr6::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read otp::csr6");
         }
         if let Some(generated) = self.generated() {
             return generated.read_csr6();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_csr6(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::otp_ctrl::bits::Csr6::Register,
         >,
@@ -755,19 +790,21 @@ pub trait OtpPeripheral {
     }
     fn read_csr7(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::otp_ctrl::bits::Csr7::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::otp_ctrl::bits::Csr7::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read otp::csr7");
         }
         if let Some(generated) = self.generated() {
             return generated.read_csr7();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_err_code_rf_err_code_0(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
     > {
@@ -777,11 +814,11 @@ pub trait OtpPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_err_code_rf_err_code_0();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_err_code_rf_err_code_1(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
     > {
@@ -791,11 +828,11 @@ pub trait OtpPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_err_code_rf_err_code_1();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_err_code_rf_err_code_2(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
     > {
@@ -805,11 +842,11 @@ pub trait OtpPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_err_code_rf_err_code_2();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_err_code_rf_err_code_3(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
     > {
@@ -819,11 +856,11 @@ pub trait OtpPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_err_code_rf_err_code_3();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_err_code_rf_err_code_4(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
     > {
@@ -833,11 +870,11 @@ pub trait OtpPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_err_code_rf_err_code_4();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_err_code_rf_err_code_5(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
     > {
@@ -847,11 +884,11 @@ pub trait OtpPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_err_code_rf_err_code_5();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_err_code_rf_err_code_6(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
     > {
@@ -861,11 +898,11 @@ pub trait OtpPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_err_code_rf_err_code_6();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_err_code_rf_err_code_7(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
     > {
@@ -875,11 +912,11 @@ pub trait OtpPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_err_code_rf_err_code_7();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_err_code_rf_err_code_8(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
     > {
@@ -889,11 +926,11 @@ pub trait OtpPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_err_code_rf_err_code_8();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_err_code_rf_err_code_9(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
     > {
@@ -903,11 +940,11 @@ pub trait OtpPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_err_code_rf_err_code_9();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_err_code_rf_err_code_10(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
     > {
@@ -917,11 +954,11 @@ pub trait OtpPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_err_code_rf_err_code_10();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_err_code_rf_err_code_11(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
     > {
@@ -931,11 +968,11 @@ pub trait OtpPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_err_code_rf_err_code_11();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_err_code_rf_err_code_12(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
     > {
@@ -945,11 +982,11 @@ pub trait OtpPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_err_code_rf_err_code_12();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_err_code_rf_err_code_13(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
     > {
@@ -959,11 +996,11 @@ pub trait OtpPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_err_code_rf_err_code_13();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_err_code_rf_err_code_14(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
     > {
@@ -973,11 +1010,11 @@ pub trait OtpPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_err_code_rf_err_code_14();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_err_code_rf_err_code_15(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
     > {
@@ -987,11 +1024,11 @@ pub trait OtpPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_err_code_rf_err_code_15();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_err_code_rf_err_code_16(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
     > {
@@ -1001,11 +1038,11 @@ pub trait OtpPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_err_code_rf_err_code_16();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_err_code_rf_err_code_17(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
     > {
@@ -1015,9 +1052,11 @@ pub trait OtpPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_err_code_rf_err_code_17();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
-    fn read_dai_wdata_rf_direct_access_wdata_0(&mut self) -> caliptra_emu_types::RvData {
+    fn read_dai_wdata_rf_direct_access_wdata_0(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read otp::dai_wdata_rf_direct_access_wdata_0"
@@ -1028,7 +1067,10 @@ pub trait OtpPeripheral {
         }
         0
     }
-    fn write_dai_wdata_rf_direct_access_wdata_0(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_dai_wdata_rf_direct_access_wdata_0(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write otp::dai_wdata_rf_direct_access_wdata_0 = 0x{:08x}" , val);
         }
@@ -1036,7 +1078,9 @@ pub trait OtpPeripheral {
             generated.write_dai_wdata_rf_direct_access_wdata_0(val);
         }
     }
-    fn read_dai_wdata_rf_direct_access_wdata_1(&mut self) -> caliptra_emu_types::RvData {
+    fn read_dai_wdata_rf_direct_access_wdata_1(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read otp::dai_wdata_rf_direct_access_wdata_1"
@@ -1047,7 +1091,10 @@ pub trait OtpPeripheral {
         }
         0
     }
-    fn write_dai_wdata_rf_direct_access_wdata_1(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_dai_wdata_rf_direct_access_wdata_1(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write otp::dai_wdata_rf_direct_access_wdata_1 = 0x{:08x}" , val);
         }
@@ -1055,7 +1102,9 @@ pub trait OtpPeripheral {
             generated.write_dai_wdata_rf_direct_access_wdata_1(val);
         }
     }
-    fn read_dai_rdata_rf_direct_access_rdata_0(&mut self) -> caliptra_emu_types::RvData {
+    fn read_dai_rdata_rf_direct_access_rdata_0(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read otp::dai_rdata_rf_direct_access_rdata_0"
@@ -1066,7 +1115,9 @@ pub trait OtpPeripheral {
         }
         0
     }
-    fn read_dai_rdata_rf_direct_access_rdata_1(&mut self) -> caliptra_emu_types::RvData {
+    fn read_dai_rdata_rf_direct_access_rdata_1(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read otp::dai_rdata_rf_direct_access_rdata_1"
@@ -1077,7 +1128,9 @@ pub trait OtpPeripheral {
         }
         0
     }
-    fn read_sw_test_unlock_partition_digest_digest_0(&mut self) -> caliptra_emu_types::RvData {
+    fn read_sw_test_unlock_partition_digest_digest_0(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read otp::sw_test_unlock_partition_digest_digest_0");
         }
@@ -1086,7 +1139,9 @@ pub trait OtpPeripheral {
         }
         0
     }
-    fn read_sw_test_unlock_partition_digest_digest_1(&mut self) -> caliptra_emu_types::RvData {
+    fn read_sw_test_unlock_partition_digest_digest_1(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read otp::sw_test_unlock_partition_digest_digest_1");
         }
@@ -1095,7 +1150,9 @@ pub trait OtpPeripheral {
         }
         0
     }
-    fn read_secret_manuf_partition_digest_digest_0(&mut self) -> caliptra_emu_types::RvData {
+    fn read_secret_manuf_partition_digest_digest_0(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read otp::secret_manuf_partition_digest_digest_0");
         }
@@ -1104,7 +1161,9 @@ pub trait OtpPeripheral {
         }
         0
     }
-    fn read_secret_manuf_partition_digest_digest_1(&mut self) -> caliptra_emu_types::RvData {
+    fn read_secret_manuf_partition_digest_digest_1(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read otp::secret_manuf_partition_digest_digest_1");
         }
@@ -1113,7 +1172,9 @@ pub trait OtpPeripheral {
         }
         0
     }
-    fn read_secret_prod_partition_0_digest_digest_0(&mut self) -> caliptra_emu_types::RvData {
+    fn read_secret_prod_partition_0_digest_digest_0(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read otp::secret_prod_partition_0_digest_digest_0");
         }
@@ -1122,7 +1183,9 @@ pub trait OtpPeripheral {
         }
         0
     }
-    fn read_secret_prod_partition_0_digest_digest_1(&mut self) -> caliptra_emu_types::RvData {
+    fn read_secret_prod_partition_0_digest_digest_1(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read otp::secret_prod_partition_0_digest_digest_1");
         }
@@ -1131,7 +1194,9 @@ pub trait OtpPeripheral {
         }
         0
     }
-    fn read_secret_prod_partition_1_digest_digest_0(&mut self) -> caliptra_emu_types::RvData {
+    fn read_secret_prod_partition_1_digest_digest_0(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read otp::secret_prod_partition_1_digest_digest_0");
         }
@@ -1140,7 +1205,9 @@ pub trait OtpPeripheral {
         }
         0
     }
-    fn read_secret_prod_partition_1_digest_digest_1(&mut self) -> caliptra_emu_types::RvData {
+    fn read_secret_prod_partition_1_digest_digest_1(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read otp::secret_prod_partition_1_digest_digest_1");
         }
@@ -1149,7 +1216,9 @@ pub trait OtpPeripheral {
         }
         0
     }
-    fn read_secret_prod_partition_2_digest_digest_0(&mut self) -> caliptra_emu_types::RvData {
+    fn read_secret_prod_partition_2_digest_digest_0(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read otp::secret_prod_partition_2_digest_digest_0");
         }
@@ -1158,7 +1227,9 @@ pub trait OtpPeripheral {
         }
         0
     }
-    fn read_secret_prod_partition_2_digest_digest_1(&mut self) -> caliptra_emu_types::RvData {
+    fn read_secret_prod_partition_2_digest_digest_1(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read otp::secret_prod_partition_2_digest_digest_1");
         }
@@ -1167,7 +1238,9 @@ pub trait OtpPeripheral {
         }
         0
     }
-    fn read_secret_prod_partition_3_digest_digest_0(&mut self) -> caliptra_emu_types::RvData {
+    fn read_secret_prod_partition_3_digest_digest_0(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read otp::secret_prod_partition_3_digest_digest_0");
         }
@@ -1176,7 +1249,9 @@ pub trait OtpPeripheral {
         }
         0
     }
-    fn read_secret_prod_partition_3_digest_digest_1(&mut self) -> caliptra_emu_types::RvData {
+    fn read_secret_prod_partition_3_digest_digest_1(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read otp::secret_prod_partition_3_digest_digest_1");
         }
@@ -1185,7 +1260,9 @@ pub trait OtpPeripheral {
         }
         0
     }
-    fn read_sw_manuf_partition_digest_digest_0(&mut self) -> caliptra_emu_types::RvData {
+    fn read_sw_manuf_partition_digest_digest_0(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read otp::sw_manuf_partition_digest_digest_0"
@@ -1196,7 +1273,9 @@ pub trait OtpPeripheral {
         }
         0
     }
-    fn read_sw_manuf_partition_digest_digest_1(&mut self) -> caliptra_emu_types::RvData {
+    fn read_sw_manuf_partition_digest_digest_1(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read otp::sw_manuf_partition_digest_digest_1"
@@ -1209,7 +1288,7 @@ pub trait OtpPeripheral {
     }
     fn read_secret_lc_transition_partition_digest_digest_0(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read otp::secret_lc_transition_partition_digest_digest_0");
         }
@@ -1220,7 +1299,7 @@ pub trait OtpPeripheral {
     }
     fn read_secret_lc_transition_partition_digest_digest_1(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read otp::secret_lc_transition_partition_digest_digest_1");
         }
@@ -1229,7 +1308,9 @@ pub trait OtpPeripheral {
         }
         0
     }
-    fn read_vendor_test_partition_digest_digest_0(&mut self) -> caliptra_emu_types::RvData {
+    fn read_vendor_test_partition_digest_digest_0(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read otp::vendor_test_partition_digest_digest_0");
         }
@@ -1238,7 +1319,9 @@ pub trait OtpPeripheral {
         }
         0
     }
-    fn read_vendor_test_partition_digest_digest_1(&mut self) -> caliptra_emu_types::RvData {
+    fn read_vendor_test_partition_digest_digest_1(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read otp::vendor_test_partition_digest_digest_1");
         }
@@ -1247,7 +1330,9 @@ pub trait OtpPeripheral {
         }
         0
     }
-    fn read_vendor_hashes_manuf_partition_digest_digest_0(&mut self) -> caliptra_emu_types::RvData {
+    fn read_vendor_hashes_manuf_partition_digest_digest_0(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read otp::vendor_hashes_manuf_partition_digest_digest_0");
         }
@@ -1256,7 +1341,9 @@ pub trait OtpPeripheral {
         }
         0
     }
-    fn read_vendor_hashes_manuf_partition_digest_digest_1(&mut self) -> caliptra_emu_types::RvData {
+    fn read_vendor_hashes_manuf_partition_digest_digest_1(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read otp::vendor_hashes_manuf_partition_digest_digest_1");
         }
@@ -1265,7 +1352,9 @@ pub trait OtpPeripheral {
         }
         0
     }
-    fn read_vendor_hashes_prod_partition_digest_digest_0(&mut self) -> caliptra_emu_types::RvData {
+    fn read_vendor_hashes_prod_partition_digest_digest_0(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read otp::vendor_hashes_prod_partition_digest_digest_0");
         }
@@ -1274,7 +1363,9 @@ pub trait OtpPeripheral {
         }
         0
     }
-    fn read_vendor_hashes_prod_partition_digest_digest_1(&mut self) -> caliptra_emu_types::RvData {
+    fn read_vendor_hashes_prod_partition_digest_digest_1(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read otp::vendor_hashes_prod_partition_digest_digest_1");
         }
@@ -1285,7 +1376,7 @@ pub trait OtpPeripheral {
     }
     fn read_vendor_revocations_prod_partition_digest_digest_0(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read otp::vendor_revocations_prod_partition_digest_digest_0");
         }
@@ -1296,7 +1387,7 @@ pub trait OtpPeripheral {
     }
     fn read_vendor_revocations_prod_partition_digest_digest_1(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read otp::vendor_revocations_prod_partition_digest_digest_1");
         }
@@ -1305,7 +1396,9 @@ pub trait OtpPeripheral {
         }
         0
     }
-    fn read_vendor_secret_prod_partition_digest_digest_0(&mut self) -> caliptra_emu_types::RvData {
+    fn read_vendor_secret_prod_partition_digest_digest_0(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read otp::vendor_secret_prod_partition_digest_digest_0");
         }
@@ -1314,7 +1407,9 @@ pub trait OtpPeripheral {
         }
         0
     }
-    fn read_vendor_secret_prod_partition_digest_digest_1(&mut self) -> caliptra_emu_types::RvData {
+    fn read_vendor_secret_prod_partition_digest_digest_1(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read otp::vendor_secret_prod_partition_digest_digest_1");
         }
@@ -1325,7 +1420,7 @@ pub trait OtpPeripheral {
     }
     fn read_vendor_non_secret_prod_partition_digest_digest_0(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read otp::vendor_non_secret_prod_partition_digest_digest_0");
         }
@@ -1336,7 +1431,7 @@ pub trait OtpPeripheral {
     }
     fn read_vendor_non_secret_prod_partition_digest_digest_1(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read otp::vendor_non_secret_prod_partition_digest_digest_1");
         }
@@ -1348,170 +1443,210 @@ pub trait OtpPeripheral {
 }
 #[derive(Clone, Debug)]
 pub struct OtpGenerated {
-    interrupt_state: caliptra_emu_types::RvData,
-    otp_interrupt_enable: caliptra_emu_types::RvData,
-    interrupt_test: caliptra_emu_types::RvData,
-    alert_test: caliptra_emu_types::RvData,
-    otp_status: caliptra_emu_types::RvData,
-    direct_access_regwen: caliptra_emu_types::RvData,
-    direct_access_cmd: caliptra_emu_types::RvData,
-    direct_access_address: caliptra_emu_types::RvData,
-    check_trigger_regwen: caliptra_emu_types::RvData,
-    check_trigger: caliptra_emu_types::RvData,
-    check_regwen: caliptra_emu_types::RvData,
-    check_timeout: caliptra_emu_types::RvData,
-    integrity_check_period: caliptra_emu_types::RvData,
-    consistency_check_period: caliptra_emu_types::RvData,
-    sw_manuf_partition_read_lock: caliptra_emu_types::RvData,
-    svn_partition_read_lock: caliptra_emu_types::RvData,
-    vendor_test_partition_read_lock: caliptra_emu_types::RvData,
-    vendor_hashes_manuf_partition_read_lock: caliptra_emu_types::RvData,
-    vendor_hashes_prod_partition_read_lock: caliptra_emu_types::RvData,
-    vendor_revocations_prod_partition_read_lock: caliptra_emu_types::RvData,
-    vendor_non_secret_prod_partition_read_lock: caliptra_emu_types::RvData,
-    vendor_pk_hash_volatile_lock: caliptra_emu_types::RvData,
-    csr0: caliptra_emu_types::RvData,
-    csr1: caliptra_emu_types::RvData,
-    csr2: caliptra_emu_types::RvData,
-    csr3: caliptra_emu_types::RvData,
-    csr4: caliptra_emu_types::RvData,
-    csr5: caliptra_emu_types::RvData,
-    csr6: caliptra_emu_types::RvData,
-    csr7: caliptra_emu_types::RvData,
-    err_code_rf_err_code_0: caliptra_emu_types::RvData,
-    err_code_rf_err_code_1: caliptra_emu_types::RvData,
-    err_code_rf_err_code_2: caliptra_emu_types::RvData,
-    err_code_rf_err_code_3: caliptra_emu_types::RvData,
-    err_code_rf_err_code_4: caliptra_emu_types::RvData,
-    err_code_rf_err_code_5: caliptra_emu_types::RvData,
-    err_code_rf_err_code_6: caliptra_emu_types::RvData,
-    err_code_rf_err_code_7: caliptra_emu_types::RvData,
-    err_code_rf_err_code_8: caliptra_emu_types::RvData,
-    err_code_rf_err_code_9: caliptra_emu_types::RvData,
-    err_code_rf_err_code_10: caliptra_emu_types::RvData,
-    err_code_rf_err_code_11: caliptra_emu_types::RvData,
-    err_code_rf_err_code_12: caliptra_emu_types::RvData,
-    err_code_rf_err_code_13: caliptra_emu_types::RvData,
-    err_code_rf_err_code_14: caliptra_emu_types::RvData,
-    err_code_rf_err_code_15: caliptra_emu_types::RvData,
-    err_code_rf_err_code_16: caliptra_emu_types::RvData,
-    err_code_rf_err_code_17: caliptra_emu_types::RvData,
-    dai_wdata_rf_direct_access_wdata_0: caliptra_emu_types::RvData,
-    dai_wdata_rf_direct_access_wdata_1: caliptra_emu_types::RvData,
-    dai_rdata_rf_direct_access_rdata_0: caliptra_emu_types::RvData,
-    dai_rdata_rf_direct_access_rdata_1: caliptra_emu_types::RvData,
-    sw_test_unlock_partition_digest_digest_0: caliptra_emu_types::RvData,
-    sw_test_unlock_partition_digest_digest_1: caliptra_emu_types::RvData,
-    secret_manuf_partition_digest_digest_0: caliptra_emu_types::RvData,
-    secret_manuf_partition_digest_digest_1: caliptra_emu_types::RvData,
-    secret_prod_partition_0_digest_digest_0: caliptra_emu_types::RvData,
-    secret_prod_partition_0_digest_digest_1: caliptra_emu_types::RvData,
-    secret_prod_partition_1_digest_digest_0: caliptra_emu_types::RvData,
-    secret_prod_partition_1_digest_digest_1: caliptra_emu_types::RvData,
-    secret_prod_partition_2_digest_digest_0: caliptra_emu_types::RvData,
-    secret_prod_partition_2_digest_digest_1: caliptra_emu_types::RvData,
-    secret_prod_partition_3_digest_digest_0: caliptra_emu_types::RvData,
-    secret_prod_partition_3_digest_digest_1: caliptra_emu_types::RvData,
-    sw_manuf_partition_digest_digest_0: caliptra_emu_types::RvData,
-    sw_manuf_partition_digest_digest_1: caliptra_emu_types::RvData,
-    secret_lc_transition_partition_digest_digest_0: caliptra_emu_types::RvData,
-    secret_lc_transition_partition_digest_digest_1: caliptra_emu_types::RvData,
-    vendor_test_partition_digest_digest_0: caliptra_emu_types::RvData,
-    vendor_test_partition_digest_digest_1: caliptra_emu_types::RvData,
-    vendor_hashes_manuf_partition_digest_digest_0: caliptra_emu_types::RvData,
-    vendor_hashes_manuf_partition_digest_digest_1: caliptra_emu_types::RvData,
-    vendor_hashes_prod_partition_digest_digest_0: caliptra_emu_types::RvData,
-    vendor_hashes_prod_partition_digest_digest_1: caliptra_emu_types::RvData,
-    vendor_revocations_prod_partition_digest_digest_0: caliptra_emu_types::RvData,
-    vendor_revocations_prod_partition_digest_digest_1: caliptra_emu_types::RvData,
-    vendor_secret_prod_partition_digest_digest_0: caliptra_emu_types::RvData,
-    vendor_secret_prod_partition_digest_digest_1: caliptra_emu_types::RvData,
-    vendor_non_secret_prod_partition_digest_digest_0: caliptra_emu_types::RvData,
-    vendor_non_secret_prod_partition_digest_digest_1: caliptra_emu_types::RvData,
+    interrupt_state: caliptra_core_tools::caliptra_emu_types::RvData,
+    otp_interrupt_enable: caliptra_core_tools::caliptra_emu_types::RvData,
+    interrupt_test: caliptra_core_tools::caliptra_emu_types::RvData,
+    alert_test: caliptra_core_tools::caliptra_emu_types::RvData,
+    otp_status: caliptra_core_tools::caliptra_emu_types::RvData,
+    direct_access_regwen: caliptra_core_tools::caliptra_emu_types::RvData,
+    direct_access_cmd: caliptra_core_tools::caliptra_emu_types::RvData,
+    direct_access_address: caliptra_core_tools::caliptra_emu_types::RvData,
+    check_trigger_regwen: caliptra_core_tools::caliptra_emu_types::RvData,
+    check_trigger: caliptra_core_tools::caliptra_emu_types::RvData,
+    check_regwen: caliptra_core_tools::caliptra_emu_types::RvData,
+    check_timeout: caliptra_core_tools::caliptra_emu_types::RvData,
+    integrity_check_period: caliptra_core_tools::caliptra_emu_types::RvData,
+    consistency_check_period: caliptra_core_tools::caliptra_emu_types::RvData,
+    sw_manuf_partition_read_lock: caliptra_core_tools::caliptra_emu_types::RvData,
+    svn_partition_read_lock: caliptra_core_tools::caliptra_emu_types::RvData,
+    vendor_test_partition_read_lock: caliptra_core_tools::caliptra_emu_types::RvData,
+    vendor_hashes_manuf_partition_read_lock: caliptra_core_tools::caliptra_emu_types::RvData,
+    vendor_hashes_prod_partition_read_lock: caliptra_core_tools::caliptra_emu_types::RvData,
+    vendor_revocations_prod_partition_read_lock: caliptra_core_tools::caliptra_emu_types::RvData,
+    vendor_non_secret_prod_partition_read_lock: caliptra_core_tools::caliptra_emu_types::RvData,
+    vendor_pk_hash_volatile_lock: caliptra_core_tools::caliptra_emu_types::RvData,
+    csr0: caliptra_core_tools::caliptra_emu_types::RvData,
+    csr1: caliptra_core_tools::caliptra_emu_types::RvData,
+    csr2: caliptra_core_tools::caliptra_emu_types::RvData,
+    csr3: caliptra_core_tools::caliptra_emu_types::RvData,
+    csr4: caliptra_core_tools::caliptra_emu_types::RvData,
+    csr5: caliptra_core_tools::caliptra_emu_types::RvData,
+    csr6: caliptra_core_tools::caliptra_emu_types::RvData,
+    csr7: caliptra_core_tools::caliptra_emu_types::RvData,
+    err_code_rf_err_code_0: caliptra_core_tools::caliptra_emu_types::RvData,
+    err_code_rf_err_code_1: caliptra_core_tools::caliptra_emu_types::RvData,
+    err_code_rf_err_code_2: caliptra_core_tools::caliptra_emu_types::RvData,
+    err_code_rf_err_code_3: caliptra_core_tools::caliptra_emu_types::RvData,
+    err_code_rf_err_code_4: caliptra_core_tools::caliptra_emu_types::RvData,
+    err_code_rf_err_code_5: caliptra_core_tools::caliptra_emu_types::RvData,
+    err_code_rf_err_code_6: caliptra_core_tools::caliptra_emu_types::RvData,
+    err_code_rf_err_code_7: caliptra_core_tools::caliptra_emu_types::RvData,
+    err_code_rf_err_code_8: caliptra_core_tools::caliptra_emu_types::RvData,
+    err_code_rf_err_code_9: caliptra_core_tools::caliptra_emu_types::RvData,
+    err_code_rf_err_code_10: caliptra_core_tools::caliptra_emu_types::RvData,
+    err_code_rf_err_code_11: caliptra_core_tools::caliptra_emu_types::RvData,
+    err_code_rf_err_code_12: caliptra_core_tools::caliptra_emu_types::RvData,
+    err_code_rf_err_code_13: caliptra_core_tools::caliptra_emu_types::RvData,
+    err_code_rf_err_code_14: caliptra_core_tools::caliptra_emu_types::RvData,
+    err_code_rf_err_code_15: caliptra_core_tools::caliptra_emu_types::RvData,
+    err_code_rf_err_code_16: caliptra_core_tools::caliptra_emu_types::RvData,
+    err_code_rf_err_code_17: caliptra_core_tools::caliptra_emu_types::RvData,
+    dai_wdata_rf_direct_access_wdata_0: caliptra_core_tools::caliptra_emu_types::RvData,
+    dai_wdata_rf_direct_access_wdata_1: caliptra_core_tools::caliptra_emu_types::RvData,
+    dai_rdata_rf_direct_access_rdata_0: caliptra_core_tools::caliptra_emu_types::RvData,
+    dai_rdata_rf_direct_access_rdata_1: caliptra_core_tools::caliptra_emu_types::RvData,
+    sw_test_unlock_partition_digest_digest_0: caliptra_core_tools::caliptra_emu_types::RvData,
+    sw_test_unlock_partition_digest_digest_1: caliptra_core_tools::caliptra_emu_types::RvData,
+    secret_manuf_partition_digest_digest_0: caliptra_core_tools::caliptra_emu_types::RvData,
+    secret_manuf_partition_digest_digest_1: caliptra_core_tools::caliptra_emu_types::RvData,
+    secret_prod_partition_0_digest_digest_0: caliptra_core_tools::caliptra_emu_types::RvData,
+    secret_prod_partition_0_digest_digest_1: caliptra_core_tools::caliptra_emu_types::RvData,
+    secret_prod_partition_1_digest_digest_0: caliptra_core_tools::caliptra_emu_types::RvData,
+    secret_prod_partition_1_digest_digest_1: caliptra_core_tools::caliptra_emu_types::RvData,
+    secret_prod_partition_2_digest_digest_0: caliptra_core_tools::caliptra_emu_types::RvData,
+    secret_prod_partition_2_digest_digest_1: caliptra_core_tools::caliptra_emu_types::RvData,
+    secret_prod_partition_3_digest_digest_0: caliptra_core_tools::caliptra_emu_types::RvData,
+    secret_prod_partition_3_digest_digest_1: caliptra_core_tools::caliptra_emu_types::RvData,
+    sw_manuf_partition_digest_digest_0: caliptra_core_tools::caliptra_emu_types::RvData,
+    sw_manuf_partition_digest_digest_1: caliptra_core_tools::caliptra_emu_types::RvData,
+    secret_lc_transition_partition_digest_digest_0: caliptra_core_tools::caliptra_emu_types::RvData,
+    secret_lc_transition_partition_digest_digest_1: caliptra_core_tools::caliptra_emu_types::RvData,
+    vendor_test_partition_digest_digest_0: caliptra_core_tools::caliptra_emu_types::RvData,
+    vendor_test_partition_digest_digest_1: caliptra_core_tools::caliptra_emu_types::RvData,
+    vendor_hashes_manuf_partition_digest_digest_0: caliptra_core_tools::caliptra_emu_types::RvData,
+    vendor_hashes_manuf_partition_digest_digest_1: caliptra_core_tools::caliptra_emu_types::RvData,
+    vendor_hashes_prod_partition_digest_digest_0: caliptra_core_tools::caliptra_emu_types::RvData,
+    vendor_hashes_prod_partition_digest_digest_1: caliptra_core_tools::caliptra_emu_types::RvData,
+    vendor_revocations_prod_partition_digest_digest_0:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    vendor_revocations_prod_partition_digest_digest_1:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    vendor_secret_prod_partition_digest_digest_0: caliptra_core_tools::caliptra_emu_types::RvData,
+    vendor_secret_prod_partition_digest_digest_1: caliptra_core_tools::caliptra_emu_types::RvData,
+    vendor_non_secret_prod_partition_digest_digest_0:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    vendor_non_secret_prod_partition_digest_digest_1:
+        caliptra_core_tools::caliptra_emu_types::RvData,
 }
 impl Default for OtpGenerated {
     fn default() -> Self {
         Self {
-            interrupt_state: 0 as caliptra_emu_types::RvData,
-            otp_interrupt_enable: 0 as caliptra_emu_types::RvData,
-            interrupt_test: 0 as caliptra_emu_types::RvData,
-            alert_test: 0 as caliptra_emu_types::RvData,
-            otp_status: 0 as caliptra_emu_types::RvData,
-            direct_access_regwen: 0 as caliptra_emu_types::RvData,
-            direct_access_cmd: 0 as caliptra_emu_types::RvData,
-            direct_access_address: 0 as caliptra_emu_types::RvData,
-            check_trigger_regwen: 0 as caliptra_emu_types::RvData,
-            check_trigger: 0 as caliptra_emu_types::RvData,
-            check_regwen: 0 as caliptra_emu_types::RvData,
-            check_timeout: 0 as caliptra_emu_types::RvData,
-            integrity_check_period: 0 as caliptra_emu_types::RvData,
-            consistency_check_period: 0 as caliptra_emu_types::RvData,
-            sw_manuf_partition_read_lock: 0 as caliptra_emu_types::RvData,
-            svn_partition_read_lock: 0 as caliptra_emu_types::RvData,
-            vendor_test_partition_read_lock: 0 as caliptra_emu_types::RvData,
-            vendor_hashes_manuf_partition_read_lock: 0 as caliptra_emu_types::RvData,
-            vendor_hashes_prod_partition_read_lock: 0 as caliptra_emu_types::RvData,
-            vendor_revocations_prod_partition_read_lock: 0 as caliptra_emu_types::RvData,
-            vendor_non_secret_prod_partition_read_lock: 0 as caliptra_emu_types::RvData,
-            vendor_pk_hash_volatile_lock: 0 as caliptra_emu_types::RvData,
-            csr0: 0 as caliptra_emu_types::RvData,
-            csr1: 0 as caliptra_emu_types::RvData,
-            csr2: 0 as caliptra_emu_types::RvData,
-            csr3: 0 as caliptra_emu_types::RvData,
-            csr4: 0 as caliptra_emu_types::RvData,
-            csr5: 0 as caliptra_emu_types::RvData,
-            csr6: 0 as caliptra_emu_types::RvData,
-            csr7: 0 as caliptra_emu_types::RvData,
-            err_code_rf_err_code_0: 0 as caliptra_emu_types::RvData,
-            err_code_rf_err_code_1: 0 as caliptra_emu_types::RvData,
-            err_code_rf_err_code_2: 0 as caliptra_emu_types::RvData,
-            err_code_rf_err_code_3: 0 as caliptra_emu_types::RvData,
-            err_code_rf_err_code_4: 0 as caliptra_emu_types::RvData,
-            err_code_rf_err_code_5: 0 as caliptra_emu_types::RvData,
-            err_code_rf_err_code_6: 0 as caliptra_emu_types::RvData,
-            err_code_rf_err_code_7: 0 as caliptra_emu_types::RvData,
-            err_code_rf_err_code_8: 0 as caliptra_emu_types::RvData,
-            err_code_rf_err_code_9: 0 as caliptra_emu_types::RvData,
-            err_code_rf_err_code_10: 0 as caliptra_emu_types::RvData,
-            err_code_rf_err_code_11: 0 as caliptra_emu_types::RvData,
-            err_code_rf_err_code_12: 0 as caliptra_emu_types::RvData,
-            err_code_rf_err_code_13: 0 as caliptra_emu_types::RvData,
-            err_code_rf_err_code_14: 0 as caliptra_emu_types::RvData,
-            err_code_rf_err_code_15: 0 as caliptra_emu_types::RvData,
-            err_code_rf_err_code_16: 0 as caliptra_emu_types::RvData,
-            err_code_rf_err_code_17: 0 as caliptra_emu_types::RvData,
-            dai_wdata_rf_direct_access_wdata_0: 0 as caliptra_emu_types::RvData,
-            dai_wdata_rf_direct_access_wdata_1: 0 as caliptra_emu_types::RvData,
-            dai_rdata_rf_direct_access_rdata_0: 0 as caliptra_emu_types::RvData,
-            dai_rdata_rf_direct_access_rdata_1: 0 as caliptra_emu_types::RvData,
-            sw_test_unlock_partition_digest_digest_0: 0 as caliptra_emu_types::RvData,
-            sw_test_unlock_partition_digest_digest_1: 0 as caliptra_emu_types::RvData,
-            secret_manuf_partition_digest_digest_0: 0 as caliptra_emu_types::RvData,
-            secret_manuf_partition_digest_digest_1: 0 as caliptra_emu_types::RvData,
-            secret_prod_partition_0_digest_digest_0: 0 as caliptra_emu_types::RvData,
-            secret_prod_partition_0_digest_digest_1: 0 as caliptra_emu_types::RvData,
-            secret_prod_partition_1_digest_digest_0: 0 as caliptra_emu_types::RvData,
-            secret_prod_partition_1_digest_digest_1: 0 as caliptra_emu_types::RvData,
-            secret_prod_partition_2_digest_digest_0: 0 as caliptra_emu_types::RvData,
-            secret_prod_partition_2_digest_digest_1: 0 as caliptra_emu_types::RvData,
-            secret_prod_partition_3_digest_digest_0: 0 as caliptra_emu_types::RvData,
-            secret_prod_partition_3_digest_digest_1: 0 as caliptra_emu_types::RvData,
-            sw_manuf_partition_digest_digest_0: 0 as caliptra_emu_types::RvData,
-            sw_manuf_partition_digest_digest_1: 0 as caliptra_emu_types::RvData,
-            secret_lc_transition_partition_digest_digest_0: 0 as caliptra_emu_types::RvData,
-            secret_lc_transition_partition_digest_digest_1: 0 as caliptra_emu_types::RvData,
-            vendor_test_partition_digest_digest_0: 0 as caliptra_emu_types::RvData,
-            vendor_test_partition_digest_digest_1: 0 as caliptra_emu_types::RvData,
-            vendor_hashes_manuf_partition_digest_digest_0: 0 as caliptra_emu_types::RvData,
-            vendor_hashes_manuf_partition_digest_digest_1: 0 as caliptra_emu_types::RvData,
-            vendor_hashes_prod_partition_digest_digest_0: 0 as caliptra_emu_types::RvData,
-            vendor_hashes_prod_partition_digest_digest_1: 0 as caliptra_emu_types::RvData,
-            vendor_revocations_prod_partition_digest_digest_0: 0 as caliptra_emu_types::RvData,
-            vendor_revocations_prod_partition_digest_digest_1: 0 as caliptra_emu_types::RvData,
-            vendor_secret_prod_partition_digest_digest_0: 0 as caliptra_emu_types::RvData,
-            vendor_secret_prod_partition_digest_digest_1: 0 as caliptra_emu_types::RvData,
-            vendor_non_secret_prod_partition_digest_digest_0: 0 as caliptra_emu_types::RvData,
-            vendor_non_secret_prod_partition_digest_digest_1: 0 as caliptra_emu_types::RvData,
+            interrupt_state: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            otp_interrupt_enable: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            interrupt_test: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            alert_test: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            otp_status: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            direct_access_regwen: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            direct_access_cmd: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            direct_access_address: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            check_trigger_regwen: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            check_trigger: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            check_regwen: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            check_timeout: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            integrity_check_period: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            consistency_check_period: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            sw_manuf_partition_read_lock: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            svn_partition_read_lock: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            vendor_test_partition_read_lock: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            vendor_hashes_manuf_partition_read_lock: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            vendor_hashes_prod_partition_read_lock: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            vendor_revocations_prod_partition_read_lock: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            vendor_non_secret_prod_partition_read_lock: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            vendor_pk_hash_volatile_lock: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            csr0: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            csr1: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            csr2: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            csr3: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            csr4: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            csr5: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            csr6: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            csr7: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            err_code_rf_err_code_0: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            err_code_rf_err_code_1: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            err_code_rf_err_code_2: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            err_code_rf_err_code_3: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            err_code_rf_err_code_4: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            err_code_rf_err_code_5: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            err_code_rf_err_code_6: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            err_code_rf_err_code_7: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            err_code_rf_err_code_8: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            err_code_rf_err_code_9: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            err_code_rf_err_code_10: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            err_code_rf_err_code_11: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            err_code_rf_err_code_12: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            err_code_rf_err_code_13: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            err_code_rf_err_code_14: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            err_code_rf_err_code_15: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            err_code_rf_err_code_16: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            err_code_rf_err_code_17: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            dai_wdata_rf_direct_access_wdata_0: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            dai_wdata_rf_direct_access_wdata_1: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            dai_rdata_rf_direct_access_rdata_0: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            dai_rdata_rf_direct_access_rdata_1: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            sw_test_unlock_partition_digest_digest_0: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            sw_test_unlock_partition_digest_digest_1: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            secret_manuf_partition_digest_digest_0: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            secret_manuf_partition_digest_digest_1: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            secret_prod_partition_0_digest_digest_0: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            secret_prod_partition_0_digest_digest_1: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            secret_prod_partition_1_digest_digest_0: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            secret_prod_partition_1_digest_digest_1: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            secret_prod_partition_2_digest_digest_0: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            secret_prod_partition_2_digest_digest_1: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            secret_prod_partition_3_digest_digest_0: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            secret_prod_partition_3_digest_digest_1: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            sw_manuf_partition_digest_digest_0: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            sw_manuf_partition_digest_digest_1: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            secret_lc_transition_partition_digest_digest_0: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            secret_lc_transition_partition_digest_digest_1: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            vendor_test_partition_digest_digest_0: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            vendor_test_partition_digest_digest_1: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            vendor_hashes_manuf_partition_digest_digest_0: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            vendor_hashes_manuf_partition_digest_digest_1: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            vendor_hashes_prod_partition_digest_digest_0: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            vendor_hashes_prod_partition_digest_digest_1: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            vendor_revocations_prod_partition_digest_digest_0: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            vendor_revocations_prod_partition_digest_digest_1: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            vendor_secret_prod_partition_digest_digest_0: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            vendor_secret_prod_partition_digest_digest_1: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            vendor_non_secret_prod_partition_digest_digest_0: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            vendor_non_secret_prod_partition_digest_digest_1: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
         }
     }
 }
@@ -1535,18 +1670,18 @@ impl OtpPeripheral for OtpGenerated {
     }
     fn read_interrupt_state(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::InterruptState::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read otp::interrupt_state");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.interrupt_state)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.interrupt_state)
     }
     fn write_interrupt_state(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::otp_ctrl::bits::InterruptState::Register,
         >,
@@ -1557,29 +1692,29 @@ impl OtpPeripheral for OtpGenerated {
                 val.reg.get()
             );
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.interrupt_state;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(2 as caliptra_emu_types::RvData))
-            | (write_val & (2 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(2 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.interrupt_state = new_val;
     }
     fn read_otp_interrupt_enable(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::OtpInterruptEnable::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read otp::otp_interrupt_enable");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.otp_interrupt_enable)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.otp_interrupt_enable)
     }
     fn write_otp_interrupt_enable(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::otp_ctrl::bits::OtpInterruptEnable::Register,
         >,
@@ -1587,18 +1722,18 @@ impl OtpPeripheral for OtpGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write otp::otp_interrupt_enable = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.otp_interrupt_enable;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(2 as caliptra_emu_types::RvData))
-            | (write_val & (2 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(2 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.otp_interrupt_enable = new_val;
     }
     fn write_interrupt_test(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::otp_ctrl::bits::InterruptTest::Register,
         >,
@@ -1609,18 +1744,18 @@ impl OtpPeripheral for OtpGenerated {
                 val.reg.get()
             );
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.interrupt_test;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(2 as caliptra_emu_types::RvData))
-            | (write_val & (2 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(2 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.interrupt_test = new_val;
     }
     fn write_alert_test(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::otp_ctrl::bits::AlertTest::Register,
         >,
@@ -1631,46 +1766,46 @@ impl OtpPeripheral for OtpGenerated {
                 val.reg.get()
             );
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.alert_test;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(2 as caliptra_emu_types::RvData))
-            | (write_val & (2 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(4 as caliptra_emu_types::RvData))
-            | (write_val & (4 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(8 as caliptra_emu_types::RvData))
-            | (write_val & (8 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x10 as caliptra_emu_types::RvData))
-            | (write_val & (0x10 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(2 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(4 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (4 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(8 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (8 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x10 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x10 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.alert_test = new_val;
     }
     fn read_otp_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::OtpStatus::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read otp::otp_status");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.otp_status)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.otp_status)
     }
     fn read_direct_access_regwen(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::DirectAccessRegwen::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read otp::direct_access_regwen");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.direct_access_regwen)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.direct_access_regwen)
     }
     fn write_direct_access_regwen(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::otp_ctrl::bits::DirectAccessRegwen::Register,
         >,
@@ -1678,16 +1813,16 @@ impl OtpPeripheral for OtpGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write otp::direct_access_regwen = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.direct_access_regwen;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.direct_access_regwen = new_val;
     }
     fn write_direct_access_cmd(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::otp_ctrl::bits::DirectAccessCmd::Register,
         >,
@@ -1698,31 +1833,31 @@ impl OtpPeripheral for OtpGenerated {
                 val.reg.get()
             );
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.direct_access_cmd;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(2 as caliptra_emu_types::RvData))
-            | (write_val & (2 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(4 as caliptra_emu_types::RvData))
-            | (write_val & (4 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(2 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(4 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (4 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.direct_access_cmd = new_val;
     }
     fn read_direct_access_address(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::DirectAccessAddress::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read otp::direct_access_address");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.direct_access_address)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.direct_access_address)
     }
     fn write_direct_access_address(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::otp_ctrl::bits::DirectAccessAddress::Register,
         >,
@@ -1730,27 +1865,27 @@ impl OtpPeripheral for OtpGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write otp::direct_access_address = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.direct_access_address;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xfff as caliptra_emu_types::RvData))
-            | (write_val & (0xfff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xfff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xfff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.direct_access_address = new_val;
     }
     fn read_check_trigger_regwen(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::CheckTriggerRegwen::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read otp::check_trigger_regwen");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.check_trigger_regwen)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.check_trigger_regwen)
     }
     fn write_check_trigger_regwen(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::otp_ctrl::bits::CheckTriggerRegwen::Register,
         >,
@@ -1758,16 +1893,16 @@ impl OtpPeripheral for OtpGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write otp::check_trigger_regwen = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.check_trigger_regwen;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.check_trigger_regwen = new_val;
     }
     fn write_check_trigger(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::otp_ctrl::bits::CheckTrigger::Register,
         >,
@@ -1778,18 +1913,18 @@ impl OtpPeripheral for OtpGenerated {
                 val.reg.get()
             );
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.check_trigger;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(2 as caliptra_emu_types::RvData))
-            | (write_val & (2 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(2 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.check_trigger = new_val;
     }
     fn write_check_regwen(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::otp_ctrl::bits::CheckRegwen::Register,
         >,
@@ -1800,51 +1935,54 @@ impl OtpPeripheral for OtpGenerated {
                 val.reg.get()
             );
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.check_regwen;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.check_regwen = new_val;
     }
-    fn read_check_timeout(&mut self) -> caliptra_emu_types::RvData {
+    fn read_check_timeout(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read otp::check_timeout");
         }
         self.check_timeout
     }
-    fn write_check_timeout(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_check_timeout(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: write otp::check_timeout = 0x{:08x}",
                 val
             );
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.check_timeout;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.check_timeout = new_val;
     }
-    fn read_integrity_check_period(&mut self) -> caliptra_emu_types::RvData {
+    fn read_integrity_check_period(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read otp::integrity_check_period");
         }
         self.integrity_check_period
     }
-    fn write_integrity_check_period(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_integrity_check_period(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write otp::integrity_check_period = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.integrity_check_period;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.integrity_check_period = new_val;
     }
-    fn read_consistency_check_period(&mut self) -> caliptra_emu_types::RvData {
+    fn read_consistency_check_period(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read otp::consistency_check_period"
@@ -1852,20 +1990,23 @@ impl OtpPeripheral for OtpGenerated {
         }
         self.consistency_check_period
     }
-    fn write_consistency_check_period(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_consistency_check_period(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write otp::consistency_check_period = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.consistency_check_period;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.consistency_check_period = new_val;
     }
     fn read_sw_manuf_partition_read_lock(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::SwManufPartitionReadLock::Register,
     > {
@@ -1874,11 +2015,13 @@ impl OtpPeripheral for OtpGenerated {
                 "[EMU] Generated default register handler: read otp::sw_manuf_partition_read_lock"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.sw_manuf_partition_read_lock)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.sw_manuf_partition_read_lock,
+        )
     }
     fn write_sw_manuf_partition_read_lock(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::otp_ctrl::bits::SwManufPartitionReadLock::Register,
         >,
@@ -1886,16 +2029,16 @@ impl OtpPeripheral for OtpGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write otp::sw_manuf_partition_read_lock = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.sw_manuf_partition_read_lock;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.sw_manuf_partition_read_lock = new_val;
     }
     fn read_svn_partition_read_lock(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::SvnPartitionReadLock::Register,
     > {
@@ -1904,11 +2047,11 @@ impl OtpPeripheral for OtpGenerated {
                 "[EMU] Generated default register handler: read otp::svn_partition_read_lock"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.svn_partition_read_lock)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.svn_partition_read_lock)
     }
     fn write_svn_partition_read_lock(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::otp_ctrl::bits::SvnPartitionReadLock::Register,
         >,
@@ -1916,27 +2059,29 @@ impl OtpPeripheral for OtpGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write otp::svn_partition_read_lock = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.svn_partition_read_lock;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.svn_partition_read_lock = new_val;
     }
     fn read_vendor_test_partition_read_lock(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::VendorTestPartitionReadLock::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read otp::vendor_test_partition_read_lock");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.vendor_test_partition_read_lock)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.vendor_test_partition_read_lock,
+        )
     }
     fn write_vendor_test_partition_read_lock(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::otp_ctrl::bits::VendorTestPartitionReadLock::Register,
         >,
@@ -1944,27 +2089,29 @@ impl OtpPeripheral for OtpGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write otp::vendor_test_partition_read_lock = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.vendor_test_partition_read_lock;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.vendor_test_partition_read_lock = new_val;
     }
     fn read_vendor_hashes_manuf_partition_read_lock(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::VendorHashesManufPartitionReadLock::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read otp::vendor_hashes_manuf_partition_read_lock");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.vendor_hashes_manuf_partition_read_lock)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.vendor_hashes_manuf_partition_read_lock,
+        )
     }
     fn write_vendor_hashes_manuf_partition_read_lock(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::otp_ctrl::bits::VendorHashesManufPartitionReadLock::Register,
         >,
@@ -1972,27 +2119,29 @@ impl OtpPeripheral for OtpGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write otp::vendor_hashes_manuf_partition_read_lock = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.vendor_hashes_manuf_partition_read_lock;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.vendor_hashes_manuf_partition_read_lock = new_val;
     }
     fn read_vendor_hashes_prod_partition_read_lock(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::VendorHashesProdPartitionReadLock::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read otp::vendor_hashes_prod_partition_read_lock");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.vendor_hashes_prod_partition_read_lock)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.vendor_hashes_prod_partition_read_lock,
+        )
     }
     fn write_vendor_hashes_prod_partition_read_lock(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::otp_ctrl::bits::VendorHashesProdPartitionReadLock::Register,
         >,
@@ -2000,27 +2149,29 @@ impl OtpPeripheral for OtpGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write otp::vendor_hashes_prod_partition_read_lock = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.vendor_hashes_prod_partition_read_lock;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.vendor_hashes_prod_partition_read_lock = new_val;
     }
     fn read_vendor_revocations_prod_partition_read_lock(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::VendorRevocationsProdPartitionReadLock::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read otp::vendor_revocations_prod_partition_read_lock");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.vendor_revocations_prod_partition_read_lock)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.vendor_revocations_prod_partition_read_lock,
+        )
     }
     fn write_vendor_revocations_prod_partition_read_lock(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::otp_ctrl::bits::VendorRevocationsProdPartitionReadLock::Register,
         >,
@@ -2028,27 +2179,29 @@ impl OtpPeripheral for OtpGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write otp::vendor_revocations_prod_partition_read_lock = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.vendor_revocations_prod_partition_read_lock;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.vendor_revocations_prod_partition_read_lock = new_val;
     }
     fn read_vendor_non_secret_prod_partition_read_lock(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::VendorNonSecretProdPartitionReadLock::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read otp::vendor_non_secret_prod_partition_read_lock");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.vendor_non_secret_prod_partition_read_lock)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.vendor_non_secret_prod_partition_read_lock,
+        )
     }
     fn write_vendor_non_secret_prod_partition_read_lock(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::otp_ctrl::bits::VendorNonSecretProdPartitionReadLock::Register,
         >,
@@ -2056,14 +2209,16 @@ impl OtpPeripheral for OtpGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write otp::vendor_non_secret_prod_partition_read_lock = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.vendor_non_secret_prod_partition_read_lock;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.vendor_non_secret_prod_partition_read_lock = new_val;
     }
-    fn read_vendor_pk_hash_volatile_lock(&mut self) -> caliptra_emu_types::RvData {
+    fn read_vendor_pk_hash_volatile_lock(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read otp::vendor_pk_hash_volatile_lock"
@@ -2071,29 +2226,34 @@ impl OtpPeripheral for OtpGenerated {
         }
         self.vendor_pk_hash_volatile_lock
     }
-    fn write_vendor_pk_hash_volatile_lock(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_vendor_pk_hash_volatile_lock(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write otp::vendor_pk_hash_volatile_lock = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.vendor_pk_hash_volatile_lock;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.vendor_pk_hash_volatile_lock = new_val;
     }
     fn read_csr0(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::otp_ctrl::bits::Csr0::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::otp_ctrl::bits::Csr0::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read otp::csr0");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.csr0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.csr0)
     }
     fn write_csr0(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::otp_ctrl::bits::Csr0::Register,
         >,
@@ -2104,33 +2264,35 @@ impl OtpPeripheral for OtpGenerated {
                 val.reg.get()
             );
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.csr0;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(2 as caliptra_emu_types::RvData))
-            | (write_val & (2 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(4 as caliptra_emu_types::RvData))
-            | (write_val & (4 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x3ff0 as caliptra_emu_types::RvData))
-            | (write_val & (0x3ff0 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x7ff_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x7ff_0000 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(2 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(4 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (4 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x3ff0 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x3ff0 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x7ff_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x7ff_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.csr0 = new_val;
     }
     fn read_csr1(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::otp_ctrl::bits::Csr1::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::otp_ctrl::bits::Csr1::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read otp::csr1");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.csr1)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.csr1)
     }
     fn write_csr1(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::otp_ctrl::bits::Csr1::Register,
         >,
@@ -2141,33 +2303,35 @@ impl OtpPeripheral for OtpGenerated {
                 val.reg.get()
             );
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.csr1;
         let mut new_val = current_val;
-        new_val = (new_val & !(0x7f as caliptra_emu_types::RvData))
-            | (write_val & (0x7f as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x80 as caliptra_emu_types::RvData))
-            | (write_val & (0x80 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x7f00 as caliptra_emu_types::RvData))
-            | (write_val & (0x7f00 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x8000 as caliptra_emu_types::RvData))
-            | (write_val & (0x8000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xffff_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_0000 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x7f as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x7f as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x80 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x80 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x7f00 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x7f00 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x8000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x8000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.csr1 = new_val;
     }
     fn read_csr2(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::otp_ctrl::bits::Csr2::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::otp_ctrl::bits::Csr2::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read otp::csr2");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.csr2)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.csr2)
     }
     fn write_csr2(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::otp_ctrl::bits::Csr2::Register,
         >,
@@ -2178,25 +2342,27 @@ impl OtpPeripheral for OtpGenerated {
                 val.reg.get()
             );
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.csr2;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.csr2 = new_val;
     }
     fn read_csr3(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::otp_ctrl::bits::Csr3::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::otp_ctrl::bits::Csr3::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read otp::csr3");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.csr3)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.csr3)
     }
     fn write_csr3(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::otp_ctrl::bits::Csr3::Register,
         >,
@@ -2207,29 +2373,31 @@ impl OtpPeripheral for OtpGenerated {
                 val.reg.get()
             );
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.csr3;
         let mut new_val = current_val;
-        new_val = (new_val & !(7 as caliptra_emu_types::RvData))
-            | (write_val & (7 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x3ff0 as caliptra_emu_types::RvData))
-            | (write_val & (0x3ff0 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x1_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x1_0000 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(7 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (7 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x3ff0 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x3ff0 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x1_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x1_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.csr3 = new_val;
     }
     fn read_csr4(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::otp_ctrl::bits::Csr4::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::otp_ctrl::bits::Csr4::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read otp::csr4");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.csr4)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.csr4)
     }
     fn write_csr4(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::otp_ctrl::bits::Csr4::Register,
         >,
@@ -2240,31 +2408,33 @@ impl OtpPeripheral for OtpGenerated {
                 val.reg.get()
             );
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.csr4;
         let mut new_val = current_val;
-        new_val = (new_val & !(0x3ff as caliptra_emu_types::RvData))
-            | (write_val & (0x3ff as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x1000 as caliptra_emu_types::RvData))
-            | (write_val & (0x1000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x2000 as caliptra_emu_types::RvData))
-            | (write_val & (0x2000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x4000 as caliptra_emu_types::RvData))
-            | (write_val & (0x4000 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x3ff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x3ff as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x1000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x1000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x2000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x2000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x4000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x4000 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.csr4 = new_val;
     }
     fn read_csr5(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::otp_ctrl::bits::Csr5::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::otp_ctrl::bits::Csr5::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read otp::csr5");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.csr5)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.csr5)
     }
     fn write_csr5(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::otp_ctrl::bits::Csr5::Register,
         >,
@@ -2275,29 +2445,31 @@ impl OtpPeripheral for OtpGenerated {
                 val.reg.get()
             );
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.csr5;
         let mut new_val = current_val;
-        new_val = (new_val & !(0x3f as caliptra_emu_types::RvData))
-            | (write_val & (0x3f as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xc0 as caliptra_emu_types::RvData))
-            | (write_val & (0xc0 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xffff_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_0000 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x3f as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x3f as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xc0 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xc0 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.csr5 = new_val;
     }
     fn read_csr6(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::otp_ctrl::bits::Csr6::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::otp_ctrl::bits::Csr6::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read otp::csr6");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.csr6)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.csr6)
     }
     fn write_csr6(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::otp_ctrl::bits::Csr6::Register,
         >,
@@ -2308,141 +2480,143 @@ impl OtpPeripheral for OtpGenerated {
                 val.reg.get()
             );
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.csr6;
         let mut new_val = current_val;
-        new_val = (new_val & !(0x3ff as caliptra_emu_types::RvData))
-            | (write_val & (0x3ff as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x800 as caliptra_emu_types::RvData))
-            | (write_val & (0x800 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x1000 as caliptra_emu_types::RvData))
-            | (write_val & (0x1000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xffff_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_0000 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x3ff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x3ff as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x800 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x800 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x1000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x1000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.csr6 = new_val;
     }
     fn read_csr7(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<u32, registers_generated::otp_ctrl::bits::Csr7::Register>
-    {
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
+        u32,
+        registers_generated::otp_ctrl::bits::Csr7::Register,
+    > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read otp::csr7");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.csr7)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.csr7)
     }
     fn read_err_code_rf_err_code_0(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read otp::err_code_rf_err_code_0");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.err_code_rf_err_code_0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.err_code_rf_err_code_0)
     }
     fn read_err_code_rf_err_code_1(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read otp::err_code_rf_err_code_1");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.err_code_rf_err_code_1)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.err_code_rf_err_code_1)
     }
     fn read_err_code_rf_err_code_2(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read otp::err_code_rf_err_code_2");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.err_code_rf_err_code_2)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.err_code_rf_err_code_2)
     }
     fn read_err_code_rf_err_code_3(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read otp::err_code_rf_err_code_3");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.err_code_rf_err_code_3)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.err_code_rf_err_code_3)
     }
     fn read_err_code_rf_err_code_4(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read otp::err_code_rf_err_code_4");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.err_code_rf_err_code_4)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.err_code_rf_err_code_4)
     }
     fn read_err_code_rf_err_code_5(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read otp::err_code_rf_err_code_5");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.err_code_rf_err_code_5)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.err_code_rf_err_code_5)
     }
     fn read_err_code_rf_err_code_6(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read otp::err_code_rf_err_code_6");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.err_code_rf_err_code_6)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.err_code_rf_err_code_6)
     }
     fn read_err_code_rf_err_code_7(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read otp::err_code_rf_err_code_7");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.err_code_rf_err_code_7)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.err_code_rf_err_code_7)
     }
     fn read_err_code_rf_err_code_8(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read otp::err_code_rf_err_code_8");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.err_code_rf_err_code_8)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.err_code_rf_err_code_8)
     }
     fn read_err_code_rf_err_code_9(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read otp::err_code_rf_err_code_9");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.err_code_rf_err_code_9)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.err_code_rf_err_code_9)
     }
     fn read_err_code_rf_err_code_10(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
     > {
@@ -2451,11 +2625,11 @@ impl OtpPeripheral for OtpGenerated {
                 "[EMU] Generated default register handler: read otp::err_code_rf_err_code_10"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.err_code_rf_err_code_10)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.err_code_rf_err_code_10)
     }
     fn read_err_code_rf_err_code_11(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
     > {
@@ -2464,11 +2638,11 @@ impl OtpPeripheral for OtpGenerated {
                 "[EMU] Generated default register handler: read otp::err_code_rf_err_code_11"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.err_code_rf_err_code_11)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.err_code_rf_err_code_11)
     }
     fn read_err_code_rf_err_code_12(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
     > {
@@ -2477,11 +2651,11 @@ impl OtpPeripheral for OtpGenerated {
                 "[EMU] Generated default register handler: read otp::err_code_rf_err_code_12"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.err_code_rf_err_code_12)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.err_code_rf_err_code_12)
     }
     fn read_err_code_rf_err_code_13(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
     > {
@@ -2490,11 +2664,11 @@ impl OtpPeripheral for OtpGenerated {
                 "[EMU] Generated default register handler: read otp::err_code_rf_err_code_13"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.err_code_rf_err_code_13)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.err_code_rf_err_code_13)
     }
     fn read_err_code_rf_err_code_14(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
     > {
@@ -2503,11 +2677,11 @@ impl OtpPeripheral for OtpGenerated {
                 "[EMU] Generated default register handler: read otp::err_code_rf_err_code_14"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.err_code_rf_err_code_14)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.err_code_rf_err_code_14)
     }
     fn read_err_code_rf_err_code_15(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
     > {
@@ -2516,11 +2690,11 @@ impl OtpPeripheral for OtpGenerated {
                 "[EMU] Generated default register handler: read otp::err_code_rf_err_code_15"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.err_code_rf_err_code_15)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.err_code_rf_err_code_15)
     }
     fn read_err_code_rf_err_code_16(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
     > {
@@ -2529,11 +2703,11 @@ impl OtpPeripheral for OtpGenerated {
                 "[EMU] Generated default register handler: read otp::err_code_rf_err_code_16"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.err_code_rf_err_code_16)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.err_code_rf_err_code_16)
     }
     fn read_err_code_rf_err_code_17(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::otp_ctrl::bits::ErrCodeRegT::Register,
     > {
@@ -2542,133 +2716,175 @@ impl OtpPeripheral for OtpGenerated {
                 "[EMU] Generated default register handler: read otp::err_code_rf_err_code_17"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.err_code_rf_err_code_17)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.err_code_rf_err_code_17)
     }
-    fn read_dai_wdata_rf_direct_access_wdata_0(&mut self) -> caliptra_emu_types::RvData {
+    fn read_dai_wdata_rf_direct_access_wdata_0(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read otp::dai_wdata_rf_direct_access_wdata_0");
         }
         self.dai_wdata_rf_direct_access_wdata_0
     }
-    fn write_dai_wdata_rf_direct_access_wdata_0(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_dai_wdata_rf_direct_access_wdata_0(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write otp::dai_wdata_rf_direct_access_wdata_0 = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.dai_wdata_rf_direct_access_wdata_0;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.dai_wdata_rf_direct_access_wdata_0 = new_val;
     }
-    fn read_dai_wdata_rf_direct_access_wdata_1(&mut self) -> caliptra_emu_types::RvData {
+    fn read_dai_wdata_rf_direct_access_wdata_1(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read otp::dai_wdata_rf_direct_access_wdata_1");
         }
         self.dai_wdata_rf_direct_access_wdata_1
     }
-    fn write_dai_wdata_rf_direct_access_wdata_1(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_dai_wdata_rf_direct_access_wdata_1(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write otp::dai_wdata_rf_direct_access_wdata_1 = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.dai_wdata_rf_direct_access_wdata_1;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.dai_wdata_rf_direct_access_wdata_1 = new_val;
     }
-    fn read_dai_rdata_rf_direct_access_rdata_0(&mut self) -> caliptra_emu_types::RvData {
+    fn read_dai_rdata_rf_direct_access_rdata_0(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read otp::dai_rdata_rf_direct_access_rdata_0");
         }
         self.dai_rdata_rf_direct_access_rdata_0
     }
-    fn read_dai_rdata_rf_direct_access_rdata_1(&mut self) -> caliptra_emu_types::RvData {
+    fn read_dai_rdata_rf_direct_access_rdata_1(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read otp::dai_rdata_rf_direct_access_rdata_1");
         }
         self.dai_rdata_rf_direct_access_rdata_1
     }
-    fn read_sw_test_unlock_partition_digest_digest_0(&mut self) -> caliptra_emu_types::RvData {
+    fn read_sw_test_unlock_partition_digest_digest_0(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read otp::sw_test_unlock_partition_digest_digest_0");
         }
         self.sw_test_unlock_partition_digest_digest_0
     }
-    fn read_sw_test_unlock_partition_digest_digest_1(&mut self) -> caliptra_emu_types::RvData {
+    fn read_sw_test_unlock_partition_digest_digest_1(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read otp::sw_test_unlock_partition_digest_digest_1");
         }
         self.sw_test_unlock_partition_digest_digest_1
     }
-    fn read_secret_manuf_partition_digest_digest_0(&mut self) -> caliptra_emu_types::RvData {
+    fn read_secret_manuf_partition_digest_digest_0(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read otp::secret_manuf_partition_digest_digest_0");
         }
         self.secret_manuf_partition_digest_digest_0
     }
-    fn read_secret_manuf_partition_digest_digest_1(&mut self) -> caliptra_emu_types::RvData {
+    fn read_secret_manuf_partition_digest_digest_1(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read otp::secret_manuf_partition_digest_digest_1");
         }
         self.secret_manuf_partition_digest_digest_1
     }
-    fn read_secret_prod_partition_0_digest_digest_0(&mut self) -> caliptra_emu_types::RvData {
+    fn read_secret_prod_partition_0_digest_digest_0(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read otp::secret_prod_partition_0_digest_digest_0");
         }
         self.secret_prod_partition_0_digest_digest_0
     }
-    fn read_secret_prod_partition_0_digest_digest_1(&mut self) -> caliptra_emu_types::RvData {
+    fn read_secret_prod_partition_0_digest_digest_1(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read otp::secret_prod_partition_0_digest_digest_1");
         }
         self.secret_prod_partition_0_digest_digest_1
     }
-    fn read_secret_prod_partition_1_digest_digest_0(&mut self) -> caliptra_emu_types::RvData {
+    fn read_secret_prod_partition_1_digest_digest_0(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read otp::secret_prod_partition_1_digest_digest_0");
         }
         self.secret_prod_partition_1_digest_digest_0
     }
-    fn read_secret_prod_partition_1_digest_digest_1(&mut self) -> caliptra_emu_types::RvData {
+    fn read_secret_prod_partition_1_digest_digest_1(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read otp::secret_prod_partition_1_digest_digest_1");
         }
         self.secret_prod_partition_1_digest_digest_1
     }
-    fn read_secret_prod_partition_2_digest_digest_0(&mut self) -> caliptra_emu_types::RvData {
+    fn read_secret_prod_partition_2_digest_digest_0(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read otp::secret_prod_partition_2_digest_digest_0");
         }
         self.secret_prod_partition_2_digest_digest_0
     }
-    fn read_secret_prod_partition_2_digest_digest_1(&mut self) -> caliptra_emu_types::RvData {
+    fn read_secret_prod_partition_2_digest_digest_1(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read otp::secret_prod_partition_2_digest_digest_1");
         }
         self.secret_prod_partition_2_digest_digest_1
     }
-    fn read_secret_prod_partition_3_digest_digest_0(&mut self) -> caliptra_emu_types::RvData {
+    fn read_secret_prod_partition_3_digest_digest_0(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read otp::secret_prod_partition_3_digest_digest_0");
         }
         self.secret_prod_partition_3_digest_digest_0
     }
-    fn read_secret_prod_partition_3_digest_digest_1(&mut self) -> caliptra_emu_types::RvData {
+    fn read_secret_prod_partition_3_digest_digest_1(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read otp::secret_prod_partition_3_digest_digest_1");
         }
         self.secret_prod_partition_3_digest_digest_1
     }
-    fn read_sw_manuf_partition_digest_digest_0(&mut self) -> caliptra_emu_types::RvData {
+    fn read_sw_manuf_partition_digest_digest_0(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read otp::sw_manuf_partition_digest_digest_0");
         }
         self.sw_manuf_partition_digest_digest_0
     }
-    fn read_sw_manuf_partition_digest_digest_1(&mut self) -> caliptra_emu_types::RvData {
+    fn read_sw_manuf_partition_digest_digest_1(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read otp::sw_manuf_partition_digest_digest_1");
         }
@@ -2676,7 +2892,7 @@ impl OtpPeripheral for OtpGenerated {
     }
     fn read_secret_lc_transition_partition_digest_digest_0(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read otp::secret_lc_transition_partition_digest_digest_0");
         }
@@ -2684,43 +2900,55 @@ impl OtpPeripheral for OtpGenerated {
     }
     fn read_secret_lc_transition_partition_digest_digest_1(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read otp::secret_lc_transition_partition_digest_digest_1");
         }
         self.secret_lc_transition_partition_digest_digest_1
     }
-    fn read_vendor_test_partition_digest_digest_0(&mut self) -> caliptra_emu_types::RvData {
+    fn read_vendor_test_partition_digest_digest_0(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read otp::vendor_test_partition_digest_digest_0");
         }
         self.vendor_test_partition_digest_digest_0
     }
-    fn read_vendor_test_partition_digest_digest_1(&mut self) -> caliptra_emu_types::RvData {
+    fn read_vendor_test_partition_digest_digest_1(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read otp::vendor_test_partition_digest_digest_1");
         }
         self.vendor_test_partition_digest_digest_1
     }
-    fn read_vendor_hashes_manuf_partition_digest_digest_0(&mut self) -> caliptra_emu_types::RvData {
+    fn read_vendor_hashes_manuf_partition_digest_digest_0(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read otp::vendor_hashes_manuf_partition_digest_digest_0");
         }
         self.vendor_hashes_manuf_partition_digest_digest_0
     }
-    fn read_vendor_hashes_manuf_partition_digest_digest_1(&mut self) -> caliptra_emu_types::RvData {
+    fn read_vendor_hashes_manuf_partition_digest_digest_1(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read otp::vendor_hashes_manuf_partition_digest_digest_1");
         }
         self.vendor_hashes_manuf_partition_digest_digest_1
     }
-    fn read_vendor_hashes_prod_partition_digest_digest_0(&mut self) -> caliptra_emu_types::RvData {
+    fn read_vendor_hashes_prod_partition_digest_digest_0(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read otp::vendor_hashes_prod_partition_digest_digest_0");
         }
         self.vendor_hashes_prod_partition_digest_digest_0
     }
-    fn read_vendor_hashes_prod_partition_digest_digest_1(&mut self) -> caliptra_emu_types::RvData {
+    fn read_vendor_hashes_prod_partition_digest_digest_1(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read otp::vendor_hashes_prod_partition_digest_digest_1");
         }
@@ -2728,7 +2956,7 @@ impl OtpPeripheral for OtpGenerated {
     }
     fn read_vendor_revocations_prod_partition_digest_digest_0(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read otp::vendor_revocations_prod_partition_digest_digest_0");
         }
@@ -2736,19 +2964,23 @@ impl OtpPeripheral for OtpGenerated {
     }
     fn read_vendor_revocations_prod_partition_digest_digest_1(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read otp::vendor_revocations_prod_partition_digest_digest_1");
         }
         self.vendor_revocations_prod_partition_digest_digest_1
     }
-    fn read_vendor_secret_prod_partition_digest_digest_0(&mut self) -> caliptra_emu_types::RvData {
+    fn read_vendor_secret_prod_partition_digest_digest_0(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read otp::vendor_secret_prod_partition_digest_digest_0");
         }
         self.vendor_secret_prod_partition_digest_digest_0
     }
-    fn read_vendor_secret_prod_partition_digest_digest_1(&mut self) -> caliptra_emu_types::RvData {
+    fn read_vendor_secret_prod_partition_digest_digest_1(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read otp::vendor_secret_prod_partition_digest_digest_1");
         }
@@ -2756,7 +2988,7 @@ impl OtpPeripheral for OtpGenerated {
     }
     fn read_vendor_non_secret_prod_partition_digest_digest_0(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read otp::vendor_non_secret_prod_partition_digest_digest_0");
         }
@@ -2764,7 +2996,7 @@ impl OtpPeripheral for OtpGenerated {
     }
     fn read_vendor_non_secret_prod_partition_digest_digest_1(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read otp::vendor_non_secret_prod_partition_digest_digest_1");
         }
@@ -2774,147 +3006,150 @@ impl OtpPeripheral for OtpGenerated {
 pub struct OtpBus {
     pub periph: Box<dyn OtpPeripheral>,
 }
-impl caliptra_emu_bus::Bus for OtpBus {
+impl caliptra_core_tools::caliptra_emu_bus::Bus for OtpBus {
     fn read(
         &mut self,
-        size: caliptra_emu_types::RvSize,
-        addr: caliptra_emu_types::RvAddr,
-    ) -> Result<caliptra_emu_types::RvData, caliptra_emu_bus::BusError> {
-        if addr & 0x3 != 0 || size != caliptra_emu_types::RvSize::Word {
-            return Err(caliptra_emu_bus::BusError::LoadAddrMisaligned);
+        size: caliptra_core_tools::caliptra_emu_types::RvSize,
+        addr: caliptra_core_tools::caliptra_emu_types::RvAddr,
+    ) -> Result<
+        caliptra_core_tools::caliptra_emu_types::RvData,
+        caliptra_core_tools::caliptra_emu_bus::BusError,
+    > {
+        if addr & 0x3 != 0 || size != caliptra_core_tools::caliptra_emu_types::RvSize::Word {
+            return Err(caliptra_core_tools::caliptra_emu_bus::BusError::LoadAddrMisaligned);
         }
         match addr {
-            0..4 => Ok(caliptra_emu_types::RvData::from(
+            0..4 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_interrupt_state().reg.get(),
             )),
-            4..8 => Ok(caliptra_emu_types::RvData::from(
+            4..8 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_otp_interrupt_enable().reg.get(),
             )),
-            0x10..0x14 => Ok(caliptra_emu_types::RvData::from(
+            0x10..0x14 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_otp_status().reg.get(),
             )),
-            0x5c..0x60 => Ok(caliptra_emu_types::RvData::from(
+            0x5c..0x60 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_direct_access_regwen().reg.get(),
             )),
-            0x64..0x68 => Ok(caliptra_emu_types::RvData::from(
+            0x64..0x68 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_direct_access_address().reg.get(),
             )),
-            0x78..0x7c => Ok(caliptra_emu_types::RvData::from(
+            0x78..0x7c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_check_trigger_regwen().reg.get(),
             )),
             0x84..0x88 => Ok(self.periph.read_check_timeout()),
             0x88..0x8c => Ok(self.periph.read_integrity_check_period()),
             0x8c..0x90 => Ok(self.periph.read_consistency_check_period()),
-            0x90..0x94 => Ok(caliptra_emu_types::RvData::from(
+            0x90..0x94 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_sw_manuf_partition_read_lock().reg.get(),
             )),
-            0x94..0x98 => Ok(caliptra_emu_types::RvData::from(
+            0x94..0x98 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_svn_partition_read_lock().reg.get(),
             )),
-            0x98..0x9c => Ok(caliptra_emu_types::RvData::from(
+            0x98..0x9c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_vendor_test_partition_read_lock().reg.get(),
             )),
-            0x9c..0xa0 => Ok(caliptra_emu_types::RvData::from(
+            0x9c..0xa0 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_vendor_hashes_manuf_partition_read_lock()
                     .reg
                     .get(),
             )),
-            0xa0..0xa4 => Ok(caliptra_emu_types::RvData::from(
+            0xa0..0xa4 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_vendor_hashes_prod_partition_read_lock()
                     .reg
                     .get(),
             )),
-            0xa4..0xa8 => Ok(caliptra_emu_types::RvData::from(
+            0xa4..0xa8 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_vendor_revocations_prod_partition_read_lock()
                     .reg
                     .get(),
             )),
-            0xa8..0xac => Ok(caliptra_emu_types::RvData::from(
+            0xa8..0xac => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_vendor_non_secret_prod_partition_read_lock()
                     .reg
                     .get(),
             )),
             0xac..0xb0 => Ok(self.periph.read_vendor_pk_hash_volatile_lock()),
-            0x120..0x124 => Ok(caliptra_emu_types::RvData::from(
+            0x120..0x124 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_csr0().reg.get(),
             )),
-            0x124..0x128 => Ok(caliptra_emu_types::RvData::from(
+            0x124..0x128 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_csr1().reg.get(),
             )),
-            0x128..0x12c => Ok(caliptra_emu_types::RvData::from(
+            0x128..0x12c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_csr2().reg.get(),
             )),
-            0x12c..0x130 => Ok(caliptra_emu_types::RvData::from(
+            0x12c..0x130 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_csr3().reg.get(),
             )),
-            0x130..0x134 => Ok(caliptra_emu_types::RvData::from(
+            0x130..0x134 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_csr4().reg.get(),
             )),
-            0x134..0x138 => Ok(caliptra_emu_types::RvData::from(
+            0x134..0x138 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_csr5().reg.get(),
             )),
-            0x138..0x13c => Ok(caliptra_emu_types::RvData::from(
+            0x138..0x13c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_csr6().reg.get(),
             )),
-            0x13c..0x140 => Ok(caliptra_emu_types::RvData::from(
+            0x13c..0x140 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_csr7().reg.get(),
             )),
-            0x14..0x18 => Ok(caliptra_emu_types::RvData::from(
+            0x14..0x18 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_err_code_rf_err_code_0().reg.get(),
             )),
-            0x18..0x1c => Ok(caliptra_emu_types::RvData::from(
+            0x18..0x1c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_err_code_rf_err_code_1().reg.get(),
             )),
-            0x1c..0x20 => Ok(caliptra_emu_types::RvData::from(
+            0x1c..0x20 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_err_code_rf_err_code_2().reg.get(),
             )),
-            0x20..0x24 => Ok(caliptra_emu_types::RvData::from(
+            0x20..0x24 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_err_code_rf_err_code_3().reg.get(),
             )),
-            0x24..0x28 => Ok(caliptra_emu_types::RvData::from(
+            0x24..0x28 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_err_code_rf_err_code_4().reg.get(),
             )),
-            0x28..0x2c => Ok(caliptra_emu_types::RvData::from(
+            0x28..0x2c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_err_code_rf_err_code_5().reg.get(),
             )),
-            0x2c..0x30 => Ok(caliptra_emu_types::RvData::from(
+            0x2c..0x30 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_err_code_rf_err_code_6().reg.get(),
             )),
-            0x30..0x34 => Ok(caliptra_emu_types::RvData::from(
+            0x30..0x34 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_err_code_rf_err_code_7().reg.get(),
             )),
-            0x34..0x38 => Ok(caliptra_emu_types::RvData::from(
+            0x34..0x38 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_err_code_rf_err_code_8().reg.get(),
             )),
-            0x38..0x3c => Ok(caliptra_emu_types::RvData::from(
+            0x38..0x3c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_err_code_rf_err_code_9().reg.get(),
             )),
-            0x3c..0x40 => Ok(caliptra_emu_types::RvData::from(
+            0x3c..0x40 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_err_code_rf_err_code_10().reg.get(),
             )),
-            0x40..0x44 => Ok(caliptra_emu_types::RvData::from(
+            0x40..0x44 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_err_code_rf_err_code_11().reg.get(),
             )),
-            0x44..0x48 => Ok(caliptra_emu_types::RvData::from(
+            0x44..0x48 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_err_code_rf_err_code_12().reg.get(),
             )),
-            0x48..0x4c => Ok(caliptra_emu_types::RvData::from(
+            0x48..0x4c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_err_code_rf_err_code_13().reg.get(),
             )),
-            0x4c..0x50 => Ok(caliptra_emu_types::RvData::from(
+            0x4c..0x50 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_err_code_rf_err_code_14().reg.get(),
             )),
-            0x50..0x54 => Ok(caliptra_emu_types::RvData::from(
+            0x50..0x54 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_err_code_rf_err_code_15().reg.get(),
             )),
-            0x54..0x58 => Ok(caliptra_emu_types::RvData::from(
+            0x54..0x58 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_err_code_rf_err_code_16().reg.get(),
             )),
-            0x58..0x5c => Ok(caliptra_emu_types::RvData::from(
+            0x58..0x5c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_err_code_rf_err_code_17().reg.get(),
             )),
             0x68..0x6c => Ok(self.periph.read_dai_wdata_rf_direct_access_wdata_0()),
@@ -2973,68 +3208,78 @@ impl caliptra_emu_bus::Bus for OtpBus {
             0x11c..0x120 => Ok(self
                 .periph
                 .read_vendor_non_secret_prod_partition_digest_digest_1()),
-            _ => Err(caliptra_emu_bus::BusError::LoadAccessFault),
+            _ => Err(caliptra_core_tools::caliptra_emu_bus::BusError::LoadAccessFault),
         }
     }
     fn write(
         &mut self,
-        size: caliptra_emu_types::RvSize,
-        addr: caliptra_emu_types::RvAddr,
-        val: caliptra_emu_types::RvData,
-    ) -> Result<(), caliptra_emu_bus::BusError> {
-        if addr & 0x3 != 0 || size != caliptra_emu_types::RvSize::Word {
-            return Err(caliptra_emu_bus::BusError::StoreAddrMisaligned);
+        size: caliptra_core_tools::caliptra_emu_types::RvSize,
+        addr: caliptra_core_tools::caliptra_emu_types::RvAddr,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) -> Result<(), caliptra_core_tools::caliptra_emu_bus::BusError> {
+        if addr & 0x3 != 0 || size != caliptra_core_tools::caliptra_emu_types::RvSize::Word {
+            return Err(caliptra_core_tools::caliptra_emu_bus::BusError::StoreAddrMisaligned);
         }
         match addr {
             0..4 => {
-                self.periph
-                    .write_interrupt_state(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_interrupt_state(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             4..8 => {
-                self.periph
-                    .write_otp_interrupt_enable(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_otp_interrupt_enable(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             8..0xc => {
-                self.periph
-                    .write_interrupt_test(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_interrupt_test(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0xc..0x10 => {
-                self.periph
-                    .write_alert_test(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_alert_test(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0x10..0x14 => Ok(()),
             0x5c..0x60 => {
-                self.periph
-                    .write_direct_access_regwen(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_direct_access_regwen(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0x60..0x64 => {
-                self.periph
-                    .write_direct_access_cmd(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_direct_access_cmd(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0x64..0x68 => {
-                self.periph
-                    .write_direct_access_address(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_direct_access_address(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0x78..0x7c => {
-                self.periph
-                    .write_check_trigger_regwen(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_check_trigger_regwen(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0x7c..0x80 => {
-                self.periph
-                    .write_check_trigger(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_check_trigger(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0x80..0x84 => {
-                self.periph
-                    .write_check_regwen(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_check_regwen(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0x84..0x88 => {
@@ -3051,44 +3296,45 @@ impl caliptra_emu_bus::Bus for OtpBus {
             }
             0x90..0x94 => {
                 self.periph.write_sw_manuf_partition_read_lock(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x94..0x98 => {
-                self.periph
-                    .write_svn_partition_read_lock(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_svn_partition_read_lock(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0x98..0x9c => {
                 self.periph.write_vendor_test_partition_read_lock(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x9c..0xa0 => {
                 self.periph.write_vendor_hashes_manuf_partition_read_lock(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0xa0..0xa4 => {
                 self.periph.write_vendor_hashes_prod_partition_read_lock(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0xa4..0xa8 => {
                 self.periph
                     .write_vendor_revocations_prod_partition_read_lock(
-                        caliptra_emu_bus::ReadWriteRegister::new(val),
+                        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                     );
                 Ok(())
             }
             0xa8..0xac => {
                 self.periph
                     .write_vendor_non_secret_prod_partition_read_lock(
-                        caliptra_emu_bus::ReadWriteRegister::new(val),
+                        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                     );
                 Ok(())
             }
@@ -3098,37 +3344,37 @@ impl caliptra_emu_bus::Bus for OtpBus {
             }
             0x120..0x124 => {
                 self.periph
-                    .write_csr0(caliptra_emu_bus::ReadWriteRegister::new(val));
+                    .write_csr0(caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
             0x124..0x128 => {
                 self.periph
-                    .write_csr1(caliptra_emu_bus::ReadWriteRegister::new(val));
+                    .write_csr1(caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
             0x128..0x12c => {
                 self.periph
-                    .write_csr2(caliptra_emu_bus::ReadWriteRegister::new(val));
+                    .write_csr2(caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
             0x12c..0x130 => {
                 self.periph
-                    .write_csr3(caliptra_emu_bus::ReadWriteRegister::new(val));
+                    .write_csr3(caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
             0x130..0x134 => {
                 self.periph
-                    .write_csr4(caliptra_emu_bus::ReadWriteRegister::new(val));
+                    .write_csr4(caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
             0x134..0x138 => {
                 self.periph
-                    .write_csr5(caliptra_emu_bus::ReadWriteRegister::new(val));
+                    .write_csr5(caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
             0x138..0x13c => {
                 self.periph
-                    .write_csr6(caliptra_emu_bus::ReadWriteRegister::new(val));
+                    .write_csr6(caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
             0x13c..0x140 => Ok(()),
@@ -3188,7 +3434,7 @@ impl caliptra_emu_bus::Bus for OtpBus {
             0x114..0x118 => Ok(()),
             0x118..0x11c => Ok(()),
             0x11c..0x120 => Ok(()),
-            _ => Err(caliptra_emu_bus::BusError::StoreAccessFault),
+            _ => Err(caliptra_core_tools::caliptra_emu_bus::BusError::StoreAccessFault),
         }
     }
     fn poll(&mut self) {

--- a/registers/generated-emulator/src/primary_flash.rs
+++ b/registers/generated-emulator/src/primary_flash.rs
@@ -5,14 +5,24 @@
 #[allow(unused_imports)]
 use tock_registers::interfaces::{Readable, Writeable};
 pub trait PrimaryFlashPeripheral {
-    fn set_dma_ram(&mut self, _ram: std::rc::Rc<std::cell::RefCell<caliptra_emu_bus::Ram>>) {}
-    fn set_dma_rom_sram(&mut self, _ram: std::rc::Rc<std::cell::RefCell<caliptra_emu_bus::Ram>>) {}
+    fn set_dma_ram(
+        &mut self,
+        _ram: std::rc::Rc<std::cell::RefCell<caliptra_core_tools::caliptra_emu_bus::Ram>>,
+    ) {
+    }
+    fn set_dma_rom_sram(
+        &mut self,
+        _ram: std::rc::Rc<std::cell::RefCell<caliptra_core_tools::caliptra_emu_bus::Ram>>,
+    ) {
+    }
     fn register_event_channels(
         &mut self,
-        _events_to_caliptra: std::sync::mpsc::Sender<caliptra_emu_bus::Event>,
-        _events_from_caliptra: std::sync::mpsc::Receiver<caliptra_emu_bus::Event>,
-        _events_to_mcu: std::sync::mpsc::Sender<caliptra_emu_bus::Event>,
-        _events_from_mcu: std::sync::mpsc::Receiver<caliptra_emu_bus::Event>,
+        _events_to_caliptra: std::sync::mpsc::Sender<caliptra_core_tools::caliptra_emu_bus::Event>,
+        _events_from_caliptra: std::sync::mpsc::Receiver<
+            caliptra_core_tools::caliptra_emu_bus::Event,
+        >,
+        _events_to_mcu: std::sync::mpsc::Sender<caliptra_core_tools::caliptra_emu_bus::Event>,
+        _events_from_mcu: std::sync::mpsc::Receiver<caliptra_core_tools::caliptra_emu_bus::Event>,
     ) {
     }
     fn poll(&mut self) {}
@@ -23,7 +33,7 @@ pub trait PrimaryFlashPeripheral {
     }
     fn read_fl_interrupt_state(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::primary_flash_ctrl::bits::FlInterruptState::Register,
     > {
@@ -33,11 +43,11 @@ pub trait PrimaryFlashPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_fl_interrupt_state();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_fl_interrupt_state(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::primary_flash_ctrl::bits::FlInterruptState::Register,
         >,
@@ -51,7 +61,7 @@ pub trait PrimaryFlashPeripheral {
     }
     fn read_fl_interrupt_enable(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::primary_flash_ctrl::bits::FlInterruptEnable::Register,
     > {
@@ -63,11 +73,11 @@ pub trait PrimaryFlashPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_fl_interrupt_enable();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_fl_interrupt_enable(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::primary_flash_ctrl::bits::FlInterruptEnable::Register,
         >,
@@ -79,7 +89,7 @@ pub trait PrimaryFlashPeripheral {
             generated.write_fl_interrupt_enable(val);
         }
     }
-    fn read_page_size(&mut self) -> caliptra_emu_types::RvData {
+    fn read_page_size(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read primary_flash::page_size");
         }
@@ -88,7 +98,7 @@ pub trait PrimaryFlashPeripheral {
         }
         0
     }
-    fn write_page_size(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_page_size(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write primary_flash::page_size = 0x{:08x}",
@@ -99,7 +109,7 @@ pub trait PrimaryFlashPeripheral {
             generated.write_page_size(val);
         }
     }
-    fn read_page_num(&mut self) -> caliptra_emu_types::RvData {
+    fn read_page_num(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read primary_flash::page_num");
         }
@@ -108,7 +118,7 @@ pub trait PrimaryFlashPeripheral {
         }
         0
     }
-    fn write_page_num(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_page_num(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write primary_flash::page_num = 0x{:08x}",
@@ -119,7 +129,7 @@ pub trait PrimaryFlashPeripheral {
             generated.write_page_num(val);
         }
     }
-    fn read_page_addr(&mut self) -> caliptra_emu_types::RvData {
+    fn read_page_addr(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read primary_flash::page_addr");
         }
@@ -128,7 +138,7 @@ pub trait PrimaryFlashPeripheral {
         }
         0
     }
-    fn write_page_addr(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_page_addr(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write primary_flash::page_addr = 0x{:08x}",
@@ -141,7 +151,7 @@ pub trait PrimaryFlashPeripheral {
     }
     fn read_fl_control(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::primary_flash_ctrl::bits::FlControl::Register,
     > {
@@ -151,11 +161,11 @@ pub trait PrimaryFlashPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_fl_control();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_fl_control(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::primary_flash_ctrl::bits::FlControl::Register,
         >,
@@ -172,7 +182,7 @@ pub trait PrimaryFlashPeripheral {
     }
     fn read_op_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::primary_flash_ctrl::bits::OpStatus::Register,
     > {
@@ -182,11 +192,11 @@ pub trait PrimaryFlashPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_op_status();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_op_status(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::primary_flash_ctrl::bits::OpStatus::Register,
         >,
@@ -203,7 +213,7 @@ pub trait PrimaryFlashPeripheral {
     }
     fn read_ctrl_regwen(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::primary_flash_ctrl::bits::CtrlRegwen::Register,
     > {
@@ -213,31 +223,31 @@ pub trait PrimaryFlashPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_ctrl_regwen();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
 }
 #[derive(Clone, Debug)]
 pub struct PrimaryFlashGenerated {
-    fl_interrupt_state: caliptra_emu_types::RvData,
-    fl_interrupt_enable: caliptra_emu_types::RvData,
-    page_size: caliptra_emu_types::RvData,
-    page_num: caliptra_emu_types::RvData,
-    page_addr: caliptra_emu_types::RvData,
-    fl_control: caliptra_emu_types::RvData,
-    op_status: caliptra_emu_types::RvData,
-    ctrl_regwen: caliptra_emu_types::RvData,
+    fl_interrupt_state: caliptra_core_tools::caliptra_emu_types::RvData,
+    fl_interrupt_enable: caliptra_core_tools::caliptra_emu_types::RvData,
+    page_size: caliptra_core_tools::caliptra_emu_types::RvData,
+    page_num: caliptra_core_tools::caliptra_emu_types::RvData,
+    page_addr: caliptra_core_tools::caliptra_emu_types::RvData,
+    fl_control: caliptra_core_tools::caliptra_emu_types::RvData,
+    op_status: caliptra_core_tools::caliptra_emu_types::RvData,
+    ctrl_regwen: caliptra_core_tools::caliptra_emu_types::RvData,
 }
 impl Default for PrimaryFlashGenerated {
     fn default() -> Self {
         Self {
-            fl_interrupt_state: 0 as caliptra_emu_types::RvData,
-            fl_interrupt_enable: 0 as caliptra_emu_types::RvData,
-            page_size: 0 as caliptra_emu_types::RvData,
-            page_num: 0 as caliptra_emu_types::RvData,
-            page_addr: 0 as caliptra_emu_types::RvData,
-            fl_control: 0 as caliptra_emu_types::RvData,
-            op_status: 0 as caliptra_emu_types::RvData,
-            ctrl_regwen: 0 as caliptra_emu_types::RvData,
+            fl_interrupt_state: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            fl_interrupt_enable: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            page_size: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            page_num: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            page_addr: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            fl_control: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            op_status: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            ctrl_regwen: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
         }
     }
 }
@@ -261,7 +271,7 @@ impl PrimaryFlashPeripheral for PrimaryFlashGenerated {
     }
     fn read_fl_interrupt_state(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::primary_flash_ctrl::bits::FlInterruptState::Register,
     > {
@@ -270,11 +280,11 @@ impl PrimaryFlashPeripheral for PrimaryFlashGenerated {
                 "[EMU] Generated default register handler: read primary_flash::fl_interrupt_state"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.fl_interrupt_state)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.fl_interrupt_state)
     }
     fn write_fl_interrupt_state(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::primary_flash_ctrl::bits::FlInterruptState::Register,
         >,
@@ -282,18 +292,18 @@ impl PrimaryFlashPeripheral for PrimaryFlashGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write primary_flash::fl_interrupt_state = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.fl_interrupt_state;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(2 as caliptra_emu_types::RvData))
-            | (write_val & (2 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(2 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.fl_interrupt_state = new_val;
     }
     fn read_fl_interrupt_enable(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::primary_flash_ctrl::bits::FlInterruptEnable::Register,
     > {
@@ -302,11 +312,11 @@ impl PrimaryFlashPeripheral for PrimaryFlashGenerated {
                 "[EMU] Generated default register handler: read primary_flash::fl_interrupt_enable"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.fl_interrupt_enable)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.fl_interrupt_enable)
     }
     fn write_fl_interrupt_enable(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::primary_flash_ctrl::bits::FlInterruptEnable::Register,
         >,
@@ -314,80 +324,80 @@ impl PrimaryFlashPeripheral for PrimaryFlashGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write primary_flash::fl_interrupt_enable = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.fl_interrupt_enable;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(2 as caliptra_emu_types::RvData))
-            | (write_val & (2 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(2 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.fl_interrupt_enable = new_val;
     }
-    fn read_page_size(&mut self) -> caliptra_emu_types::RvData {
+    fn read_page_size(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read primary_flash::page_size");
         }
         self.page_size
     }
-    fn write_page_size(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_page_size(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write primary_flash::page_size = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.page_size;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.page_size = new_val;
     }
-    fn read_page_num(&mut self) -> caliptra_emu_types::RvData {
+    fn read_page_num(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read primary_flash::page_num");
         }
         self.page_num
     }
-    fn write_page_num(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_page_num(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write primary_flash::page_num = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.page_num;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.page_num = new_val;
     }
-    fn read_page_addr(&mut self) -> caliptra_emu_types::RvData {
+    fn read_page_addr(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read primary_flash::page_addr");
         }
         self.page_addr
     }
-    fn write_page_addr(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_page_addr(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write primary_flash::page_addr = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.page_addr;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.page_addr = new_val;
     }
     fn read_fl_control(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::primary_flash_ctrl::bits::FlControl::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read primary_flash::fl_control");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.fl_control)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.fl_control)
     }
     fn write_fl_control(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::primary_flash_ctrl::bits::FlControl::Register,
         >,
@@ -395,29 +405,29 @@ impl PrimaryFlashPeripheral for PrimaryFlashGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write primary_flash::fl_control = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.fl_control;
         let mut new_val = current_val;
-        new_val = (new_val & !(6 as caliptra_emu_types::RvData))
-            | (write_val & (6 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(6 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (6 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.fl_control = new_val;
     }
     fn read_op_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::primary_flash_ctrl::bits::OpStatus::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read primary_flash::op_status");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.op_status)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.op_status)
     }
     fn write_op_status(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::primary_flash_ctrl::bits::OpStatus::Register,
         >,
@@ -425,79 +435,84 @@ impl PrimaryFlashPeripheral for PrimaryFlashGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write primary_flash::op_status = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.op_status;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xe as caliptra_emu_types::RvData))
-            | (write_val & (0xe as caliptra_emu_types::RvData));
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xe as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xe as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.op_status = new_val;
     }
     fn read_ctrl_regwen(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::primary_flash_ctrl::bits::CtrlRegwen::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read primary_flash::ctrl_regwen");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.ctrl_regwen)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.ctrl_regwen)
     }
 }
 pub struct PrimaryFlashBus {
     pub periph: Box<dyn PrimaryFlashPeripheral>,
 }
-impl caliptra_emu_bus::Bus for PrimaryFlashBus {
+impl caliptra_core_tools::caliptra_emu_bus::Bus for PrimaryFlashBus {
     fn read(
         &mut self,
-        size: caliptra_emu_types::RvSize,
-        addr: caliptra_emu_types::RvAddr,
-    ) -> Result<caliptra_emu_types::RvData, caliptra_emu_bus::BusError> {
-        if addr & 0x3 != 0 || size != caliptra_emu_types::RvSize::Word {
-            return Err(caliptra_emu_bus::BusError::LoadAddrMisaligned);
+        size: caliptra_core_tools::caliptra_emu_types::RvSize,
+        addr: caliptra_core_tools::caliptra_emu_types::RvAddr,
+    ) -> Result<
+        caliptra_core_tools::caliptra_emu_types::RvData,
+        caliptra_core_tools::caliptra_emu_bus::BusError,
+    > {
+        if addr & 0x3 != 0 || size != caliptra_core_tools::caliptra_emu_types::RvSize::Word {
+            return Err(caliptra_core_tools::caliptra_emu_bus::BusError::LoadAddrMisaligned);
         }
         match addr {
-            0..4 => Ok(caliptra_emu_types::RvData::from(
+            0..4 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_fl_interrupt_state().reg.get(),
             )),
-            4..8 => Ok(caliptra_emu_types::RvData::from(
+            4..8 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_fl_interrupt_enable().reg.get(),
             )),
             8..0xc => Ok(self.periph.read_page_size()),
             0xc..0x10 => Ok(self.periph.read_page_num()),
             0x10..0x14 => Ok(self.periph.read_page_addr()),
-            0x14..0x18 => Ok(caliptra_emu_types::RvData::from(
+            0x14..0x18 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_fl_control().reg.get(),
             )),
-            0x18..0x1c => Ok(caliptra_emu_types::RvData::from(
+            0x18..0x1c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_op_status().reg.get(),
             )),
-            0x1c..0x20 => Ok(caliptra_emu_types::RvData::from(
+            0x1c..0x20 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_ctrl_regwen().reg.get(),
             )),
-            _ => Err(caliptra_emu_bus::BusError::LoadAccessFault),
+            _ => Err(caliptra_core_tools::caliptra_emu_bus::BusError::LoadAccessFault),
         }
     }
     fn write(
         &mut self,
-        size: caliptra_emu_types::RvSize,
-        addr: caliptra_emu_types::RvAddr,
-        val: caliptra_emu_types::RvData,
-    ) -> Result<(), caliptra_emu_bus::BusError> {
-        if addr & 0x3 != 0 || size != caliptra_emu_types::RvSize::Word {
-            return Err(caliptra_emu_bus::BusError::StoreAddrMisaligned);
+        size: caliptra_core_tools::caliptra_emu_types::RvSize,
+        addr: caliptra_core_tools::caliptra_emu_types::RvAddr,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) -> Result<(), caliptra_core_tools::caliptra_emu_bus::BusError> {
+        if addr & 0x3 != 0 || size != caliptra_core_tools::caliptra_emu_types::RvSize::Word {
+            return Err(caliptra_core_tools::caliptra_emu_bus::BusError::StoreAddrMisaligned);
         }
         match addr {
             0..4 => {
-                self.periph
-                    .write_fl_interrupt_state(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_fl_interrupt_state(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             4..8 => {
-                self.periph
-                    .write_fl_interrupt_enable(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_fl_interrupt_enable(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             8..0xc => {
@@ -513,17 +528,19 @@ impl caliptra_emu_bus::Bus for PrimaryFlashBus {
                 Ok(())
             }
             0x14..0x18 => {
-                self.periph
-                    .write_fl_control(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_fl_control(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0x18..0x1c => {
-                self.periph
-                    .write_op_status(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_op_status(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0x1c..0x20 => Ok(()),
-            _ => Err(caliptra_emu_bus::BusError::StoreAccessFault),
+            _ => Err(caliptra_core_tools::caliptra_emu_bus::BusError::StoreAccessFault),
         }
     }
     fn poll(&mut self) {

--- a/registers/generated-emulator/src/root_bus.rs
+++ b/registers/generated-emulator/src/root_bus.rs
@@ -65,7 +65,7 @@ impl Default for AutoRootBusOffsets {
     }
 }
 pub struct AutoRootBus {
-    delegates: Vec<Box<dyn caliptra_emu_bus::Bus>>,
+    delegates: Vec<Box<dyn caliptra_core_tools::caliptra_emu_bus::Bus>>,
     offsets: AutoRootBusOffsets,
     pub i3c_periph: Option<crate::i3c::I3cBus>,
     pub i3c1_periph: Option<crate::i3c1::I3c1Bus>,
@@ -84,7 +84,7 @@ pub struct AutoRootBus {
 impl AutoRootBus {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        delegates: Vec<Box<dyn caliptra_emu_bus::Bus>>,
+        delegates: Vec<Box<dyn caliptra_core_tools::caliptra_emu_bus::Bus>>,
         offsets: Option<AutoRootBusOffsets>,
         i3c_periph: Option<Box<dyn crate::i3c::I3cPeripheral>>,
         i3c1_periph: Option<Box<dyn crate::i3c1::I3c1Peripheral>>,
@@ -122,12 +122,15 @@ impl AutoRootBus {
         }
     }
 }
-impl caliptra_emu_bus::Bus for AutoRootBus {
+impl caliptra_core_tools::caliptra_emu_bus::Bus for AutoRootBus {
     fn read(
         &mut self,
-        size: caliptra_emu_types::RvSize,
-        addr: caliptra_emu_types::RvAddr,
-    ) -> Result<caliptra_emu_types::RvData, caliptra_emu_bus::BusError> {
+        size: caliptra_core_tools::caliptra_emu_types::RvSize,
+        addr: caliptra_core_tools::caliptra_emu_types::RvAddr,
+    ) -> Result<
+        caliptra_core_tools::caliptra_emu_types::RvData,
+        caliptra_core_tools::caliptra_emu_bus::BusError,
+    > {
         if addr >= self.offsets.i3c_offset && addr < self.offsets.i3c_offset + self.offsets.i3c_size
         {
             if let Some(periph) = self.i3c_periph.as_mut() {
@@ -215,18 +218,21 @@ impl caliptra_emu_bus::Bus for AutoRootBus {
         }
         for delegate in self.delegates.iter_mut() {
             let result = delegate.read(size, addr);
-            if !matches!(result, Err(caliptra_emu_bus::BusError::LoadAccessFault)) {
+            if !matches!(
+                result,
+                Err(caliptra_core_tools::caliptra_emu_bus::BusError::LoadAccessFault)
+            ) {
                 return result;
             }
         }
-        Err(caliptra_emu_bus::BusError::LoadAccessFault)
+        Err(caliptra_core_tools::caliptra_emu_bus::BusError::LoadAccessFault)
     }
     fn write(
         &mut self,
-        size: caliptra_emu_types::RvSize,
-        addr: caliptra_emu_types::RvAddr,
-        val: caliptra_emu_types::RvData,
-    ) -> Result<(), caliptra_emu_bus::BusError> {
+        size: caliptra_core_tools::caliptra_emu_types::RvSize,
+        addr: caliptra_core_tools::caliptra_emu_types::RvAddr,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) -> Result<(), caliptra_core_tools::caliptra_emu_bus::BusError> {
         if addr >= self.offsets.i3c_offset && addr < self.offsets.i3c_offset + self.offsets.i3c_size
         {
             if let Some(periph) = self.i3c_periph.as_mut() {
@@ -314,11 +320,14 @@ impl caliptra_emu_bus::Bus for AutoRootBus {
         }
         for delegate in self.delegates.iter_mut() {
             let result = delegate.write(size, addr, val);
-            if !matches!(result, Err(caliptra_emu_bus::BusError::StoreAccessFault)) {
+            if !matches!(
+                result,
+                Err(caliptra_core_tools::caliptra_emu_bus::BusError::StoreAccessFault)
+            ) {
                 return result;
             }
         }
-        Err(caliptra_emu_bus::BusError::StoreAccessFault)
+        Err(caliptra_core_tools::caliptra_emu_bus::BusError::StoreAccessFault)
     }
     fn poll(&mut self) {
         if let Some(periph) = self.i3c_periph.as_mut() {
@@ -452,7 +461,7 @@ impl caliptra_emu_bus::Bus for AutoRootBus {
             delegate.update_reset();
         }
     }
-    fn incoming_event(&mut self, event: std::rc::Rc<caliptra_emu_bus::Event>) {
+    fn incoming_event(&mut self, event: std::rc::Rc<caliptra_core_tools::caliptra_emu_bus::Event>) {
         if let Some(periph) = self.i3c_periph.as_mut() {
             periph.incoming_event(event.clone());
         }
@@ -498,7 +507,7 @@ impl caliptra_emu_bus::Bus for AutoRootBus {
     }
     fn register_outgoing_events(
         &mut self,
-        sender: std::sync::mpsc::Sender<caliptra_emu_bus::Event>,
+        sender: std::sync::mpsc::Sender<caliptra_core_tools::caliptra_emu_bus::Event>,
     ) {
         if let Some(periph) = self.i3c_periph.as_mut() {
             periph.register_outgoing_events(sender.clone());

--- a/registers/generated-emulator/src/secondary_flash.rs
+++ b/registers/generated-emulator/src/secondary_flash.rs
@@ -5,14 +5,24 @@
 #[allow(unused_imports)]
 use tock_registers::interfaces::{Readable, Writeable};
 pub trait SecondaryFlashPeripheral {
-    fn set_dma_ram(&mut self, _ram: std::rc::Rc<std::cell::RefCell<caliptra_emu_bus::Ram>>) {}
-    fn set_dma_rom_sram(&mut self, _ram: std::rc::Rc<std::cell::RefCell<caliptra_emu_bus::Ram>>) {}
+    fn set_dma_ram(
+        &mut self,
+        _ram: std::rc::Rc<std::cell::RefCell<caliptra_core_tools::caliptra_emu_bus::Ram>>,
+    ) {
+    }
+    fn set_dma_rom_sram(
+        &mut self,
+        _ram: std::rc::Rc<std::cell::RefCell<caliptra_core_tools::caliptra_emu_bus::Ram>>,
+    ) {
+    }
     fn register_event_channels(
         &mut self,
-        _events_to_caliptra: std::sync::mpsc::Sender<caliptra_emu_bus::Event>,
-        _events_from_caliptra: std::sync::mpsc::Receiver<caliptra_emu_bus::Event>,
-        _events_to_mcu: std::sync::mpsc::Sender<caliptra_emu_bus::Event>,
-        _events_from_mcu: std::sync::mpsc::Receiver<caliptra_emu_bus::Event>,
+        _events_to_caliptra: std::sync::mpsc::Sender<caliptra_core_tools::caliptra_emu_bus::Event>,
+        _events_from_caliptra: std::sync::mpsc::Receiver<
+            caliptra_core_tools::caliptra_emu_bus::Event,
+        >,
+        _events_to_mcu: std::sync::mpsc::Sender<caliptra_core_tools::caliptra_emu_bus::Event>,
+        _events_from_mcu: std::sync::mpsc::Receiver<caliptra_core_tools::caliptra_emu_bus::Event>,
     ) {
     }
     fn poll(&mut self) {}
@@ -23,7 +33,7 @@ pub trait SecondaryFlashPeripheral {
     }
     fn read_fl_interrupt_state(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::primary_flash_ctrl::bits::FlInterruptState::Register,
     > {
@@ -35,11 +45,11 @@ pub trait SecondaryFlashPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_fl_interrupt_state();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_fl_interrupt_state(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::primary_flash_ctrl::bits::FlInterruptState::Register,
         >,
@@ -53,7 +63,7 @@ pub trait SecondaryFlashPeripheral {
     }
     fn read_fl_interrupt_enable(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::primary_flash_ctrl::bits::FlInterruptEnable::Register,
     > {
@@ -65,11 +75,11 @@ pub trait SecondaryFlashPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_fl_interrupt_enable();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_fl_interrupt_enable(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::primary_flash_ctrl::bits::FlInterruptEnable::Register,
         >,
@@ -81,7 +91,7 @@ pub trait SecondaryFlashPeripheral {
             generated.write_fl_interrupt_enable(val);
         }
     }
-    fn read_page_size(&mut self) -> caliptra_emu_types::RvData {
+    fn read_page_size(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read secondary_flash::page_size");
         }
@@ -90,7 +100,7 @@ pub trait SecondaryFlashPeripheral {
         }
         0
     }
-    fn write_page_size(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_page_size(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write secondary_flash::page_size = 0x{:08x}",
@@ -101,7 +111,7 @@ pub trait SecondaryFlashPeripheral {
             generated.write_page_size(val);
         }
     }
-    fn read_page_num(&mut self) -> caliptra_emu_types::RvData {
+    fn read_page_num(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read secondary_flash::page_num");
         }
@@ -110,7 +120,7 @@ pub trait SecondaryFlashPeripheral {
         }
         0
     }
-    fn write_page_num(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_page_num(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write secondary_flash::page_num = 0x{:08x}",
@@ -121,7 +131,7 @@ pub trait SecondaryFlashPeripheral {
             generated.write_page_num(val);
         }
     }
-    fn read_page_addr(&mut self) -> caliptra_emu_types::RvData {
+    fn read_page_addr(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read secondary_flash::page_addr");
         }
@@ -130,7 +140,7 @@ pub trait SecondaryFlashPeripheral {
         }
         0
     }
-    fn write_page_addr(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_page_addr(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write secondary_flash::page_addr = 0x{:08x}",
@@ -143,7 +153,7 @@ pub trait SecondaryFlashPeripheral {
     }
     fn read_fl_control(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::primary_flash_ctrl::bits::FlControl::Register,
     > {
@@ -153,11 +163,11 @@ pub trait SecondaryFlashPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_fl_control();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_fl_control(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::primary_flash_ctrl::bits::FlControl::Register,
         >,
@@ -174,7 +184,7 @@ pub trait SecondaryFlashPeripheral {
     }
     fn read_op_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::primary_flash_ctrl::bits::OpStatus::Register,
     > {
@@ -184,11 +194,11 @@ pub trait SecondaryFlashPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_op_status();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_op_status(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::primary_flash_ctrl::bits::OpStatus::Register,
         >,
@@ -205,7 +215,7 @@ pub trait SecondaryFlashPeripheral {
     }
     fn read_ctrl_regwen(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::primary_flash_ctrl::bits::CtrlRegwen::Register,
     > {
@@ -215,31 +225,31 @@ pub trait SecondaryFlashPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_ctrl_regwen();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
 }
 #[derive(Clone, Debug)]
 pub struct SecondaryFlashGenerated {
-    fl_interrupt_state: caliptra_emu_types::RvData,
-    fl_interrupt_enable: caliptra_emu_types::RvData,
-    page_size: caliptra_emu_types::RvData,
-    page_num: caliptra_emu_types::RvData,
-    page_addr: caliptra_emu_types::RvData,
-    fl_control: caliptra_emu_types::RvData,
-    op_status: caliptra_emu_types::RvData,
-    ctrl_regwen: caliptra_emu_types::RvData,
+    fl_interrupt_state: caliptra_core_tools::caliptra_emu_types::RvData,
+    fl_interrupt_enable: caliptra_core_tools::caliptra_emu_types::RvData,
+    page_size: caliptra_core_tools::caliptra_emu_types::RvData,
+    page_num: caliptra_core_tools::caliptra_emu_types::RvData,
+    page_addr: caliptra_core_tools::caliptra_emu_types::RvData,
+    fl_control: caliptra_core_tools::caliptra_emu_types::RvData,
+    op_status: caliptra_core_tools::caliptra_emu_types::RvData,
+    ctrl_regwen: caliptra_core_tools::caliptra_emu_types::RvData,
 }
 impl Default for SecondaryFlashGenerated {
     fn default() -> Self {
         Self {
-            fl_interrupt_state: 0 as caliptra_emu_types::RvData,
-            fl_interrupt_enable: 0 as caliptra_emu_types::RvData,
-            page_size: 0 as caliptra_emu_types::RvData,
-            page_num: 0 as caliptra_emu_types::RvData,
-            page_addr: 0 as caliptra_emu_types::RvData,
-            fl_control: 0 as caliptra_emu_types::RvData,
-            op_status: 0 as caliptra_emu_types::RvData,
-            ctrl_regwen: 0 as caliptra_emu_types::RvData,
+            fl_interrupt_state: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            fl_interrupt_enable: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            page_size: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            page_num: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            page_addr: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            fl_control: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            op_status: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            ctrl_regwen: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
         }
     }
 }
@@ -263,18 +273,18 @@ impl SecondaryFlashPeripheral for SecondaryFlashGenerated {
     }
     fn read_fl_interrupt_state(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::primary_flash_ctrl::bits::FlInterruptState::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read secondary_flash::fl_interrupt_state");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.fl_interrupt_state)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.fl_interrupt_state)
     }
     fn write_fl_interrupt_state(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::primary_flash_ctrl::bits::FlInterruptState::Register,
         >,
@@ -282,29 +292,29 @@ impl SecondaryFlashPeripheral for SecondaryFlashGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write secondary_flash::fl_interrupt_state = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.fl_interrupt_state;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(2 as caliptra_emu_types::RvData))
-            | (write_val & (2 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(2 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.fl_interrupt_state = new_val;
     }
     fn read_fl_interrupt_enable(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::primary_flash_ctrl::bits::FlInterruptEnable::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read secondary_flash::fl_interrupt_enable");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.fl_interrupt_enable)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.fl_interrupt_enable)
     }
     fn write_fl_interrupt_enable(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::primary_flash_ctrl::bits::FlInterruptEnable::Register,
         >,
@@ -312,80 +322,80 @@ impl SecondaryFlashPeripheral for SecondaryFlashGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write secondary_flash::fl_interrupt_enable = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.fl_interrupt_enable;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(2 as caliptra_emu_types::RvData))
-            | (write_val & (2 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(2 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.fl_interrupt_enable = new_val;
     }
-    fn read_page_size(&mut self) -> caliptra_emu_types::RvData {
+    fn read_page_size(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read secondary_flash::page_size");
         }
         self.page_size
     }
-    fn write_page_size(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_page_size(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write secondary_flash::page_size = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.page_size;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.page_size = new_val;
     }
-    fn read_page_num(&mut self) -> caliptra_emu_types::RvData {
+    fn read_page_num(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read secondary_flash::page_num");
         }
         self.page_num
     }
-    fn write_page_num(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_page_num(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write secondary_flash::page_num = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.page_num;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.page_num = new_val;
     }
-    fn read_page_addr(&mut self) -> caliptra_emu_types::RvData {
+    fn read_page_addr(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read secondary_flash::page_addr");
         }
         self.page_addr
     }
-    fn write_page_addr(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_page_addr(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write secondary_flash::page_addr = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.page_addr;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.page_addr = new_val;
     }
     fn read_fl_control(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::primary_flash_ctrl::bits::FlControl::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read secondary_flash::fl_control");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.fl_control)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.fl_control)
     }
     fn write_fl_control(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::primary_flash_ctrl::bits::FlControl::Register,
         >,
@@ -393,29 +403,29 @@ impl SecondaryFlashPeripheral for SecondaryFlashGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write secondary_flash::fl_control = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.fl_control;
         let mut new_val = current_val;
-        new_val = (new_val & !(6 as caliptra_emu_types::RvData))
-            | (write_val & (6 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(6 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (6 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.fl_control = new_val;
     }
     fn read_op_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::primary_flash_ctrl::bits::OpStatus::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read secondary_flash::op_status");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.op_status)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.op_status)
     }
     fn write_op_status(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::primary_flash_ctrl::bits::OpStatus::Register,
         >,
@@ -423,18 +433,18 @@ impl SecondaryFlashPeripheral for SecondaryFlashGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write secondary_flash::op_status = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.op_status;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xe as caliptra_emu_types::RvData))
-            | (write_val & (0xe as caliptra_emu_types::RvData));
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xe as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xe as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.op_status = new_val;
     }
     fn read_ctrl_regwen(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::primary_flash_ctrl::bits::CtrlRegwen::Register,
     > {
@@ -443,61 +453,66 @@ impl SecondaryFlashPeripheral for SecondaryFlashGenerated {
                 "[EMU] Generated default register handler: read secondary_flash::ctrl_regwen"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.ctrl_regwen)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.ctrl_regwen)
     }
 }
 pub struct SecondaryFlashBus {
     pub periph: Box<dyn SecondaryFlashPeripheral>,
 }
-impl caliptra_emu_bus::Bus for SecondaryFlashBus {
+impl caliptra_core_tools::caliptra_emu_bus::Bus for SecondaryFlashBus {
     fn read(
         &mut self,
-        size: caliptra_emu_types::RvSize,
-        addr: caliptra_emu_types::RvAddr,
-    ) -> Result<caliptra_emu_types::RvData, caliptra_emu_bus::BusError> {
-        if addr & 0x3 != 0 || size != caliptra_emu_types::RvSize::Word {
-            return Err(caliptra_emu_bus::BusError::LoadAddrMisaligned);
+        size: caliptra_core_tools::caliptra_emu_types::RvSize,
+        addr: caliptra_core_tools::caliptra_emu_types::RvAddr,
+    ) -> Result<
+        caliptra_core_tools::caliptra_emu_types::RvData,
+        caliptra_core_tools::caliptra_emu_bus::BusError,
+    > {
+        if addr & 0x3 != 0 || size != caliptra_core_tools::caliptra_emu_types::RvSize::Word {
+            return Err(caliptra_core_tools::caliptra_emu_bus::BusError::LoadAddrMisaligned);
         }
         match addr {
-            0..4 => Ok(caliptra_emu_types::RvData::from(
+            0..4 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_fl_interrupt_state().reg.get(),
             )),
-            4..8 => Ok(caliptra_emu_types::RvData::from(
+            4..8 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_fl_interrupt_enable().reg.get(),
             )),
             8..0xc => Ok(self.periph.read_page_size()),
             0xc..0x10 => Ok(self.periph.read_page_num()),
             0x10..0x14 => Ok(self.periph.read_page_addr()),
-            0x14..0x18 => Ok(caliptra_emu_types::RvData::from(
+            0x14..0x18 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_fl_control().reg.get(),
             )),
-            0x18..0x1c => Ok(caliptra_emu_types::RvData::from(
+            0x18..0x1c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_op_status().reg.get(),
             )),
-            0x1c..0x20 => Ok(caliptra_emu_types::RvData::from(
+            0x1c..0x20 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_ctrl_regwen().reg.get(),
             )),
-            _ => Err(caliptra_emu_bus::BusError::LoadAccessFault),
+            _ => Err(caliptra_core_tools::caliptra_emu_bus::BusError::LoadAccessFault),
         }
     }
     fn write(
         &mut self,
-        size: caliptra_emu_types::RvSize,
-        addr: caliptra_emu_types::RvAddr,
-        val: caliptra_emu_types::RvData,
-    ) -> Result<(), caliptra_emu_bus::BusError> {
-        if addr & 0x3 != 0 || size != caliptra_emu_types::RvSize::Word {
-            return Err(caliptra_emu_bus::BusError::StoreAddrMisaligned);
+        size: caliptra_core_tools::caliptra_emu_types::RvSize,
+        addr: caliptra_core_tools::caliptra_emu_types::RvAddr,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) -> Result<(), caliptra_core_tools::caliptra_emu_bus::BusError> {
+        if addr & 0x3 != 0 || size != caliptra_core_tools::caliptra_emu_types::RvSize::Word {
+            return Err(caliptra_core_tools::caliptra_emu_bus::BusError::StoreAddrMisaligned);
         }
         match addr {
             0..4 => {
-                self.periph
-                    .write_fl_interrupt_state(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_fl_interrupt_state(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             4..8 => {
-                self.periph
-                    .write_fl_interrupt_enable(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_fl_interrupt_enable(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             8..0xc => {
@@ -513,17 +528,19 @@ impl caliptra_emu_bus::Bus for SecondaryFlashBus {
                 Ok(())
             }
             0x14..0x18 => {
-                self.periph
-                    .write_fl_control(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_fl_control(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0x18..0x1c => {
-                self.periph
-                    .write_op_status(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_op_status(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0x1c..0x20 => Ok(()),
-            _ => Err(caliptra_emu_bus::BusError::StoreAccessFault),
+            _ => Err(caliptra_core_tools::caliptra_emu_bus::BusError::StoreAccessFault),
         }
     }
     fn poll(&mut self) {

--- a/registers/generated-emulator/src/sha512_acc.rs
+++ b/registers/generated-emulator/src/sha512_acc.rs
@@ -5,14 +5,24 @@
 #[allow(unused_imports)]
 use tock_registers::interfaces::{Readable, Writeable};
 pub trait Sha512AccPeripheral {
-    fn set_dma_ram(&mut self, _ram: std::rc::Rc<std::cell::RefCell<caliptra_emu_bus::Ram>>) {}
-    fn set_dma_rom_sram(&mut self, _ram: std::rc::Rc<std::cell::RefCell<caliptra_emu_bus::Ram>>) {}
+    fn set_dma_ram(
+        &mut self,
+        _ram: std::rc::Rc<std::cell::RefCell<caliptra_core_tools::caliptra_emu_bus::Ram>>,
+    ) {
+    }
+    fn set_dma_rom_sram(
+        &mut self,
+        _ram: std::rc::Rc<std::cell::RefCell<caliptra_core_tools::caliptra_emu_bus::Ram>>,
+    ) {
+    }
     fn register_event_channels(
         &mut self,
-        _events_to_caliptra: std::sync::mpsc::Sender<caliptra_emu_bus::Event>,
-        _events_from_caliptra: std::sync::mpsc::Receiver<caliptra_emu_bus::Event>,
-        _events_to_mcu: std::sync::mpsc::Sender<caliptra_emu_bus::Event>,
-        _events_from_mcu: std::sync::mpsc::Receiver<caliptra_emu_bus::Event>,
+        _events_to_caliptra: std::sync::mpsc::Sender<caliptra_core_tools::caliptra_emu_bus::Event>,
+        _events_from_caliptra: std::sync::mpsc::Receiver<
+            caliptra_core_tools::caliptra_emu_bus::Event,
+        >,
+        _events_to_mcu: std::sync::mpsc::Sender<caliptra_core_tools::caliptra_emu_bus::Event>,
+        _events_from_mcu: std::sync::mpsc::Receiver<caliptra_core_tools::caliptra_emu_bus::Event>,
     ) {
     }
     fn poll(&mut self) {}
@@ -23,7 +33,7 @@ pub trait Sha512AccPeripheral {
     }
     fn read_lock(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::sha512_acc::bits::Lock::Register,
     > {
@@ -33,11 +43,11 @@ pub trait Sha512AccPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_lock();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_lock(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::sha512_acc::bits::Lock::Register,
         >,
@@ -52,7 +62,7 @@ pub trait Sha512AccPeripheral {
             generated.write_lock(val);
         }
     }
-    fn read_user(&mut self) -> caliptra_emu_types::RvData {
+    fn read_user(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read sha512_acc::user");
         }
@@ -63,7 +73,7 @@ pub trait Sha512AccPeripheral {
     }
     fn read_mode(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::sha512_acc::bits::Mode::Register,
     > {
@@ -73,11 +83,11 @@ pub trait Sha512AccPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_mode();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_mode(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::sha512_acc::bits::Mode::Register,
         >,
@@ -92,7 +102,7 @@ pub trait Sha512AccPeripheral {
             generated.write_mode(val);
         }
     }
-    fn read_start_address(&mut self) -> caliptra_emu_types::RvData {
+    fn read_start_address(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read sha512_acc::start_address");
         }
@@ -101,7 +111,7 @@ pub trait Sha512AccPeripheral {
         }
         0
     }
-    fn write_start_address(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_start_address(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write sha512_acc::start_address = 0x{:08x}",
@@ -112,7 +122,7 @@ pub trait Sha512AccPeripheral {
             generated.write_start_address(val);
         }
     }
-    fn read_dlen(&mut self) -> caliptra_emu_types::RvData {
+    fn read_dlen(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read sha512_acc::dlen");
         }
@@ -121,7 +131,7 @@ pub trait Sha512AccPeripheral {
         }
         0
     }
-    fn write_dlen(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_dlen(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write sha512_acc::dlen = 0x{:08x}",
@@ -132,7 +142,7 @@ pub trait Sha512AccPeripheral {
             generated.write_dlen(val);
         }
     }
-    fn read_datain(&mut self) -> caliptra_emu_types::RvData {
+    fn read_datain(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read sha512_acc::datain");
         }
@@ -141,7 +151,7 @@ pub trait Sha512AccPeripheral {
         }
         0
     }
-    fn write_datain(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_datain(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write sha512_acc::datain = 0x{:08x}",
@@ -154,7 +164,7 @@ pub trait Sha512AccPeripheral {
     }
     fn read_execute(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::sha512_acc::bits::Execute::Register,
     > {
@@ -164,11 +174,11 @@ pub trait Sha512AccPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_execute();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_execute(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::sha512_acc::bits::Execute::Register,
         >,
@@ -185,7 +195,7 @@ pub trait Sha512AccPeripheral {
     }
     fn read_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::sha512_acc::bits::Status::Register,
     > {
@@ -195,9 +205,9 @@ pub trait Sha512AccPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_status();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
-    fn read_digest(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_digest(&mut self, index: usize) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read sha512_acc::digest[{}]",
@@ -211,7 +221,7 @@ pub trait Sha512AccPeripheral {
     }
     fn read_control(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::sha512_acc::bits::Control::Register,
     > {
@@ -221,11 +231,11 @@ pub trait Sha512AccPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_control();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_control(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::sha512_acc::bits::Control::Register,
         >,
@@ -242,7 +252,7 @@ pub trait Sha512AccPeripheral {
     }
     fn read_intr_block_rf_global_intr_en_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::sha512_acc::bits::GlobalIntrEnT::Register,
     > {
@@ -252,11 +262,11 @@ pub trait Sha512AccPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_intr_block_rf_global_intr_en_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_intr_block_rf_global_intr_en_r(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::sha512_acc::bits::GlobalIntrEnT::Register,
         >,
@@ -270,7 +280,7 @@ pub trait Sha512AccPeripheral {
     }
     fn read_intr_block_rf_error_intr_en_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::sha512_acc::bits::ErrorIntrEnT::Register,
     > {
@@ -280,11 +290,11 @@ pub trait Sha512AccPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_intr_block_rf_error_intr_en_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_intr_block_rf_error_intr_en_r(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::sha512_acc::bits::ErrorIntrEnT::Register,
         >,
@@ -298,7 +308,7 @@ pub trait Sha512AccPeripheral {
     }
     fn read_intr_block_rf_notif_intr_en_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::sha512_acc::bits::NotifIntrEnT::Register,
     > {
@@ -308,11 +318,11 @@ pub trait Sha512AccPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_intr_block_rf_notif_intr_en_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_intr_block_rf_notif_intr_en_r(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::sha512_acc::bits::NotifIntrEnT::Register,
         >,
@@ -326,7 +336,7 @@ pub trait Sha512AccPeripheral {
     }
     fn read_intr_block_rf_error_global_intr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::sha512_acc::bits::GlobalIntrT::Register,
     > {
@@ -336,11 +346,11 @@ pub trait Sha512AccPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_intr_block_rf_error_global_intr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_intr_block_rf_notif_global_intr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::sha512_acc::bits::GlobalIntrT::Register,
     > {
@@ -350,11 +360,11 @@ pub trait Sha512AccPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_intr_block_rf_notif_global_intr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_intr_block_rf_error_internal_intr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::sha512_acc::bits::ErrorIntrT::Register,
     > {
@@ -364,11 +374,11 @@ pub trait Sha512AccPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_intr_block_rf_error_internal_intr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_intr_block_rf_error_internal_intr_r(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::sha512_acc::bits::ErrorIntrT::Register,
         >,
@@ -382,7 +392,7 @@ pub trait Sha512AccPeripheral {
     }
     fn read_intr_block_rf_notif_internal_intr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::sha512_acc::bits::NotifIntrT::Register,
     > {
@@ -392,11 +402,11 @@ pub trait Sha512AccPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_intr_block_rf_notif_internal_intr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_intr_block_rf_notif_internal_intr_r(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::sha512_acc::bits::NotifIntrT::Register,
         >,
@@ -410,7 +420,7 @@ pub trait Sha512AccPeripheral {
     }
     fn read_intr_block_rf_error_intr_trig_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::sha512_acc::bits::ErrorIntrTrigT::Register,
     > {
@@ -420,11 +430,11 @@ pub trait Sha512AccPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_intr_block_rf_error_intr_trig_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_intr_block_rf_error_intr_trig_r(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::sha512_acc::bits::ErrorIntrTrigT::Register,
         >,
@@ -438,7 +448,7 @@ pub trait Sha512AccPeripheral {
     }
     fn read_intr_block_rf_notif_intr_trig_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::sha512_acc::bits::NotifIntrTrigT::Register,
     > {
@@ -448,11 +458,11 @@ pub trait Sha512AccPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_intr_block_rf_notif_intr_trig_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_intr_block_rf_notif_intr_trig_r(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::sha512_acc::bits::NotifIntrTrigT::Register,
         >,
@@ -464,7 +474,9 @@ pub trait Sha512AccPeripheral {
             generated.write_intr_block_rf_notif_intr_trig_r(val);
         }
     }
-    fn read_intr_block_rf_error0_intr_count_r(&mut self) -> caliptra_emu_types::RvData {
+    fn read_intr_block_rf_error0_intr_count_r(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read sha512_acc::intr_block_rf_error0_intr_count_r");
         }
@@ -473,7 +485,10 @@ pub trait Sha512AccPeripheral {
         }
         0
     }
-    fn write_intr_block_rf_error0_intr_count_r(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_intr_block_rf_error0_intr_count_r(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write sha512_acc::intr_block_rf_error0_intr_count_r = 0x{:08x}" , val);
         }
@@ -481,7 +496,9 @@ pub trait Sha512AccPeripheral {
             generated.write_intr_block_rf_error0_intr_count_r(val);
         }
     }
-    fn read_intr_block_rf_error1_intr_count_r(&mut self) -> caliptra_emu_types::RvData {
+    fn read_intr_block_rf_error1_intr_count_r(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read sha512_acc::intr_block_rf_error1_intr_count_r");
         }
@@ -490,7 +507,10 @@ pub trait Sha512AccPeripheral {
         }
         0
     }
-    fn write_intr_block_rf_error1_intr_count_r(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_intr_block_rf_error1_intr_count_r(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write sha512_acc::intr_block_rf_error1_intr_count_r = 0x{:08x}" , val);
         }
@@ -498,7 +518,9 @@ pub trait Sha512AccPeripheral {
             generated.write_intr_block_rf_error1_intr_count_r(val);
         }
     }
-    fn read_intr_block_rf_error2_intr_count_r(&mut self) -> caliptra_emu_types::RvData {
+    fn read_intr_block_rf_error2_intr_count_r(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read sha512_acc::intr_block_rf_error2_intr_count_r");
         }
@@ -507,7 +529,10 @@ pub trait Sha512AccPeripheral {
         }
         0
     }
-    fn write_intr_block_rf_error2_intr_count_r(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_intr_block_rf_error2_intr_count_r(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write sha512_acc::intr_block_rf_error2_intr_count_r = 0x{:08x}" , val);
         }
@@ -515,7 +540,9 @@ pub trait Sha512AccPeripheral {
             generated.write_intr_block_rf_error2_intr_count_r(val);
         }
     }
-    fn read_intr_block_rf_error3_intr_count_r(&mut self) -> caliptra_emu_types::RvData {
+    fn read_intr_block_rf_error3_intr_count_r(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read sha512_acc::intr_block_rf_error3_intr_count_r");
         }
@@ -524,7 +551,10 @@ pub trait Sha512AccPeripheral {
         }
         0
     }
-    fn write_intr_block_rf_error3_intr_count_r(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_intr_block_rf_error3_intr_count_r(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write sha512_acc::intr_block_rf_error3_intr_count_r = 0x{:08x}" , val);
         }
@@ -532,7 +562,9 @@ pub trait Sha512AccPeripheral {
             generated.write_intr_block_rf_error3_intr_count_r(val);
         }
     }
-    fn read_intr_block_rf_notif_cmd_done_intr_count_r(&mut self) -> caliptra_emu_types::RvData {
+    fn read_intr_block_rf_notif_cmd_done_intr_count_r(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read sha512_acc::intr_block_rf_notif_cmd_done_intr_count_r");
         }
@@ -541,7 +573,10 @@ pub trait Sha512AccPeripheral {
         }
         0
     }
-    fn write_intr_block_rf_notif_cmd_done_intr_count_r(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_intr_block_rf_notif_cmd_done_intr_count_r(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write sha512_acc::intr_block_rf_notif_cmd_done_intr_count_r = 0x{:08x}" , val);
         }
@@ -551,7 +586,7 @@ pub trait Sha512AccPeripheral {
     }
     fn read_intr_block_rf_error0_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::sha512_acc::bits::IntrCountIncrT::Register,
     > {
@@ -561,11 +596,11 @@ pub trait Sha512AccPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_intr_block_rf_error0_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_intr_block_rf_error1_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::sha512_acc::bits::IntrCountIncrT::Register,
     > {
@@ -575,11 +610,11 @@ pub trait Sha512AccPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_intr_block_rf_error1_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_intr_block_rf_error2_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::sha512_acc::bits::IntrCountIncrT::Register,
     > {
@@ -589,11 +624,11 @@ pub trait Sha512AccPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_intr_block_rf_error2_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_intr_block_rf_error3_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::sha512_acc::bits::IntrCountIncrT::Register,
     > {
@@ -603,11 +638,11 @@ pub trait Sha512AccPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_intr_block_rf_error3_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_intr_block_rf_notif_cmd_done_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::sha512_acc::bits::IntrCountIncrT::Register,
     > {
@@ -617,73 +652,81 @@ pub trait Sha512AccPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_intr_block_rf_notif_cmd_done_intr_count_incr_r();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
 }
 #[derive(Clone, Debug)]
 pub struct Sha512AccGenerated {
-    lock: caliptra_emu_types::RvData,
-    user: caliptra_emu_types::RvData,
-    mode: caliptra_emu_types::RvData,
-    start_address: caliptra_emu_types::RvData,
-    dlen: caliptra_emu_types::RvData,
-    datain: caliptra_emu_types::RvData,
-    execute: caliptra_emu_types::RvData,
-    status: caliptra_emu_types::RvData,
-    digest: Vec<caliptra_emu_types::RvData>,
-    control: caliptra_emu_types::RvData,
-    intr_block_rf_global_intr_en_r: caliptra_emu_types::RvData,
-    intr_block_rf_error_intr_en_r: caliptra_emu_types::RvData,
-    intr_block_rf_notif_intr_en_r: caliptra_emu_types::RvData,
-    intr_block_rf_error_global_intr_r: caliptra_emu_types::RvData,
-    intr_block_rf_notif_global_intr_r: caliptra_emu_types::RvData,
-    intr_block_rf_error_internal_intr_r: caliptra_emu_types::RvData,
-    intr_block_rf_notif_internal_intr_r: caliptra_emu_types::RvData,
-    intr_block_rf_error_intr_trig_r: caliptra_emu_types::RvData,
-    intr_block_rf_notif_intr_trig_r: caliptra_emu_types::RvData,
-    intr_block_rf_error0_intr_count_r: caliptra_emu_types::RvData,
-    intr_block_rf_error1_intr_count_r: caliptra_emu_types::RvData,
-    intr_block_rf_error2_intr_count_r: caliptra_emu_types::RvData,
-    intr_block_rf_error3_intr_count_r: caliptra_emu_types::RvData,
-    intr_block_rf_notif_cmd_done_intr_count_r: caliptra_emu_types::RvData,
-    intr_block_rf_error0_intr_count_incr_r: caliptra_emu_types::RvData,
-    intr_block_rf_error1_intr_count_incr_r: caliptra_emu_types::RvData,
-    intr_block_rf_error2_intr_count_incr_r: caliptra_emu_types::RvData,
-    intr_block_rf_error3_intr_count_incr_r: caliptra_emu_types::RvData,
-    intr_block_rf_notif_cmd_done_intr_count_incr_r: caliptra_emu_types::RvData,
+    lock: caliptra_core_tools::caliptra_emu_types::RvData,
+    user: caliptra_core_tools::caliptra_emu_types::RvData,
+    mode: caliptra_core_tools::caliptra_emu_types::RvData,
+    start_address: caliptra_core_tools::caliptra_emu_types::RvData,
+    dlen: caliptra_core_tools::caliptra_emu_types::RvData,
+    datain: caliptra_core_tools::caliptra_emu_types::RvData,
+    execute: caliptra_core_tools::caliptra_emu_types::RvData,
+    status: caliptra_core_tools::caliptra_emu_types::RvData,
+    digest: Vec<caliptra_core_tools::caliptra_emu_types::RvData>,
+    control: caliptra_core_tools::caliptra_emu_types::RvData,
+    intr_block_rf_global_intr_en_r: caliptra_core_tools::caliptra_emu_types::RvData,
+    intr_block_rf_error_intr_en_r: caliptra_core_tools::caliptra_emu_types::RvData,
+    intr_block_rf_notif_intr_en_r: caliptra_core_tools::caliptra_emu_types::RvData,
+    intr_block_rf_error_global_intr_r: caliptra_core_tools::caliptra_emu_types::RvData,
+    intr_block_rf_notif_global_intr_r: caliptra_core_tools::caliptra_emu_types::RvData,
+    intr_block_rf_error_internal_intr_r: caliptra_core_tools::caliptra_emu_types::RvData,
+    intr_block_rf_notif_internal_intr_r: caliptra_core_tools::caliptra_emu_types::RvData,
+    intr_block_rf_error_intr_trig_r: caliptra_core_tools::caliptra_emu_types::RvData,
+    intr_block_rf_notif_intr_trig_r: caliptra_core_tools::caliptra_emu_types::RvData,
+    intr_block_rf_error0_intr_count_r: caliptra_core_tools::caliptra_emu_types::RvData,
+    intr_block_rf_error1_intr_count_r: caliptra_core_tools::caliptra_emu_types::RvData,
+    intr_block_rf_error2_intr_count_r: caliptra_core_tools::caliptra_emu_types::RvData,
+    intr_block_rf_error3_intr_count_r: caliptra_core_tools::caliptra_emu_types::RvData,
+    intr_block_rf_notif_cmd_done_intr_count_r: caliptra_core_tools::caliptra_emu_types::RvData,
+    intr_block_rf_error0_intr_count_incr_r: caliptra_core_tools::caliptra_emu_types::RvData,
+    intr_block_rf_error1_intr_count_incr_r: caliptra_core_tools::caliptra_emu_types::RvData,
+    intr_block_rf_error2_intr_count_incr_r: caliptra_core_tools::caliptra_emu_types::RvData,
+    intr_block_rf_error3_intr_count_incr_r: caliptra_core_tools::caliptra_emu_types::RvData,
+    intr_block_rf_notif_cmd_done_intr_count_incr_r: caliptra_core_tools::caliptra_emu_types::RvData,
 }
 impl Default for Sha512AccGenerated {
     fn default() -> Self {
         Self {
-            lock: 1 as caliptra_emu_types::RvData,
-            user: 0 as caliptra_emu_types::RvData,
-            mode: 0 as caliptra_emu_types::RvData,
-            start_address: 0 as caliptra_emu_types::RvData,
-            dlen: 0 as caliptra_emu_types::RvData,
-            datain: 0 as caliptra_emu_types::RvData,
-            execute: 0 as caliptra_emu_types::RvData,
-            status: 0 as caliptra_emu_types::RvData,
-            digest: vec![0 as caliptra_emu_types::RvData; 16],
-            control: 0 as caliptra_emu_types::RvData,
-            intr_block_rf_global_intr_en_r: 0 as caliptra_emu_types::RvData,
-            intr_block_rf_error_intr_en_r: 0 as caliptra_emu_types::RvData,
-            intr_block_rf_notif_intr_en_r: 0 as caliptra_emu_types::RvData,
-            intr_block_rf_error_global_intr_r: 0 as caliptra_emu_types::RvData,
-            intr_block_rf_notif_global_intr_r: 0 as caliptra_emu_types::RvData,
-            intr_block_rf_error_internal_intr_r: 0 as caliptra_emu_types::RvData,
-            intr_block_rf_notif_internal_intr_r: 0 as caliptra_emu_types::RvData,
-            intr_block_rf_error_intr_trig_r: 0 as caliptra_emu_types::RvData,
-            intr_block_rf_notif_intr_trig_r: 0 as caliptra_emu_types::RvData,
-            intr_block_rf_error0_intr_count_r: 0 as caliptra_emu_types::RvData,
-            intr_block_rf_error1_intr_count_r: 0 as caliptra_emu_types::RvData,
-            intr_block_rf_error2_intr_count_r: 0 as caliptra_emu_types::RvData,
-            intr_block_rf_error3_intr_count_r: 0 as caliptra_emu_types::RvData,
-            intr_block_rf_notif_cmd_done_intr_count_r: 0 as caliptra_emu_types::RvData,
-            intr_block_rf_error0_intr_count_incr_r: 0 as caliptra_emu_types::RvData,
-            intr_block_rf_error1_intr_count_incr_r: 0 as caliptra_emu_types::RvData,
-            intr_block_rf_error2_intr_count_incr_r: 0 as caliptra_emu_types::RvData,
-            intr_block_rf_error3_intr_count_incr_r: 0 as caliptra_emu_types::RvData,
-            intr_block_rf_notif_cmd_done_intr_count_incr_r: 0 as caliptra_emu_types::RvData,
+            lock: 1 as caliptra_core_tools::caliptra_emu_types::RvData,
+            user: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            mode: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            start_address: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            dlen: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            datain: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            execute: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            status: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            digest: vec![0 as caliptra_core_tools::caliptra_emu_types::RvData; 16],
+            control: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            intr_block_rf_global_intr_en_r: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            intr_block_rf_error_intr_en_r: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            intr_block_rf_notif_intr_en_r: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            intr_block_rf_error_global_intr_r: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            intr_block_rf_notif_global_intr_r: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            intr_block_rf_error_internal_intr_r: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            intr_block_rf_notif_internal_intr_r: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            intr_block_rf_error_intr_trig_r: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            intr_block_rf_notif_intr_trig_r: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            intr_block_rf_error0_intr_count_r: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            intr_block_rf_error1_intr_count_r: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            intr_block_rf_error2_intr_count_r: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            intr_block_rf_error3_intr_count_r: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            intr_block_rf_notif_cmd_done_intr_count_r: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            intr_block_rf_error0_intr_count_incr_r: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            intr_block_rf_error1_intr_count_incr_r: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            intr_block_rf_error2_intr_count_incr_r: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            intr_block_rf_error3_intr_count_incr_r: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            intr_block_rf_notif_cmd_done_intr_count_incr_r: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
         }
     }
 }
@@ -707,18 +750,18 @@ impl Sha512AccPeripheral for Sha512AccGenerated {
     }
     fn read_lock(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::sha512_acc::bits::Lock::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read sha512_acc::lock");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.lock)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.lock)
     }
     fn write_lock(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::sha512_acc::bits::Lock::Register,
         >,
@@ -729,14 +772,14 @@ impl Sha512AccPeripheral for Sha512AccGenerated {
                 val.reg.get()
             );
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.lock;
         let mut new_val = current_val;
-        let bits_to_clear_0 = write_val & (1 as caliptra_emu_types::RvData);
+        let bits_to_clear_0 = write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_0;
         self.lock = new_val;
     }
-    fn read_user(&mut self) -> caliptra_emu_types::RvData {
+    fn read_user(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read sha512_acc::user");
         }
@@ -744,18 +787,18 @@ impl Sha512AccPeripheral for Sha512AccGenerated {
     }
     fn read_mode(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::sha512_acc::bits::Mode::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read sha512_acc::mode");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.mode)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.mode)
     }
     fn write_mode(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::sha512_acc::bits::Mode::Register,
         >,
@@ -766,86 +809,86 @@ impl Sha512AccPeripheral for Sha512AccGenerated {
                 val.reg.get()
             );
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.mode;
         let mut new_val = current_val;
-        new_val = (new_val & !(3 as caliptra_emu_types::RvData))
-            | (write_val & (3 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(4 as caliptra_emu_types::RvData))
-            | (write_val & (4 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(3 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (3 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(4 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (4 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.mode = new_val;
     }
-    fn read_start_address(&mut self) -> caliptra_emu_types::RvData {
+    fn read_start_address(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read sha512_acc::start_address");
         }
         self.start_address
     }
-    fn write_start_address(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_start_address(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write sha512_acc::start_address = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.start_address;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.start_address = new_val;
     }
-    fn read_dlen(&mut self) -> caliptra_emu_types::RvData {
+    fn read_dlen(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read sha512_acc::dlen");
         }
         self.dlen
     }
-    fn write_dlen(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_dlen(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: write sha512_acc::dlen = 0x{:08x}",
                 val
             );
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.dlen;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.dlen = new_val;
     }
-    fn read_datain(&mut self) -> caliptra_emu_types::RvData {
+    fn read_datain(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read sha512_acc::datain");
         }
         self.datain
     }
-    fn write_datain(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_datain(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: write sha512_acc::datain = 0x{:08x}",
                 val
             );
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.datain;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.datain = new_val;
     }
     fn read_execute(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::sha512_acc::bits::Execute::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read sha512_acc::execute");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.execute)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.execute)
     }
     fn write_execute(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::sha512_acc::bits::Execute::Register,
         >,
@@ -856,25 +899,25 @@ impl Sha512AccPeripheral for Sha512AccGenerated {
                 val.reg.get()
             );
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.execute;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.execute = new_val;
     }
     fn read_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::sha512_acc::bits::Status::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read sha512_acc::status");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.status)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.status)
     }
-    fn read_digest(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_digest(&mut self, index: usize) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read sha512_acc::digest[{}]",
@@ -885,18 +928,18 @@ impl Sha512AccPeripheral for Sha512AccGenerated {
     }
     fn read_control(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::sha512_acc::bits::Control::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read sha512_acc::control");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.control)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.control)
     }
     fn write_control(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::sha512_acc::bits::Control::Register,
         >,
@@ -907,27 +950,29 @@ impl Sha512AccPeripheral for Sha512AccGenerated {
                 val.reg.get()
             );
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.control;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.control = new_val;
     }
     fn read_intr_block_rf_global_intr_en_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::sha512_acc::bits::GlobalIntrEnT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read sha512_acc::intr_block_rf_global_intr_en_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.intr_block_rf_global_intr_en_r)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.intr_block_rf_global_intr_en_r,
+        )
     }
     fn write_intr_block_rf_global_intr_en_r(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::sha512_acc::bits::GlobalIntrEnT::Register,
         >,
@@ -935,29 +980,31 @@ impl Sha512AccPeripheral for Sha512AccGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write sha512_acc::intr_block_rf_global_intr_en_r = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.intr_block_rf_global_intr_en_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(2 as caliptra_emu_types::RvData))
-            | (write_val & (2 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(2 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.intr_block_rf_global_intr_en_r = new_val;
     }
     fn read_intr_block_rf_error_intr_en_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::sha512_acc::bits::ErrorIntrEnT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read sha512_acc::intr_block_rf_error_intr_en_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.intr_block_rf_error_intr_en_r)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.intr_block_rf_error_intr_en_r,
+        )
     }
     fn write_intr_block_rf_error_intr_en_r(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::sha512_acc::bits::ErrorIntrEnT::Register,
         >,
@@ -965,33 +1012,35 @@ impl Sha512AccPeripheral for Sha512AccGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write sha512_acc::intr_block_rf_error_intr_en_r = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.intr_block_rf_error_intr_en_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(2 as caliptra_emu_types::RvData))
-            | (write_val & (2 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(4 as caliptra_emu_types::RvData))
-            | (write_val & (4 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(8 as caliptra_emu_types::RvData))
-            | (write_val & (8 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(2 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(4 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (4 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(8 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (8 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.intr_block_rf_error_intr_en_r = new_val;
     }
     fn read_intr_block_rf_notif_intr_en_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::sha512_acc::bits::NotifIntrEnT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read sha512_acc::intr_block_rf_notif_intr_en_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.intr_block_rf_notif_intr_en_r)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.intr_block_rf_notif_intr_en_r,
+        )
     }
     fn write_intr_block_rf_notif_intr_en_r(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::sha512_acc::bits::NotifIntrEnT::Register,
         >,
@@ -999,49 +1048,55 @@ impl Sha512AccPeripheral for Sha512AccGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write sha512_acc::intr_block_rf_notif_intr_en_r = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.intr_block_rf_notif_intr_en_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.intr_block_rf_notif_intr_en_r = new_val;
     }
     fn read_intr_block_rf_error_global_intr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::sha512_acc::bits::GlobalIntrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read sha512_acc::intr_block_rf_error_global_intr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.intr_block_rf_error_global_intr_r)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.intr_block_rf_error_global_intr_r,
+        )
     }
     fn read_intr_block_rf_notif_global_intr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::sha512_acc::bits::GlobalIntrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read sha512_acc::intr_block_rf_notif_global_intr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.intr_block_rf_notif_global_intr_r)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.intr_block_rf_notif_global_intr_r,
+        )
     }
     fn read_intr_block_rf_error_internal_intr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::sha512_acc::bits::ErrorIntrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read sha512_acc::intr_block_rf_error_internal_intr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.intr_block_rf_error_internal_intr_r)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.intr_block_rf_error_internal_intr_r,
+        )
     }
     fn write_intr_block_rf_error_internal_intr_r(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::sha512_acc::bits::ErrorIntrT::Register,
         >,
@@ -1049,33 +1104,35 @@ impl Sha512AccPeripheral for Sha512AccGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write sha512_acc::intr_block_rf_error_internal_intr_r = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.intr_block_rf_error_internal_intr_r;
         let mut new_val = current_val;
-        let bits_to_clear_0 = write_val & (1 as caliptra_emu_types::RvData);
+        let bits_to_clear_0 = write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_0;
-        let bits_to_clear_1 = write_val & (2 as caliptra_emu_types::RvData);
+        let bits_to_clear_1 = write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_1;
-        let bits_to_clear_2 = write_val & (4 as caliptra_emu_types::RvData);
+        let bits_to_clear_2 = write_val & (4 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_2;
-        let bits_to_clear_3 = write_val & (8 as caliptra_emu_types::RvData);
+        let bits_to_clear_3 = write_val & (8 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_3;
         self.intr_block_rf_error_internal_intr_r = new_val;
     }
     fn read_intr_block_rf_notif_internal_intr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::sha512_acc::bits::NotifIntrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read sha512_acc::intr_block_rf_notif_internal_intr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.intr_block_rf_notif_internal_intr_r)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.intr_block_rf_notif_internal_intr_r,
+        )
     }
     fn write_intr_block_rf_notif_internal_intr_r(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::sha512_acc::bits::NotifIntrT::Register,
         >,
@@ -1083,27 +1140,29 @@ impl Sha512AccPeripheral for Sha512AccGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write sha512_acc::intr_block_rf_notif_internal_intr_r = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.intr_block_rf_notif_internal_intr_r;
         let mut new_val = current_val;
-        let bits_to_clear_0 = write_val & (1 as caliptra_emu_types::RvData);
+        let bits_to_clear_0 = write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_0;
         self.intr_block_rf_notif_internal_intr_r = new_val;
     }
     fn read_intr_block_rf_error_intr_trig_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::sha512_acc::bits::ErrorIntrTrigT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read sha512_acc::intr_block_rf_error_intr_trig_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.intr_block_rf_error_intr_trig_r)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.intr_block_rf_error_intr_trig_r,
+        )
     }
     fn write_intr_block_rf_error_intr_trig_r(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::sha512_acc::bits::ErrorIntrTrigT::Register,
         >,
@@ -1111,33 +1170,35 @@ impl Sha512AccPeripheral for Sha512AccGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write sha512_acc::intr_block_rf_error_intr_trig_r = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.intr_block_rf_error_intr_trig_r;
         let mut new_val = current_val;
-        let bits_to_set_0 = write_val & (1 as caliptra_emu_types::RvData);
+        let bits_to_set_0 = write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_0;
-        let bits_to_set_1 = write_val & (2 as caliptra_emu_types::RvData);
+        let bits_to_set_1 = write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_1;
-        let bits_to_set_2 = write_val & (4 as caliptra_emu_types::RvData);
+        let bits_to_set_2 = write_val & (4 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_2;
-        let bits_to_set_3 = write_val & (8 as caliptra_emu_types::RvData);
+        let bits_to_set_3 = write_val & (8 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_3;
         self.intr_block_rf_error_intr_trig_r = new_val;
     }
     fn read_intr_block_rf_notif_intr_trig_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::sha512_acc::bits::NotifIntrTrigT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read sha512_acc::intr_block_rf_notif_intr_trig_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.intr_block_rf_notif_intr_trig_r)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.intr_block_rf_notif_intr_trig_r,
+        )
     }
     fn write_intr_block_rf_notif_intr_trig_r(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::sha512_acc::bits::NotifIntrTrigT::Register,
         >,
@@ -1145,152 +1206,185 @@ impl Sha512AccPeripheral for Sha512AccGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write sha512_acc::intr_block_rf_notif_intr_trig_r = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.intr_block_rf_notif_intr_trig_r;
         let mut new_val = current_val;
-        let bits_to_set_0 = write_val & (1 as caliptra_emu_types::RvData);
+        let bits_to_set_0 = write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val |= bits_to_set_0;
         self.intr_block_rf_notif_intr_trig_r = new_val;
     }
-    fn read_intr_block_rf_error0_intr_count_r(&mut self) -> caliptra_emu_types::RvData {
+    fn read_intr_block_rf_error0_intr_count_r(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read sha512_acc::intr_block_rf_error0_intr_count_r");
         }
         self.intr_block_rf_error0_intr_count_r
     }
-    fn write_intr_block_rf_error0_intr_count_r(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_intr_block_rf_error0_intr_count_r(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write sha512_acc::intr_block_rf_error0_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.intr_block_rf_error0_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.intr_block_rf_error0_intr_count_r = new_val;
     }
-    fn read_intr_block_rf_error1_intr_count_r(&mut self) -> caliptra_emu_types::RvData {
+    fn read_intr_block_rf_error1_intr_count_r(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read sha512_acc::intr_block_rf_error1_intr_count_r");
         }
         self.intr_block_rf_error1_intr_count_r
     }
-    fn write_intr_block_rf_error1_intr_count_r(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_intr_block_rf_error1_intr_count_r(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write sha512_acc::intr_block_rf_error1_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.intr_block_rf_error1_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.intr_block_rf_error1_intr_count_r = new_val;
     }
-    fn read_intr_block_rf_error2_intr_count_r(&mut self) -> caliptra_emu_types::RvData {
+    fn read_intr_block_rf_error2_intr_count_r(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read sha512_acc::intr_block_rf_error2_intr_count_r");
         }
         self.intr_block_rf_error2_intr_count_r
     }
-    fn write_intr_block_rf_error2_intr_count_r(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_intr_block_rf_error2_intr_count_r(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write sha512_acc::intr_block_rf_error2_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.intr_block_rf_error2_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.intr_block_rf_error2_intr_count_r = new_val;
     }
-    fn read_intr_block_rf_error3_intr_count_r(&mut self) -> caliptra_emu_types::RvData {
+    fn read_intr_block_rf_error3_intr_count_r(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read sha512_acc::intr_block_rf_error3_intr_count_r");
         }
         self.intr_block_rf_error3_intr_count_r
     }
-    fn write_intr_block_rf_error3_intr_count_r(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_intr_block_rf_error3_intr_count_r(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write sha512_acc::intr_block_rf_error3_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.intr_block_rf_error3_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.intr_block_rf_error3_intr_count_r = new_val;
     }
-    fn read_intr_block_rf_notif_cmd_done_intr_count_r(&mut self) -> caliptra_emu_types::RvData {
+    fn read_intr_block_rf_notif_cmd_done_intr_count_r(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read sha512_acc::intr_block_rf_notif_cmd_done_intr_count_r");
         }
         self.intr_block_rf_notif_cmd_done_intr_count_r
     }
-    fn write_intr_block_rf_notif_cmd_done_intr_count_r(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_intr_block_rf_notif_cmd_done_intr_count_r(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write sha512_acc::intr_block_rf_notif_cmd_done_intr_count_r = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.intr_block_rf_notif_cmd_done_intr_count_r;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.intr_block_rf_notif_cmd_done_intr_count_r = new_val;
     }
     fn read_intr_block_rf_error0_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::sha512_acc::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read sha512_acc::intr_block_rf_error0_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.intr_block_rf_error0_intr_count_incr_r)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.intr_block_rf_error0_intr_count_incr_r,
+        )
     }
     fn read_intr_block_rf_error1_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::sha512_acc::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read sha512_acc::intr_block_rf_error1_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.intr_block_rf_error1_intr_count_incr_r)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.intr_block_rf_error1_intr_count_incr_r,
+        )
     }
     fn read_intr_block_rf_error2_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::sha512_acc::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read sha512_acc::intr_block_rf_error2_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.intr_block_rf_error2_intr_count_incr_r)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.intr_block_rf_error2_intr_count_incr_r,
+        )
     }
     fn read_intr_block_rf_error3_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::sha512_acc::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read sha512_acc::intr_block_rf_error3_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.intr_block_rf_error3_intr_count_incr_r)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.intr_block_rf_error3_intr_count_incr_r,
+        )
     }
     fn read_intr_block_rf_notif_cmd_done_intr_count_incr_r(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::sha512_acc::bits::IntrCountIncrT::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read sha512_acc::intr_block_rf_notif_cmd_done_intr_count_incr_r");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
             self.intr_block_rf_notif_cmd_done_intr_count_incr_r,
         )
     }
@@ -1298,73 +1392,76 @@ impl Sha512AccPeripheral for Sha512AccGenerated {
 pub struct Sha512AccBus {
     pub periph: Box<dyn Sha512AccPeripheral>,
 }
-impl caliptra_emu_bus::Bus for Sha512AccBus {
+impl caliptra_core_tools::caliptra_emu_bus::Bus for Sha512AccBus {
     fn read(
         &mut self,
-        size: caliptra_emu_types::RvSize,
-        addr: caliptra_emu_types::RvAddr,
-    ) -> Result<caliptra_emu_types::RvData, caliptra_emu_bus::BusError> {
-        if addr & 0x3 != 0 || size != caliptra_emu_types::RvSize::Word {
-            return Err(caliptra_emu_bus::BusError::LoadAddrMisaligned);
+        size: caliptra_core_tools::caliptra_emu_types::RvSize,
+        addr: caliptra_core_tools::caliptra_emu_types::RvAddr,
+    ) -> Result<
+        caliptra_core_tools::caliptra_emu_types::RvData,
+        caliptra_core_tools::caliptra_emu_bus::BusError,
+    > {
+        if addr & 0x3 != 0 || size != caliptra_core_tools::caliptra_emu_types::RvSize::Word {
+            return Err(caliptra_core_tools::caliptra_emu_bus::BusError::LoadAddrMisaligned);
         }
         match addr {
-            0..4 => Ok(caliptra_emu_types::RvData::from(
+            0..4 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_lock().reg.get(),
             )),
             4..8 => Ok(self.periph.read_user()),
-            8..0xc => Ok(caliptra_emu_types::RvData::from(
+            8..0xc => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_mode().reg.get(),
             )),
             0xc..0x10 => Ok(self.periph.read_start_address()),
             0x10..0x14 => Ok(self.periph.read_dlen()),
             0x14..0x18 => Ok(self.periph.read_datain()),
-            0x18..0x1c => Ok(caliptra_emu_types::RvData::from(
+            0x18..0x1c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_execute().reg.get(),
             )),
-            0x1c..0x20 => Ok(caliptra_emu_types::RvData::from(
+            0x1c..0x20 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_status().reg.get(),
             )),
             0x20..0x60 => Ok(self.periph.read_digest((addr as usize - 0x20) / 4)),
-            0x60..0x64 => Ok(caliptra_emu_types::RvData::from(
+            0x60..0x64 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_control().reg.get(),
             )),
-            0x800..0x804 => Ok(caliptra_emu_types::RvData::from(
+            0x800..0x804 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_intr_block_rf_global_intr_en_r().reg.get(),
             )),
-            0x804..0x808 => Ok(caliptra_emu_types::RvData::from(
+            0x804..0x808 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_intr_block_rf_error_intr_en_r().reg.get(),
             )),
-            0x808..0x80c => Ok(caliptra_emu_types::RvData::from(
+            0x808..0x80c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_intr_block_rf_notif_intr_en_r().reg.get(),
             )),
-            0x80c..0x810 => Ok(caliptra_emu_types::RvData::from(
+            0x80c..0x810 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_intr_block_rf_error_global_intr_r()
                     .reg
                     .get(),
             )),
-            0x810..0x814 => Ok(caliptra_emu_types::RvData::from(
+            0x810..0x814 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_intr_block_rf_notif_global_intr_r()
                     .reg
                     .get(),
             )),
-            0x814..0x818 => Ok(caliptra_emu_types::RvData::from(
+            0x814..0x818 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_intr_block_rf_error_internal_intr_r()
                     .reg
                     .get(),
             )),
-            0x818..0x81c => Ok(caliptra_emu_types::RvData::from(
+            0x818..0x81c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_intr_block_rf_notif_internal_intr_r()
                     .reg
                     .get(),
             )),
-            0x81c..0x820 => Ok(caliptra_emu_types::RvData::from(
+            0x81c..0x820 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_intr_block_rf_error_intr_trig_r().reg.get(),
             )),
-            0x820..0x824 => Ok(caliptra_emu_types::RvData::from(
+            0x820..0x824 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_intr_block_rf_notif_intr_trig_r().reg.get(),
             )),
             0x900..0x904 => Ok(self.periph.read_intr_block_rf_error0_intr_count_r()),
@@ -1372,58 +1469,58 @@ impl caliptra_emu_bus::Bus for Sha512AccBus {
             0x908..0x90c => Ok(self.periph.read_intr_block_rf_error2_intr_count_r()),
             0x90c..0x910 => Ok(self.periph.read_intr_block_rf_error3_intr_count_r()),
             0x980..0x984 => Ok(self.periph.read_intr_block_rf_notif_cmd_done_intr_count_r()),
-            0xa00..0xa04 => Ok(caliptra_emu_types::RvData::from(
+            0xa00..0xa04 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_intr_block_rf_error0_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0xa04..0xa08 => Ok(caliptra_emu_types::RvData::from(
+            0xa04..0xa08 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_intr_block_rf_error1_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0xa08..0xa0c => Ok(caliptra_emu_types::RvData::from(
+            0xa08..0xa0c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_intr_block_rf_error2_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0xa0c..0xa10 => Ok(caliptra_emu_types::RvData::from(
+            0xa0c..0xa10 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_intr_block_rf_error3_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            0xa10..0xa14 => Ok(caliptra_emu_types::RvData::from(
+            0xa10..0xa14 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_intr_block_rf_notif_cmd_done_intr_count_incr_r()
                     .reg
                     .get(),
             )),
-            _ => Err(caliptra_emu_bus::BusError::LoadAccessFault),
+            _ => Err(caliptra_core_tools::caliptra_emu_bus::BusError::LoadAccessFault),
         }
     }
     fn write(
         &mut self,
-        size: caliptra_emu_types::RvSize,
-        addr: caliptra_emu_types::RvAddr,
-        val: caliptra_emu_types::RvData,
-    ) -> Result<(), caliptra_emu_bus::BusError> {
-        if addr & 0x3 != 0 || size != caliptra_emu_types::RvSize::Word {
-            return Err(caliptra_emu_bus::BusError::StoreAddrMisaligned);
+        size: caliptra_core_tools::caliptra_emu_types::RvSize,
+        addr: caliptra_core_tools::caliptra_emu_types::RvAddr,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) -> Result<(), caliptra_core_tools::caliptra_emu_bus::BusError> {
+        if addr & 0x3 != 0 || size != caliptra_core_tools::caliptra_emu_types::RvSize::Word {
+            return Err(caliptra_core_tools::caliptra_emu_bus::BusError::StoreAddrMisaligned);
         }
         match addr {
             0..4 => {
                 self.periph
-                    .write_lock(caliptra_emu_bus::ReadWriteRegister::new(val));
+                    .write_lock(caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
             4..8 => Ok(()),
             8..0xc => {
                 self.periph
-                    .write_mode(caliptra_emu_bus::ReadWriteRegister::new(val));
+                    .write_mode(caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val));
                 Ok(())
             }
             0xc..0x10 => {
@@ -1439,32 +1536,34 @@ impl caliptra_emu_bus::Bus for Sha512AccBus {
                 Ok(())
             }
             0x18..0x1c => {
-                self.periph
-                    .write_execute(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_execute(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0x1c..0x20 => Ok(()),
             0x20..0x60 => Ok(()),
             0x60..0x64 => {
-                self.periph
-                    .write_control(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_control(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0x800..0x804 => {
                 self.periph.write_intr_block_rf_global_intr_en_r(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x804..0x808 => {
                 self.periph.write_intr_block_rf_error_intr_en_r(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x808..0x80c => {
                 self.periph.write_intr_block_rf_notif_intr_en_r(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
@@ -1472,25 +1571,25 @@ impl caliptra_emu_bus::Bus for Sha512AccBus {
             0x810..0x814 => Ok(()),
             0x814..0x818 => {
                 self.periph.write_intr_block_rf_error_internal_intr_r(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x818..0x81c => {
                 self.periph.write_intr_block_rf_notif_internal_intr_r(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x81c..0x820 => {
                 self.periph.write_intr_block_rf_error_intr_trig_r(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x820..0x824 => {
                 self.periph.write_intr_block_rf_notif_intr_trig_r(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
@@ -1520,7 +1619,7 @@ impl caliptra_emu_bus::Bus for Sha512AccBus {
             0xa08..0xa0c => Ok(()),
             0xa0c..0xa10 => Ok(()),
             0xa10..0xa14 => Ok(()),
-            _ => Err(caliptra_emu_bus::BusError::StoreAccessFault),
+            _ => Err(caliptra_core_tools::caliptra_emu_bus::BusError::StoreAccessFault),
         }
     }
     fn poll(&mut self) {

--- a/registers/generated-emulator/src/soc.rs
+++ b/registers/generated-emulator/src/soc.rs
@@ -5,14 +5,24 @@
 #[allow(unused_imports)]
 use tock_registers::interfaces::{Readable, Writeable};
 pub trait SocPeripheral {
-    fn set_dma_ram(&mut self, _ram: std::rc::Rc<std::cell::RefCell<caliptra_emu_bus::Ram>>) {}
-    fn set_dma_rom_sram(&mut self, _ram: std::rc::Rc<std::cell::RefCell<caliptra_emu_bus::Ram>>) {}
+    fn set_dma_ram(
+        &mut self,
+        _ram: std::rc::Rc<std::cell::RefCell<caliptra_core_tools::caliptra_emu_bus::Ram>>,
+    ) {
+    }
+    fn set_dma_rom_sram(
+        &mut self,
+        _ram: std::rc::Rc<std::cell::RefCell<caliptra_core_tools::caliptra_emu_bus::Ram>>,
+    ) {
+    }
     fn register_event_channels(
         &mut self,
-        _events_to_caliptra: std::sync::mpsc::Sender<caliptra_emu_bus::Event>,
-        _events_from_caliptra: std::sync::mpsc::Receiver<caliptra_emu_bus::Event>,
-        _events_to_mcu: std::sync::mpsc::Sender<caliptra_emu_bus::Event>,
-        _events_from_mcu: std::sync::mpsc::Receiver<caliptra_emu_bus::Event>,
+        _events_to_caliptra: std::sync::mpsc::Sender<caliptra_core_tools::caliptra_emu_bus::Event>,
+        _events_from_caliptra: std::sync::mpsc::Receiver<
+            caliptra_core_tools::caliptra_emu_bus::Event,
+        >,
+        _events_to_mcu: std::sync::mpsc::Sender<caliptra_core_tools::caliptra_emu_bus::Event>,
+        _events_from_mcu: std::sync::mpsc::Receiver<caliptra_core_tools::caliptra_emu_bus::Event>,
     ) {
     }
     fn poll(&mut self) {}
@@ -23,7 +33,7 @@ pub trait SocPeripheral {
     }
     fn read_cptra_hw_error_fatal(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraHwErrorFatal::Register,
     > {
@@ -33,11 +43,11 @@ pub trait SocPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_cptra_hw_error_fatal();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_cptra_hw_error_fatal(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::CptraHwErrorFatal::Register,
         >,
@@ -54,7 +64,7 @@ pub trait SocPeripheral {
     }
     fn read_cptra_hw_error_non_fatal(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraHwErrorNonFatal::Register,
     > {
@@ -64,11 +74,11 @@ pub trait SocPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_cptra_hw_error_non_fatal();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_cptra_hw_error_non_fatal(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::CptraHwErrorNonFatal::Register,
         >,
@@ -80,7 +90,7 @@ pub trait SocPeripheral {
             generated.write_cptra_hw_error_non_fatal(val);
         }
     }
-    fn read_cptra_fw_error_fatal(&mut self) -> caliptra_emu_types::RvData {
+    fn read_cptra_fw_error_fatal(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read soc::cptra_fw_error_fatal");
         }
@@ -89,7 +99,7 @@ pub trait SocPeripheral {
         }
         0
     }
-    fn write_cptra_fw_error_fatal(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_cptra_fw_error_fatal(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write soc::cptra_fw_error_fatal = 0x{:08x}",
@@ -100,7 +110,7 @@ pub trait SocPeripheral {
             generated.write_cptra_fw_error_fatal(val);
         }
     }
-    fn read_cptra_fw_error_non_fatal(&mut self) -> caliptra_emu_types::RvData {
+    fn read_cptra_fw_error_non_fatal(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read soc::cptra_fw_error_non_fatal");
         }
@@ -109,7 +119,10 @@ pub trait SocPeripheral {
         }
         0
     }
-    fn write_cptra_fw_error_non_fatal(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_cptra_fw_error_non_fatal(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write soc::cptra_fw_error_non_fatal = 0x{:08x}" , val);
         }
@@ -117,7 +130,7 @@ pub trait SocPeripheral {
             generated.write_cptra_fw_error_non_fatal(val);
         }
     }
-    fn read_cptra_hw_error_enc(&mut self) -> caliptra_emu_types::RvData {
+    fn read_cptra_hw_error_enc(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read soc::cptra_hw_error_enc");
         }
@@ -126,7 +139,7 @@ pub trait SocPeripheral {
         }
         0
     }
-    fn write_cptra_hw_error_enc(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_cptra_hw_error_enc(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write soc::cptra_hw_error_enc = 0x{:08x}",
@@ -137,7 +150,7 @@ pub trait SocPeripheral {
             generated.write_cptra_hw_error_enc(val);
         }
     }
-    fn read_cptra_fw_error_enc(&mut self) -> caliptra_emu_types::RvData {
+    fn read_cptra_fw_error_enc(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read soc::cptra_fw_error_enc");
         }
@@ -146,7 +159,7 @@ pub trait SocPeripheral {
         }
         0
     }
-    fn write_cptra_fw_error_enc(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_cptra_fw_error_enc(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write soc::cptra_fw_error_enc = 0x{:08x}",
@@ -157,7 +170,10 @@ pub trait SocPeripheral {
             generated.write_cptra_fw_error_enc(val);
         }
     }
-    fn read_cptra_fw_extended_error_info(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_cptra_fw_extended_error_info(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read soc::cptra_fw_extended_error_info[{}]",
@@ -171,7 +187,7 @@ pub trait SocPeripheral {
     }
     fn write_cptra_fw_extended_error_info(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
         index: usize,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
@@ -181,7 +197,7 @@ pub trait SocPeripheral {
             generated.write_cptra_fw_extended_error_info(val, index);
         }
     }
-    fn read_cptra_boot_status(&mut self) -> caliptra_emu_types::RvData {
+    fn read_cptra_boot_status(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read soc::cptra_boot_status");
         }
@@ -190,7 +206,7 @@ pub trait SocPeripheral {
         }
         0
     }
-    fn write_cptra_boot_status(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_cptra_boot_status(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write soc::cptra_boot_status = 0x{:08x}",
@@ -203,7 +219,7 @@ pub trait SocPeripheral {
     }
     fn read_cptra_flow_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraFlowStatus::Register,
     > {
@@ -213,11 +229,11 @@ pub trait SocPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_cptra_flow_status();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_cptra_flow_status(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::CptraFlowStatus::Register,
         >,
@@ -234,7 +250,7 @@ pub trait SocPeripheral {
     }
     fn read_cptra_reset_reason(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraResetReason::Register,
     > {
@@ -244,11 +260,11 @@ pub trait SocPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_cptra_reset_reason();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_cptra_security_state(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraSecurityState::Register,
     > {
@@ -258,9 +274,12 @@ pub trait SocPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_cptra_security_state();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
-    fn read_cptra_mbox_valid_axi_user(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_cptra_mbox_valid_axi_user(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read soc::cptra_mbox_valid_axi_user[{}]",
@@ -272,7 +291,11 @@ pub trait SocPeripheral {
         }
         0
     }
-    fn write_cptra_mbox_valid_axi_user(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    fn write_cptra_mbox_valid_axi_user(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+        index: usize,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write soc::cptra_mbox_valid_axi_user[{}] = 0x{:08x}" , index , val);
         }
@@ -283,7 +306,7 @@ pub trait SocPeripheral {
     fn read_cptra_mbox_axi_user_lock(
         &mut self,
         index: usize,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraXxxxAxiUserLock::Register,
     > {
@@ -296,11 +319,11 @@ pub trait SocPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_cptra_mbox_axi_user_lock(index);
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_cptra_mbox_axi_user_lock(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::CptraXxxxAxiUserLock::Register,
         >,
@@ -313,7 +336,9 @@ pub trait SocPeripheral {
             generated.write_cptra_mbox_axi_user_lock(val, index);
         }
     }
-    fn read_cptra_trng_valid_axi_user(&mut self) -> caliptra_emu_types::RvData {
+    fn read_cptra_trng_valid_axi_user(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read soc::cptra_trng_valid_axi_user");
         }
@@ -322,7 +347,10 @@ pub trait SocPeripheral {
         }
         0
     }
-    fn write_cptra_trng_valid_axi_user(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_cptra_trng_valid_axi_user(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write soc::cptra_trng_valid_axi_user = 0x{:08x}" , val);
         }
@@ -332,7 +360,7 @@ pub trait SocPeripheral {
     }
     fn read_cptra_trng_axi_user_lock(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraXxxxAxiUserLock::Register,
     > {
@@ -342,11 +370,11 @@ pub trait SocPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_cptra_trng_axi_user_lock();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_cptra_trng_axi_user_lock(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::CptraXxxxAxiUserLock::Register,
         >,
@@ -358,7 +386,10 @@ pub trait SocPeripheral {
             generated.write_cptra_trng_axi_user_lock(val);
         }
     }
-    fn read_cptra_trng_data(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_cptra_trng_data(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read soc::cptra_trng_data[{}]",
@@ -370,7 +401,11 @@ pub trait SocPeripheral {
         }
         0
     }
-    fn write_cptra_trng_data(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    fn write_cptra_trng_data(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+        index: usize,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write soc::cptra_trng_data[{}] = 0x{:08x}",
@@ -383,7 +418,7 @@ pub trait SocPeripheral {
     }
     fn read_cptra_trng_ctrl(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraTrngCtrl::Register,
     > {
@@ -393,11 +428,11 @@ pub trait SocPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_cptra_trng_ctrl();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_cptra_trng_ctrl(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::CptraTrngCtrl::Register,
         >,
@@ -414,7 +449,7 @@ pub trait SocPeripheral {
     }
     fn read_cptra_trng_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraTrngStatus::Register,
     > {
@@ -424,11 +459,11 @@ pub trait SocPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_cptra_trng_status();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_cptra_trng_status(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::CptraTrngStatus::Register,
         >,
@@ -445,7 +480,7 @@ pub trait SocPeripheral {
     }
     fn read_cptra_fuse_wr_done(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraFuseWrDone::Register,
     > {
@@ -455,11 +490,11 @@ pub trait SocPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_cptra_fuse_wr_done();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_cptra_fuse_wr_done(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::CptraFuseWrDone::Register,
         >,
@@ -474,7 +509,7 @@ pub trait SocPeripheral {
             generated.write_cptra_fuse_wr_done(val);
         }
     }
-    fn read_cptra_timer_config(&mut self) -> caliptra_emu_types::RvData {
+    fn read_cptra_timer_config(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read soc::cptra_timer_config");
         }
@@ -483,7 +518,7 @@ pub trait SocPeripheral {
         }
         0
     }
-    fn write_cptra_timer_config(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_cptra_timer_config(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write soc::cptra_timer_config = 0x{:08x}",
@@ -496,7 +531,7 @@ pub trait SocPeripheral {
     }
     fn read_cptra_bootfsm_go(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraBootfsmGo::Register,
     > {
@@ -506,11 +541,11 @@ pub trait SocPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_cptra_bootfsm_go();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_cptra_bootfsm_go(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::CptraBootfsmGo::Register,
         >,
@@ -525,7 +560,9 @@ pub trait SocPeripheral {
             generated.write_cptra_bootfsm_go(val);
         }
     }
-    fn read_cptra_dbg_manuf_service_reg(&mut self) -> caliptra_emu_types::RvData {
+    fn read_cptra_dbg_manuf_service_reg(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read soc::cptra_dbg_manuf_service_reg");
         }
@@ -534,7 +571,10 @@ pub trait SocPeripheral {
         }
         0
     }
-    fn write_cptra_dbg_manuf_service_reg(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_cptra_dbg_manuf_service_reg(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write soc::cptra_dbg_manuf_service_reg = 0x{:08x}" , val);
         }
@@ -544,7 +584,7 @@ pub trait SocPeripheral {
     }
     fn read_cptra_clk_gating_en(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraClkGatingEn::Register,
     > {
@@ -554,11 +594,11 @@ pub trait SocPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_cptra_clk_gating_en();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_cptra_clk_gating_en(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::CptraClkGatingEn::Register,
         >,
@@ -573,7 +613,10 @@ pub trait SocPeripheral {
             generated.write_cptra_clk_gating_en(val);
         }
     }
-    fn read_cptra_generic_input_wires(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_cptra_generic_input_wires(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read soc::cptra_generic_input_wires[{}]",
@@ -585,7 +628,10 @@ pub trait SocPeripheral {
         }
         0
     }
-    fn read_cptra_generic_output_wires(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_cptra_generic_output_wires(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read soc::cptra_generic_output_wires[{}]",
@@ -597,7 +643,11 @@ pub trait SocPeripheral {
         }
         0
     }
-    fn write_cptra_generic_output_wires(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    fn write_cptra_generic_output_wires(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+        index: usize,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write soc::cptra_generic_output_wires[{}] = 0x{:08x}" , index , val);
         }
@@ -607,7 +657,7 @@ pub trait SocPeripheral {
     }
     fn read_cptra_hw_rev_id(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraHwRevId::Register,
     > {
@@ -617,9 +667,12 @@ pub trait SocPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_cptra_hw_rev_id();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
-    fn read_cptra_fw_rev_id(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_cptra_fw_rev_id(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read soc::cptra_fw_rev_id[{}]",
@@ -631,7 +684,11 @@ pub trait SocPeripheral {
         }
         0
     }
-    fn write_cptra_fw_rev_id(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    fn write_cptra_fw_rev_id(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+        index: usize,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write soc::cptra_fw_rev_id[{}] = 0x{:08x}",
@@ -644,7 +701,7 @@ pub trait SocPeripheral {
     }
     fn read_cptra_hw_config(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraHwConfig::Register,
     > {
@@ -654,11 +711,11 @@ pub trait SocPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_cptra_hw_config();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn read_cptra_wdt_timer1_en(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraWdtTimer1En::Register,
     > {
@@ -668,11 +725,11 @@ pub trait SocPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_cptra_wdt_timer1_en();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_cptra_wdt_timer1_en(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::CptraWdtTimer1En::Register,
         >,
@@ -689,7 +746,7 @@ pub trait SocPeripheral {
     }
     fn read_cptra_wdt_timer1_ctrl(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraWdtTimer1Ctrl::Register,
     > {
@@ -699,11 +756,11 @@ pub trait SocPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_cptra_wdt_timer1_ctrl();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_cptra_wdt_timer1_ctrl(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::CptraWdtTimer1Ctrl::Register,
         >,
@@ -718,7 +775,10 @@ pub trait SocPeripheral {
             generated.write_cptra_wdt_timer1_ctrl(val);
         }
     }
-    fn read_cptra_wdt_timer1_timeout_period(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_cptra_wdt_timer1_timeout_period(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read soc::cptra_wdt_timer1_timeout_period[{}]",
@@ -732,7 +792,7 @@ pub trait SocPeripheral {
     }
     fn write_cptra_wdt_timer1_timeout_period(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
         index: usize,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
@@ -744,7 +804,7 @@ pub trait SocPeripheral {
     }
     fn read_cptra_wdt_timer2_en(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraWdtTimer2En::Register,
     > {
@@ -754,11 +814,11 @@ pub trait SocPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_cptra_wdt_timer2_en();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_cptra_wdt_timer2_en(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::CptraWdtTimer2En::Register,
         >,
@@ -775,7 +835,7 @@ pub trait SocPeripheral {
     }
     fn read_cptra_wdt_timer2_ctrl(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraWdtTimer2Ctrl::Register,
     > {
@@ -785,11 +845,11 @@ pub trait SocPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_cptra_wdt_timer2_ctrl();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_cptra_wdt_timer2_ctrl(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::CptraWdtTimer2Ctrl::Register,
         >,
@@ -804,7 +864,10 @@ pub trait SocPeripheral {
             generated.write_cptra_wdt_timer2_ctrl(val);
         }
     }
-    fn read_cptra_wdt_timer2_timeout_period(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_cptra_wdt_timer2_timeout_period(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read soc::cptra_wdt_timer2_timeout_period[{}]",
@@ -818,7 +881,7 @@ pub trait SocPeripheral {
     }
     fn write_cptra_wdt_timer2_timeout_period(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
         index: usize,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
@@ -830,7 +893,7 @@ pub trait SocPeripheral {
     }
     fn read_cptra_wdt_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraWdtStatus::Register,
     > {
@@ -840,11 +903,11 @@ pub trait SocPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_cptra_wdt_status();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_cptra_wdt_status(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::CptraWdtStatus::Register,
         >,
@@ -859,7 +922,9 @@ pub trait SocPeripheral {
             generated.write_cptra_wdt_status(val);
         }
     }
-    fn read_cptra_fuse_valid_axi_user(&mut self) -> caliptra_emu_types::RvData {
+    fn read_cptra_fuse_valid_axi_user(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read soc::cptra_fuse_valid_axi_user");
         }
@@ -868,7 +933,10 @@ pub trait SocPeripheral {
         }
         0
     }
-    fn write_cptra_fuse_valid_axi_user(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_cptra_fuse_valid_axi_user(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write soc::cptra_fuse_valid_axi_user = 0x{:08x}" , val);
         }
@@ -878,7 +946,7 @@ pub trait SocPeripheral {
     }
     fn read_cptra_fuse_axi_user_lock(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraXxxxAxiUserLock::Register,
     > {
@@ -888,11 +956,11 @@ pub trait SocPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_cptra_fuse_axi_user_lock();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_cptra_fuse_axi_user_lock(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::CptraXxxxAxiUserLock::Register,
         >,
@@ -904,7 +972,10 @@ pub trait SocPeripheral {
             generated.write_cptra_fuse_axi_user_lock(val);
         }
     }
-    fn read_cptra_wdt_cfg(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_cptra_wdt_cfg(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read soc::cptra_wdt_cfg[{}]",
@@ -916,7 +987,11 @@ pub trait SocPeripheral {
         }
         0
     }
-    fn write_cptra_wdt_cfg(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    fn write_cptra_wdt_cfg(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+        index: usize,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write soc::cptra_wdt_cfg[{}] = 0x{:08x}",
@@ -929,7 +1004,7 @@ pub trait SocPeripheral {
     }
     fn read_cptra_i_trng_entropy_config_0(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraItrngEntropyConfig0::Register,
     > {
@@ -941,11 +1016,11 @@ pub trait SocPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_cptra_i_trng_entropy_config_0();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_cptra_i_trng_entropy_config_0(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::CptraItrngEntropyConfig0::Register,
         >,
@@ -959,7 +1034,7 @@ pub trait SocPeripheral {
     }
     fn read_cptra_i_trng_entropy_config_1(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraItrngEntropyConfig1::Register,
     > {
@@ -971,11 +1046,11 @@ pub trait SocPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_cptra_i_trng_entropy_config_1();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_cptra_i_trng_entropy_config_1(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::CptraItrngEntropyConfig1::Register,
         >,
@@ -987,7 +1062,10 @@ pub trait SocPeripheral {
             generated.write_cptra_i_trng_entropy_config_1(val);
         }
     }
-    fn read_cptra_rsvd_reg(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_cptra_rsvd_reg(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read soc::cptra_rsvd_reg[{}]",
@@ -999,7 +1077,11 @@ pub trait SocPeripheral {
         }
         0
     }
-    fn write_cptra_rsvd_reg(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    fn write_cptra_rsvd_reg(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+        index: usize,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write soc::cptra_rsvd_reg[{}] = 0x{:08x}",
@@ -1010,7 +1092,7 @@ pub trait SocPeripheral {
             generated.write_cptra_rsvd_reg(val, index);
         }
     }
-    fn read_cptra_hw_capabilities(&mut self) -> caliptra_emu_types::RvData {
+    fn read_cptra_hw_capabilities(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read soc::cptra_hw_capabilities");
         }
@@ -1019,7 +1101,10 @@ pub trait SocPeripheral {
         }
         0
     }
-    fn write_cptra_hw_capabilities(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_cptra_hw_capabilities(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write soc::cptra_hw_capabilities = 0x{:08x}",
@@ -1030,7 +1115,7 @@ pub trait SocPeripheral {
             generated.write_cptra_hw_capabilities(val);
         }
     }
-    fn read_cptra_fw_capabilities(&mut self) -> caliptra_emu_types::RvData {
+    fn read_cptra_fw_capabilities(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read soc::cptra_fw_capabilities");
         }
@@ -1039,7 +1124,10 @@ pub trait SocPeripheral {
         }
         0
     }
-    fn write_cptra_fw_capabilities(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_cptra_fw_capabilities(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write soc::cptra_fw_capabilities = 0x{:08x}",
@@ -1052,7 +1140,7 @@ pub trait SocPeripheral {
     }
     fn read_cptra_cap_lock(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraXxxxxxxk::Register,
     > {
@@ -1062,11 +1150,11 @@ pub trait SocPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_cptra_cap_lock();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_cptra_cap_lock(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::CptraXxxxxxxk::Register,
         >,
@@ -1081,7 +1169,10 @@ pub trait SocPeripheral {
             generated.write_cptra_cap_lock(val);
         }
     }
-    fn read_cptra_owner_pk_hash(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_cptra_owner_pk_hash(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read soc::cptra_owner_pk_hash[{}]",
@@ -1093,7 +1184,11 @@ pub trait SocPeripheral {
         }
         0
     }
-    fn write_cptra_owner_pk_hash(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    fn write_cptra_owner_pk_hash(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+        index: usize,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write soc::cptra_owner_pk_hash[{}] = 0x{:08x}",
@@ -1106,7 +1201,7 @@ pub trait SocPeripheral {
     }
     fn read_cptra_owner_pk_hash_lock(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraXxxxxxxk::Register,
     > {
@@ -1116,11 +1211,11 @@ pub trait SocPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_cptra_owner_pk_hash_lock();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_cptra_owner_pk_hash_lock(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::CptraXxxxxxxk::Register,
         >,
@@ -1132,7 +1227,11 @@ pub trait SocPeripheral {
             generated.write_cptra_owner_pk_hash_lock(val);
         }
     }
-    fn write_fuse_uds_seed(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    fn write_fuse_uds_seed(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+        index: usize,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write soc::fuse_uds_seed[{}] = 0x{:08x}",
@@ -1143,7 +1242,11 @@ pub trait SocPeripheral {
             generated.write_fuse_uds_seed(val, index);
         }
     }
-    fn write_fuse_field_entropy(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    fn write_fuse_field_entropy(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+        index: usize,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write soc::fuse_field_entropy[{}] = 0x{:08x}",
@@ -1154,7 +1257,10 @@ pub trait SocPeripheral {
             generated.write_fuse_field_entropy(val, index);
         }
     }
-    fn read_fuse_vendor_pk_hash(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_fuse_vendor_pk_hash(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read soc::fuse_vendor_pk_hash[{}]",
@@ -1166,7 +1272,11 @@ pub trait SocPeripheral {
         }
         0
     }
-    fn write_fuse_vendor_pk_hash(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    fn write_fuse_vendor_pk_hash(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+        index: usize,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write soc::fuse_vendor_pk_hash[{}] = 0x{:08x}",
@@ -1179,7 +1289,7 @@ pub trait SocPeripheral {
     }
     fn read_fuse_ecc_revocation(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::FuseEccRevocation::Register,
     > {
@@ -1189,11 +1299,11 @@ pub trait SocPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_fuse_ecc_revocation();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_fuse_ecc_revocation(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::FuseEccRevocation::Register,
         >,
@@ -1208,7 +1318,9 @@ pub trait SocPeripheral {
             generated.write_fuse_ecc_revocation(val);
         }
     }
-    fn read_fuse_fmc_key_manifest_svn(&mut self) -> caliptra_emu_types::RvData {
+    fn read_fuse_fmc_key_manifest_svn(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read soc::fuse_fmc_key_manifest_svn");
         }
@@ -1217,7 +1329,10 @@ pub trait SocPeripheral {
         }
         0
     }
-    fn write_fuse_fmc_key_manifest_svn(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_fuse_fmc_key_manifest_svn(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write soc::fuse_fmc_key_manifest_svn = 0x{:08x}" , val);
         }
@@ -1225,7 +1340,10 @@ pub trait SocPeripheral {
             generated.write_fuse_fmc_key_manifest_svn(val);
         }
     }
-    fn read_fuse_runtime_svn(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_fuse_runtime_svn(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read soc::fuse_runtime_svn[{}]",
@@ -1237,7 +1355,11 @@ pub trait SocPeripheral {
         }
         0
     }
-    fn write_fuse_runtime_svn(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    fn write_fuse_runtime_svn(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+        index: usize,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write soc::fuse_runtime_svn[{}] = 0x{:08x}",
@@ -1250,7 +1372,7 @@ pub trait SocPeripheral {
     }
     fn read_fuse_anti_rollback_disable(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::FuseAntiRollbackDisable::Register,
     > {
@@ -1260,11 +1382,11 @@ pub trait SocPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_fuse_anti_rollback_disable();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_fuse_anti_rollback_disable(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::FuseAntiRollbackDisable::Register,
         >,
@@ -1276,7 +1398,10 @@ pub trait SocPeripheral {
             generated.write_fuse_anti_rollback_disable(val);
         }
     }
-    fn read_fuse_idevid_cert_attr(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_fuse_idevid_cert_attr(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read soc::fuse_idevid_cert_attr[{}]",
@@ -1288,7 +1413,11 @@ pub trait SocPeripheral {
         }
         0
     }
-    fn write_fuse_idevid_cert_attr(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    fn write_fuse_idevid_cert_attr(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+        index: usize,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write soc::fuse_idevid_cert_attr[{}] = 0x{:08x}" , index , val);
         }
@@ -1296,7 +1425,10 @@ pub trait SocPeripheral {
             generated.write_fuse_idevid_cert_attr(val, index);
         }
     }
-    fn read_fuse_idevid_manuf_hsm_id(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_fuse_idevid_manuf_hsm_id(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read soc::fuse_idevid_manuf_hsm_id[{}]",
@@ -1308,7 +1440,11 @@ pub trait SocPeripheral {
         }
         0
     }
-    fn write_fuse_idevid_manuf_hsm_id(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    fn write_fuse_idevid_manuf_hsm_id(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+        index: usize,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write soc::fuse_idevid_manuf_hsm_id[{}] = 0x{:08x}" , index , val);
         }
@@ -1316,7 +1452,7 @@ pub trait SocPeripheral {
             generated.write_fuse_idevid_manuf_hsm_id(val, index);
         }
     }
-    fn read_fuse_lms_revocation(&mut self) -> caliptra_emu_types::RvData {
+    fn read_fuse_lms_revocation(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read soc::fuse_lms_revocation");
         }
@@ -1325,7 +1461,7 @@ pub trait SocPeripheral {
         }
         0
     }
-    fn write_fuse_lms_revocation(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_fuse_lms_revocation(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write soc::fuse_lms_revocation = 0x{:08x}",
@@ -1338,7 +1474,7 @@ pub trait SocPeripheral {
     }
     fn read_fuse_mldsa_revocation(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::FuseMldsaRevocation::Register,
     > {
@@ -1348,11 +1484,11 @@ pub trait SocPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_fuse_mldsa_revocation();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_fuse_mldsa_revocation(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::FuseMldsaRevocation::Register,
         >,
@@ -1369,7 +1505,7 @@ pub trait SocPeripheral {
     }
     fn read_fuse_soc_stepping_id(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::FuseSocSteppingId::Register,
     > {
@@ -1379,11 +1515,11 @@ pub trait SocPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_fuse_soc_stepping_id();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_fuse_soc_stepping_id(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::FuseSocSteppingId::Register,
         >,
@@ -1398,7 +1534,10 @@ pub trait SocPeripheral {
             generated.write_fuse_soc_stepping_id(val);
         }
     }
-    fn read_fuse_manuf_dbg_unlock_token(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_fuse_manuf_dbg_unlock_token(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read soc::fuse_manuf_dbg_unlock_token[{}]",
@@ -1410,7 +1549,11 @@ pub trait SocPeripheral {
         }
         0
     }
-    fn write_fuse_manuf_dbg_unlock_token(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    fn write_fuse_manuf_dbg_unlock_token(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+        index: usize,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write soc::fuse_manuf_dbg_unlock_token[{}] = 0x{:08x}" , index , val);
         }
@@ -1420,7 +1563,7 @@ pub trait SocPeripheral {
     }
     fn read_fuse_pqc_key_type(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::FusePqcKeyType::Register,
     > {
@@ -1430,11 +1573,11 @@ pub trait SocPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_fuse_pqc_key_type();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_fuse_pqc_key_type(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::FusePqcKeyType::Register,
         >,
@@ -1449,7 +1592,10 @@ pub trait SocPeripheral {
             generated.write_fuse_pqc_key_type(val);
         }
     }
-    fn read_fuse_soc_manifest_svn(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_fuse_soc_manifest_svn(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read soc::fuse_soc_manifest_svn[{}]",
@@ -1461,7 +1607,11 @@ pub trait SocPeripheral {
         }
         0
     }
-    fn write_fuse_soc_manifest_svn(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    fn write_fuse_soc_manifest_svn(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+        index: usize,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write soc::fuse_soc_manifest_svn[{}] = 0x{:08x}" , index , val);
         }
@@ -1471,7 +1621,7 @@ pub trait SocPeripheral {
     }
     fn read_fuse_soc_manifest_max_svn(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::FuseSocManifestMaxSvn::Register,
     > {
@@ -1481,11 +1631,11 @@ pub trait SocPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_fuse_soc_manifest_max_svn();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_fuse_soc_manifest_max_svn(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::FuseSocManifestMaxSvn::Register,
         >,
@@ -1497,7 +1647,7 @@ pub trait SocPeripheral {
             generated.write_fuse_soc_manifest_max_svn(val);
         }
     }
-    fn read_ss_caliptra_base_addr_l(&mut self) -> caliptra_emu_types::RvData {
+    fn read_ss_caliptra_base_addr_l(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read soc::ss_caliptra_base_addr_l");
         }
@@ -1506,7 +1656,10 @@ pub trait SocPeripheral {
         }
         0
     }
-    fn write_ss_caliptra_base_addr_l(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_ss_caliptra_base_addr_l(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write soc::ss_caliptra_base_addr_l = 0x{:08x}",
@@ -1517,7 +1670,7 @@ pub trait SocPeripheral {
             generated.write_ss_caliptra_base_addr_l(val);
         }
     }
-    fn read_ss_caliptra_base_addr_h(&mut self) -> caliptra_emu_types::RvData {
+    fn read_ss_caliptra_base_addr_h(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read soc::ss_caliptra_base_addr_h");
         }
@@ -1526,7 +1679,10 @@ pub trait SocPeripheral {
         }
         0
     }
-    fn write_ss_caliptra_base_addr_h(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_ss_caliptra_base_addr_h(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write soc::ss_caliptra_base_addr_h = 0x{:08x}",
@@ -1537,7 +1693,7 @@ pub trait SocPeripheral {
             generated.write_ss_caliptra_base_addr_h(val);
         }
     }
-    fn read_ss_mci_base_addr_l(&mut self) -> caliptra_emu_types::RvData {
+    fn read_ss_mci_base_addr_l(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read soc::ss_mci_base_addr_l");
         }
@@ -1546,7 +1702,7 @@ pub trait SocPeripheral {
         }
         0
     }
-    fn write_ss_mci_base_addr_l(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_ss_mci_base_addr_l(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write soc::ss_mci_base_addr_l = 0x{:08x}",
@@ -1557,7 +1713,7 @@ pub trait SocPeripheral {
             generated.write_ss_mci_base_addr_l(val);
         }
     }
-    fn read_ss_mci_base_addr_h(&mut self) -> caliptra_emu_types::RvData {
+    fn read_ss_mci_base_addr_h(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read soc::ss_mci_base_addr_h");
         }
@@ -1566,7 +1722,7 @@ pub trait SocPeripheral {
         }
         0
     }
-    fn write_ss_mci_base_addr_h(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_ss_mci_base_addr_h(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write soc::ss_mci_base_addr_h = 0x{:08x}",
@@ -1577,7 +1733,9 @@ pub trait SocPeripheral {
             generated.write_ss_mci_base_addr_h(val);
         }
     }
-    fn read_ss_recovery_ifc_base_addr_l(&mut self) -> caliptra_emu_types::RvData {
+    fn read_ss_recovery_ifc_base_addr_l(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read soc::ss_recovery_ifc_base_addr_l");
         }
@@ -1586,7 +1744,10 @@ pub trait SocPeripheral {
         }
         0
     }
-    fn write_ss_recovery_ifc_base_addr_l(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_ss_recovery_ifc_base_addr_l(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write soc::ss_recovery_ifc_base_addr_l = 0x{:08x}" , val);
         }
@@ -1594,7 +1755,9 @@ pub trait SocPeripheral {
             generated.write_ss_recovery_ifc_base_addr_l(val);
         }
     }
-    fn read_ss_recovery_ifc_base_addr_h(&mut self) -> caliptra_emu_types::RvData {
+    fn read_ss_recovery_ifc_base_addr_h(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read soc::ss_recovery_ifc_base_addr_h");
         }
@@ -1603,7 +1766,10 @@ pub trait SocPeripheral {
         }
         0
     }
-    fn write_ss_recovery_ifc_base_addr_h(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_ss_recovery_ifc_base_addr_h(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write soc::ss_recovery_ifc_base_addr_h = 0x{:08x}" , val);
         }
@@ -1611,7 +1777,7 @@ pub trait SocPeripheral {
             generated.write_ss_recovery_ifc_base_addr_h(val);
         }
     }
-    fn read_ss_otp_fc_base_addr_l(&mut self) -> caliptra_emu_types::RvData {
+    fn read_ss_otp_fc_base_addr_l(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read soc::ss_otp_fc_base_addr_l");
         }
@@ -1620,7 +1786,10 @@ pub trait SocPeripheral {
         }
         0
     }
-    fn write_ss_otp_fc_base_addr_l(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_ss_otp_fc_base_addr_l(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write soc::ss_otp_fc_base_addr_l = 0x{:08x}",
@@ -1631,7 +1800,7 @@ pub trait SocPeripheral {
             generated.write_ss_otp_fc_base_addr_l(val);
         }
     }
-    fn read_ss_otp_fc_base_addr_h(&mut self) -> caliptra_emu_types::RvData {
+    fn read_ss_otp_fc_base_addr_h(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read soc::ss_otp_fc_base_addr_h");
         }
@@ -1640,7 +1809,10 @@ pub trait SocPeripheral {
         }
         0
     }
-    fn write_ss_otp_fc_base_addr_h(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_ss_otp_fc_base_addr_h(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write soc::ss_otp_fc_base_addr_h = 0x{:08x}",
@@ -1651,7 +1823,7 @@ pub trait SocPeripheral {
             generated.write_ss_otp_fc_base_addr_h(val);
         }
     }
-    fn read_ss_uds_seed_base_addr_l(&mut self) -> caliptra_emu_types::RvData {
+    fn read_ss_uds_seed_base_addr_l(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read soc::ss_uds_seed_base_addr_l");
         }
@@ -1660,7 +1832,10 @@ pub trait SocPeripheral {
         }
         0
     }
-    fn write_ss_uds_seed_base_addr_l(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_ss_uds_seed_base_addr_l(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write soc::ss_uds_seed_base_addr_l = 0x{:08x}",
@@ -1671,7 +1846,7 @@ pub trait SocPeripheral {
             generated.write_ss_uds_seed_base_addr_l(val);
         }
     }
-    fn read_ss_uds_seed_base_addr_h(&mut self) -> caliptra_emu_types::RvData {
+    fn read_ss_uds_seed_base_addr_h(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read soc::ss_uds_seed_base_addr_h");
         }
@@ -1680,7 +1855,10 @@ pub trait SocPeripheral {
         }
         0
     }
-    fn write_ss_uds_seed_base_addr_h(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_ss_uds_seed_base_addr_h(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write soc::ss_uds_seed_base_addr_h = 0x{:08x}",
@@ -1693,7 +1871,7 @@ pub trait SocPeripheral {
     }
     fn read_ss_prod_debug_unlock_auth_pk_hash_reg_bank_offset(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read soc::ss_prod_debug_unlock_auth_pk_hash_reg_bank_offset");
         }
@@ -1704,7 +1882,7 @@ pub trait SocPeripheral {
     }
     fn write_ss_prod_debug_unlock_auth_pk_hash_reg_bank_offset(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write soc::ss_prod_debug_unlock_auth_pk_hash_reg_bank_offset = 0x{:08x}" , val);
@@ -1713,7 +1891,9 @@ pub trait SocPeripheral {
             generated.write_ss_prod_debug_unlock_auth_pk_hash_reg_bank_offset(val);
         }
     }
-    fn read_ss_num_of_prod_debug_unlock_auth_pk_hashes(&mut self) -> caliptra_emu_types::RvData {
+    fn read_ss_num_of_prod_debug_unlock_auth_pk_hashes(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: read soc::ss_num_of_prod_debug_unlock_auth_pk_hashes");
         }
@@ -1724,7 +1904,7 @@ pub trait SocPeripheral {
     }
     fn write_ss_num_of_prod_debug_unlock_auth_pk_hashes(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write soc::ss_num_of_prod_debug_unlock_auth_pk_hashes = 0x{:08x}" , val);
@@ -1735,7 +1915,7 @@ pub trait SocPeripheral {
     }
     fn read_ss_debug_intent(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::SsDebugIntent::Register,
     > {
@@ -1745,9 +1925,9 @@ pub trait SocPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_ss_debug_intent();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
-    fn read_ss_caliptra_dma_axi_user(&mut self) -> caliptra_emu_types::RvData {
+    fn read_ss_caliptra_dma_axi_user(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Non-functional register stub: read soc::ss_caliptra_dma_axi_user");
         }
@@ -1756,7 +1936,10 @@ pub trait SocPeripheral {
         }
         0
     }
-    fn write_ss_caliptra_dma_axi_user(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_ss_caliptra_dma_axi_user(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write soc::ss_caliptra_dma_axi_user = 0x{:08x}" , val);
         }
@@ -1764,7 +1947,10 @@ pub trait SocPeripheral {
             generated.write_ss_caliptra_dma_axi_user(val);
         }
     }
-    fn read_ss_strap_generic(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_ss_strap_generic(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read soc::ss_strap_generic[{}]",
@@ -1776,7 +1962,11 @@ pub trait SocPeripheral {
         }
         0
     }
-    fn write_ss_strap_generic(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    fn write_ss_strap_generic(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+        index: usize,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: write soc::ss_strap_generic[{}] = 0x{:08x}",
@@ -1789,7 +1979,7 @@ pub trait SocPeripheral {
     }
     fn read_ss_dbg_manuf_service_reg_req(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::SsDbgManufServiceRegReq::Register,
     > {
@@ -1799,11 +1989,11 @@ pub trait SocPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_ss_dbg_manuf_service_reg_req();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_ss_dbg_manuf_service_reg_req(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::SsDbgManufServiceRegReq::Register,
         >,
@@ -1817,7 +2007,7 @@ pub trait SocPeripheral {
     }
     fn read_ss_dbg_manuf_service_reg_rsp(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::SsDbgManufServiceRegRsp::Register,
     > {
@@ -1827,11 +2017,11 @@ pub trait SocPeripheral {
         if let Some(generated) = self.generated() {
             return generated.read_ss_dbg_manuf_service_reg_rsp();
         }
-        caliptra_emu_bus::ReadWriteRegister::new(0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(0)
     }
     fn write_ss_dbg_manuf_service_reg_rsp(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::SsDbgManufServiceRegRsp::Register,
         >,
@@ -1843,7 +2033,10 @@ pub trait SocPeripheral {
             generated.write_ss_dbg_manuf_service_reg_rsp(val);
         }
     }
-    fn read_ss_soc_dbg_unlock_level(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_ss_soc_dbg_unlock_level(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read soc::ss_soc_dbg_unlock_level[{}]",
@@ -1855,7 +2048,11 @@ pub trait SocPeripheral {
         }
         0
     }
-    fn write_ss_soc_dbg_unlock_level(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    fn write_ss_soc_dbg_unlock_level(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+        index: usize,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write soc::ss_soc_dbg_unlock_level[{}] = 0x{:08x}" , index , val);
         }
@@ -1863,7 +2060,10 @@ pub trait SocPeripheral {
             generated.write_ss_soc_dbg_unlock_level(val, index);
         }
     }
-    fn read_ss_generic_fw_exec_ctrl(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_ss_generic_fw_exec_ctrl(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Non-functional register stub: read soc::ss_generic_fw_exec_ctrl[{}]",
@@ -1875,7 +2075,11 @@ pub trait SocPeripheral {
         }
         0
     }
-    fn write_ss_generic_fw_exec_ctrl(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    fn write_ss_generic_fw_exec_ctrl(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+        index: usize,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Non-functional register stub: write soc::ss_generic_fw_exec_ctrl[{}] = 0x{:08x}" , index , val);
         }
@@ -1886,172 +2090,195 @@ pub trait SocPeripheral {
 }
 #[derive(Clone, Debug)]
 pub struct SocGenerated {
-    cptra_hw_error_fatal: caliptra_emu_types::RvData,
-    cptra_hw_error_non_fatal: caliptra_emu_types::RvData,
-    cptra_fw_error_fatal: caliptra_emu_types::RvData,
-    cptra_fw_error_non_fatal: caliptra_emu_types::RvData,
-    cptra_hw_error_enc: caliptra_emu_types::RvData,
-    cptra_fw_error_enc: caliptra_emu_types::RvData,
-    cptra_fw_extended_error_info: Vec<caliptra_emu_types::RvData>,
-    cptra_boot_status: caliptra_emu_types::RvData,
-    cptra_flow_status: caliptra_emu_types::RvData,
-    cptra_reset_reason: caliptra_emu_types::RvData,
-    cptra_security_state: caliptra_emu_types::RvData,
-    cptra_mbox_valid_axi_user: Vec<caliptra_emu_types::RvData>,
-    cptra_mbox_axi_user_lock: Vec<caliptra_emu_types::RvData>,
-    cptra_trng_valid_axi_user: caliptra_emu_types::RvData,
-    cptra_trng_axi_user_lock: caliptra_emu_types::RvData,
-    cptra_trng_data: Vec<caliptra_emu_types::RvData>,
-    cptra_trng_ctrl: caliptra_emu_types::RvData,
-    cptra_trng_status: caliptra_emu_types::RvData,
-    cptra_fuse_wr_done: caliptra_emu_types::RvData,
-    cptra_timer_config: caliptra_emu_types::RvData,
-    cptra_bootfsm_go: caliptra_emu_types::RvData,
-    cptra_dbg_manuf_service_reg: caliptra_emu_types::RvData,
-    cptra_clk_gating_en: caliptra_emu_types::RvData,
-    cptra_generic_input_wires: Vec<caliptra_emu_types::RvData>,
-    cptra_generic_output_wires: Vec<caliptra_emu_types::RvData>,
-    cptra_hw_rev_id: caliptra_emu_types::RvData,
-    cptra_fw_rev_id: Vec<caliptra_emu_types::RvData>,
-    cptra_hw_config: caliptra_emu_types::RvData,
-    cptra_wdt_timer1_en: caliptra_emu_types::RvData,
-    cptra_wdt_timer1_ctrl: caliptra_emu_types::RvData,
-    cptra_wdt_timer1_timeout_period: Vec<caliptra_emu_types::RvData>,
-    cptra_wdt_timer2_en: caliptra_emu_types::RvData,
-    cptra_wdt_timer2_ctrl: caliptra_emu_types::RvData,
-    cptra_wdt_timer2_timeout_period: Vec<caliptra_emu_types::RvData>,
-    cptra_wdt_status: caliptra_emu_types::RvData,
-    cptra_fuse_valid_axi_user: caliptra_emu_types::RvData,
-    cptra_fuse_axi_user_lock: caliptra_emu_types::RvData,
-    cptra_wdt_cfg: Vec<caliptra_emu_types::RvData>,
-    cptra_i_trng_entropy_config_0: caliptra_emu_types::RvData,
-    cptra_i_trng_entropy_config_1: caliptra_emu_types::RvData,
-    cptra_rsvd_reg: Vec<caliptra_emu_types::RvData>,
-    cptra_hw_capabilities: caliptra_emu_types::RvData,
-    cptra_fw_capabilities: caliptra_emu_types::RvData,
-    cptra_cap_lock: caliptra_emu_types::RvData,
-    cptra_owner_pk_hash: Vec<caliptra_emu_types::RvData>,
-    cptra_owner_pk_hash_lock: caliptra_emu_types::RvData,
-    fuse_uds_seed: Vec<caliptra_emu_types::RvData>,
-    fuse_field_entropy: Vec<caliptra_emu_types::RvData>,
-    fuse_vendor_pk_hash: Vec<caliptra_emu_types::RvData>,
-    fuse_ecc_revocation: caliptra_emu_types::RvData,
-    fuse_fmc_key_manifest_svn: caliptra_emu_types::RvData,
-    fuse_runtime_svn: Vec<caliptra_emu_types::RvData>,
-    fuse_anti_rollback_disable: caliptra_emu_types::RvData,
-    fuse_idevid_cert_attr: Vec<caliptra_emu_types::RvData>,
-    fuse_idevid_manuf_hsm_id: Vec<caliptra_emu_types::RvData>,
-    fuse_lms_revocation: caliptra_emu_types::RvData,
-    fuse_mldsa_revocation: caliptra_emu_types::RvData,
-    fuse_soc_stepping_id: caliptra_emu_types::RvData,
-    fuse_manuf_dbg_unlock_token: Vec<caliptra_emu_types::RvData>,
-    fuse_pqc_key_type: caliptra_emu_types::RvData,
-    fuse_soc_manifest_svn: Vec<caliptra_emu_types::RvData>,
-    fuse_soc_manifest_max_svn: caliptra_emu_types::RvData,
-    ss_caliptra_base_addr_l: caliptra_emu_types::RvData,
-    ss_caliptra_base_addr_h: caliptra_emu_types::RvData,
-    ss_mci_base_addr_l: caliptra_emu_types::RvData,
-    ss_mci_base_addr_h: caliptra_emu_types::RvData,
-    ss_recovery_ifc_base_addr_l: caliptra_emu_types::RvData,
-    ss_recovery_ifc_base_addr_h: caliptra_emu_types::RvData,
-    ss_otp_fc_base_addr_l: caliptra_emu_types::RvData,
-    ss_otp_fc_base_addr_h: caliptra_emu_types::RvData,
-    ss_uds_seed_base_addr_l: caliptra_emu_types::RvData,
-    ss_uds_seed_base_addr_h: caliptra_emu_types::RvData,
-    ss_prod_debug_unlock_auth_pk_hash_reg_bank_offset: caliptra_emu_types::RvData,
-    ss_num_of_prod_debug_unlock_auth_pk_hashes: caliptra_emu_types::RvData,
-    ss_debug_intent: caliptra_emu_types::RvData,
-    ss_caliptra_dma_axi_user: caliptra_emu_types::RvData,
-    ss_strap_generic: Vec<caliptra_emu_types::RvData>,
-    ss_dbg_manuf_service_reg_req: caliptra_emu_types::RvData,
-    ss_dbg_manuf_service_reg_rsp: caliptra_emu_types::RvData,
-    ss_soc_dbg_unlock_level: Vec<caliptra_emu_types::RvData>,
-    ss_generic_fw_exec_ctrl: Vec<caliptra_emu_types::RvData>,
+    cptra_hw_error_fatal: caliptra_core_tools::caliptra_emu_types::RvData,
+    cptra_hw_error_non_fatal: caliptra_core_tools::caliptra_emu_types::RvData,
+    cptra_fw_error_fatal: caliptra_core_tools::caliptra_emu_types::RvData,
+    cptra_fw_error_non_fatal: caliptra_core_tools::caliptra_emu_types::RvData,
+    cptra_hw_error_enc: caliptra_core_tools::caliptra_emu_types::RvData,
+    cptra_fw_error_enc: caliptra_core_tools::caliptra_emu_types::RvData,
+    cptra_fw_extended_error_info: Vec<caliptra_core_tools::caliptra_emu_types::RvData>,
+    cptra_boot_status: caliptra_core_tools::caliptra_emu_types::RvData,
+    cptra_flow_status: caliptra_core_tools::caliptra_emu_types::RvData,
+    cptra_reset_reason: caliptra_core_tools::caliptra_emu_types::RvData,
+    cptra_security_state: caliptra_core_tools::caliptra_emu_types::RvData,
+    cptra_mbox_valid_axi_user: Vec<caliptra_core_tools::caliptra_emu_types::RvData>,
+    cptra_mbox_axi_user_lock: Vec<caliptra_core_tools::caliptra_emu_types::RvData>,
+    cptra_trng_valid_axi_user: caliptra_core_tools::caliptra_emu_types::RvData,
+    cptra_trng_axi_user_lock: caliptra_core_tools::caliptra_emu_types::RvData,
+    cptra_trng_data: Vec<caliptra_core_tools::caliptra_emu_types::RvData>,
+    cptra_trng_ctrl: caliptra_core_tools::caliptra_emu_types::RvData,
+    cptra_trng_status: caliptra_core_tools::caliptra_emu_types::RvData,
+    cptra_fuse_wr_done: caliptra_core_tools::caliptra_emu_types::RvData,
+    cptra_timer_config: caliptra_core_tools::caliptra_emu_types::RvData,
+    cptra_bootfsm_go: caliptra_core_tools::caliptra_emu_types::RvData,
+    cptra_dbg_manuf_service_reg: caliptra_core_tools::caliptra_emu_types::RvData,
+    cptra_clk_gating_en: caliptra_core_tools::caliptra_emu_types::RvData,
+    cptra_generic_input_wires: Vec<caliptra_core_tools::caliptra_emu_types::RvData>,
+    cptra_generic_output_wires: Vec<caliptra_core_tools::caliptra_emu_types::RvData>,
+    cptra_hw_rev_id: caliptra_core_tools::caliptra_emu_types::RvData,
+    cptra_fw_rev_id: Vec<caliptra_core_tools::caliptra_emu_types::RvData>,
+    cptra_hw_config: caliptra_core_tools::caliptra_emu_types::RvData,
+    cptra_wdt_timer1_en: caliptra_core_tools::caliptra_emu_types::RvData,
+    cptra_wdt_timer1_ctrl: caliptra_core_tools::caliptra_emu_types::RvData,
+    cptra_wdt_timer1_timeout_period: Vec<caliptra_core_tools::caliptra_emu_types::RvData>,
+    cptra_wdt_timer2_en: caliptra_core_tools::caliptra_emu_types::RvData,
+    cptra_wdt_timer2_ctrl: caliptra_core_tools::caliptra_emu_types::RvData,
+    cptra_wdt_timer2_timeout_period: Vec<caliptra_core_tools::caliptra_emu_types::RvData>,
+    cptra_wdt_status: caliptra_core_tools::caliptra_emu_types::RvData,
+    cptra_fuse_valid_axi_user: caliptra_core_tools::caliptra_emu_types::RvData,
+    cptra_fuse_axi_user_lock: caliptra_core_tools::caliptra_emu_types::RvData,
+    cptra_wdt_cfg: Vec<caliptra_core_tools::caliptra_emu_types::RvData>,
+    cptra_i_trng_entropy_config_0: caliptra_core_tools::caliptra_emu_types::RvData,
+    cptra_i_trng_entropy_config_1: caliptra_core_tools::caliptra_emu_types::RvData,
+    cptra_rsvd_reg: Vec<caliptra_core_tools::caliptra_emu_types::RvData>,
+    cptra_hw_capabilities: caliptra_core_tools::caliptra_emu_types::RvData,
+    cptra_fw_capabilities: caliptra_core_tools::caliptra_emu_types::RvData,
+    cptra_cap_lock: caliptra_core_tools::caliptra_emu_types::RvData,
+    cptra_owner_pk_hash: Vec<caliptra_core_tools::caliptra_emu_types::RvData>,
+    cptra_owner_pk_hash_lock: caliptra_core_tools::caliptra_emu_types::RvData,
+    fuse_uds_seed: Vec<caliptra_core_tools::caliptra_emu_types::RvData>,
+    fuse_field_entropy: Vec<caliptra_core_tools::caliptra_emu_types::RvData>,
+    fuse_vendor_pk_hash: Vec<caliptra_core_tools::caliptra_emu_types::RvData>,
+    fuse_ecc_revocation: caliptra_core_tools::caliptra_emu_types::RvData,
+    fuse_fmc_key_manifest_svn: caliptra_core_tools::caliptra_emu_types::RvData,
+    fuse_runtime_svn: Vec<caliptra_core_tools::caliptra_emu_types::RvData>,
+    fuse_anti_rollback_disable: caliptra_core_tools::caliptra_emu_types::RvData,
+    fuse_idevid_cert_attr: Vec<caliptra_core_tools::caliptra_emu_types::RvData>,
+    fuse_idevid_manuf_hsm_id: Vec<caliptra_core_tools::caliptra_emu_types::RvData>,
+    fuse_lms_revocation: caliptra_core_tools::caliptra_emu_types::RvData,
+    fuse_mldsa_revocation: caliptra_core_tools::caliptra_emu_types::RvData,
+    fuse_soc_stepping_id: caliptra_core_tools::caliptra_emu_types::RvData,
+    fuse_manuf_dbg_unlock_token: Vec<caliptra_core_tools::caliptra_emu_types::RvData>,
+    fuse_pqc_key_type: caliptra_core_tools::caliptra_emu_types::RvData,
+    fuse_soc_manifest_svn: Vec<caliptra_core_tools::caliptra_emu_types::RvData>,
+    fuse_soc_manifest_max_svn: caliptra_core_tools::caliptra_emu_types::RvData,
+    ss_caliptra_base_addr_l: caliptra_core_tools::caliptra_emu_types::RvData,
+    ss_caliptra_base_addr_h: caliptra_core_tools::caliptra_emu_types::RvData,
+    ss_mci_base_addr_l: caliptra_core_tools::caliptra_emu_types::RvData,
+    ss_mci_base_addr_h: caliptra_core_tools::caliptra_emu_types::RvData,
+    ss_recovery_ifc_base_addr_l: caliptra_core_tools::caliptra_emu_types::RvData,
+    ss_recovery_ifc_base_addr_h: caliptra_core_tools::caliptra_emu_types::RvData,
+    ss_otp_fc_base_addr_l: caliptra_core_tools::caliptra_emu_types::RvData,
+    ss_otp_fc_base_addr_h: caliptra_core_tools::caliptra_emu_types::RvData,
+    ss_uds_seed_base_addr_l: caliptra_core_tools::caliptra_emu_types::RvData,
+    ss_uds_seed_base_addr_h: caliptra_core_tools::caliptra_emu_types::RvData,
+    ss_prod_debug_unlock_auth_pk_hash_reg_bank_offset:
+        caliptra_core_tools::caliptra_emu_types::RvData,
+    ss_num_of_prod_debug_unlock_auth_pk_hashes: caliptra_core_tools::caliptra_emu_types::RvData,
+    ss_debug_intent: caliptra_core_tools::caliptra_emu_types::RvData,
+    ss_caliptra_dma_axi_user: caliptra_core_tools::caliptra_emu_types::RvData,
+    ss_strap_generic: Vec<caliptra_core_tools::caliptra_emu_types::RvData>,
+    ss_dbg_manuf_service_reg_req: caliptra_core_tools::caliptra_emu_types::RvData,
+    ss_dbg_manuf_service_reg_rsp: caliptra_core_tools::caliptra_emu_types::RvData,
+    ss_soc_dbg_unlock_level: Vec<caliptra_core_tools::caliptra_emu_types::RvData>,
+    ss_generic_fw_exec_ctrl: Vec<caliptra_core_tools::caliptra_emu_types::RvData>,
 }
 impl Default for SocGenerated {
     fn default() -> Self {
         Self {
-            cptra_hw_error_fatal: 0 as caliptra_emu_types::RvData,
-            cptra_hw_error_non_fatal: 0 as caliptra_emu_types::RvData,
-            cptra_fw_error_fatal: 0 as caliptra_emu_types::RvData,
-            cptra_fw_error_non_fatal: 0 as caliptra_emu_types::RvData,
-            cptra_hw_error_enc: 0 as caliptra_emu_types::RvData,
-            cptra_fw_error_enc: 0 as caliptra_emu_types::RvData,
-            cptra_fw_extended_error_info: vec![0 as caliptra_emu_types::RvData; 8],
-            cptra_boot_status: 0 as caliptra_emu_types::RvData,
-            cptra_flow_status: 0 as caliptra_emu_types::RvData,
-            cptra_reset_reason: 0 as caliptra_emu_types::RvData,
-            cptra_security_state: 0 as caliptra_emu_types::RvData,
-            cptra_mbox_valid_axi_user: vec![0xffff_ffff as caliptra_emu_types::RvData; 5],
-            cptra_mbox_axi_user_lock: vec![0 as caliptra_emu_types::RvData; 5],
-            cptra_trng_valid_axi_user: 0xffff_ffff as caliptra_emu_types::RvData,
-            cptra_trng_axi_user_lock: 0 as caliptra_emu_types::RvData,
-            cptra_trng_data: vec![0 as caliptra_emu_types::RvData; 12],
-            cptra_trng_ctrl: 0 as caliptra_emu_types::RvData,
-            cptra_trng_status: 0 as caliptra_emu_types::RvData,
-            cptra_fuse_wr_done: 0 as caliptra_emu_types::RvData,
-            cptra_timer_config: 0 as caliptra_emu_types::RvData,
-            cptra_bootfsm_go: 0 as caliptra_emu_types::RvData,
-            cptra_dbg_manuf_service_reg: 0 as caliptra_emu_types::RvData,
-            cptra_clk_gating_en: 0 as caliptra_emu_types::RvData,
-            cptra_generic_input_wires: vec![0 as caliptra_emu_types::RvData; 2],
-            cptra_generic_output_wires: vec![0 as caliptra_emu_types::RvData; 2],
-            cptra_hw_rev_id: 0x302 as caliptra_emu_types::RvData,
-            cptra_fw_rev_id: vec![0 as caliptra_emu_types::RvData; 2],
-            cptra_hw_config: 0 as caliptra_emu_types::RvData,
-            cptra_wdt_timer1_en: 0 as caliptra_emu_types::RvData,
-            cptra_wdt_timer1_ctrl: 0 as caliptra_emu_types::RvData,
-            cptra_wdt_timer1_timeout_period: vec![0xffff_ffff as caliptra_emu_types::RvData; 2],
-            cptra_wdt_timer2_en: 0 as caliptra_emu_types::RvData,
-            cptra_wdt_timer2_ctrl: 0 as caliptra_emu_types::RvData,
-            cptra_wdt_timer2_timeout_period: vec![0xffff_ffff as caliptra_emu_types::RvData; 2],
-            cptra_wdt_status: 0 as caliptra_emu_types::RvData,
-            cptra_fuse_valid_axi_user: 0xffff_ffff as caliptra_emu_types::RvData,
-            cptra_fuse_axi_user_lock: 0 as caliptra_emu_types::RvData,
-            cptra_wdt_cfg: vec![0 as caliptra_emu_types::RvData; 2],
-            cptra_i_trng_entropy_config_0: 0 as caliptra_emu_types::RvData,
-            cptra_i_trng_entropy_config_1: 0 as caliptra_emu_types::RvData,
-            cptra_rsvd_reg: vec![0 as caliptra_emu_types::RvData; 2],
-            cptra_hw_capabilities: 0 as caliptra_emu_types::RvData,
-            cptra_fw_capabilities: 0 as caliptra_emu_types::RvData,
-            cptra_cap_lock: 0 as caliptra_emu_types::RvData,
-            cptra_owner_pk_hash: vec![0 as caliptra_emu_types::RvData; 12],
-            cptra_owner_pk_hash_lock: 0 as caliptra_emu_types::RvData,
-            fuse_uds_seed: vec![0 as caliptra_emu_types::RvData; 16],
-            fuse_field_entropy: vec![0 as caliptra_emu_types::RvData; 8],
-            fuse_vendor_pk_hash: vec![0 as caliptra_emu_types::RvData; 12],
-            fuse_ecc_revocation: 0 as caliptra_emu_types::RvData,
-            fuse_fmc_key_manifest_svn: 0 as caliptra_emu_types::RvData,
-            fuse_runtime_svn: vec![0 as caliptra_emu_types::RvData; 4],
-            fuse_anti_rollback_disable: 0 as caliptra_emu_types::RvData,
-            fuse_idevid_cert_attr: vec![0 as caliptra_emu_types::RvData; 24],
-            fuse_idevid_manuf_hsm_id: vec![0 as caliptra_emu_types::RvData; 4],
-            fuse_lms_revocation: 0 as caliptra_emu_types::RvData,
-            fuse_mldsa_revocation: 0 as caliptra_emu_types::RvData,
-            fuse_soc_stepping_id: 0 as caliptra_emu_types::RvData,
-            fuse_manuf_dbg_unlock_token: vec![0 as caliptra_emu_types::RvData; 16],
-            fuse_pqc_key_type: 0 as caliptra_emu_types::RvData,
-            fuse_soc_manifest_svn: vec![0 as caliptra_emu_types::RvData; 4],
-            fuse_soc_manifest_max_svn: 0 as caliptra_emu_types::RvData,
-            ss_caliptra_base_addr_l: 0 as caliptra_emu_types::RvData,
-            ss_caliptra_base_addr_h: 0 as caliptra_emu_types::RvData,
-            ss_mci_base_addr_l: 0 as caliptra_emu_types::RvData,
-            ss_mci_base_addr_h: 0 as caliptra_emu_types::RvData,
-            ss_recovery_ifc_base_addr_l: 0 as caliptra_emu_types::RvData,
-            ss_recovery_ifc_base_addr_h: 0 as caliptra_emu_types::RvData,
-            ss_otp_fc_base_addr_l: 0 as caliptra_emu_types::RvData,
-            ss_otp_fc_base_addr_h: 0 as caliptra_emu_types::RvData,
-            ss_uds_seed_base_addr_l: 0 as caliptra_emu_types::RvData,
-            ss_uds_seed_base_addr_h: 0 as caliptra_emu_types::RvData,
-            ss_prod_debug_unlock_auth_pk_hash_reg_bank_offset: 0 as caliptra_emu_types::RvData,
-            ss_num_of_prod_debug_unlock_auth_pk_hashes: 8 as caliptra_emu_types::RvData,
-            ss_debug_intent: 0 as caliptra_emu_types::RvData,
-            ss_caliptra_dma_axi_user: 0 as caliptra_emu_types::RvData,
-            ss_strap_generic: vec![0 as caliptra_emu_types::RvData; 4],
-            ss_dbg_manuf_service_reg_req: 0 as caliptra_emu_types::RvData,
-            ss_dbg_manuf_service_reg_rsp: 0 as caliptra_emu_types::RvData,
-            ss_soc_dbg_unlock_level: vec![0 as caliptra_emu_types::RvData; 2],
-            ss_generic_fw_exec_ctrl: vec![0 as caliptra_emu_types::RvData; 4],
+            cptra_hw_error_fatal: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            cptra_hw_error_non_fatal: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            cptra_fw_error_fatal: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            cptra_fw_error_non_fatal: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            cptra_hw_error_enc: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            cptra_fw_error_enc: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            cptra_fw_extended_error_info: vec![
+                0 as caliptra_core_tools::caliptra_emu_types::RvData;
+                8
+            ],
+            cptra_boot_status: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            cptra_flow_status: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            cptra_reset_reason: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            cptra_security_state: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            cptra_mbox_valid_axi_user: vec![
+                0xffff_ffff
+                    as caliptra_core_tools::caliptra_emu_types::RvData;
+                5
+            ],
+            cptra_mbox_axi_user_lock: vec![0 as caliptra_core_tools::caliptra_emu_types::RvData; 5],
+            cptra_trng_valid_axi_user: 0xffff_ffff
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            cptra_trng_axi_user_lock: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            cptra_trng_data: vec![0 as caliptra_core_tools::caliptra_emu_types::RvData; 12],
+            cptra_trng_ctrl: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            cptra_trng_status: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            cptra_fuse_wr_done: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            cptra_timer_config: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            cptra_bootfsm_go: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            cptra_dbg_manuf_service_reg: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            cptra_clk_gating_en: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            cptra_generic_input_wires: vec![
+                0 as caliptra_core_tools::caliptra_emu_types::RvData;
+                2
+            ],
+            cptra_generic_output_wires: vec![
+                0 as caliptra_core_tools::caliptra_emu_types::RvData;
+                2
+            ],
+            cptra_hw_rev_id: 0x302 as caliptra_core_tools::caliptra_emu_types::RvData,
+            cptra_fw_rev_id: vec![0 as caliptra_core_tools::caliptra_emu_types::RvData; 2],
+            cptra_hw_config: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            cptra_wdt_timer1_en: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            cptra_wdt_timer1_ctrl: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            cptra_wdt_timer1_timeout_period:
+                vec![0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData; 2],
+            cptra_wdt_timer2_en: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            cptra_wdt_timer2_ctrl: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            cptra_wdt_timer2_timeout_period:
+                vec![0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData; 2],
+            cptra_wdt_status: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            cptra_fuse_valid_axi_user: 0xffff_ffff
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            cptra_fuse_axi_user_lock: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            cptra_wdt_cfg: vec![0 as caliptra_core_tools::caliptra_emu_types::RvData; 2],
+            cptra_i_trng_entropy_config_0: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            cptra_i_trng_entropy_config_1: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            cptra_rsvd_reg: vec![0 as caliptra_core_tools::caliptra_emu_types::RvData; 2],
+            cptra_hw_capabilities: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            cptra_fw_capabilities: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            cptra_cap_lock: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            cptra_owner_pk_hash: vec![0 as caliptra_core_tools::caliptra_emu_types::RvData; 12],
+            cptra_owner_pk_hash_lock: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            fuse_uds_seed: vec![0 as caliptra_core_tools::caliptra_emu_types::RvData; 16],
+            fuse_field_entropy: vec![0 as caliptra_core_tools::caliptra_emu_types::RvData; 8],
+            fuse_vendor_pk_hash: vec![0 as caliptra_core_tools::caliptra_emu_types::RvData; 12],
+            fuse_ecc_revocation: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            fuse_fmc_key_manifest_svn: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            fuse_runtime_svn: vec![0 as caliptra_core_tools::caliptra_emu_types::RvData; 4],
+            fuse_anti_rollback_disable: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            fuse_idevid_cert_attr: vec![0 as caliptra_core_tools::caliptra_emu_types::RvData; 24],
+            fuse_idevid_manuf_hsm_id: vec![0 as caliptra_core_tools::caliptra_emu_types::RvData; 4],
+            fuse_lms_revocation: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            fuse_mldsa_revocation: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            fuse_soc_stepping_id: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            fuse_manuf_dbg_unlock_token: vec![
+                0 as caliptra_core_tools::caliptra_emu_types::RvData;
+                16
+            ],
+            fuse_pqc_key_type: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            fuse_soc_manifest_svn: vec![0 as caliptra_core_tools::caliptra_emu_types::RvData; 4],
+            fuse_soc_manifest_max_svn: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            ss_caliptra_base_addr_l: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            ss_caliptra_base_addr_h: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            ss_mci_base_addr_l: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            ss_mci_base_addr_h: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            ss_recovery_ifc_base_addr_l: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            ss_recovery_ifc_base_addr_h: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            ss_otp_fc_base_addr_l: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            ss_otp_fc_base_addr_h: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            ss_uds_seed_base_addr_l: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            ss_uds_seed_base_addr_h: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            ss_prod_debug_unlock_auth_pk_hash_reg_bank_offset: 0
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            ss_num_of_prod_debug_unlock_auth_pk_hashes: 8
+                as caliptra_core_tools::caliptra_emu_types::RvData,
+            ss_debug_intent: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            ss_caliptra_dma_axi_user: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            ss_strap_generic: vec![0 as caliptra_core_tools::caliptra_emu_types::RvData; 4],
+            ss_dbg_manuf_service_reg_req: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            ss_dbg_manuf_service_reg_rsp: 0 as caliptra_core_tools::caliptra_emu_types::RvData,
+            ss_soc_dbg_unlock_level: vec![0 as caliptra_core_tools::caliptra_emu_types::RvData; 2],
+            ss_generic_fw_exec_ctrl: vec![0 as caliptra_core_tools::caliptra_emu_types::RvData; 4],
         }
     }
 }
@@ -2075,18 +2302,18 @@ impl SocPeripheral for SocGenerated {
     }
     fn read_cptra_hw_error_fatal(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraHwErrorFatal::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read soc::cptra_hw_error_fatal");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.cptra_hw_error_fatal)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.cptra_hw_error_fatal)
     }
     fn write_cptra_hw_error_fatal(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::CptraHwErrorFatal::Register,
         >,
@@ -2094,22 +2321,22 @@ impl SocPeripheral for SocGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write soc::cptra_hw_error_fatal = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.cptra_hw_error_fatal;
         let mut new_val = current_val;
-        let bits_to_clear_0 = write_val & (1 as caliptra_emu_types::RvData);
+        let bits_to_clear_0 = write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_0;
-        let bits_to_clear_1 = write_val & (2 as caliptra_emu_types::RvData);
+        let bits_to_clear_1 = write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_1;
-        let bits_to_clear_2 = write_val & (4 as caliptra_emu_types::RvData);
+        let bits_to_clear_2 = write_val & (4 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_2;
-        let bits_to_clear_3 = write_val & (8 as caliptra_emu_types::RvData);
+        let bits_to_clear_3 = write_val & (8 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_3;
         self.cptra_hw_error_fatal = new_val;
     }
     fn read_cptra_hw_error_non_fatal(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraHwErrorNonFatal::Register,
     > {
@@ -2118,11 +2345,11 @@ impl SocPeripheral for SocGenerated {
                 "[EMU] Generated default register handler: read soc::cptra_hw_error_non_fatal"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.cptra_hw_error_non_fatal)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.cptra_hw_error_non_fatal)
     }
     fn write_cptra_hw_error_non_fatal(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::CptraHwErrorNonFatal::Register,
         >,
@@ -2130,35 +2357,35 @@ impl SocPeripheral for SocGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write soc::cptra_hw_error_non_fatal = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.cptra_hw_error_non_fatal;
         let mut new_val = current_val;
-        let bits_to_clear_0 = write_val & (1 as caliptra_emu_types::RvData);
+        let bits_to_clear_0 = write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_0;
-        let bits_to_clear_1 = write_val & (2 as caliptra_emu_types::RvData);
+        let bits_to_clear_1 = write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_1;
-        let bits_to_clear_2 = write_val & (4 as caliptra_emu_types::RvData);
+        let bits_to_clear_2 = write_val & (4 as caliptra_core_tools::caliptra_emu_types::RvData);
         new_val &= !bits_to_clear_2;
         self.cptra_hw_error_non_fatal = new_val;
     }
-    fn read_cptra_fw_error_fatal(&mut self) -> caliptra_emu_types::RvData {
+    fn read_cptra_fw_error_fatal(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read soc::cptra_fw_error_fatal");
         }
         self.cptra_fw_error_fatal
     }
-    fn write_cptra_fw_error_fatal(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_cptra_fw_error_fatal(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write soc::cptra_fw_error_fatal = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.cptra_fw_error_fatal;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.cptra_fw_error_fatal = new_val;
     }
-    fn read_cptra_fw_error_non_fatal(&mut self) -> caliptra_emu_types::RvData {
+    fn read_cptra_fw_error_non_fatal(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read soc::cptra_fw_error_non_fatal"
@@ -2166,52 +2393,58 @@ impl SocPeripheral for SocGenerated {
         }
         self.cptra_fw_error_non_fatal
     }
-    fn write_cptra_fw_error_non_fatal(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_cptra_fw_error_non_fatal(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write soc::cptra_fw_error_non_fatal = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.cptra_fw_error_non_fatal;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.cptra_fw_error_non_fatal = new_val;
     }
-    fn read_cptra_hw_error_enc(&mut self) -> caliptra_emu_types::RvData {
+    fn read_cptra_hw_error_enc(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read soc::cptra_hw_error_enc");
         }
         self.cptra_hw_error_enc
     }
-    fn write_cptra_hw_error_enc(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_cptra_hw_error_enc(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write soc::cptra_hw_error_enc = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.cptra_hw_error_enc;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.cptra_hw_error_enc = new_val;
     }
-    fn read_cptra_fw_error_enc(&mut self) -> caliptra_emu_types::RvData {
+    fn read_cptra_fw_error_enc(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read soc::cptra_fw_error_enc");
         }
         self.cptra_fw_error_enc
     }
-    fn write_cptra_fw_error_enc(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_cptra_fw_error_enc(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write soc::cptra_fw_error_enc = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.cptra_fw_error_enc;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.cptra_fw_error_enc = new_val;
     }
-    fn read_cptra_fw_extended_error_info(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_cptra_fw_extended_error_info(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read soc::cptra_fw_extended_error_info[{}]" , index);
         }
@@ -2219,53 +2452,53 @@ impl SocPeripheral for SocGenerated {
     }
     fn write_cptra_fw_extended_error_info(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
         index: usize,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write soc::cptra_fw_extended_error_info[{}] = 0x{:08x}" , index , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.cptra_fw_extended_error_info[index];
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.cptra_fw_extended_error_info[index] = new_val;
     }
-    fn read_cptra_boot_status(&mut self) -> caliptra_emu_types::RvData {
+    fn read_cptra_boot_status(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read soc::cptra_boot_status");
         }
         self.cptra_boot_status
     }
-    fn write_cptra_boot_status(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_cptra_boot_status(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: write soc::cptra_boot_status = 0x{:08x}",
                 val
             );
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.cptra_boot_status;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.cptra_boot_status = new_val;
     }
     fn read_cptra_flow_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraFlowStatus::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read soc::cptra_flow_status");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.cptra_flow_status)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.cptra_flow_status)
     }
     fn write_cptra_flow_status(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::CptraFlowStatus::Register,
         >,
@@ -2276,44 +2509,47 @@ impl SocPeripheral for SocGenerated {
                 val.reg.get()
             );
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.cptra_flow_status;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xff_ffff as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x100_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x100_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x1000_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x1000_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x2000_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x2000_0000 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x8000_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0x8000_0000 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x100_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x100_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x1000_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x1000_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x2000_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x2000_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x8000_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x8000_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.cptra_flow_status = new_val;
     }
     fn read_cptra_reset_reason(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraResetReason::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read soc::cptra_reset_reason");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.cptra_reset_reason)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.cptra_reset_reason)
     }
     fn read_cptra_security_state(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraSecurityState::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read soc::cptra_security_state");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.cptra_security_state)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.cptra_security_state)
     }
-    fn read_cptra_mbox_valid_axi_user(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_cptra_mbox_valid_axi_user(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read soc::cptra_mbox_valid_axi_user[{}]",
@@ -2322,21 +2558,25 @@ impl SocPeripheral for SocGenerated {
         }
         self.cptra_mbox_valid_axi_user[index]
     }
-    fn write_cptra_mbox_valid_axi_user(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    fn write_cptra_mbox_valid_axi_user(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+        index: usize,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write soc::cptra_mbox_valid_axi_user[{}] = 0x{:08x}" , index , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.cptra_mbox_valid_axi_user[index];
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.cptra_mbox_valid_axi_user[index] = new_val;
     }
     fn read_cptra_mbox_axi_user_lock(
         &mut self,
         index: usize,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraXxxxAxiUserLock::Register,
     > {
@@ -2346,11 +2586,13 @@ impl SocPeripheral for SocGenerated {
                 index
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.cptra_mbox_axi_user_lock[index])
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.cptra_mbox_axi_user_lock[index],
+        )
     }
     fn write_cptra_mbox_axi_user_lock(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::CptraXxxxAxiUserLock::Register,
         >,
@@ -2359,14 +2601,16 @@ impl SocPeripheral for SocGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write soc::cptra_mbox_axi_user_lock[{}] = 0x{:08x}" , index , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.cptra_mbox_axi_user_lock[index];
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.cptra_mbox_axi_user_lock[index] = new_val;
     }
-    fn read_cptra_trng_valid_axi_user(&mut self) -> caliptra_emu_types::RvData {
+    fn read_cptra_trng_valid_axi_user(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read soc::cptra_trng_valid_axi_user"
@@ -2374,20 +2618,23 @@ impl SocPeripheral for SocGenerated {
         }
         self.cptra_trng_valid_axi_user
     }
-    fn write_cptra_trng_valid_axi_user(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_cptra_trng_valid_axi_user(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write soc::cptra_trng_valid_axi_user = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.cptra_trng_valid_axi_user;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.cptra_trng_valid_axi_user = new_val;
     }
     fn read_cptra_trng_axi_user_lock(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraXxxxAxiUserLock::Register,
     > {
@@ -2396,11 +2643,11 @@ impl SocPeripheral for SocGenerated {
                 "[EMU] Generated default register handler: read soc::cptra_trng_axi_user_lock"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.cptra_trng_axi_user_lock)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.cptra_trng_axi_user_lock)
     }
     fn write_cptra_trng_axi_user_lock(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::CptraXxxxAxiUserLock::Register,
         >,
@@ -2408,14 +2655,17 @@ impl SocPeripheral for SocGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write soc::cptra_trng_axi_user_lock = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.cptra_trng_axi_user_lock;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.cptra_trng_axi_user_lock = new_val;
     }
-    fn read_cptra_trng_data(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_cptra_trng_data(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read soc::cptra_trng_data[{}]",
@@ -2424,31 +2674,35 @@ impl SocPeripheral for SocGenerated {
         }
         self.cptra_trng_data[index]
     }
-    fn write_cptra_trng_data(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    fn write_cptra_trng_data(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+        index: usize,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write soc::cptra_trng_data[{}] = 0x{:08x}" , index , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.cptra_trng_data[index];
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.cptra_trng_data[index] = new_val;
     }
     fn read_cptra_trng_ctrl(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraTrngCtrl::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read soc::cptra_trng_ctrl");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.cptra_trng_ctrl)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.cptra_trng_ctrl)
     }
     fn write_cptra_trng_ctrl(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::CptraTrngCtrl::Register,
         >,
@@ -2459,27 +2713,27 @@ impl SocPeripheral for SocGenerated {
                 val.reg.get()
             );
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.cptra_trng_ctrl;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.cptra_trng_ctrl = new_val;
     }
     fn read_cptra_trng_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraTrngStatus::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read soc::cptra_trng_status");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.cptra_trng_status)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.cptra_trng_status)
     }
     fn write_cptra_trng_status(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::CptraTrngStatus::Register,
         >,
@@ -2490,29 +2744,29 @@ impl SocPeripheral for SocGenerated {
                 val.reg.get()
             );
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.cptra_trng_status;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(2 as caliptra_emu_types::RvData))
-            | (write_val & (2 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(2 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.cptra_trng_status = new_val;
     }
     fn read_cptra_fuse_wr_done(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraFuseWrDone::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read soc::cptra_fuse_wr_done");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.cptra_fuse_wr_done)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.cptra_fuse_wr_done)
     }
     fn write_cptra_fuse_wr_done(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::CptraFuseWrDone::Register,
         >,
@@ -2520,44 +2774,44 @@ impl SocPeripheral for SocGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write soc::cptra_fuse_wr_done = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.cptra_fuse_wr_done;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.cptra_fuse_wr_done = new_val;
     }
-    fn read_cptra_timer_config(&mut self) -> caliptra_emu_types::RvData {
+    fn read_cptra_timer_config(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read soc::cptra_timer_config");
         }
         self.cptra_timer_config
     }
-    fn write_cptra_timer_config(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_cptra_timer_config(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write soc::cptra_timer_config = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.cptra_timer_config;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.cptra_timer_config = new_val;
     }
     fn read_cptra_bootfsm_go(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraBootfsmGo::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read soc::cptra_bootfsm_go");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.cptra_bootfsm_go)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.cptra_bootfsm_go)
     }
     fn write_cptra_bootfsm_go(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::CptraBootfsmGo::Register,
         >,
@@ -2568,14 +2822,16 @@ impl SocPeripheral for SocGenerated {
                 val.reg.get()
             );
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.cptra_bootfsm_go;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.cptra_bootfsm_go = new_val;
     }
-    fn read_cptra_dbg_manuf_service_reg(&mut self) -> caliptra_emu_types::RvData {
+    fn read_cptra_dbg_manuf_service_reg(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read soc::cptra_dbg_manuf_service_reg"
@@ -2583,31 +2839,34 @@ impl SocPeripheral for SocGenerated {
         }
         self.cptra_dbg_manuf_service_reg
     }
-    fn write_cptra_dbg_manuf_service_reg(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_cptra_dbg_manuf_service_reg(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write soc::cptra_dbg_manuf_service_reg = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.cptra_dbg_manuf_service_reg;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.cptra_dbg_manuf_service_reg = new_val;
     }
     fn read_cptra_clk_gating_en(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraClkGatingEn::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read soc::cptra_clk_gating_en");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.cptra_clk_gating_en)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.cptra_clk_gating_en)
     }
     fn write_cptra_clk_gating_en(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::CptraClkGatingEn::Register,
         >,
@@ -2615,14 +2874,17 @@ impl SocPeripheral for SocGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write soc::cptra_clk_gating_en = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.cptra_clk_gating_en;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.cptra_clk_gating_en = new_val;
     }
-    fn read_cptra_generic_input_wires(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_cptra_generic_input_wires(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read soc::cptra_generic_input_wires[{}]",
@@ -2631,35 +2893,45 @@ impl SocPeripheral for SocGenerated {
         }
         self.cptra_generic_input_wires[index]
     }
-    fn read_cptra_generic_output_wires(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_cptra_generic_output_wires(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read soc::cptra_generic_output_wires[{}]" , index);
         }
         self.cptra_generic_output_wires[index]
     }
-    fn write_cptra_generic_output_wires(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    fn write_cptra_generic_output_wires(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+        index: usize,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write soc::cptra_generic_output_wires[{}] = 0x{:08x}" , index , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.cptra_generic_output_wires[index];
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.cptra_generic_output_wires[index] = new_val;
     }
     fn read_cptra_hw_rev_id(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraHwRevId::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read soc::cptra_hw_rev_id");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.cptra_hw_rev_id)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.cptra_hw_rev_id)
     }
-    fn read_cptra_fw_rev_id(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_cptra_fw_rev_id(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read soc::cptra_fw_rev_id[{}]",
@@ -2668,42 +2940,46 @@ impl SocPeripheral for SocGenerated {
         }
         self.cptra_fw_rev_id[index]
     }
-    fn write_cptra_fw_rev_id(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    fn write_cptra_fw_rev_id(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+        index: usize,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write soc::cptra_fw_rev_id[{}] = 0x{:08x}" , index , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.cptra_fw_rev_id[index];
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.cptra_fw_rev_id[index] = new_val;
     }
     fn read_cptra_hw_config(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraHwConfig::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read soc::cptra_hw_config");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.cptra_hw_config)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.cptra_hw_config)
     }
     fn read_cptra_wdt_timer1_en(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraWdtTimer1En::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read soc::cptra_wdt_timer1_en");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.cptra_wdt_timer1_en)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.cptra_wdt_timer1_en)
     }
     fn write_cptra_wdt_timer1_en(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::CptraWdtTimer1En::Register,
         >,
@@ -2711,27 +2987,27 @@ impl SocPeripheral for SocGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write soc::cptra_wdt_timer1_en = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.cptra_wdt_timer1_en;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.cptra_wdt_timer1_en = new_val;
     }
     fn read_cptra_wdt_timer1_ctrl(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraWdtTimer1Ctrl::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read soc::cptra_wdt_timer1_ctrl");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.cptra_wdt_timer1_ctrl)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.cptra_wdt_timer1_ctrl)
     }
     fn write_cptra_wdt_timer1_ctrl(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::CptraWdtTimer1Ctrl::Register,
         >,
@@ -2739,14 +3015,17 @@ impl SocPeripheral for SocGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write soc::cptra_wdt_timer1_ctrl = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.cptra_wdt_timer1_ctrl;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.cptra_wdt_timer1_ctrl = new_val;
     }
-    fn read_cptra_wdt_timer1_timeout_period(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_cptra_wdt_timer1_timeout_period(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read soc::cptra_wdt_timer1_timeout_period[{}]" , index);
         }
@@ -2754,33 +3033,33 @@ impl SocPeripheral for SocGenerated {
     }
     fn write_cptra_wdt_timer1_timeout_period(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
         index: usize,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write soc::cptra_wdt_timer1_timeout_period[{}] = 0x{:08x}" , index , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.cptra_wdt_timer1_timeout_period[index];
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.cptra_wdt_timer1_timeout_period[index] = new_val;
     }
     fn read_cptra_wdt_timer2_en(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraWdtTimer2En::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read soc::cptra_wdt_timer2_en");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.cptra_wdt_timer2_en)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.cptra_wdt_timer2_en)
     }
     fn write_cptra_wdt_timer2_en(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::CptraWdtTimer2En::Register,
         >,
@@ -2788,27 +3067,27 @@ impl SocPeripheral for SocGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write soc::cptra_wdt_timer2_en = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.cptra_wdt_timer2_en;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.cptra_wdt_timer2_en = new_val;
     }
     fn read_cptra_wdt_timer2_ctrl(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraWdtTimer2Ctrl::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read soc::cptra_wdt_timer2_ctrl");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.cptra_wdt_timer2_ctrl)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.cptra_wdt_timer2_ctrl)
     }
     fn write_cptra_wdt_timer2_ctrl(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::CptraWdtTimer2Ctrl::Register,
         >,
@@ -2816,14 +3095,17 @@ impl SocPeripheral for SocGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write soc::cptra_wdt_timer2_ctrl = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.cptra_wdt_timer2_ctrl;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.cptra_wdt_timer2_ctrl = new_val;
     }
-    fn read_cptra_wdt_timer2_timeout_period(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_cptra_wdt_timer2_timeout_period(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read soc::cptra_wdt_timer2_timeout_period[{}]" , index);
         }
@@ -2831,33 +3113,33 @@ impl SocPeripheral for SocGenerated {
     }
     fn write_cptra_wdt_timer2_timeout_period(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
         index: usize,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write soc::cptra_wdt_timer2_timeout_period[{}] = 0x{:08x}" , index , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.cptra_wdt_timer2_timeout_period[index];
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.cptra_wdt_timer2_timeout_period[index] = new_val;
     }
     fn read_cptra_wdt_status(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraWdtStatus::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read soc::cptra_wdt_status");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.cptra_wdt_status)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.cptra_wdt_status)
     }
     fn write_cptra_wdt_status(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::CptraWdtStatus::Register,
         >,
@@ -2868,16 +3150,18 @@ impl SocPeripheral for SocGenerated {
                 val.reg.get()
             );
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.cptra_wdt_status;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(2 as caliptra_emu_types::RvData))
-            | (write_val & (2 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(2 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.cptra_wdt_status = new_val;
     }
-    fn read_cptra_fuse_valid_axi_user(&mut self) -> caliptra_emu_types::RvData {
+    fn read_cptra_fuse_valid_axi_user(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read soc::cptra_fuse_valid_axi_user"
@@ -2885,20 +3169,23 @@ impl SocPeripheral for SocGenerated {
         }
         self.cptra_fuse_valid_axi_user
     }
-    fn write_cptra_fuse_valid_axi_user(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_cptra_fuse_valid_axi_user(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write soc::cptra_fuse_valid_axi_user = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.cptra_fuse_valid_axi_user;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.cptra_fuse_valid_axi_user = new_val;
     }
     fn read_cptra_fuse_axi_user_lock(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraXxxxAxiUserLock::Register,
     > {
@@ -2907,11 +3194,11 @@ impl SocPeripheral for SocGenerated {
                 "[EMU] Generated default register handler: read soc::cptra_fuse_axi_user_lock"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.cptra_fuse_axi_user_lock)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.cptra_fuse_axi_user_lock)
     }
     fn write_cptra_fuse_axi_user_lock(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::CptraXxxxAxiUserLock::Register,
         >,
@@ -2919,14 +3206,17 @@ impl SocPeripheral for SocGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write soc::cptra_fuse_axi_user_lock = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.cptra_fuse_axi_user_lock;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.cptra_fuse_axi_user_lock = new_val;
     }
-    fn read_cptra_wdt_cfg(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_cptra_wdt_cfg(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read soc::cptra_wdt_cfg[{}]",
@@ -2935,23 +3225,27 @@ impl SocPeripheral for SocGenerated {
         }
         self.cptra_wdt_cfg[index]
     }
-    fn write_cptra_wdt_cfg(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    fn write_cptra_wdt_cfg(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+        index: usize,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: write soc::cptra_wdt_cfg[{}] = 0x{:08x}",
                 index, val
             );
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.cptra_wdt_cfg[index];
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.cptra_wdt_cfg[index] = new_val;
     }
     fn read_cptra_i_trng_entropy_config_0(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraItrngEntropyConfig0::Register,
     > {
@@ -2960,11 +3254,13 @@ impl SocPeripheral for SocGenerated {
                 "[EMU] Generated default register handler: read soc::cptra_i_trng_entropy_config_0"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.cptra_i_trng_entropy_config_0)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.cptra_i_trng_entropy_config_0,
+        )
     }
     fn write_cptra_i_trng_entropy_config_0(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::CptraItrngEntropyConfig0::Register,
         >,
@@ -2972,18 +3268,18 @@ impl SocPeripheral for SocGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write soc::cptra_i_trng_entropy_config_0 = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.cptra_i_trng_entropy_config_0;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xffff_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_0000 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.cptra_i_trng_entropy_config_0 = new_val;
     }
     fn read_cptra_i_trng_entropy_config_1(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraItrngEntropyConfig1::Register,
     > {
@@ -2992,11 +3288,13 @@ impl SocPeripheral for SocGenerated {
                 "[EMU] Generated default register handler: read soc::cptra_i_trng_entropy_config_1"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.cptra_i_trng_entropy_config_1)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.cptra_i_trng_entropy_config_1,
+        )
     }
     fn write_cptra_i_trng_entropy_config_1(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::CptraItrngEntropyConfig1::Register,
         >,
@@ -3004,16 +3302,19 @@ impl SocPeripheral for SocGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write soc::cptra_i_trng_entropy_config_1 = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.cptra_i_trng_entropy_config_1;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0xffff_0000 as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_0000 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_0000 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_0000 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.cptra_i_trng_entropy_config_1 = new_val;
     }
-    fn read_cptra_rsvd_reg(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_cptra_rsvd_reg(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read soc::cptra_rsvd_reg[{}]",
@@ -3022,65 +3323,75 @@ impl SocPeripheral for SocGenerated {
         }
         self.cptra_rsvd_reg[index]
     }
-    fn write_cptra_rsvd_reg(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    fn write_cptra_rsvd_reg(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+        index: usize,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write soc::cptra_rsvd_reg[{}] = 0x{:08x}" , index , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.cptra_rsvd_reg[index];
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.cptra_rsvd_reg[index] = new_val;
     }
-    fn read_cptra_hw_capabilities(&mut self) -> caliptra_emu_types::RvData {
+    fn read_cptra_hw_capabilities(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read soc::cptra_hw_capabilities");
         }
         self.cptra_hw_capabilities
     }
-    fn write_cptra_hw_capabilities(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_cptra_hw_capabilities(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write soc::cptra_hw_capabilities = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.cptra_hw_capabilities;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.cptra_hw_capabilities = new_val;
     }
-    fn read_cptra_fw_capabilities(&mut self) -> caliptra_emu_types::RvData {
+    fn read_cptra_fw_capabilities(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read soc::cptra_fw_capabilities");
         }
         self.cptra_fw_capabilities
     }
-    fn write_cptra_fw_capabilities(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_cptra_fw_capabilities(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write soc::cptra_fw_capabilities = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.cptra_fw_capabilities;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.cptra_fw_capabilities = new_val;
     }
     fn read_cptra_cap_lock(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraXxxxxxxk::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read soc::cptra_cap_lock");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.cptra_cap_lock)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.cptra_cap_lock)
     }
     fn write_cptra_cap_lock(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::CptraXxxxxxxk::Register,
         >,
@@ -3091,14 +3402,17 @@ impl SocPeripheral for SocGenerated {
                 val.reg.get()
             );
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.cptra_cap_lock;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.cptra_cap_lock = new_val;
     }
-    fn read_cptra_owner_pk_hash(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_cptra_owner_pk_hash(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read soc::cptra_owner_pk_hash[{}]",
@@ -3107,20 +3421,24 @@ impl SocPeripheral for SocGenerated {
         }
         self.cptra_owner_pk_hash[index]
     }
-    fn write_cptra_owner_pk_hash(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    fn write_cptra_owner_pk_hash(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+        index: usize,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write soc::cptra_owner_pk_hash[{}] = 0x{:08x}" , index , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.cptra_owner_pk_hash[index];
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.cptra_owner_pk_hash[index] = new_val;
     }
     fn read_cptra_owner_pk_hash_lock(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::CptraXxxxxxxk::Register,
     > {
@@ -3129,11 +3447,11 @@ impl SocPeripheral for SocGenerated {
                 "[EMU] Generated default register handler: read soc::cptra_owner_pk_hash_lock"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.cptra_owner_pk_hash_lock)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.cptra_owner_pk_hash_lock)
     }
     fn write_cptra_owner_pk_hash_lock(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::CptraXxxxxxxk::Register,
         >,
@@ -3141,39 +3459,50 @@ impl SocPeripheral for SocGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write soc::cptra_owner_pk_hash_lock = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.cptra_owner_pk_hash_lock;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.cptra_owner_pk_hash_lock = new_val;
     }
-    fn write_fuse_uds_seed(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    fn write_fuse_uds_seed(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+        index: usize,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: write soc::fuse_uds_seed[{}] = 0x{:08x}",
                 index, val
             );
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.fuse_uds_seed[index];
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.fuse_uds_seed[index] = new_val;
     }
-    fn write_fuse_field_entropy(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    fn write_fuse_field_entropy(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+        index: usize,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write soc::fuse_field_entropy[{}] = 0x{:08x}" , index , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.fuse_field_entropy[index];
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.fuse_field_entropy[index] = new_val;
     }
-    fn read_fuse_vendor_pk_hash(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_fuse_vendor_pk_hash(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read soc::fuse_vendor_pk_hash[{}]",
@@ -3182,31 +3511,35 @@ impl SocPeripheral for SocGenerated {
         }
         self.fuse_vendor_pk_hash[index]
     }
-    fn write_fuse_vendor_pk_hash(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    fn write_fuse_vendor_pk_hash(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+        index: usize,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write soc::fuse_vendor_pk_hash[{}] = 0x{:08x}" , index , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.fuse_vendor_pk_hash[index];
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.fuse_vendor_pk_hash[index] = new_val;
     }
     fn read_fuse_ecc_revocation(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::FuseEccRevocation::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read soc::fuse_ecc_revocation");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.fuse_ecc_revocation)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.fuse_ecc_revocation)
     }
     fn write_fuse_ecc_revocation(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::FuseEccRevocation::Register,
         >,
@@ -3214,14 +3547,16 @@ impl SocPeripheral for SocGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write soc::fuse_ecc_revocation = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.fuse_ecc_revocation;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xf as caliptra_emu_types::RvData))
-            | (write_val & (0xf as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xf as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xf as caliptra_core_tools::caliptra_emu_types::RvData));
         self.fuse_ecc_revocation = new_val;
     }
-    fn read_fuse_fmc_key_manifest_svn(&mut self) -> caliptra_emu_types::RvData {
+    fn read_fuse_fmc_key_manifest_svn(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read soc::fuse_fmc_key_manifest_svn"
@@ -3229,18 +3564,24 @@ impl SocPeripheral for SocGenerated {
         }
         self.fuse_fmc_key_manifest_svn
     }
-    fn write_fuse_fmc_key_manifest_svn(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_fuse_fmc_key_manifest_svn(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write soc::fuse_fmc_key_manifest_svn = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.fuse_fmc_key_manifest_svn;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.fuse_fmc_key_manifest_svn = new_val;
     }
-    fn read_fuse_runtime_svn(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_fuse_runtime_svn(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read soc::fuse_runtime_svn[{}]",
@@ -3249,20 +3590,24 @@ impl SocPeripheral for SocGenerated {
         }
         self.fuse_runtime_svn[index]
     }
-    fn write_fuse_runtime_svn(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    fn write_fuse_runtime_svn(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+        index: usize,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write soc::fuse_runtime_svn[{}] = 0x{:08x}" , index , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.fuse_runtime_svn[index];
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.fuse_runtime_svn[index] = new_val;
     }
     fn read_fuse_anti_rollback_disable(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::FuseAntiRollbackDisable::Register,
     > {
@@ -3271,11 +3616,13 @@ impl SocPeripheral for SocGenerated {
                 "[EMU] Generated default register handler: read soc::fuse_anti_rollback_disable"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.fuse_anti_rollback_disable)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.fuse_anti_rollback_disable,
+        )
     }
     fn write_fuse_anti_rollback_disable(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::FuseAntiRollbackDisable::Register,
         >,
@@ -3283,14 +3630,17 @@ impl SocPeripheral for SocGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write soc::fuse_anti_rollback_disable = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.fuse_anti_rollback_disable;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.fuse_anti_rollback_disable = new_val;
     }
-    fn read_fuse_idevid_cert_attr(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_fuse_idevid_cert_attr(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read soc::fuse_idevid_cert_attr[{}]",
@@ -3299,18 +3649,25 @@ impl SocPeripheral for SocGenerated {
         }
         self.fuse_idevid_cert_attr[index]
     }
-    fn write_fuse_idevid_cert_attr(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    fn write_fuse_idevid_cert_attr(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+        index: usize,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write soc::fuse_idevid_cert_attr[{}] = 0x{:08x}" , index , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.fuse_idevid_cert_attr[index];
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.fuse_idevid_cert_attr[index] = new_val;
     }
-    fn read_fuse_idevid_manuf_hsm_id(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_fuse_idevid_manuf_hsm_id(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read soc::fuse_idevid_manuf_hsm_id[{}]",
@@ -3319,48 +3676,52 @@ impl SocPeripheral for SocGenerated {
         }
         self.fuse_idevid_manuf_hsm_id[index]
     }
-    fn write_fuse_idevid_manuf_hsm_id(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    fn write_fuse_idevid_manuf_hsm_id(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+        index: usize,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write soc::fuse_idevid_manuf_hsm_id[{}] = 0x{:08x}" , index , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.fuse_idevid_manuf_hsm_id[index];
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.fuse_idevid_manuf_hsm_id[index] = new_val;
     }
-    fn read_fuse_lms_revocation(&mut self) -> caliptra_emu_types::RvData {
+    fn read_fuse_lms_revocation(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read soc::fuse_lms_revocation");
         }
         self.fuse_lms_revocation
     }
-    fn write_fuse_lms_revocation(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_fuse_lms_revocation(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write soc::fuse_lms_revocation = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.fuse_lms_revocation;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.fuse_lms_revocation = new_val;
     }
     fn read_fuse_mldsa_revocation(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::FuseMldsaRevocation::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read soc::fuse_mldsa_revocation");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.fuse_mldsa_revocation)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.fuse_mldsa_revocation)
     }
     fn write_fuse_mldsa_revocation(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::FuseMldsaRevocation::Register,
         >,
@@ -3368,27 +3729,27 @@ impl SocPeripheral for SocGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write soc::fuse_mldsa_revocation = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.fuse_mldsa_revocation;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xf as caliptra_emu_types::RvData))
-            | (write_val & (0xf as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xf as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xf as caliptra_core_tools::caliptra_emu_types::RvData));
         self.fuse_mldsa_revocation = new_val;
     }
     fn read_fuse_soc_stepping_id(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::FuseSocSteppingId::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read soc::fuse_soc_stepping_id");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.fuse_soc_stepping_id)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.fuse_soc_stepping_id)
     }
     fn write_fuse_soc_stepping_id(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::FuseSocSteppingId::Register,
         >,
@@ -3396,44 +3757,51 @@ impl SocPeripheral for SocGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write soc::fuse_soc_stepping_id = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.fuse_soc_stepping_id;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.fuse_soc_stepping_id = new_val;
     }
-    fn read_fuse_manuf_dbg_unlock_token(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_fuse_manuf_dbg_unlock_token(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read soc::fuse_manuf_dbg_unlock_token[{}]" , index);
         }
         self.fuse_manuf_dbg_unlock_token[index]
     }
-    fn write_fuse_manuf_dbg_unlock_token(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    fn write_fuse_manuf_dbg_unlock_token(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+        index: usize,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write soc::fuse_manuf_dbg_unlock_token[{}] = 0x{:08x}" , index , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.fuse_manuf_dbg_unlock_token[index];
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.fuse_manuf_dbg_unlock_token[index] = new_val;
     }
     fn read_fuse_pqc_key_type(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::FusePqcKeyType::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read soc::fuse_pqc_key_type");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.fuse_pqc_key_type)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.fuse_pqc_key_type)
     }
     fn write_fuse_pqc_key_type(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::FusePqcKeyType::Register,
         >,
@@ -3444,14 +3812,17 @@ impl SocPeripheral for SocGenerated {
                 val.reg.get()
             );
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.fuse_pqc_key_type;
         let mut new_val = current_val;
-        new_val = (new_val & !(3 as caliptra_emu_types::RvData))
-            | (write_val & (3 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(3 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (3 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.fuse_pqc_key_type = new_val;
     }
-    fn read_fuse_soc_manifest_svn(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_fuse_soc_manifest_svn(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read soc::fuse_soc_manifest_svn[{}]",
@@ -3460,20 +3831,24 @@ impl SocPeripheral for SocGenerated {
         }
         self.fuse_soc_manifest_svn[index]
     }
-    fn write_fuse_soc_manifest_svn(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    fn write_fuse_soc_manifest_svn(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+        index: usize,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write soc::fuse_soc_manifest_svn[{}] = 0x{:08x}" , index , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.fuse_soc_manifest_svn[index];
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.fuse_soc_manifest_svn[index] = new_val;
     }
     fn read_fuse_soc_manifest_max_svn(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::FuseSocManifestMaxSvn::Register,
     > {
@@ -3482,11 +3857,13 @@ impl SocPeripheral for SocGenerated {
                 "[EMU] Generated default register handler: read soc::fuse_soc_manifest_max_svn"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.fuse_soc_manifest_max_svn)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.fuse_soc_manifest_max_svn,
+        )
     }
     fn write_fuse_soc_manifest_max_svn(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::FuseSocManifestMaxSvn::Register,
         >,
@@ -3494,14 +3871,14 @@ impl SocPeripheral for SocGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write soc::fuse_soc_manifest_max_svn = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.fuse_soc_manifest_max_svn;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xff as caliptra_emu_types::RvData))
-            | (write_val & (0xff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.fuse_soc_manifest_max_svn = new_val;
     }
-    fn read_ss_caliptra_base_addr_l(&mut self) -> caliptra_emu_types::RvData {
+    fn read_ss_caliptra_base_addr_l(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read soc::ss_caliptra_base_addr_l"
@@ -3509,18 +3886,21 @@ impl SocPeripheral for SocGenerated {
         }
         self.ss_caliptra_base_addr_l
     }
-    fn write_ss_caliptra_base_addr_l(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_ss_caliptra_base_addr_l(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write soc::ss_caliptra_base_addr_l = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.ss_caliptra_base_addr_l;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.ss_caliptra_base_addr_l = new_val;
     }
-    fn read_ss_caliptra_base_addr_h(&mut self) -> caliptra_emu_types::RvData {
+    fn read_ss_caliptra_base_addr_h(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read soc::ss_caliptra_base_addr_h"
@@ -3528,52 +3908,57 @@ impl SocPeripheral for SocGenerated {
         }
         self.ss_caliptra_base_addr_h
     }
-    fn write_ss_caliptra_base_addr_h(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_ss_caliptra_base_addr_h(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write soc::ss_caliptra_base_addr_h = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.ss_caliptra_base_addr_h;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.ss_caliptra_base_addr_h = new_val;
     }
-    fn read_ss_mci_base_addr_l(&mut self) -> caliptra_emu_types::RvData {
+    fn read_ss_mci_base_addr_l(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read soc::ss_mci_base_addr_l");
         }
         self.ss_mci_base_addr_l
     }
-    fn write_ss_mci_base_addr_l(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_ss_mci_base_addr_l(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write soc::ss_mci_base_addr_l = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.ss_mci_base_addr_l;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.ss_mci_base_addr_l = new_val;
     }
-    fn read_ss_mci_base_addr_h(&mut self) -> caliptra_emu_types::RvData {
+    fn read_ss_mci_base_addr_h(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read soc::ss_mci_base_addr_h");
         }
         self.ss_mci_base_addr_h
     }
-    fn write_ss_mci_base_addr_h(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_ss_mci_base_addr_h(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write soc::ss_mci_base_addr_h = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.ss_mci_base_addr_h;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.ss_mci_base_addr_h = new_val;
     }
-    fn read_ss_recovery_ifc_base_addr_l(&mut self) -> caliptra_emu_types::RvData {
+    fn read_ss_recovery_ifc_base_addr_l(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read soc::ss_recovery_ifc_base_addr_l"
@@ -3581,18 +3966,23 @@ impl SocPeripheral for SocGenerated {
         }
         self.ss_recovery_ifc_base_addr_l
     }
-    fn write_ss_recovery_ifc_base_addr_l(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_ss_recovery_ifc_base_addr_l(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write soc::ss_recovery_ifc_base_addr_l = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.ss_recovery_ifc_base_addr_l;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.ss_recovery_ifc_base_addr_l = new_val;
     }
-    fn read_ss_recovery_ifc_base_addr_h(&mut self) -> caliptra_emu_types::RvData {
+    fn read_ss_recovery_ifc_base_addr_h(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read soc::ss_recovery_ifc_base_addr_h"
@@ -3600,52 +3990,61 @@ impl SocPeripheral for SocGenerated {
         }
         self.ss_recovery_ifc_base_addr_h
     }
-    fn write_ss_recovery_ifc_base_addr_h(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_ss_recovery_ifc_base_addr_h(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write soc::ss_recovery_ifc_base_addr_h = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.ss_recovery_ifc_base_addr_h;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.ss_recovery_ifc_base_addr_h = new_val;
     }
-    fn read_ss_otp_fc_base_addr_l(&mut self) -> caliptra_emu_types::RvData {
+    fn read_ss_otp_fc_base_addr_l(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read soc::ss_otp_fc_base_addr_l");
         }
         self.ss_otp_fc_base_addr_l
     }
-    fn write_ss_otp_fc_base_addr_l(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_ss_otp_fc_base_addr_l(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write soc::ss_otp_fc_base_addr_l = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.ss_otp_fc_base_addr_l;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.ss_otp_fc_base_addr_l = new_val;
     }
-    fn read_ss_otp_fc_base_addr_h(&mut self) -> caliptra_emu_types::RvData {
+    fn read_ss_otp_fc_base_addr_h(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read soc::ss_otp_fc_base_addr_h");
         }
         self.ss_otp_fc_base_addr_h
     }
-    fn write_ss_otp_fc_base_addr_h(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_ss_otp_fc_base_addr_h(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write soc::ss_otp_fc_base_addr_h = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.ss_otp_fc_base_addr_h;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.ss_otp_fc_base_addr_h = new_val;
     }
-    fn read_ss_uds_seed_base_addr_l(&mut self) -> caliptra_emu_types::RvData {
+    fn read_ss_uds_seed_base_addr_l(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read soc::ss_uds_seed_base_addr_l"
@@ -3653,18 +4052,21 @@ impl SocPeripheral for SocGenerated {
         }
         self.ss_uds_seed_base_addr_l
     }
-    fn write_ss_uds_seed_base_addr_l(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_ss_uds_seed_base_addr_l(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write soc::ss_uds_seed_base_addr_l = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.ss_uds_seed_base_addr_l;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.ss_uds_seed_base_addr_l = new_val;
     }
-    fn read_ss_uds_seed_base_addr_h(&mut self) -> caliptra_emu_types::RvData {
+    fn read_ss_uds_seed_base_addr_h(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read soc::ss_uds_seed_base_addr_h"
@@ -3672,20 +4074,23 @@ impl SocPeripheral for SocGenerated {
         }
         self.ss_uds_seed_base_addr_h
     }
-    fn write_ss_uds_seed_base_addr_h(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_ss_uds_seed_base_addr_h(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write soc::ss_uds_seed_base_addr_h = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.ss_uds_seed_base_addr_h;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.ss_uds_seed_base_addr_h = new_val;
     }
     fn read_ss_prod_debug_unlock_auth_pk_hash_reg_bank_offset(
         &mut self,
-    ) -> caliptra_emu_types::RvData {
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read soc::ss_prod_debug_unlock_auth_pk_hash_reg_bank_offset");
         }
@@ -3693,19 +4098,21 @@ impl SocPeripheral for SocGenerated {
     }
     fn write_ss_prod_debug_unlock_auth_pk_hash_reg_bank_offset(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write soc::ss_prod_debug_unlock_auth_pk_hash_reg_bank_offset = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.ss_prod_debug_unlock_auth_pk_hash_reg_bank_offset;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.ss_prod_debug_unlock_auth_pk_hash_reg_bank_offset = new_val;
     }
-    fn read_ss_num_of_prod_debug_unlock_auth_pk_hashes(&mut self) -> caliptra_emu_types::RvData {
+    fn read_ss_num_of_prod_debug_unlock_auth_pk_hashes(
+        &mut self,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: read soc::ss_num_of_prod_debug_unlock_auth_pk_hashes");
         }
@@ -3713,30 +4120,30 @@ impl SocPeripheral for SocGenerated {
     }
     fn write_ss_num_of_prod_debug_unlock_auth_pk_hashes(
         &mut self,
-        val: caliptra_emu_types::RvData,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
     ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write soc::ss_num_of_prod_debug_unlock_auth_pk_hashes = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.ss_num_of_prod_debug_unlock_auth_pk_hashes;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.ss_num_of_prod_debug_unlock_auth_pk_hashes = new_val;
     }
     fn read_ss_debug_intent(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::SsDebugIntent::Register,
     > {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!("[EMU] Generated default register handler: read soc::ss_debug_intent");
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.ss_debug_intent)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.ss_debug_intent)
     }
-    fn read_ss_caliptra_dma_axi_user(&mut self) -> caliptra_emu_types::RvData {
+    fn read_ss_caliptra_dma_axi_user(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read soc::ss_caliptra_dma_axi_user"
@@ -3744,18 +4151,24 @@ impl SocPeripheral for SocGenerated {
         }
         self.ss_caliptra_dma_axi_user
     }
-    fn write_ss_caliptra_dma_axi_user(&mut self, val: caliptra_emu_types::RvData) {
+    fn write_ss_caliptra_dma_axi_user(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write soc::ss_caliptra_dma_axi_user = 0x{:08x}" , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.ss_caliptra_dma_axi_user;
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.ss_caliptra_dma_axi_user = new_val;
     }
-    fn read_ss_strap_generic(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_ss_strap_generic(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read soc::ss_strap_generic[{}]",
@@ -3764,20 +4177,24 @@ impl SocPeripheral for SocGenerated {
         }
         self.ss_strap_generic[index]
     }
-    fn write_ss_strap_generic(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    fn write_ss_strap_generic(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+        index: usize,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write soc::ss_strap_generic[{}] = 0x{:08x}" , index , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.ss_strap_generic[index];
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.ss_strap_generic[index] = new_val;
     }
     fn read_ss_dbg_manuf_service_reg_req(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::SsDbgManufServiceRegReq::Register,
     > {
@@ -3786,11 +4203,13 @@ impl SocPeripheral for SocGenerated {
                 "[EMU] Generated default register handler: read soc::ss_dbg_manuf_service_reg_req"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.ss_dbg_manuf_service_reg_req)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.ss_dbg_manuf_service_reg_req,
+        )
     }
     fn write_ss_dbg_manuf_service_reg_req(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::SsDbgManufServiceRegReq::Register,
         >,
@@ -3798,20 +4217,20 @@ impl SocPeripheral for SocGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write soc::ss_dbg_manuf_service_reg_req = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.ss_dbg_manuf_service_reg_req;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(2 as caliptra_emu_types::RvData))
-            | (write_val & (2 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(4 as caliptra_emu_types::RvData))
-            | (write_val & (4 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(2 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(4 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (4 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.ss_dbg_manuf_service_reg_req = new_val;
     }
     fn read_ss_dbg_manuf_service_reg_rsp(
         &mut self,
-    ) -> caliptra_emu_bus::ReadWriteRegister<
+    ) -> caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
         u32,
         registers_generated::soc::bits::SsDbgManufServiceRegRsp::Register,
     > {
@@ -3820,11 +4239,13 @@ impl SocPeripheral for SocGenerated {
                 "[EMU] Generated default register handler: read soc::ss_dbg_manuf_service_reg_rsp"
             );
         }
-        caliptra_emu_bus::ReadWriteRegister::new(self.ss_dbg_manuf_service_reg_rsp)
+        caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(
+            self.ss_dbg_manuf_service_reg_rsp,
+        )
     }
     fn write_ss_dbg_manuf_service_reg_rsp(
         &mut self,
-        val: caliptra_emu_bus::ReadWriteRegister<
+        val: caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister<
             u32,
             registers_generated::soc::bits::SsDbgManufServiceRegRsp::Register,
         >,
@@ -3832,32 +4253,35 @@ impl SocPeripheral for SocGenerated {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write soc::ss_dbg_manuf_service_reg_rsp = 0x{:08x}" , val . reg . get ());
         }
-        let write_val = (val.reg.get()) as caliptra_emu_types::RvData;
+        let write_val = (val.reg.get()) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.ss_dbg_manuf_service_reg_rsp;
         let mut new_val = current_val;
-        new_val = (new_val & !(1 as caliptra_emu_types::RvData))
-            | (write_val & (1 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(2 as caliptra_emu_types::RvData))
-            | (write_val & (2 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(4 as caliptra_emu_types::RvData))
-            | (write_val & (4 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(8 as caliptra_emu_types::RvData))
-            | (write_val & (8 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x10 as caliptra_emu_types::RvData))
-            | (write_val & (0x10 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x20 as caliptra_emu_types::RvData))
-            | (write_val & (0x20 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x40 as caliptra_emu_types::RvData))
-            | (write_val & (0x40 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x80 as caliptra_emu_types::RvData))
-            | (write_val & (0x80 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x100 as caliptra_emu_types::RvData))
-            | (write_val & (0x100 as caliptra_emu_types::RvData));
-        new_val = (new_val & !(0x200 as caliptra_emu_types::RvData))
-            | (write_val & (0x200 as caliptra_emu_types::RvData));
+        new_val = (new_val & !(1 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (1 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(2 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (2 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(4 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (4 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(8 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (8 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x10 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x10 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x20 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x20 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x40 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x40 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x80 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x80 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x100 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x100 as caliptra_core_tools::caliptra_emu_types::RvData));
+        new_val = (new_val & !(0x200 as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0x200 as caliptra_core_tools::caliptra_emu_types::RvData));
         self.ss_dbg_manuf_service_reg_rsp = new_val;
     }
-    fn read_ss_soc_dbg_unlock_level(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_ss_soc_dbg_unlock_level(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read soc::ss_soc_dbg_unlock_level[{}]",
@@ -3866,18 +4290,25 @@ impl SocPeripheral for SocGenerated {
         }
         self.ss_soc_dbg_unlock_level[index]
     }
-    fn write_ss_soc_dbg_unlock_level(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    fn write_ss_soc_dbg_unlock_level(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+        index: usize,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write soc::ss_soc_dbg_unlock_level[{}] = 0x{:08x}" , index , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.ss_soc_dbg_unlock_level[index];
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.ss_soc_dbg_unlock_level[index] = new_val;
     }
-    fn read_ss_generic_fw_exec_ctrl(&mut self, index: usize) -> caliptra_emu_types::RvData {
+    fn read_ss_generic_fw_exec_ctrl(
+        &mut self,
+        index: usize,
+    ) -> caliptra_core_tools::caliptra_emu_types::RvData {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln!(
                 "[EMU] Generated default register handler: read soc::ss_generic_fw_exec_ctrl[{}]",
@@ -3886,35 +4317,42 @@ impl SocPeripheral for SocGenerated {
         }
         self.ss_generic_fw_exec_ctrl[index]
     }
-    fn write_ss_generic_fw_exec_ctrl(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+    fn write_ss_generic_fw_exec_ctrl(
+        &mut self,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+        index: usize,
+    ) {
         if crate::stub_warnings::stub_warnings_enabled() {
             eprintln ! ("[EMU] Generated default register handler: write soc::ss_generic_fw_exec_ctrl[{}] = 0x{:08x}" , index , val);
         }
-        let write_val = (val) as caliptra_emu_types::RvData;
+        let write_val = (val) as caliptra_core_tools::caliptra_emu_types::RvData;
         let current_val = self.ss_generic_fw_exec_ctrl[index];
         let mut new_val = current_val;
-        new_val = (new_val & !(0xffff_ffff as caliptra_emu_types::RvData))
-            | (write_val & (0xffff_ffff as caliptra_emu_types::RvData));
+        new_val = (new_val & !(0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData))
+            | (write_val & (0xffff_ffff as caliptra_core_tools::caliptra_emu_types::RvData));
         self.ss_generic_fw_exec_ctrl[index] = new_val;
     }
 }
 pub struct SocBus {
     pub periph: Box<dyn SocPeripheral>,
 }
-impl caliptra_emu_bus::Bus for SocBus {
+impl caliptra_core_tools::caliptra_emu_bus::Bus for SocBus {
     fn read(
         &mut self,
-        size: caliptra_emu_types::RvSize,
-        addr: caliptra_emu_types::RvAddr,
-    ) -> Result<caliptra_emu_types::RvData, caliptra_emu_bus::BusError> {
-        if addr & 0x3 != 0 || size != caliptra_emu_types::RvSize::Word {
-            return Err(caliptra_emu_bus::BusError::LoadAddrMisaligned);
+        size: caliptra_core_tools::caliptra_emu_types::RvSize,
+        addr: caliptra_core_tools::caliptra_emu_types::RvAddr,
+    ) -> Result<
+        caliptra_core_tools::caliptra_emu_types::RvData,
+        caliptra_core_tools::caliptra_emu_bus::BusError,
+    > {
+        if addr & 0x3 != 0 || size != caliptra_core_tools::caliptra_emu_types::RvSize::Word {
+            return Err(caliptra_core_tools::caliptra_emu_bus::BusError::LoadAddrMisaligned);
         }
         match addr {
-            0..4 => Ok(caliptra_emu_types::RvData::from(
+            0..4 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_cptra_hw_error_fatal().reg.get(),
             )),
-            4..8 => Ok(caliptra_emu_types::RvData::from(
+            4..8 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_cptra_hw_error_non_fatal().reg.get(),
             )),
             8..0xc => Ok(self.periph.read_cptra_fw_error_fatal()),
@@ -3925,44 +4363,44 @@ impl caliptra_emu_bus::Bus for SocBus {
                 .periph
                 .read_cptra_fw_extended_error_info((addr as usize - 0x18) / 4)),
             0x38..0x3c => Ok(self.periph.read_cptra_boot_status()),
-            0x3c..0x40 => Ok(caliptra_emu_types::RvData::from(
+            0x3c..0x40 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_cptra_flow_status().reg.get(),
             )),
-            0x40..0x44 => Ok(caliptra_emu_types::RvData::from(
+            0x40..0x44 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_cptra_reset_reason().reg.get(),
             )),
-            0x44..0x48 => Ok(caliptra_emu_types::RvData::from(
+            0x44..0x48 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_cptra_security_state().reg.get(),
             )),
             0x48..0x5c => Ok(self
                 .periph
                 .read_cptra_mbox_valid_axi_user((addr as usize - 0x48) / 4)),
-            0x5c..0x70 => Ok(caliptra_emu_types::RvData::from(
+            0x5c..0x70 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph
                     .read_cptra_mbox_axi_user_lock((addr as usize - 0x5c) / 4)
                     .reg
                     .get(),
             )),
             0x70..0x74 => Ok(self.periph.read_cptra_trng_valid_axi_user()),
-            0x74..0x78 => Ok(caliptra_emu_types::RvData::from(
+            0x74..0x78 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_cptra_trng_axi_user_lock().reg.get(),
             )),
             0x78..0xa8 => Ok(self.periph.read_cptra_trng_data((addr as usize - 0x78) / 4)),
-            0xa8..0xac => Ok(caliptra_emu_types::RvData::from(
+            0xa8..0xac => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_cptra_trng_ctrl().reg.get(),
             )),
-            0xac..0xb0 => Ok(caliptra_emu_types::RvData::from(
+            0xac..0xb0 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_cptra_trng_status().reg.get(),
             )),
-            0xb0..0xb4 => Ok(caliptra_emu_types::RvData::from(
+            0xb0..0xb4 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_cptra_fuse_wr_done().reg.get(),
             )),
             0xb4..0xb8 => Ok(self.periph.read_cptra_timer_config()),
-            0xb8..0xbc => Ok(caliptra_emu_types::RvData::from(
+            0xb8..0xbc => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_cptra_bootfsm_go().reg.get(),
             )),
             0xbc..0xc0 => Ok(self.periph.read_cptra_dbg_manuf_service_reg()),
-            0xc0..0xc4 => Ok(caliptra_emu_types::RvData::from(
+            0xc0..0xc4 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_cptra_clk_gating_en().reg.get(),
             )),
             0xc4..0xcc => Ok(self
@@ -3971,68 +4409,68 @@ impl caliptra_emu_bus::Bus for SocBus {
             0xcc..0xd4 => Ok(self
                 .periph
                 .read_cptra_generic_output_wires((addr as usize - 0xcc) / 4)),
-            0xd4..0xd8 => Ok(caliptra_emu_types::RvData::from(
+            0xd4..0xd8 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_cptra_hw_rev_id().reg.get(),
             )),
             0xd8..0xe0 => Ok(self.periph.read_cptra_fw_rev_id((addr as usize - 0xd8) / 4)),
-            0xe0..0xe4 => Ok(caliptra_emu_types::RvData::from(
+            0xe0..0xe4 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_cptra_hw_config().reg.get(),
             )),
-            0xe4..0xe8 => Ok(caliptra_emu_types::RvData::from(
+            0xe4..0xe8 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_cptra_wdt_timer1_en().reg.get(),
             )),
-            0xe8..0xec => Ok(caliptra_emu_types::RvData::from(
+            0xe8..0xec => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_cptra_wdt_timer1_ctrl().reg.get(),
             )),
             0xec..0xf4 => Ok(self
                 .periph
                 .read_cptra_wdt_timer1_timeout_period((addr as usize - 0xec) / 4)),
-            0xf4..0xf8 => Ok(caliptra_emu_types::RvData::from(
+            0xf4..0xf8 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_cptra_wdt_timer2_en().reg.get(),
             )),
-            0xf8..0xfc => Ok(caliptra_emu_types::RvData::from(
+            0xf8..0xfc => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_cptra_wdt_timer2_ctrl().reg.get(),
             )),
             0xfc..0x104 => Ok(self
                 .periph
                 .read_cptra_wdt_timer2_timeout_period((addr as usize - 0xfc) / 4)),
-            0x104..0x108 => Ok(caliptra_emu_types::RvData::from(
+            0x104..0x108 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_cptra_wdt_status().reg.get(),
             )),
             0x108..0x10c => Ok(self.periph.read_cptra_fuse_valid_axi_user()),
-            0x10c..0x110 => Ok(caliptra_emu_types::RvData::from(
+            0x10c..0x110 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_cptra_fuse_axi_user_lock().reg.get(),
             )),
             0x110..0x118 => Ok(self.periph.read_cptra_wdt_cfg((addr as usize - 0x110) / 4)),
-            0x118..0x11c => Ok(caliptra_emu_types::RvData::from(
+            0x118..0x11c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_cptra_i_trng_entropy_config_0().reg.get(),
             )),
-            0x11c..0x120 => Ok(caliptra_emu_types::RvData::from(
+            0x11c..0x120 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_cptra_i_trng_entropy_config_1().reg.get(),
             )),
             0x120..0x128 => Ok(self.periph.read_cptra_rsvd_reg((addr as usize - 0x120) / 4)),
             0x128..0x12c => Ok(self.periph.read_cptra_hw_capabilities()),
             0x12c..0x130 => Ok(self.periph.read_cptra_fw_capabilities()),
-            0x130..0x134 => Ok(caliptra_emu_types::RvData::from(
+            0x130..0x134 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_cptra_cap_lock().reg.get(),
             )),
             0x140..0x170 => Ok(self
                 .periph
                 .read_cptra_owner_pk_hash((addr as usize - 0x140) / 4)),
-            0x170..0x174 => Ok(caliptra_emu_types::RvData::from(
+            0x170..0x174 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_cptra_owner_pk_hash_lock().reg.get(),
             )),
             0x260..0x290 => Ok(self
                 .periph
                 .read_fuse_vendor_pk_hash((addr as usize - 0x260) / 4)),
-            0x290..0x294 => Ok(caliptra_emu_types::RvData::from(
+            0x290..0x294 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_fuse_ecc_revocation().reg.get(),
             )),
             0x2b4..0x2b8 => Ok(self.periph.read_fuse_fmc_key_manifest_svn()),
             0x2b8..0x2c8 => Ok(self
                 .periph
                 .read_fuse_runtime_svn((addr as usize - 0x2b8) / 4)),
-            0x2c8..0x2cc => Ok(caliptra_emu_types::RvData::from(
+            0x2c8..0x2cc => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_fuse_anti_rollback_disable().reg.get(),
             )),
             0x2cc..0x32c => Ok(self
@@ -4042,22 +4480,22 @@ impl caliptra_emu_bus::Bus for SocBus {
                 .periph
                 .read_fuse_idevid_manuf_hsm_id((addr as usize - 0x32c) / 4)),
             0x340..0x344 => Ok(self.periph.read_fuse_lms_revocation()),
-            0x344..0x348 => Ok(caliptra_emu_types::RvData::from(
+            0x344..0x348 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_fuse_mldsa_revocation().reg.get(),
             )),
-            0x348..0x34c => Ok(caliptra_emu_types::RvData::from(
+            0x348..0x34c => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_fuse_soc_stepping_id().reg.get(),
             )),
             0x34c..0x38c => Ok(self
                 .periph
                 .read_fuse_manuf_dbg_unlock_token((addr as usize - 0x34c) / 4)),
-            0x38c..0x390 => Ok(caliptra_emu_types::RvData::from(
+            0x38c..0x390 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_fuse_pqc_key_type().reg.get(),
             )),
             0x390..0x3a0 => Ok(self
                 .periph
                 .read_fuse_soc_manifest_svn((addr as usize - 0x390) / 4)),
-            0x3a0..0x3a4 => Ok(caliptra_emu_types::RvData::from(
+            0x3a0..0x3a4 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_fuse_soc_manifest_max_svn().reg.get(),
             )),
             0x500..0x504 => Ok(self.periph.read_ss_caliptra_base_addr_l()),
@@ -4076,17 +4514,17 @@ impl caliptra_emu_bus::Bus for SocBus {
             0x52c..0x530 => Ok(self
                 .periph
                 .read_ss_num_of_prod_debug_unlock_auth_pk_hashes()),
-            0x530..0x534 => Ok(caliptra_emu_types::RvData::from(
+            0x530..0x534 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_ss_debug_intent().reg.get(),
             )),
             0x534..0x538 => Ok(self.periph.read_ss_caliptra_dma_axi_user()),
             0x5a0..0x5b0 => Ok(self
                 .periph
                 .read_ss_strap_generic((addr as usize - 0x5a0) / 4)),
-            0x5c0..0x5c4 => Ok(caliptra_emu_types::RvData::from(
+            0x5c0..0x5c4 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_ss_dbg_manuf_service_reg_req().reg.get(),
             )),
-            0x5c4..0x5c8 => Ok(caliptra_emu_types::RvData::from(
+            0x5c4..0x5c8 => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(
                 self.periph.read_ss_dbg_manuf_service_reg_rsp().reg.get(),
             )),
             0x5c8..0x5d0 => Ok(self
@@ -4095,27 +4533,29 @@ impl caliptra_emu_bus::Bus for SocBus {
             0x5d0..0x5e0 => Ok(self
                 .periph
                 .read_ss_generic_fw_exec_ctrl((addr as usize - 0x5d0) / 4)),
-            _ => Err(caliptra_emu_bus::BusError::LoadAccessFault),
+            _ => Err(caliptra_core_tools::caliptra_emu_bus::BusError::LoadAccessFault),
         }
     }
     fn write(
         &mut self,
-        size: caliptra_emu_types::RvSize,
-        addr: caliptra_emu_types::RvAddr,
-        val: caliptra_emu_types::RvData,
-    ) -> Result<(), caliptra_emu_bus::BusError> {
-        if addr & 0x3 != 0 || size != caliptra_emu_types::RvSize::Word {
-            return Err(caliptra_emu_bus::BusError::StoreAddrMisaligned);
+        size: caliptra_core_tools::caliptra_emu_types::RvSize,
+        addr: caliptra_core_tools::caliptra_emu_types::RvAddr,
+        val: caliptra_core_tools::caliptra_emu_types::RvData,
+    ) -> Result<(), caliptra_core_tools::caliptra_emu_bus::BusError> {
+        if addr & 0x3 != 0 || size != caliptra_core_tools::caliptra_emu_types::RvSize::Word {
+            return Err(caliptra_core_tools::caliptra_emu_bus::BusError::StoreAddrMisaligned);
         }
         match addr {
             0..4 => {
-                self.periph
-                    .write_cptra_hw_error_fatal(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_cptra_hw_error_fatal(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             4..8 => {
-                self.periph
-                    .write_cptra_hw_error_non_fatal(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_cptra_hw_error_non_fatal(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             8..0xc => {
@@ -4144,8 +4584,9 @@ impl caliptra_emu_bus::Bus for SocBus {
                 Ok(())
             }
             0x3c..0x40 => {
-                self.periph
-                    .write_cptra_flow_status(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_cptra_flow_status(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0x40..0x44 => Ok(()),
@@ -4157,7 +4598,7 @@ impl caliptra_emu_bus::Bus for SocBus {
             }
             0x5c..0x70 => {
                 self.periph.write_cptra_mbox_axi_user_lock(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                     (addr as usize - 0x5c) / 4,
                 );
                 Ok(())
@@ -4167,8 +4608,9 @@ impl caliptra_emu_bus::Bus for SocBus {
                 Ok(())
             }
             0x74..0x78 => {
-                self.periph
-                    .write_cptra_trng_axi_user_lock(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_cptra_trng_axi_user_lock(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0x78..0xa8 => {
@@ -4177,18 +4619,21 @@ impl caliptra_emu_bus::Bus for SocBus {
                 Ok(())
             }
             0xa8..0xac => {
-                self.periph
-                    .write_cptra_trng_ctrl(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_cptra_trng_ctrl(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0xac..0xb0 => {
-                self.periph
-                    .write_cptra_trng_status(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_cptra_trng_status(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0xb0..0xb4 => {
-                self.periph
-                    .write_cptra_fuse_wr_done(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_cptra_fuse_wr_done(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0xb4..0xb8 => {
@@ -4196,8 +4641,9 @@ impl caliptra_emu_bus::Bus for SocBus {
                 Ok(())
             }
             0xb8..0xbc => {
-                self.periph
-                    .write_cptra_bootfsm_go(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_cptra_bootfsm_go(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0xbc..0xc0 => {
@@ -4205,8 +4651,9 @@ impl caliptra_emu_bus::Bus for SocBus {
                 Ok(())
             }
             0xc0..0xc4 => {
-                self.periph
-                    .write_cptra_clk_gating_en(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_cptra_clk_gating_en(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0xc4..0xcc => Ok(()),
@@ -4223,13 +4670,15 @@ impl caliptra_emu_bus::Bus for SocBus {
             }
             0xe0..0xe4 => Ok(()),
             0xe4..0xe8 => {
-                self.periph
-                    .write_cptra_wdt_timer1_en(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_cptra_wdt_timer1_en(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0xe8..0xec => {
-                self.periph
-                    .write_cptra_wdt_timer1_ctrl(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_cptra_wdt_timer1_ctrl(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0xec..0xf4 => {
@@ -4238,13 +4687,15 @@ impl caliptra_emu_bus::Bus for SocBus {
                 Ok(())
             }
             0xf4..0xf8 => {
-                self.periph
-                    .write_cptra_wdt_timer2_en(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_cptra_wdt_timer2_en(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0xf8..0xfc => {
-                self.periph
-                    .write_cptra_wdt_timer2_ctrl(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_cptra_wdt_timer2_ctrl(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0xfc..0x104 => {
@@ -4253,8 +4704,9 @@ impl caliptra_emu_bus::Bus for SocBus {
                 Ok(())
             }
             0x104..0x108 => {
-                self.periph
-                    .write_cptra_wdt_status(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_cptra_wdt_status(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0x108..0x10c => {
@@ -4262,8 +4714,9 @@ impl caliptra_emu_bus::Bus for SocBus {
                 Ok(())
             }
             0x10c..0x110 => {
-                self.periph
-                    .write_cptra_fuse_axi_user_lock(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_cptra_fuse_axi_user_lock(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0x110..0x118 => {
@@ -4273,13 +4726,13 @@ impl caliptra_emu_bus::Bus for SocBus {
             }
             0x118..0x11c => {
                 self.periph.write_cptra_i_trng_entropy_config_0(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x11c..0x120 => {
                 self.periph.write_cptra_i_trng_entropy_config_1(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
@@ -4297,8 +4750,9 @@ impl caliptra_emu_bus::Bus for SocBus {
                 Ok(())
             }
             0x130..0x134 => {
-                self.periph
-                    .write_cptra_cap_lock(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_cptra_cap_lock(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0x140..0x170 => {
@@ -4307,8 +4761,9 @@ impl caliptra_emu_bus::Bus for SocBus {
                 Ok(())
             }
             0x170..0x174 => {
-                self.periph
-                    .write_cptra_owner_pk_hash_lock(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_cptra_owner_pk_hash_lock(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0x200..0x240 => {
@@ -4327,8 +4782,9 @@ impl caliptra_emu_bus::Bus for SocBus {
                 Ok(())
             }
             0x290..0x294 => {
-                self.periph
-                    .write_fuse_ecc_revocation(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_fuse_ecc_revocation(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0x2b4..0x2b8 => {
@@ -4342,7 +4798,7 @@ impl caliptra_emu_bus::Bus for SocBus {
             }
             0x2c8..0x2cc => {
                 self.periph.write_fuse_anti_rollback_disable(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
@@ -4361,13 +4817,15 @@ impl caliptra_emu_bus::Bus for SocBus {
                 Ok(())
             }
             0x344..0x348 => {
-                self.periph
-                    .write_fuse_mldsa_revocation(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_fuse_mldsa_revocation(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0x348..0x34c => {
-                self.periph
-                    .write_fuse_soc_stepping_id(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_fuse_soc_stepping_id(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0x34c..0x38c => {
@@ -4376,8 +4834,9 @@ impl caliptra_emu_bus::Bus for SocBus {
                 Ok(())
             }
             0x38c..0x390 => {
-                self.periph
-                    .write_fuse_pqc_key_type(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_fuse_pqc_key_type(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0x390..0x3a0 => {
@@ -4386,8 +4845,9 @@ impl caliptra_emu_bus::Bus for SocBus {
                 Ok(())
             }
             0x3a0..0x3a4 => {
-                self.periph
-                    .write_fuse_soc_manifest_max_svn(caliptra_emu_bus::ReadWriteRegister::new(val));
+                self.periph.write_fuse_soc_manifest_max_svn(
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
+                );
                 Ok(())
             }
             0x500..0x504 => {
@@ -4452,13 +4912,13 @@ impl caliptra_emu_bus::Bus for SocBus {
             }
             0x5c0..0x5c4 => {
                 self.periph.write_ss_dbg_manuf_service_reg_req(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
             0x5c4..0x5c8 => {
                 self.periph.write_ss_dbg_manuf_service_reg_rsp(
-                    caliptra_emu_bus::ReadWriteRegister::new(val),
+                    caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val),
                 );
                 Ok(())
             }
@@ -4472,7 +4932,7 @@ impl caliptra_emu_bus::Bus for SocBus {
                     .write_ss_generic_fw_exec_ctrl(val, (addr as usize - 0x5d0) / 4);
                 Ok(())
             }
-            _ => Err(caliptra_emu_bus::BusError::StoreAccessFault),
+            _ => Err(caliptra_core_tools::caliptra_emu_bus::BusError::StoreAccessFault),
         }
     }
     fn poll(&mut self) {

--- a/rom/Cargo.toml
+++ b/rom/Cargo.toml
@@ -7,11 +7,9 @@ authors.workspace = true
 edition.workspace = true
 
 [dependencies]
+caliptra-core-firmware = { workspace = true, default-features = false, features = ["2_0"] }
 bitfield.workspace = true
 bitflags.workspace = true
-caliptra-api.workspace = true
-caliptra-api-types.workspace = true
-caliptra-drivers.workspace = true
 constant_time_eq.workspace = true
 flash-image.workspace = true
 mcu-config.workspace = true

--- a/rom/src/cold_boot.rs
+++ b/rom/src/cold_boot.rs
@@ -20,10 +20,12 @@ use crate::{
     verify_mcu_mbox_axi_users, verify_prod_debug_unlock_pk_hash, AxiUsers, BootFlow, DotBlob,
     McuBootMilestones, RomEnv, RomParameters, MCU_MEMORY_MAP,
 };
-use caliptra_api::mailbox::{CmStableKeyType, CommandId, FeProgReq, MailboxReqHeader};
-use caliptra_api::CaliptraApiError;
-use caliptra_api::SocManager;
-use caliptra_api_types::{DeviceLifecycle, SecurityState};
+use caliptra_core_firmware::caliptra_api::mailbox::{
+    CmStableKeyType, CommandId, FeProgReq, MailboxReqHeader,
+};
+use caliptra_core_firmware::caliptra_api::CaliptraApiError;
+use caliptra_core_firmware::caliptra_api::SocManager;
+use caliptra_core_firmware::caliptra_api_types::{DeviceLifecycle, SecurityState};
 use core::fmt::Write;
 use core::ops::Deref;
 use mcu_error::McuError;
@@ -55,7 +57,8 @@ impl ColdBoot {
                 ..Default::default()
             };
             let req = req.as_bytes();
-            let chksum = caliptra_api::calc_checksum(CommandId::FE_PROG.into(), req);
+            let chksum =
+                caliptra_core_firmware::caliptra_api::calc_checksum(CommandId::FE_PROG.into(), req);
             // set the checksum
             let req = FeProgReq {
                 hdr: MailboxReqHeader { chksum },

--- a/rom/src/device_ownership_transfer.rs
+++ b/rom/src/device_ownership_transfer.rs
@@ -16,7 +16,7 @@ use crate::fuses::OwnerPkHash;
 use crate::hil::FlashStorage;
 use crate::otp::Otp;
 use crate::{McuRomBootStatus, RomEnv};
-use caliptra_api::mailbox::{
+use caliptra_core_firmware::caliptra_api::mailbox::{
     CmDeriveStableKeyReq, CmDeriveStableKeyResp, CmHashAlgorithm, CmHmacResp, CmShaReqHdr,
     CmShaResp, CmStableKeyType, CommandId, EcdsaVerifyReq, MailboxReqHeader, MailboxRespHeader,
 };

--- a/rom/src/fw_hitless_update.rs
+++ b/rom/src/fw_hitless_update.rs
@@ -17,7 +17,7 @@ Abstract:
 #[cfg(target_arch = "riscv32")]
 use crate::MCU_MEMORY_MAP;
 use crate::{fatal_error, BootFlow, RomEnv, RomParameters};
-use caliptra_api::{mailbox::MailboxRespHeader, CaliptraApiError};
+use caliptra_core_firmware::caliptra_api::{mailbox::MailboxRespHeader, CaliptraApiError};
 use core::fmt::Write;
 use mcu_error::McuError;
 use romtime::HexWord;

--- a/rom/src/rom.rs
+++ b/rom/src/rom.rs
@@ -28,7 +28,7 @@ use crate::LifecycleToken;
 use crate::McuBootMilestones;
 use crate::RomEnv;
 use crate::WarmBoot;
-use caliptra_api::mailbox::CmStableKeyType;
+use caliptra_core_firmware::caliptra_api::mailbox::CmStableKeyType;
 use core::fmt::Write;
 use mcu_error::McuError;
 use registers_generated::fuses;

--- a/rom/src/warm_boot.rs
+++ b/rom/src/warm_boot.rs
@@ -18,7 +18,7 @@ use crate::{
     configure_mcu_mbox_axi_users, fatal_error, verify_mcu_mbox_axi_users, AxiUsers, BootFlow,
     McuBootMilestones, McuRomBootStatus, RomEnv, RomParameters, MCU_MEMORY_MAP,
 };
-use caliptra_api_types::{DeviceLifecycle, SecurityState};
+use caliptra_core_firmware::caliptra_api_types::{DeviceLifecycle, SecurityState};
 use core::{fmt::Write, ops::Deref};
 use mcu_error::McuError;
 

--- a/romtime/Cargo.toml
+++ b/romtime/Cargo.toml
@@ -7,11 +7,9 @@ authors.workspace = true
 edition.workspace = true
 
 [dependencies]
-caliptra-api.workspace = true
-caliptra-registers.workspace = true
+caliptra-core-firmware = { workspace = true, default-features = false, features = ["2_0"] }
 registers-generated.workspace = true
 tock-registers.workspace = true
-ureg.workspace = true
 zerocopy.workspace = true
 
 [target.'cfg(target_arch = "riscv32")'.dependencies]

--- a/romtime/src/soc_manager.rs
+++ b/romtime/src/soc_manager.rs
@@ -2,13 +2,13 @@
 
 use core::mem;
 
-use caliptra_api::{
+use caliptra_core_firmware::caliptra_api::{
     calc_checksum,
     mailbox::{MailboxReqHeader, MailboxRespHeader},
     CaliptraApiError, SocManager,
 };
+use caliptra_core_firmware::ureg::RealMmioMut;
 use registers_generated::{mbox, soc};
-use ureg::RealMmioMut;
 use zerocopy::{FromBytes, IntoBytes};
 
 const MAILBOX_SIZE: usize = 256 * 1024;
@@ -34,7 +34,7 @@ impl SocManager for CaliptraSoC {
 
     /// Returns a mutable reference to the memory-mapped I/O.
     fn mmio_mut(&mut self) -> Self::TMmio<'_> {
-        ureg::RealMmioMut::default()
+        caliptra_core_firmware::ureg::RealMmioMut::default()
     }
 
     /// Provides a delay function to be invoked when polling mailbox status.
@@ -44,9 +44,11 @@ impl SocManager for CaliptraSoC {
 
     /// A register block that can be used to manipulate the soc_ifc peripheral
     /// over the simulated SoC->Caliptra APB bus.
-    fn soc_ifc(&mut self) -> caliptra_registers::soc_ifc::RegisterBlock<Self::TMmio<'_>> {
+    fn soc_ifc(
+        &mut self,
+    ) -> caliptra_core_firmware::caliptra_registers::soc_ifc::RegisterBlock<Self::TMmio<'_>> {
         unsafe {
-            caliptra_registers::soc_ifc::RegisterBlock::new_with_mmio(
+            caliptra_core_firmware::caliptra_registers::soc_ifc::RegisterBlock::new_with_mmio(
                 self.soc_ifc_addr,
                 self.mmio_mut(),
             )
@@ -55,9 +57,12 @@ impl SocManager for CaliptraSoC {
 
     /// A register block that can be used to manipulate the soc_ifc peripheral TRNG registers
     /// over the simulated SoC->Caliptra APB bus.
-    fn soc_ifc_trng(&mut self) -> caliptra_registers::soc_ifc_trng::RegisterBlock<Self::TMmio<'_>> {
+    fn soc_ifc_trng(
+        &mut self,
+    ) -> caliptra_core_firmware::caliptra_registers::soc_ifc_trng::RegisterBlock<Self::TMmio<'_>>
+    {
         unsafe {
-            caliptra_registers::soc_ifc_trng::RegisterBlock::new_with_mmio(
+            caliptra_core_firmware::caliptra_registers::soc_ifc_trng::RegisterBlock::new_with_mmio(
                 self.soc_ifc_trng_addr,
                 self.mmio_mut(),
             )
@@ -66,9 +71,11 @@ impl SocManager for CaliptraSoC {
 
     /// A register block that can be used to manipulate the mbox peripheral
     /// over the simulated SoC->Caliptra APB bus.
-    fn soc_mbox(&mut self) -> caliptra_registers::mbox::RegisterBlock<Self::TMmio<'_>> {
+    fn soc_mbox(
+        &mut self,
+    ) -> caliptra_core_firmware::caliptra_registers::mbox::RegisterBlock<Self::TMmio<'_>> {
         unsafe {
-            caliptra_registers::mbox::RegisterBlock::new_with_mmio(
+            caliptra_core_firmware::caliptra_registers::mbox::RegisterBlock::new_with_mmio(
                 self.soc_mbox_addr,
                 self.mmio_mut(),
             )
@@ -356,7 +363,7 @@ impl CaliptraSoC {
 }
 
 pub struct CaliptraMailboxResponse<'a> {
-    soc_mbox: caliptra_registers::mbox::RegisterBlock<RealMmioMut<'a>>,
+    soc_mbox: caliptra_core_firmware::caliptra_registers::mbox::RegisterBlock<RealMmioMut<'a>>,
     idx: usize,
     dlen_bytes: usize,
     checksum: u32,

--- a/runtime/bare-metal/Cargo.toml
+++ b/runtime/bare-metal/Cargo.toml
@@ -7,7 +7,7 @@ authors.workspace = true
 edition.workspace = true
 
 [dependencies]
-caliptra-drivers.workspace = true
+caliptra-core-firmware = { workspace = true, default-features = false, features = ["2_0"] }
 romtime.workspace = true
 
 [target.'cfg(target_arch = "riscv32")'.dependencies]

--- a/runtime/kernel/capsules/Cargo.toml
+++ b/runtime/kernel/capsules/Cargo.toml
@@ -7,8 +7,8 @@ authors.workspace = true
 edition.workspace = true
 
 [dependencies]
+caliptra-core-firmware = { workspace = true, default-features = false, features = ["2_0"] }
 bitfield.workspace = true
-caliptra-api.workspace = true
 capsules-core.workspace = true
 capsules-extra.workspace = true
 doe-transport.workspace = true
@@ -19,5 +19,4 @@ kernel.workspace = true
 registers-generated.workspace = true
 romtime.workspace = true
 tock-registers.workspace = true
-ureg.workspace = true
 zerocopy.workspace = true

--- a/runtime/kernel/capsules/src/mailbox.rs
+++ b/runtime/kernel/capsules/src/mailbox.rs
@@ -3,7 +3,7 @@
 //! This provides the mailbox capsule that calls the underlying mailbox driver to
 //! communicate with Caliptra.
 
-use caliptra_api::CaliptraApiError;
+use caliptra_core_firmware::caliptra_api::CaliptraApiError;
 use core::cell::Cell;
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
 use kernel::hil::time::{Alarm, AlarmClient};

--- a/runtime/userspace/api/caliptra-api/Cargo.toml
+++ b/runtime/userspace/api/caliptra-api/Cargo.toml
@@ -7,10 +7,8 @@ authors.workspace = true
 edition.workspace = true
 
 [dependencies]
+caliptra-core-firmware = { workspace = true, default-features = false, features = ["2_0"] }
 async-trait.workspace = true
-caliptra-api.workspace = true
-caliptra-auth-man-types.workspace = true
-caliptra-error.workspace = true
 dpe.workspace = true
 embassy-executor.workspace = true
 embassy-sync.workspace = true
@@ -23,7 +21,6 @@ libtock_runtime.workspace = true
 pldm-common.workspace = true
 pldm-lib.workspace = true
 zerocopy.workspace = true
-ocp-eat.workspace = true
 
 
 [target.'cfg(not(target_arch = "riscv32"))'.dependencies]

--- a/runtime/userspace/api/caliptra-api/src/certificate.rs
+++ b/runtime/userspace/api/caliptra-api/src/certificate.rs
@@ -5,7 +5,7 @@ use crate::mailbox_api::{
     execute_mailbox_cmd, CertificateChainResp, CertifyEcKeyResp, DpeEcResp, DpeResponse,
     MAX_DPE_RESP_DATA_SIZE,
 };
-use caliptra_api::mailbox::{
+use caliptra_core_firmware::caliptra_api::mailbox::{
     CommandId, GetFmcAliasEcc384CertReq, GetIdevCsrReq, GetIdevCsrResp, GetLdevCertResp,
     GetLdevEcc384CertReq, GetRtAliasEcc384CertReq, InvokeDpeReq, MailboxRespHeader,
     PopulateIdevEcc384CertReq, Request,

--- a/runtime/userspace/api/caliptra-api/src/crypto/aes_gcm.rs
+++ b/runtime/userspace/api/caliptra-api/src/crypto/aes_gcm.rs
@@ -2,7 +2,7 @@
 
 use crate::error::{CaliptraApiError, CaliptraApiResult};
 use crate::mailbox_api::execute_mailbox_cmd;
-use caliptra_api::mailbox::{
+use caliptra_core_firmware::caliptra_api::mailbox::{
     CmAesGcmDecryptFinalReq, CmAesGcmDecryptFinalResp, CmAesGcmDecryptInitReq,
     CmAesGcmDecryptInitResp, CmAesGcmDecryptUpdateReq, CmAesGcmDecryptUpdateResp,
     CmAesGcmEncryptFinalReq, CmAesGcmEncryptFinalResp, CmAesGcmEncryptInitReq,

--- a/runtime/userspace/api/caliptra-api/src/crypto/asym/ecdh.rs
+++ b/runtime/userspace/api/caliptra-api/src/crypto/asym/ecdh.rs
@@ -2,7 +2,7 @@
 
 use crate::error::CaliptraApiResult;
 use crate::mailbox_api::execute_mailbox_cmd;
-use caliptra_api::mailbox::{
+use caliptra_core_firmware::caliptra_api::mailbox::{
     CmEcdhFinishReq, CmEcdhFinishResp, CmEcdhGenerateReq, CmEcdhGenerateResp, Cmk,
     MailboxReqHeader, Request,
 };
@@ -10,7 +10,9 @@ use libsyscall_caliptra::mailbox::Mailbox;
 use zerocopy::IntoBytes;
 
 // re-export
-pub use caliptra_api::mailbox::{CmKeyUsage, CMB_ECDH_EXCHANGE_DATA_MAX_SIZE};
+pub use caliptra_core_firmware::caliptra_api::mailbox::{
+    CmKeyUsage, CMB_ECDH_EXCHANGE_DATA_MAX_SIZE,
+};
 
 pub struct Ecdh;
 

--- a/runtime/userspace/api/caliptra-api/src/crypto/asym/ecdsa.rs
+++ b/runtime/userspace/api/caliptra-api/src/crypto/asym/ecdsa.rs
@@ -4,7 +4,9 @@ use crate::crypto::asym::{ECC_P384_PARAM_X_SIZE, ECC_P384_PARAM_Y_SIZE, ECC_P384
 use crate::crypto::hash::SHA384_HASH_SIZE;
 use crate::error::CaliptraApiResult;
 use crate::mailbox_api::execute_mailbox_cmd;
-use caliptra_api::mailbox::{EcdsaVerifyReq, MailboxReqHeader, MailboxRespHeader, Request};
+use caliptra_core_firmware::caliptra_api::mailbox::{
+    EcdsaVerifyReq, MailboxReqHeader, MailboxRespHeader, Request,
+};
 use libsyscall_caliptra::mailbox::Mailbox;
 use zerocopy::IntoBytes;
 

--- a/runtime/userspace/api/caliptra-api/src/crypto/hash.rs
+++ b/runtime/userspace/api/caliptra-api/src/crypto/hash.rs
@@ -4,7 +4,7 @@ use crate::error::{CaliptraApiError, CaliptraApiResult};
 use crate::mailbox_api::{
     execute_mailbox_cmd, ShaFinalReq, ShaInitReq, ShaUpdateReq, MAX_CRYPTO_MBOX_DATA_SIZE,
 };
-use caliptra_api::mailbox::{
+use caliptra_core_firmware::caliptra_api::mailbox::{
     CmHashAlgorithm, CmShaFinalReq, CmShaFinalResp, CmShaInitReq, CmShaInitResp, CmShaUpdateReq,
     MailboxReqHeader, Request, CMB_SHA_CONTEXT_SIZE,
 };

--- a/runtime/userspace/api/caliptra-api/src/crypto/hmac.rs
+++ b/runtime/userspace/api/caliptra-api/src/crypto/hmac.rs
@@ -3,7 +3,7 @@
 use crate::crypto::import::Import;
 use crate::error::{CaliptraApiError, CaliptraApiResult};
 use crate::mailbox_api::execute_mailbox_cmd;
-use caliptra_api::mailbox::{
+use caliptra_core_firmware::caliptra_api::mailbox::{
     CmHashAlgorithm, CmHkdfExpandReq, CmHkdfExpandResp, CmHkdfExtractReq, CmHkdfExtractResp,
     CmHmacReq, CmHmacResp, CmKeyUsage, Cmk, Request, MAX_CMB_DATA_SIZE,
 };

--- a/runtime/userspace/api/caliptra-api/src/crypto/import.rs
+++ b/runtime/userspace/api/caliptra-api/src/crypto/import.rs
@@ -2,12 +2,14 @@
 
 use crate::error::{CaliptraApiError, CaliptraApiResult};
 use crate::mailbox_api::execute_mailbox_cmd;
-use caliptra_api::mailbox::{CmImportReq, CmImportResp, Request};
+use caliptra_core_firmware::caliptra_api::mailbox::{CmImportReq, CmImportResp, Request};
 use libsyscall_caliptra::mailbox::Mailbox;
 use zerocopy::IntoBytes;
 
 // re-export
-pub use caliptra_api::mailbox::{CmKeyUsage, CMB_ECDH_EXCHANGE_DATA_MAX_SIZE};
+pub use caliptra_core_firmware::caliptra_api::mailbox::{
+    CmKeyUsage, CMB_ECDH_EXCHANGE_DATA_MAX_SIZE,
+};
 
 pub struct Import;
 

--- a/runtime/userspace/api/caliptra-api/src/crypto/rng.rs
+++ b/runtime/userspace/api/caliptra-api/src/crypto/rng.rs
@@ -5,7 +5,7 @@ use crate::mailbox_api::{
     execute_mailbox_cmd, RandomGenerateResp, RandomStirReq, MAX_RANDOM_NUM_SIZE,
     MAX_RANDOM_STIR_SIZE,
 };
-use caliptra_api::mailbox::{
+use caliptra_core_firmware::caliptra_api::mailbox::{
     CmRandomGenerateReq, CmRandomStirReq, MailboxReqHeader, MailboxRespHeader,
     MailboxRespHeaderVarSize, Request,
 };

--- a/runtime/userspace/api/caliptra-api/src/error.rs
+++ b/runtime/userspace/api/caliptra-api/src/error.rs
@@ -1,8 +1,8 @@
 // Licensed under the Apache-2.0 license
 
+use caliptra_core_firmware::ocp_eat::EatError;
 use libsyscall_caliptra::mailbox::MailboxError;
 use libtock_platform::ErrorCode;
-use ocp_eat::EatError;
 
 pub type CaliptraApiResult<T> = Result<T, CaliptraApiError>;
 

--- a/runtime/userspace/api/caliptra-api/src/evidence/device_state.rs
+++ b/runtime/userspace/api/caliptra-api/src/evidence/device_state.rs
@@ -2,7 +2,7 @@
 
 use crate::error::{CaliptraApiError, CaliptraApiResult};
 use crate::mailbox_api::execute_mailbox_cmd;
-use caliptra_api::mailbox::{
+use caliptra_core_firmware::caliptra_api::mailbox::{
     CommandId, FipsVersionResp, FwInfoResp, GetImageInfoReq, GetImageInfoResp, MailboxReqHeader,
 };
 use core::mem::size_of;

--- a/runtime/userspace/api/caliptra-api/src/evidence/ocp_eat_claims.rs
+++ b/runtime/userspace/api/caliptra-api/src/evidence/ocp_eat_claims.rs
@@ -2,8 +2,10 @@
 
 use crate::crypto::rng::Rng;
 use crate::error::{CaliptraApiError, CaliptraApiResult};
-use ocp_eat::ocp_profile::{ConciseEvidence, DebugStatus, MeasurementFormat, OcpEatClaims};
-use ocp_eat::CborEncoder;
+use caliptra_core_firmware::ocp_eat::ocp_profile::{
+    ConciseEvidence, DebugStatus, MeasurementFormat, OcpEatClaims,
+};
+use caliptra_core_firmware::ocp_eat::CborEncoder;
 
 /// Scratch buffer size for encoding Concise Evidence.
 /// This should be sized based on the expected number of target environments added to the evidence.

--- a/runtime/userspace/api/caliptra-api/src/evidence/pcr_quote.rs
+++ b/runtime/userspace/api/caliptra-api/src/evidence/pcr_quote.rs
@@ -4,7 +4,7 @@ use crate::crypto::hash::SHA384_HASH_SIZE;
 use crate::crypto::rng::Rng;
 use crate::error::{CaliptraApiError, CaliptraApiResult};
 use crate::mailbox_api::execute_mailbox_cmd;
-use caliptra_api::mailbox::{
+use caliptra_core_firmware::caliptra_api::mailbox::{
     MailboxReqHeader, MailboxRespHeader, QuotePcrsEcc384Req, QuotePcrsEcc384Resp,
     QuotePcrsMldsa87Req, QuotePcrsMldsa87Resp, Request,
 };

--- a/runtime/userspace/api/caliptra-api/src/firmware_update/mod.rs
+++ b/runtime/userspace/api/caliptra-api/src/firmware_update/mod.rs
@@ -10,11 +10,11 @@ use crate::firmware_update::pldm_context::State;
 use crate::mailbox_api::MAX_CRYPTO_MBOX_DATA_SIZE;
 use alloc::boxed::Box;
 use async_trait::async_trait;
-use caliptra_api::mailbox::{
+use caliptra_core_firmware::caliptra_api::mailbox::{
     ActivateFirmwareReq, ActivateFirmwareResp, CommandId, FirmwareVerifyResp, FirmwareVerifyResult,
     FwInfoResp, GetImageInfoReq, GetImageInfoResp, MailboxReqHeader, MailboxRespHeader, Request,
 };
-use caliptra_auth_man_types::{
+use caliptra_core_firmware::caliptra_auth_man_types::{
     AuthManifestImageMetadata, AuthManifestImageMetadataCollection, AuthorizationManifest,
 };
 use embassy_executor::Spawner;

--- a/runtime/userspace/api/caliptra-api/src/image_loading/mod.rs
+++ b/runtime/userspace/api/caliptra-api/src/image_loading/mod.rs
@@ -8,7 +8,7 @@ mod pldm_fdops;
 
 use alloc::boxed::Box;
 use async_trait::async_trait;
-use caliptra_api::mailbox::{
+use caliptra_core_firmware::caliptra_api::mailbox::{
     AuthorizeAndStashReq, AuthorizeAndStashResp, CommandId, GetImageInfoReq, GetImageInfoResp,
     ImageHashSource, MailboxReqHeader, MailboxRespHeader, Request,
 };

--- a/runtime/userspace/api/caliptra-api/src/mailbox_api.rs
+++ b/runtime/userspace/api/caliptra-api/src/mailbox_api.rs
@@ -36,8 +36,8 @@
 
 use crate::error::CaliptraApiError;
 use crate::error::CaliptraApiResult;
-use caliptra_api::mailbox::CmRandomGenerateResp;
-use caliptra_api::mailbox::{
+use caliptra_core_firmware::caliptra_api::mailbox::CmRandomGenerateResp;
+use caliptra_core_firmware::caliptra_api::mailbox::{
     CmRandomStirReq, InvokeDpeResp, MailboxReqHeader, MailboxRespHeader, MailboxRespHeaderVarSize,
     CMB_SHA_CONTEXT_SIZE, MAX_CMB_DATA_SIZE,
 };

--- a/runtime/userspace/api/caliptra-api/src/signed_eat.rs
+++ b/runtime/userspace/api/caliptra-api/src/signed_eat.rs
@@ -4,7 +4,9 @@ use crate::certificate::{CertContext, KEY_LABEL_SIZE, MAX_ECC_CERT_SIZE};
 use crate::crypto::asym::{AsymAlgo, ECC_P384_SIGNATURE_SIZE};
 use crate::crypto::hash::{HashAlgoType, HashContext, SHA384_HASH_SIZE};
 use crate::error::{CaliptraApiError, CaliptraApiResult};
-use ocp_eat::{cbor_tags, header_params, CoseHeaderPair, CoseSign1, ProtectedHeader};
+use caliptra_core_firmware::ocp_eat::{
+    cbor_tags, header_params, CoseHeaderPair, CoseSign1, ProtectedHeader,
+};
 
 const MAX_SIG_CONTEXT_SIZE: usize = 2048;
 

--- a/runtime/userspace/api/mcu-mbox-lib/Cargo.toml
+++ b/runtime/userspace/api/mcu-mbox-lib/Cargo.toml
@@ -7,10 +7,10 @@ edition.workspace = true
 authors.workspace = true
 
 [dependencies]
+caliptra-core-firmware = { workspace = true, default-features = false, features = ["2_0"] }
 embassy-executor.workspace = true
 embassy-sync.workspace = true
 external-cmds-common.workspace = true
-caliptra-api.workspace = true
 libapi-caliptra.workspace = true
 libsyscall-caliptra.workspace = true
 libtock_alarm.workspace = true

--- a/runtime/userspace/api/mcu-mbox-lib/src/cmd_interface.rs
+++ b/runtime/userspace/api/mcu-mbox-lib/src/cmd_interface.rs
@@ -1,7 +1,9 @@
 // Licensed under the Apache-2.0 license
 
 use crate::transport::McuMboxTransport;
-use caliptra_api::mailbox::{CommandId as CaliptraCommandId, MailboxReqHeader};
+use caliptra_core_firmware::caliptra_api::mailbox::{
+    CommandId as CaliptraCommandId, MailboxReqHeader,
+};
 use core::sync::atomic::{AtomicBool, Ordering};
 use external_cmds_common::{
     DeviceCapabilities, DeviceId, DeviceInfo, FirmwareVersion, UnifiedCommandHandler, MAX_UID_LEN,

--- a/runtime/userspace/api/mcu-mbox-lib/src/fips_periodic.rs
+++ b/runtime/userspace/api/mcu-mbox-lib/src/fips_periodic.rs
@@ -5,7 +5,7 @@
 //! This module provides functionality to run FIPS self-tests periodically
 //! in the background. It can be enabled/disabled via MCU mailbox commands.
 
-use caliptra_api::mailbox::CommandId as CaliptraCommandId;
+use caliptra_core_firmware::caliptra_api::mailbox::CommandId as CaliptraCommandId;
 use core::fmt::Write;
 use core::sync::atomic::{AtomicU32, Ordering};
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;

--- a/runtime/userspace/api/spdm-lib/Cargo.toml
+++ b/runtime/userspace/api/spdm-lib/Cargo.toml
@@ -7,10 +7,10 @@ authors.workspace = true
 edition.workspace = true
 
 [dependencies]
+caliptra-core-firmware = { workspace = true, default-features = false, features = ["2_0"] }
 arrayvec.workspace = true
 async-trait.workspace = true
 bitfield.workspace = true
-caliptra-api.workspace = true
 constant_time_eq.workspace = true
 libapi-caliptra.workspace = true
 libsyscall-caliptra.workspace = true

--- a/runtime/userspace/api/spdm-lib/src/session/key_schedule.rs
+++ b/runtime/userspace/api/spdm-lib/src/session/key_schedule.rs
@@ -6,7 +6,7 @@
 
 use crate::protocol::SpdmVersion;
 use arrayvec::ArrayVec;
-use caliptra_api::mailbox::Cmk;
+use caliptra_core_firmware::caliptra_api::mailbox::Cmk;
 use libapi_caliptra::crypto::aes_gcm::{Aes256GcmTag, AesGcm};
 use libapi_caliptra::crypto::asym::ecdh::{CmKeyUsage, Ecdh, CMB_ECDH_EXCHANGE_DATA_MAX_SIZE};
 use libapi_caliptra::crypto::hash::SHA384_HASH_SIZE;

--- a/runtime/userspace/syscall/Cargo.toml
+++ b/runtime/userspace/syscall/Cargo.toml
@@ -7,8 +7,8 @@ authors.workspace = true
 edition.workspace = true
 
 [dependencies]
+caliptra-core-firmware = { workspace = true, default-features = false, features = ["2_0"] }
 async-trait.workspace = true
-caliptra-api.workspace = true
 embassy-sync.workspace = true
 libtock_console.workspace = true
 libtock_platform.workspace = true

--- a/runtime/userspace/syscall/src/mailbox.rs
+++ b/runtime/userspace/syscall/src/mailbox.rs
@@ -5,7 +5,7 @@ extern crate alloc;
 use crate::DefaultSyscalls;
 use alloc::boxed::Box;
 use async_trait::async_trait;
-use caliptra_api::mailbox::MailboxReqHeader;
+use caliptra_core_firmware::caliptra_api::mailbox::MailboxReqHeader;
 use core::{hint::black_box, marker::PhantomData};
 use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, mutex::Mutex};
 use libtock_platform::{share, DefaultConfig, ErrorCode, Syscalls};
@@ -33,7 +33,7 @@ impl<S: Syscalls> Default for Mailbox<S> {
 // Populate the checksum for a mailbox request.
 pub fn populate_checksum(cmd: u32, data: &mut [u8]) -> Result<(), ErrorCode> {
     // Calc checksum, use the size override if provided
-    let checksum = caliptra_api::calc_checksum(cmd, data);
+    let checksum = caliptra_core_firmware::caliptra_api::calc_checksum(cmd, data);
 
     if data.len() < size_of::<MailboxReqHeader>() {
         Err(ErrorCode::Invalid)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,3 @@
+// Licensed under the Apache-2.0 license
+
+#![no_std]

--- a/tests/integration/Cargo.toml
+++ b/tests/integration/Cargo.toml
@@ -15,15 +15,7 @@ itrng = []
 [dependencies]
 aes-gcm.workspace = true
 anyhow.workspace = true
-caliptra-api.workspace = true
-caliptra-api-types.workspace = true
-caliptra-auth-man-types.workspace = true
-caliptra-builder.workspace = true
-caliptra-hw-model-types.workspace = true
-caliptra-hw-model.workspace = true
-caliptra-image-gen.workspace = true
-caliptra-image-types.workspace = true
-caliptra-image-fake-keys.workspace = true
+caliptra-core-tools.workspace = true
 chrono.workspace = true
 crc.workspace = true
 ecdsa.workspace = true

--- a/tests/integration/src/jtag/mod.rs
+++ b/tests/integration/src/jtag/mod.rs
@@ -8,9 +8,9 @@ mod test_uds;
 
 #[cfg(test)]
 mod test {
-    use caliptra_hw_model::jtag::{CsrReg, DmReg};
-    use caliptra_hw_model::openocd::openocd_jtag_tap::OpenOcdJtagTap;
-    use caliptra_hw_model::Fuses;
+    use caliptra_core_tools::caliptra_hw_model::jtag::{CsrReg, DmReg};
+    use caliptra_core_tools::caliptra_hw_model::openocd::openocd_jtag_tap::OpenOcdJtagTap;
+    use caliptra_core_tools::caliptra_hw_model::Fuses;
     use mcu_builder::FirmwareBinaries;
     use mcu_config_fpga::FPGA_MEMORY_MAP;
     use mcu_hw_model::{DefaultHwModel, InitParams, McuHwModel};

--- a/tests/integration/src/jtag/test_jtag_taps.rs
+++ b/tests/integration/src/jtag/test_jtag_taps.rs
@@ -4,8 +4,8 @@
 mod test {
     use std::path::PathBuf;
 
-    use caliptra_hw_model::lcc::{LcCtrlReg, LcCtrlStatus};
-    use caliptra_hw_model::openocd::openocd_jtag_tap::{JtagParams, JtagTap};
+    use caliptra_core_tools::caliptra_hw_model::lcc::{LcCtrlReg, LcCtrlStatus};
+    use caliptra_core_tools::caliptra_hw_model::openocd::openocd_jtag_tap::{JtagParams, JtagTap};
     use mcu_builder::FirmwareBinaries;
     use mcu_hw_model::{DefaultHwModel, InitParams, McuHwModel};
     use mcu_rom_common::LifecycleControllerState;

--- a/tests/integration/src/jtag/test_lc_transitions.rs
+++ b/tests/integration/src/jtag/test_lc_transitions.rs
@@ -6,9 +6,9 @@ mod test {
 
     use crate::jtag::test::ss_setup;
 
-    use caliptra_hw_model::openocd::openocd_jtag_tap::{JtagParams, JtagTap};
-    use caliptra_hw_model::HwModel;
-    use caliptra_hw_model::DEFAULT_LIFECYCLE_RAW_TOKEN;
+    use caliptra_core_tools::caliptra_hw_model::openocd::openocd_jtag_tap::{JtagParams, JtagTap};
+    use caliptra_core_tools::caliptra_hw_model::HwModel;
+    use caliptra_core_tools::caliptra_hw_model::DEFAULT_LIFECYCLE_RAW_TOKEN;
     use mcu_hw_model::lcc::{lc_token_to_words, lc_transition, read_lc_state};
     use mcu_rom_common::LifecycleControllerState;
 

--- a/tests/integration/src/jtag/test_manuf_debug_unlock.rs
+++ b/tests/integration/src/jtag/test_manuf_debug_unlock.rs
@@ -8,11 +8,11 @@ mod test {
 
     use crate::jtag::test::{debug_is_unlocked, ss_setup, verify_execute_from_sram};
 
-    use caliptra_api::mailbox::CommandId;
-    use caliptra_hw_model::jtag::CaliptraCoreReg;
-    use caliptra_hw_model::openocd::openocd_jtag_tap::{JtagParams, JtagTap};
-    use caliptra_hw_model::HwModel;
-    use caliptra_hw_model::DEFAULT_MANUF_DEBUG_UNLOCK_RAW_TOKEN;
+    use caliptra_core_tools::caliptra_api::mailbox::CommandId;
+    use caliptra_core_tools::caliptra_hw_model::jtag::CaliptraCoreReg;
+    use caliptra_core_tools::caliptra_hw_model::openocd::openocd_jtag_tap::{JtagParams, JtagTap};
+    use caliptra_core_tools::caliptra_hw_model::HwModel;
+    use caliptra_core_tools::caliptra_hw_model::DEFAULT_MANUF_DEBUG_UNLOCK_RAW_TOKEN;
     use mcu_hw_model::jtag::{jtag_get_caliptra_mailbox_resp, jtag_send_caliptra_mailbox_cmd};
     use mcu_rom_common::LifecycleControllerState;
 

--- a/tests/integration/src/jtag/test_prod_debug_unlock.rs
+++ b/tests/integration/src/jtag/test_prod_debug_unlock.rs
@@ -8,14 +8,14 @@ mod test {
 
     use crate::jtag::test::{debug_is_unlocked, ss_setup, verify_execute_from_sram};
 
-    use caliptra_hw_model::jtag::CaliptraCoreReg;
-    use caliptra_hw_model::openocd::openocd_jtag_tap::{JtagParams, JtagTap};
-    use caliptra_hw_model::HwModel;
-    use caliptra_image_fake_keys::{
+    use caliptra_core_tools::caliptra_hw_model::jtag::CaliptraCoreReg;
+    use caliptra_core_tools::caliptra_hw_model::openocd::openocd_jtag_tap::{JtagParams, JtagTap};
+    use caliptra_core_tools::caliptra_hw_model::HwModel;
+    use caliptra_core_tools::caliptra_image_fake_keys::{
         VENDOR_ECC_KEY_0_PRIVATE, VENDOR_ECC_KEY_0_PUBLIC, VENDOR_MLDSA_KEY_0_PRIVATE,
         VENDOR_MLDSA_KEY_0_PUBLIC,
     };
-    use caliptra_image_types::{
+    use caliptra_core_tools::caliptra_image_types::{
         ECC384_SCALAR_BYTE_SIZE, ECC384_SCALAR_WORD_SIZE, MLDSA87_PRIV_KEY_BYTE_SIZE,
     };
     use mcu_hw_model::debug_unlock::{

--- a/tests/integration/src/jtag/test_uds.rs
+++ b/tests/integration/src/jtag/test_uds.rs
@@ -8,9 +8,9 @@ mod test {
 
     use crate::jtag::test::ss_setup;
 
-    use caliptra_hw_model::jtag::CaliptraCoreReg;
-    use caliptra_hw_model::openocd::openocd_jtag_tap::{JtagParams, JtagTap};
-    use caliptra_hw_model::HwModel;
+    use caliptra_core_tools::caliptra_hw_model::jtag::CaliptraCoreReg;
+    use caliptra_core_tools::caliptra_hw_model::openocd::openocd_jtag_tap::{JtagParams, JtagTap};
+    use caliptra_core_tools::caliptra_hw_model::HwModel;
     use mcu_hw_model::McuHwModel;
     use mcu_rom_common::LifecycleControllerState;
     use registers_generated::fuses::{

--- a/tests/integration/src/lib.rs
+++ b/tests/integration/src/lib.rs
@@ -31,7 +31,7 @@ pub fn platform() -> &'static str {
 
 #[cfg(test)]
 mod test {
-    use caliptra_image_types::FwVerificationPqcKeyType;
+    use caliptra_core_tools::caliptra_image_types::FwVerificationPqcKeyType;
     use mcu_builder::flash_image::build_flash_image_bytes;
     use mcu_builder::{CaliptraBuilder, EmulatorBinaries, FirmwareBinaries, ImageCfg, TARGET};
     use mcu_hw_model::{DefaultHwModel, Fuses, InitParams, McuHwModel};

--- a/tests/integration/src/rom/test_ecc_errors.rs
+++ b/tests/integration/src/rom/test_ecc_errors.rs
@@ -5,8 +5,8 @@
 //! via the `cptra_hw_error_fatal` register.
 
 use anyhow::Result;
-use caliptra_api::SocManager;
-use caliptra_image_types::FwVerificationPqcKeyType;
+use caliptra_core_tools::caliptra_api::SocManager;
+use caliptra_core_tools::caliptra_image_types::FwVerificationPqcKeyType;
 use mcu_builder::flash_image::build_flash_image_bytes;
 use mcu_hw_model::McuHwModel;
 use mcu_hw_model::{new, Fuses, InitParams};

--- a/tests/integration/src/rom/test_hitless_update.rs
+++ b/tests/integration/src/rom/test_hitless_update.rs
@@ -10,7 +10,8 @@ use mcu_rom_common::McuBootMilestones;
 #[test]
 fn test_hitless_update_flow() -> Result<()> {
     let mcu_rom_id = &mcu_builder::firmware::hw_model_tests::HITLESS_UPDATE_FLOW;
-    let cptra_rom_id = &caliptra_builder::firmware::hw_model_tests::MCU_HITLESS_UPDATE_FLOW;
+    let cptra_rom_id =
+        &caliptra_core_tools::caliptra_builder::firmware::hw_model_tests::MCU_HITLESS_UPDATE_FLOW;
     let (caliptra_rom, mcu_rom) = if let Ok(binaries) = mcu_builder::FirmwareBinaries::from_env() {
         (
             binaries.caliptra_test_rom(cptra_rom_id)?,
@@ -19,7 +20,7 @@ fn test_hitless_update_flow() -> Result<()> {
     } else {
         let rom_file = mcu_builder::test_rom_build(Some(platform()), mcu_rom_id, None)?;
         (
-            caliptra_builder::build_firmware_rom(cptra_rom_id).unwrap(),
+            caliptra_core_tools::caliptra_builder::build_firmware_rom(cptra_rom_id).unwrap(),
             std::fs::read(&rom_file)?,
         )
     };

--- a/tests/integration/src/rom/test_sw_digest_lock.rs
+++ b/tests/integration/src/rom/test_sw_digest_lock.rs
@@ -9,7 +9,7 @@
 #[cfg(test)]
 mod test {
     use crate::platform;
-    use caliptra_hw_model::HwModel;
+    use caliptra_core_tools::caliptra_hw_model::HwModel;
     use mcu_builder::firmware;
     use mcu_hw_model::{InitParams, McuHwModel};
     use mcu_rom_common::LifecycleControllerState;

--- a/tests/integration/src/rom/test_warm_reset.rs
+++ b/tests/integration/src/rom/test_warm_reset.rs
@@ -1,7 +1,7 @@
 // Licensed under the Apache-2.0 license
 
 use anyhow::Result;
-use caliptra_image_types::FwVerificationPqcKeyType;
+use caliptra_core_tools::caliptra_image_types::FwVerificationPqcKeyType;
 use mcu_builder::flash_image::build_flash_image_bytes;
 use mcu_hw_model::McuHwModel;
 use mcu_hw_model::{new, Fuses, InitParams};

--- a/tests/integration/src/test_dot.rs
+++ b/tests/integration/src/test_dot.rs
@@ -10,16 +10,20 @@ mod test {
     };
 
     use crate::test::{start_runtime_hw_model, CustomCaliptraFw, TestParams, TEST_LOCK};
-    use caliptra_api::{
+    use caliptra_core_tools::caliptra_api::{
         calc_checksum,
         mailbox::{
             CmDeriveStableKeyReq, CmDeriveStableKeyResp, CmHashAlgorithm, CmHmacReq, CmHmacResp,
             CmStableKeyType, CommandId,
         },
     };
-    use caliptra_auth_man_types::{AuthManifestPrivKeysConfig, AuthManifestPubKeysConfig};
-    use caliptra_image_gen::ImageGeneratorOwnerConfig;
-    use caliptra_image_types::{ImageManifest, ImageOwnerPrivKeys, OwnerPubKeyConfig};
+    use caliptra_core_tools::caliptra_auth_man_types::{
+        AuthManifestPrivKeysConfig, AuthManifestPubKeysConfig,
+    };
+    use caliptra_core_tools::caliptra_image_gen::ImageGeneratorOwnerConfig;
+    use caliptra_core_tools::caliptra_image_types::{
+        ImageManifest, ImageOwnerPrivKeys, OwnerPubKeyConfig,
+    };
     use mcu_builder::{AuthManifestOwnerConfig, CaliptraBuilder, FirmwareBinaries};
     use mcu_error::McuError;
     use mcu_hw_model::McuHwModel;
@@ -337,7 +341,7 @@ mod test {
         let lock = TEST_LOCK.lock().unwrap();
         lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 
-        use caliptra_image_fake_keys::{
+        use caliptra_core_tools::caliptra_image_fake_keys::{
             VENDOR_ECC_KEY_1_PRIVATE, VENDOR_ECC_KEY_1_PUBLIC, VENDOR_LMS_KEY_1_PRIVATE,
             VENDOR_LMS_KEY_1_PUBLIC, VENDOR_MLDSA_KEY_0_PRIVATE, VENDOR_MLDSA_KEY_0_PUBLIC,
         };

--- a/tests/integration/src/test_firmware_update.rs
+++ b/tests/integration/src/test_firmware_update.rs
@@ -5,7 +5,7 @@ mod test {
     use crate::test::{
         compile_runtime, get_rom_with_feature, has_prebuilt_binaries, run_runtime, TEST_LOCK,
     };
-    use caliptra_image_types::ImageManifest;
+    use caliptra_core_tools::caliptra_image_types::ImageManifest;
     use chrono::{TimeZone, Utc};
     use flash_image::{MCU_RT_IDENTIFIER, SOC_IMAGES_BASE_IDENTIFIER};
     use hex::ToHex;

--- a/tests/integration/src/test_mcu_mbox.rs
+++ b/tests/integration/src/test_mcu_mbox.rs
@@ -5,7 +5,7 @@
 pub mod test {
     use crate::test::{finish_runtime_hw_model, start_runtime_hw_model, TestParams, TEST_LOCK};
     use aes_gcm::{aead::AeadMutInPlace, Aes256Gcm, Key, KeyInit};
-    use caliptra_api::mailbox::CmHashAlgorithm;
+    use caliptra_core_tools::caliptra_api::mailbox::CmHashAlgorithm;
     use hkdf::Hkdf;
     use hmac::{Hmac, Mac};
     use mcu_hw_model::mcu_mbox_transport::{

--- a/tests/integration/src/test_soc_boot.rs
+++ b/tests/integration/src/test_soc_boot.rs
@@ -5,7 +5,7 @@ mod test {
     use crate::test::{
         compile_runtime, get_rom_with_feature, has_prebuilt_binaries, run_runtime, TEST_LOCK,
     };
-    use caliptra_image_types::ImageManifest;
+    use caliptra_core_tools::caliptra_image_types::ImageManifest;
     use chrono::{TimeZone, Utc};
     use hex::ToHex;
     use mcu_builder::{CaliptraBuilder, FirmwareBinaries, ImageCfg};

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -9,22 +9,16 @@ edition = "2021"
 parallel-build = ["mcu-builder/parallel-build"]
 fpga_realtime = [
 	"mcu-hw-model/fpga_realtime",
-	"dep:caliptra-hw-model",
 	"dep:mcu-hw-model",
 	"dep:mcu-rom-common",
 ]
 
 [dependencies]
 base64.workspace = true
-caliptra-api-types.workspace = true
-caliptra-auth-man-types.workspace = true
-caliptra-builder.workspace = true
+caliptra-core-tools = { workspace = true, features = ["2_0"] }
 anyhow.workspace = true
 cargo_metadata.workspace = true
 cc.workspace = true
-caliptra-image-gen.workspace = true
-caliptra-image-types.workspace = true
-caliptra-hw-model = { workspace = true, optional = true }
 clap.workspace = true
 clap-num.workspace = true
 ecdsa.workspace = true

--- a/xtask/src/auth_manifest.rs
+++ b/xtask/src/auth_manifest.rs
@@ -1,7 +1,7 @@
 // Licensed under the Apache-2.0 license
 
 use anyhow::Result;
-use caliptra_auth_man_types::AuthorizationManifest;
+use caliptra_core_tools::caliptra_auth_man_types::AuthorizationManifest;
 use clap::Subcommand;
 use hex::ToHex;
 use mcu_builder::{CaliptraBuilder, ImageCfg};

--- a/xtask/src/corim.rs
+++ b/xtask/src/corim.rs
@@ -3,8 +3,8 @@
 use anyhow::{bail, Result};
 use base64::engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD};
 use base64::Engine;
-use caliptra_auth_man_types::AuthorizationManifest;
-use caliptra_image_types::{ImageManifest, IMAGE_MANIFEST_BYTE_SIZE};
+use caliptra_core_tools::caliptra_auth_man_types::AuthorizationManifest;
+use caliptra_core_tools::caliptra_image_types::{ImageManifest, IMAGE_MANIFEST_BYTE_SIZE};
 use p384::elliptic_curve::sec1::ToEncodedPoint;
 use p384::pkcs8::EncodePrivateKey;
 use serde::Deserialize;

--- a/xtask/src/deps.rs
+++ b/xtask/src/deps.rs
@@ -5,7 +5,7 @@ use mcu_builder::PROJECT_ROOT;
 use std::path::{Path, PathBuf};
 use toml::Table;
 
-const IGNORE_DIRS: [&str; 1] = ["libtock"];
+const IGNORE_DIRS: [&str; 2] = ["libtock", "caliptra-core"];
 
 pub(crate) fn check() -> Result<()> {
     let cargo_tomls = find_cargo_tomls(&PROJECT_ROOT)?;
@@ -60,7 +60,7 @@ pub(crate) fn find_cargo_tomls(dir: &Path) -> Result<Vec<PathBuf>> {
         {
             continue;
         }
-        if entry.file_name() == "Cargo.toml" {
+        if entry.file_name() == "Cargo.toml" && entry.path().parent() != Some(&PROJECT_ROOT) {
             result.push(entry.into_path());
         }
     }

--- a/xtask/src/fpga/mod.rs
+++ b/xtask/src/fpga/mod.rs
@@ -1,8 +1,8 @@
 // Licensed under the Apache-2.0 license
 
 use anyhow::{anyhow, bail, Result};
-use caliptra_image_gen::to_hw_format;
-use caliptra_image_types::FwVerificationPqcKeyType;
+use caliptra_core_tools::caliptra_image_gen::to_hw_format;
+use caliptra_core_tools::caliptra_image_types::FwVerificationPqcKeyType;
 use clap::Subcommand;
 use configurations::Configuration;
 use mcu_builder::flash_image::build_flash_image_bytes;
@@ -378,7 +378,7 @@ pub(crate) fn fpga_run(args: crate::Commands) -> Result<()> {
     );
 
     let mut model = ModelFpgaRealtime::new_unbooted(InitParams {
-        fuses: caliptra_api_types::Fuses {
+        fuses: caliptra_core_tools::caliptra_api_types::Fuses {
             vendor_pk_hash: binaries
                 .vendor_pk_hash()
                 .map(|h| to_hw_format(&h))

--- a/xtask/src/fpga/utils.rs
+++ b/xtask/src/fpga/utils.rs
@@ -446,16 +446,19 @@ pub fn build_caliptra_firmware(caliptra_workspace: &PathBuf, fw_id: Option<&str>
         "mkdir -p /tmp/caliptra-test-firmware/caliptra-test-firmware",
     )?;
     let binaries = match fw_id {
-        None => caliptra_builder::firmware::REGISTERED_FW.to_vec(),
-        Some(fw_id) => caliptra_builder::firmware::REGISTERED_FW
+        None => caliptra_core_tools::caliptra_builder::firmware::REGISTERED_FW.to_vec(),
+        Some(fw_id) => caliptra_core_tools::caliptra_builder::firmware::REGISTERED_FW
             .iter()
             .cloned()
             .filter(|&fw| fw.bin_name == fw_id)
             .collect(),
     };
 
-    for (fwid, elf_bytes) in
-        caliptra_builder::build_firmware_elfs_uncached(Some(caliptra_workspace), &binaries).unwrap()
+    for (fwid, elf_bytes) in caliptra_core_tools::caliptra_builder::build_firmware_elfs_uncached(
+        Some(caliptra_workspace),
+        &binaries,
+    )
+    .unwrap()
     {
         let elf_filename = fwid.elf_filename();
         std::fs::write(fw_dir.join(elf_filename), elf_bytes).unwrap();

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,6 +1,6 @@
 // Licensed under the Apache-2.0 license
 
-use caliptra_api_types::DeviceLifecycle;
+use caliptra_core_tools::caliptra_api_types::DeviceLifecycle;
 use clap::{Parser, Subcommand};
 use clap_num::maybe_hex;
 use mcu_builder::ImageCfg;

--- a/xtask/src/registers.rs
+++ b/xtask/src/registers.rs
@@ -417,17 +417,17 @@ fn emu_make_peripheral_trait(
                 let len = register.array_dimensions.iter().product::<u64>() as usize;
                 let len_literal = Literal::usize_unsuffixed(len);
                 struct_fields.extend(quote! {
-                    #state_ident: Vec<caliptra_emu_types::RvData>,
+                    #state_ident: Vec<caliptra_core_tools::caliptra_emu_types::RvData>,
                 });
                 struct_defaults.extend(quote! {
-                    #state_ident: vec![#default_literal as caliptra_emu_types::RvData; #len_literal],
+                    #state_ident: vec![#default_literal as caliptra_core_tools::caliptra_emu_types::RvData; #len_literal],
                 });
             } else {
                 struct_fields.extend(quote! {
-                    #state_ident: caliptra_emu_types::RvData,
+                    #state_ident: caliptra_core_tools::caliptra_emu_types::RvData,
                 });
                 struct_defaults.extend(quote! {
-                    #state_ident: #default_literal as caliptra_emu_types::RvData,
+                    #state_ident: #default_literal as caliptra_core_tools::caliptra_emu_types::RvData,
                 });
             }
         }
@@ -474,7 +474,7 @@ fn emu_make_peripheral_trait(
             if register.can_read() {
                 if register.is_array() {
                     fn_tokens.extend(quote! {
-                        fn #read_name(&mut self, index: usize) -> caliptra_emu_types::RvData {
+                        fn #read_name(&mut self, index: usize) -> caliptra_core_tools::caliptra_emu_types::RvData {
                             if crate::stub_warnings::stub_warnings_enabled() {
                                 eprintln!(#stub_read_arr, index);
                             }
@@ -485,7 +485,7 @@ fn emu_make_peripheral_trait(
                         }
                     });
                     impl_tokens.extend(quote! {
-                        fn #read_name(&mut self, index: usize) -> caliptra_emu_types::RvData {
+                        fn #read_name(&mut self, index: usize) -> caliptra_core_tools::caliptra_emu_types::RvData {
                             if crate::stub_warnings::stub_warnings_enabled() {
                                 eprintln!(#gen_read_arr, index);
                             }
@@ -494,7 +494,7 @@ fn emu_make_peripheral_trait(
                     });
                 } else {
                     fn_tokens.extend(quote! {
-                        fn #read_name(&mut self) -> caliptra_emu_types::RvData {
+                        fn #read_name(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
                             if crate::stub_warnings::stub_warnings_enabled() {
                                 eprintln!(#stub_read);
                             }
@@ -505,7 +505,7 @@ fn emu_make_peripheral_trait(
                         }
                     });
                     impl_tokens.extend(quote! {
-                        fn #read_name(&mut self) -> caliptra_emu_types::RvData {
+                        fn #read_name(&mut self) -> caliptra_core_tools::caliptra_emu_types::RvData {
                             if crate::stub_warnings::stub_warnings_enabled() {
                                 eprintln!(#gen_read);
                             }
@@ -517,7 +517,7 @@ fn emu_make_peripheral_trait(
             if register.can_write() {
                 if register.is_array() {
                     fn_tokens.extend(quote! {
-                        fn #write_name(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+                        fn #write_name(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData, index: usize) {
                             if crate::stub_warnings::stub_warnings_enabled() {
                                 eprintln!(#stub_write_arr, index, val);
                             }
@@ -530,7 +530,7 @@ fn emu_make_peripheral_trait(
                     let write_logic =
                         make_register_write_logic(register, target_expr.clone(), quote! { val });
                     impl_tokens.extend(quote! {
-                        fn #write_name(&mut self, val: caliptra_emu_types::RvData, index: usize) {
+                        fn #write_name(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData, index: usize) {
                             if crate::stub_warnings::stub_warnings_enabled() {
                                 eprintln!(#gen_write_arr, index, val);
                             }
@@ -539,7 +539,7 @@ fn emu_make_peripheral_trait(
                     });
                 } else {
                     fn_tokens.extend(quote! {
-                        fn #write_name(&mut self, val: caliptra_emu_types::RvData) {
+                        fn #write_name(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
                             if crate::stub_warnings::stub_warnings_enabled() {
                                 eprintln!(#stub_write, val);
                             }
@@ -552,7 +552,7 @@ fn emu_make_peripheral_trait(
                     let write_logic =
                         make_register_write_logic(register, target_expr.clone(), quote! { val });
                     impl_tokens.extend(quote! {
-                        fn #write_name(&mut self, val: caliptra_emu_types::RvData) {
+                        fn #write_name(&mut self, val: caliptra_core_tools::caliptra_emu_types::RvData) {
                             if crate::stub_warnings::stub_warnings_enabled() {
                                 eprintln!(#gen_write, val);
                             }
@@ -582,7 +582,7 @@ fn emu_make_peripheral_trait(
             let tyn = camel_ident(register.ty.name.as_ref().unwrap());
             let read_val = quote! { registers_generated :: #rcrate :: bits :: #tyn :: Register };
             let prim = format_ident!("{}", register.ty.width.rust_primitive_name());
-            let fulltyn = quote! { caliptra_emu_bus::ReadWriteRegister::<#prim, #read_val> };
+            let fulltyn = quote! { caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::<#prim, #read_val> };
             if register.can_read() {
                 if register.is_array() {
                     fn_tokens.extend(quote! {
@@ -593,7 +593,7 @@ fn emu_make_peripheral_trait(
                             if let Some(generated) = self.generated() {
                                 return generated.#read_name(index);
                             }
-                            caliptra_emu_bus::ReadWriteRegister :: new(0)
+                            caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister :: new(0)
                         }
                     });
                     impl_tokens.extend(quote! {
@@ -601,7 +601,7 @@ fn emu_make_peripheral_trait(
                             if crate::stub_warnings::stub_warnings_enabled() {
                                 eprintln!(#gen_read_arr, index);
                             }
-                            caliptra_emu_bus::ReadWriteRegister::new(self.#state_ident[index])
+                            caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.#state_ident[index])
                         }
                     });
                 } else {
@@ -613,7 +613,7 @@ fn emu_make_peripheral_trait(
                             if let Some(generated) = self.generated() {
                                 return generated.#read_name();
                             }
-                            caliptra_emu_bus::ReadWriteRegister :: new(0)
+                            caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister :: new(0)
                         }
                     });
                     impl_tokens.extend(quote! {
@@ -621,7 +621,7 @@ fn emu_make_peripheral_trait(
                             if crate::stub_warnings::stub_warnings_enabled() {
                                 eprintln!(#gen_read);
                             }
-                            caliptra_emu_bus::ReadWriteRegister::new(self.#state_ident)
+                            caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(self.#state_ident)
                         }
                     });
                 }
@@ -685,14 +685,14 @@ fn emu_make_peripheral_trait(
     let mut tokens = TokenStream::new();
     tokens.extend(quote! {
         pub trait #periph {
-            fn set_dma_ram(&mut self, _ram: std::rc::Rc<std::cell::RefCell<caliptra_emu_bus::Ram>>) {}
-            fn set_dma_rom_sram(&mut self, _ram: std::rc::Rc<std::cell::RefCell<caliptra_emu_bus::Ram>>) {}
+            fn set_dma_ram(&mut self, _ram: std::rc::Rc<std::cell::RefCell<caliptra_core_tools::caliptra_emu_bus::Ram>>) {}
+            fn set_dma_rom_sram(&mut self, _ram: std::rc::Rc<std::cell::RefCell<caliptra_core_tools::caliptra_emu_bus::Ram>>) {}
             fn register_event_channels(
                 &mut self,
-                _events_to_caliptra: std::sync::mpsc::Sender<caliptra_emu_bus::Event>,
-                _events_from_caliptra: std::sync::mpsc::Receiver<caliptra_emu_bus::Event>,
-                _events_to_mcu: std::sync::mpsc::Sender<caliptra_emu_bus::Event>,
-                _events_from_mcu: std::sync::mpsc::Receiver<caliptra_emu_bus::Event>,
+                _events_to_caliptra: std::sync::mpsc::Sender<caliptra_core_tools::caliptra_emu_bus::Event>,
+                _events_from_caliptra: std::sync::mpsc::Receiver<caliptra_core_tools::caliptra_emu_bus::Event>,
+                _events_to_mcu: std::sync::mpsc::Sender<caliptra_core_tools::caliptra_emu_bus::Event>,
+                _events_from_mcu: std::sync::mpsc::Receiver<caliptra_core_tools::caliptra_emu_bus::Event>,
             ) {
             }
             fn poll(&mut self) {}
@@ -763,7 +763,7 @@ fn make_register_write_logic(
 ) -> TokenStream {
     let mut tokens = TokenStream::new();
     tokens.extend(quote! {
-        let write_val = (#write_val_expr) as caliptra_emu_types::RvData;
+        let write_val = (#write_val_expr) as caliptra_core_tools::caliptra_emu_types::RvData;
     });
 
     if register.ty.fields.is_empty() {
@@ -782,7 +782,8 @@ fn make_register_write_logic(
 
     for (idx, field) in register.ty.fields.iter().enumerate() {
         let mask_literal = hex_literal(field.mask());
-        let mask_expr = quote! { (#mask_literal as caliptra_emu_types::RvData) };
+        let mask_expr =
+            quote! { (#mask_literal as caliptra_core_tools::caliptra_emu_types::RvData) };
         match field.ty {
             FieldType::RO => {}
             FieldType::RW | FieldType::WO | FieldType::WRC => {
@@ -928,16 +929,16 @@ fn emu_make_peripheral_bus_impl(block: RegisterBlock) -> Result<TokenStream> {
                 if r.is_array() {
                     if offset + r.offset == 0 {
                         read_tokens.extend(quote! {
-                            #a..#b => Ok(caliptra_emu_types::RvData::from(self.periph.#read_name(addr as usize / 4).reg.get())),
+                            #a..#b => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(self.periph.#read_name(addr as usize / 4).reg.get())),
                         });
                     } else {
                         read_tokens.extend(quote! {
-                            #a..#b => Ok(caliptra_emu_types::RvData::from(self.periph.#read_name((addr as usize - #a) / 4).reg.get())),
+                            #a..#b => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(self.periph.#read_name((addr as usize - #a) / 4).reg.get())),
                         });
                     }
                 } else {
                     read_tokens.extend(quote! {
-                        #a..#b => Ok(caliptra_emu_types::RvData::from(self.periph.#read_name().reg.get())),
+                        #a..#b => Ok(caliptra_core_tools::caliptra_emu_types::RvData::from(self.periph.#read_name().reg.get())),
                     });
                 }
             }
@@ -947,14 +948,14 @@ fn emu_make_peripheral_bus_impl(block: RegisterBlock) -> Result<TokenStream> {
                         if start == 0 {
                             write_tokens.extend(quote! {
                                 #a..#b => {
-                                    self.periph.#write_name(caliptra_emu_bus::ReadWriteRegister::new(val), addr as usize / 4);
+                                    self.periph.#write_name(caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val), addr as usize / 4);
                                     Ok(())
                                 }
                             });
                         } else {
                             write_tokens.extend(quote! {
                                 #a..#b => {
-                                    self.periph.#write_name(caliptra_emu_bus::ReadWriteRegister::new(val), (addr as usize - #a) / 4);
+                                    self.periph.#write_name(caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val), (addr as usize - #a) / 4);
                                     Ok(())
                                 }
                             });
@@ -962,7 +963,7 @@ fn emu_make_peripheral_bus_impl(block: RegisterBlock) -> Result<TokenStream> {
                     } else {
                         write_tokens.extend(quote! {
                             #a..#b => {
-                                self.periph.#write_name(caliptra_emu_bus::ReadWriteRegister::new(val));
+                                self.periph.#write_name(caliptra_core_tools::caliptra_emu_bus::ReadWriteRegister::new(val));
                                 Ok(())
                             }
                         });
@@ -981,23 +982,23 @@ fn emu_make_peripheral_bus_impl(block: RegisterBlock) -> Result<TokenStream> {
         pub struct #bus {
             pub periph: Box<dyn #periph>,
         }
-        impl caliptra_emu_bus::Bus for #bus {
-            fn read(&mut self, size: caliptra_emu_types::RvSize, addr: caliptra_emu_types::RvAddr) -> Result<caliptra_emu_types::RvData, caliptra_emu_bus::BusError> {
-                if addr & 0x3 != 0 || size != caliptra_emu_types::RvSize::Word {
-                    return Err(caliptra_emu_bus::BusError::LoadAddrMisaligned);
+        impl caliptra_core_tools::caliptra_emu_bus::Bus for #bus {
+            fn read(&mut self, size: caliptra_core_tools::caliptra_emu_types::RvSize, addr: caliptra_core_tools::caliptra_emu_types::RvAddr) -> Result<caliptra_core_tools::caliptra_emu_types::RvData, caliptra_core_tools::caliptra_emu_bus::BusError> {
+                if addr & 0x3 != 0 || size != caliptra_core_tools::caliptra_emu_types::RvSize::Word {
+                    return Err(caliptra_core_tools::caliptra_emu_bus::BusError::LoadAddrMisaligned);
                 }
                 match addr {
                     #read_tokens
-                    _ => Err(caliptra_emu_bus::BusError::LoadAccessFault),
+                    _ => Err(caliptra_core_tools::caliptra_emu_bus::BusError::LoadAccessFault),
                 }
             }
-            fn write(&mut self, size: caliptra_emu_types::RvSize, addr: caliptra_emu_types::RvAddr, val: caliptra_emu_types::RvData) -> Result<(), caliptra_emu_bus::BusError> {
-                if addr & 0x3 != 0 || size != caliptra_emu_types::RvSize::Word {
-                    return Err(caliptra_emu_bus::BusError::StoreAddrMisaligned);
+            fn write(&mut self, size: caliptra_core_tools::caliptra_emu_types::RvSize, addr: caliptra_core_tools::caliptra_emu_types::RvAddr, val: caliptra_core_tools::caliptra_emu_types::RvData) -> Result<(), caliptra_core_tools::caliptra_emu_bus::BusError> {
+                if addr & 0x3 != 0 || size != caliptra_core_tools::caliptra_emu_types::RvSize::Word {
+                    return Err(caliptra_core_tools::caliptra_emu_bus::BusError::StoreAddrMisaligned);
                 }
                 match addr {
                     #write_tokens
-                    _ => Err(caliptra_emu_bus::BusError::StoreAccessFault),
+                    _ => Err(caliptra_core_tools::caliptra_emu_bus::BusError::StoreAccessFault),
                 }
             }
             fn poll(&mut self) {
@@ -1147,14 +1148,14 @@ fn emu_make_root_bus<'a>(
         }
 
         pub struct AutoRootBus {
-            delegates: Vec<Box<dyn caliptra_emu_bus::Bus>>,
+            delegates: Vec<Box<dyn caliptra_core_tools::caliptra_emu_bus::Bus>>,
             offsets: AutoRootBusOffsets,
             #field_tokens
         }
         impl AutoRootBus {
             #[allow(clippy::too_many_arguments)]
             pub fn new(
-                delegates: Vec<Box<dyn caliptra_emu_bus::Bus>>,
+                delegates: Vec<Box<dyn caliptra_core_tools::caliptra_emu_bus::Bus>>,
                 offsets: Option<AutoRootBusOffsets>,
                 #constructor_params_tokens
             ) -> Self {
@@ -1165,26 +1166,26 @@ fn emu_make_root_bus<'a>(
                 }
             }
         }
-        impl caliptra_emu_bus::Bus for AutoRootBus {
-            fn read(&mut self, size: caliptra_emu_types::RvSize, addr: caliptra_emu_types::RvAddr) -> Result<caliptra_emu_types::RvData, caliptra_emu_bus::BusError> {
+        impl caliptra_core_tools::caliptra_emu_bus::Bus for AutoRootBus {
+            fn read(&mut self, size: caliptra_core_tools::caliptra_emu_types::RvSize, addr: caliptra_core_tools::caliptra_emu_types::RvAddr) -> Result<caliptra_core_tools::caliptra_emu_types::RvData, caliptra_core_tools::caliptra_emu_bus::BusError> {
                 #read_tokens
                 for delegate in self.delegates.iter_mut() {
                     let result = delegate.read(size, addr);
-                    if !matches!(result, Err(caliptra_emu_bus::BusError::LoadAccessFault)) {
+                    if !matches!(result, Err(caliptra_core_tools::caliptra_emu_bus::BusError::LoadAccessFault)) {
                         return result;
                     }
                 }
-                Err(caliptra_emu_bus::BusError::LoadAccessFault)
+                Err(caliptra_core_tools::caliptra_emu_bus::BusError::LoadAccessFault)
             }
-            fn write(&mut self, size: caliptra_emu_types::RvSize, addr: caliptra_emu_types::RvAddr, val: caliptra_emu_types::RvData) -> Result<(), caliptra_emu_bus::BusError> {
+            fn write(&mut self, size: caliptra_core_tools::caliptra_emu_types::RvSize, addr: caliptra_core_tools::caliptra_emu_types::RvAddr, val: caliptra_core_tools::caliptra_emu_types::RvData) -> Result<(), caliptra_core_tools::caliptra_emu_bus::BusError> {
                 #write_tokens
                 for delegate in self.delegates.iter_mut() {
                     let result = delegate.write(size, addr, val);
-                    if !matches!(result, Err(caliptra_emu_bus::BusError::StoreAccessFault)) {
+                    if !matches!(result, Err(caliptra_core_tools::caliptra_emu_bus::BusError::StoreAccessFault)) {
                         return result;
                     }
                 }
-                Err(caliptra_emu_bus::BusError::StoreAccessFault)
+                Err(caliptra_core_tools::caliptra_emu_bus::BusError::StoreAccessFault)
             }
             fn poll(&mut self) {
                 #poll_tokens
@@ -1204,13 +1205,13 @@ fn emu_make_root_bus<'a>(
                     delegate.update_reset();
                 }
             }
-            fn incoming_event(&mut self, event: std::rc::Rc<caliptra_emu_bus::Event>) {
+            fn incoming_event(&mut self, event: std::rc::Rc<caliptra_core_tools::caliptra_emu_bus::Event>) {
                 #incoming_event_tokens
                 for delegate in self.delegates.iter_mut() {
                     delegate.incoming_event(event.clone());
                 }
             }
-            fn register_outgoing_events(&mut self, sender: std::sync::mpsc::Sender<caliptra_emu_bus::Event>) {
+            fn register_outgoing_events(&mut self, sender: std::sync::mpsc::Sender<caliptra_core_tools::caliptra_emu_bus::Event>) {
                 #register_outgoing_events_tokens
                 for delegate in self.delegates.iter_mut() {
                     delegate.register_outgoing_events(sender.clone());

--- a/xtask/src/runtime.rs
+++ b/xtask/src/runtime.rs
@@ -2,7 +2,7 @@
 
 use crate::Commands;
 use anyhow::{anyhow, Result};
-use caliptra_api_types::DeviceLifecycle;
+use caliptra_core_tools::caliptra_api_types::DeviceLifecycle;
 use mcu_builder::{runtime_build_with_apps, CaliptraBuilder, PROJECT_ROOT};
 use std::process::Command;
 


### PR DESCRIPTION
This crate re-exports caliptra-sw types. This allows switching between different versions of caliptra-sw with feature flags.

This is a step towards supporting both 2.0 and 2.1 in the same source tree.