### PR TITLE
[rom] Set FW protected region boundary

### DIFF
--- a/docs/src/rom.md
+++ b/docs/src/rom.md
@@ -57,6 +57,7 @@ These are selected based on the MCI `RESET_REASON` register that is set by hardw
 1. Configure MCU mailbox AXI users (see [Security Configuration](#security-configuration) below).
 1. Set mailbox AXI user lock registers.
 1. [2.1] Set [FC_FIPS_ZEROZATION](https://chipsalliance.github.io/caliptra-ss/main/regs/?p=soc.mci_top.mci_reg.FC_FIPS_ZEROZATION) to the appropriate value.
+1. Configure the MCU SRAM execution region size by writing to the `FW_SRAM_EXEC_REGION_SIZE` register. If not specified in `RomParameters`, it defaults to reserving 32KB at the top of SRAM for the Protected Data Region.
 1. Set `SS_CONFIG_DONE_STICKY`, `SS_CONFIG_DONE` registers to lock MCI configuration.
 1. Verify PK hashes and MCU mailbox AXI users after locking (see [Security Configuration](#security-configuration) below).
 1. Poll on Caliptra `FLOW_STATUS` registers for Caliptra to deassert the Ready for Fuses state.
@@ -102,6 +103,7 @@ sequenceDiagram
     mcu->>caliptra: set non-secret fuses
     mcu->>mci: configure MCU mailbox AXI users
     mcu->>mci: lock MCU mailbox AXI users
+    mcu->>mci: set FW_SRAM_EXEC_REGION_SIZE
     mcu->>mci: set SS_CONFIG_DONE_STICKY
     mcu->>mci: set SS_CONFIG_DONE
     mcu->>mci: verify PK hashes
@@ -198,6 +200,7 @@ Warm Reset Flow occurs when the subsystem reset is toggled while `powergood` is 
 1. Check the MCI `RESET_REASON` register for reset status (it should be in warm reset mode `WarmReset`)
 1. Assert Caliptra boot go signal to bring Caliptra out of reset.
 1. Wait for Caliptra to be ready for fuses (even though fuses won't be rewritten)
+1. Configure the MCU SRAM execution region size by writing to the `FW_SRAM_EXEC_REGION_SIZE` register.
 1. Set `SS_CONFIG_DONE` register to lock MCI configuration until next warm reset.
 1. Signal fuse write done to Caliptra to complete the fuse handshake protocol
 1. Wait for Caliptra to deassert ready for fuses state
@@ -214,7 +217,6 @@ sequenceDiagram
     loop wait for ready for fuses
         mcu->>caliptra: check ready for fuses status
     end
-    mcu->>mci: set SS_CONFIG_DONE
     mcu->>mci: set SS_CONFIG_DONE
     mcu->>caliptra: signal fuse write done
     loop wait for NOT ready for fuses

--- a/rom/src/cold_boot.rs
+++ b/rom/src/cold_boot.rs
@@ -512,6 +512,13 @@ impl BootFlow for ColdBoot {
         );
         mci.set_flow_checkpoint(McuRomBootStatus::McuMboxAxiUsersConfigured.into());
 
+        let size_value = params.mcu_fw_sram_exec_region_size.unwrap_or(
+            unsafe { MCU_MEMORY_MAP.sram_size }
+                - crate::MCU_SRAM_DEFAULT_PROTECTED_REGION_BLOCKS * 4096
+                - 1,
+        );
+        mci.set_fw_sram_exec_region_size(size_value);
+
         // Set SS_CONFIG_DONE_STICKY to lock MCI configuration registers
         caliptra_mcu_romtime::println!(
             "[mcu-rom] Setting SS_CONFIG_DONE_STICKY to lock configuration"

--- a/rom/src/rom.rs
+++ b/rom/src/rom.rs
@@ -45,6 +45,8 @@ const LMS_CALIPTRA_VALUE: u8 = 3;
 const OTP_DAI_IDLE_BIT_OFFSET: u32 = 22;
 const OTP_DIRECT_ACCESS_CMD_REG_OFFSET: u32 = 0x60;
 
+pub const MCU_SRAM_DEFAULT_PROTECTED_REGION_BLOCKS: u32 = 8; // 32 kB / 4 kB chunks
+
 /// Trait for different boot flows (cold boot, warm reset, firmware update)
 pub trait BootFlow {
     /// Execute the boot flow
@@ -739,6 +741,8 @@ pub struct RomParameters<'a> {
     /// Note that in 2.0, Caliptra already sets recovery status as successful so there may be a race
     /// condition depending on when a BMC reads the recovery status.
     pub recovery_status_open: bool,
+    /// Size of the executable SRAM region to pass into FW_SRAM_EXEC_REGION_SIZE
+    pub mcu_fw_sram_exec_region_size: Option<u32>,
     /// Valid AXI users for Caliptra mailbox. 0 values are ignored.
     pub cptra_mbox_axi_users: [u32; 5],
     /// Valid AXI user for Caliptra fuse registers. 0 = don't configure.

--- a/rom/src/warm_boot.rs
+++ b/rom/src/warm_boot.rs
@@ -94,6 +94,13 @@ impl BootFlow for WarmBoot {
         );
         mci.set_flow_checkpoint(McuRomBootStatus::McuMboxAxiUsersConfigured.into());
 
+        let size_value = params.mcu_fw_sram_exec_region_size.unwrap_or(
+            unsafe { MCU_MEMORY_MAP.sram_size }
+                - crate::MCU_SRAM_DEFAULT_PROTECTED_REGION_BLOCKS * 4096
+                - 1,
+        );
+        mci.set_fw_sram_exec_region_size(size_value);
+
         // Set SS_CONFIG_DONE_STICKY to lock MCI configuration registers
         caliptra_mcu_romtime::println!(
             "[mcu-rom] Setting SS_CONFIG_DONE_STICKY to lock configuration"

--- a/romtime/src/mci.rs
+++ b/romtime/src/mci.rs
@@ -193,6 +193,10 @@ impl Mci {
         }
     }
 
+    pub fn set_fw_sram_exec_region_size(&self, size: u32) {
+        self.registers.mci_reg_fw_sram_exec_region_size.set(size);
+    }
+
     pub fn trigger_warm_reset(&self) {
         self.registers.mci_reg_reset_request.set(1);
     }


### PR DESCRIPTION
Per https://chipsalliance.github.io/caliptra-web/docs/2.1/subsystem/ss_hardware_spec.html#mcu-sram-1

Set the FW_SRAM_EXEC_REGION_SIZE MCI register to set the protected region of the SRAM from a value in the RomParameters.

Note that if this value is too small, the MCU RT will fail, as the instruction fetch unit does NOT have access to the protected region; only the executable region. By default, make the SRAM executable up to the last 32k