### PR TITLE
[ATTESTATION] Authenticate refval corims

### DIFF
--- a/.github/workflows/attestation.yml
+++ b/.github/workflows/attestation.yml
@@ -151,33 +151,26 @@ jobs:
         run: |
           cat $SPDM_VALIDATOR_DIR/spdm_requester_emu_output.txt
 
-      # ---- Verify COSE_Sign1 signature on EAT using ocptoken -------------------------------
-      - name: Verify EAT COSE_Sign1 signature
-        working-directory: ocp-eat-verifier
-        env:
-          SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-emu/build/bin
-        run: |
-          cargo build --release -p ocptoken
-          ./target/release/ocptoken verify \
-            -e $SPDM_VALIDATOR_DIR/measurement_block_fd.bin
-
       # ---- Authenticate evidence against Trust Anchor Store -------------------------------
       - name: Prepare Attestation Artifacts and Build Trust Anchor Store
         env:
           SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-emu/build/bin
-          CORIM_DIR: attestation-artifacts/refval-corim
+          CORIM_DIR: ${{ github.workspace }}/attestation-artifacts/refval-corim
+          SIGNED_CORIM_DIR: ${{ github.workspace }}/attestation-artifacts/signed-refval-corim
         run: |
           # Copy evidence artifacts
           EVIDENCE_DIR="attestation-artifacts/evidence"
           mkdir -p "$EVIDENCE_DIR"
           cp $SPDM_VALIDATOR_DIR/measurement_block_fd.bin "$EVIDENCE_DIR/"
           cp $SPDM_VALIDATOR_DIR/certificate_chain_slot_00.der "$EVIDENCE_DIR/"
-          echo "Evidence artifacts:"
+          echo "Copied evidence artifacts:"
           ls -la "$EVIDENCE_DIR"
 
-          #  Signed Reference CoRIMs
-          echo "Reference CoRIM artifacts:"
-          ls -la "$CORIM_DIR"/signed-*.cbor | sort
+          # Copy only the signed CoRIM files into a dedicated directory.
+          mkdir -p "$SIGNED_CORIM_DIR"
+          cp "$CORIM_DIR"/signed-*.cbor "$SIGNED_CORIM_DIR/"
+          echo "Copied signed Reference CoRIM artifacts:"
+          ls -la "$SIGNED_CORIM_DIR" | sort
 
           # Build Trust Anchor Store
           TA_STORE_DIR="attestation-artifacts/ta_store"
@@ -194,12 +187,13 @@ jobs:
           echo "Trust Anchor Store contents:"
           find "$TA_STORE_DIR" -type f | sort
 
-      # ---- Authenticate and verify EAT evidence -------------------------------
-      - name: Authenticate and verify EAT evidence
+      # ---- Authenticate and verify attestation inputs -------------------------------
+      - name: Authenticate and verify verifier inputs
         working-directory: ocp-eat-verifier
         env:
           EVIDENCE_DIR: ${{ github.workspace }}/attestation-artifacts/evidence
-          OCP_TA_STORE_PATH: ${{ github.workspace }}/attestation-artifacts/ta_store
+          TA_STORE_PATH: ${{ github.workspace }}/attestation-artifacts/ta_store
+          SIGNED_REFVAL_CORIM_PATH: ${{ github.workspace }}/attestation-artifacts/signed-refval-corim
         run: |
           ./target/release/ocptoken authenticate \
             -e $EVIDENCE_DIR/measurement_block_fd.bin \

--- a/ocp-eat-verifier/Cargo.toml
+++ b/ocp-eat-verifier/Cargo.toml
@@ -19,3 +19,5 @@ hex = "0.4"
 thiserror = "2.0"
 openssl = { version = "0.10", features = ["vendored"] }
 clap = { version = "4", features = ["derive"] }
+corim-rs = { git = "https://github.com/parvathib/corim-rs.git", branch = "pbhogaraju/add_coev" }
+chrono = { version = "0.4", default-features = false, features = ["clock"] }

--- a/ocp-eat-verifier/ocptoken-lib/Cargo.toml
+++ b/ocp-eat-verifier/ocptoken-lib/Cargo.toml
@@ -18,6 +18,7 @@ coset.workspace = true
 hex.workspace = true
 thiserror.workspace = true
 openssl = { workspace = true, optional = true }
+corim-rs.workspace = true
 
 [dev-dependencies]
 openssl.workspace = true

