### PR TITLE
Set I3C CmdEmptyBufThld to 1 (spec minimum)

### DIFF
--- a/rom/src/i3c.rs
+++ b/rom/src/i3c.rs
@@ -60,7 +60,7 @@ impl I3c {
         // TODO: pass this timing information in
         let clocks = 0;
         regs.soc_mgmt_if_t_r_reg.set(clocks); // rise time of both SDA and SCL in clock units
-        regs.soc_mgmt_if_t_f_reg.set(clocks); // rise time of both SDA and SCL in clock units
+        regs.soc_mgmt_if_t_f_reg.set(clocks); // fall time of both SDA and SCL in clock units
 
         // if this is set to 6+ then ACKs start failing
         regs.soc_mgmt_if_t_hd_dat_reg.set(clocks); // data hold time in clock units


### PR DESCRIPTION
QUEUE_THLD_CTRL.CMD_EMPTY_BUF_THLD was set to 0, which is outside the valid range (1–255) per the I3C [HW spec](https://chipsalliance.github.io/caliptra-ss/main/regs/?p=soc.I3CCSR.PIOControl.QUEUE_THLD_CTRL). Changed to 1 to match the register reset default. 
Also fixed a copy-paste comment typo on t_f_reg ("rise time" → "fall time").

Fixes #946 