### PR TITLE
Add MCTP VDM transport and client for caliptra-util-host

### DIFF
--- a/caliptra-util-host/Cargo.toml
+++ b/caliptra-util-host/Cargo.toml
@@ -12,7 +12,9 @@ members = [
     "xtask",
     "apps/mailbox/config",
     "apps/mailbox/client",
-    "apps/mailbox/server"
+    "apps/mailbox/server",
+    "apps/mctp-vdm/config",
+    "apps/mctp-vdm/client"
 ]
 
 [workspace.package]
@@ -31,6 +33,8 @@ caliptra-util-host-cbinding = { path = "cbinding" }
 caliptra-util-host-mailbox-test-config = { path = "apps/mailbox/config" }
 caliptra-mailbox-client = { path = "apps/mailbox/client" }
 caliptra-mailbox-server = { path = "apps/mailbox/server" }
+caliptra-util-host-mctp-vdm-test-config = { path = "apps/mctp-vdm/config" }
+caliptra-mctp-vdm-client = { path = "apps/mctp-vdm/client" }
 
 # External dependencies
 anyhow = "1.0.97"
@@ -46,6 +50,8 @@ clap = { version = "4.5.23", features = [
     "wrap_help",
 ] }
 hmac = "0.12"
+mctp-vdm-common = { path = "../common/mctp-vdm" }
+mcu-testing-common = { path = "../common/testing" }
 serde = { version = "1.0.209", features = ["alloc", "derive", "serde_derive"] }
 serde_json = { version = "1.0.127", features = ["alloc"] }
 sha2 = "0.10"

--- a/caliptra-util-host/apps/mctp-vdm/client/Cargo.toml
+++ b/caliptra-util-host/apps/mctp-vdm/client/Cargo.toml
@@ -1,0 +1,25 @@
+# Licensed under the Apache-2.0 license
+
+[package]
+name = "caliptra-mctp-vdm-client"
+version.workspace = true
+edition.workspace = true
+description = "Caliptra MCTP VDM Client Library with Validation Support"
+
+[lib]
+name = "caliptra_mctp_vdm_client"
+path = "src/lib.rs"
+
+[[bin]]
+name = "mctp-vdm-validator"
+path = "src/main.rs"
+
+[dependencies]
+anyhow.workspace = true
+clap.workspace = true
+caliptra-util-host-mctp-vdm-test-config.workspace = true
+caliptra-util-host-transport.workspace = true
+caliptra-util-host-command-types.workspace = true
+mcu-testing-common.workspace = true
+mctp-vdm-common.workspace = true
+zerocopy.workspace = true

--- a/caliptra-util-host/apps/mctp-vdm/client/src/lib.rs
+++ b/caliptra-util-host/apps/mctp-vdm/client/src/lib.rs
@@ -1,0 +1,113 @@
+// Licensed under the Apache-2.0 license
+
+//! Caliptra MCTP VDM Client Library
+//!
+//! Provides a high-level `VdmClient` for issuing MCTP VDM commands through the
+//! `MctpVdmTransport` layer. The underlying I3C/MCTP transport is provided by
+//! `MctpVdmSocketDriver`, which wraps the existing `MctpVdmSocket` from
+//! `mcu-testing-common`.
+
+mod network_driver;
+pub mod validator;
+
+pub use network_driver::MctpVdmSocketDriver;
+pub use validator::{ValidationResult, Validator};
+
+// Re-export shared config.
+pub use caliptra_util_host_mctp_vdm_test_config::*;
+
+// Re-export the I3C address type so callers don't need a direct dep.
+pub use mcu_testing_common::i3c::DynamicI3cAddress;
+
+use anyhow::Result;
+use caliptra_util_host_command_types::*;
+use caliptra_util_host_transport::{MctpVdmTransport, Transport};
+
+/// High-level MCTP VDM client.
+pub struct VdmClient<'a> {
+    transport: MctpVdmTransport<'a>,
+}
+
+impl<'a> VdmClient<'a> {
+    /// Create a new `VdmClient` over any `MctpVdmDriver` implementation.
+    pub fn new(driver: &'a mut dyn caliptra_util_host_transport::MctpVdmDriver) -> Self {
+        let transport = MctpVdmTransport::new(driver);
+        Self { transport }
+    }
+
+    /// Create a `VdmClient` backed by the common/testing MCTP VDM socket driver.
+    pub fn with_socket_driver(driver: &'a mut MctpVdmSocketDriver) -> Self {
+        let transport =
+            MctpVdmTransport::new(driver as &mut dyn caliptra_util_host_transport::MctpVdmDriver);
+        Self { transport }
+    }
+
+    /// Connect the underlying transport.
+    pub fn connect(&mut self) -> Result<()> {
+        self.transport
+            .connect()
+            .map_err(|e| anyhow::anyhow!("VDM connect failed: {e:?}"))
+    }
+
+    /// Disconnect the underlying transport.
+    pub fn disconnect(&mut self) -> Result<()> {
+        self.transport
+            .disconnect()
+            .map_err(|e| anyhow::anyhow!("VDM disconnect failed: {e:?}"))
+    }
+
+    // ------------------------------------------------------------------
+    // Device Information commands
+    // ------------------------------------------------------------------
+
+    /// Retrieve the device ID (VDM command 0x03).
+    pub fn get_device_id(&mut self) -> Result<GetDeviceIdResponse> {
+        let req = GetDeviceIdRequest {};
+        self.send_command(CaliptraCommandId::GetDeviceId as u32, &req)
+    }
+
+    /// Retrieve device capabilities (VDM command 0x02).
+    pub fn get_device_capabilities(&mut self) -> Result<GetDeviceCapabilitiesResponse> {
+        let req = GetDeviceCapabilitiesRequest {};
+        self.send_command(CaliptraCommandId::GetDeviceCapabilities as u32, &req)
+    }
+
+    /// Retrieve the firmware version for the given index (VDM command 0x01).
+    pub fn get_firmware_version(&mut self, fw_id: u32) -> Result<GetFirmwareVersionResponse> {
+        let req = GetFirmwareVersionRequest { index: fw_id };
+        self.send_command(CaliptraCommandId::GetFirmwareVersion as u32, &req)
+    }
+
+    /// Retrieve device info for the given index (VDM command 0x04).
+    pub fn get_device_info(&mut self) -> Result<GetDeviceInfoResponse> {
+        let req = GetDeviceInfoRequest { info_type: 0 };
+        self.send_command(CaliptraCommandId::GetDeviceInfo as u32, &req)
+    }
+
+    // ------------------------------------------------------------------
+    // Generic send helper
+    // ------------------------------------------------------------------
+
+    fn send_command<Req, Resp>(&mut self, command_id: u32, req: &Req) -> Result<Resp>
+    where
+        Req: zerocopy::IntoBytes + zerocopy::Immutable,
+        Resp: zerocopy::FromBytes,
+    {
+        let payload = req.as_bytes();
+        self.transport
+            .send(command_id, payload)
+            .map_err(|e| anyhow::anyhow!("VDM send failed: {e:?}"))?;
+
+        let mut buf = vec![0u8; 2048];
+        let n = self
+            .transport
+            .receive(&mut buf)
+            .map_err(|e| anyhow::anyhow!("VDM receive failed: {e:?}"))?;
+        if n == 0 {
+            anyhow::bail!("Empty response from device");
+        }
+
+        Resp::read_from_bytes(&buf[..n])
+            .map_err(|_| anyhow::anyhow!("Failed to parse response ({n} bytes)"))
+    }
+}

