### PR TITLE
rom: Set I3C BUS_ENABLE true (2.1)

### DIFF
--- a/rom/src/i3c.rs
+++ b/rom/src/i3c.rs
@@ -162,11 +162,8 @@ impl I3c {
 
         romtime::println!("[mcu-rom-i3c] Enable PHY to the bus");
         // enable the PHY connection to the bus
-        regs.i3c_base_hc_control.modify(
-            HcControl::ModeSelector::SET +
-                // clear is bus enabled, set is suspended
-                HcControl::BusEnable::CLEAR,
-        );
+        regs.i3c_base_hc_control
+            .modify(HcControl::ModeSelector::SET + HcControl::BusEnable::SET);
     }
 
     pub fn disable_recovery(&mut self) {


### PR DESCRIPTION
This logic is needed for the latest RTL release, where this bit is fixed. It has no effect on older RTL releases.

(cherry picked from commit 58ce4d21a4ae57e1b80b791015ddb9fcf5ba3bef)