### PR TITLE
Add Export Attested CSR VDM command (0x0C)

### DIFF
--- a/common/mctp-vdm/src/message/export_attested_csr.rs
+++ b/common/mctp-vdm/src/message/export_attested_csr.rs
@@ -1,0 +1,302 @@
+// Licensed under the Apache-2.0 license
+
+//! Export Attested CSR command (0x0C)
+//!
+//! Exports an attested Certificate Signing Request (CSR) for a specified device key.
+
+use crate::codec::{VdmCodec, VdmCodecError};
+use crate::error::VdmError;
+use crate::protocol::{VdmCommand, VdmMsgHeader};
+use core::convert::TryFrom;
+use zerocopy::{FromBytes, Immutable, IntoBytes};
+
+/// Maximum size of attested CSR response data (from Caliptra core), 32-bit aligned.
+// TODO: Replace with actual max attested CSR response size from Caliptra mailbox commands.
+pub const MAX_ATTESTED_CSR_SIZE: usize = 12800;
+
+/// Device Key ID values for Export Attested CSR.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u32)]
+pub enum DeviceKeyId {
+    /// LDevID key.
+    LDevId = 0x0001,
+    /// FMC Alias key.
+    FmcAlias = 0x0002,
+    /// RT Alias key.
+    RtAlias = 0x0003,
+}
+
+impl TryFrom<u32> for DeviceKeyId {
+    type Error = VdmError;
+
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        match value {
+            0x0001 => Ok(DeviceKeyId::LDevId),
+            0x0002 => Ok(DeviceKeyId::FmcAlias),
+            0x0003 => Ok(DeviceKeyId::RtAlias),
+            _ => Err(VdmError::InvalidData),
+        }
+    }
+}
+
+/// Asymmetric algorithm values for Export Attested CSR.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u32)]
+pub enum AsymAlgorithm {
+    /// ECC P-384.
+    Ecc384 = 0x0001,
+    /// ML-DSA-87 (Dilithium).
+    MlDsa87 = 0x0002,
+}
+
+impl TryFrom<u32> for AsymAlgorithm {
+    type Error = VdmError;
+
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        match value {
+            0x0001 => Ok(AsymAlgorithm::Ecc384),
+            0x0002 => Ok(AsymAlgorithm::MlDsa87),
+            _ => Err(VdmError::InvalidData),
+        }
+    }
+}
+
+/// Export Attested CSR Request.
+///
+/// Request Payload:
+/// - Bytes 0:3 - device_key_id (u32): Identifier of the device key to export CSR for
+///   - 0x0001 = LDevID
+///   - 0x0002 = FMC Alias
+///   - 0x0003 = RT Alias
+/// - Bytes 4:7 - algorithm (u32): Asymmetric algorithm
+///   - 0x0001 = ECC384
+///   - 0x0002 = MLDSA87
+#[derive(Debug, Clone, Copy, PartialEq, FromBytes, IntoBytes, Immutable)]
+#[repr(C, packed)]
+pub struct ExportAttestedCsrRequest {
+    /// VDM message header.
+    pub hdr: VdmMsgHeader,
+    /// Device key identifier.
+    pub device_key_id: u32,
+    /// Asymmetric algorithm.
+    pub algorithm: u32,
+}
+
+impl ExportAttestedCsrRequest {
+    /// Create a new Export Attested CSR request.
+    pub fn new(device_key_id: u32, algorithm: u32) -> Self {
+        ExportAttestedCsrRequest {
+            hdr: VdmMsgHeader::new_request(VdmCommand::ExportAttestedCsr.into()),
+            device_key_id,
+            algorithm,
+        }
+    }
+}
+
+impl Default for ExportAttestedCsrRequest {
+    fn default() -> Self {
+        Self::new(DeviceKeyId::LDevId as u32, AsymAlgorithm::Ecc384 as u32)
+    }
+}
+
+/// Export Attested CSR Response (fixed header part).
+///
+/// Response Payload:
+/// - Bytes 0:3 - completion_code (u32): Command completion status
+/// - Bytes 4:7 - data_size (u32): Length in bytes of the attested CSR data
+/// - Bytes 8:N - data (u8[data_size]): Attested CSR data blob
+#[derive(Debug, Clone, Copy, PartialEq, FromBytes, IntoBytes, Immutable)]
+#[repr(C, packed)]
+pub struct ExportAttestedCsrResponseHeader {
+    /// VDM message header.
+    pub hdr: VdmMsgHeader,
+    /// Command completion status.
+    pub completion_code: u32,
+    /// Size of the attested CSR data in bytes.
+    pub data_size: u32,
+}
+
+impl ExportAttestedCsrResponseHeader {
+    /// Create a new Export Attested CSR response header.
+    pub fn new(completion_code: u32, data_size: u32) -> Self {
+        ExportAttestedCsrResponseHeader {
+            hdr: VdmMsgHeader::new_response(VdmCommand::ExportAttestedCsr.into()),
+            completion_code,
+            data_size,
+        }
+    }
+}
+
+impl Default for ExportAttestedCsrResponseHeader {
+    fn default() -> Self {
+        ExportAttestedCsrResponseHeader {
+            hdr: VdmMsgHeader::new_response(VdmCommand::ExportAttestedCsr.into()),
+            completion_code: 0,
+            data_size: 0,
+        }
+    }
+}
+
+/// Export Attested CSR Response with variable-length data.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ExportAttestedCsrResponse {
+    /// Response header.
+    pub header: ExportAttestedCsrResponseHeader,
+    /// Attested CSR data buffer.
+    pub data: [u8; MAX_ATTESTED_CSR_SIZE],
+}
+
+impl ExportAttestedCsrResponse {
+    /// Create a new Export Attested CSR response.
+    pub fn new(completion_code: u32, data: &[u8]) -> Self {
+        let data_size = data.len().min(MAX_ATTESTED_CSR_SIZE);
+        let mut response_data = [0u8; MAX_ATTESTED_CSR_SIZE];
+        response_data[..data_size].copy_from_slice(&data[..data_size]);
+
+        ExportAttestedCsrResponse {
+            header: ExportAttestedCsrResponseHeader::new(completion_code, data_size as u32),
+            data: response_data,
+        }
+    }
+
+    /// Get the actual data size.
+    pub fn data_size(&self) -> usize {
+        self.header.data_size as usize
+    }
+
+    /// Get a slice of the actual data.
+    pub fn data(&self) -> &[u8] {
+        let size = self.data_size().min(MAX_ATTESTED_CSR_SIZE);
+        &self.data[..size]
+    }
+}
+
+impl Default for ExportAttestedCsrResponse {
+    fn default() -> Self {
+        ExportAttestedCsrResponse {
+            header: ExportAttestedCsrResponseHeader::default(),
+            data: [0u8; MAX_ATTESTED_CSR_SIZE],
+        }
+    }
+}
+
+impl VdmCodec for ExportAttestedCsrResponse {
+    fn encode(&self, buffer: &mut [u8]) -> Result<usize, VdmCodecError> {
+        let header_size = core::mem::size_of::<ExportAttestedCsrResponseHeader>();
+        let data_size = self.data_size();
+        let total_size = header_size + data_size;
+
+        if buffer.len() < total_size {
+            return Err(VdmCodecError::BufferTooShort);
+        }
+
+        // Encode header
+        self.header.encode(buffer)?;
+
+        // Copy data
+        buffer[header_size..total_size].copy_from_slice(&self.data[..data_size]);
+
+        Ok(total_size)
+    }
+
+    fn decode(buffer: &[u8]) -> Result<Self, VdmCodecError> {
+        let header_size = core::mem::size_of::<ExportAttestedCsrResponseHeader>();
+
+        if buffer.len() < header_size {
+            return Err(VdmCodecError::BufferTooShort);
+        }
+
+        let header = ExportAttestedCsrResponseHeader::decode(buffer)?;
+        let data_size = (header.data_size as usize).min(MAX_ATTESTED_CSR_SIZE);
+
+        if buffer.len() < header_size + data_size {
+            return Err(VdmCodecError::BufferTooShort);
+        }
+
+        let mut data = [0u8; MAX_ATTESTED_CSR_SIZE];
+        data[..data_size].copy_from_slice(&buffer[header_size..header_size + data_size]);
+
+        Ok(ExportAttestedCsrResponse { header, data })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::{VdmCompletionCode, VDM_MSG_HEADER_LEN};
+
+    #[test]
+    fn test_export_attested_csr_request() {
+        let req =
+            ExportAttestedCsrRequest::new(DeviceKeyId::LDevId as u32, AsymAlgorithm::Ecc384 as u32);
+        assert!(req.hdr.is_request());
+        let command_code = req.hdr.command_code;
+        let device_key_id = req.device_key_id;
+        let algorithm = req.algorithm;
+        assert_eq!(command_code, VdmCommand::ExportAttestedCsr as u8);
+        assert_eq!(device_key_id, 0x0001);
+        assert_eq!(algorithm, 0x0001);
+
+        let mut buffer = [0u8; 64];
+        let size = req.encode(&mut buffer).unwrap();
+        assert_eq!(size, VDM_MSG_HEADER_LEN + 8);
+
+        let decoded = ExportAttestedCsrRequest::decode(&buffer).unwrap();
+        assert_eq!(req, decoded);
+    }
+
+    #[test]
+    fn test_export_attested_csr_response() {
+        let data = [0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x01, 0x02];
+        let resp = ExportAttestedCsrResponse::new(VdmCompletionCode::Success as u32, &data);
+        assert!(resp.header.hdr.is_response());
+
+        let header_size = core::mem::size_of::<ExportAttestedCsrResponseHeader>();
+        let mut buffer = [0u8; MAX_ATTESTED_CSR_SIZE + 64];
+        let size = resp.encode(&mut buffer).unwrap();
+        assert_eq!(size, header_size + data.len());
+
+        let decoded = ExportAttestedCsrResponse::decode(&buffer[..size]).unwrap();
+        assert_eq!(decoded.data_size(), data.len());
+        assert_eq!(decoded.data(), &data);
+    }
+
+    #[test]
+    fn test_export_attested_csr_response_empty() {
+        let resp = ExportAttestedCsrResponse::new(VdmCompletionCode::GeneralError as u32, &[]);
+        assert_eq!(resp.data_size(), 0);
+        assert_eq!(resp.data(), &[]);
+    }
+
+    #[test]
+    fn test_device_key_id_values() {
+        assert_eq!(DeviceKeyId::LDevId as u32, 0x0001);
+        assert_eq!(DeviceKeyId::FmcAlias as u32, 0x0002);
+        assert_eq!(DeviceKeyId::RtAlias as u32, 0x0003);
+    }
+
+    #[test]
+    fn test_asym_algorithm_values() {
+        assert_eq!(AsymAlgorithm::Ecc384 as u32, 0x0001);
+        assert_eq!(AsymAlgorithm::MlDsa87 as u32, 0x0002);
+    }
+
+    #[test]
+    fn test_device_key_id_try_from() {
+        assert_eq!(DeviceKeyId::try_from(0x0001), Ok(DeviceKeyId::LDevId));
+        assert_eq!(DeviceKeyId::try_from(0x0002), Ok(DeviceKeyId::FmcAlias));
+        assert_eq!(DeviceKeyId::try_from(0x0003), Ok(DeviceKeyId::RtAlias));
+        assert!(DeviceKeyId::try_from(0x0000).is_err());
+        assert!(DeviceKeyId::try_from(0x0004).is_err());
+        assert!(DeviceKeyId::try_from(0xFFFF).is_err());
+    }
+
+    #[test]
+    fn test_asym_algorithm_try_from() {
+        assert_eq!(AsymAlgorithm::try_from(0x0001), Ok(AsymAlgorithm::Ecc384));
+        assert_eq!(AsymAlgorithm::try_from(0x0002), Ok(AsymAlgorithm::MlDsa87));
+        assert!(AsymAlgorithm::try_from(0x0000).is_err());
+        assert!(AsymAlgorithm::try_from(0x0003).is_err());
+        assert!(AsymAlgorithm::try_from(0xFFFF).is_err());
+    }
+}

--- a/common/mctp-vdm/src/message/mod.rs
+++ b/common/mctp-vdm/src/message/mod.rs
@@ -3,9 +3,11 @@
 pub mod device_capabilities;
 pub mod device_id;
 pub mod device_info;
+pub mod export_attested_csr;
 pub mod firmware_version;
 
 pub use device_capabilities::*;
 pub use device_id::*;
 pub use device_info::*;
+pub use export_attested_csr::*;
 pub use firmware_version::*;

--- a/common/mctp-vdm/src/protocol/commands.rs
+++ b/common/mctp-vdm/src/protocol/commands.rs
@@ -18,6 +18,7 @@ pub enum VdmCommand {
     ClearLog = 0x09,
     RequestDebugUnlock = 0x0A,
     AuthorizeDebugUnlockToken = 0x0B,
+    ExportAttestedCsr = 0x0C,
 }
 
 impl TryFrom<u8> for VdmCommand {
@@ -36,6 +37,7 @@ impl TryFrom<u8> for VdmCommand {
             0x09 => Ok(VdmCommand::ClearLog),
             0x0A => Ok(VdmCommand::RequestDebugUnlock),
             0x0B => Ok(VdmCommand::AuthorizeDebugUnlockToken),
+            0x0C => Ok(VdmCommand::ExportAttestedCsr),
             _ => Err(VdmError::UnsupportedCommand),
         }
     }
@@ -74,6 +76,10 @@ mod tests {
         assert_eq!(VdmCommand::try_from(0x03), Ok(VdmCommand::DeviceId));
         assert_eq!(VdmCommand::try_from(0x04), Ok(VdmCommand::DeviceInfo));
         assert_eq!(
+            VdmCommand::try_from(0x0C),
+            Ok(VdmCommand::ExportAttestedCsr)
+        );
+        assert_eq!(
             VdmCommand::try_from(0xFF),
             Err(VdmError::UnsupportedCommand)
         );
@@ -85,6 +91,7 @@ mod tests {
         assert_eq!(u8::from(VdmCommand::DeviceCapabilities), 0x02);
         assert_eq!(u8::from(VdmCommand::DeviceId), 0x03);
         assert_eq!(u8::from(VdmCommand::DeviceInfo), 0x04);
+        assert_eq!(u8::from(VdmCommand::ExportAttestedCsr), 0x0C);
     }
 
     #[test]
@@ -93,6 +100,7 @@ mod tests {
         assert!(is_command_supported(VdmCommand::DeviceCapabilities));
         assert!(is_command_supported(VdmCommand::DeviceId));
         assert!(is_command_supported(VdmCommand::DeviceInfo));
+        assert!(!is_command_supported(VdmCommand::ExportAttestedCsr));
         assert!(!is_command_supported(VdmCommand::GetLog));
         assert!(!is_command_supported(VdmCommand::ClearLog));
     }

--- a/docs/src/unified_external_command_handling.md
+++ b/docs/src/unified_external_command_handling.md
@@ -18,6 +18,7 @@ The Caliptra MCU firmware provides two external command interfaces: [MCTP VDM ex
 | Clear Log                         | MC_CLEAR_LOG                           | Clears the log in the RoT subsystem.                    |
 | Request Debug Unlock              | MC_PRODUCTION_DEBUG_UNLOCK_REQ         | Requests debug unlock in a production environment.       |
 | Authorize Debug Unlock Token      | MC_PRODUCTION_DEBUG_UNLOCK_TOKEN       | Sends the debug unlock token for authorization.         |
+| Export Attested CSR               | -                                      | Exports attested CSR for a specified device key.        |
 
 To ensure consistent command behavior and maximize code reuse, we define a protocol-agnostic command handler trait with unified command IDs and input/output types. Both MCTP VDM and MCI mailbox frontends parse their protocol, map to the unified command and call the same backend handler, ensuring code reuse and consistent behavior.
 
@@ -155,6 +156,8 @@ pub enum UnifiedCommandId {
     GetLog,
     /// Clear device logs.
     ClearLog,
+    /// Export an attested CSR for a specified device key.
+    ExportAttestedCsr,
     // ... add more as needed
 }
 

--- a/platforms/emulator/runtime/userspace/apps/user/src/mcu_mbox/cmd_handler_mock.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/mcu_mbox/cmd_handler_mock.rs
@@ -5,7 +5,7 @@ extern crate alloc;
 use alloc::boxed::Box;
 use async_trait::async_trait;
 use external_cmds_common::{
-    CommandError, DeviceCapabilities, DeviceId, DeviceInfo, FirmwareVersion, Uid,
+    AttestedCsrData, CommandError, DeviceCapabilities, DeviceId, DeviceInfo, FirmwareVersion, Uid,
     UnifiedCommandHandler, MAX_FW_VERSION_LEN, MAX_UID_LEN,
 };
 use mcu_mbox_common::config;
@@ -83,5 +83,14 @@ impl UnifiedCommandHandler for NonCryptoCmdHandlerMock {
         capabilities.mcu_rom = test_capabilities.mcu_rom;
         capabilities.reserved = test_capabilities.reserved;
         Ok(())
+    }
+
+    async fn export_attested_csr(
+        &self,
+        _device_key_id: u32,
+        _algorithm: u32,
+        _csr_data: &mut AttestedCsrData,
+    ) -> Result<(), CommandError> {
+        Err(CommandError::NotSupported)
     }
 }

--- a/platforms/emulator/runtime/userspace/apps/user/src/vdm/cmd_handler_mock.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/vdm/cmd_handler_mock.rs
@@ -5,7 +5,7 @@ extern crate alloc;
 use alloc::boxed::Box;
 use async_trait::async_trait;
 use external_cmds_common::{
-    CommandError, DeviceCapabilities, DeviceId, DeviceInfo, FirmwareVersion, Uid,
+    AttestedCsrData, CommandError, DeviceCapabilities, DeviceId, DeviceInfo, FirmwareVersion, Uid,
     UnifiedCommandHandler, MAX_FW_VERSION_LEN, MAX_UID_LEN,
 };
 use mcu_mbox_common::config;
@@ -83,5 +83,14 @@ impl UnifiedCommandHandler for NonCryptoCmdHandlerMock {
         capabilities.mcu_rom = test_capabilities.mcu_rom;
         capabilities.reserved = test_capabilities.reserved;
         Ok(())
+    }
+
+    async fn export_attested_csr(
+        &self,
+        _device_key_id: u32,
+        _algorithm: u32,
+        _csr_data: &mut AttestedCsrData,
+    ) -> Result<(), CommandError> {
+        Err(CommandError::NotSupported)
     }
 }

--- a/runtime/userspace/api/external-cmds-common/src/lib.rs
+++ b/runtime/userspace/api/external-cmds-common/src/lib.rs
@@ -10,6 +10,8 @@ use zerocopy::{Immutable, IntoBytes};
 
 pub const MAX_FW_VERSION_LEN: usize = 32;
 pub const MAX_UID_LEN: usize = 32;
+// TODO: Replace with imported constant from Caliptra core crate when available.
+pub const MAX_ATTESTED_CSR_DATA_LEN: usize = 12800;
 
 /// Common error type for unified commands.
 #[derive(Debug)]
@@ -19,6 +21,21 @@ pub enum CommandError {
     InternalError,
     NotSupported,
     Busy,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AttestedCsrData {
+    pub len: usize,
+    pub data: [u8; MAX_ATTESTED_CSR_DATA_LEN],
+}
+
+impl Default for AttestedCsrData {
+    fn default() -> Self {
+        Self {
+            len: 0,
+            data: [0u8; MAX_ATTESTED_CSR_DATA_LEN],
+        }
+    }
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
@@ -108,5 +125,21 @@ pub trait UnifiedCommandHandler {
     async fn get_device_capabilities(
         &self,
         capabilities: &mut DeviceCapabilities,
+    ) -> Result<(), CommandError>;
+
+    /// Exports an attested CSR for the specified device key.
+    ///
+    /// # Arguments
+    /// * `device_key_id` - The device key identifier (0x0001=LDevID, 0x0002=FMC Alias, 0x0003=RT Alias).
+    /// * `algorithm` - The asymmetric algorithm (0x0001=ECC384, 0x0002=MLDSA87).
+    /// * `csr_data` - Mutable reference to store the attested CSR data.
+    ///
+    /// # Returns
+    /// * `Result<(), CommandError>` - Ok on success, or an error.
+    async fn export_attested_csr(
+        &self,
+        device_key_id: u32,
+        algorithm: u32,
+        csr_data: &mut AttestedCsrData,
     ) -> Result<(), CommandError>;
 }

--- a/runtime/userspace/api/mctp-vdm-lib/src/cmd_interface.rs
+++ b/runtime/userspace/api/mctp-vdm-lib/src/cmd_interface.rs
@@ -4,12 +4,13 @@ use crate::error::VdmLibError;
 use crate::transport::MctpVdmTransport;
 use core::convert::TryFrom;
 use external_cmds_common::{
-    DeviceCapabilities, DeviceId, DeviceInfo, FirmwareVersion, Uid, UnifiedCommandHandler,
-    MAX_UID_LEN,
+    AttestedCsrData, CommandError, DeviceCapabilities, DeviceId, DeviceInfo, FirmwareVersion, Uid,
+    UnifiedCommandHandler, MAX_ATTESTED_CSR_DATA_LEN, MAX_UID_LEN,
 };
 use mctp_vdm_common::codec::VdmCodec;
 use mctp_vdm_common::message::{
-    DeviceCapabilitiesResponse, DeviceIdResponse, DeviceInfoRequest, DeviceInfoResponse,
+    AsymAlgorithm, DeviceCapabilitiesResponse, DeviceIdResponse, DeviceInfoRequest,
+    DeviceInfoResponse, ExportAttestedCsrRequest, ExportAttestedCsrResponse,
     FirmwareVersionRequest, FirmwareVersionResponse, DEVICE_CAPS_SIZE,
 };
 use mctp_vdm_common::protocol::{
@@ -119,6 +120,9 @@ impl<'a> CmdInterface<'a> {
             }
             VdmCommand::DeviceId => self.handle_device_id(msg_buf, vdm_req_len).await,
             VdmCommand::DeviceInfo => self.handle_device_info(msg_buf, vdm_req_len).await,
+            VdmCommand::ExportAttestedCsr => {
+                self.handle_export_attested_csr(msg_buf, vdm_req_len).await
+            }
             _ => self.send_error_response(
                 msg_buf,
                 hdr.command_code,
@@ -296,6 +300,75 @@ impl<'a> CmdInterface<'a> {
         &self,
         msg_buf: &mut [u8],
         resp: &DeviceInfoResponse,
+    ) -> Result<usize, VdmLibError> {
+        // Construct MCTP header and get VDM message slice.
+        let vdm_msg = construct_mctp_vdm_msg(msg_buf).map_err(|_| VdmLibError::EncodingError)?;
+
+        // Encode the response.
+        let resp_len = resp
+            .encode(vdm_msg)
+            .map_err(|_| VdmLibError::EncodingError)?;
+
+        // Return total MCTP payload length (1 byte MCTP header + VDM response).
+        Ok(VDM_MSG_OFFSET + resp_len)
+    }
+
+    /// Handle Export Attested CSR command.
+    async fn handle_export_attested_csr(
+        &self,
+        msg_buf: &mut [u8],
+        req_len: usize,
+    ) -> Result<usize, VdmLibError> {
+        // Extract VDM message portion.
+        let vdm_msg = extract_vdm_msg(msg_buf).map_err(|_| VdmLibError::DecodingError)?;
+
+        // Decode the request.
+        let req = ExportAttestedCsrRequest::decode(&vdm_msg[..req_len])
+            .map_err(|_| VdmLibError::DecodingError)?;
+
+        let device_key_id = req.device_key_id;
+        let algorithm = req.algorithm;
+
+        // Validate algorithm at protocol layer since ECC384 and MLDSA-87
+        // map to different Caliptra backend commands.
+        if AsymAlgorithm::try_from(algorithm).is_err() {
+            let resp = ExportAttestedCsrResponse::new(VdmCompletionCode::InvalidData as u32, &[]);
+            return self.encode_export_attested_csr_response(msg_buf, &resp);
+        }
+
+        // Get the attested CSR using the unified handler.
+        // device_key_id validation is delegated to the Caliptra backend.
+        let mut csr_data = AttestedCsrData::default();
+        let result = self
+            .unified_handler
+            .export_attested_csr(device_key_id, algorithm, &mut csr_data)
+            .await;
+
+        // Build the response with appropriate completion code per error type.
+        let (completion_code, data) = match result {
+            Ok(()) => {
+                let len = csr_data.len.min(MAX_ATTESTED_CSR_DATA_LEN);
+                (VdmCompletionCode::Success, csr_data.data[..len].to_vec())
+            }
+            Err(CommandError::InvalidParams) => (VdmCompletionCode::InvalidData, alloc::vec![]),
+            Err(CommandError::NotSupported) => {
+                (VdmCompletionCode::UnsupportedCommand, alloc::vec![])
+            }
+            Err(CommandError::Busy) => (VdmCompletionCode::NotReady, alloc::vec![]),
+            Err(_) => (VdmCompletionCode::GeneralError, alloc::vec![]),
+        };
+
+        let resp = ExportAttestedCsrResponse::new(completion_code as u32, &data);
+
+        // Encode the response into the MCTP payload.
+        self.encode_export_attested_csr_response(msg_buf, &resp)
+    }
+
+    /// Encode an ExportAttestedCsrResponse (variable length) into the MCTP payload buffer.
+    fn encode_export_attested_csr_response(
+        &self,
+        msg_buf: &mut [u8],
+        resp: &ExportAttestedCsrResponse,
     ) -> Result<usize, VdmLibError> {
         // Construct MCTP header and get VDM message slice.
         let vdm_msg = construct_mctp_vdm_msg(msg_buf).map_err(|_| VdmLibError::EncodingError)?;


### PR DESCRIPTION
Add Caliptra VDM command to export attested Certificate Signing Requests for LDevID, FMC Alias, and RT Alias device keys with ECC384 and MLDSA-87 algorithm support