--- a/caliptra-util-host/apps/mctp-vdm/client/src/main.rs
+++ b/caliptra-util-host/apps/mctp-vdm/client/src/main.rs
@@ -1,0 +1,84 @@
+// Licensed under the Apache-2.0 license
+
+//! MCTP VDM Client Validator Binary
+//!
+//! Command-line tool that validates VDM communication with a Caliptra device
+//! via the I3C controller socket exposed by the emulator.
+
+use anyhow::Result;
+use caliptra_mctp_vdm_client::{TestConfig, Validator};
+use clap::Parser;
+use std::path::PathBuf;
+
+#[derive(Parser)]
+#[command(name = "mctp-vdm-validator")]
+#[command(about = "Validates MCTP VDM communication with a Caliptra device")]
+#[command(version)]
+struct Args {
+    /// I3C controller socket port
+    #[arg(short = 'p', long, default_value = "63333")]
+    port: u16,
+
+    /// I3C dynamic target address (hex)
+    #[arg(short = 'a', long, default_value = "8")]
+    target_addr: u8,
+
+    /// Enable verbose output
+    #[arg(short, long)]
+    verbose: bool,
+
+    /// Path to TOML configuration file
+    #[arg(short, long)]
+    config: Option<PathBuf>,
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+
+    println!("Caliptra MCTP VDM Client Validator");
+    println!("==================================\n");
+
+    let validator = if let Some(config_path) = args.config {
+        println!("Loading configuration from: {:?}", config_path);
+        let config = TestConfig::from_file(&config_path)?;
+        Validator::new(&config)?
+    } else {
+        match TestConfig::load_default() {
+            Ok(config) => {
+                println!("Using default configuration file");
+                Validator::new(&config)?
+            }
+            Err(_) => {
+                println!("No configuration file found, using command line arguments");
+                println!(
+                    "Connecting to port {} target 0x{:02X}",
+                    args.port, args.target_addr
+                );
+                let config = TestConfig {
+                    network: caliptra_mctp_vdm_client::NetworkConfig {
+                        default_server_address: format!("127.0.0.1:{}", args.port),
+                        target_i3c_address: args.target_addr,
+                    },
+                    ..TestConfig::default()
+                };
+                Validator::new(&config)?
+            }
+        }
+    }
+    .set_verbose(args.verbose);
+
+    if args.verbose {
+        println!("Verbose mode: enabled\n");
+    }
+
+    let results = validator.start()?;
+    let success = results.iter().all(|r| r.passed);
+
+    if success {
+        println!("\n✓ All validation tests passed!");
+        std::process::exit(0);
+    } else {
+        println!("\n✗ Some validation tests failed!");
+        std::process::exit(1);
+    }
+}

--- a/caliptra-util-host/apps/mctp-vdm/client/src/network_driver.rs
+++ b/caliptra-util-host/apps/mctp-vdm/client/src/network_driver.rs
@@ -1,0 +1,79 @@
+// Licensed under the Apache-2.0 license
+
+//! Adapter that wraps `MctpVdmSocket` from `mcu-testing-common` and implements
+//! the `MctpVdmDriver` trait from `caliptra-util-host-transport`.
+//!
+//! `MctpVdmTransport` (from common/testing) connects over TCP to the emulator's
+//! I3C controller socket and performs real MCTP framing. This adapter simply
+//! bridges that existing transport into the caliptra-util-host command framework.
+
+use caliptra_util_host_transport::{MctpVdmDriver, MctpVdmError};
+use mcu_testing_common::i3c::DynamicI3cAddress;
+use mcu_testing_common::mctp_vdm_transport::{MctpVdmSocket, MctpVdmTransport, VdmTransportError};
+
+const DRIVER_BUF_SIZE: usize = 4 * 1024;
+
+/// Adapter that owns an `MctpVdmSocket` and implements `MctpVdmDriver`.
+pub struct MctpVdmSocketDriver {
+    /// Factory used to (re-)create sockets.
+    transport: MctpVdmTransport,
+    /// Active socket (created on `connect()`).
+    socket: Option<MctpVdmSocket>,
+    /// Internal buffer to hold the last response so we can return `&[u8]`.
+    buffer: Vec<u8>,
+}
+
+impl MctpVdmSocketDriver {
+    /// Create a new driver that will connect to the given I3C socket port and
+    /// target address.
+    pub fn new(port: u16, target_addr: DynamicI3cAddress) -> Self {
+        Self {
+            transport: MctpVdmTransport::new(port, target_addr),
+            socket: None,
+            buffer: vec![0u8; DRIVER_BUF_SIZE],
+        }
+    }
+}
+
+impl MctpVdmDriver for MctpVdmSocketDriver {
+    fn send_request(&mut self, vdm_request: &[u8]) -> Result<&[u8], MctpVdmError> {
+        let socket = self.socket.as_mut().ok_or(MctpVdmError::NotReady)?;
+
+        let response = socket
+            .send_request(vdm_request)
+            .map_err(vdm_transport_err_to_driver_err)?;
+
+        let copy_len = response.len().min(self.buffer.len());
+        self.buffer[..copy_len].copy_from_slice(&response[..copy_len]);
+        Ok(&self.buffer[..copy_len])
+    }
+
+    fn is_ready(&self) -> bool {
+        self.socket.is_some()
+    }
+
+    fn connect(&mut self) -> Result<(), MctpVdmError> {
+        let socket = self
+            .transport
+            .create_socket()
+            .map_err(vdm_transport_err_to_driver_err)?;
+        self.socket = Some(socket);
+        Ok(())
+    }
+
+    fn disconnect(&mut self) -> Result<(), MctpVdmError> {
+        self.socket = None;
+        Ok(())
+    }
+}
+
+fn vdm_transport_err_to_driver_err(e: VdmTransportError) -> MctpVdmError {
+    match e {
+        VdmTransportError::Disconnected => MctpVdmError::NotReady,
+        VdmTransportError::Underflow => MctpVdmError::CommunicationError,
+        VdmTransportError::Timeout => MctpVdmError::Timeout,
+        VdmTransportError::InvalidResponse => MctpVdmError::CommunicationError,
+        VdmTransportError::CodecError => MctpVdmError::CodecError,
+        VdmTransportError::CommandFailed(_) => MctpVdmError::CommunicationError,
+    }
+}

