### PR TITLE
[rom] skip first functional PK hash slot on strap assertion

### DIFF
--- a/docs/src/rom.md
+++ b/docs/src/rom.md
@@ -283,7 +283,7 @@ The verification process:
 The MCU ROM supports locking the selected vendor public key hash slot (and all higher order slots) to prevent post-ROM manipulation. This is controlled by writing to the `VENDOR_PK_HASH_VOLATILE_LOCK` register.
 
 **Strapping Override**:
-The locking behavior is gated by bit 0 of the hardware strapping register `SS_STRAP_GENERIC[2]`.
+The locking behavior is gated by bit 0 of the hardware strapping register `SS_STRAP_GENERIC[3]`.
 *   **Production Mode** (Bit 0 is `0`): The ROM automatically applies the volatile lock to the selected key slot index (locking that slot and all higher slots).
 *   **Provisioning Mode** (Bit 0 is `1`): The ROM skips applying the lock, allowing potential post-ROM code to provision higher order hash slots.
 

--- a/rom/src/fuses.rs
+++ b/rom/src/fuses.rs
@@ -148,23 +148,28 @@ pub trait VendorKeyPolicy {
 ///
 /// This policy selects the first key slot that is both marked valid
 /// in the VENDOR_PK_HASH_VALID mask and is functional (not fully revoked).
-pub struct DefaultVendorKeyPolicy;
+pub struct DefaultVendorKeyPolicy {
+    rotate_pk_hash: bool,
+}
 
 impl DefaultVendorKeyPolicy {
-    pub const fn new() -> Self {
-        Self
+    pub const fn new(rotate_pk_hash: bool) -> Self {
+        Self { rotate_pk_hash }
     }
 }
 
 impl Default for DefaultVendorKeyPolicy {
     fn default() -> Self {
-        Self::new()
+        Self::new(false)
     }
 }
 
 impl VendorKeyPolicy for DefaultVendorKeyPolicy {
     fn select_key(&self, otp: &Otp) -> McuResult<usize> {
         let valid_mask = otp.read_entry_multi::<1>(generated_fuses::VENDOR_PK_HASH_VALID)?[0];
+        let target_slot_count = if self.rotate_pk_hash { 2 } else { 1 };
+        let mut slots_found = 0;
+        let mut first_functional: Option<usize> = None;
 
         for i in 0..16 {
             if (valid_mask >> i) & 1 == 1 {
@@ -188,10 +193,19 @@ impl VendorKeyPolicy for DefaultVendorKeyPolicy {
             };
 
             if ecc_functional && pqc_functional {
-                return Ok(i);
+                slots_found += 1;
+                first_functional = Some(i);
+                if slots_found == target_slot_count {
+                    return Ok(i);
+                }
             }
         }
 
-        Err(McuError::ROM_PK_HASH_SELECTION_FAILED)
+        match first_functional {
+            // if the rotation strap is asserted, but we only found one valid PK hash
+            // fall back to that one.
+            Some(i) => Ok(i),
+            None => Err(McuError::ROM_PK_HASH_SELECTION_FAILED),
+        }
     }
 }

--- a/rom/src/rom.rs
+++ b/rom/src/rom.rs
@@ -62,7 +62,8 @@ pub struct Soc {
 
 impl Soc {
     pub const BOOT_FSM_DONE: u32 = 4;
-    pub const PK_HASH_STRAPPING_MASK: u32 = 0x1;
+    pub const PK_HASH_SKIP_LOCK_STRAPPING_MASK: u32 = 0x1;
+    pub const PK_HASH_ROTATION_STRAPPING_MASK: u32 = 0x1 << 1;
 
     pub const fn new(registers: StaticRef<soc::regs::Soc>) -> Self {
         Soc { registers }
@@ -203,7 +204,9 @@ impl Soc {
         self.registers.ss_strap_generic[1].set(OTP_DIRECT_ACCESS_CMD_REG_OFFSET);
 
         // Select the vendor public key slot to use.
-        let default_policy = DefaultVendorKeyPolicy::new();
+        let default_policy = DefaultVendorKeyPolicy::new(
+            self.registers.ss_strap_generic[3].get() & Self::PK_HASH_ROTATION_STRAPPING_MASK != 0,
+        );
         let policy = params.vendor_key_policy.unwrap_or(&default_policy);
         let pk_hash_idx = policy
             .select_key(otp)
@@ -365,8 +368,8 @@ impl Soc {
 
     pub fn pk_hash_volatile_lock(&self, otp: &Otp, selected_index: usize) {
         // Read strap register to check for provisioning mode.
-        let strap_reg = self.registers.ss_strap_generic[2].get();
-        if (strap_reg & Self::PK_HASH_STRAPPING_MASK) != 0 {
+        let strap_reg = self.registers.ss_strap_generic[3].get();
+        if (strap_reg & Self::PK_HASH_SKIP_LOCK_STRAPPING_MASK) != 0 {
             caliptra_mcu_romtime::println!(
               "[mcu-fuse-write] PK Hash provisioning mode detected, skipping vendor PK hash lock."
           );

--- a/tests/integration/src/rom/test_vendor_key_policy.rs
+++ b/tests/integration/src/rom/test_vendor_key_policy.rs
@@ -3,6 +3,7 @@
 #[cfg(test)]
 mod test {
     use anyhow::Result;
+    use caliptra_api::SocManager;
     use caliptra_mcu_error::McuError;
     use caliptra_mcu_hw_model::{new, DefaultHwModel, InitParams, McuHwModel, McuManager};
     use caliptra_mcu_registers_generated::fuses;
@@ -14,12 +15,23 @@ mod test {
 
     use crate::test::{start_runtime_hw_model, TestParams};
 
-    #[derive(Default, Clone, Copy)]
+    #[derive(Clone, Copy)]
     struct SlotConfig {
         pqc_type: Option<PqcKeyType>,
         ecc_revocation: u32,
         lms_revocation: u32,
         mldsa_revocation: u32,
+    }
+
+    impl Default for SlotConfig {
+        fn default() -> Self {
+            SlotConfig {
+                pqc_type: Some(PqcKeyType::MLDSA),
+                ecc_revocation: 0,
+                lms_revocation: 0,
+                mldsa_revocation: 0,
+            }
+        }
     }
 
     fn build_otp_memory(valid_mask: u16, slot_configs: &[(usize, SlotConfig)]) -> Vec<u8> {
@@ -45,7 +57,7 @@ mod test {
                     .copy_from_slice(&raw_pqc.to_le_bytes());
             }
 
-            // 3. Populate Revocations (OneHotLinearMajorityVote)
+            // 3. Populate Revocations (LinearMajorityVote)
             let ecc_entry =
                 vendor_ecc_revocation_entry(slot).expect("Invalid ECC Revocation entry");
             let ecc_layout = FuseLayout::from_generated(&ecc_entry.layout).unwrap();
@@ -84,16 +96,7 @@ mod test {
 
     #[test]
     fn test_select_first_functional() -> Result<()> {
-        let mut hw = setup_hw_model(
-            0x0000,
-            &[(
-                0,
-                SlotConfig {
-                    pqc_type: Some(PqcKeyType::MLDSA),
-                    ..SlotConfig::default()
-                },
-            )],
-        );
+        let mut hw = setup_hw_model(0x0000, &[(0, SlotConfig::default())]);
         hw.step_until_output_contains("[mcu-fuse-write] Selected vendor PK slot 0")?;
         Ok(())
     }
@@ -106,18 +109,11 @@ mod test {
                 (
                     0,
                     SlotConfig {
-                        pqc_type: Some(PqcKeyType::MLDSA),
                         ecc_revocation: 0b1111,
                         ..SlotConfig::default()
                     },
                 ),
-                (
-                    1,
-                    SlotConfig {
-                        pqc_type: Some(PqcKeyType::MLDSA),
-                        ..SlotConfig::default()
-                    },
-                ),
+                (1, SlotConfig::default()),
             ],
         );
         hw.step_until_output_contains("[mcu-fuse-write] Selected vendor PK slot 1")?;
@@ -132,18 +128,11 @@ mod test {
                 (
                     0,
                     SlotConfig {
-                        pqc_type: Some(PqcKeyType::MLDSA),
                         mldsa_revocation: 0b1111,
                         ..SlotConfig::default()
                     },
                 ),
-                (
-                    1,
-                    SlotConfig {
-                        pqc_type: Some(PqcKeyType::MLDSA),
-                        ..SlotConfig::default()
-                    },
-                ),
+                (1, SlotConfig::default()),
             ],
         );
         hw.step_until_output_contains("[mcu-fuse-write] Selected vendor PK slot 1")?;
@@ -169,32 +158,14 @@ mod test {
 
     #[test]
     fn test_middle_slot_selection() -> Result<()> {
-        let mut hw = setup_hw_model(
-            0x00FF,
-            &[(
-                8,
-                SlotConfig {
-                    pqc_type: Some(PqcKeyType::MLDSA),
-                    ..SlotConfig::default()
-                },
-            )],
-        );
+        let mut hw = setup_hw_model(0x00FF, &[(8, SlotConfig::default())]);
         hw.step_until_output_contains("[mcu-fuse-write] Selected vendor PK slot 8")?;
         Ok(())
     }
 
     #[test]
     fn test_last_slot_selection() -> Result<()> {
-        let mut hw = setup_hw_model(
-            0x7FFF,
-            &[(
-                15,
-                SlotConfig {
-                    pqc_type: Some(PqcKeyType::MLDSA),
-                    ..SlotConfig::default()
-                },
-            )],
-        );
+        let mut hw = setup_hw_model(0x7FFF, &[(15, SlotConfig::default())]);
         hw.step_until_output_contains("[mcu-fuse-write] Selected vendor PK slot 15")?;
         Ok(())
     }
@@ -219,7 +190,6 @@ mod test {
                 (
                     0,
                     SlotConfig {
-                        pqc_type: Some(PqcKeyType::MLDSA),
                         ecc_revocation: 0b1111,
                         ..SlotConfig::default()
                     },
@@ -269,6 +239,53 @@ mod test {
             .mcu_manager()
             .with_otp(|otp| otp.vendor_pk_hash_volatile_lock().read());
         assert_eq!(lock_val, 1);
+        Ok(())
+    }
+
+    #[test]
+    fn test_vendor_pk_lock_not_applied() -> Result<()> {
+        let mut hw = setup_hw_model(0x0000, &[(0, SlotConfig::default())]);
+
+        // Set strapping bit to not lock the pk hashes
+        hw.caliptra_soc_manager()
+            .soc_ifc()
+            .ss_strap_generic()
+            .get(3)
+            .expect("failed to get strapping register")
+            .write(|_| 0x1);
+
+        hw.step_until_output_contains("[mcu-fuse-write] Selected vendor PK slot 0")?;
+
+        // Step a few cycles
+        for _ in 0..100 {
+            hw.step();
+        }
+
+        let lock_val = hw
+            .mcu_manager()
+            .with_otp(|otp| otp.vendor_pk_hash_volatile_lock().read());
+        assert_eq!(lock_val, 0);
+        Ok(())
+    }
+
+    #[test]
+    fn test_key_rotation_strap() -> Result<()> {
+        let mut hw = setup_hw_model(
+            0x0002,
+            &[(0, SlotConfig::default()), (2, SlotConfig::default())],
+        );
+        // Set strapping bit to jump 1 PK hash slot
+        hw.caliptra_soc_manager()
+            .soc_ifc()
+            .ss_strap_generic()
+            .get(3)
+            .expect("failed to get strapping register")
+            .write(|_| 0x2);
+
+        // Slot 0 is the first functional slot which we skip
+        // Slot 1 is marked invalid
+        // Slot 2 should be selected
+        hw.step_until_output_contains("[mcu-fuse-write] Selected vendor PK slot 2")?;
         Ok(())
     }
 }


### PR DESCRIPTION
To allow PK hash rotation without disabling rollback in fuses. includes emulator tests (and slight enhancements to the overall vendor key selection tests).

We are using ss_strap_generic[3]  - this is fully unused and not copied to Caliptra Core
