### PR TITLE
tests: fix DOT recovery invalid HMAC test for OTP scrambling

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -17,7 +17,6 @@ slow-timeout = { period = "30s", terminate-after = 30 }
 # Disable tests that are currently failing in CI
 default-filter = """
 !(package(caliptra-mcu-tests-integration) and test(test_bare_metal::test::test_bare_metal_runtime_boot)
-| package(caliptra-mcu-tests-integration) and test(test_dot::test::test_dot_recovery_backup_blob_invalid_hmac)
 | package(caliptra-mcu-tests-integration) and test(test::test_mcu_mbox_driver)
 | package(caliptra-mcu-tests-integration) and test(test::test_mcu_mbox_soc_requester_loopback)
 | package(caliptra-mcu-tests-integration) and test(test::test_mcu_svn_gt_fuse)

--- a/tests/integration/src/test_dot.rs
+++ b/tests/integration/src/test_dot.rs
@@ -1044,6 +1044,7 @@ mod test {
     /// Creates OTP memory with DOT in locked state (ODD, 1 fuse bit burned).
     /// Uses the generated fuse entry offsets for correct placement.
     fn create_locked_otp_memory() -> Vec<u8> {
+        use caliptra_mcu_otp_digest::{otp_scramble, OTP_SCRAMBLE_KEYS};
         use caliptra_mcu_registers_generated::fuses;
         let mut otp =
             vec![0u8; fuses::DOT_FUSE_ARRAY.byte_offset + fuses::DOT_FUSE_ARRAY.byte_size];
@@ -1051,6 +1052,21 @@ mod test {
         otp[fuses::DOT_INITIALIZED.byte_offset] = 0x07;
         // Set bit 0 of dot_fuse_array to 1 (burned=1, ODD/locked state)
         otp[fuses::DOT_FUSE_ARRAY.byte_offset] = 0x01;
+
+        // VendorSecretProdPartition (partition index 13) is scrambled.
+        // Pre-scramble zero blocks so the DAI read path unscrambles them
+        // back to zeros, ensuring recovery_pk_hash reads as all-zeros (None).
+        let key = OTP_SCRAMBLE_KEYS[5];
+        let part_start = fuses::VENDOR_SECRET_PROD_PARTITION_BYTE_OFFSET;
+        let part_end = part_start + fuses::VENDOR_SECRET_PROD_PARTITION_BYTE_SIZE;
+        let end = part_end.min(otp.len());
+        for off in (part_start..end).step_by(8) {
+            let scrambled = otp_scramble(0, key);
+            let bytes = scrambled.to_le_bytes();
+            let copy_len = bytes.len().min(otp.len() - off);
+            otp[off..off + copy_len].copy_from_slice(&bytes[..copy_len]);
+        }
+
         otp
     }
 


### PR DESCRIPTION
create_locked_otp_memory() left the VendorSecretProdPartition region (partition index 13) as all-zeros in raw OTP memory. Since this partition is scrambled, the DAI read path unscrambles those zeros into non-zero values, causing recovery_pk_hash to appear non-empty. This made the ROM enter the DOT override challenge/response flow (which blocks waiting for I3C commands) instead of immediately fatal-erroring after the backup blob HMAC check failed.

Pre-scramble the zero blocks in the VendorSecretProdPartition so they unscramble back to zeros, matching the pattern used by create_challenge_recovery_otp_memory(). Re-enable the test in nextest.