### PR TITLE
[userspace] Add Command Authorizer Trait for commands that need authorization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1152,6 +1152,7 @@ name = "caliptra-mcu-external-cmds-common"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "caliptra-mcu-mbox-common",
  "zerocopy",
 ]
 

--- a/common/mcu-mbox/src/messages.rs
+++ b/common/mcu-mbox/src/messages.rs
@@ -66,7 +66,7 @@ where
     const MIN_SIZE: usize = core::mem::size_of::<Self>();
 }
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
 pub struct CommandId(pub u32);
 
 impl CommandId {
@@ -116,6 +116,9 @@ impl CommandId {
     pub const MC_FUSE_READ: Self = Self(0x4946_5052); // "IFPR"
     pub const MC_FUSE_WRITE: Self = Self(0x4946_5057); // "IFPW"
     pub const MC_FUSE_LOCK_PARTITION: Self = Self(0x4946_504B); // "IFPK"
+
+    // Authorized commands
+    pub const MC_ROTATE_VENDOR_PK_HASH: Self = Self(0x4D56_504B); // "MVPK"
 }
 
 impl From<u32> for CommandId {

--- a/platforms/emulator/runtime/userspace/apps/user/src/mcu_mbox/cmd_auth_mock.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/mcu_mbox/cmd_auth_mock.rs
@@ -1,0 +1,14 @@
+// Licensed under the Apache-2.0 license
+use caliptra_mcu_external_cmds_common::CommandAuthorizer;
+
+pub struct MockCommandAuthorizer;
+
+impl CommandAuthorizer for MockCommandAuthorizer {
+    fn is_authorized<'a>(
+        &self,
+        _cmd_id: caliptra_mcu_mbox_common::messages::CommandId,
+        req: &'a [u8],
+    ) -> Result<&'a [u8], caliptra_mcu_external_cmds_common::AuthorizationError> {
+        Ok(req)
+    }
+}

--- a/platforms/emulator/runtime/userspace/apps/user/src/mcu_mbox/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/mcu_mbox/mod.rs
@@ -6,6 +6,13 @@
     feature = "test-mcu-mbox-fips-periodic",
     feature = "test-caliptra-util-host-validator"
 ))]
+mod cmd_auth_mock;
+#[cfg(any(
+    feature = "test-mcu-mbox-cmds",
+    feature = "test-mcu-mbox-fips-self-test",
+    feature = "test-mcu-mbox-fips-periodic",
+    feature = "test-caliptra-util-host-validator"
+))]
 mod cmd_handler_mock;
 
 use caliptra_mcu_libsyscall_caliptra::system::System;
@@ -40,11 +47,13 @@ async fn start_mcu_mbox_service() -> Result<(), ErrorCode> {
     ))]
     {
         let handler = cmd_handler_mock::NonCryptoCmdHandlerMock::default();
+        let cmd_authorizer = cmd_auth_mock::MockCommandAuthorizer;
         let mut transport = caliptra_mcu_mbox_lib::transport::McuMboxTransport::new(
             caliptra_mcu_libsyscall_caliptra::mcu_mbox::MCU_MBOX0_DRIVER_NUM,
         );
         let mut mcu_mbox_service = caliptra_mcu_mbox_lib::daemon::McuMboxService::init(
             &handler,
+            &cmd_authorizer,
             &mut transport,
             crate::EXECUTOR.get().spawner(),
         );

--- a/runtime/userspace/api/external-cmds-common/Cargo.toml
+++ b/runtime/userspace/api/external-cmds-common/Cargo.toml
@@ -8,4 +8,5 @@ authors.workspace = true
 
 [dependencies]
 async-trait.workspace = true
+caliptra-mcu-mbox-common.workspace = true
 zerocopy.workspace = true

--- a/runtime/userspace/api/external-cmds-common/src/lib.rs
+++ b/runtime/userspace/api/external-cmds-common/src/lib.rs
@@ -6,6 +6,7 @@ extern crate alloc;
 
 use alloc::boxed::Box;
 use async_trait::async_trait;
+use caliptra_mcu_mbox_common::messages::CommandId;
 use zerocopy::{Immutable, IntoBytes};
 
 pub const MAX_FW_VERSION_LEN: usize = 32;
@@ -142,4 +143,8 @@ pub trait UnifiedCommandHandler {
         algorithm: u32,
         csr_data: &mut AttestedCsrData,
     ) -> Result<(), CommandError>;
+}
+
+pub trait CommandAuthorizer {
+    fn is_authorized(&self, cmd_id: CommandId, msg_buf: &mut [u8], req_len: usize) -> bool;
 }

--- a/runtime/userspace/api/external-cmds-common/src/lib.rs
+++ b/runtime/userspace/api/external-cmds-common/src/lib.rs
@@ -145,6 +145,24 @@ pub trait UnifiedCommandHandler {
     ) -> Result<(), CommandError>;
 }
 
+pub struct AuthorizationError;
+
 pub trait CommandAuthorizer {
-    fn is_authorized(&self, cmd_id: CommandId, msg_buf: &mut [u8], req_len: usize) -> bool;
+    /// Validates if a message is authorized.
+    ///
+    /// The request can contain authorization data (e.g. a HMAC).
+    /// This method is responsible for unpacking the contained
+    /// request message and returning it as a slice.
+    ///
+    /// # Arguments
+    /// * `cmd_id` - Command identifier
+    /// * `req` - Message to be authorized
+    ///
+    /// # Returns
+    /// * `Result<&[u8], CommandError>` - Unpacked command or Error
+    fn is_authorized<'a>(
+        &self,
+        cmd_id: CommandId,
+        req: &'a [u8],
+    ) -> Result<&'a [u8], AuthorizationError>;
 }

