### PR TITLE
[nextest]: Reduce test timeout from 3 hours to 15 minutes

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -13,7 +13,7 @@ store-failure-output = true
 [profile.nightly-emulator]
 failure-output = "immediate-final"
 fail-fast = false
-slow-timeout = { period = "30m", terminate-after = 6 }
+slow-timeout = { period = "30s", terminate-after = 30 }
 
 [profile.nightly-emulator.junit]
 path = "/tmp/junit.xml"


### PR DESCRIPTION
This way we can see the test logs after they timeout.