### PR TITLE
Fix CI workflow package names and import formatting

### DIFF
--- a/.github/workflows/caliptra-util-host-validator.yml
+++ b/.github/workflows/caliptra-util-host-validator.yml
@@ -113,12 +113,12 @@ jobs:
       - name: Run Caliptra Util Host validator tests
         run: |
           cargo xtask all-build
-          cargo test --package tests-integration --lib -- test::test_caliptra_util_host_validator --nocapture --include-ignored
+          cargo test --package caliptra-mcu-tests-integration --lib -- test::test_caliptra_util_host_validator --nocapture --include-ignored
           sccache --show-stats
 
       - name: Run Caliptra Util Host MCTP VDM validator tests
         run: |
-          cargo test --package tests-integration --lib -- test_mctp_vdm_validator::test::test_caliptra_util_host_mctp_vdm_validator --nocapture --include-ignored
+          cargo test --package caliptra-mcu-tests-integration --lib -- test_mctp_vdm_validator::test::test_caliptra_util_host_mctp_vdm_validator --nocapture --include-ignored
           sccache --show-stats
 
       - name: Upload test results and logs

--- a/caliptra-util-host/apps/mailbox/client/src/lib.rs
+++ b/caliptra-util-host/apps/mailbox/client/src/lib.rs
@@ -35,6 +35,7 @@ use caliptra_mcu_core_util_host_command_types::{
     GetDeviceCapabilitiesResponse, GetDeviceIdResponse, GetDeviceInfoResponse,
     GetFirmwareVersionResponse,
 };
