### PR TITLE
[xtask] add --test-filter option to test command

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -216,6 +216,10 @@ enum Commands {
         /// Path to the emulator bundle ZIP
         #[arg(long)]
         emulator_bundle: Option<PathBuf>,
+
+        /// A specific test filter to apply (e.g., "test(my_test)")
+        #[arg(long)]
+        test_filter: Option<String>,
     },
     /// Archive tests to a file
     TestArchive {
@@ -542,12 +546,14 @@ fn main() {
             workspace_remap,
             firmware_bundle,
             emulator_bundle,
+            test_filter,
         } => test::test(test::TestArgs {
             archive: archive.as_deref().and_then(|p| p.to_str()),
             shard: shard.as_deref(),
             workspace_remap: workspace_remap.as_deref().and_then(|p| p.to_str()),
             firmware_bundle: firmware_bundle.as_deref().and_then(|p| p.to_str()),
             emulator_bundle: emulator_bundle.as_deref().and_then(|p| p.to_str()),
+            test_filter: test_filter.as_deref(),
         }),
         Commands::TestArchive { archive } => test::test_archive(archive.clone()),
         Commands::RegistersAutogen {

--- a/xtask/src/test.rs
+++ b/xtask/src/test.rs
@@ -12,6 +12,7 @@ pub(crate) struct TestArgs<'a> {
     pub workspace_remap: Option<&'a str>,
     pub firmware_bundle: Option<&'a str>,
     pub emulator_bundle: Option<&'a str>,
+    pub test_filter: Option<&'a str>,
 }
 
 const EXCLUDED_PACKAGES: &[&str] = &[
@@ -44,7 +45,12 @@ pub(crate) fn test(args: TestArgs) -> Result<()> {
         std::env::set_var("CPTRA_EMULATOR_BUNDLE", emulator_bundle);
     }
 
-    cargo_test(args.shard, args.workspace_remap, args.archive)
+    cargo_test(
+        args.shard,
+        args.workspace_remap,
+        args.archive,
+        args.test_filter,
+    )
 }
 
 pub(crate) fn test_archive(archive_file: String) -> Result<()> {
@@ -55,6 +61,7 @@ fn cargo_test(
     shard: Option<&str>,
     workspace_remap: Option<&str>,
     archive: Option<&str>,
+    test_filter: Option<&str>,
 ) -> Result<()> {
     // Run all tests with nextest for proper sequencing, excluding ROM packages that don't have tests
     println!("Running: cargo nextest run");
@@ -85,6 +92,11 @@ fn cargo_test(
     if let Some(remap) = workspace_remap {
         args.push("--workspace-remap");
         args.push(remap);
+    }
+
+    if let Some(filter) = test_filter {
+        args.push("-E");
+        args.push(filter);
     }
 
     let nextest_status = Command::new("cargo")


### PR DESCRIPTION
Adds a new --test-filter argument to the cargo xtask test command. This allows users to pass cargo-nextest filter expressions (e.g., test(name)) to isolate specific tests during emulator-based integration testing.

Useful for debugging individual test failures.