### PR TITLE
rom: Remove dynamic switching of I3C to recovery bypass mode

### DIFF
--- a/rom/src/cold_boot.rs
+++ b/rom/src/cold_boot.rs
@@ -31,8 +31,9 @@ use core::fmt::Write;
 use core::ops::Deref;
 use mcu_error::McuError;
 use registers_generated::fuses;
+use registers_generated::i3c::bits::RecIntfCfg;
 use romtime::{CaliptraSoC, HexBytes, HexWord, McuBootMilestones, McuRomBootStatus};
-use tock_registers::interfaces::Readable;
+use tock_registers::interfaces::{ReadWriteable, Readable};
 use zerocopy::{transmute, IntoBytes};
 
 pub struct ColdBoot {}
@@ -677,6 +678,11 @@ impl BootFlow for ColdBoot {
             if let Some(flash_driver) = params.flash_partition_driver {
                 romtime::println!("[mcu-rom] Starting Flash recovery flow");
                 mci.set_flow_checkpoint(McuRomBootStatus::FlashRecoveryFlowStarted.into());
+
+                // Set AXI bypass mode once before the recovery flow
+                i3c_base
+                    .soc_mgmt_if_rec_intf_cfg
+                    .modify(RecIntfCfg::RecIntfBypass::SET);
 
                 crate::recovery::load_flash_image_to_recovery(i3c_base, flash_driver)
                     .unwrap_or_else(|_| fatal_error(McuError::ROM_COLD_BOOT_LOAD_IMAGE_ERROR));

--- a/rom/src/recovery.rs
+++ b/rom/src/recovery.rs
@@ -14,8 +14,6 @@ use tock_registers::interfaces::{ReadWriteable, Readable, Writeable};
 use zerocopy::{FromBytes, IntoBytes};
 
 const ACTIVATE_RECOVERY_IMAGE_CMD: u32 = 0xF;
-const BYPASS_CFG_USE_I3C: u32 = 0x0;
-const BYPASS_CFG_AXI_DIRECT: u32 = 0x1;
 
 statemachine! {
     derive_states: [Clone, Copy, Debug],
@@ -272,9 +270,6 @@ pub fn load_flash_image_to_recovery(
     let mut next_print_offset = 0u32;
     let mut start_cycle = None;
 
-    i3c_periph
-        .soc_mgmt_if_rec_intf_cfg
-        .modify(RecIntfCfg::RecIntfBypass.val(BYPASS_CFG_AXI_DIRECT));
     while *state_machine.state() != States::Done {
         if prev_state != *state_machine.state() {
             romtime::println!(
@@ -422,9 +417,6 @@ pub fn load_flash_image_to_recovery(
             _ => {}
         }
     }
-    i3c_periph
-        .soc_mgmt_if_rec_intf_cfg
-        .modify(RecIntfCfg::RecIntfBypass.val(BYPASS_CFG_USE_I3C));
 
     Ok(())
 }


### PR DESCRIPTION
HW does not support dynamic switching, so we have to remove this from the ROM.

Fixes #725