### PR TITLE
[xtask] add optional configuration argument to fpga build commands

### DIFF
--- a/xtask/src/fpga/configurations.rs
+++ b/xtask/src/fpga/configurations.rs
@@ -15,7 +15,7 @@ use super::{
 };
 
 /// The FPGA configuration mode
-#[derive(Copy, Clone, ValueEnum, Debug)]
+#[derive(Copy, Clone, ValueEnum, Debug, PartialEq, Eq)]
 pub enum Configuration {
     /// Testing FPGA in Subsystem mode. For example running tests in caliptra-mcu-sw.
     Subsystem,
@@ -81,6 +81,20 @@ impl<'a> Configuration {
         let cache_contents = run_command_with_output(target_host, "cat /dev/shm/fpga-config")?;
         let cache_contents = cache_contents.trim_end();
         Self::from_cache(cache_contents)
+    }
+
+    /// Attempts to retrieve the FPGA configuration from the target host.
+    /// Returns `Ok(None)` if the configuration file is missing.
+    pub fn from_cmd_optional(target_host: Option<&str>) -> Result<Option<Self>> {
+        check_ssh_access(target_host)?;
+        // cat will fail if file doesn't exist, run_command_with_output returns empty stdout in that case
+        let cache_contents =
+            run_command_with_output(target_host, "cat /dev/shm/fpga-config || true")?;
+        let cache_contents = cache_contents.trim_end();
+        if cache_contents.is_empty() {
+            return Ok(None);
+        }
+        Ok(Some(Self::from_cache(cache_contents)?))
     }
 
     pub fn executor(self) -> CommandExecutor {

--- a/xtask/src/fpga/mod.rs
+++ b/xtask/src/fpga/mod.rs
@@ -107,6 +107,10 @@ pub(crate) enum Fpga {
     },
     /// Build FPGA firmware
     Build {
+        /// The FPGA configuration mode
+        #[arg(long, value_enum)]
+        configuration: Option<Configuration>,
+
         /// When set copy firmware to `target_host`
         #[arg(long)]
         target_host: Option<String>,
@@ -141,6 +145,10 @@ pub(crate) enum Fpga {
     },
     /// Build FPGA test binaries
     BuildTest {
+        /// The FPGA configuration mode
+        #[arg(long, value_enum)]
+        configuration: Option<Configuration>,
+
         /// When set copy test binaries to `target_host`
         #[arg(long)]
         target_host: Option<String>,
@@ -231,6 +239,7 @@ pub(crate) fn fpga_entry(args: &Fpga) -> Result<()> {
     check_host_dependencies()?;
     match args {
         Fpga::Build {
+            configuration,
             target_host,
             mcu,
             fw_id,
@@ -239,7 +248,7 @@ pub(crate) fn fpga_entry(args: &Fpga) -> Result<()> {
             mcu_cfgs,
         } => {
             println!("Building FPGA firmware");
-            let config = Configuration::from_cmd(target_host.as_deref())?;
+            let config = get_and_validate_configuration(*configuration, target_host.as_deref())?;
             config
                 .executor()
                 .set_target_host(target_host.as_deref())
@@ -252,11 +261,12 @@ pub(crate) fn fpga_entry(args: &Fpga) -> Result<()> {
                 })?;
         }
         Fpga::BuildTest {
+            configuration,
             target_host,
             package_filter,
         } => {
             println!("Building FPGA tests");
-            let config = Configuration::from_cmd(target_host.as_deref())?;
+            let config = get_and_validate_configuration(*configuration, target_host.as_deref())?;
             config
                 .executor()
                 .set_target_host(target_host.as_deref())
@@ -474,4 +484,24 @@ pub(crate) fn fpga_run(args: crate::Commands) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Validates the provided configuration against the configuration on the target host.
+/// If no configuration is provided, attempts to retrieve it from the target host.
+fn get_and_validate_configuration(
+    provided: Option<Configuration>,
+    target_host: Option<&str>,
+) -> Result<Configuration> {
+    let host_config = Configuration::from_cmd_optional(target_host)?;
+    match (provided, host_config) {
+        (Some(p), Some(h)) => {
+            if p != h {
+                bail!("Provided configuration {:?} does not match FPGA configuration {:?} on host", p, h);
+            }
+            Ok(p)
+        }
+        (Some(p), None) => Ok(p),
+        (None, Some(h)) => Ok(h),
+        (None, None) => bail!("FPGA is not bootstrapped. Need to run `xtask fpga bootstrap` or provide `--configuration`"),
+    }
 }


### PR DESCRIPTION
This change allows the `fpga build` and `fpga build-test` commands to run in environments like CI where the FPGA has not been bootstrapped. It adds an optional `--configuration` CLI argument and a validation mechanism to ensure consistency with the host's configuration if it exists.

- Added `Configuration::from_cmd_optional` to try getting config without bailing.
- Added `--configuration` to `Build` and `BuildTest` Fpga subcommands.
- Added `get_and_validate_configuration` to handle CLI vs host config logic.
- Implemented `PartialEq` and `Eq` for `Configuration` to allow comparison.

This partially addresses #1245.