### PR TITLE
[tests] fix emulator package name

### DIFF
--- a/tests/integration/src/lib.rs
+++ b/tests/integration/src/lib.rs
@@ -758,7 +758,7 @@ mod test {
             let mut cargo_args: Vec<String> = vec![
                 "run".to_string(),
                 "-p".to_string(),
-                "emulator".to_string(),
+                "caliptra-mcu-emulator".to_string(),
                 "--profile".to_string(),
                 "test".to_string(),
                 "--".to_string(),


### PR DESCRIPTION
The emulator package was renamed to caliptra-mcu-emulator, but the
integration tests were still trying to run it using the old name 'emulator'
when a prebuilt binary was not provided. This change updates the package
name in the integration test library.

Signed-off-by: Tim Trippel <ttrippel@google.com>