--- a/runtime/userspace/api/mcu-mbox-lib/src/cmd_interface.rs
+++ b/runtime/userspace/api/mcu-mbox-lib/src/cmd_interface.rs
@@ -12,22 +12,14 @@ use caliptra_mcu_libsyscall_caliptra::mcu_mbox::MbxCmdStatus;
 use caliptra_mcu_mbox_common::messages::{
     CommandId, DeviceCapsReq, DeviceCapsResp, DeviceIdReq, DeviceIdResp, DeviceInfoReq,
     DeviceInfoResp, FirmwareVersionReq, FirmwareVersionResp, MailboxRespHeader,
-    MailboxRespHeaderVarSize, McuAesDecryptInitReq, McuAesDecryptInitResp, McuAesDecryptUpdateReq,
-    McuAesDecryptUpdateResp, McuAesEncryptInitReq, McuAesEncryptInitResp, McuAesEncryptUpdateReq,
-    McuAesEncryptUpdateResp, McuAesGcmDecryptFinalReq, McuAesGcmDecryptFinalResp,
-    McuAesGcmDecryptInitReq, McuAesGcmDecryptInitResp, McuAesGcmDecryptUpdateReq,
-    McuAesGcmDecryptUpdateResp, McuAesGcmEncryptFinalReq, McuAesGcmEncryptFinalResp,
-    McuAesGcmEncryptInitReq, McuAesGcmEncryptInitResp, McuAesGcmEncryptUpdateReq,
-    McuAesGcmEncryptUpdateResp, McuCmDeleteReq, McuCmDeleteResp, McuCmImportReq, McuCmImportResp,
-    McuCmStatusReq, McuCmStatusResp, McuEcdhFinishReq, McuEcdhFinishResp, McuEcdhGenerateReq,
-    McuEcdhGenerateResp, McuEcdsaCmkPublicKeyReq, McuEcdsaCmkPublicKeyResp, McuEcdsaCmkSignReq,
-    McuEcdsaCmkSignResp, McuEcdsaCmkVerifyReq, McuEcdsaCmkVerifyResp, McuFipsSelfTestGetResultsReq,
-    McuFipsSelfTestGetResultsResp, McuFipsSelfTestStartReq, McuFipsSelfTestStartResp,
-    McuHkdfExpandReq, McuHkdfExpandResp, McuHkdfExtractReq, McuHkdfExtractResp,
-    McuHmacKdfCounterReq, McuHmacKdfCounterResp, McuHmacReq, McuHmacResp, McuProdDebugUnlockReqReq,
-    McuProdDebugUnlockReqResp, McuProdDebugUnlockTokenReq, McuProdDebugUnlockTokenResp,
-    McuRandomGenerateReq, McuRandomGenerateResp, McuRandomStirReq, McuRandomStirResp,
-    McuResponseVarSize, McuShaFinalReq, McuShaFinalResp, McuShaInitReq, McuShaInitResp,
+    MailboxRespHeaderVarSize, McuAesDecryptInitReq, McuAesDecryptUpdateReq, McuAesEncryptInitReq,
+    McuAesEncryptUpdateReq, McuAesGcmDecryptFinalReq, McuAesGcmDecryptInitReq,
+    McuAesGcmDecryptUpdateReq, McuAesGcmEncryptFinalReq, McuAesGcmEncryptInitReq,
+    McuAesGcmEncryptUpdateReq, McuCmDeleteReq, McuCmImportReq, McuCmStatusReq, McuEcdhFinishReq,
+    McuEcdhGenerateReq, McuEcdsaCmkPublicKeyReq, McuEcdsaCmkSignReq, McuEcdsaCmkVerifyReq,
+    McuFipsSelfTestGetResultsReq, McuFipsSelfTestStartReq, McuHkdfExpandReq, McuHkdfExtractReq,
+    McuHmacKdfCounterReq, McuHmacReq, McuProdDebugUnlockReqReq, McuProdDebugUnlockTokenReq,
+    McuRandomGenerateReq, McuRandomStirReq, McuResponseVarSize, McuShaFinalReq, McuShaInitReq,
     McuShaUpdateReq, DEVICE_CAPS_SIZE, MAX_FW_VERSION_STR_LEN,
 };
 #[cfg(feature = "periodic-fips-self-test")]
@@ -72,32 +64,44 @@ impl<'a> CmdInterface<'a> {
         }
     }
 
