### PR TITLE
[xtask] make test preludes flexible and add bitstream management options

### DIFF
--- a/xtask/src/fpga/configurations.rs
+++ b/xtask/src/fpga/configurations.rs
@@ -11,7 +11,7 @@ use super::{
         check_ssh_access, download_bitstream, load_bitstream, rsync_file, run_test_suite,
         NextestArchiveCommand,
     },
-    ActionHandler, BuildArgs, BuildTestArgs, TestArgs,
+    ActionHandler, BootstrapArgs, BuildArgs, BuildTestArgs, TestArgs,
 };
 
 /// The FPGA configuration mode
@@ -89,11 +89,11 @@ impl<'a> Configuration {
 }
 
 impl<'a> ActionHandler<'a> for CommandExecutor {
-    fn bootstrap(&self) -> Result<()> {
+    fn bootstrap(&self, args: &'a BootstrapArgs<'a>) -> Result<()> {
         match self {
-            Self::Subsystem(sub) => sub.bootstrap(),
-            Self::CoreOnSubsystem(core) => core.bootstrap(),
-            Self::Core(core) => core.bootstrap(),
+            Self::Subsystem(sub) => sub.bootstrap(args),
+            Self::CoreOnSubsystem(core) => core.bootstrap(args),
+            Self::Core(core) => core.bootstrap(args),
         }
     }
 
@@ -170,7 +170,7 @@ impl Subsystem {
 }
 
 impl<'a> ActionHandler<'a> for Subsystem {
-    fn bootstrap(&self) -> Result<()> {
+    fn bootstrap(&self, args: &'a BootstrapArgs<'a>) -> Result<()> {
         let bootstrap_cmd= "[ -d caliptra-mcu-sw ] || git clone https://github.com/chipsalliance/caliptra-mcu-sw --branch=main --depth=1";
         let target_host = self.target_host.as_deref();
         run_command(target_host, bootstrap_cmd).context("failed to clone caliptra-mcu-sw repo")?;
@@ -180,23 +180,19 @@ impl<'a> ActionHandler<'a> for Subsystem {
             return Ok(());
         }
 
-        let subsystem_bitstream = PROJECT_ROOT
-            .join("hw")
-            .join("fpga")
-            .join("bitstream_manifests")
-            .join("subsystem.toml");
-        download_bitstream(self.target_host.as_deref(), &subsystem_bitstream)?;
-        load_bitstream(self.target_host.as_deref())?;
+        handle_bitstream_bootstrap(
+            target_host,
+            args.bitstream.as_deref(),
+            &bitstream_manifest_path(&PROJECT_ROOT, "subsystem.toml"),
+        )?;
         Ok(())
     }
 
     fn download_bitstream(&self) -> Result<()> {
-        let subsystem_bitstream = PROJECT_ROOT
-            .join("hw")
-            .join("fpga")
-            .join("bitstream_manifests")
-            .join("subsystem.toml");
-        download_bitstream(None, &subsystem_bitstream)?;
+        download_bitstream(
+            None,
+            &bitstream_manifest_path(&PROJECT_ROOT, "subsystem.toml"),
+        )?;
         Ok(())
     }
 
@@ -285,7 +281,7 @@ impl CoreOnSubsystem {
 }
 
 impl<'a> ActionHandler<'a> for CoreOnSubsystem {
-    fn bootstrap(&self) -> Result<()> {
+    fn bootstrap(&self, args: &'a BootstrapArgs<'a>) -> Result<()> {
         let bootstrap_cmd= "[ -d caliptra-sw ] || git clone https://github.com/chipsalliance/caliptra-sw --branch=caliptra-2.0 --depth=1";
         let target_host = self.target_host.as_deref();
         run_command(target_host, bootstrap_cmd).context("failed to clone caliptra-sw repo")?;
@@ -295,14 +291,19 @@ impl<'a> ActionHandler<'a> for CoreOnSubsystem {
             return Ok(());
         }
 
-        let caliptra_sw = caliptra_sw_workspace_root();
-        let subsystem_bitstream = caliptra_sw
-            .join("hw")
-            .join("fpga")
-            .join("bitstream_manifests")
-            .join("subsystem.toml");
-        download_bitstream(self.target_host.as_deref(), &subsystem_bitstream)?;
-        load_bitstream(self.target_host.as_deref())?;
+        handle_bitstream_bootstrap(
+            target_host,
+            args.bitstream.as_deref(),
+            &bitstream_manifest_path(&caliptra_sw_workspace_root(), "subsystem.toml"),
+        )?;
+        Ok(())
+    }
+
+    fn download_bitstream(&self) -> Result<()> {
+        download_bitstream(
+            None,
+            &bitstream_manifest_path(&caliptra_sw_workspace_root(), "subsystem.toml"),
+        )?;
         Ok(())
     }
 
@@ -406,7 +407,7 @@ impl Core {
 }
 
 impl<'a> ActionHandler<'a> for Core {
-    fn bootstrap(&self) -> Result<()> {
+    fn bootstrap(&self, args: &'a BootstrapArgs<'a>) -> Result<()> {
         let bootstrap_cmd= "[ -d caliptra-sw ] || git clone https://github.com/chipsalliance/caliptra-sw --branch=caliptra-2.0 --depth=1";
         let target_host = self.target_host.as_deref();
         run_command(target_host, bootstrap_cmd).context("failed to clone caliptra-sw repo")?;
@@ -416,25 +417,19 @@ impl<'a> ActionHandler<'a> for Core {
             return Ok(());
         }
 
-        let caliptra_sw = caliptra_sw_workspace_root();
-        let core_bitstream = caliptra_sw
-            .join("hw")
-            .join("fpga")
-            .join("bitstream_manifests")
-            .join("core.toml");
-        download_bitstream(self.target_host.as_deref(), &core_bitstream)?;
-        load_bitstream(self.target_host.as_deref())?;
+        handle_bitstream_bootstrap(
+            target_host,
+            args.bitstream.as_deref(),
+            &bitstream_manifest_path(&caliptra_sw_workspace_root(), "core.toml"),
+        )?;
         Ok(())
     }
 
     fn download_bitstream(&self) -> Result<()> {
-        let caliptra_sw = caliptra_sw_workspace_root();
-        let core_bitstream = caliptra_sw
-            .join("hw")
-            .join("fpga")
-            .join("bitstream_manifests")
-            .join("core.toml");
-        download_bitstream(None, &core_bitstream)?;
+        download_bitstream(
+            None,
+            &bitstream_manifest_path(&caliptra_sw_workspace_root(), "core.toml"),
+        )?;
         Ok(())
     }
     fn build(&self, args: &'a BuildArgs<'a>) -> Result<()> {
@@ -497,4 +492,35 @@ impl<'a> ActionHandler<'a> for Core {
         )?;
         Ok(())
     }
+}
+
+fn bitstream_manifest_path(root: &std::path::Path, toml_name: &str) -> std::path::PathBuf {
+    root.join("hw")
+        .join("fpga")
+        .join("bitstream_manifests")
+        .join(toml_name)
+}
+
+fn handle_bitstream_bootstrap(
+    target_host: Option<&str>,
+    bitstream_arg: Option<&std::path::Path>,
+    manifest_path: &std::path::Path,
+) -> Result<()> {
+    if let Some(bitstream) = bitstream_arg {
+        if let Some(target_host) = target_host {
+            rsync_file(
+                target_host,
+                &bitstream.display().to_string(),
+                "caliptra-bitstream.pdi",
+                false,
+            )
+            .context("failed to copy bitstream to fpga")?;
+        } else {
+            std::fs::copy(bitstream, "caliptra-bitstream.pdi").context("copy bitstream pdi")?;
+        }
+    } else {
+        download_bitstream(target_host, manifest_path)?;
+    }
+    load_bitstream(target_host)?;
+    Ok(())
 }

--- a/xtask/src/fpga/configurations.rs
+++ b/xtask/src/fpga/configurations.rs
@@ -251,10 +251,12 @@ impl<'a> ActionHandler<'a> for Subsystem {
             "--test-threads=1"
         };
 
-        let prelude = "CPTRA_FIRMWARE_BUNDLE=$HOME/all-fw.zip";
+        let bundle = std::env::var("CPTRA_FIRMWARE_BUNDLE")
+            .unwrap_or_else(|_| "$HOME/all-fw.zip".to_string());
+        let prelude = format!("CPTRA_FIRMWARE_BUNDLE={bundle}");
         run_test_suite(
             "caliptra-mcu-sw",
-            prelude,
+            &prelude,
             test_filters,
             to,
             self.target_host.as_deref(),
@@ -304,17 +306,6 @@ impl<'a> ActionHandler<'a> for CoreOnSubsystem {
             None,
             &bitstream_manifest_path(&caliptra_sw_workspace_root(), "subsystem.toml"),
         )?;
-        Ok(())
-    }
-
-    fn download_bitstream(&self) -> Result<()> {
-        let caliptra_sw = caliptra_sw_workspace_root();
-        let subsystem_bitstream = caliptra_sw
-            .join("hw")
-            .join("fpga")
-            .join("bitstream_manifests")
-            .join("subsystem.toml");
-        download_bitstream(None, &subsystem_bitstream)?;
         Ok(())
     }
     fn build(&self, args: &'a BuildArgs<'a>) -> Result<()> {
@@ -377,10 +368,15 @@ impl<'a> ActionHandler<'a> for CoreOnSubsystem {
             "--test-threads=1"
         };
 
-        let prelude = "CPTRA_MCU_ROM=/home/runner/mcu-rom-fpga.bin CPTRA_UIO_NUM=0 CALIPTRA_PREBUILT_FW_DIR=/tmp/caliptra-test-firmware/caliptra-test-firmware CALIPTRA_IMAGE_NO_GIT_REVISION=1";
+        let mcu_rom = std::env::var("CPTRA_MCU_ROM")
+            .unwrap_or_else(|_| "/home/runner/mcu-rom-fpga.bin".to_string());
+        let uio_num = std::env::var("CPTRA_UIO_NUM").unwrap_or_else(|_| "0".to_string());
+        let fw_dir = std::env::var("CALIPTRA_PREBUILT_FW_DIR")
+            .unwrap_or_else(|_| "/tmp/caliptra-test-firmware/caliptra-test-firmware".to_string());
+        let prelude = format!("CPTRA_MCU_ROM={mcu_rom} CPTRA_UIO_NUM={uio_num} CALIPTRA_PREBUILT_FW_DIR={fw_dir} CALIPTRA_IMAGE_NO_GIT_REVISION=1");
         run_test_suite(
             "caliptra-sw",
-            prelude,
+            &prelude,
             test_filters,
             to,
             self.target_host.as_deref(),
@@ -481,10 +477,13 @@ impl<'a> ActionHandler<'a> for Core {
             "--test-threads=1"
         };
 
-        let prelude = "CPTRA_UIO_NUM=0 CALIPTRA_PREBUILT_FW_DIR=/tmp/caliptra-test-firmware/caliptra-test-firmware CALIPTRA_IMAGE_NO_GIT_REVISION=1";
+        let uio_num = std::env::var("CPTRA_UIO_NUM").unwrap_or_else(|_| "0".to_string());
+        let fw_dir = std::env::var("CALIPTRA_PREBUILT_FW_DIR")
+            .unwrap_or_else(|_| "/tmp/caliptra-test-firmware/caliptra-test-firmware".to_string());
+        let prelude = format!("CPTRA_UIO_NUM={uio_num} CALIPTRA_PREBUILT_FW_DIR={fw_dir} CALIPTRA_IMAGE_NO_GIT_REVISION=1");
         run_test_suite(
             "caliptra-sw",
-            prelude,
+            &prelude,
             test_filters,
             to,
             self.target_host.as_deref(),

--- a/xtask/src/fpga/mod.rs
+++ b/xtask/src/fpga/mod.rs
@@ -25,6 +25,10 @@ struct BuildArgs<'a> {
     fw_id: &'a Option<String>,
 }
 
+struct BootstrapArgs<'a> {
+    bitstream: &'a Option<PathBuf>,
+}
+
 struct BuildTestArgs<'a> {
     package_filter: &'a Option<String>,
 }
@@ -34,7 +38,7 @@ struct TestArgs<'a> {
     default_test_profile: &'a str,
 }
 trait ActionHandler<'a> {
-    fn bootstrap(&self) -> Result<()>;
+    fn bootstrap(&self, args: &'a BootstrapArgs<'a>) -> Result<()>;
     fn download_bitstream(&self) -> Result<()>;
     fn build(&self, args: &'a BuildArgs<'a>) -> Result<()>;
     fn build_test(&self, args: &'a BuildTestArgs<'a>) -> Result<()>;
@@ -49,6 +53,9 @@ pub(crate) enum Fpga {
         target_host: Option<String>,
         #[arg(long, default_value_t = Configuration::Subsystem, value_enum)]
         configuration: Configuration,
+        /// Path to a bitstream pdi file. If provided, don't download it.
+        #[arg(long)]
+        bitstream: Option<PathBuf>,
     },
     /// Download an FPGA bitstream.
     DownloadBitstream {
@@ -230,6 +237,7 @@ pub(crate) fn fpga_entry(args: &Fpga) -> Result<()> {
         Fpga::Bootstrap {
             target_host,
             configuration,
+            bitstream,
         } => {
             println!("Bootstrapping FPGA");
             println!("configuration: {:?}", configuration);
@@ -259,7 +267,7 @@ pub(crate) fn fpga_entry(args: &Fpga) -> Result<()> {
                 .executor()
                 .set_target_host(target_host)
                 .set_caliptra_fpga(caliptra_fpga)
-                .bootstrap()?;
+                .bootstrap(&BootstrapArgs { bitstream })?;
         }
         Fpga::DownloadBitstream { configuration } => {
             println!("Downloading FPGA bitstream");


### PR DESCRIPTION
This includes two commits to the xtask FPGA commands to partially address #1245: 

1. makes test preludes flexible via environment variables to make FPGA test execution more flexible in both local and CI environments.
2. enhances the 'bootstrap' command to allow loading a pre-downloaded bitstream via the --bitstream flag. If not provided, it continues to download and load the default bitstream (required by the CI flow)