--- a/caliptra-util-host/apps/mctp-vdm/client/src/validator.rs
+++ b/caliptra-util-host/apps/mctp-vdm/client/src/validator.rs
@@ -1,0 +1,189 @@
+// Licensed under the Apache-2.0 license
+
+//! Validator for MCTP VDM client — runs the 4 supported device-info commands
+//! against a VDM server and reports pass/fail.
+
+use crate::{DynamicI3cAddress, MctpVdmSocketDriver, TestConfig, VdmClient};
+use anyhow::Result;
+use std::net::SocketAddr;
+
+/// Single validation result.
+#[derive(Debug, Clone)]
+pub struct ValidationResult {
+    pub test_name: String,
+    pub passed: bool,
+    pub error_message: Option<String>,
+}
+
+/// MCTP VDM Validator.
+pub struct Validator {
+    port: u16,
+    target_addr: DynamicI3cAddress,
+    verbose: bool,
+    config: Option<TestConfig>,
+}
+
+impl Validator {
+    /// Create a validator from a test configuration.
+    pub fn new(config: &TestConfig) -> Result<Self> {
+        let addr: SocketAddr = config.network.default_server_address.parse()?;
+        Ok(Self {
+            port: addr.port(),
+            target_addr: DynamicI3cAddress::from(config.network.target_i3c_address),
+            verbose: config.validation.verbose_output,
+            config: Some(config.clone()),
+        })
+    }
+
+    /// Toggle verbose output.
+    pub fn set_verbose(mut self, verbose: bool) -> Self {
+        self.verbose = verbose;
+        self
+    }
+
+    /// Run all validation tests and return results.
+    pub fn start(&self) -> Result<Vec<ValidationResult>> {
+        let mut driver = MctpVdmSocketDriver::new(self.port, self.target_addr);
+        let mut client = VdmClient::new(&mut driver);
+        client.connect()?;
+
+        let results = vec![
+            self.validate_get_device_id(&mut client),
+            self.validate_get_device_capabilities(&mut client),
+            self.validate_get_firmware_version(&mut client),
+            self.validate_get_device_info(&mut client),
+        ];
+
+        client.disconnect().ok();
+
+        self.print_summary(&results);
+        Ok(results)
+    }
+
+    // ------------------------------------------------------------------
+    // Individual validators
+    // ------------------------------------------------------------------
+
+    fn validate_get_device_id(&self, client: &mut VdmClient) -> ValidationResult {
+        let test_name = "GetDeviceId".to_string();
+        match client.get_device_id() {
+            Ok(resp) => {
+                if self.verbose {
+                    println!(
+                        "  DeviceId: vendor=0x{:04X} device=0x{:04X} sub_vendor=0x{:04X} sub=0x{:04X}",
+                        resp.vendor_id, resp.device_id,
+                        resp.subsystem_vendor_id, resp.subsystem_id,
+                    );
+                }
+                // If config has expected values, compare them.
+                if let Some(cfg) = &self.config {
+                    if resp.vendor_id != cfg.device.vendor_id
+                        || resp.device_id != cfg.device.device_id
+                    {
+                        return ValidationResult {
+                            test_name,
+                            passed: false,
+                            error_message: Some("Device ID mismatch".into()),
+                        };
+                    }
+                }
+                ValidationResult {
+                    test_name,
+                    passed: true,
+                    error_message: None,
+                }
+            }
+            Err(e) => ValidationResult {
+                test_name,
+                passed: false,
+                error_message: Some(format!("{e:#}")),
+            },
+        }
+    }
+
+    fn validate_get_device_capabilities(&self, client: &mut VdmClient) -> ValidationResult {
+        let test_name = "GetDeviceCapabilities".to_string();
+        match client.get_device_capabilities() {
+            Ok(resp) => {
+                if self.verbose {
+                    println!(
+                        "  Capabilities: caps=0x{:08X} lifecycle={}",
+                        resp.capabilities, resp.device_lifecycle,
+                    );
+                }
+                ValidationResult {
+                    test_name,
+                    passed: true,
+                    error_message: None,
+                }
+            }
+            Err(e) => ValidationResult {
+                test_name,
+                passed: false,
+                error_message: Some(format!("{e:#}")),
+            },
+        }
+    }
+
+    fn validate_get_firmware_version(&self, client: &mut VdmClient) -> ValidationResult {
+        let test_name = "GetFirmwareVersion".to_string();
+        match client.get_firmware_version(0) {
+            Ok(resp) => {
+                if self.verbose {
+                    println!(
+                        "  FirmwareVersion: {}.{}.{}.{}",
+                        resp.version[0], resp.version[1], resp.version[2], resp.version[3],
+                    );
+                }
+                ValidationResult {
+                    test_name,
+                    passed: true,
+                    error_message: None,
+                }
+            }
+            Err(e) => ValidationResult {
+                test_name,
+                passed: false,
+                error_message: Some(format!("{e:#}")),
+            },
+        }
+    }
+
+    fn validate_get_device_info(&self, client: &mut VdmClient) -> ValidationResult {
+        let test_name = "GetDeviceInfo".to_string();
+        match client.get_device_info() {
+            Ok(resp) => {
+                if self.verbose {
+                    println!("  DeviceInfo: {} bytes", resp.info_length);
+                }
+                ValidationResult {
+                    test_name,
+                    passed: true,
+                    error_message: None,
+                }
+            }
+            Err(e) => ValidationResult {
+                test_name,
+                passed: false,
+                error_message: Some(format!("{e:#}")),
+            },
+        }
+    }
+
+    // ------------------------------------------------------------------
+
+    fn print_summary(&self, results: &[ValidationResult]) {
+        println!("\nValidation Summary");
+        println!("==================");
+        for r in results {
+            let status = if r.passed { "PASS" } else { "FAIL" };
+            print!("  [{status}] {}", r.test_name);
+            if let Some(msg) = &r.error_message {
+                print!(" — {msg}");
+            }
+            println!();
+        }
+        let passed = results.iter().filter(|r| r.passed).count();
+        println!("\n  {passed}/{} tests passed", results.len());
+    }
+}

