### PR TITLE
xtask: update rom and runtime commands for ROM digest

### DIFF
--- a/.github/workflows/verify_reproducible_build.yml
+++ b/.github/workflows/verify_reproducible_build.yml
@@ -29,7 +29,7 @@ jobs:
           rustup toolchain install -c clippy,rust-src,llvm-tools,rustfmt,rustc-dev
 
       - name: Build
-        run: cargo xtask rom
+        run: cargo xtask rom-build
 
       - name: Calculate ROM and runtime digests
         run: |
@@ -40,7 +40,7 @@ jobs:
         run: cargo clean
 
       - name: Build again
-        run: cargo xtask rom
+        run: cargo xtask rom-build
 
       - name: Calculate digests again and ensure it hasn't changed
         run: |

--- a/builder/src/lib.rs
+++ b/builder/src/lib.rs
@@ -13,7 +13,7 @@ pub use all::{
     all_build, emulator_build, AllBuildArgs, EmulatorBinaries, EmulatorBuildArgs, FirmwareBinaries,
 };
 pub use caliptra::{AuthManifestOwnerConfig, CaliptraBuilder, ImageCfg};
-pub use rom::{rom_build, test_rom_build};
+pub use rom::{append_rom_digest, rom_build, rom_size_for_platform, test_rom_build};
 pub use runtime::{bare_metal_build, runtime_build_with_apps};
 
 #[derive(Default, Clone)]

--- a/builder/src/rom.rs
+++ b/builder/src/rom.rs
@@ -52,7 +52,7 @@ pub fn rom_build(args: &CaliptraBuildArgs) -> Result<PathBuf> {
 }
 
 /// Pad the ROM binary to its full size and append a SHA384 digest of its contents to the end.