+    /// Handle a MCU mailbox request
+    ///
+    /// # Arguments
+    /// * `req_buf` - Buffer for receiving the command
+    /// * `resp_buf` - Buffer for response encoding
+    ///
+    /// `req_buf` should be sized to fit`size_of::<McuMailboxReq>()` (see [McuMailboxReq](caliptra_mcu_mbox_common::messages::McuMailboxReq)).
+    ///
+    /// `resp_buf` should be sized to fit `size_of::<McuMailboxResp>()` (see [McuMailboxResp]).
     pub async fn handle_responder_msg(
         &mut self,
-        msg_buf: &mut [u8],
+        req_buf: &mut [u8],
+        resp_buf: &mut [u8],
     ) -> Result<(), MsgHandlerError> {
         // Make sure at least the header can be written to the buffer.
-        if msg_buf.len() < size_of::<MailboxRespHeader>() {
+        if resp_buf.len() < size_of::<MailboxRespHeader>() {
             return Err(MsgHandlerError::InvalidParams);
         }
 
         // Receive a request from the transport.
-        let receive_result = self.transport.receive_request(msg_buf).await;
+        let receive_result = self.transport.receive_request(req_buf).await;
 
         let status = match receive_result {
-            Ok((cmd_id, req_len)) => {
+            Ok((cmd_id, req)) => {
                 // Process the request and prepare the response.
-                match self.process_request(msg_buf, cmd_id, req_len).await {
-                    Ok((resp_len, status)) => {
+                match self.process_request(req, cmd_id, resp_buf).await {
+                    Ok((resp, status)) => {
                         if status == MbxCmdStatus::Complete {
                             // guarantee it is big enough to hold the header
-                            let resp_len = resp_len.max(size_of::<MailboxRespHeader>());
-                            let msg_buf = &mut msg_buf[..resp_len];
+                            if resp.len() < size_of::<MailboxRespHeader>() {
+                                let _ = self.transport.finalize_response(MbxCmdStatus::Failure);
+                                return Err(MsgHandlerError::McuMboxCommon);
+                            }
 
                             // Generate response checksum
-                            populate_checksum(msg_buf);
+                            populate_checksum(resp);
 
-                            self.transport.send_response(msg_buf).await.map_err(|_| {
+                            self.transport.send_response(resp).await.map_err(|_| {
                                 let _ = self.transport.finalize_response(MbxCmdStatus::Failure);
                                 MsgHandlerError::Transport
                             })?;
@@ -124,12 +128,12 @@ impl<'a> CmdInterface<'a> {
         Ok(())
     }
 
-    async fn process_request(
+    async fn process_request<'r>(
         &mut self,
-        msg_buf: &mut [u8],
+        req: &[u8],
         cmd: u32,
-        req_len: usize,
-    ) -> Result<(usize, MbxCmdStatus), MsgHandlerError> {
+        resp_buf: &'r mut [u8],
+    ) -> Result<(&'r mut [u8], MbxCmdStatus), MsgHandlerError> {
         if self.busy.load(Ordering::SeqCst) {
             return Err(MsgHandlerError::NotReady);
         }
@@ -137,342 +141,279 @@ impl<'a> CmdInterface<'a> {
         self.busy.store(true, Ordering::SeqCst);
 
         let result = match CommandId::from(cmd) {
-            CommandId::MC_FIRMWARE_VERSION => self.handle_fw_version(msg_buf, req_len).await,
-            CommandId::MC_DEVICE_CAPABILITIES => self.handle_device_caps(msg_buf, req_len).await,
-            CommandId::MC_DEVICE_ID => self.handle_device_id(msg_buf, req_len).await,
-            CommandId::MC_DEVICE_INFO => self.handle_device_info(msg_buf, req_len).await,
+            CommandId::MC_FIRMWARE_VERSION => self.handle_fw_version(req, resp_buf).await,
+            CommandId::MC_DEVICE_CAPABILITIES => self.handle_device_caps(req, resp_buf).await,
+            CommandId::MC_DEVICE_ID => self.handle_device_id(req, resp_buf).await,
+            CommandId::MC_DEVICE_INFO => self.handle_device_info(req, resp_buf).await,
             CommandId::MC_FIPS_SELF_TEST_START => {
-                let mut resp_bytes = [0u8; core::mem::size_of::<McuFipsSelfTestStartResp>()];
                 self.handle_crypto_passthrough::<McuFipsSelfTestStartReq>(
-                    msg_buf,
-                    req_len,
+                    req,
                     CaliptraCommandId::SELF_TEST_START.into(),
-                    &mut resp_bytes,
+                    resp_buf,
                 )
                 .await
             }
             CommandId::MC_FIPS_SELF_TEST_GET_RESULTS => {
-                let mut resp_bytes = [0u8; core::mem::size_of::<McuFipsSelfTestGetResultsResp>()];
                 self.handle_crypto_passthrough::<McuFipsSelfTestGetResultsReq>(
-                    msg_buf,
-                    req_len,
+                    req,
                     CaliptraCommandId::SELF_TEST_GET_RESULTS.into(),
-                    &mut resp_bytes,
+                    resp_buf,
                 )
                 .await
             }
             #[cfg(feature = "periodic-fips-self-test")]
             CommandId::MC_FIPS_PERIODIC_ENABLE => {
-                self.handle_fips_periodic_enable(msg_buf, req_len).await
+                self.handle_fips_periodic_enable(req, resp_buf).await
             }
             #[cfg(feature = "periodic-fips-self-test")]
             CommandId::MC_FIPS_PERIODIC_STATUS => {
-                self.handle_fips_periodic_status(msg_buf, req_len).await
+                self.handle_fips_periodic_status(req, resp_buf).await
             }
             CommandId::MC_SHA_INIT => {
-                let mut resp_bytes = [0u8; core::mem::size_of::<McuShaInitResp>()];
                 self.handle_crypto_passthrough::<McuShaInitReq>(
-                    msg_buf,
-                    req_len,
+                    req,
                     CaliptraCommandId::CM_SHA_INIT.into(),
-                    &mut resp_bytes,
+                    resp_buf,
                 )
                 .await
             }
             CommandId::MC_SHA_UPDATE => {
-                let mut resp_bytes = [0u8; core::mem::size_of::<McuShaInitResp>()];
                 self.handle_crypto_passthrough::<McuShaUpdateReq>(
-                    msg_buf,
-                    req_len,
+                    req,
                     CaliptraCommandId::CM_SHA_UPDATE.into(),
-                    &mut resp_bytes,
+                    resp_buf,
                 )
                 .await
             }
             CommandId::MC_SHA_FINAL => {
-                let mut resp_bytes = [0u8; core::mem::size_of::<McuShaFinalResp>()];
                 self.handle_crypto_passthrough::<McuShaFinalReq>(
-                    msg_buf,
-                    req_len,
+                    req,
                     CaliptraCommandId::CM_SHA_FINAL.into(),
-                    &mut resp_bytes,
+                    resp_buf,
                 )
                 .await
             }
             // Add HMAC command
             CommandId::MC_HMAC => {
-                let mut resp_bytes = [0u8; core::mem::size_of::<McuHmacResp>()];
                 self.handle_crypto_passthrough::<McuHmacReq>(
-                    msg_buf,
-                    req_len,
+                    req,
                     CaliptraCommandId::CM_HMAC.into(),
-                    &mut resp_bytes,
+                    resp_buf,
                 )
                 .await
             }
             // Add HMAC KDF Counter command
             CommandId::MC_HMAC_KDF_COUNTER => {
-                let mut resp_bytes = [0u8; core::mem::size_of::<McuHmacKdfCounterResp>()];
                 self.handle_crypto_passthrough::<McuHmacKdfCounterReq>(
-                    msg_buf,
-                    req_len,
+                    req,
                     CaliptraCommandId::CM_HMAC_KDF_COUNTER.into(),
-                    &mut resp_bytes,
+                    resp_buf,
                 )
                 .await
             }
             // Add HKDF Extract command
             CommandId::MC_HKDF_EXTRACT => {
-                let mut resp_bytes = [0u8; core::mem::size_of::<McuHkdfExtractResp>()];
                 self.handle_crypto_passthrough::<McuHkdfExtractReq>(
-                    msg_buf,
-                    req_len,
+                    req,
                     CaliptraCommandId::CM_HKDF_EXTRACT.into(),
-                    &mut resp_bytes,
+                    resp_buf,
                 )
                 .await
             }
             // Add HKDF Expand command
             CommandId::MC_HKDF_EXPAND => {
-                let mut resp_bytes = [0u8; core::mem::size_of::<McuHkdfExpandResp>()];
                 self.handle_crypto_passthrough::<McuHkdfExpandReq>(
-                    msg_buf,
-                    req_len,
+                    req,
                     CaliptraCommandId::CM_HKDF_EXPAND.into(),
-                    &mut resp_bytes,
+                    resp_buf,
                 )
                 .await
             }
             CommandId::MC_IMPORT => {
-                let mut resp_bytes = [0u8; core::mem::size_of::<McuCmImportResp>()];
                 self.handle_crypto_passthrough::<McuCmImportReq>(
-                    msg_buf,
-                    req_len,
+                    req,
                     CaliptraCommandId::CM_IMPORT.into(),
-                    &mut resp_bytes,
+                    resp_buf,
                 )
                 .await
             }
             CommandId::MC_DELETE => {
-                let mut resp_bytes = [0u8; core::mem::size_of::<McuCmDeleteResp>()];
                 self.handle_crypto_passthrough::<McuCmDeleteReq>(
-                    msg_buf,
-                    req_len,
+                    req,
                     CaliptraCommandId::CM_DELETE.into(),
-                    &mut resp_bytes,
+                    resp_buf,
                 )
                 .await
             }
             CommandId::MC_CM_STATUS => {
-                let mut resp_bytes = [0u8; core::mem::size_of::<McuCmStatusResp>()];
                 self.handle_crypto_passthrough::<McuCmStatusReq>(
-                    msg_buf,
-                    req_len,
+                    req,
                     CaliptraCommandId::CM_STATUS.into(),
-                    &mut resp_bytes,
+                    resp_buf,
                 )
                 .await
             }
             CommandId::MC_RANDOM_GENERATE => {
-                let mut resp_bytes = [0u8; core::mem::size_of::<McuRandomGenerateResp>()];
                 self.handle_crypto_passthrough::<McuRandomGenerateReq>(
-                    msg_buf,
-                    req_len,
+                    req,
                     CaliptraCommandId::CM_RANDOM_GENERATE.into(),
-                    &mut resp_bytes,
+                    resp_buf,
                 )
                 .await
             }
             CommandId::MC_RANDOM_STIR => {
-                let mut resp_bytes = [0u8; core::mem::size_of::<McuRandomStirResp>()];
                 self.handle_crypto_passthrough::<McuRandomStirReq>(
-                    msg_buf,
-                    req_len,
+                    req,
                     CaliptraCommandId::CM_RANDOM_STIR.into(),
-                    &mut resp_bytes,
+                    resp_buf,
                 )
                 .await
             }
             // Add AES Encrypt commands
             CommandId::MC_AES_ENCRYPT_INIT => {
-                let mut resp_bytes = [0u8; core::mem::size_of::<McuAesEncryptInitResp>()];
                 self.handle_crypto_passthrough::<McuAesEncryptInitReq>(
-                    msg_buf,
-                    req_len,
+                    req,
                     CaliptraCommandId::CM_AES_ENCRYPT_INIT.into(),
-                    &mut resp_bytes,
+                    resp_buf,
                 )
                 .await
             }
             CommandId::MC_AES_ENCRYPT_UPDATE => {
-                let mut resp_bytes = [0u8; core::mem::size_of::<McuAesEncryptUpdateResp>()];
                 self.handle_crypto_passthrough::<McuAesEncryptUpdateReq>(
-                    msg_buf,
-                    req_len,
+                    req,
                     CaliptraCommandId::CM_AES_ENCRYPT_UPDATE.into(),
-                    &mut resp_bytes,
+                    resp_buf,
                 )
                 .await
             }
             // Add AES Decrypt commands
             CommandId::MC_AES_DECRYPT_INIT => {
-                let mut resp_bytes = [0u8; core::mem::size_of::<McuAesDecryptInitResp>()];
                 self.handle_crypto_passthrough::<McuAesDecryptInitReq>(
-                    msg_buf,
-                    req_len,
+                    req,
                     CaliptraCommandId::CM_AES_DECRYPT_INIT.into(),
-                    &mut resp_bytes,
+                    resp_buf,
                 )
                 .await
             }
             CommandId::MC_AES_DECRYPT_UPDATE => {
-                let mut resp_bytes = [0u8; core::mem::size_of::<McuAesDecryptUpdateResp>()];
                 self.handle_crypto_passthrough::<McuAesDecryptUpdateReq>(
-                    msg_buf,
-                    req_len,
+                    req,
                     CaliptraCommandId::CM_AES_DECRYPT_UPDATE.into(),
-                    &mut resp_bytes,
+                    resp_buf,
                 )
                 .await
             }
             // Add AES GCM encrypt commands here.
             CommandId::MC_AES_GCM_ENCRYPT_INIT => {
-                let mut resp_bytes = [0u8; core::mem::size_of::<McuAesGcmEncryptInitResp>()];
                 self.handle_crypto_passthrough::<McuAesGcmEncryptInitReq>(
-                    msg_buf,
-                    req_len,
+                    req,
                     CaliptraCommandId::CM_AES_GCM_ENCRYPT_INIT.into(),
-                    &mut resp_bytes,
+                    resp_buf,
                 )
                 .await
             }
             CommandId::MC_AES_GCM_ENCRYPT_UPDATE => {
-                let mut resp_bytes = [0u8; core::mem::size_of::<McuAesGcmEncryptUpdateResp>()];
                 self.handle_crypto_passthrough::<McuAesGcmEncryptUpdateReq>(
-                    msg_buf,
-                    req_len,
+                    req,
                     CaliptraCommandId::CM_AES_GCM_ENCRYPT_UPDATE.into(),
-                    &mut resp_bytes,
+                    resp_buf,
                 )
                 .await
             }
             CommandId::MC_AES_GCM_ENCRYPT_FINAL => {
-                let mut resp_bytes = [0u8; core::mem::size_of::<McuAesGcmEncryptFinalResp>()];
                 self.handle_crypto_passthrough::<McuAesGcmEncryptFinalReq>(
-                    msg_buf,
-                    req_len,
+                    req,
                     CaliptraCommandId::CM_AES_GCM_ENCRYPT_FINAL.into(),
-                    &mut resp_bytes,
+                    resp_buf,
                 )
                 .await
             }
             // Add AES GCM decrypt commands here.
             CommandId::MC_AES_GCM_DECRYPT_INIT => {
-                let mut resp_bytes = [0u8; core::mem::size_of::<McuAesGcmDecryptInitResp>()];
                 self.handle_crypto_passthrough::<McuAesGcmDecryptInitReq>(
-                    msg_buf,
-                    req_len,
+                    req,
                     CaliptraCommandId::CM_AES_GCM_DECRYPT_INIT.into(),
-                    &mut resp_bytes,
+                    resp_buf,
                 )
                 .await
             }
             CommandId::MC_AES_GCM_DECRYPT_UPDATE => {
-                let mut resp_bytes = [0u8; core::mem::size_of::<McuAesGcmDecryptUpdateResp>()];
                 self.handle_crypto_passthrough::<McuAesGcmDecryptUpdateReq>(
-                    msg_buf,
-                    req_len,
+                    req,
                     CaliptraCommandId::CM_AES_GCM_DECRYPT_UPDATE.into(),
-                    &mut resp_bytes,
+                    resp_buf,
                 )
                 .await
             }
             CommandId::MC_AES_GCM_DECRYPT_FINAL => {
-                let mut resp_bytes = [0u8; core::mem::size_of::<McuAesGcmDecryptFinalResp>()];
                 self.handle_crypto_passthrough::<McuAesGcmDecryptFinalReq>(
-                    msg_buf,
-                    req_len,
+                    req,
                     CaliptraCommandId::CM_AES_GCM_DECRYPT_FINAL.into(),
-                    &mut resp_bytes,
+                    resp_buf,
                 )
                 .await
             }
             // Add ECDH commands
             CommandId::MC_ECDH_GENERATE => {
-                let mut resp_bytes = [0u8; core::mem::size_of::<McuEcdhGenerateResp>()];
                 self.handle_crypto_passthrough::<McuEcdhGenerateReq>(
-                    msg_buf,
-                    req_len,
+                    req,
                     CaliptraCommandId::CM_ECDH_GENERATE.into(),
-                    &mut resp_bytes,
+                    resp_buf,
                 )
                 .await
             }
             CommandId::MC_ECDH_FINISH => {
-                let mut resp_bytes = [0u8; core::mem::size_of::<McuEcdhFinishResp>()];
                 self.handle_crypto_passthrough::<McuEcdhFinishReq>(
-                    msg_buf,
-                    req_len,
+                    req,
                     CaliptraCommandId::CM_ECDH_FINISH.into(),
-                    &mut resp_bytes,
+                    resp_buf,
                 )
                 .await
             }
             // Add ECDSA CMK commands
             CommandId::MC_ECDSA_CMK_PUBLIC_KEY => {
-                let mut resp_bytes = [0u8; core::mem::size_of::<McuEcdsaCmkPublicKeyResp>()];
                 self.handle_crypto_passthrough::<McuEcdsaCmkPublicKeyReq>(
-                    msg_buf,
-                    req_len,
+                    req,
                     CaliptraCommandId::CM_ECDSA_PUBLIC_KEY.into(),
-                    &mut resp_bytes,
+                    resp_buf,
                 )
                 .await
             }
             CommandId::MC_ECDSA_CMK_SIGN => {
-                let mut resp_bytes = [0u8; core::mem::size_of::<McuEcdsaCmkSignResp>()];
                 self.handle_crypto_passthrough::<McuEcdsaCmkSignReq>(
-                    msg_buf,
-                    req_len,
+                    req,
                     CaliptraCommandId::CM_ECDSA_SIGN.into(),
-                    &mut resp_bytes,
+                    resp_buf,
                 )
                 .await
             }
             CommandId::MC_ECDSA_CMK_VERIFY => {
-                let mut resp_bytes = [0u8; core::mem::size_of::<McuEcdsaCmkVerifyResp>()];
                 self.handle_crypto_passthrough::<McuEcdsaCmkVerifyReq>(
-                    msg_buf,
-                    req_len,
+                    req,
                     CaliptraCommandId::CM_ECDSA_VERIFY.into(),
-                    &mut resp_bytes,
+                    resp_buf,
                 )
                 .await
             }
             // Debug Unlock commands
             CommandId::MC_PROD_DEBUG_UNLOCK_REQ => {
-                let mut resp_bytes = [0u8; core::mem::size_of::<McuProdDebugUnlockReqResp>()];
                 self.handle_crypto_passthrough::<McuProdDebugUnlockReqReq>(
-                    msg_buf,
-                    req_len,
+                    req,
                     CaliptraCommandId::PRODUCTION_AUTH_DEBUG_UNLOCK_REQ.into(),
-                    &mut resp_bytes,
+                    resp_buf,
                 )
                 .await
             }
             CommandId::MC_PROD_DEBUG_UNLOCK_TOKEN => {
-                let mut resp_bytes = [0u8; core::mem::size_of::<McuProdDebugUnlockTokenResp>()];
                 self.handle_crypto_passthrough::<McuProdDebugUnlockTokenReq>(
-                    msg_buf,
-                    req_len,
+                    req,
                     CaliptraCommandId::PRODUCTION_AUTH_DEBUG_UNLOCK_TOKEN.into(),
-                    &mut resp_bytes,
+                    resp_buf,
                 )
                 .await
             }
             cmd_id @ CommandId::MC_ROTATE_VENDOR_PK_HASH => {
-                self.handle_authorized_command(cmd_id, msg_buf, req_len)
-                    .await
+                self.handle_authorized_command(cmd_id, req, resp_buf).await
             }
             // TODO: add more command handlers.
             // TODO: DOT runtime commands (DOT_CAK_INSTALL, DOT_LOCK, DOT_DISABLE,
@@ -485,14 +426,14 @@ impl<'a> CmdInterface<'a> {
         result
     }
 
-    async fn handle_fw_version(
+    async fn handle_fw_version<'r>(
         &self,
-        msg_buf: &mut [u8],
-        req_len: usize,
-    ) -> Result<(usize, MbxCmdStatus), MsgHandlerError> {
+        req: &[u8],
+        resp_buf: &'r mut [u8],
+    ) -> Result<(&'r mut [u8], MbxCmdStatus), MsgHandlerError> {
         // Decode the request
-        let req: &FirmwareVersionReq = FirmwareVersionReq::ref_from_bytes(&msg_buf[..req_len])
-            .map_err(|_| MsgHandlerError::InvalidParams)?;
+        let req: &FirmwareVersionReq =
+            FirmwareVersionReq::ref_from_bytes(req).map_err(|_| MsgHandlerError::InvalidParams)?;
 
         let index = req.index;
         let mut version = FirmwareVersion::default();
@@ -520,23 +461,23 @@ impl<'a> CmdInterface<'a> {
             FirmwareVersionResp::default()
         };
 
-        // Encode the response and copy to msg_buf.
+        // Encode the response and copy to resp_buf.
         let resp_bytes = resp
             .as_bytes_partial()
             .map_err(|_| MsgHandlerError::McuMboxCommon)?;
 
-        msg_buf[..resp_bytes.len()].copy_from_slice(resp_bytes);
+        resp_buf[..resp_bytes.len()].copy_from_slice(resp_bytes);
 
-        Ok((resp_bytes.len(), mbox_cmd_status))
+        Ok((&mut resp_buf[..resp_bytes.len()], mbox_cmd_status))
     }
 
-    async fn handle_device_caps(
+    async fn handle_device_caps<'r>(
         &self,
-        msg_buf: &mut [u8],
-        req_len: usize,
-    ) -> Result<(usize, MbxCmdStatus), MsgHandlerError> {
-        let _req = DeviceCapsReq::ref_from_bytes(&msg_buf[..req_len])
-            .map_err(|_| MsgHandlerError::InvalidParams)?;
+        req: &[u8],
+        resp_buf: &'r mut [u8],
+    ) -> Result<(&'r mut [u8], MbxCmdStatus), MsgHandlerError> {
+        let _req =
+            DeviceCapsReq::ref_from_bytes(req).map_err(|_| MsgHandlerError::InvalidParams)?;
 
         // Prepare response
         let mut caps = DeviceCapabilities::default();
@@ -562,21 +503,20 @@ impl<'a> CmdInterface<'a> {
             DeviceCapsResp::default()
         };
 
-        // Encode the response and copy to msg_buf.
+        // Encode the response and copy to resp_buf.
         let resp_bytes = resp.as_bytes();
 
-        msg_buf[..resp_bytes.len()].copy_from_slice(resp_bytes);
+        resp_buf[..resp_bytes.len()].copy_from_slice(resp_bytes);
 
-        Ok((resp_bytes.len(), mbox_cmd_status))
+        Ok((&mut resp_buf[..resp_bytes.len()], mbox_cmd_status))
     }
 
-    async fn handle_device_id(
+    async fn handle_device_id<'r>(
         &self,
-        msg_buf: &mut [u8],
-        req_len: usize,
-    ) -> Result<(usize, MbxCmdStatus), MsgHandlerError> {
-        let _req = DeviceIdReq::ref_from_bytes(&msg_buf[..req_len])
-            .map_err(|_| MsgHandlerError::InvalidParams)?;
+        req: &[u8],
+        resp_buf: &'r mut [u8],
+    ) -> Result<(&'r mut [u8], MbxCmdStatus), MsgHandlerError> {
+        let _req = DeviceIdReq::ref_from_bytes(req).map_err(|_| MsgHandlerError::InvalidParams)?;
 
         // Prepare response
         let mut device_id = DeviceId::default();
@@ -599,22 +539,21 @@ impl<'a> CmdInterface<'a> {
             subsystem_id: device_id.subsystem_id,
         };
 
-        // Encode the response and copy to msg_buf.
+        // Encode the response and copy to resp_buf.
         let resp_bytes = resp.as_bytes();
 
-        msg_buf[..resp_bytes.len()].copy_from_slice(resp_bytes);
+        resp_buf[..resp_bytes.len()].copy_from_slice(resp_bytes);
 
-        Ok((resp_bytes.len(), mbox_cmd_status))
+        Ok((&mut resp_buf[..resp_bytes.len()], mbox_cmd_status))
     }
 
-    async fn handle_device_info(
+    async fn handle_device_info<'r>(
         &self,
-        msg_buf: &mut [u8],
-        req_len: usize,
-    ) -> Result<(usize, MbxCmdStatus), MsgHandlerError> {
+        req: &[u8],
+        resp_buf: &'r mut [u8],
+    ) -> Result<(&'r mut [u8], MbxCmdStatus), MsgHandlerError> {
         // Decode the request
-        let req = DeviceInfoReq::ref_from_bytes(&msg_buf[..req_len])
-            .map_err(|_| MsgHandlerError::InvalidParams)?;
+        let req = DeviceInfoReq::ref_from_bytes(req).map_err(|_| MsgHandlerError::InvalidParams)?;
 
         // Prepare response
         let mut device_info = DeviceInfo::Uid(Default::default());
@@ -644,85 +583,84 @@ impl<'a> CmdInterface<'a> {
             DeviceInfoResp::default()
         };
 
-        // Encode the response and copy to msg_buf.
+        // Encode the response and copy to resp_buf.
         let resp_bytes = resp
             .as_bytes_partial()
             .map_err(|_| MsgHandlerError::McuMboxCommon)?;
 
-        msg_buf[..resp_bytes.len()].copy_from_slice(resp_bytes);
+        resp_buf[..resp_bytes.len()].copy_from_slice(resp_bytes);
 
-        Ok((resp_bytes.len(), mbox_cmd_status))
+        Ok((&mut resp_buf[..resp_bytes.len()], mbox_cmd_status))
     }
 
-    pub async fn handle_crypto_passthrough<T: Default + IntoBytes + FromBytes>(
+    pub async fn handle_crypto_passthrough<'r, T: Default + IntoBytes + FromBytes>(
         &self,
-        msg_buf: &mut [u8],
-        req_len: usize,
+        req: &[u8],
         caliptra_cmd_code: u32,
-        resp_buf: &mut [u8],
-    ) -> Result<(usize, MbxCmdStatus), MsgHandlerError> {
-        if req_len > core::mem::size_of::<T>() {
-            return Err(MsgHandlerError::InvalidParams);
-        }
-        let mut req = T::default();
-        req.as_mut_bytes()[..req_len].copy_from_slice(&msg_buf[..req_len]);
+        resp_buf: &'r mut [u8],
+    ) -> Result<(&'r mut [u8], MbxCmdStatus), MsgHandlerError> {
+        let mut caliptra_req = T::default();
+        caliptra_req
+            .as_mut_bytes()
+            .get_mut(..req.len())
+            .ok_or(MsgHandlerError::InvalidParams)?
+            .copy_from_slice(req);
 
         // Clear the header checksum field because it was computed for the MCU mailbox CmdID and payload.
-        req.as_mut_bytes()[..core::mem::size_of::<MailboxReqHeader>()].fill(0);
+        caliptra_req.as_mut_bytes()[..core::mem::size_of::<MailboxReqHeader>()].fill(0);
 
         // Invoke Caliptra mailbox API
         let status = execute_mailbox_cmd(
             &self.caliptra_mbox,
             caliptra_cmd_code,
-            req.as_mut_bytes(),
+            caliptra_req.as_mut_bytes(),
             resp_buf,
         )
         .await;
 
         match status {
-            Ok(resp_len) => {
-                msg_buf[..resp_len].copy_from_slice(&resp_buf[..resp_len]);
-                Ok((resp_len, MbxCmdStatus::Complete))
-            }
-            Err(_) => Ok((0, MbxCmdStatus::Failure)),
+            Ok(resp_len) => Ok((&mut resp_buf[..resp_len], MbxCmdStatus::Complete)),
+            Err(_) => Ok((&mut resp_buf[..0], MbxCmdStatus::Failure)),
         }
     }
 
-    async fn handle_authorized_command(
+    async fn handle_authorized_command<'r>(
         &self,
         cmd_id: CommandId,
-        msg_buf: &mut [u8],
-        req_len: usize,
-    ) -> Result<(usize, MbxCmdStatus), MsgHandlerError> {
-        if !self.cmd_authorizer.is_authorized(cmd_id, msg_buf, req_len) {
-            return Err(MsgHandlerError::UnauthorizedCommand);
-        }
+        req: &[u8],
+        resp_buf: &'r mut [u8],
+    ) -> Result<(&'r mut [u8], MbxCmdStatus), MsgHandlerError> {
+        let cmd = self
+            .cmd_authorizer
+            .is_authorized(cmd_id, req)
+            .map_err(|_| MsgHandlerError::UnauthorizedCommand)?;
         match cmd_id {
             CommandId::MC_ROTATE_VENDOR_PK_HASH => {
-                self.handle_rotate_vendor_pk_hash(msg_buf, req_len).await
+                self.handle_rotate_vendor_pk_hash(cmd, resp_buf).await
             }
             _ => Err(MsgHandlerError::UnsupportedCommand),
         }
     }
 
-    async fn handle_rotate_vendor_pk_hash(
+    async fn handle_rotate_vendor_pk_hash<'r>(
         &self,
-        _msg_buf: &mut [u8],
-        _req_len: usize,
-    ) -> Result<(usize, MbxCmdStatus), MsgHandlerError> {
-        todo!()
+        _req: &[u8],
+        _resp_buf: &'r mut [u8],
+    ) -> Result<(&'r mut [u8], MbxCmdStatus), MsgHandlerError> {
+        // TODO
+        Err(MsgHandlerError::UnsupportedCommand)
     }
 
     #[cfg(feature = "periodic-fips-self-test")]
-    async fn handle_fips_periodic_enable(
+    async fn handle_fips_periodic_enable<'r>(
         &self,
-        msg_buf: &mut [u8],
-        req_len: usize,
-    ) -> Result<(usize, MbxCmdStatus), MsgHandlerError> {
+        req: &[u8],
+        resp_buf: &'r mut [u8],
+    ) -> Result<(&'r mut [u8], MbxCmdStatus), MsgHandlerError> {
         use crate::fips_periodic;
 
         // Parse the request
-        let req = McuFipsPeriodicEnableReq::ref_from_bytes(&msg_buf[..req_len])
+        let req = McuFipsPeriodicEnableReq::ref_from_bytes(req)
             .map_err(|_| MsgHandlerError::InvalidParams)?;
 
         // Enable or disable based on request
@@ -731,24 +669,23 @@ impl<'a> CmdInterface<'a> {
         // Prepare response
         let resp = McuFipsPeriodicEnableResp(MailboxRespHeader::default());
 
-        // Encode the response and copy to msg_buf
+        // Encode the response and copy to resp_buf
         let resp_bytes = resp.as_bytes();
+        resp_buf[..resp_bytes.len()].copy_from_slice(resp_bytes);
 
-        msg_buf[..resp_bytes.len()].copy_from_slice(resp_bytes);
-
-        Ok((resp_bytes.len(), MbxCmdStatus::Complete))
+        Ok((&mut resp_buf[..resp_bytes.len()], MbxCmdStatus::Complete))
     }
 
     #[cfg(feature = "periodic-fips-self-test")]
-    async fn handle_fips_periodic_status(
+    async fn handle_fips_periodic_status<'r>(
         &self,
-        msg_buf: &mut [u8],
-        req_len: usize,
-    ) -> Result<(usize, MbxCmdStatus), MsgHandlerError> {
+        req: &[u8],
+        resp_buf: &'r mut [u8],
+    ) -> Result<(&'r mut [u8], MbxCmdStatus), MsgHandlerError> {
         use crate::fips_periodic;
 
         // Parse the request (just header, no additional data)
-        let _req = McuFipsPeriodicStatusReq::ref_from_bytes(&msg_buf[..req_len])
+        let _req = McuFipsPeriodicStatusReq::ref_from_bytes(req)
             .map_err(|_| MsgHandlerError::InvalidParams)?;
 
         // Get status
@@ -762,11 +699,11 @@ impl<'a> CmdInterface<'a> {
             last_result,
         };
 
-        // Encode the response and copy to msg_buf
+        // Encode the response and copy to resp_buf
         let resp_bytes = resp.as_bytes();
 
-        msg_buf[..resp_bytes.len()].copy_from_slice(resp_bytes);
+        resp_buf[..resp_bytes.len()].copy_from_slice(resp_bytes);
 
-        Ok((resp_bytes.len(), MbxCmdStatus::Complete))
+        Ok((&mut resp_buf[..resp_bytes.len()], MbxCmdStatus::Complete))
     }
 }

--- a/runtime/userspace/api/mcu-mbox-lib/src/cmd_interface.rs
+++ b/runtime/userspace/api/mcu-mbox-lib/src/cmd_interface.rs
@@ -3,7 +3,8 @@
 use crate::transport::McuMboxTransport;
 use caliptra_api::mailbox::{populate_checksum, CommandId as CaliptraCommandId, MailboxReqHeader};
 use caliptra_mcu_external_cmds_common::{
-    DeviceCapabilities, DeviceId, DeviceInfo, FirmwareVersion, UnifiedCommandHandler, MAX_UID_LEN,
+    CommandAuthorizer, DeviceCapabilities, DeviceId, DeviceInfo, FirmwareVersion,
+    UnifiedCommandHandler, MAX_UID_LEN,
 };
 use caliptra_mcu_libapi_caliptra::mailbox_api::execute_mailbox_cmd;
 use caliptra_mcu_libsyscall_caliptra::mailbox::Mailbox;
@@ -44,12 +45,14 @@ pub enum MsgHandlerError {
     NotReady,
     InvalidParams,
     UnsupportedCommand,
+    UnauthorizedCommand,
 }
 
 /// Command interface for handling MCU mailbox commands.
 pub struct CmdInterface<'a> {
     transport: &'a mut McuMboxTransport,
     non_crypto_cmds_handler: &'a dyn UnifiedCommandHandler,
+    cmd_authorizer: &'a dyn CommandAuthorizer,
     caliptra_mbox: caliptra_mcu_libsyscall_caliptra::mailbox::Mailbox, // Handle crypto commands via caliptra mailbox
     busy: AtomicBool,
 }
@@ -58,10 +61,12 @@ impl<'a> CmdInterface<'a> {
     pub fn new(
         transport: &'a mut McuMboxTransport,
         non_crypto_cmds_handler: &'a dyn UnifiedCommandHandler,
+        cmd_authorizer: &'a dyn CommandAuthorizer,
     ) -> Self {
         Self {
             transport,
             non_crypto_cmds_handler,
+            cmd_authorizer,
             caliptra_mbox: Mailbox::new(),
             busy: AtomicBool::new(false),
         }
@@ -465,6 +470,10 @@ impl<'a> CmdInterface<'a> {
                 )
                 .await
             }
+            cmd_id @ CommandId::MC_ROTATE_VENDOR_PK_HASH => {
+                self.handle_authorized_command(cmd_id, msg_buf, req_len)
+                    .await
+            }
             // TODO: add more command handlers.
             // TODO: DOT runtime commands (DOT_CAK_INSTALL, DOT_LOCK, DOT_DISABLE,
             // DOT_UNLOCK_CHALLENGE, DOT_UNLOCK) are not yet handled here. These require
@@ -677,6 +686,31 @@ impl<'a> CmdInterface<'a> {
             }
             Err(_) => Ok((0, MbxCmdStatus::Failure)),
         }
+    }
+
+    async fn handle_authorized_command(
+        &self,
+        cmd_id: CommandId,
+        msg_buf: &mut [u8],
+        req_len: usize,
+    ) -> Result<(usize, MbxCmdStatus), MsgHandlerError> {
+        if !self.cmd_authorizer.is_authorized(cmd_id, msg_buf, req_len) {
+            return Err(MsgHandlerError::UnauthorizedCommand);
+        }
+        match cmd_id {
+            CommandId::MC_ROTATE_VENDOR_PK_HASH => {
+                self.handle_rotate_vendor_pk_hash(msg_buf, req_len).await
+            }
+            _ => Err(MsgHandlerError::UnsupportedCommand),
+        }
+    }
+
+    async fn handle_rotate_vendor_pk_hash(
+        &self,
+        _msg_buf: &mut [u8],
+        _req_len: usize,
+    ) -> Result<(usize, MbxCmdStatus), MsgHandlerError> {
+        todo!()
     }
 
     #[cfg(feature = "periodic-fips-self-test")]

--- a/runtime/userspace/api/mcu-mbox-lib/src/daemon.rs
+++ b/runtime/userspace/api/mcu-mbox-lib/src/daemon.rs
@@ -5,11 +5,10 @@ use crate::transport::McuMboxTransport;
 use caliptra_mcu_external_cmds_common::{CommandAuthorizer, UnifiedCommandHandler};
 use caliptra_mcu_libsyscall_caliptra::DefaultSyscalls;
 use caliptra_mcu_libtock_console::Console;
+use caliptra_mcu_mbox_common::messages::{McuMailboxReq, McuMailboxResp};
 use core::fmt::Write;
 use core::sync::atomic::{AtomicBool, Ordering};
 use embassy_executor::Spawner;
-
-const MAX_MCU_MBOX_MSG_SIZE: usize = 8192;
 
 #[derive(Debug)]
 pub enum McuMboxServiceError {
@@ -83,9 +82,13 @@ pub async fn mcu_mbox_responder(
     cmd_interface: &'static mut CmdInterface<'static>,
     running: &'static AtomicBool,
 ) {
-    let mut msg_buffer = [0; MAX_MCU_MBOX_MSG_SIZE];
+    let mut req_buf = [0; size_of::<McuMailboxReq>()];
+    let mut resp_buf = [0; size_of::<McuMailboxResp>()];
     while running.load(Ordering::SeqCst) {
-        if let Err(e) = cmd_interface.handle_responder_msg(&mut msg_buffer).await {
+        if let Err(e) = cmd_interface
+            .handle_responder_msg(&mut req_buf, &mut resp_buf)
+            .await
+        {
             // Debug print on error
             writeln!(
                 Console::<DefaultSyscalls>::writer(),

--- a/runtime/userspace/api/mcu-mbox-lib/src/daemon.rs
+++ b/runtime/userspace/api/mcu-mbox-lib/src/daemon.rs
@@ -2,7 +2,7 @@
 
 use crate::cmd_interface::CmdInterface;
 use crate::transport::McuMboxTransport;
-use caliptra_mcu_external_cmds_common::UnifiedCommandHandler;
+use caliptra_mcu_external_cmds_common::{CommandAuthorizer, UnifiedCommandHandler};
 use caliptra_mcu_libsyscall_caliptra::DefaultSyscalls;
 use caliptra_mcu_libtock_console::Console;
 use core::fmt::Write;
@@ -34,10 +34,11 @@ pub struct McuMboxService<'a> {
 impl<'a> McuMboxService<'a> {
     pub fn init(
         non_crypto_cmd_handler: &'a dyn UnifiedCommandHandler,
+        cmd_authorizer: &'a dyn CommandAuthorizer,
         transport: &'a mut McuMboxTransport,
         spawner: Spawner,
     ) -> Self {
-        let cmd_interface = CmdInterface::new(transport, non_crypto_cmd_handler);
+        let cmd_interface = CmdInterface::new(transport, non_crypto_cmd_handler, cmd_authorizer);
         Self {
             spawner,
             cmd_interface,

--- a/runtime/userspace/api/mcu-mbox-lib/src/transport.rs
+++ b/runtime/userspace/api/mcu-mbox-lib/src/transport.rs
@@ -30,10 +30,10 @@ impl McuMboxTransport {
         }
     }
 
-    pub async fn receive_request(
+    pub async fn receive_request<'a>(
         &mut self,
-        buf: &mut [u8],
-    ) -> Result<(CmdCode, usize), TransportError> {
+        buf: &'a mut [u8],
+    ) -> Result<(CmdCode, &'a [u8]), TransportError> {
         if buf.len() < size_of::<MailboxReqHeader>() {
             return Err(TransportError::BufferTooSmall);
         }
@@ -68,7 +68,7 @@ impl McuMboxTransport {
             return Err(TransportError::ChkSumMismatch);
         }
 
-        Ok((cmd_opcode, req_len))
+        Ok((cmd_opcode, &buf[..req_len]))
     }
 
     pub async fn send_response(&mut self, resp: &[u8]) -> Result<(), TransportError> {


### PR DESCRIPTION
Adds a `CommandAuthorizer` trait that is used to authorize every external command that needs authorization.
A stub is added to showcase this for a _rotate vendor PK hash_ command.

To give the implementer the option to embed the command, that is to be authorized, anywhere in the request, the handler logic was refactored to use slices for the request and response (instead of passing a `&mut` buffer and a lenght around).
This has the disadvantage, that a `MAX_DATA_SIZE` sized buffer for the response is allocated regardless of the command.
But since most command handlers used an intermediate buffer anyway this is no big deal imo. 

First step to resolve #897. 