### PR TITLE
tests: fix test_mctp_user_loopback, test_boot_with_i3c1_active

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -16,10 +16,8 @@ fail-fast = false
 slow-timeout = { period = "30s", terminate-after = 30 }
 # Disable tests that are currently failing in CI
 default-filter = """
-!(package(caliptra-mcu-tests-integration) and test(test_active_i3c::test::test_boot_with_i3c1_active)
-| package(caliptra-mcu-tests-integration) and test(test_bare_metal::test::test_bare_metal_runtime_boot)
+!(package(caliptra-mcu-tests-integration) and test(test_bare_metal::test::test_bare_metal_runtime_boot)
 | package(caliptra-mcu-tests-integration) and test(test_dot::test::test_dot_recovery_backup_blob_invalid_hmac)
-| package(caliptra-mcu-tests-integration) and test(test::test_mctp_user_loopback)
 | package(caliptra-mcu-tests-integration) and test(test::test_mcu_mbox_driver)
 | package(caliptra-mcu-tests-integration) and test(test::test_mcu_mbox_soc_requester_loopback)
 | package(caliptra-mcu-tests-integration) and test(test::test_mcu_svn_gt_fuse)

--- a/builder/src/all.rs
+++ b/builder/src/all.rs
@@ -68,6 +68,7 @@ const FEATURES_WITH_EXAMPLE_APP: &[&str] = &[
     "test-log-flash-usermode",
     "test-mbox-sram",
     "test-mci",
+    "test-mctp-user-loopback",
     "test-mcu-mbox-soc-requester-loopback",
     "test-mcu-mbox-usermode",
     "test-warm-reset",

--- a/builder/src/features.rs
+++ b/builder/src/features.rs
@@ -1,6 +1,7 @@
 // Licensed under the Apache-2.0 license
 
 pub const EMULATOR_RUNTIME_TEST_FEATURES: &[&str] = &[
+    "active-i3c1",
     "test-i3c-simple",
     "test-i3c-constant-writes",
     "test-mctp-capsule-loopback",


### PR DESCRIPTION
- Add test-mctp-user-loopback to FEATURES_WITH_EXAMPLE_APP and re-enable the test in nextest.
- Add active-i3c1 to EMULATOR_RUNTIME_TEST_FEATURES so the all-build produces the needed binaries, and re-enable the test in nextest.