### PR TITLE
[tests] fix test_bare_metal_runtime_boot test in CI

### DIFF
--- a/builder/src/all.rs
+++ b/builder/src/all.rs
@@ -182,6 +182,7 @@ pub struct FirmwareBinaries {
     pub caliptra_fw: Vec<u8>,
     pub mcu_rom: Vec<u8>,
     pub mcu_runtime: Vec<u8>,
+    pub mcu_bare_metal_runtime: Vec<u8>,
     pub soc_manifest: Vec<u8>,
     pub test_roms: Vec<(String, Vec<u8>)>,
     pub caliptra_test_roms: Vec<(String, Vec<u8>)>,
@@ -198,6 +199,7 @@ impl FirmwareBinaries {
     const CALIPTRA_FW_NAME: &'static str = "caliptra_fw.bin";
     const MCU_ROM_NAME: &'static str = "mcu_rom.bin";
     const MCU_RUNTIME_NAME: &'static str = "mcu_runtime.bin";
+    const MCU_BARE_METAL_RUNTIME_NAME: &'static str = "mcu_bare_metal_runtime.bin";
     const SOC_MANIFEST_NAME: &'static str = "soc_manifest.bin";
     const FLASH_IMAGE_NAME: &'static str = "flash_image.bin";
     const PLDM_FW_PKG_NAME: &'static str = "pldm_fw_pkg.bin";
@@ -237,6 +239,7 @@ impl FirmwareBinaries {
                 Self::CALIPTRA_FW_NAME => binaries.caliptra_fw = data,
                 Self::MCU_ROM_NAME => binaries.mcu_rom = data,
                 Self::MCU_RUNTIME_NAME => binaries.mcu_runtime = data,
+                Self::MCU_BARE_METAL_RUNTIME_NAME => binaries.mcu_bare_metal_runtime = data,
                 Self::SOC_MANIFEST_NAME => binaries.soc_manifest = data,
                 name if name.contains("mcu-test-soc-manifest") => {
                     binaries.test_soc_manifests.push((name.to_string(), data));
@@ -567,6 +570,14 @@ pub fn all_build(args: AllBuildArgs) -> Result<()> {
         ..Default::default()
     })?;
 
+    // Only build the bare-metal runtime for the emulator platform, as it
+    // is currently only configured and supported for the emulator.
+    let mcu_bare_metal_runtime = if platform == "emulator" {
+        Some(crate::bare_metal_build()?)
+    } else {
+        None
+    };
+
     let mcu_image_cfg = get_image_cfg_feature(&mcu_cfgs.clone().unwrap_or_default(), "none");
     let mut caliptra_builder = crate::CaliptraBuilder::new(&CaliptraBuildArgs {
         fpga: platform == "fpga",
@@ -815,6 +826,14 @@ pub fn all_build(args: AllBuildArgs) -> Result<()> {
         &mut zip,
         options,
     )?;
+    if let Some(bare_metal) = mcu_bare_metal_runtime {
+        add_to_zip(
+            &bare_metal,
+            FirmwareBinaries::MCU_BARE_METAL_RUNTIME_NAME,
+            &mut zip,
+            options,
+        )?;
+    }
     add_to_zip(
         &soc_manifest,
         FirmwareBinaries::SOC_MANIFEST_NAME,

--- a/tests/integration/src/test_bare_metal.rs
+++ b/tests/integration/src/test_bare_metal.rs
@@ -11,7 +11,16 @@ mod test {
         let lock = TEST_LOCK.lock().unwrap();
 
         let rom_path = ROM.clone();
-        let runtime_path = compile_bare_metal_runtime();
+        let runtime_path = if let Ok(binaries) = caliptra_mcu_builder::FirmwareBinaries::from_env()
+        {
+            let path = std::env::temp_dir().join("mcu_bare_metal_runtime_prebuilt.bin");
+            if !path.exists() {
+                std::fs::write(&path, &binaries.mcu_bare_metal_runtime).unwrap();
+            }
+            path
+        } else {
+            compile_bare_metal_runtime()
+        };
 
         let i3c_port = PortPicker::new().random(true).pick().unwrap().to_string();
 

--- a/xtask/src/fpga/mod.rs
+++ b/xtask/src/fpga/mod.rs
@@ -356,16 +356,11 @@ pub(crate) fn fpga_run(args: crate::Commands) -> Result<()> {
         FirmwareBinaries {
             mcu_rom,
             mcu_runtime: blank.to_vec(),
+            mcu_bare_metal_runtime: blank.to_vec(),
             caliptra_rom,
             caliptra_fw: blank.to_vec(),
             soc_manifest: blank.to_vec(),
-            test_roms: vec![],
-            caliptra_test_roms: vec![],
-            test_runtimes: vec![],
-            test_soc_manifests: vec![],
-            test_pldm_fw_pkgs: vec![],
-            test_flash_images: vec![],
-            test_update_flash_images: vec![],
+            ..Default::default()
         }
     };
     let otp_memory = if otp_file.is_some() && otp_file.unwrap().exists() {


### PR DESCRIPTION
This change fixes test failures in CI caused by attempting to build firmware from source when the source code is unavailable. In CI, the test and firmware binaries are built in one CI stage and passed to the next stage to run. The following fixes were applied:

1. Update all_build to include the bare-metal runtime in the firmware bundle (for emulator platform).
2. Update test_bare_metal_runtime_boot to use the pre-built bare-metal untime from the bundle.