+use caliptra_mcu_core_util_host_transport::Mailbox;
 use caliptra_util_host_commands::api::crypto_aes::{
     caliptra_aes_decrypt, caliptra_aes_encrypt, caliptra_aes_gcm_decrypt, caliptra_aes_gcm_encrypt,
     AesEncryptResult, AesGcmDecryptResult, AesGcmEncryptResult,
@@ -56,7 +57,6 @@ use caliptra_util_host_commands::api::device_info::{
     caliptra_cmd_get_firmware_version,
 };
 use caliptra_util_host_session::CaliptraSession;
-use caliptra_mcu_core_util_host_transport::Mailbox;
 
 /// High-level Mailbox Client for communicating with Caliptra devices
 pub struct MailboxClient<'a> {
@@ -65,15 +65,18 @@ pub struct MailboxClient<'a> {
 
 impl<'a> MailboxClient<'a> {
     /// Create a new MailboxClient with the provided mailbox driver
-    pub fn new(mailbox_driver: &'a mut dyn caliptra_mcu_core_util_host_transport::MailboxDriver) -> Self {
+    pub fn new(
+        mailbox_driver: &'a mut dyn caliptra_mcu_core_util_host_transport::MailboxDriver,
+    ) -> Self {
         let transport = Mailbox::new(mailbox_driver);
         Self { transport }
     }
 
     /// Create a new MailboxClient with UDP transport
     pub fn with_udp_driver(udp_driver: &'a mut UdpTransportDriver) -> Self {
-        let transport =
-            Mailbox::new(udp_driver as &mut dyn caliptra_mcu_core_util_host_transport::MailboxDriver);
+        let transport = Mailbox::new(
+            udp_driver as &mut dyn caliptra_mcu_core_util_host_transport::MailboxDriver,
+        );
         Self { transport }
     }
 

--- a/caliptra-util-host/cbinding/src/session.rs
+++ b/caliptra-util-host/cbinding/src/session.rs
@@ -4,8 +4,8 @@
 
 use std::boxed::Box;
 
-use caliptra_util_host_session::CaliptraSession;
 use caliptra_mcu_core_util_host_transport::{Mailbox, Transport};
+use caliptra_util_host_session::CaliptraSession;
 
 use crate::{CaliptraError, CaliptraTransport};
 

--- a/caliptra-util-host/session/src/lib.rs
+++ b/caliptra-util-host/session/src/lib.rs
@@ -6,7 +6,9 @@
 
 #![no_std]
 
-use caliptra_mcu_core_util_host_command_types::{CaliptraCommandId, CommandRequest, CommandResponse};
+use caliptra_mcu_core_util_host_command_types::{
+    CaliptraCommandId, CommandRequest, CommandResponse,
+};
 use caliptra_mcu_core_util_host_osal::time::{sleep, Duration, Instant};
 use caliptra_mcu_core_util_host_transport::Transport;
 use zerocopy::{FromBytes, Immutable, IntoBytes};

--- a/caliptra-util-host/src/lib.rs
+++ b/caliptra-util-host/src/lib.rs
@@ -104,12 +104,12 @@ pub use caliptra_util_host_commands::api::device_info::{
     caliptra_cmd_get_firmware_version,
 };
 // Re-export SHA API functions
+pub use caliptra_mcu_core_util_host_transport::{Mailbox, Transport};
 pub use caliptra_util_host_commands::api::crypto_hash::{
     caliptra_cmd_sha_final, caliptra_cmd_sha_hash, caliptra_cmd_sha_init, caliptra_cmd_sha_update,
 };
 pub use caliptra_util_host_session::CaliptraSession;
-pub use caliptra_mcu_core_util_host_transport::{Mailbox, Transport};
 
 // Re-export error types
-pub use caliptra_util_host_session::SessionError;
 pub use caliptra_mcu_core_util_host_transport::TransportError;
+pub use caliptra_util_host_session::SessionError;

--- a/caliptra-util-host/tests/src/integration_tests.rs
+++ b/caliptra-util-host/tests/src/integration_tests.rs
@@ -16,8 +16,8 @@
 //! - `caliptra-osal`: OS abstraction layer (only module with std access)
 
 use crate::common::{test_constants::*, MockMailbox};
-use caliptra_util_host_session::CaliptraSession;
 use caliptra_mcu_core_util_host_transport::Mailbox;
+use caliptra_util_host_session::CaliptraSession;
 
 /// Integration test demonstrating session lifecycle management
 ///

--- a/caliptra-util-host/tests/src/test_aes.rs
+++ b/caliptra-util-host/tests/src/test_aes.rs
@@ -9,12 +9,12 @@ use caliptra_mcu_core_util_host_command_types::crypto_aes::{
     AesMode, AES_CONTEXT_SIZE, AES_GCM_CONTEXT_SIZE, AES_GCM_IV_SIZE, AES_IV_SIZE,
 };
 use caliptra_mcu_core_util_host_command_types::crypto_hmac::Cmk;
+use caliptra_mcu_core_util_host_transport::Mailbox;
 use caliptra_util_host_commands::api::crypto_aes::{
     caliptra_cmd_aes_decrypt_init, caliptra_cmd_aes_encrypt_init,
     caliptra_cmd_aes_gcm_decrypt_init, caliptra_cmd_aes_gcm_encrypt_init,
 };
 use caliptra_util_host_session::CaliptraSession;
-use caliptra_mcu_core_util_host_transport::Mailbox;
 
 #[test]
 fn test_aes_encrypt_init_basic() {

--- a/caliptra-util-host/tests/src/test_crypto_asymmetric.rs
+++ b/caliptra-util-host/tests/src/test_crypto_asymmetric.rs
@@ -11,11 +11,11 @@ use caliptra_mcu_core_util_host_command_types::crypto_asymmetric::{
     ECC384_SCALAR_BYTE_SIZE, MAX_CMB_DATA_SIZE,
 };
 use caliptra_mcu_core_util_host_command_types::crypto_hmac::{CmKeyUsage, Cmk, CMK_SIZE};
+use caliptra_mcu_core_util_host_transport::Mailbox;
 use caliptra_util_host_commands::api::crypto_asymmetric::{
     caliptra_cmd_ecdh_generate, caliptra_cmd_ecdsa_public_key, caliptra_cmd_ecdsa_sign,
 };
 use caliptra_util_host_session::CaliptraSession;
-use caliptra_mcu_core_util_host_transport::Mailbox;
 
 /// Test ECDSA public key request construction
 #[test]

--- a/caliptra-util-host/tests/src/test_get_device_capabilities.rs
+++ b/caliptra-util-host/tests/src/test_get_device_capabilities.rs
@@ -6,9 +6,9 @@
 //! actual high-level API with CaliptraSession and VDM transport.
 
 use crate::common::{test_constants::*, MockMailbox};
+use caliptra_mcu_core_util_host_transport::Mailbox;
 use caliptra_util_host_commands::api::device_info::caliptra_cmd_get_device_capabilities;
 use caliptra_util_host_session::CaliptraSession;
-use caliptra_mcu_core_util_host_transport::Mailbox;
 
 /// Test GetDeviceCapabilities command with basic configuration
 #[test]

--- a/caliptra-util-host/tests/src/test_get_device_id.rs
+++ b/caliptra-util-host/tests/src/test_get_device_id.rs
@@ -6,9 +6,9 @@
 //! actual high-level API with CaliptraSession and VDM transport.
 
 use crate::common::{test_constants::*, MockMailbox};
+use caliptra_mcu_core_util_host_transport::Mailbox;
 use caliptra_util_host_commands::api::device_info::caliptra_cmd_get_device_id;
 use caliptra_util_host_session::CaliptraSession;
-use caliptra_mcu_core_util_host_transport::Mailbox;
 
 /// Test GetDeviceId command with default configuration
 #[test]

--- a/caliptra-util-host/tests/src/test_get_device_info.rs
+++ b/caliptra-util-host/tests/src/test_get_device_info.rs
@@ -6,9 +6,9 @@
 //! actual high-level API with CaliptraSession and VDM transport.
 
 use crate::common::{test_constants::*, MockMailbox};
+use caliptra_mcu_core_util_host_transport::Mailbox;
 use caliptra_util_host_commands::api::device_info::caliptra_cmd_get_device_info;
 use caliptra_util_host_session::CaliptraSession;
-use caliptra_mcu_core_util_host_transport::Mailbox;
 
 /// Test GetDeviceInfo command with basic configuration
 #[test]

--- a/caliptra-util-host/tests/src/test_get_firmware_version.rs
+++ b/caliptra-util-host/tests/src/test_get_firmware_version.rs
@@ -6,9 +6,9 @@
 //! actual high-level API with CaliptraSession and VDM transport.
 
 use crate::common::{test_constants::*, MockMailbox};
+use caliptra_mcu_core_util_host_transport::Mailbox;
 use caliptra_util_host_commands::api::device_info::caliptra_cmd_get_firmware_version;
 use caliptra_util_host_session::CaliptraSession;
-use caliptra_mcu_core_util_host_transport::Mailbox;
 
 /// Test GetFirmwareVersion command with ROM firmware
 #[test]

--- a/caliptra-util-host/tests/src/test_hmac.rs
+++ b/caliptra-util-host/tests/src/test_hmac.rs
@@ -9,11 +9,11 @@ use caliptra_mcu_core_util_host_command_types::crypto_hmac::{
     CmKeyUsage, Cmk, HmacAlgorithm, HmacKdfCounterRequest, HmacRequest, CMK_SIZE,
     MAX_HMAC_INPUT_SIZE,
 };
+use caliptra_mcu_core_util_host_transport::Mailbox;
 use caliptra_util_host_commands::api::crypto_hmac::{
     caliptra_cmd_hmac, caliptra_cmd_hmac_kdf_counter,
 };
 use caliptra_util_host_session::CaliptraSession;
-use caliptra_mcu_core_util_host_transport::Mailbox;
 
 /// Test HMAC SHA384 command
 #[test]

--- a/caliptra-util-host/tests/src/test_sha.rs
+++ b/caliptra-util-host/tests/src/test_sha.rs
@@ -6,9 +6,9 @@
 
 use crate::common::{test_constants::*, MockMailbox};
 use caliptra_mcu_core_util_host_command_types::crypto_hash::{ShaAlgorithm, SHA_CONTEXT_SIZE};
+use caliptra_mcu_core_util_host_transport::Mailbox;
 use caliptra_util_host_commands::api::crypto_hash::caliptra_cmd_sha_init;
 use caliptra_util_host_session::CaliptraSession;
-use caliptra_mcu_core_util_host_transport::Mailbox;
 
 /// Test SHA384 init command
 #[test]

--- a/tests/integration/src/lib.rs
+++ b/tests/integration/src/lib.rs
@@ -705,7 +705,7 @@ mod test {
             let mut cargo_args: Vec<String> = vec![
                 "run".to_string(),
                 "-p".to_string(),
-                "emulator".to_string(),
+                "caliptra-mcu-emulator".to_string(),
                 "--profile".to_string(),
                 "test".to_string(),
                 "--".to_string(),


### PR DESCRIPTION
- Fix caliptra-util-host-validator CI workflow to use the renamed package name caliptra-mcu-tests-integration (was tests-integration). 
- Fix emulator package reference in integration test runner (was emulator, now caliptra-mcu-emulator). 
- Apply cargo fmt import ordering fixes across caliptra-util-host crates.