### PR TITLE
[xtask] add FPGA build options for CI parity

### DIFF
--- a/xtask/src/fpga/configurations.rs
+++ b/xtask/src/fpga/configurations.rs
@@ -196,23 +196,26 @@ impl<'a> ActionHandler<'a> for Subsystem {
         Ok(())
     }
 
-    fn build(&self, _: &'a BuildArgs<'a>) -> Result<()> {
+    fn build(&self, args: &'a BuildArgs<'a>) -> Result<()> {
         // TODO(clundin): Modify `caliptra_mcu_builder::all_build` to return the zip instead of writing it?
         // TODO(clundin): Place FPGA xtask artifacts in a specific folder?
-        let mcu_cfgs = Some(vec![ImageCfg {
-            path: "mcu".into(),
-            load_addr: 0x0,
-            staging_addr: 0xB00C0000,
-            image_id: 2,
-            exec_bit: 2,
-            component_id: 2,
-            feature: "test-fpga-flash-ctrl".to_string(),
-        }]);
+        let mcu_cfgs = args.mcu_cfgs.clone().or_else(|| {
+            Some(vec![ImageCfg {
+                path: "mcu".into(),
+                load_addr: 0x0,
+                staging_addr: 0xB00C0000,
+                image_id: 2,
+                exec_bit: 2,
+                component_id: 2,
+                feature: "test-fpga-flash-ctrl".to_string(),
+            }])
+        });
         let args = AllBuildArgs {
             output: Some("all-fw.zip"),
             platform: Some("fpga"),
+            rom_features: args.rom_features.as_deref(),
             mcu_cfgs: mcu_cfgs,
-            separate_runtimes: true,
+            separate_runtimes: args.separate_runtimes,
             ..Default::default()
         };
         caliptra_mcu_builder::all_build(args)?;
@@ -223,12 +226,12 @@ impl<'a> ActionHandler<'a> for Subsystem {
     }
 
     fn build_test(&self, args: &'a BuildTestArgs<'a>) -> Result<()> {
-        let mut container = build_base_container_command()?;
         let cmd = NextestArchiveCommand::new("/work-dir")
             .feature("fpga_realtime")
             .package_filter(args.package_filter.as_deref())
             .build();
 
+        let mut container = build_base_container_command()?;
         container.arg(&cmd);
         container
             .status()
@@ -312,7 +315,7 @@ impl<'a> ActionHandler<'a> for CoreOnSubsystem {
         let caliptra_sw = caliptra_sw_workspace_root();
         let rom_path = caliptra_mcu_builder::rom_build(&caliptra_mcu_builder::CaliptraBuildArgs {
             platform: Some("fpga"),
-            features: Some("core_test"),
+            features: args.rom_features.as_deref().or(Some("core_test")),
             ..Default::default()
         })?;
         if !args.mcu {
@@ -339,12 +342,12 @@ impl<'a> ActionHandler<'a> for CoreOnSubsystem {
         let caliptra_sw = caliptra_sw_workspace_root();
         let base_name = caliptra_sw.file_name().unwrap().to_str().unwrap();
 
-        let mut container = build_base_container_command()?;
         let cmd = NextestArchiveCommand::new(&format!("/{base_name}"))
             .features(&["fpga_subsystem", "itrng"])
             .package_filter(args.package_filter.as_deref())
             .build();
 
+        let mut container = build_base_container_command()?;
         container.arg(&cmd);
         container
             .status()
@@ -448,12 +451,12 @@ impl<'a> ActionHandler<'a> for Core {
         let caliptra_sw = caliptra_sw_workspace_root();
         let base_name = caliptra_sw.file_name().unwrap().to_str().unwrap();
 
-        let mut container = build_base_container_command()?;
         let cmd = NextestArchiveCommand::new(&format!("/{base_name}"))
             .features(&["fpga_realtime", "itrng"])
             .package_filter(args.package_filter.as_deref())
             .build();
 
+        let mut container = build_base_container_command()?;
         container.arg(&cmd);
         container
             .status()

--- a/xtask/src/fpga/mod.rs
+++ b/xtask/src/fpga/mod.rs
@@ -4,7 +4,7 @@ use anyhow::{anyhow, bail, Result};
 use caliptra_image_gen::to_hw_format;
 use caliptra_image_types::FwVerificationPqcKeyType;
 use caliptra_mcu_builder::flash_image::build_flash_image_bytes;
-use caliptra_mcu_builder::FirmwareBinaries;
+use caliptra_mcu_builder::{FirmwareBinaries, ImageCfg};
 use caliptra_mcu_hw_model::{InitParams, McuHwModel, ModelFpgaRealtime};
 use caliptra_mcu_rom_common::LifecycleControllerState;
 use clap::Subcommand;
@@ -23,6 +23,9 @@ mod utils;
 struct BuildArgs<'a> {
     mcu: bool,
     fw_id: &'a Option<String>,
+    rom_features: &'a Option<String>,
+    separate_runtimes: bool,
+    mcu_cfgs: &'a Option<Vec<ImageCfg>>,
 }
 
 struct BootstrapArgs<'a> {
@@ -116,6 +119,25 @@ pub(crate) enum Fpga {
         /// By default all Caliptra firmware binaries are built
         #[arg(long)]
         fw_id: Option<String>,
+
+        /// Rom features to build with
+        #[arg(long)]
+        rom_features: Option<String>,
+
+        /// Build a separate runtime for each feature flag
+        #[arg(long)]
+        separate_runtimes: bool,
+
+        // MCU configuration to include in the SoC manifest
+        // format: mcu,<load_addr>,<staging_addr>,<image_id>,<exec_bit>,<component_id>,<feature>
+        // Example: --mcu_cfg mcu,0x10000000,0x10000000,1,1,1,test-dma
+        #[arg(
+            long = "mcu_cfg",
+            value_name = "MCU_CFG",
+            num_args = 1..,
+            required = false
+        )]
+        mcu_cfgs: Option<Vec<ImageCfg>>,
     },
     /// Build FPGA test binaries
     BuildTest {
@@ -211,7 +233,10 @@ pub(crate) fn fpga_entry(args: &Fpga) -> Result<()> {
         Fpga::Build {
             target_host,
             mcu,
-            fw_id: calitpra_fw_id,
+            fw_id,
+            rom_features,
+            separate_runtimes,
+            mcu_cfgs,
         } => {
             println!("Building FPGA firmware");
             let config = Configuration::from_cmd(target_host.as_deref())?;
@@ -220,7 +245,10 @@ pub(crate) fn fpga_entry(args: &Fpga) -> Result<()> {
                 .set_target_host(target_host.as_deref())
                 .build(&BuildArgs {
                     mcu: *mcu,
-                    fw_id: calitpra_fw_id,
+                    fw_id,
+                    rom_features,
+                    separate_runtimes: *separate_runtimes,
+                    mcu_cfgs,
                 })?;
         }
         Fpga::BuildTest {
@@ -449,5 +477,6 @@ pub(crate) fn fpga_run(args: crate::Commands) -> Result<()> {
         );
         model.save_otp_memory(otp_file.as_ref().unwrap())?;
     }
+
     Ok(())
 }


### PR DESCRIPTION
Introduce new flags to streamline FPGA build operations:

- Add --rom-features and --separate-runtimes to 'build' for parity
  with previous all-build flows.
- Add --mcu_cfg to 'build' to allow custom SoC manifest configurations.
- Add --no-container to 'build-test' to allow native cross-compilation
  in CI environments.

Partially addresses #1245 ; depends on #1246