### PR TITLE
[test] fix failing test_new_unbooted in CI

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -18,8 +18,7 @@ slow-timeout = { period = "30s", terminate-after = 30 }
 default-filter = """
 !(package(caliptra-mcu-tests-integration) and test(test_bare_metal::test::test_bare_metal_runtime_boot)
 | package(caliptra-mcu-tests-integration) and test(test::test_mcu_mbox_driver)
-| package(caliptra-mcu-tests-integration) and test(test::test_mcu_mbox_soc_requester_loopback)
-| package(caliptra-mcu-hw-model) and test(model_emulated::test::test_new_unbooted))
+| package(caliptra-mcu-tests-integration) and test(test::test_mcu_mbox_soc_requester_loopback))
 """
 
 [profile.nightly-emulator.junit]

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -19,8 +19,6 @@ default-filter = """
 !(package(caliptra-mcu-tests-integration) and test(test_bare_metal::test::test_bare_metal_runtime_boot)
 | package(caliptra-mcu-tests-integration) and test(test::test_mcu_mbox_driver)
 | package(caliptra-mcu-tests-integration) and test(test::test_mcu_mbox_soc_requester_loopback)
-| package(caliptra-mcu-tests-integration) and test(test::test_mcu_svn_gt_fuse)
-| package(caliptra-mcu-tests-integration) and test(test::test_mcu_svn_lt_fuse)
 | package(caliptra-mcu-hw-model) and test(model_emulated::test::test_new_unbooted))
 """
 

--- a/builder/src/lib.rs
+++ b/builder/src/lib.rs
@@ -134,9 +134,5 @@ pub fn objcopy() -> Result<String> {
 
 #[allow(dead_code)]
 pub(crate) fn target_binary(name: &str) -> PathBuf {
-    PROJECT_ROOT
-        .join("target")
-        .join(TARGET)
-        .join("release")
-        .join(name)
+    target_dir().join(TARGET).join("release").join(name)
 }

--- a/firmware-bundler/src/ld.rs
+++ b/firmware-bundler/src/ld.rs
@@ -602,49 +602,50 @@ INCLUDE $BASE_LD_CONTENTS
 
 /// Output a linker file for the application.
 fn content_aware_write(prefix: &str, content: &str, linker_dir: &Path) -> Result<PathBuf> {
-    // Determine if a previous file matching this prefix has already been generated.
-    // First read through the linker-script directory
-    let maybe_previous_file = std::fs::read_dir(linker_dir)?
-        .find(|f| {
-            f.as_ref()
-                .map(|f| {
-                    // Then check if each entry has a name which starts with the same name as
-                    // this linker file.  If so return it as the previous file.
-                    f.file_name()
-                        .to_str()
-                        .map(|n| n.starts_with(prefix))
-                        .unwrap_or(false)
-                })
-                .unwrap_or(false)
-        })
-        .transpose()?;
+    // Determine if any previous files matching this prefix have already been generated.
+    let mut matching_content_file = None;
+    let mut files_to_remove = Vec::new();
 
-    // To keep incremental builds fast, only output the linker contents if they differ from the
-    // previously existing file.
-    if let Some(previous_file) = maybe_previous_file {
-        let previous_file = previous_file.path();
-        // If the contents match exactly, just use the previous file, and perhaps the cached
-        // build.
-        if std::fs::read_to_string(&previous_file)
-            .map(|prev| prev == content)
-            .unwrap_or(false)
-        {
-            return Ok(previous_file);
-        } else {
-            // If they are different clean up the old file to avoid confusing multiple entries
-            // within the linker-script directory.
-            std::fs::remove_file(previous_file)?;
+    for entry in std::fs::read_dir(linker_dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_file() {
+            if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+                if name.starts_with(prefix) && name.ends_with(".ld") {
+                    if matching_content_file.is_none() {
+                        if let Ok(prev_content) = std::fs::read_to_string(&path) {
+                            if prev_content == content {
+                                matching_content_file = Some(path.clone());
+                                continue;
+                            }
+                        }
+                    }
+                    files_to_remove.push(path);
+                }
+            }
         }
     }
 
-    // Finally output the linker script file if we need to.  Use a unique UUID with each linker
-    // script generated.  This allows the `rustc` compiler to recognize when different scripts
-    // are used, and thus trigger a new build when memory space allocations change.
-    //
-    // If this is not done, compilation can diverge from the actual status of the Manifest toml
-    // until `cargo clean` is executed which can be quite confusing.
+    if let Some(file) = matching_content_file {
+        // We found a file with matching content. We can ignore other files with the same prefix.
+        return Ok(file);
+    }
+
+    // If we didn't find a matching file, we need to write a new one.
+    // Use a unique UUID with each linker script generated.
     let output_file = linker_dir.join(format!("{}-{}.ld", prefix, uuid::Uuid::new_v4()));
     std::fs::write(&output_file, content)?;
+
+    // Only remove OLD files AFTER we've successfully written the new one,
+    // and ideally we should be careful here. For now, let's remove them
+    // to keep the directory clean, but this is still slightly risky if
+    // another process just started using one of them.
+    // However, since we just wrote a NEW one with a NEW UUID, any OTHER
+    // process will either find this one or write its own.
+    for path in files_to_remove {
+        let _ = std::fs::remove_file(path);
+    }
+
     Ok(output_file)
 }
 

--- a/hw/model/src/lib.rs
+++ b/hw/model/src/lib.rs
@@ -226,6 +226,9 @@ pub struct InitParams<'a> {
     pub flash_boot: bool,
 
     pub active_i3c1: bool,
+
+    /// Initial contents of the vendor test partition in OTP.
+    pub vendor_test_partition: Option<Vec<u8>>,
 }
 
 impl InitParams<'_> {
@@ -297,6 +300,7 @@ impl Default for InitParams<'_> {
             caliptra_soc_axi_user: None,
             flash_boot: false,
             active_i3c1: false,
+            vendor_test_partition: None,
         }
     }
 }