--- a/caliptra-util-host/apps/mctp-vdm/config/Cargo.toml
+++ b/caliptra-util-host/apps/mctp-vdm/config/Cargo.toml
@@ -1,0 +1,12 @@
+# Licensed under the Apache-2.0 license
+
+[package]
+name = "caliptra-util-host-mctp-vdm-test-config"
+version.workspace = true
+edition.workspace = true
+description = "Shared configuration for MCTP VDM test client and server"
+
+[dependencies]
+serde.workspace = true
+toml.workspace = true
+anyhow.workspace = true

--- a/caliptra-util-host/apps/mctp-vdm/config/src/lib.rs
+++ b/caliptra-util-host/apps/mctp-vdm/config/src/lib.rs
@@ -1,0 +1,185 @@
+// Licensed under the Apache-2.0 license
+
+//! Shared configuration for MCTP VDM test client and server.
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+/// Top-level test configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TestConfig {
+    pub device: DeviceConfig,
+    pub network: NetworkConfig,
+    pub validation: ValidationConfig,
+    pub server: ServerConfig,
+    #[serde(default)]
+    pub device_capabilities: Option<DeviceCapabilitiesConfig>,
+    #[serde(default)]
+    pub firmware_version: Option<FirmwareVersionConfig>,
+    #[serde(default)]
+    pub device_info: Option<DeviceInfoConfig>,
+}
+
+/// Device identification values returned by the emulated device.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeviceConfig {
+    pub device_id: u16,
+    pub vendor_id: u16,
+    pub subsystem_vendor_id: u16,
+    pub subsystem_id: u16,
+}
+
+/// Network configuration (TCP socket to I3C controller).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NetworkConfig {
+    pub default_server_address: String,
+    /// I3C dynamic address of the target device (default: 0x08).
+    #[serde(default = "default_target_i3c_address")]
+    pub target_i3c_address: u8,
+}
+
+fn default_target_i3c_address() -> u8 {
+    0x08
+}
+
+/// Validation test tuning.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ValidationConfig {
+    pub timeout_seconds: u64,
+    pub retry_count: u32,
+    pub verbose_output: bool,
+}
+
+/// Server configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ServerConfig {
+    pub bind_address: String,
+    pub max_connections: u32,
+}
+
+/// Expected device capabilities.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeviceCapabilitiesConfig {
+    pub capabilities: u32,
+    pub max_cert_size: u32,
+    pub max_csr_size: u32,
+    pub device_lifecycle: u32,
+    pub fips_status: u32,
+}
+
+/// Expected firmware version information.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FirmwareVersionConfig {
+    pub rom_version: String,
+    pub runtime_version: String,
+    pub fips_status: u32,
+    pub rom_firmware_id: u32,
+    pub runtime_firmware_id: u32,
+}
+
+/// Expected device information.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeviceInfoConfig {
+    pub info_index: u32,
+    pub expected_info: String,
+    pub min_info_length: u32,
+    pub max_info_length: u32,
+    pub fips_status: u32,
+}
+
+impl TestConfig {
+    /// Load configuration from a TOML file.
+    pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Self> {
+        let contents = std::fs::read_to_string(path.as_ref())
+            .with_context(|| format!("Failed to read config file: {:?}", path.as_ref()))?;
+        let config: TestConfig =
+            toml::from_str(&contents).with_context(|| "Failed to parse TOML configuration")?;
+        Ok(config)
+    }
+
+    /// Search standard locations for a `test-config.toml`.
+    pub fn load_default() -> Result<Self> {
+        let mut current_dir = std::env::current_dir()?;
+        loop {
+            for candidate in &[
+                current_dir.join("test-config.toml"),
+                current_dir
+                    .join("apps")
+                    .join("mctp-vdm")
+                    .join("test-config.toml"),
+                current_dir
+                    .join("caliptra-util-host")
+                    .join("apps")
+                    .join("mctp-vdm")
+                    .join("test-config.toml"),
+            ] {
+                if candidate.exists() {
+                    return Self::from_file(candidate);
+                }
+            }
+            if let Some(parent) = current_dir.parent() {
+                current_dir = parent.to_path_buf();
+            } else {
+                break;
+            }
+        }
+        Ok(Self::default())
+    }
+
+    /// Save configuration to a TOML file.
+    pub fn save_to_file<P: AsRef<Path>>(&self, path: P) -> Result<()> {
+        let contents = toml::to_string_pretty(self)
+            .with_context(|| "Failed to serialize configuration to TOML")?;
+        std::fs::write(path.as_ref(), contents)
+            .with_context(|| format!("Failed to write config file: {:?}", path.as_ref()))?;
+        Ok(())
+    }
+}
+
+impl Default for TestConfig {
+    fn default() -> Self {
+        Self {
+            device: DeviceConfig {
+                device_id: 0x0010,
+                vendor_id: 0x1414,
+                subsystem_vendor_id: 0x0001,
+                subsystem_id: 0x0002,
+            },
+            network: NetworkConfig {
+                default_server_address: "127.0.0.1:63333".to_string(),
+                target_i3c_address: 0x08,
+            },
+            validation: ValidationConfig {
+                timeout_seconds: 30,
+                retry_count: 3,
+                verbose_output: false,
+            },
+            server: ServerConfig {
+                bind_address: "127.0.0.1:63333".to_string(),
+                max_connections: 10,
+            },
+            device_capabilities: Some(DeviceCapabilitiesConfig {
+                capabilities: 0x000001F3,
+                max_cert_size: 4096,
+                max_csr_size: 2048,
+                device_lifecycle: 1,
+                fips_status: 0x00000001,
+            }),
+            firmware_version: Some(FirmwareVersionConfig {
+                rom_version: "1.0.0".to_string(),
+                runtime_version: "1.0.0".to_string(),
+                fips_status: 0x00000001,
+                rom_firmware_id: 0,
+                runtime_firmware_id: 1,
+            }),
+            device_info: Some(DeviceInfoConfig {
+                info_index: 0,
+                expected_info: "Caliptra VDM Test Device v1.0".to_string(),
+                min_info_length: 16,
+                max_info_length: 64,
+                fips_status: 0,
+            }),
+        }
+    }
+}

