### PR TITLE
Set boot milestones during FW initialization

### DIFF
--- a/platforms/emulator/runtime/src/board.rs
+++ b/platforms/emulator/runtime/src/board.rs
@@ -841,6 +841,7 @@ pub unsafe fn main() {
         unsafe { StaticRef::new(MCU_MEMORY_MAP.mci_offset as *const mci::regs::Mci) };
     let mci_wdt = romtime::Mci::new(mci);
     mci_wdt.disable_wdt();
+    mci_wdt.set_flow_milestone(McuBootMilestones::FIRMWARE_OS_INITIALIZED.into());
     board_kernel.kernel_loop(veer, chip, None::<&kernel::ipc::IPC<0>>, &main_loop_cap);
 }
 

--- a/platforms/emulator/runtime/userspace/apps/example/src/test_mcu_mbox_usermode.rs
+++ b/platforms/emulator/runtime/userspace/apps/example/src/test_mcu_mbox_usermode.rs
@@ -9,7 +9,10 @@ pub async fn test_mcu_mbox_usermode_loopback() {
 
     let mut request_buffer: [u8; 256] = [0; 256];
     loop {
-        let recv_result = mcu_mbox0.receive_command(&mut request_buffer).await;
+        let on_listening_cb: Option<fn()> = None;
+        let recv_result = mcu_mbox0
+            .receive_command(&mut request_buffer, on_listening_cb)
+            .await;
 
         assert!(
             recv_result.is_ok(),

--- a/platforms/fpga/runtime/src/board.rs
+++ b/platforms/fpga/runtime/src/board.rs
@@ -761,6 +761,7 @@ pub unsafe fn main() {
     mci.intr_block_rf_notif0_intr_en_r
         .modify(mci::bits::Notif0IntrEnT::NotifCptraMcuResetReqEn::SET);
 
+    mci_wdt.set_flow_milestone(McuBootMilestones::FIRMWARE_OS_INITIALIZED.into());
     board_kernel.kernel_loop(veer, chip, None::<&kernel::ipc::IPC<0>>, &main_loop_cap);
 }
 

--- a/romtime/src/boot_status.rs
+++ b/romtime/src/boot_status.rs
@@ -124,6 +124,8 @@ bitflags! {
         const COLD_BOOT_FLOW_COMPLETE       = 0b1 << 5;
         const WARM_RESET_FLOW_COMPLETE      = 0b1 << 6;
         const FIRMWARE_BOOT_FLOW_COMPLETE   = 0b1 << 7;
+        const FIRMWARE_OS_INITIALIZED       = 0b1 << 8;
+        const FIRMWARE_MAILBOX_READY        = 0b1 << 9;
     }
 }
 

--- a/runtime/kernel/capsules/src/mci.rs
+++ b/runtime/kernel/capsules/src/mci.rs
@@ -14,6 +14,7 @@ mod cmd {
     pub const MCI_WRITE: u32 = 2;
     pub const MCI_SET_REGISTER: u32 = 3;
     pub const MCI_TRIGGER_WARM_RESET: u32 = 4;
+    pub const MCI_SET_MAILBOX_READY: u32 = 5;
 }
 
 mod mci_reg {
@@ -106,6 +107,11 @@ impl SyscallDriver for Mci {
             cmd::MCI_SET_REGISTER => self.set_reg(arg1 as u32, arg2 as u32, processid),
             cmd::MCI_TRIGGER_WARM_RESET => {
                 self.driver.trigger_warm_reset();
+                CommandReturn::success()
+            }
+            cmd::MCI_SET_MAILBOX_READY => {
+                self.driver
+                    .set_flow_milestone(romtime::McuBootMilestones::FIRMWARE_MAILBOX_READY.into());
                 CommandReturn::success()
             }
             _ => CommandReturn::failure(ErrorCode::NOSUPPORT),

--- a/runtime/userspace/api/mcu-mbox-lib/src/transport.rs
+++ b/runtime/userspace/api/mcu-mbox-lib/src/transport.rs
@@ -1,7 +1,9 @@
 // Licensed under the Apache-2.0 license
 
 use core::mem::size_of;
+use libsyscall_caliptra::mci::Mci;
 use libsyscall_caliptra::mcu_mbox::{CmdCode, MbxCmdStatus, McuMbox};
+use libsyscall_caliptra::DefaultSyscalls;
 use mcu_mbox_common::messages::{verify_checksum, MailboxReqHeader, MailboxRespHeader};
 use zerocopy::FromBytes;
 
@@ -17,12 +19,14 @@ pub enum TransportError {
 /// MCU Mailbox Transport implementation using the McuMbox syscall interface.
 pub struct McuMboxTransport {
     mbox: McuMbox,
+    ready_signaled: bool,
 }
 
 impl McuMboxTransport {
     pub fn new(drv_num: u32) -> Self {
         Self {
             mbox: McuMbox::new(drv_num),
+            ready_signaled: false,
         }
     }
 
@@ -36,9 +40,19 @@ impl McuMboxTransport {
 
         buf.fill(0);
 
+        let on_listening_cb = if !self.ready_signaled {
+            self.ready_signaled = true;
+            Some(|| {
+                let mci = Mci::<DefaultSyscalls>::new();
+                mci.set_mailbox_ready().unwrap();
+            })
+        } else {
+            None
+        };
+
         let (cmd_opcode, req_len) = self
             .mbox
-            .receive_command(buf)
+            .receive_command(buf, on_listening_cb)
             .await
             .map_err(|_| TransportError::DriverRxError)?;
 

--- a/runtime/userspace/syscall/src/mci.rs
+++ b/runtime/userspace/syscall/src/mci.rs
@@ -42,6 +42,10 @@ impl<S: Syscalls> Mci<S> {
     pub fn trigger_warm_reset(&self) -> Result<(), ErrorCode> {
         S::command(self.driver_num, cmd::MCI_TRIGGER_WARM_RESET, 0, 0).to_result::<(), ErrorCode>()
     }
+
+    pub fn set_mailbox_ready(&self) -> Result<(), ErrorCode> {
+        S::command(self.driver_num, cmd::MCI_SET_MAILBOX_READY, 0, 0).to_result::<(), ErrorCode>()
+    }
 }
 
 // -----------------------------------------------------------------------------
@@ -56,6 +60,7 @@ pub mod cmd {
     pub const MCI_WRITE: u32 = 2;
     pub const MCI_SET_REGISTER: u32 = 3;
     pub const MCI_TRIGGER_WARM_RESET: u32 = 4;
+    pub const MCI_SET_MAILBOX_READY: u32 = 5;
 }
 
 pub mod mci_reg {

--- a/runtime/userspace/syscall/src/mcu_mbox.rs
+++ b/runtime/userspace/syscall/src/mcu_mbox.rs
@@ -78,13 +78,17 @@ impl<S: Syscalls> McuMbox<S> {
     ///
     /// Returns a tuple containing the command code and the number of bytes received,
     /// or an error if the operation fails.
-    pub async fn receive_command(&self, data: &mut [u8]) -> Result<(CmdCode, usize), ErrorCode> {
+    pub async fn receive_command(
+        &self,
+        data: &mut [u8],
+        on_listening_cb: Option<impl FnOnce()>,
+    ) -> Result<(CmdCode, usize), ErrorCode> {
         if data.is_empty() {
             return Err(ErrorCode::Invalid);
         }
 
         let mutex = MCU_MBOX_MUTEX.lock().await;
-        let (command, recv_len, _) = share::scope::<(), _, _>(|_handle| {
+        let rx_fut = share::scope::<(), _, _>(|_handle| {
             let mut sub = TockSubscribe::subscribe_allow_rw::<S, DefaultConfig>(
                 self.driver_num,
                 subscribe::REQUEST_RECEIVED,
@@ -100,8 +104,13 @@ impl<S: Syscalls> McuMbox<S> {
             }
 
             Ok(TockSubscribe::subscribe_finish(sub))
-        })?
-        .await?;
+        })?;
+
+        if let Some(on_listening_cb) = on_listening_cb {
+            on_listening_cb();
+        }
+
+        let (command, recv_len, _) = rx_fut.await?;
 
         black_box(*mutex); // Ensure the mutex is not optimized away
 


### PR DESCRIPTION
This adds two new milestones:

## Firmware OS initialized

This can help further understand where the MCU is during boot by indicating when the Tock kernel is fully initialized.

## Firmware mailbox ready

This will be useful in tests that require the use of the mailbox.

This creates a new kernel syscall which is used by the mailbox userspace app to set the bit in the hardware register.