--- a/hw/model/src/model_emulated.rs
+++ b/hw/model/src/model_emulated.rs
@@ -226,6 +226,7 @@ impl McuHwModel for ModelEmulated {
                 raw_memory: Some(otp_mem),
                 vendor_pk_hash: params.vendor_pk_hash,
                 vendor_pqc_type: params.vendor_pqc_type,
+                vendor_test_partition: params.vendor_test_partition.clone(),
                 ..Default::default()
             },
         )?;

--- a/hw/model/src/model_emulated.rs
+++ b/hw/model/src/model_emulated.rs
@@ -723,36 +723,57 @@ mod test {
 
     #[test]
     fn test_new_unbooted() {
-        let mcu_rom =
-            caliptra_mcu_builder::rom_build(&caliptra_mcu_builder::CaliptraBuildArgs::default())
+        let (mcu_rom, mcu_runtime, caliptra_rom, caliptra_fw, vendor_pk_hash, soc_manifest) =
+            if let Ok(binaries) = caliptra_mcu_builder::FirmwareBinaries::from_env() {
+                (
+                    binaries.mcu_rom.clone(),
+                    binaries.mcu_runtime.clone(),
+                    binaries.caliptra_rom.clone(),
+                    binaries.caliptra_fw.clone(),
+                    binaries.vendor_pk_hash().unwrap(),
+                    binaries.soc_manifest.clone(),
+                )
+            } else {
+                let mcu_rom = caliptra_mcu_builder::rom_build(
+                    &caliptra_mcu_builder::CaliptraBuildArgs::default(),
+                )
                 .expect("Could not build MCU ROM");
-        let mcu_runtime = &caliptra_mcu_builder::runtime_build_with_apps(
-            &caliptra_mcu_builder::CaliptraBuildArgs::default(),
-        )
-        .expect("Could not build MCU runtime");
-        let mut caliptra_builder =
-            caliptra_mcu_builder::CaliptraBuilder::new(&caliptra_mcu_builder::CaliptraBuildArgs {
-                mcu_firmware: Some(mcu_runtime.clone()),
-                ..Default::default()
-            });
-        let caliptra_rom = caliptra_builder
-            .get_caliptra_rom()
-            .expect("Could not build Caliptra ROM");
-        let caliptra_fw = caliptra_builder
-            .get_caliptra_fw()
-            .expect("Could not build Caliptra FW bundle");
-        let vendor_pk_hash = caliptra_builder
-            .get_vendor_pk_hash()
-            .expect("Could not get vendor PK hash");
-        println!("Vendor PK hash: {:x?}", vendor_pk_hash);
-        let vendor_pk_hash = hex::decode(vendor_pk_hash).unwrap().try_into().unwrap();
-        let soc_manifest = caliptra_builder.get_soc_manifest(None).unwrap();
+                let mcu_runtime = caliptra_mcu_builder::runtime_build_with_apps(
+                    &caliptra_mcu_builder::CaliptraBuildArgs::default(),
+                )
+                .expect("Could not build MCU runtime");
+                let mut caliptra_builder = caliptra_mcu_builder::CaliptraBuilder::new(
+                    &caliptra_mcu_builder::CaliptraBuildArgs {
+                        mcu_firmware: Some(mcu_runtime.clone()),
+                        ..Default::default()
+                    },
+                );
+                let caliptra_rom = caliptra_builder
+                    .get_caliptra_rom()
+                    .expect("Could not build Caliptra ROM");
+                let caliptra_fw = caliptra_builder
+                    .get_caliptra_fw()
+                    .expect("Could not build Caliptra FW bundle");
+                let vendor_pk_hash = caliptra_builder
+                    .get_vendor_pk_hash()
+                    .expect("Could not get vendor PK hash");
+                let vendor_pk_hash = hex::decode(vendor_pk_hash).unwrap().try_into().unwrap();
+                let soc_manifest = caliptra_builder.get_soc_manifest(None).unwrap();
 
-        let mcu_rom = std::fs::read(mcu_rom).unwrap();
-        let mcu_runtime = std::fs::read(mcu_runtime).unwrap();
-        let soc_manifest = std::fs::read(soc_manifest).unwrap();
-        let caliptra_rom = std::fs::read(caliptra_rom).unwrap();
-        let caliptra_fw = std::fs::read(caliptra_fw).unwrap();
+                let mcu_rom = std::fs::read(mcu_rom).unwrap();
+                let mcu_runtime = std::fs::read(mcu_runtime).unwrap();
+                let soc_manifest = std::fs::read(soc_manifest).unwrap();
+                let caliptra_rom = std::fs::read(caliptra_rom).unwrap();
+                let caliptra_fw = std::fs::read(caliptra_fw).unwrap();
+                (
+                    mcu_rom,
+                    mcu_runtime,
+                    caliptra_rom,
+                    caliptra_fw,
+                    vendor_pk_hash,
+                    soc_manifest,
+                )
+            };
 
         let mut model = ModelEmulated::new_unbooted(InitParams {
             mcu_rom: &mcu_rom,

--- a/tests/integration/src/lib.rs
+++ b/tests/integration/src/lib.rs
@@ -38,7 +38,7 @@ mod test {
     use caliptra_image_types::FwVerificationPqcKeyType;
     use caliptra_mcu_builder::flash_image::build_flash_image_bytes;
     use caliptra_mcu_builder::{
-        CaliptraBuilder, EmulatorBinaries, FirmwareBinaries, ImageCfg, TARGET,
+        target_dir, CaliptraBuilder, EmulatorBinaries, FirmwareBinaries, ImageCfg, TARGET,
     };
     use caliptra_mcu_hw_model::{DefaultHwModel, Fuses, InitParams, McuHwModel};
     use caliptra_mcu_testing_common::{DeviceLifecycle, MCU_RUNNING};
@@ -122,11 +122,7 @@ mod test {
     });
 
     fn target_binary(name: &str) -> PathBuf {
-        PROJECT_ROOT
-            .join("target")
-            .join(TARGET)
-            .join("release")
-            .join(name)
+        target_dir().join(TARGET).join("release").join(name)
     }
 
     // Get ROM from prebuilt or compile
@@ -1037,16 +1033,16 @@ mod test {
             "test-mcu-svn-lt-fuse"
         };
         let name = format!("runtime-{}.bin", feature);
-        let test_runtime = target_binary(&name);
-
         println!("Compiling test firmware {}", &feature);
-        caliptra_mcu_builder::runtime_build_with_apps(&caliptra_mcu_builder::CaliptraBuildArgs {
-            features: Some(feature),
-            output_name: Some(name),
-            example_app: true,
-            svn: Some(image_svn),
-            ..Default::default()
-        })
+        let test_runtime = caliptra_mcu_builder::runtime_build_with_apps(
+            &caliptra_mcu_builder::CaliptraBuildArgs {
+                features: Some(feature),
+                output_name: Some(name),
+                example_app: true,
+                svn: Some(image_svn),
+                ..Default::default()
+            },
+        )
         .expect("Runtime build failed");
         assert!(test_runtime.exists());
 


### PR DESCRIPTION
Update test_new_unbooted to use pre-built binaries from the environment when available. This prevents the test from attempting to build MCU and Caliptra components from source in CI environments where the source code is not present.

Partially addresses #1226; Depends on #1233 (only review the last commit).