--- a/ocp-eat-verifier/ocptoken-lib/src/corim/mod.rs
+++ b/ocp-eat-verifier/ocptoken-lib/src/corim/mod.rs
@@ -1,0 +1,205 @@
+// Licensed under the Apache-2.0 license
+
+//! Signed CoRIM authentication and verification.
+//!
+//! Each signed CoRIM is a COSE_Sign1 envelope (CBOR tag 18) produced by
+//! `cocli corim sign`. The signing certificate is carried in the x5chain
+//! (label 33) of the **protected** header and authenticated against the
+//! Trust Anchor Store before the signature is verified.
+//!
+//! # Usage
+//!
+//! ```ignore
+//! let corims = SignedCorim::decode_files(&corims_dir, &ta_store)?;
+//! for corim in &corims {
+//!     corim.authenticate()?;
+//!     corim.verify(&verifier)?;
+//! }
+//! ```
+
+pub mod refval;
+pub use refval::RefValCorims;
+
+use std::fs;
+use std::path::Path;
+
+use crate::cose_verify::{authenticate_signer, CoseSign1Verifier, CryptoBackend, DecodedCoseSign1};
+use crate::ta_store::TrustAnchorStore;
+
+/// CBOR tag for COSE_Sign1.
+const CBOR_TAG_COSE_SIGN1: u64 = 18;
+
+/// A decoded signed CoRIM bound to a [`TrustAnchorStore`].
+///
+/// Mirrors the [`Evidence`](crate::token::evidence::Evidence) pattern:
+/// decode first, then authenticate and verify as separate steps.
+pub struct SignedCorim<'a> {
+    decoded: DecodedCoseSign1,
+    ta_store: &'a dyn TrustAnchorStore,
+    file_name: String,
+}
+
+impl<'a> SignedCorim<'a> {
+    /// Decode a single signed CoRIM from raw CBOR bytes.
+    pub fn decode(
+        data: &[u8],
+        file_name: String,
+        ta_store: &'a dyn TrustAnchorStore,
+    ) -> CorimResult<Self> {
+        let decoded = DecodedCoseSign1::decode(data, &[CBOR_TAG_COSE_SIGN1]).map_err(|e| {
+            CorimError::Decode {
+                file: file_name.clone(),
+                source: e,
+            }
+        })?;
+
+        Ok(SignedCorim {
+            decoded,
+            ta_store,
+            file_name,
+        })
+    }
+
+    /// Decode all `.cbor` files in a directory, returning a `SignedCorim`
+    /// for each one.
+    pub fn decode_files(dir: &Path, ta_store: &'a dyn TrustAnchorStore) -> CorimResult<Vec<Self>> {
+        let entries = collect_cbor_entries(dir)?;
+        let mut corims = Vec::with_capacity(entries.len());
+
+        for entry in &entries {
+            let path = entry.path();
+            let file_name = path
+                .file_name()
+                .unwrap_or_default()
+                .to_string_lossy()
+                .to_string();
+
+            let data = fs::read(&path).map_err(|e| CorimError::FileRead {
+                file: file_name.clone(),
+                source: e,
+            })?;
+
+            corims.push(Self::decode(&data, file_name, ta_store)?);
+        }
+
+        Ok(corims)
+    }
+
+    /// Authenticate the signing certificate against the Trust Anchor Store.
+    ///
+    /// Returns the DER-encoded authenticated leaf certificate on success.
+    pub fn authenticate(&self) -> CorimResult<Vec<u8>> {
+        authenticate_signer(&self.decoded, self.ta_store, &[], &Default::default()).map_err(|e| {
+            CorimError::Authentication {
+                file: self.file_name.clone(),
+                source: e,
+            }
+        })
+    }
+
+    /// Authenticate the signing certificate and verify the COSE_Sign1
+    /// signature.
+    pub fn verify(&self, verifier: &CoseSign1Verifier<impl CryptoBackend>) -> CorimResult<()> {
+        let signing_cert = self.authenticate()?;
+        verifier
+            .verify_ref(&self.decoded, &signing_cert)
+            .map_err(|e| CorimError::SignatureVerification {
+                file: self.file_name.clone(),
+                source: e,
+            })?;
+        Ok(())
+    }
+
+    /// Decode the COSE_Sign1 payload into a `corim_rs::CorimMap`.
+    ///
+    /// This should be called after [`verify()`](Self::verify) to access the
+    /// reference values, endorsed values, and other CoRIM content carried
+    /// inside the signed envelope.
+    pub fn payload(&self) -> CorimResult<corim_rs::CorimMap<'static>> {
+        let payload_bytes = self.decoded.payload().ok_or(CorimError::NoPayload {
+            file: self.file_name.clone(),
+        })?;
+        let corim: corim_rs::Corim<'static> =
+            corim_rs::Corim::from_cbor(payload_bytes).map_err(|e| CorimError::PayloadDecode {
+                file: self.file_name.clone(),
+                detail: e.to_string(),
+            })?;
+        Ok(corim.into_map())
+    }
+
+    /// The file name this CoRIM was loaded from.
+    pub fn file_name(&self) -> &str {
+        &self.file_name
+    }
+}
+
+/// Errors from signed CoRIM operations.
+#[derive(Debug, thiserror::Error)]
+pub enum CorimError {
+    #[error("directory does not exist: {0}")]
+    DirNotFound(String),
+
+    #[error("failed to read directory '{path}': {source}")]
+    ReadDir {
+        path: String,
+        source: std::io::Error,
+    },
+
+    #[error("no .cbor files found in directory: {0}")]
+    NoCborFiles(String),
+
+    #[error("{file}: read error: {source}")]
+    FileRead {
+        file: String,
+        source: std::io::Error,
+    },
+
+    #[error("{file}: COSE_Sign1 decode failed: {source}")]
+    Decode {
+        file: String,
+        source: crate::cose_verify::CoseSign1Error,
+    },
+
+    #[error("{file}: signer authentication failed: {source}")]
+    Authentication {
+        file: String,
+        source: crate::cose_verify::CoseSign1Error,
+    },
+
+    #[error("{file}: signature verification failed: {source}")]
+    SignatureVerification {
+        file: String,
+        source: crate::cose_verify::CoseSign1Error,
+    },
+
+    #[error("{file}: COSE_Sign1 payload is missing")]
+    NoPayload { file: String },
+
+    #[error("{file}: CoRIM payload decode failed: {detail}")]
+    PayloadDecode { file: String, detail: String },
+}
+
+pub type CorimResult<T> = std::result::Result<T, CorimError>;
+
+/// Collect sorted `.cbor` file entries from a directory.
+pub(crate) fn collect_cbor_entries(dir: &Path) -> CorimResult<Vec<fs::DirEntry>> {
+    if !dir.is_dir() {
+        return Err(CorimError::DirNotFound(dir.display().to_string()));
+    }
+
+    let mut entries: Vec<_> = fs::read_dir(dir)
+        .map_err(|e| CorimError::ReadDir {
+            path: dir.display().to_string(),
+            source: e,
+        })?
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().map_or(false, |ext| ext == "cbor"))
+        .collect();
+    entries.sort_by_key(|e| e.file_name());
+
+    if entries.is_empty() {
+        return Err(CorimError::NoCborFiles(dir.display().to_string()));
+    }
+
+    Ok(entries)
+}

