### PR TITLE
Add hw-model mailbox test against the userspace application

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3048,6 +3048,7 @@ dependencies = [
  "mcu-builder",
  "mcu-config",
  "mcu-config-fpga",
+ "mcu-mbox-common",
  "mcu-otp-lifecycle",
  "mcu-rom-common",
  "mcu-testing-common",

--- a/emulator/periph/src/mci.rs
+++ b/emulator/periph/src/mci.rs
@@ -563,6 +563,16 @@ impl MciPeripheral for Mci {
             .intr_block_rf_notif0_internal_intr_r = new_val;
 
         self.update_mci_irq();
+
+        // Raise CPU IRQ if any enabled interrupt bits are now set.
+        let notif_en = self
+            .ext_mci_regs
+            .regs
+            .borrow()
+            .intr_block_rf_notif0_intr_en_r;
+        if new_val & notif_en != 0 {
+            self.irq.borrow_mut().set_level(true);
+        }
     }
 
     fn write_mci_reg_reset_request(
@@ -1439,7 +1449,7 @@ mod tests {
         assert_eq!(
             next_action(&clock),
             Some(TimerAction::Nmi {
-                mcause: 0x0000_0000,
+                mcause: 0x0000_0000
             })
         );
     }

--- a/hw/model/Cargo.toml
+++ b/hw/model/Cargo.toml
@@ -38,6 +38,7 @@ int-enum.workspace = true
 mcu-builder.workspace = true
 mcu-config-fpga = { workspace = true, optional = true }
 mcu-config.workspace = true
+mcu-mbox-common.workspace = true
 mcu-rom-common.workspace = true
 mcu-testing-common.workspace = true
 mcu-otp-lifecycle = { workspace = true, features = ["sha3", "std"] }

--- a/hw/model/src/lib.rs
+++ b/hw/model/src/lib.rs
@@ -1,8 +1,9 @@
 // Licensed under the Apache-2.0 license
 
-use anyhow::{bail, Result};
+use anyhow::{anyhow, bail, Result};
 pub use api::mailbox::mbox_write_fifo;
 pub use api_types::{DbgManufServiceRegReq, DeviceLifecycle, Fuses, U4};
+use caliptra_api::mailbox::MailboxReqHeader;
 use caliptra_api::{self as api, SocManager};
 use caliptra_api_types as api_types;
 use caliptra_emu_bus::Event;
@@ -13,6 +14,7 @@ use caliptra_hw_model_types::{
 };
 use caliptra_image_types::FwVerificationPqcKeyType;
 use caliptra_registers::mcu_mbox0::enums::MboxStatusE;
+use mcu_mbox_common::messages::calc_checksum;
 pub use mcu_mgr::McuManager;
 use mcu_rom_common::{LifecycleControllerState, LifecycleRawTokens, LifecycleToken};
 use mcu_testing_common::MCU_RUNNING;
@@ -28,6 +30,7 @@ use std::sync::atomic::Ordering;
 use std::sync::mpsc;
 use ureg::MmioMut;
 pub use vmem::read_otp_vmem_data;
+use zerocopy::FromBytes;
 
 // Re-export flash image builder for creating flash images from firmware bytes
 pub use mcu_builder::flash_image::build_flash_image_bytes;
@@ -509,6 +512,54 @@ pub trait McuHwModel {
         McuBootMilestones::from((self.mci_flow_status() >> 16) as u16)
     }
 
+    /// Executes a typed request and (on success), returns the typed response.
+    /// The checksum field of the request is calculated, and the checksum of the
+    /// response is validated.
+    fn mailbox_execute_req<R: mcu_mbox_common::messages::Request>(
+        &mut self,
+        mut req: R,
+    ) -> Result<R::Resp> {
+        let req_bytes = req.as_mut_bytes();
+
+        // Populate the request checksum
+        let checksum = calc_checksum(R::ID.into(), &req_bytes[size_of::<i32>()..]);
+        let hdr: &mut MailboxReqHeader =
+            MailboxReqHeader::mut_from_bytes(&mut req_bytes[..size_of::<MailboxReqHeader>()])
+                .unwrap();
+        hdr.chksum = checksum;
+
+        // Send the request to the mailbox
+        let mut response = self
+            .mailbox_execute(R::ID.into(), req_bytes)?
+            .unwrap_or_default();
+
+        // Check the reponse checksum
+        if response.len() < 4 {
+            bail!("Response too short to contain checksum");
+        }
+        let received_chksum = u32::from_le_bytes(response[..4].try_into().unwrap());
+        let calculated_chksum = calc_checksum(0, &response[4..]);
+        if received_chksum != calculated_chksum {
+            bail!(
+                "Response checksum mismatch: expected {:08x}, calculated {:08x}",
+                received_chksum,
+                calculated_chksum
+            );
+        }
+
+        if response.len() < std::mem::size_of::<R::Resp>() {
+            response.resize(std::mem::size_of::<R::Resp>(), 0);
+        }
+        let response = R::Resp::read_from_bytes(&response).map_err(|_| {
+            anyhow!(
+                "Failed to read response into struct: expected len {}, response len {}",
+                std::mem::size_of::<R::Resp>(),
+                response.len()
+            )
+        })?;
+        Ok(response)
+    }
+
     /// Executes `cmd` with request data `buf`. Returns `Ok(Some(_))` if
     /// the uC responded with data, `Ok(None)` if the uC indicated success
     /// without data, Err(ModelError::MailboxCmdFailed) if the microcontroller
@@ -611,11 +662,13 @@ pub trait McuHwModel {
 
         self.mcu_manager().with_mbox0(|mbox| {
             if status.cmd_complete() {
-                println!(">>> mbox cmd response: success");
-                mbox.mbox_execute().write(|w| w.execute(false));
-                return Ok(None);
-            }
-            if !status.data_ready() {
+                let dlen = mbox.mbox_dlen().read() as usize;
+                if dlen == 0 {
+                    println!(">>> mbox cmd response: success");
+                    mbox.mbox_execute().write(|w| w.execute(false));
+                    return Ok(None);
+                }
+            } else if !status.data_ready() {
                 bail!("Unknown mailbox status {:x}", u32::from(status));
             }
 

--- a/runtime/userspace/api/mcu-mbox-lib/src/cmd_interface.rs
+++ b/runtime/userspace/api/mcu-mbox-lib/src/cmd_interface.rs
@@ -71,22 +71,32 @@ impl<'a> CmdInterface<'a> {
         msg_buf: &mut [u8],
     ) -> Result<(), MsgHandlerError> {
         // Receive a request from the transport.
-        let (cmd_id, req_len) = self
-            .transport
-            .receive_request(msg_buf)
-            .await
-            .map_err(|_| MsgHandlerError::Transport)?;
+        let receive_result = self.transport.receive_request(msg_buf).await;
 
-        // Process the request and prepare the response.
-        let (resp_len, status) = self.process_request(msg_buf, cmd_id, req_len).await?;
-
-        // Send the response if the command completed successfully.
-        if status == MbxCmdStatus::Complete {
-            self.transport
-                .send_response(&msg_buf[..resp_len])
-                .await
-                .map_err(|_| MsgHandlerError::Transport)?;
-        }
+        let status = match receive_result {
+            Ok((cmd_id, req_len)) => {
+                // Process the request and prepare the response.
+                match self.process_request(msg_buf, cmd_id, req_len).await {
+                    Ok((resp_len, status)) => {
+                        if status == MbxCmdStatus::Complete {
+                            self.transport
+                                .send_response(&msg_buf[..resp_len])
+                                .await
+                                .map_err(|_| MsgHandlerError::Transport)?;
+                        }
+                        status
+                    }
+                    Err(_) => MbxCmdStatus::Failure,
+                }
+            }
+            Err(_) => {
+                // If the driver accepted the request but transport-level
+                // validation failed, we still need to finalize. If no request
+                // was received the finalize is harmlessly rejected.
+                let _ = self.transport.finalize_response(MbxCmdStatus::Failure);
+                return Err(MsgHandlerError::Transport);
+            }
+        };
 
         // Finalize the response as the last step of handling the message.
         self.transport

--- a/tests/integration/src/lib.rs
+++ b/tests/integration/src/lib.rs
@@ -5,6 +5,8 @@ mod i3c_socket;
 mod jtag;
 #[cfg(test)]
 mod rom;
+#[cfg(test)]
+mod runtime;
 mod test_active_i3c;
 mod test_bare_metal;
 mod test_dot;

--- a/tests/integration/src/runtime/mod.rs
+++ b/tests/integration/src/runtime/mod.rs
@@ -1,0 +1,3 @@
+// Licensed under the Apache-2.0 license
+
+mod test_mcu_mailbox;

--- a/tests/integration/src/runtime/test_mcu_mailbox.rs
+++ b/tests/integration/src/runtime/test_mcu_mailbox.rs
@@ -1,0 +1,56 @@
+// Licensed under the Apache-2.0 license
+
+use crate::test::{start_runtime_hw_model, TestParams};
+use anyhow::Result;
+use mcu_hw_model::McuHwModel;
+use mcu_mbox_common::messages::FirmwareVersionReq;
+use romtime::McuBootMilestones;
+
+#[test]
+fn test_invalid_mailbox_cmd() -> Result<()> {
+    let mut hw = start_runtime_hw_model(TestParams {
+        feature: Some("test-mcu-mbox-cmds"),
+        ..Default::default()
+    });
+
+    // wait another little bit for the mailbox to come up after the runtime
+    hw.step_until(|hw| {
+        hw.mci_boot_milestones()
+            .contains(McuBootMilestones::FIRMWARE_MAILBOX_READY)
+    });
+
+    // Send an unknown command (0x0) with an invalid checksum.
+    // The firmware should reject it with a mailbox failure.
+    let cmd: u32 = 0x0;
+    let resp = hw.mailbox_execute(cmd, &[0xaau8; 8]);
+    let err_msg = format!("{}", resp.unwrap_err());
+    assert!(
+        !err_msg.contains("timed out"),
+        "Mailbox command should fail with error, not time out. Got: {err_msg}"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_firmware_version_cmd() -> Result<()> {
+    let mut hw = start_runtime_hw_model(TestParams {
+        feature: Some("test-mcu-mbox-cmds"),
+        ..Default::default()
+    });
+
+    // wait another little bit for the mailbox to come up after the runtime
+    hw.step_until(|hw| {
+        hw.mci_boot_milestones()
+            .contains(McuBootMilestones::FIRMWARE_MAILBOX_READY)
+    });
+
+    let cmd = FirmwareVersionReq::default();
+    let resp = hw.mailbox_execute_req(cmd)?;
+
+    let expected_version = mcu_mbox_common::config::TEST_FIRMWARE_VERSIONS[0];
+    assert_eq!(resp.hdr.data_len, expected_version.len() as u32);
+    let resp_version_str = std::str::from_utf8(&resp.version[..resp.hdr.data_len as usize])
+        .expect("Version string is not valid UTF-8");
+    assert_eq!(resp_version_str, expected_version);
+    Ok(())
+}


### PR DESCRIPTION
This adds a simple test that the mailbox is accessible from the hardware model. It sends a command that is invalid with an invalid checksum. It mainly checks the application can receive the interrupt and send back an error because it is invalid.