-fn append_rom_digest(binary: &PathBuf, rom_size: usize) -> Result<()> {
+pub fn append_rom_digest(binary: &PathBuf, rom_size: usize) -> Result<()> {
     let mut data = std::fs::read(binary)?;
     const DIGEST_SIZE: usize = 48;
     let digest_offset = rom_size - DIGEST_SIZE;
@@ -64,7 +64,7 @@ fn append_rom_digest(binary: &PathBuf, rom_size: usize) -> Result<()> {
     Ok(())
 }
 
-fn rom_size_for_platform(platform: &str) -> usize {
+pub fn rom_size_for_platform(platform: &str) -> usize {
     match platform {
         "fpga" => mcu_config_fpga::FPGA_MEMORY_MAP.rom_size as usize,
         _ => mcu_config_emulator::EMULATOR_MEMORY_MAP.rom_size as usize,

--- a/builder/src/runtime.rs
+++ b/builder/src/runtime.rs
@@ -32,7 +32,8 @@ pub fn runtime_build_with_apps(args: &CaliptraBuildArgs) -> Result<PathBuf> {
         target_dir,
         ..Default::default()
     };
-    let runtime_bin = common.release_dir()?.join(&output_name);
+    let release_dir = common.release_dir()?;
+    let runtime_bin = release_dir.join(&output_name);
 
     let runtime_features = features.filter(|s| !s.is_empty()).map(|f| f.to_string());
     let bundle_cmd = BundleCommands::Bundle {
@@ -48,6 +49,16 @@ pub fn runtime_build_with_apps(args: &CaliptraBuildArgs) -> Result<PathBuf> {
     };
 
     mcu_firmware_bundler::execute(bundle_cmd)?;
+
+    // The bundle step rebuilds the ROM via objcopy, which strips the SHA-384
+    // digest appended by rom_build(). Re-apply the digest so the ROM binary
+    // stays valid regardless of build order.
+    let rom_binary = release_dir.join(format!("mcu-rom-{platform_str}.bin"));
+    if rom_binary.exists() {
+        let rom_size = crate::rom::rom_size_for_platform(platform_str);
+        crate::rom::append_rom_digest(&rom_binary, rom_size)?;
+    }
+
     Ok(runtime_bin)
 }
 

--- a/runtime/bare-metal/Cargo.toml
+++ b/runtime/bare-metal/Cargo.toml
@@ -12,9 +12,3 @@ romtime.workspace = true
 
 [target.'cfg(target_arch = "riscv32")'.dependencies]
 rv32i.workspace = true
-
-[profile.release]
-panic = "abort"
-lto = true
-opt-level = "z"
-codegen-units = 1

--- a/xtask/src/rom.rs
+++ b/xtask/src/rom.rs
@@ -1,11 +1,30 @@
 // Licensed under the Apache-2.0 license
 
 use anyhow::Result;
-use mcu_builder::PROJECT_ROOT;
+use mcu_builder::{CaliptraBuilder, PROJECT_ROOT};
 use std::process::Command;
 
 pub(crate) fn rom_run(trace: bool) -> Result<()> {
     let rom_binary = mcu_builder::rom_build(&mcu_builder::CaliptraBuildArgs::default())?;
+
+    // Use a minimal infinite-loop binary as the MCU firmware instead of
+    // building the full runtime — this command is for testing the ROM only.
+    let firmware_dir = PROJECT_ROOT.join("target");
+    std::fs::create_dir_all(&firmware_dir)?;
+    let firmware_path = firmware_dir.join("rom-stub-firmware.bin");
+    // RISC-V JAL x0, 0 — jump-to-self infinite loop
+    std::fs::write(&firmware_path, [0x6fu8, 0x00, 0x00, 0x00])?;
+
+    let mut caliptra_builder = CaliptraBuilder::new(&mcu_builder::CaliptraBuildArgs {
+        mcu_firmware: Some(firmware_path.clone()),
+        ..Default::default()
+    });
+
+    let caliptra_rom = caliptra_builder.get_caliptra_rom()?;
+    let caliptra_firmware = caliptra_builder.get_caliptra_fw()?;
+    let soc_manifest = caliptra_builder.get_soc_manifest(None)?;
+    let vendor_pk_hash = caliptra_builder.get_vendor_pk_hash()?;
+
     let mut cargo_run_args = vec![
         "run",
         "-p",
@@ -15,7 +34,85 @@ pub(crate) fn rom_run(trace: bool) -> Result<()> {
         "--",
         "--rom",
         rom_binary.to_str().unwrap(),
+        "--firmware",
+        firmware_path.to_str().unwrap(),
+        "--caliptra-rom",
+        caliptra_rom.to_str().unwrap(),
+        "--caliptra-firmware",
+        caliptra_firmware.to_str().unwrap(),
+        "--soc-manifest",
+        soc_manifest.to_str().unwrap(),
+        "--vendor-pk-hash",
+        vendor_pk_hash,
     ];
+
+    // Map the memory layout to the emulator
+    let rom_offset = format!(
+        "0x{:x}",
+        mcu_config_emulator::EMULATOR_MEMORY_MAP.rom_offset
+    );
+    cargo_run_args.extend(["--rom-offset", &rom_offset]);
+    let rom_size = format!("0x{:x}", mcu_config_emulator::EMULATOR_MEMORY_MAP.rom_size);
+    cargo_run_args.extend(["--rom-size", &rom_size]);
+    let dccm_offset = format!(
+        "0x{:x}",
+        mcu_config_emulator::EMULATOR_MEMORY_MAP.dccm_offset
+    );
+    cargo_run_args.extend(["--dccm-offset", &dccm_offset]);
+    let dccm_size = format!("0x{:x}", mcu_config_emulator::EMULATOR_MEMORY_MAP.dccm_size);
+    cargo_run_args.extend(["--dccm-size", &dccm_size]);
+    let sram_offset = format!(
+        "0x{:x}",
+        mcu_config_emulator::EMULATOR_MEMORY_MAP.sram_offset
+    );
+    cargo_run_args.extend(["--sram-offset", &sram_offset]);
+    let sram_size = format!("0x{:x}", mcu_config_emulator::EMULATOR_MEMORY_MAP.sram_size);
+    cargo_run_args.extend(["--sram-size", &sram_size]);
+    let pic_offset = format!(
+        "0x{:x}",
+        mcu_config_emulator::EMULATOR_MEMORY_MAP.pic_offset
+    );
+    cargo_run_args.extend(["--pic-offset", &pic_offset]);
+    let i3c_offset = format!(
+        "0x{:x}",
+        mcu_config_emulator::EMULATOR_MEMORY_MAP.i3c_offset
+    );
+    cargo_run_args.extend(["--i3c-offset", &i3c_offset]);
+    let i3c_size = format!("0x{:x}", mcu_config_emulator::EMULATOR_MEMORY_MAP.i3c_size);
+    cargo_run_args.extend(["--i3c-size", &i3c_size]);
+    let mci_offset = format!(
+        "0x{:x}",
+        mcu_config_emulator::EMULATOR_MEMORY_MAP.mci_offset
+    );
+    cargo_run_args.extend(["--mci-offset", &mci_offset]);
+    let mci_size = format!("0x{:x}", mcu_config_emulator::EMULATOR_MEMORY_MAP.mci_size);
+    cargo_run_args.extend(["--mci-size", &mci_size]);
+    let mbox_offset = format!(
+        "0x{:x}",
+        mcu_config_emulator::EMULATOR_MEMORY_MAP.mbox_offset
+    );
+    cargo_run_args.extend(["--mbox-offset", &mbox_offset]);
+    let mbox_size = format!("0x{:x}", mcu_config_emulator::EMULATOR_MEMORY_MAP.mbox_size);
+    cargo_run_args.extend(["--mbox-size", &mbox_size]);
+    let soc_offset = format!(
+        "0x{:x}",
+        mcu_config_emulator::EMULATOR_MEMORY_MAP.soc_offset
+    );
+    cargo_run_args.extend(["--soc-offset", &soc_offset]);
+    let soc_size = format!("0x{:x}", mcu_config_emulator::EMULATOR_MEMORY_MAP.soc_size);
+    cargo_run_args.extend(["--soc-size", &soc_size]);
+    let otp_offset = format!(
+        "0x{:x}",
+        mcu_config_emulator::EMULATOR_MEMORY_MAP.otp_offset
+    );
+    cargo_run_args.extend(["--otp-offset", &otp_offset]);
+    let otp_size = format!("0x{:x}", mcu_config_emulator::EMULATOR_MEMORY_MAP.otp_size);
+    cargo_run_args.extend(["--otp-size", &otp_size]);
+    let lc_offset = format!("0x{:x}", mcu_config_emulator::EMULATOR_MEMORY_MAP.lc_offset);
+    cargo_run_args.extend(["--lc-offset", &lc_offset]);
+    let lc_size = format!("0x{:x}", mcu_config_emulator::EMULATOR_MEMORY_MAP.lc_size);
+    cargo_run_args.extend(["--lc-size", &lc_size]);
+
     if trace {
         cargo_run_args.extend(["-t", "-l", PROJECT_ROOT.to_str().unwrap()]);
     }


### PR DESCRIPTION
`cargo xtask rom` and `cargo xtask runtime` were no longer working after the recent ROM digest fixes. (`cargo xtask rom` had been failing for a while due to missing emulator arguments).

Also fixes a build warning: 'warning: profiles for the non root package will be ignored, specify profiles at the workspace root'