--- a/caliptra-util-host/apps/mctp-vdm/test-config.toml
+++ b/caliptra-util-host/apps/mctp-vdm/test-config.toml
@@ -1,0 +1,43 @@
+# Licensed under the Apache-2.0 license
+
+# MCTP VDM Test Configuration
+
+[device]
+device_id = 0x0010
+vendor_id = 0x1414
+subsystem_vendor_id = 0x0001
+subsystem_id = 0x0002
+
+[network]
+default_server_address = "127.0.0.1:63333"
+target_i3c_address = 0x08
+
+[validation]
+timeout_seconds = 30
+retry_count = 3
+verbose_output = false
+
+[server]
+bind_address = "127.0.0.1:63333"
+max_connections = 10
+
+[device_capabilities]
+capabilities = 0x000001F3
+max_cert_size = 4096
+max_csr_size = 2048
+device_lifecycle = 1
+fips_status = 0x00000001
+
+[firmware_version]
+rom_version = "1.0.0"
+runtime_version = "1.0.0"
+fips_status = 0x00000001
+rom_firmware_id = 0
+runtime_firmware_id = 1
+
+[device_info]
+info_index = 0
+expected_info = "Caliptra VDM Test Device v1.0"
+min_info_length = 16
+max_info_length = 64
+fips_status = 0

--- a/caliptra-util-host/transport/Cargo.toml
+++ b/caliptra-util-host/transport/Cargo.toml
@@ -9,6 +9,7 @@ description = "Transport layer for Caliptra Utility Host Library"
 [dependencies]
 caliptra-util-host-osal.workspace = true
 caliptra-util-host-command-types.workspace = true
+mctp-vdm-common.workspace = true
 zerocopy.workspace = true
 
 [features]

--- a/caliptra-util-host/transport/src/lib.rs
+++ b/caliptra-util-host/transport/src/lib.rs
@@ -20,6 +20,9 @@ pub use error::{TransportError, TransportResult};
 // Re-export mailbox types specifically
 pub use transports::mailbox::{Mailbox, MailboxDriver, MailboxError};
 
