### PR TITLE
Extend SPDM validator nightly to main-2.1 and fix test failures

### DIFF
--- a/.github/workflows/spdm-validator.yml
+++ b/.github/workflows/spdm-validator.yml
@@ -11,6 +11,10 @@ on:
 jobs:
   spdm_validator_tests:
     runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        branch: [main, main-2.1]
+      fail-fast: false
 
     env:
       CARGO_INCREMENTAL: 0
@@ -26,6 +30,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
+          ref: ${{ matrix.branch }}
           submodules: recursive
 
       - name: Test commit name
@@ -115,7 +120,7 @@ jobs:
         env:
           SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-emu/build/bin
         with:
-          name: spdm-mctp-validator-test-results
+          name: spdm-mctp-validator-test-results-${{ matrix.branch }}
           path: |
             ${{ env.SPDM_VALIDATOR_DIR }}/test.log
             ${{ env.SPDM_VALIDATOR_DIR }}/caliptra_spdm_validator.pcap
@@ -157,7 +162,7 @@ jobs:
         env:
           SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-emu/build/bin
         with:
-          name: spdm-doe-validator-test-results
+          name: spdm-doe-validator-test-results-${{ matrix.branch }}
           path: |
             ${{ env.SPDM_VALIDATOR_DIR }}/test.log
             ${{ env.SPDM_VALIDATOR_DIR }}/caliptra_spdm_validator.pcap
@@ -220,6 +225,6 @@ jobs:
         env:
           SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-rs/target/debug
         with:
-          name: spdm-tdisp-ide-validator-test-results
+          name: spdm-tdisp-ide-validator-test-results-${{ matrix.branch }}
           path: |
             ${{ env.SPDM_VALIDATOR_DIR }}/tdisp_ide_validator_output.txt

--- a/.github/workflows/spdm-validator.yml
+++ b/.github/workflows/spdm-validator.yml
@@ -15,6 +15,10 @@ env:
 jobs:
   spdm_validator_tests:
     runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        branch: [main, main-2.1]
+      fail-fast: false
 
     env:
       CARGO_INCREMENTAL: 0
@@ -30,6 +34,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v7
         with:
+          ref: ${{ matrix.branch }}
           submodules: recursive
 
       - name: Test commit name
@@ -119,7 +124,7 @@ jobs:
         env:
           SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-emu/build/bin
         with:
-          name: spdm-mctp-validator-test-results
+          name: spdm-mctp-validator-test-results-${{ matrix.branch }}
           path: |
             ${{ env.SPDM_VALIDATOR_DIR }}/test.log
             ${{ env.SPDM_VALIDATOR_DIR }}/caliptra_spdm_validator.pcap
@@ -161,7 +166,7 @@ jobs:
         env:
           SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-emu/build/bin
         with:
-          name: spdm-doe-validator-test-results
+          name: spdm-doe-validator-test-results-${{ matrix.branch }}
           path: |
             ${{ env.SPDM_VALIDATOR_DIR }}/test.log
             ${{ env.SPDM_VALIDATOR_DIR }}/caliptra_spdm_validator.pcap
@@ -224,6 +229,6 @@ jobs:
         env:
           SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-rs/target/debug
         with:
-          name: spdm-tdisp-ide-validator-test-results
+          name: spdm-tdisp-ide-validator-test-results-${{ matrix.branch }}
           path: |
             ${{ env.SPDM_VALIDATOR_DIR }}/tdisp_ide_validator_output.txt


### PR DESCRIPTION
Extend the SPDM validator nightly workflow to run against both `main` and
`main-2.1`, and carry the small adaptations needed for the tests to build
and pass on `main-2.1`.

Workflow changes:
- Add a `branch: [main, main-2.1]` matrix to `spdm-validator.yml` with
  `fail-fast: false`, and check out the matrix branch.
- Suffix uploaded artifact names with `${{ matrix.branch }}` so both runs
  upload distinct result bundles.
- Add the missing `SPDM_VALIDATOR_DIR` env block to the MCTP
  "Check for test failures" step.
- Guard the EAT measurement-block verification with a file-existence
  check so the step skips gracefully when the validator does not produce
  `measurement_block_fd.bin` (e.g. on `main`).

Code adaptations on `main-2.1`:
- `apps/user/src/riscv.rs`: bump `HEAP_SIZE` from `0x4000` to `0x6000`.
- `ocp_eat/claims.rs`: adapt to the new ocp-eat types — wrap class IDs
  in `ClassIdTypeChoice::TaggedOid(TaggedOid::new(..))` and version
  fields in `VersionMap { version, version_scheme: None }`.
- `caliptra-api`: move `MAX_ECC_CERT_SIZE` re-exports from
  `mailbox_api` to `certificate` to match where it now lives on
  `main-2.1`.
- Refresh test IDEVID certs.

Note: the earlier iteration of this PR bumped caliptra-sw
(`49927b62` → `19764abe`) and caliptra-dpe (`4986ac50` → `cfc9a713`)
and cherry-picked a stack-safe `DpeResp` refactor to work around a
Caliptra FW stack overflow in DPE `GetCertificateChain`. Those changes
are no longer needed: `main-2.1` has since advanced to caliptra-sw
`06b6aa0d` and dpe `337f7e41`, and carries its own DPE API redesign
(`DpeEcResp` / `DpeResponse` / `MAX_DPE_RESP_DATA_SIZE = 4096`) that
supersedes the workaround.