### PR TITLE
adding pub modifier to exception_handler prototype

### DIFF
--- a/rom/src/lib.rs
+++ b/rom/src/lib.rs
@@ -78,7 +78,7 @@ pub fn set_fatal_error_handler(handler: &'static mut dyn FatalErrorHandler) {
 /// execution of this function.
 #[no_mangle]
 #[cfg(target_arch = "riscv32")]
-fn exception_handler() -> ! {
+pub extern "C" fn exception_handler() -> ! {
     let mut mcause: usize;
     let mut mepc: usize;
     let mut sp: usize;


### PR DESCRIPTION
Changes the RISC‑V exception_handler to use the C calling convention so it can be correctly invoked from assembly or external trap vectors.