+// Re-export MCTP VDM types
+pub use transports::mctp_vdm::{MctpVdmDriver, MctpVdmError, MctpVdmTransport};
+
 /// Transport configuration
 #[derive(Debug, Clone, Default)]
 pub struct TransportConfig {

--- a/caliptra-util-host/transport/src/transports/mctp_vdm/dispatch.rs
+++ b/caliptra-util-host/transport/src/transports/mctp_vdm/dispatch.rs
@@ -1,0 +1,29 @@
+// Licensed under the Apache-2.0 license
+
+//! Command dispatch for MCTP VDM transport
+//!
+//! Maps internal `CaliptraCommandId` values to the VDM command
+//! handler functions defined in the `encode` module.
+
+use super::encode;
+
+/// Type alias for VDM command handler functions.
+pub type VdmCommandHandlerFn = fn(
+    &[u8],
+    &mut dyn super::transport::MctpVdmDriver,
+    &mut [u8],
+) -> Result<usize, crate::TransportError>;
+
+/// Look up the VDM command handler for a given internal command ID.
+///
+/// Returns `Some(handler)` for supported commands, `None` otherwise.
+pub fn get_command_handler(command_id: u32) -> Option<VdmCommandHandlerFn> {
+    match command_id {
+        // Device Info Commands (matching CaliptraCommandId values)
+        1 => Some(encode::handle_firmware_version), // GetFirmwareVersion
+        2 => Some(encode::handle_device_capabilities), // GetDeviceCapabilities
+        3 => Some(encode::handle_device_id),        // GetDeviceId
+        4 => Some(encode::handle_device_info),      // GetDeviceInfo
+        _ => None,
+    }
+}

--- a/caliptra-util-host/transport/src/transports/mctp_vdm/encode.rs
+++ b/caliptra-util-host/transport/src/transports/mctp_vdm/encode.rs
@@ -1,0 +1,307 @@
+// Licensed under the Apache-2.0 license
+
+//! VDM command encoder/decoder
+//!
+//! This module provides encoding of internal `caliptra-util-host-command-types`
+//! requests into MCTP VDM wire-format packets (using `mctp-vdm-common` message
+//! types) and decoding of VDM responses back into internal response types.
+//!
+//! Currently supported commands:
+//! - FirmwareVersion  (0x01)
+//! - DeviceCapabilities (0x02)
+//! - DeviceId (0x03)
+//! - DeviceInfo (0x04)
+
+use super::transport::MctpVdmError;
+use crate::TransportError;
+use caliptra_util_host_command_types::*;
+use mctp_vdm_common::codec::VdmCodec;
+use mctp_vdm_common::message::{
+    DeviceCapabilitiesRequest, DeviceCapabilitiesResponse, DeviceIdRequest, DeviceIdResponse,
+    DeviceInfoRequest, DeviceInfoResponse, FirmwareVersionRequest, FirmwareVersionResponse,
+    MAX_FW_VERSION_LEN,
+};
+use mctp_vdm_common::protocol::{VdmCompletionCode, VdmMsgHeader, VDM_MSG_HEADER_LEN};
+
+/// Maximum buffer for encoding a VDM request.
+const MAX_VDM_REQ_BUF: usize = 128;
+
+/// Maximum buffer for a VDM response from the driver.
+const MAX_VDM_RESP_BUF: usize = 256;
+
+// ---------------------------------------------------------------------------
+// Helper: send a VDM request and get raw response bytes (copied into buf)
+// ---------------------------------------------------------------------------
+
+/// Encode a VDM message, send it via the driver, copy the response into `buf`,
+/// and return the number of response bytes.
+fn send_vdm<R: VdmCodec>(
+    request: &R,
+    driver: &mut dyn super::transport::MctpVdmDriver,
+    buf: &mut [u8; MAX_VDM_RESP_BUF],
+) -> Result<usize, TransportError> {
+    let mut req_buf = [0u8; MAX_VDM_REQ_BUF];
+    let req_len = request
+        .encode(&mut req_buf)
+        .map_err(|_| TransportError::InvalidMessage)?;
+
+    let resp = driver
+        .send_request(&req_buf[..req_len])
+        .map_err(TransportError::from)?;
+
+    let copy_len = resp.len().min(MAX_VDM_RESP_BUF);
+    buf[..copy_len].copy_from_slice(&resp[..copy_len]);
+    Ok(copy_len)
+}
+
+/// Validate the VDM response header: check it is a response and that the
+/// completion code is `Success`. Returns the completion code on error.
+fn validate_response_header(resp: &[u8]) -> Result<(), TransportError> {
+    if resp.len() < VDM_MSG_HEADER_LEN + 4 {
+        return Err(TransportError::InvalidMessage);
+    }
+    let hdr = VdmMsgHeader::decode(resp).map_err(|_| TransportError::InvalidMessage)?;
+    if !hdr.is_response() {
+        return Err(TransportError::InvalidMessage);
+    }
+    let cc_bytes: [u8; 4] = resp[VDM_MSG_HEADER_LEN..VDM_MSG_HEADER_LEN + 4]
+        .try_into()
+        .map_err(|_| TransportError::InvalidMessage)?;
+    let cc = u32::from_le_bytes(cc_bytes);
+    let code = VdmCompletionCode::try_from(cc).map_err(|_| TransportError::InvalidMessage)?;
+    if code != VdmCompletionCode::Success {
+        return Err(TransportError::from(MctpVdmError::DeviceError(cc)));
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// FirmwareVersion (command_id = 1 / CaliptraCommandId::GetFirmwareVersion)
+// ---------------------------------------------------------------------------
+
+pub fn handle_firmware_version(
+    payload: &[u8],
+    driver: &mut dyn super::transport::MctpVdmDriver,
+    response_buffer: &mut [u8],
+) -> Result<usize, TransportError> {
+    // Parse internal request (may be empty → default to index 0)
+    let area_index = if payload.len() >= core::mem::size_of::<GetFirmwareVersionRequest>() {
+        let req = GetFirmwareVersionRequest::from_bytes(payload)
+            .map_err(|_| TransportError::InvalidMessage)?;
+        req.index
+    } else {
+        0
+    };
+
+    // Build VDM request
+    let vdm_req = FirmwareVersionRequest::new(area_index);
+    let mut resp_buf = [0u8; MAX_VDM_RESP_BUF];
+    let resp_len = send_vdm(&vdm_req, driver, &mut resp_buf)?;
+    let resp_bytes = &resp_buf[..resp_len];
+    validate_response_header(resp_bytes)?;
+
+    // Decode VDM response
+    let vdm_resp =
+        FirmwareVersionResponse::decode(resp_bytes).map_err(|_| TransportError::InvalidMessage)?;
+
+    // Convert to internal response
+    let version_data = &vdm_resp.version;
+    let mut version = [0u32; 4];
+    let actual_len = version_data
+        .iter()
+        .position(|&b| b == 0)
+        .unwrap_or(MAX_FW_VERSION_LEN);
+    let version_str = core::str::from_utf8(&version_data[..actual_len])
+        .unwrap_or("")
+        .trim_end_matches('\0');
+    if let Some((version_part, _)) = version_str.split_once(' ') {
+        for (i, part) in version_part.split('.').take(4).enumerate() {
+            if let Ok(num) = part.parse::<u32>() {
+                version[i] = num;
+            }
+        }
+    } else {
+        for (i, part) in version_str.split('.').take(4).enumerate() {
+            if let Ok(num) = part.parse::<u32>() {
+                version[i] = num;
+            }
+        }
+    }
+
+    let mut commit_id = [0u8; 20];
+    if let Some((_, commit_part)) = version_str.split_once(' ') {
+        let cb = commit_part.as_bytes();
+        let len = cb.len().min(20);
+        commit_id[..len].copy_from_slice(&cb[..len]);
+    }
+
+    let internal_resp = GetFirmwareVersionResponse {
+        common: CommonResponse {
+            fips_status: vdm_resp.completion_code,
+        },
+        version,
+        commit_id,
+    };
+
+    let resp_bytes = internal_resp.as_bytes();
+    let copy_len = resp_bytes.len().min(response_buffer.len());
+    response_buffer[..copy_len].copy_from_slice(&resp_bytes[..copy_len]);
+    Ok(copy_len)
+}
+
+// ---------------------------------------------------------------------------
+// DeviceCapabilities (command_id = 2 / CaliptraCommandId::GetDeviceCapabilities)
+// ---------------------------------------------------------------------------
+
+pub fn handle_device_capabilities(
+    _payload: &[u8],
+    driver: &mut dyn super::transport::MctpVdmDriver,
+    response_buffer: &mut [u8],
+) -> Result<usize, TransportError> {
+    let vdm_req = DeviceCapabilitiesRequest::new();
+    let mut resp_buf = [0u8; MAX_VDM_RESP_BUF];
+    let resp_len = send_vdm(&vdm_req, driver, &mut resp_buf)?;
+    let resp_bytes = &resp_buf[..resp_len];
+    validate_response_header(resp_bytes)?;
+
+    let vdm_resp = DeviceCapabilitiesResponse::decode(resp_bytes)
+        .map_err(|_| TransportError::InvalidMessage)?;
+
+    let caps = vdm_resp.caps;
+    let internal_resp = GetDeviceCapabilitiesResponse {
+        common: CommonResponse {
+            fips_status: vdm_resp.completion_code,
+        },
+        capabilities: u32::from_le_bytes([caps[0], caps[1], caps[2], caps[3]]),
+        max_cert_size: u32::from_le_bytes([caps[4], caps[5], caps[6], caps[7]]),
+        max_csr_size: u32::from_le_bytes([caps[8], caps[9], caps[10], caps[11]]),
+        device_lifecycle: u32::from_le_bytes([caps[12], caps[13], caps[14], caps[15]]),
+    };
+
+    let resp_bytes = internal_resp.as_bytes();
+    let copy_len = resp_bytes.len().min(response_buffer.len());
+    response_buffer[..copy_len].copy_from_slice(&resp_bytes[..copy_len]);
+    Ok(copy_len)
+}
+
+// ---------------------------------------------------------------------------
+// DeviceId (command_id = 3 / CaliptraCommandId::GetDeviceId)
+// ---------------------------------------------------------------------------
+
+pub fn handle_device_id(
+    _payload: &[u8],
+    driver: &mut dyn super::transport::MctpVdmDriver,
+    response_buffer: &mut [u8],
+) -> Result<usize, TransportError> {
+    let vdm_req = DeviceIdRequest::new();
+    let mut resp_buf = [0u8; MAX_VDM_RESP_BUF];
+    let resp_len = send_vdm(&vdm_req, driver, &mut resp_buf)?;
+    let resp_bytes = &resp_buf[..resp_len];
+    validate_response_header(resp_bytes)?;
+
+    let vdm_resp =
+        DeviceIdResponse::decode(resp_bytes).map_err(|_| TransportError::InvalidMessage)?;
+
+    let internal_resp = GetDeviceIdResponse {
+        vendor_id: vdm_resp.vendor_id,
+        device_id: vdm_resp.device_id,
+        subsystem_vendor_id: vdm_resp.subsystem_vendor_id,
+        subsystem_id: vdm_resp.subsystem_id,
+    };
+
+    let resp_bytes = internal_resp.as_bytes();
+    let copy_len = resp_bytes.len().min(response_buffer.len());
+    response_buffer[..copy_len].copy_from_slice(&resp_bytes[..copy_len]);
+    Ok(copy_len)
+}
+
+// ---------------------------------------------------------------------------
+// DeviceInfo (command_id = 4 / CaliptraCommandId::GetDeviceInfo)
+// ---------------------------------------------------------------------------
+
+pub fn handle_device_info(
+    payload: &[u8],
+    driver: &mut dyn super::transport::MctpVdmDriver,
+    response_buffer: &mut [u8],
+) -> Result<usize, TransportError> {
+    let info_index = if payload.len() >= core::mem::size_of::<GetDeviceInfoRequest>() {
+        let req = GetDeviceInfoRequest::from_bytes(payload)
+            .map_err(|_| TransportError::InvalidMessage)?;
+        req.info_type
+    } else {
+        0
+    };
+
+    let vdm_req = DeviceInfoRequest::new(info_index);
+    let mut resp_buf = [0u8; MAX_VDM_RESP_BUF];
+    let resp_len = send_vdm(&vdm_req, driver, &mut resp_buf)?;
+    let resp_bytes = &resp_buf[..resp_len];
+    validate_response_header(resp_bytes)?;
+
+    let vdm_resp =
+        DeviceInfoResponse::decode(resp_bytes).map_err(|_| TransportError::InvalidMessage)?;
+
+    let data = vdm_resp.data();
+    let mut info_data = [0u8; 64];
+    let data_len = data.len().min(64);
+    info_data[..data_len].copy_from_slice(&data[..data_len]);
+
+    let internal_resp = GetDeviceInfoResponse {
+        common: CommonResponse {
+            fips_status: vdm_resp.header.completion_code,
+        },
+        info_length: data_len as u32,
+        info_data,
+    };
+
+    let resp_bytes = internal_resp.as_bytes();
+    let copy_len = resp_bytes.len().min(response_buffer.len());
+    response_buffer[..copy_len].copy_from_slice(&resp_bytes[..copy_len]);
+    Ok(copy_len)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mctp_vdm_common::codec::VdmCodec;
+
+    // Verify that request encoding produces valid VDM wire bytes
+    #[test]
+    fn test_encode_firmware_version_request() {
+        let req = FirmwareVersionRequest::new(1);
+        let mut buf = [0u8; 64];
+        let len = req.encode(&mut buf).unwrap();
+        assert_eq!(len, VDM_MSG_HEADER_LEN + 4);
+        // First two bytes = vendor ID 0x1414 LE
+        assert_eq!(buf[0], 0x14);
+        assert_eq!(buf[1], 0x14);
+    }
+
+    #[test]
+    fn test_encode_device_id_request() {
+        let req = DeviceIdRequest::new();
+        let mut buf = [0u8; 64];
+        let len = req.encode(&mut buf).unwrap();
+        assert_eq!(len, VDM_MSG_HEADER_LEN);
+    }
+
+    #[test]
+    fn test_encode_device_capabilities_request() {
+        let req = DeviceCapabilitiesRequest::new();
+        let mut buf = [0u8; 64];
+        let len = req.encode(&mut buf).unwrap();
+        assert_eq!(len, VDM_MSG_HEADER_LEN);
+    }
+
+    #[test]
+    fn test_encode_device_info_request() {
+        let req = DeviceInfoRequest::new(0);
+        let mut buf = [0u8; 64];
+        let len = req.encode(&mut buf).unwrap();
+        assert_eq!(len, VDM_MSG_HEADER_LEN + 4);
+    }
+}

--- a/caliptra-util-host/transport/src/transports/mctp_vdm/mod.rs
+++ b/caliptra-util-host/transport/src/transports/mctp_vdm/mod.rs
@@ -1,0 +1,16 @@
+// Licensed under the Apache-2.0 license
+
+//! MCTP VDM Transport Module
+//!
+//! This module provides MCTP VDM (Vendor Defined Message) transport implementation
+//! with protocol encoding/decoding for supported VDM commands. It follows the same
+//! pattern as the mailbox transport: a trait-based driver abstraction with an
+//! encoder/decoder layer that converts generic command IDs and payloads into
+//! MCTP VDM packets.
+
+pub mod dispatch;
+pub mod encode;
+pub mod transport;
+
+// Re-export main types
+pub use transport::{MctpVdmDriver, MctpVdmError, MctpVdmTransport};

--- a/caliptra-util-host/transport/src/transports/mctp_vdm/transport.rs
+++ b/caliptra-util-host/transport/src/transports/mctp_vdm/transport.rs
@@ -1,0 +1,151 @@
+// Licensed under the Apache-2.0 license
+
+//! MCTP VDM Transport Implementation
+//!
+//! This module provides the MCTP VDM transport with a trait-based driver
+//! abstraction. The `MctpVdmDriver` trait defines the low-level interface
+//! for sending/receiving MCTP VDM packets over any physical transport (I3C,
+//! TCP socket for testing, etc.). The `MctpVdmTransport` struct implements
+//! the `Transport` trait and handles command encoding/decoding.
+
+use super::dispatch::get_command_handler;
+use crate::{Transport, TransportError, TransportResult};
+
+/// Maximum VDM response buffer size in bytes.
+pub const MAX_VDM_RESP_BUF: usize = 2 * 1024;
+
+/// Trait for MCTP VDM low-level communication.
+///
+/// Implementors of this trait provide the actual MCTP VDM packet transport
+/// over a specific physical medium (e.g., I3C, TCP socket). The transport
+/// layer handles MCTP framing and reassembly; this trait operates at the
+/// VDM message level (after the MCTP common header byte).
+pub trait MctpVdmDriver: Send + Sync {
+    /// Send a VDM request and return the VDM response payload.
+    ///
+    /// `vdm_request` is the full VDM message (header + payload) *without*
+    /// the MCTP common header byte. The returned slice is the VDM response
+    /// message (header + payload), also without the MCTP common header.
+    fn send_request(&mut self, vdm_request: &[u8]) -> Result<&[u8], MctpVdmError>;
+
+    /// Check if the transport is ready.
+    fn is_ready(&self) -> bool;
+
+    /// Establish a connection.
+    fn connect(&mut self) -> Result<(), MctpVdmError>;
+
+    /// Close the connection.
+    fn disconnect(&mut self) -> Result<(), MctpVdmError>;
+}
+
+/// MCTP VDM error types.
+#[derive(Debug, Clone)]
+pub enum MctpVdmError {
+    /// Transport is not ready / not connected.
+    NotReady,
+    /// Timeout waiting for a response.
+    Timeout,
+    /// The command is not supported.
+    InvalidCommand,
+    /// Low-level communication failure.
+    CommunicationError,
+    /// Response buffer overflow.
+    BufferOverflow,
+    /// The device returned a non-success completion code.
+    DeviceError(u32),
+    /// Encoding / decoding error.
+    CodecError,
+}
+
+impl From<MctpVdmError> for TransportError {
+    fn from(err: MctpVdmError) -> Self {
+        match err {
+            MctpVdmError::NotReady => TransportError::ConnectionFailed(Some("MCTP VDM not ready")),
+            MctpVdmError::Timeout => TransportError::Timeout,
+            MctpVdmError::InvalidCommand => TransportError::InvalidMessage,
+            MctpVdmError::CommunicationError => {
+                TransportError::ConnectionFailed(Some("MCTP VDM communication error"))
+            }
+            MctpVdmError::BufferOverflow => TransportError::BufferError("Buffer overflow"),
+            MctpVdmError::DeviceError(_) => {
+                TransportError::ConnectionFailed(Some("MCTP VDM device error"))
+            }
+            MctpVdmError::CodecError => TransportError::InvalidMessage,
+        }
+    }
+}
+
+/// MCTP VDM Transport using dynamic dispatch via `MctpVdmDriver`.
+pub struct MctpVdmTransport<'a> {
+    driver: &'a mut dyn MctpVdmDriver,
+    connected: bool,
+    response_buffer: [u8; MAX_VDM_RESP_BUF],
+    response_len: usize,
+    has_response: bool,
+}
+
+impl<'a> MctpVdmTransport<'a> {
+    pub fn new(driver: &'a mut dyn MctpVdmDriver) -> Self {
+        Self {
+            driver,
+            connected: false,
+            response_buffer: [0; MAX_VDM_RESP_BUF],
+            response_len: 0,
+            has_response: false,
+        }
+    }
+
+    /// Process a command: encode internal request → VDM packet, send, decode response.
+    fn process_command(&mut self, command_id: u32, payload: &[u8]) -> TransportResult<()> {
+        if let Some(handler) = get_command_handler(command_id) {
+            self.response_len = handler(payload, self.driver, &mut self.response_buffer)?;
+            self.has_response = true;
+            Ok(())
+        } else {
+            Err(TransportError::NotSupported(
+                "Command not supported by MCTP VDM transport",
+            ))
+        }
+    }
+}
+
+impl Transport for MctpVdmTransport<'_> {
+    fn connect(&mut self) -> TransportResult<()> {
+        self.driver.connect().map_err(TransportError::from)?;
+        self.connected = true;
+        Ok(())
+    }
+
+    fn disconnect(&mut self) -> TransportResult<()> {
+        self.driver.disconnect().map_err(TransportError::from)?;
+        self.connected = false;
+        Ok(())
+    }
+
+    fn send(&mut self, command_id: u32, data: &[u8]) -> TransportResult<()> {
+        if !self.connected {
+            return Err(TransportError::Disconnected);
+        }
+        self.process_command(command_id, data)
+    }
+
+    fn receive(&mut self, buffer: &mut [u8]) -> TransportResult<usize> {
+        if !self.connected {
+            return Err(TransportError::Disconnected);
+        }
+
+        if !self.has_response {
+            return Ok(0);
+        }
+
+        let copy_len = core::cmp::min(self.response_len, buffer.len());
+        buffer[..copy_len].copy_from_slice(&self.response_buffer[..copy_len]);
+
+        self.has_response = false;
+        Ok(copy_len)
+    }
+
+    fn is_connected(&self) -> bool {
+        self.connected && self.driver.is_ready()
+    }
+}

--- a/caliptra-util-host/transport/src/transports/mod.rs
+++ b/caliptra-util-host/transport/src/transports/mod.rs
@@ -2,6 +2,7 @@
 
 //! Transport modules
 //!
-//! Mailbox transport implementation
+//! Mailbox and MCTP VDM transport implementations
 
 pub mod mailbox;
+pub mod mctp_vdm;


### PR DESCRIPTION
Add MctpVdmDriver trait, MctpVdmTransport, encode/decode handlers for the 4 supported VDM commands (FirmwareVersion, DeviceCapabilities, DeviceId, DeviceInfo), and dispatch module.

Add MCTP VDM client app with:
- MctpVdmSocketDriver adapter wrapping mcu-testing-common MctpVdmSocket
- VdmClient high-level API
- Validator with pass/fail reporting
- Shared TOML test configuration
- CLI binary (mctp-vdm-validator)