### PR TITLE
ci: Create backport + AI workflow

### DIFF
--- a/.github/workflows/backport-ai.yml
+++ b/.github/workflows/backport-ai.yml
@@ -1,0 +1,221 @@
+# Licensed under the Apache-2.0 license
+
+name: Backport Cherry-Pick with AI Assist
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      commit_sha:
+        description: 'Commit SHA to cherry-pick'
+        required: true
+      target_branch:
+        description: 'Target branch for cherry-pick'
+        required: false
+        default: 'main-2.1'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  backport:
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.merged == true &&
+       !contains(github.event.pull_request.labels.*.name, 'no-backport'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Determine cherry-pick parameters
+        id: params
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "commit_sha=${{ github.event.inputs.commit_sha }}" >> "$GITHUB_OUTPUT"
+            echo "target_branch=${{ github.event.inputs.target_branch }}" >> "$GITHUB_OUTPUT"
+            # Look up the GitHub login of the commit author
+            AUTHOR=$(gh api "repos/${{ github.repository }}/commits/${{ github.event.inputs.commit_sha }}" \
+              --jq '.author.login // empty' 2>/dev/null || true)
+            echo "pr_author=${AUTHOR}" >> "$GITHUB_OUTPUT"
+          else
+            echo "commit_sha=${{ github.event.pull_request.merge_commit_sha }}" >> "$GITHUB_OUTPUT"
+            echo "target_branch=main-2.1" >> "$GITHUB_OUTPUT"
+            echo "pr_author=${{ github.event.pull_request.user.login }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Fetch all branches
+        run: git fetch origin '+refs/heads/*:refs/remotes/origin/*'
+
+      - name: Create backport branch and attempt cherry-pick
+        id: cherry_pick
+        run: |
+          COMMIT_SHA="${{ steps.params.outputs.commit_sha }}"
+          TARGET_BRANCH="${{ steps.params.outputs.target_branch }}"
+          SHORT_SHA="${COMMIT_SHA:0:8}"
+          BACKPORT_BRANCH="backport/${SHORT_SHA}-to-${TARGET_BRANCH}"
+
+          echo "backport_branch=${BACKPORT_BRANCH}" >> "$GITHUB_OUTPUT"
+          echo "short_sha=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git checkout -b "${BACKPORT_BRANCH}" "origin/${TARGET_BRANCH}"
+
+          # Detect merge commits (need -m 1 flag for cherry-pick)
+          PARENT_COUNT=$(git rev-list --parents -n1 "${COMMIT_SHA}" | wc -w)
+          PARENT_COUNT=$((PARENT_COUNT - 1))
+
+          if [ "$PARENT_COUNT" -gt 1 ]; then
+            CHERRY_PICK_CMD="git cherry-pick -x -m 1 ${COMMIT_SHA}"
+          else
+            CHERRY_PICK_CMD="git cherry-pick -x ${COMMIT_SHA}"
+          fi
+
+          echo "Running: ${CHERRY_PICK_CMD}"
+          if ${CHERRY_PICK_CMD}; then
+            echo "status=clean" >> "$GITHUB_OUTPUT"
+            echo "::notice::Cherry-pick applied cleanly"
+          else
+            echo "status=conflict" >> "$GITHUB_OUTPUT"
+            echo "::warning::Cherry-pick has conflicts — Copilot will attempt to resolve"
+          fi
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+
+      - name: Install Copilot CLI
+        run: npm install -g @github/copilot
+
+      - name: Copilot — Evaluate clean cherry-pick for adaptations
+        if: steps.cherry_pick.outputs.status == 'clean'
+        continue-on-error: true
+        env:
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_PAT }}
+          GIT_AUTHOR_NAME: "github-actions[bot]"
+          GIT_AUTHOR_EMAIL: "github-actions[bot]@users.noreply.github.com"
+          GIT_COMMITTER_NAME: "github-actions[bot]"
+          GIT_COMMITTER_EMAIL: "github-actions[bot]@users.noreply.github.com"
+        run: |
+          COMMIT_SHA="${{ steps.params.outputs.commit_sha }}"
+          TARGET_BRANCH="${{ steps.params.outputs.target_branch }}"
+
+          copilot -p "A commit (${COMMIT_SHA}) was just cherry-picked cleanly from 'main' \
+          onto the '${TARGET_BRANCH}' branch. \
+
+          Review the cherry-picked changes ('git diff HEAD~1') and the surrounding code \
+          on this branch to determine if any adaptations are needed for '${TARGET_BRANCH}'. \
+          Consider version references, feature flags, API differences, or dependencies \
+          that differ between branches. \
+
+          If changes are needed, make them and create a git commit explaining the \
+          adaptations. If no changes are needed, do nothing." \
+            --model claude-opus-4.6 \
+            --allow-tool='shell(git:*)' \
+            --allow-tool=read \
+            --allow-tool=edit \
+            --no-ask-user
+
+      - name: Copilot — Resolve cherry-pick conflicts
+        if: steps.cherry_pick.outputs.status == 'conflict'
+        env:
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_PAT }}
+          GIT_AUTHOR_NAME: "github-actions[bot]"
+          GIT_AUTHOR_EMAIL: "github-actions[bot]@users.noreply.github.com"
+          GIT_COMMITTER_NAME: "github-actions[bot]"
+          GIT_COMMITTER_EMAIL: "github-actions[bot]@users.noreply.github.com"
+          GIT_EDITOR: "true"
+        run: |
+          COMMIT_SHA="${{ steps.params.outputs.commit_sha }}"
+          TARGET_BRANCH="${{ steps.params.outputs.target_branch }}"
+
+          copilot -p "A cherry-pick of commit ${COMMIT_SHA} from 'main' onto \
+          '${TARGET_BRANCH}' has merge conflicts. \
+
+          Steps: \
+          1. Run 'git status' to identify conflicted files \
+          2. Run 'git diff' to see the conflict markers \
+          3. Examine the original commit with 'git show ${COMMIT_SHA}' to understand its intent \
+          4. Resolve all conflicts, preserving the original change's intent while adapting \
+             to the state of '${TARGET_BRANCH}' \
+          5. Stage resolved files with 'git add' \
+          6. Complete the cherry-pick with 'git cherry-pick --continue --no-edit' \
+          7. Review the result and make any further branch-specific adaptations in a \
+             separate commit" \
+            --model claude-opus-4.6 \
+            --allow-tool='shell(git:*)' \
+            --allow-tool=read \
+            --allow-tool=edit \
+            --allow-tool=write \
+            --no-ask-user
+
+      - name: Push backport branch and create PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BACKPORT_BRANCH="${{ steps.cherry_pick.outputs.backport_branch }}"
+          TARGET_BRANCH="${{ steps.params.outputs.target_branch }}"
+          COMMIT_SHA="${{ steps.params.outputs.commit_sha }}"
+          STATUS="${{ steps.cherry_pick.outputs.status }}"
+          PR_AUTHOR="${{ steps.params.outputs.pr_author }}"
+
+          ORIGINAL_MSG=$(git log -1 --format="%s" "${COMMIT_SHA}")
+
+          git push origin "${BACKPORT_BRANCH}"
+
+          # Ensure the 'backport' label exists
+          gh label create backport --description "Automated backport cherry-pick" \
+            --color "0E8A16" 2>/dev/null || true
+
+          PR_BODY="Backport of ${COMMIT_SHA} to \`${TARGET_BRANCH}\`."
+
+          if [ "$STATUS" = "conflict" ]; then
+            PR_BODY="${PR_BODY}
+
+          > [!WARNING]
+          > The original cherry-pick had conflicts that were resolved by Copilot. Please review carefully."
+          else
+            PR_BODY="${PR_BODY}
+
+          > [!NOTE]
+          > The cherry-pick applied cleanly."
+          fi
+
+          if [ "${{ github.event_name }}" != "workflow_dispatch" ]; then
+            PR_BODY="${PR_BODY}
+
+          Original PR: #${{ github.event.pull_request.number }}"
+          fi
+
+          # Build reviewer/assignee flags if we know the original author
+          AUTHOR_FLAGS=""
+          if [ -n "$PR_AUTHOR" ]; then
+            AUTHOR_FLAGS="--reviewer ${PR_AUTHOR}"
+          fi
+
+          PR_URL=$(gh pr create \
+            --base "${TARGET_BRANCH}" \
+            --head "${BACKPORT_BRANCH}" \
+            --title "[Backport ${TARGET_BRANCH}] ${ORIGINAL_MSG}" \
+            --body "${PR_BODY}" \
+            --label "backport" \
+            ${AUTHOR_FLAGS})
+
+          echo "Created PR: ${PR_URL}"
+
+          # Attempt to assign the original author (may fail for external contributors)
+          if [ -n "$PR_AUTHOR" ]; then
+            gh pr edit "${PR_URL}" --add-assignee "${PR_AUTHOR}" || \
+              echo "::notice::Could not assign ${PR_AUTHOR} (they may not have repo access)"
+          fi


### PR DESCRIPTION
For any PR merged to main, this will create a PR to main-2.1 with the change.

If the commit cherry picks cleanly, then Copilot (currently using the Opus 4.6 model) will check if there is anything else that should be done to adapt the commit.

If the commit does not cherry pick cleanly, then Copilot will try to resolve the merge conflicts and fix the PR.

The resultant PR will be assigned to the original author to review (or tag them if they cannot be assigned).

This is currently using a Copilot personal access token (PAT) for this action. An organization access token won't work, as it doesn't have the ability to make copilot requests.

Tested here: https://github.com/swenson/caliptra-mcu-sw/actions/runs/23807857975/job/69386316145