--- a/ocp-eat-verifier/ocptoken-lib/src/corim/refval.rs
+++ b/ocp-eat-verifier/ocptoken-lib/src/corim/refval.rs
@@ -1,0 +1,48 @@
+// Licensed under the Apache-2.0 license
+
+//! Reference-value CoRIM collection.
+
+use std::path::Path;
+
+use crate::corim::{CorimResult, SignedCorim};
+use crate::cose_verify::{CoseSign1Verifier, CryptoBackend};
+use crate::ta_store::TrustAnchorStore;
+
+/// A collection of verified and decoded reference-value CoRIM payloads.
+///
+/// Each entry is the source file name paired with the decoded [`corim_rs::CorimMap`].
+/// This struct is produced by [`RefValCorims::decode_and_verify`] and can be
+/// passed to later stages (printing, appraisal) without re-decoding.
+pub struct RefValCorims {
+    pub entries: Vec<(String, corim_rs::CorimMap<'static>)>,
+}
+
+impl RefValCorims {
+    /// Decode, authenticate, verify, and extract payloads from all signed
+    /// CoRIM `.cbor` files in `dir`.
+    pub fn decode_and_verify(
+        dir: &Path,
+        ta_store: &dyn TrustAnchorStore,
+        verifier: &CoseSign1Verifier<impl CryptoBackend>,
+    ) -> CorimResult<Self> {
+        let entries = SignedCorim::decode_files(dir, ta_store)?
+            .iter()
+            .map(|c| {
+                c.verify(verifier)?;
+                Ok((c.file_name().to_string(), c.payload()?))
+            })
+            .collect::<CorimResult<Vec<_>>>()?;
+
+        Ok(Self { entries })
+    }
+
+    /// Returns `true` if there are no CoRIM entries.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Iterate over `(file_name, corim_map)` pairs.
+    pub fn iter(&self) -> impl Iterator<Item = &(String, corim_rs::CorimMap<'static>)> {
+        self.entries.iter()
+    }
+}

--- a/ocp-eat-verifier/ocptoken-lib/src/cose_verify/authenticate.rs
+++ b/ocp-eat-verifier/ocptoken-lib/src/cose_verify/authenticate.rs
@@ -1,0 +1,234 @@
+// Licensed under the Apache-2.0 license
+
+//! Signer identification and authentication for COSE_Sign1 messages.
+//!
+//! In COSE (RFC 9052 §4.2), COSE_Sign1 carries a single signer whose
+//! key is identified via header parameters — typically `x5chain`
+//! (RFC 9360, label 33) or `kid` (label 4).
+//!
+//! This module extracts the signer's certificate from the COSE headers
+//! and authenticates it against a [`TrustAnchorStore`].
+
+use coset::{cbor::value::Value, Header, Label};
+
+use crate::cose_verify::decode::DecodedCoseSign1;
+use crate::cose_verify::{CoseSign1Error, CoseSign1Result};
+use crate::ta_store::TrustAnchorStore;
+
+/// COSE header label for x5chain (RFC 9360).
+const COSE_HDR_PARAM_X5CHAIN: i64 = 33;
+
+/// Which COSE headers to search for signer identification.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HeaderSelection {
+    /// Search the protected header only.
+    Protected,
+    /// Search the unprotected header only.
+    Unprotected,
+    /// Search the protected header first, then the unprotected header (default).
+    Both,
+}
+
+/// Which identification method to use for locating the signer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SignerIdMethod {
+    /// Look for x5chain (label 33) only.
+    X5chain,
+    /// Look for kid (label 4) only.
+    Kid,
+    /// Try x5chain first, then fall back to kid (default).
+    Both,
+}
+
+/// Options controlling how the signer is identified and authenticated.
+///
+/// The default searches both protected and unprotected headers, trying
+/// x5chain first then kid — suitable when no profile constrains the
+/// header layout.
+#[derive(Debug, Clone)]
+pub struct AuthenticateOptions {
+    pub header: HeaderSelection,
+    pub method: SignerIdMethod,
+}
+
+impl Default for AuthenticateOptions {
+    fn default() -> Self {
+        Self {
+            header: HeaderSelection::Both,
+            method: SignerIdMethod::Both,
+        }
+    }
+}
+
+/// Identify and authenticate the signer of a COSE_Sign1 message.
+///
+/// The `options` parameter controls which headers and identification
+/// methods are tried.  With [`AuthenticateOptions::default()`] the
+/// search order is (first match wins):
+///
+/// 1. x5chain (label 33) in the **protected** header
+/// 2. x5chain (label 33) in the **unprotected** header
+/// 3. kid (label 4) in the **protected** header
+/// 4. kid (label 4) in the **unprotected** header
+///
+/// When `external_chain` is non-empty it is treated as a concatenated
+/// DER certificate blob from the device (root-first order, e.g. from
+/// SPDM GET_CERTIFICATE).  The device leaf (last cert in the blob) is
+/// dropped and the remaining certs are appended (leaf-first) after the
+/// x5chain certificates before authentication.
+///
+/// Pass an empty slice when no external chain is available.
+pub fn authenticate_signer(
+    decoded: &DecodedCoseSign1,
+    ta_store: &dyn TrustAnchorStore,
+    external_chain: &[u8],
+    options: &AuthenticateOptions,
+) -> CoseSign1Result<Vec<u8>> {
+    let headers = select_headers(decoded, options.header);
+
+    // Try x5chain
+    if matches!(
+        options.method,
+        SignerIdMethod::X5chain | SignerIdMethod::Both
+    ) {
+        for header in &headers {
+            if let Some(x5chain) = try_extract_x5chain(header) {
+                let full_chain = build_chain(x5chain, external_chain)?;
+                return Ok(ta_store.authenticate_chain(&full_chain)?);
+            }
+        }
+    }
+
+    // Try kid
+    if matches!(options.method, SignerIdMethod::Kid | SignerIdMethod::Both) {
+        for header in &headers {
+            if !header.key_id.is_empty() {
+                return Ok(ta_store.authenticate_by_kid(&header.key_id)?);
+            }
+        }
+    }
+
+    Err(CoseSign1Error::SignerNotFound)
+}
+
+/// Select headers to search based on [`HeaderSelection`].
+fn select_headers<'a>(
+    decoded: &'a DecodedCoseSign1,
+    selection: HeaderSelection,
+) -> Vec<&'a Header> {
+    match selection {
+        HeaderSelection::Protected => vec![decoded.protected_header()],
+        HeaderSelection::Unprotected => vec![decoded.unprotected_header()],
+        HeaderSelection::Both => {
+            vec![decoded.protected_header(), decoded.unprotected_header()]
+        }
+    }
+}
+
+/// Extract the signer's leaf certificate from x5chain without authentication.
+///
+/// Checks the protected header first, then the unprotected header.
+/// Returns `None` if x5chain is not present in either header.
+pub fn extract_signer_key_cert(decoded: &DecodedCoseSign1) -> Option<Vec<u8>> {
+    [decoded.protected_header(), decoded.unprotected_header()]
+        .iter()
+        .find_map(|h| try_extract_x5chain(h))
+        .and_then(|certs| certs.into_iter().next())
+}
+
+/// Build the full authentication chain from x5chain certs and an
+/// optional external DER blob.
+fn build_chain(x5chain: Vec<Vec<u8>>, external_chain: &[u8]) -> CoseSign1Result<Vec<Vec<u8>>> {
+    if external_chain.is_empty() {
+        return Ok(x5chain);
+    }
+
+    let mut chain_certs =
+        split_der_certs(external_chain).map_err(CoseSign1Error::CertificateError)?;
+    // Drop the device leaf (last cert in root-first blob)
+    if !chain_certs.is_empty() {
+        chain_certs.pop();
+    }
+    // Reverse to leaf-first order, then prepend x5chain
+    chain_certs.reverse();
+    let mut full = x5chain;
+    full.extend(chain_certs);
+    Ok(full)
+}
+
+/// Try to extract the full x5chain certificate list from a single header.
+/// Returns `None` if x5chain (label 33) is not present.
+fn try_extract_x5chain(header: &Header) -> Option<Vec<Vec<u8>>> {
+    let value = header.rest.iter().find_map(|(l, v)| {
+        if *l == Label::Int(COSE_HDR_PARAM_X5CHAIN) {
+            Some(v)
+        } else {
+            None
+        }
+    })?;
+
+    match value {
+        Value::Bytes(bytes) => Some(vec![bytes.clone()]),
+        Value::Array(arr) => {
+            let certs: Vec<Vec<u8>> = arr
+                .iter()
+                .filter_map(|v| match v {
+                    Value::Bytes(b) => Some(b.clone()),
+                    _ => None,
+                })
+                .collect();
+            if certs.is_empty() {
+                None
+            } else {
+                Some(certs)
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Split a concatenated DER blob into individual DER-encoded certificates.
+fn split_der_certs(blob: &[u8]) -> Result<Vec<Vec<u8>>, String> {
+    let mut certs = Vec::new();
+    let mut offset = 0;
+
+    while offset < blob.len() {
+        if blob[offset] != 0x30 {
+            return Err(format!(
+                "Expected SEQUENCE tag (0x30) at offset {}, found 0x{:02x}",
+                offset, blob[offset]
+            ));
+        }
+        let (content_len, header_len) = parse_der_length(&blob[offset + 1..])?;
+        let total_len = 1 + header_len + content_len;
+        if offset + total_len > blob.len() {
+            return Err(format!(
+                "DER certificate at offset {} extends beyond input",
+                offset
+            ));
+        }
+        certs.push(blob[offset..offset + total_len].to_vec());
+        offset += total_len;
+    }
+
+    Ok(certs)
+}
+
+/// Parse a DER length field. Returns (content_length, header_bytes_consumed).
+fn parse_der_length(data: &[u8]) -> Result<(usize, usize), String> {
+    if data.is_empty() {
+        return Err("Truncated DER length".into());
+    }
+    if data[0] < 0x80 {
+        return Ok((data[0] as usize, 1));
+    }
+    let num_bytes = (data[0] & 0x7f) as usize;
+    if num_bytes == 0 || num_bytes > 4 || data.len() < 1 + num_bytes {
+        return Err("Invalid DER length encoding".into());
+    }
+    let mut len = 0usize;
+    for i in 0..num_bytes {
+        len = (len << 8) | (data[1 + i] as usize);
+    }
+    Ok((len, 1 + num_bytes))
+}

--- a/ocp-eat-verifier/ocptoken-lib/src/cose_verify/mod.rs
+++ b/ocp-eat-verifier/ocptoken-lib/src/cose_verify/mod.rs
@@ -1,13 +1,16 @@
 // Licensed under the Apache-2.0 license
 
+use crate::ta_store::TrustAnchorError;
 use thiserror::Error;
 
+pub mod authenticate;
 #[cfg(feature = "openssl")]
 pub mod backends;
 pub mod decode;
 pub mod verifier;
 
 // Convenience re-exports
+pub use authenticate::{authenticate_signer, extract_signer_key_cert, AuthenticateOptions};
 #[cfg(feature = "openssl")]
 pub use backends::openssl::OpenSslBackend;
 pub use decode::{DecodedCoseSign1, VerifiedCoseSign1};
@@ -51,6 +54,14 @@ pub enum CoseSign1Error {
     /// An error from the underlying crypto backend.
     #[error("Crypto backend error: {0}")]
     CryptoError(String),
+
+    /// No signer key identification (x5chain or kid) found in COSE headers.
+    #[error("no x5chain or kid found in COSE headers")]
+    SignerNotFound,
+
+    /// Signer authentication against the trust anchor store failed.
+    #[error("signer authentication failed: {0}")]
+    Authentication(#[from] TrustAnchorError),
 }
 
 /// Result type alias for this module.

--- a/ocp-eat-verifier/ocptoken-lib/src/cose_verify/verifier.rs
+++ b/ocp-eat-verifier/ocptoken-lib/src/cose_verify/verifier.rs
@@ -1,7 +1,7 @@
 // Licensed under the Apache-2.0 license
 
-use super::decode::{DecodedCoseSign1, VerifiedCoseSign1};
-use super::{CoseSign1Error, CoseSign1Result, CryptoBackend, SigningAlgorithm};
+use crate::cose_verify::decode::{DecodedCoseSign1, VerifiedCoseSign1};
+use crate::cose_verify::{CoseSign1Error, CoseSign1Result, CryptoBackend, SigningAlgorithm};
 
 /// The main entry point for COSE_Sign1 signature verification.
 ///
@@ -43,19 +43,11 @@ impl<C: CryptoBackend> CoseSign1Verifier<C> {
 
     /// Verify the signature without consuming the decoded token.
     /// Returns `Ok(())` on success.
-    pub fn verify_ref(
-        &self,
-        decoded: &DecodedCoseSign1,
-        cert_der: &[u8],
-    ) -> CoseSign1Result<()> {
+    pub fn verify_ref(&self, decoded: &DecodedCoseSign1, cert_der: &[u8]) -> CoseSign1Result<()> {
         self.verify_inner(decoded, cert_der)
     }
 
-    fn verify_inner(
-        &self,
-        decoded: &DecodedCoseSign1,
-        cert_der: &[u8],
-    ) -> CoseSign1Result<()> {
+    fn verify_inner(&self, decoded: &DecodedCoseSign1, cert_der: &[u8]) -> CoseSign1Result<()> {
         // 1. Extract and validate algorithm
         let cose_alg = decoded
             .protected_header()

--- a/ocp-eat-verifier/ocptoken-lib/src/lib.rs
+++ b/ocp-eat-verifier/ocptoken-lib/src/lib.rs
@@ -1,5 +1,6 @@
 // Licensed under the Apache-2.0 license
 
+pub mod corim;
 pub mod cose_verify;
 pub mod error;
 pub mod ta_store;

--- a/ocp-eat-verifier/ocptoken/Cargo.toml
+++ b/ocp-eat-verifier/ocptoken/Cargo.toml
@@ -14,3 +14,6 @@ path = "src/main.rs"
 ocptoken.workspace = true
 clap.workspace = true
 coset.workspace = true
+corim-rs.workspace = true
+hex.workspace = true
+chrono.workspace = true

--- a/ocp-eat-verifier/ocptoken/src/authenticate.rs
+++ b/ocp-eat-verifier/ocptoken/src/authenticate.rs
@@ -1,20 +1,23 @@
 // Licensed under the Apache-2.0 license
 
 //! The `authenticate` subcommand: load the trust anchor store,
-//! authenticate the certificate chain, and verify the COSE_Sign1 signature.
+//! authenticate the certificate chain, verify the COSE_Sign1 signature,
+//! and optionally authenticate signed reference-value CoRIMs.
 
 use clap::Parser;
 use std::path::PathBuf;
 use std::{env, fs};
 
-use ocptoken::cose_verify::{CoseSign1Verifier, OpenSslBackend};
-use ocptoken::ta_store::FsTrustAnchorStore;
+use ocptoken::corim::RefValCorims;
+use ocptoken::cose_verify::{CoseSign1Verifier, CryptoBackend};
+use ocptoken::ta_store::TrustAnchorStore;
 use ocptoken::token::evidence::Evidence;
 
 use crate::common::load_evidence;
+use crate::display::print_corim_payload;
 
-/// Environment variable for the trust anchor store path.
-const TA_STORE_PATH_ENV: &str = "OCP_TA_STORE_PATH";
+/// Environment variable for the signed reference-value CoRIM directory path.
+const SIGNED_REFVAL_CORIM_PATH: &str = "SIGNED_REFVAL_CORIM_PATH";
 
 #[derive(Parser, Debug)]
 pub(crate) struct AuthenticateArgs {
@@ -43,42 +46,15 @@ Omit this option if the x5chain already contains the full chain."
     cert_chain: Option<PathBuf>,
 }
 
-/// Authenticate and verify: load the trust anchor store, authenticate
-/// the certificate chain, and verify the COSE_Sign1 signature.
-pub(crate) fn run(args: &AuthenticateArgs) {
-    // 1. Load the Trust Anchor Store from OCP_TA_STORE_PATH
-    let ta_store_path = match env::var(TA_STORE_PATH_ENV) {
-        Ok(p) => PathBuf::from(p),
-        Err(_) => {
-            eprintln!(
-                "Environment variable {} is not set. \
-                 Set it to the path of the trust anchor store directory \
-                 (containing roots/ and optionally endorsement-certs/).",
-                TA_STORE_PATH_ENV
-            );
-            std::process::exit(1);
-        }
-    };
-
-    let ta_store = match FsTrustAnchorStore::load(&ta_store_path) {
-        Ok(s) => {
-            println!(
-                "Loaded trust anchor store from '{}'",
-                ta_store_path.display()
-            );
-            s
-        }
-        Err(e) => {
-            eprintln!(
-                "Failed to load trust anchor store '{}': {}",
-                ta_store_path.display(),
-                e
-            );
-            std::process::exit(1);
-        }
-    };
-
-    // 2. Load the certificate chain blob (if provided)
+/// Load, decode, authenticate, and verify the evidence.
+/// Returns the verified `Evidence` and the certificate chain blob.
+/// Exits the process on failure.
+fn authenticate_evidence<'a>(
+    args: &AuthenticateArgs,
+    ta_store: &'a dyn TrustAnchorStore,
+    verifier: &CoseSign1Verifier<impl CryptoBackend>,
+) -> (Evidence<'a>, Vec<u8>) {
+    // Load the certificate chain blob (if provided)
     let cert_chain_blob = match &args.cert_chain {
         Some(path) => match fs::read(path) {
             Ok(b) => {
@@ -101,13 +77,13 @@ pub(crate) fn run(args: &AuthenticateArgs) {
         None => Vec::new(),
     };
 
-    // 3. Load the binary evidence file
+    // Load the binary evidence file
     let encoded = load_evidence(&args.evidence);
 
-    // 4. Decode the evidence
-    let ev = match Evidence::decode(&encoded, &ta_store) {
+    // Decode the evidence
+    let evidence = match Evidence::decode(&encoded, ta_store) {
         Ok(ev) => {
-            println!("Decode successful");
+            println!("Evidence decoded successfully.");
             ev
         }
         Err(e) => {
@@ -116,26 +92,107 @@ pub(crate) fn run(args: &AuthenticateArgs) {
         }
     };
 
-    // 5. Authenticate the signing key
-    match ev.authenticate(&cert_chain_blob) {
+    // Authenticate the signing key
+    println!("Authenticating the Evidence...");
+    match evidence.authenticate(&cert_chain_blob) {
         Ok(_) => {
-            println!("Certificate chain authentication successful");
+            println!("  Evidence signer certificate chain authentication successful");
         }
         Err(e) => {
-            eprintln!("Evidence::authenticate failed: {:?}", e);
+            eprintln!("  Evidence::authenticate failed: {:?}", e);
             std::process::exit(1);
         }
     }
 
-    // 6. Verify the COSE_Sign1 signature
-    let verifier = CoseSign1Verifier::new(OpenSslBackend);
-    match ev.verify(&cert_chain_blob, &verifier) {
+    // Verify the COSE_Sign1 signature
+    match evidence.verify(&cert_chain_blob, verifier) {
         Ok(()) => {
-            println!("Signature verification successful");
+            println!("  Evidence signature verification successful");
         }
         Err(e) => {
-            eprintln!("Evidence::verify failed: {:?}", e);
+            eprintln!("  Evidence::verify failed: {:?}", e);
             std::process::exit(1);
         }
     }
+
+    (evidence, cert_chain_blob)
+}
+
+/// Authenticate and verify signed reference-value CoRIM files from
+/// the SIGNED_REFVAL_CORIM_PATH environment variable directory.
+/// Returns `None` if the environment variable is not set.
+/// Exits the process on failure.
+fn authenticate_refval_corims(
+    ta_store: &dyn TrustAnchorStore,
+    verifier: &CoseSign1Verifier<impl CryptoBackend>,
+) -> Option<RefValCorims> {
+    let corims_path = match env::var(SIGNED_REFVAL_CORIM_PATH) {
+        Ok(p) => p,
+        Err(_) => return None,
+    };
+
+    let corims_dir = PathBuf::from(corims_path);
+    println!("\nAuthenticating Signed CoRIMs ...");
+    match RefValCorims::decode_and_verify(&corims_dir, ta_store, verifier) {
+        Ok(refval_corims) => {
+            for (name, _) in refval_corims.iter() {
+                println!("  {}: signer authenticated, signature verified", name);
+            }
+            println!("All signed CoRIM files verified successfully.");
+            Some(refval_corims)
+        }
+        Err(e) => {
+            eprintln!("Signed CoRIM processing failed: {}", e);
+            std::process::exit(1);
+        }
+    }
+}
+
+/// Result of a full authentication pipeline.
+pub(crate) struct AuthenticateResult<'a> {
+    pub evidence: Evidence<'a>,
+    pub cert_chain_blob: Vec<u8>,
+    pub refval_corims: Option<RefValCorims>,
+}
+
+/// Run the full authentication pipeline: authenticate evidence and
+/// optionally authenticate signed reference-value CoRIMs.
+///
+/// Returns the authenticated evidence and decoded CoRIM payloads for
+/// downstream use (e.g. appraisal).  Exits the process on failure.
+pub(crate) fn authenticate<'a>(
+    args: &AuthenticateArgs,
+    ta_store: &'a dyn TrustAnchorStore,
+    verifier: &CoseSign1Verifier<impl CryptoBackend>,
+) -> AuthenticateResult<'a> {
+    let (evidence, cert_chain_blob) = authenticate_evidence(args, ta_store, verifier);
+    let refval_corims = authenticate_refval_corims(ta_store, verifier);
+    AuthenticateResult {
+        evidence,
+        cert_chain_blob,
+        refval_corims,
+    }
+}
+
+/// Authenticate and verify all inputs: load the trust anchor store, authenticate
+/// the certificate chain, verify the COSE_Sign1 signature, and optionally
+/// authenticate signed reference-value CoRIMs.
+pub(crate) fn run(
+    args: &AuthenticateArgs,
+    ta_store: &dyn TrustAnchorStore,
+    verifier: &CoseSign1Verifier<impl CryptoBackend>,
+) {
+    let result = authenticate(args, ta_store, verifier);
+
+    if let Some(ref refval_corims) = result.refval_corims {
+        if !refval_corims.is_empty() {
+            println!("\n=== Decoded CoRIM Reference Values ===");
+            for (file_name, corim_map) in refval_corims.iter() {
+                print_corim_payload(file_name, corim_map);
+            }
+            println!("======================================\n");
+        }
+    }
+
+    println!("\nAll verifier inputs authenticated and verified successfully.");
 }

--- a/ocp-eat-verifier/ocptoken/src/common.rs
+++ b/ocp-eat-verifier/ocptoken/src/common.rs
@@ -1,9 +1,50 @@
 // Licensed under the Apache-2.0 license
 
-//! Shared display helpers and utility functions used across CLI subcommands.
+//! Shared utility functions used across CLI subcommands.
 
+use std::env;
 use std::fs;
 use std::path::PathBuf;
+
+use ocptoken::ta_store::{FsTrustAnchorStore, TrustAnchorStore};
+
+/// Environment variable for the trust anchor store path.
+const TA_STORE_PATH_ENV: &str = "TA_STORE_PATH";
+
+/// Load the Trust Anchor Store from a local directory specified by
+/// the TA_STORE_PATH environment variable.  Exits the process on failure.
+pub(crate) fn load_fs_ta_store() -> Box<dyn TrustAnchorStore> {
+    let ta_store_path = match env::var(TA_STORE_PATH_ENV) {
+        Ok(p) => PathBuf::from(p),
+        Err(_) => {
+            eprintln!(
+                "Environment variable {} is not set. \
+                 Set it to the path of the trust anchor store directory \
+                 (containing roots/ and optionally endorsement-certs/).",
+                TA_STORE_PATH_ENV
+            );
+            std::process::exit(1);
+        }
+    };
+
+    match FsTrustAnchorStore::load(&ta_store_path) {
+        Ok(s) => {
+            println!(
+                "Loaded trust anchor store from '{}'",
+                ta_store_path.display()
+            );
+            Box::new(s)
+        }
+        Err(e) => {
+            eprintln!(
+                "Failed to load trust anchor store '{}': {}",
+                ta_store_path.display(),
+                e
+            );
+            std::process::exit(1);
+        }
+    }
+}
 
 /// Load a binary evidence file from disk, printing its name and size.
 /// Exits the process on failure.

--- a/ocp-eat-verifier/ocptoken/src/display.rs
+++ b/ocp-eat-verifier/ocptoken/src/display.rs
@@ -1,0 +1,137 @@
+// Licensed under the Apache-2.0 license
+
+//! CoRIM display helpers for pretty-printing decoded CoRIM payloads.
+
+fn format_unix_timestamp(secs: i128) -> String {
+    use chrono::DateTime;
+    match DateTime::from_timestamp(secs as i64, 0) {
+        Some(dt) => dt.format("%Y-%m-%d %H:%M:%S UTC").to_string(),
+        None => format!("{}(unknown)", secs),
+    }
+}
+
+/// Print a decoded CoRIM payload (reference values, entities, tags).
+pub(crate) fn print_corim_payload(file_name: &str, corim_map: &corim_rs::CorimMap) {
+    println!("  File: {}", file_name);
+    println!("  CoRIM ID: {:?}", corim_map.id);
+    if let Some(ref profile) = corim_map.profile {
+        println!("  Profile:  {:?}", profile);
+    }
+    if let Some(ref validity) = corim_map.rim_validity {
+        let not_after_secs = validity.not_after.as_i128();
+        let not_after_str = format_unix_timestamp(not_after_secs);
+        if let Some(ref not_before) = validity.not_before {
+            let not_before_secs = not_before.as_i128();
+            let not_before_str = format_unix_timestamp(not_before_secs);
+            println!("  Validity: {} to {}", not_before_str, not_after_str);
+        } else {
+            println!("  Validity: until {}", not_after_str);
+        }
+    }
+    if let Some(ref entities) = corim_map.entities {
+        println!("  Entities ({}):", entities.len());
+        for (i, entity) in entities.iter().enumerate() {
+            println!("    [{}] {:?}", i, entity);
+        }
+    }
+    println!("  Tags ({}):", corim_map.tags.len());
+    for (i, tag) in corim_map.tags.iter().enumerate() {
+        match tag {
+            corim_rs::ConciseTagTypeChoice::Mid(tagged_comid) => {
+                let comid = &tagged_comid.0 .0;
+                println!("    [{}] CoMID: tag-id={:?}", i, comid.tag_identity.tag_id);
+                print_comid_triples(&comid.triples);
+            }
+            _ => {
+                println!("    [{}] {:?}", i, tag);
+            }
+        }
+    }
+}
+
+fn print_comid_triples(triples: &corim_rs::TriplesMap) {
+    if let Some(ref ref_triples) = triples.reference_triples {
+        println!("      Reference Triples ({}):", ref_triples.len());
+        for (i, triple) in ref_triples.iter().enumerate() {
+            println!("        [{}] Environment:", i);
+            print_environment(&triple.ref_env);
+            println!("            Measurements ({}):", triple.ref_claims.len());
+            for (j, meas) in triple.ref_claims.iter().enumerate() {
+                print_measurement(j, meas);
+            }
+        }
+    }
+    if let Some(ref end_triples) = triples.endorsed_triples {
+        println!("      Endorsed Triples ({}):", end_triples.len());
+        for (i, triple) in end_triples.iter().enumerate() {
+            println!("        [{}] {:?}", i, triple);
+        }
+    }
+    if let Some(ref id_triples) = triples.identity_triples {
+        println!("      Identity Triples ({}):", id_triples.len());
+        for (i, triple) in id_triples.iter().enumerate() {
+            println!("        [{}] {:?}", i, triple);
+        }
+    }
+    if let Some(ref ak_triples) = triples.attest_key_triples {
+        println!("      Attest Key Triples ({}):", ak_triples.len());
+        for (i, triple) in ak_triples.iter().enumerate() {
+            println!("        [{}] {:?}", i, triple);
+        }
+    }
+}
+
+fn print_environment(env: &corim_rs::EnvironmentMap) {
+    if let Some(ref class) = env.class {
+        if let Some(ref class_id) = class.class_id {
+            if let Some(bytes) = class_id.as_bytes() {
+                match std::str::from_utf8(bytes) {
+                    Ok(s) => println!("                Class ID:  \"{}\"", s),
+                    Err(_) => println!("                Class ID:  {:?}", class_id),
+                }
+            } else {
+                println!("                Class ID:  {:?}", class_id);
+            }
+        }
+        if let Some(ref vendor) = class.vendor {
+            println!("                Vendor:    {}", vendor);
+        }
+        if let Some(ref model) = class.model {
+            println!("                Model:     {}", model);
+        }
+        if let Some(ref layer) = class.layer {
+            println!("                Layer:     {}", layer);
+        }
+        if let Some(ref index) = class.index {
+            println!("                Index:     {}", index);
+        }
+    }
+    if let Some(ref instance) = env.instance {
+        println!("                Instance:  {:?}", instance);
+    }
+    if let Some(ref group) = env.group {
+        println!("                Group:     {:?}", group);
+    }
+}
+
+fn print_measurement(_idx: usize, meas: &corim_rs::MeasurementMap) {
+    let mval = &meas.mval;
+    if let Some(ref ver) = mval.version {
+        println!("                    Version:  {:?}", ver);
+    }
+    if let Some(ref svn) = mval.svn {
+        println!("                    SVN:      {:?}", svn);
+    }
+    if let Some(ref digests) = mval.digests {
+        println!("                    Digests:");
+        for d in digests.iter() {
+            println!("                      {:?}: {}", d.alg, hex::encode(&d.val));
+        }
+    }
+    if let Some(ref flags) = mval.flags {
+        println!("                    Flags:    {:?}", flags);
+    }
+    if let Some(ref raw) = mval.raw {
+        println!("                    Raw:      {:?}", raw);
+    }
+}

--- a/ocp-eat-verifier/ocptoken/src/main.rs
+++ b/ocp-eat-verifier/ocptoken/src/main.rs
@@ -2,9 +2,13 @@
 
 mod authenticate;
 mod common;
+mod display;
 mod verify;
 
 use clap::{Parser, Subcommand};
+use ocptoken::cose_verify::{CoseSign1Verifier, OpenSslBackend};
+
+use crate::common::load_fs_ta_store;
 
 #[derive(Parser, Debug)]
 #[command(
@@ -31,9 +35,13 @@ enum Commands {
 
 fn main() {
     let cli = Cli::parse();
+    let verifier = CoseSign1Verifier::new(OpenSslBackend);
 
     match cli.command {
-        Commands::Verify(args) => verify::run(&args),
-        Commands::Authenticate(args) => authenticate::run(&args),
+        Commands::Verify(args) => verify::run(&args, &verifier),
+        Commands::Authenticate(args) => {
+            let ta_store = load_fs_ta_store();
+            authenticate::run(&args, ta_store.as_ref(), &verifier);
+        }
     }
 }

--- a/ocp-eat-verifier/ocptoken/src/verify.rs
+++ b/ocp-eat-verifier/ocptoken/src/verify.rs
@@ -6,7 +6,7 @@
 use clap::Parser;
 use std::path::PathBuf;
 
-use ocptoken::cose_verify::{CoseSign1Verifier, DecodedCoseSign1, OpenSslBackend};
+use ocptoken::cose_verify::{CoseSign1Verifier, CryptoBackend, DecodedCoseSign1};
 use ocptoken::token::evidence::OCP_EAT_TAGS;
 
 use crate::common::{extract_x5chain_leaf, load_evidence};
@@ -24,7 +24,7 @@ pub(crate) struct VerifyArgs {
 
 /// Verify only: decode the EAT, extract the x5chain leaf, and
 /// cryptographically verify the COSE_Sign1 signature.
-pub(crate) fn run(args: &VerifyArgs) {
+pub(crate) fn run(args: &VerifyArgs, verifier: &CoseSign1Verifier<impl CryptoBackend>) {
     // 1. Load the binary evidence file
     let encoded = load_evidence(&args.evidence);
 
@@ -50,7 +50,6 @@ pub(crate) fn run(args: &VerifyArgs) {
     };
 
     // 4. Verify the COSE_Sign1 signature
-    let verifier = CoseSign1Verifier::new(OpenSslBackend);
     match verifier.verify_ref(&decoded, &leaf_cert) {
         Ok(()) => {
             println!("Signature verification successful");


### PR DESCRIPTION
fixes #1035

This PR adds support for decoding and authenticating CBOR‑encoded CoRIMs and printing CoMID triples, with reusable logic for endorsement CoRIMs and evidence triples.