### PR TITLE
runtime: track precise PMP entry usage in PMPRegionList

### DIFF
--- a/platforms/common/src/pmp_config.rs
+++ b/platforms/common/src/pmp_config.rs
@@ -1,7 +1,35 @@
 // Licensed under the Apache-2.0 license
 
 use caliptra_mcu_config::McuMemoryMap;
-use caliptra_mcu_tock_veer::pmp::PMPRegionList;
+use caliptra_mcu_tock_veer::pmp::{PMPRegionList, MAX_KERNEL_REGIONS};
+
+/// Upper bound on the number of MMIO regions contributed by the MCU memory
+/// map (rom/sram/dccm are filtered out, the remaining entries are MMIO).
+/// Used by a `debug_assert!` to catch the case where the memory map grows
+/// past what the platform-region pipeline expects.
+const MCU_MEMORY_MAP_MAX_MMIO_REGIONS: usize = 16;
+
+/// Size of the temporary buffer used to collect raw `PlatformRegion`s before
+/// they are filtered, coalesced (`coalesce_regions_in_place`), optionally
+/// upgraded to NAPOT (`optimize_mmio_napot`), and finally converted to
+/// `PMPRegion`s.
+///
+/// Conceptually distinct from `MAX_KERNEL_REGIONS` (which is the *output*
+/// PMP-side capacity): this buffer holds *input* regions that may still be
+/// reduced before reaching the PMP. Sized to `2 × MAX_KERNEL_REGIONS` to
+/// give the input pipeline head-room — `coalesce_regions_in_place` may
+/// merge adjacent same-property regions, so the input count can legitimately
+/// exceed the PMP-side capacity as long as the merged result fits. The real
+/// admission constraint (PMP hardware entries) is still enforced by
+/// `PMPRegionList::add_region` against `MAX_KERNEL_ENTRIES`.
+const MAX_PLATFORM_REGIONS: usize = MAX_KERNEL_REGIONS * 2;
+
+// Compile-time invariant: the input buffer must be able to hold at least
+// the MCU memory-map MMIO regions plus the PMP-side capacity, so that no
+// legitimate configuration is rejected before the optimizer (coalescing /
+// NAPOT upgrade) has a chance to shrink the working set. This bound also
+// implies `MAX_PLATFORM_REGIONS >= MAX_KERNEL_REGIONS`.
+const _: () = assert!(MAX_PLATFORM_REGIONS >= MCU_MEMORY_MAP_MAX_MMIO_REGIONS + MAX_KERNEL_REGIONS);
 
 /// Input from platform: a memory region with its properties
 #[derive(Debug, Clone, Copy)]
@@ -89,7 +117,10 @@ fn try_convert_to_napot(region: PlatformRegion) -> Result<PlatformRegion, Platfo
 }
 
 /// Convert MMIO regions to NAPOT where possible (best effort)
-fn optimize_mmio_napot(regions: &mut [Option<PlatformRegion>; 32], region_count: usize) -> usize {
+fn optimize_mmio_napot(
+    regions: &mut [Option<PlatformRegion>; MAX_PLATFORM_REGIONS],
+    region_count: usize,
+) -> usize {
     // Try to convert each MMIO region to NAPOT (best effort)
     for i in 0..region_count {
         if let Some(original_region) = regions[i] {
@@ -127,9 +158,14 @@ fn optimize_mmio_napot(regions: &mut [Option<PlatformRegion>; 32], region_count:
     region_count
 }
 
-/// Coalesce adjacent regions with identical properties in-place
+/// Coalesce adjacent regions with identical properties in-place.
+///
+/// May reduce `region_count`. This is what allows `MAX_PLATFORM_REGIONS`
+/// (the input buffer size) to be larger than `MAX_KERNEL_REGIONS` (the
+/// final PMP-side capacity): inputs can temporarily exceed the PMP budget
+/// and still produce a valid configuration after merging.
 fn coalesce_regions_in_place(
-    regions: &mut [Option<PlatformRegion>; 32],
+    regions: &mut [Option<PlatformRegion>; MAX_PLATFORM_REGIONS],
     region_count: usize,
 ) -> usize {
     if region_count <= 1 {
@@ -395,8 +431,9 @@ fn convert_platform_regions_to_pmp(
 /// - Non-MMIO regions must have valid permission combinations: R+X, R+W, or R (hard error)
 /// - Non-MMIO region overlaps are allowed with priority-based resolution (warning)
 pub fn create_pmp_regions(config: PlatformPMPConfig<'_>) -> Result<PMPRegionList, ()> {
-    // Step 1: Create static array to collect all regions (assume max 32 regions)
-    let mut all_regions: [Option<PlatformRegion>; 32] = [None; 32];
+    // Step 1: Create static array to collect all regions
+    let mut all_regions: [Option<PlatformRegion>; MAX_PLATFORM_REGIONS] =
+        [None; MAX_PLATFORM_REGIONS];
     let mut region_count = 0;
 
     // Step 2: Add MCU memory map regions to array
@@ -406,7 +443,7 @@ pub fn create_pmp_regions(config: PlatformPMPConfig<'_>) -> Result<PMPRegionList
     let mut add_region =
         |offset: u32, size: u32, properties: caliptra_mcu_config::MemoryRegionType| {
             // Only add MMIO regions (side_effect = true)
-            if size > 0 && region_count < 32 && properties.side_effect {
+            if size > 0 && region_count < MAX_PLATFORM_REGIONS && properties.side_effect {
                 all_regions[region_count] = Some(PlatformRegion {
                     start_addr: offset as *const u8,
                     size: size as usize,
@@ -469,10 +506,11 @@ pub fn create_pmp_regions(config: PlatformPMPConfig<'_>) -> Result<PMPRegionList
         memory_map.lc_properties,
     ); // MMIO - will be added
 
-    // Assert MCU memory map didn't exceed expected region count
-    // MCU memory map has at most 7 MMIO regions, so this should never fail
+    // Assert MCU memory map didn't exceed expected region count.
+    // MCU memory map has at most 7 MMIO regions today, so this should never
+    // fail unless the map grows beyond `MCU_MEMORY_MAP_MAX_MMIO_REGIONS`.
     debug_assert!(
-        region_count <= 16,
+        region_count <= MCU_MEMORY_MAP_MAX_MMIO_REGIONS,
         "MCU memory map generated too many regions: {}",
         region_count
     );
@@ -483,7 +521,7 @@ pub fn create_pmp_regions(config: PlatformPMPConfig<'_>) -> Result<PMPRegionList
             continue; // Skip empty regions
         }
 
-        if region_count >= 32 {
+        if region_count >= MAX_PLATFORM_REGIONS {
             return Err(()); // Too many regions to fit in array
         }
 

--- a/runtime/kernel/veer/Cargo.toml
+++ b/runtime/kernel/veer/Cargo.toml
@@ -23,3 +23,11 @@ riscv.workspace = true
 caliptra-mcu-romtime.workspace = true
 rv32i.workspace = true
 tock-registers.workspace = true
+
+# Host-only deps so the `pmp` module (and its accounting unit tests) can be
+# compiled and run on the host via `cargo test`/`nextest`. These are not used
+# by firmware (riscv32) builds, which pull these crates from the target deps
+# above.
+[dev-dependencies]
+kernel.workspace = true
+rv32i.workspace = true

--- a/runtime/kernel/veer/src/lib.rs
+++ b/runtime/kernel/veer/src/lib.rs
@@ -6,7 +6,7 @@
 pub mod chip;
 #[cfg(target_arch = "riscv32")]
 pub mod pic;
-#[cfg(target_arch = "riscv32")]
+#[cfg(any(target_arch = "riscv32", test))]
 pub mod pmp;
 #[cfg(target_arch = "riscv32")]
 pub mod timers;

--- a/runtime/kernel/veer/src/pmp.rs
+++ b/runtime/kernel/veer/src/pmp.rs
@@ -16,6 +16,16 @@ use rv32i::pmp::{pmpcfg_octet, NAPOTRegionSpec, TORRegionSpec, TORUserPMP, TORUs
 
 const MPU_REGIONS: usize = 16;
 pub const AVAILABLE_ENTRIES: usize = 64;
+pub const MAX_KERNEL_ENTRIES: usize = AVAILABLE_ENTRIES - MPU_REGIONS * 2;
+
+/// Maximum number of logical kernel PMP regions that can fit in a
+/// `PMPRegionList`.
+///
+/// Equal to `MAX_KERNEL_ENTRIES` because each region consumes at least one
+/// PMP entry (NAPOT).  This is used to size the in-list array; the binding
+/// hardware constraint is the *entry* budget (`MAX_KERNEL_ENTRIES`), which
+/// `add_region` enforces precisely via `total_entries`.
+pub const MAX_KERNEL_REGIONS: usize = MAX_KERNEL_ENTRIES;
 
 pub type VeeRPMP = PMPUserMPU<MPU_REGIONS, VeeRProtectionMMLEPMP>;
 
@@ -74,15 +84,16 @@ fn write_pmpaddr_pmpcfg(i: usize, pmpcfg: u8, pmpaddr: usize) {
 // these memory regions as arguments. They further encode whether a region
 // must adhere to the `NAPOT` or `TOR` addressing mode constraints:
 
-/// The code (kernel + apps) RAM region address range.
+/// A read-only data region (e.g., the ROM area covering constants, strings
+/// and other non-executable read-only data from the code section).
 ///
-/// Configured in the PMP as a `NAPOT` region.
+/// Configured in the PMP as a `TOR` region with R-only permissions.
 #[derive(Copy, Clone, Debug)]
 pub struct ReadOnlyRegion(pub TORRegionSpec);
 
 /// The Data RAM region address range.
 ///
-/// Configured in the PMP as a `NAPOT` region.
+/// Configured in the PMP as a `TOR` region with R+W permissions.
 #[derive(Copy, Clone, Debug)]
 pub struct DataRegion(pub TORRegionSpec);
 
@@ -109,38 +120,108 @@ pub enum PMPRegion {
     MachineMMIO(MMIORegion),
 }
 
-/// Configuration result containing all PMP regions in a simple list
+impl PMPRegion {
+    /// Returns the number of PMP hardware entries this region consumes.
+    /// TOR regions use 2 entries (start + end), NAPOT regions use 1 entry.
+    pub const fn entry_count(&self) -> usize {
+        match self {
+            PMPRegion::KernelText(_) | PMPRegion::ReadOnly(_) | PMPRegion::Data(_) => 2,
+            PMPRegion::UserMMIO(_) | PMPRegion::MachineMMIO(_) => 1,
+        }
+    }
+}
+
+/// An ordered list of kernel-side PMP regions, ready to be programmed into
+/// the PMP hardware.
+///
+/// The list is bounded by the kernel PMP hardware entry budget
+/// (`MAX_KERNEL_ENTRIES`), not by an artificial region count: NAPOT regions
+/// consume 1 PMP entry each while TOR regions consume 2, so the maximum
+/// number of logical regions depends on the mix of addressing modes. The
+/// internal storage is sized to `MAX_KERNEL_REGIONS` (the theoretical
+/// maximum when every region is NAPOT).
+///
+/// Invariants (maintained by [`PMPRegionList::add_region`]):
+/// - `count() <= MAX_KERNEL_REGIONS`
+/// - `total_entries() <= MAX_KERNEL_ENTRIES`
+/// - `total_entries() == sum of region.entry_count() over iter()`
+///
+/// Construct with [`PMPRegionList::new`], populate with
+/// [`PMPRegionList::add_region`], inspect with [`PMPRegionList::iter`],
+/// [`PMPRegionList::count`] and [`PMPRegionList::total_entries`].
 pub struct PMPRegionList {
-    /// Fixed-size array of regions (no heap allocation)
-    /// Size 16 assumes worst case that all regions are TOR regions (using 2 PMP entries each)
-    /// User regions: MPU_REGIONS, Kernel regions: ~3-4, total fits within AVAILABLE_ENTRIES
-    pub regions: [Option<PMPRegion>; 16],
-    /// Number of actual regions used
-    pub count: usize,
+    regions: [Option<PMPRegion>; MAX_KERNEL_REGIONS],
+    // Number of populated entries in `regions`.
+    count: usize,
+    // Cached sum of `region.entry_count()` over the populated entries.
+    total_entries: usize,
 }
 
 impl PMPRegionList {
-    /// Create a new empty region list
-    pub fn new() -> Self {
+    /// Create a new empty region list.
+    pub const fn new() -> Self {
         Self {
-            regions: [None; 16],
+            regions: [None; MAX_KERNEL_REGIONS],
             count: 0,
+            total_entries: 0,
         }
     }
 
     /// Add a region to the list
+    ///
+    /// Returns `Err(())` if either:
+    /// - the in-list array is already full (`MAX_KERNEL_REGIONS` regions), or
+    /// - accepting this region would exceed the kernel PMP hardware entry
+    ///   budget (`MAX_KERNEL_ENTRIES`).
+    ///
+    /// Both conditions are checked explicitly. Today they are equivalent
+    /// (`MAX_KERNEL_REGIONS == MAX_KERNEL_ENTRIES` and every region uses at
+    /// least one entry, so the entry-budget check implies the array-bound
+    /// check), but they guard distinct concerns — the array bound protects
+    /// the `regions` storage while the entry budget protects the PMP
+    /// hardware — so they are kept separate so the function remains correct
+    /// even if the two constants ever diverge.
     pub fn add_region(&mut self, region: PMPRegion) -> Result<(), ()> {
-        if self.count >= 16 {
+        let entries_needed = region.entry_count();
+        let new_total = self.total_entries + entries_needed;
+
+        // Array bound: refuse if the in-list array is already full.
+        if self.count >= MAX_KERNEL_REGIONS {
             return Err(());
         }
+        // Hardware budget: refuse if accepting this region would exceed the
+        // PMP hardware entries reserved for the kernel side.
+        if new_total > MAX_KERNEL_ENTRIES {
+            return Err(());
+        }
+
         self.regions[self.count] = Some(region);
         self.count += 1;
+        self.total_entries = new_total;
         Ok(())
     }
 
-    /// Iterate through all regions
+    /// Iterate through all regions in insertion order.
     pub fn iter(&self) -> impl Iterator<Item = &PMPRegion> {
         self.regions[..self.count].iter().filter_map(|r| r.as_ref())
+    }
+
+    /// Number of logical regions currently stored in the list.
+    pub fn count(&self) -> usize {
+        self.count
+    }
+
+    /// Total PMP hardware entries consumed by the regions in this list.
+    /// TOR regions contribute 2 entries each, NAPOT regions contribute 1.
+    /// Always `<= MAX_KERNEL_ENTRIES`.
+    pub fn total_entries(&self) -> usize {
+        self.total_entries
+    }
+}
+
+impl Default for PMPRegionList {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -193,7 +274,11 @@ impl fmt::Display for PMPRegion {
 
 impl fmt::Display for PMPRegionList {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        writeln!(f, "PMPRegionList ({} regions):", self.count)?;
+        writeln!(
+            f,
+            "PMPRegionList ({} regions, {}/{} kernel PMP entries used):",
+            self.count, self.total_entries, MAX_KERNEL_ENTRIES
+        )?;
         writeln!(f, "  Format: [MODE, RWX, LOCK] where:")?;
         writeln!(
             f,
@@ -277,17 +362,18 @@ impl VeeRProtectionMMLEPMP {
             reset_entry(i);
         }
 
-        // Conservative approach: assume worst-case that all regions are TOR regions (2 entries each)
-        let max_kernel_entries = pmp_regions.count * 2;
+        // Use precise entry counting: TOR regions consume 2 entries, NAPOT regions consume 1.
+        // `PMPRegionList::add_region` guarantees `total_entries() <= MAX_KERNEL_ENTRIES`;
+        // we re-check below as defence in depth.
+        let actual_kernel_entries = pmp_regions.total_entries();
 
         // Ensure we don't exceed available PMP entries (reserve MPU_REGIONS*2 for user MPU)
-        if max_kernel_entries > (AVAILABLE_ENTRIES - MPU_REGIONS * 2) {
-            return Err(()); // Too many kernel regions
+        if actual_kernel_entries > MAX_KERNEL_ENTRIES {
+            return Err(()); // Too many kernel entries
         }
 
         // Calculate starting entry for kernel regions (at the end of PMP entries)
-        // We'll use conservative allocation but only consume what we actually need
-        let kernel_start_entry = AVAILABLE_ENTRIES - max_kernel_entries;
+        let kernel_start_entry = AVAILABLE_ENTRIES - actual_kernel_entries;
 
         // Process regions from PMPRegionList in order, writing directly to PMP registers
         // This creates a 1:1 mapping from PMPRegionList to PMP hardware entries.

--- a/runtime/kernel/veer/src/pmp.rs
+++ b/runtime/kernel/veer/src/pmp.rs
@@ -16,6 +16,16 @@ use rv32i::pmp::{pmpcfg_octet, NAPOTRegionSpec, TORRegionSpec, TORUserPMP, TORUs
 
 const MPU_REGIONS: usize = 16;
 pub const AVAILABLE_ENTRIES: usize = 64;
+const MAX_KERNEL_ENTRIES: usize = AVAILABLE_ENTRIES - MPU_REGIONS * 2;
+
+/// Maximum number of logical kernel PMP regions that can fit in a
+/// `PMPRegionList`.
+///
+/// Equal to `MAX_KERNEL_ENTRIES` because each region consumes at least one
+/// PMP entry (NAPOT).  This is used to size the in-list array; the binding
+/// hardware constraint is the *entry* budget (`MAX_KERNEL_ENTRIES`), which
+/// `add_region` enforces precisely via `total_entries`.
+const MAX_KERNEL_REGIONS: usize = MAX_KERNEL_ENTRIES;
 
 pub type VeeRPMP = PMPUserMPU<MPU_REGIONS, VeeRProtectionMMLEPMP>;
 
@@ -74,15 +84,16 @@ fn write_pmpaddr_pmpcfg(i: usize, pmpcfg: u8, pmpaddr: usize) {
 // these memory regions as arguments. They further encode whether a region
 // must adhere to the `NAPOT` or `TOR` addressing mode constraints:
 
-/// The code (kernel + apps) RAM region address range.
+/// A read-only data region (e.g., the ROM area covering constants, strings
+/// and other non-executable read-only data from the code section).
 ///
-/// Configured in the PMP as a `NAPOT` region.
+/// Configured in the PMP as a `TOR` region with R-only permissions.
 #[derive(Copy, Clone, Debug)]
 pub struct ReadOnlyRegion(pub TORRegionSpec);
 
 /// The Data RAM region address range.
 ///
-/// Configured in the PMP as a `NAPOT` region.
+/// Configured in the PMP as a `TOR` region with R+W permissions.
 #[derive(Copy, Clone, Debug)]
 pub struct DataRegion(pub TORRegionSpec);
 
@@ -109,38 +120,108 @@ pub enum PMPRegion {
     MachineMMIO(MMIORegion),
 }
 
-/// Configuration result containing all PMP regions in a simple list
+impl PMPRegion {
+    /// Returns the number of PMP hardware entries this region consumes.
+    /// TOR regions use 2 entries (start + end), NAPOT regions use 1 entry.
+    pub const fn entry_count(&self) -> usize {
+        match self {
+            PMPRegion::KernelText(_) | PMPRegion::ReadOnly(_) | PMPRegion::Data(_) => 2,
+            PMPRegion::UserMMIO(_) | PMPRegion::MachineMMIO(_) => 1,
+        }
+    }
+}
+
+/// An ordered list of kernel-side PMP regions, ready to be programmed into
+/// the PMP hardware.
+///
+/// The list is bounded by the kernel PMP hardware entry budget
+/// (`MAX_KERNEL_ENTRIES`), not by an artificial region count: NAPOT regions
+/// consume 1 PMP entry each while TOR regions consume 2, so the maximum
+/// number of logical regions depends on the mix of addressing modes. The
+/// internal storage is sized to `MAX_KERNEL_REGIONS` (the theoretical
+/// maximum when every region is NAPOT).
+///
+/// Invariants (maintained by [`PMPRegionList::add_region`]):
+/// - `count() <= MAX_KERNEL_REGIONS`
+/// - `total_entries() <= MAX_KERNEL_ENTRIES`
+/// - `total_entries() == sum of region.entry_count() over iter()`
+///
+/// Construct with [`PMPRegionList::new`], populate with
+/// [`PMPRegionList::add_region`], inspect with [`PMPRegionList::iter`],
+/// [`PMPRegionList::count`] and [`PMPRegionList::total_entries`].
 pub struct PMPRegionList {
-    /// Fixed-size array of regions (no heap allocation)
-    /// Size 16 assumes worst case that all regions are TOR regions (using 2 PMP entries each)
-    /// User regions: MPU_REGIONS, Kernel regions: ~3-4, total fits within AVAILABLE_ENTRIES
-    pub regions: [Option<PMPRegion>; 16],
-    /// Number of actual regions used
-    pub count: usize,
+    regions: [Option<PMPRegion>; MAX_KERNEL_REGIONS],
+    // Number of populated entries in `regions`.
+    count: usize,
+    // Cached sum of `region.entry_count()` over the populated entries.
+    total_entries: usize,
 }
 
 impl PMPRegionList {
-    /// Create a new empty region list
-    pub fn new() -> Self {
+    /// Create a new empty region list.
+    pub const fn new() -> Self {
         Self {
-            regions: [None; 16],
+            regions: [None; MAX_KERNEL_REGIONS],
             count: 0,
+            total_entries: 0,
         }
     }
 
     /// Add a region to the list
+    ///
+    /// Returns `Err(())` if either:
+    /// - the in-list array is already full (`MAX_KERNEL_REGIONS` regions), or
+    /// - accepting this region would exceed the kernel PMP hardware entry
+    ///   budget (`MAX_KERNEL_ENTRIES`).
+    ///
+    /// Both conditions are checked explicitly. Today they are equivalent
+    /// (`MAX_KERNEL_REGIONS == MAX_KERNEL_ENTRIES` and every region uses at
+    /// least one entry, so the entry-budget check implies the array-bound
+    /// check), but they guard distinct concerns — the array bound protects
+    /// the `regions` storage while the entry budget protects the PMP
+    /// hardware — so they are kept separate so the function remains correct
+    /// even if the two constants ever diverge.
     pub fn add_region(&mut self, region: PMPRegion) -> Result<(), ()> {
-        if self.count >= 16 {
+        let entries_needed = region.entry_count();
+        let new_total = self.total_entries + entries_needed;
+
+        // Array bound: refuse if the in-list array is already full.
+        if self.count >= MAX_KERNEL_REGIONS {
             return Err(());
         }
+        // Hardware budget: refuse if accepting this region would exceed the
+        // PMP hardware entries reserved for the kernel side.
+        if new_total > MAX_KERNEL_ENTRIES {
+            return Err(());
+        }
+
         self.regions[self.count] = Some(region);
         self.count += 1;
+        self.total_entries = new_total;
         Ok(())
     }
 
-    /// Iterate through all regions
+    /// Iterate through all regions in insertion order.
     pub fn iter(&self) -> impl Iterator<Item = &PMPRegion> {
         self.regions[..self.count].iter().filter_map(|r| r.as_ref())
+    }
+
+    /// Number of logical regions currently stored in the list.
+    pub fn count(&self) -> usize {
+        self.count
+    }
+
+    /// Total PMP hardware entries consumed by the regions in this list.
+    /// TOR regions contribute 2 entries each, NAPOT regions contribute 1.
+    /// Always `<= MAX_KERNEL_ENTRIES`.
+    pub fn total_entries(&self) -> usize {
+        self.total_entries
+    }
+}
+
+impl Default for PMPRegionList {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -193,7 +274,11 @@ impl fmt::Display for PMPRegion {
 
 impl fmt::Display for PMPRegionList {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        writeln!(f, "PMPRegionList ({} regions):", self.count)?;
+        writeln!(
+            f,
+            "PMPRegionList ({} regions, {}/{} kernel PMP entries used):",
+            self.count, self.total_entries, MAX_KERNEL_ENTRIES
+        )?;
         writeln!(f, "  Format: [MODE, RWX, LOCK] where:")?;
         writeln!(
             f,
@@ -277,17 +362,18 @@ impl VeeRProtectionMMLEPMP {
             reset_entry(i);
         }
 
-        // Conservative approach: assume worst-case that all regions are TOR regions (2 entries each)
-        let max_kernel_entries = pmp_regions.count * 2;
+        // Use precise entry counting: TOR regions consume 2 entries, NAPOT regions consume 1.
+        // `PMPRegionList::add_region` guarantees `total_entries() <= MAX_KERNEL_ENTRIES`;
+        // we re-check below as defence in depth.
+        let actual_kernel_entries = pmp_regions.total_entries();
 
         // Ensure we don't exceed available PMP entries (reserve MPU_REGIONS*2 for user MPU)
-        if max_kernel_entries > (AVAILABLE_ENTRIES - MPU_REGIONS * 2) {
-            return Err(()); // Too many kernel regions
+        if actual_kernel_entries > MAX_KERNEL_ENTRIES {
+            return Err(()); // Too many kernel entries
         }
 
         // Calculate starting entry for kernel regions (at the end of PMP entries)
-        // We'll use conservative allocation but only consume what we actually need
-        let kernel_start_entry = AVAILABLE_ENTRIES - max_kernel_entries;
+        let kernel_start_entry = AVAILABLE_ENTRIES - actual_kernel_entries;
 
         // Process regions from PMPRegionList in order, writing directly to PMP registers
         // This creates a 1:1 mapping from PMPRegionList to PMP hardware entries.
@@ -714,5 +800,112 @@ impl fmt::Display for VeeRProtectionMMLEPMP {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rv32i::pmp::{NAPOTRegionSpec, TORRegionSpec};
+
+    // A valid NAPOT-backed region. NAPOT regions consume exactly 1 PMP entry.
+    fn napot() -> PMPRegion {
+        // size: power-of-two >= 8; start: naturally aligned to size.
+        let spec = NAPOTRegionSpec::new(0x1000_0000 as *const u8, 0x1000).expect("valid NAPOT");
+        PMPRegion::MachineMMIO(MMIORegion(spec))
+    }
+
+    // A valid TOR-backed region. TOR regions consume exactly 2 PMP entries.
+    fn tor() -> PMPRegion {
+        // start/end: 4-byte aligned; span >= 4 bytes.
+        let spec = TORRegionSpec::new(0x2000_0000 as *const u8, 0x2000_1000 as *const u8)
+            .expect("valid TOR");
+        PMPRegion::Data(DataRegion(spec))
+    }
+
+    #[test]
+    fn entry_count_per_addressing_mode() {
+        assert_eq!(napot().entry_count(), 1);
+        assert_eq!(tor().entry_count(), 2);
+    }
+
+    #[test]
+    fn accepts_napot_list_filling_entry_budget() {
+        // MAX_KERNEL_ENTRIES NAPOT regions (1 entry each) exactly fill the budget.
+        let mut list = PMPRegionList::new();
+        for _ in 0..MAX_KERNEL_ENTRIES {
+            assert!(list.add_region(napot()).is_ok());
+        }
+        assert_eq!(list.count(), MAX_KERNEL_ENTRIES);
+        assert_eq!(list.total_entries(), MAX_KERNEL_ENTRIES);
+    }
+
+    #[test]
+    fn rejects_napot_region_beyond_budget() {
+        let mut list = PMPRegionList::new();
+        for _ in 0..MAX_KERNEL_ENTRIES {
+            list.add_region(napot()).unwrap();
+        }
+        // The next NAPOT region is rejected...
+        assert!(list.add_region(napot()).is_err());
+        // ...and a rejected add must not mutate the list.
+        assert_eq!(list.count(), MAX_KERNEL_ENTRIES);
+        assert_eq!(list.total_entries(), MAX_KERNEL_ENTRIES);
+    }
+
+    #[test]
+    fn accepts_mixed_list_reaching_exact_budget() {
+        // 14 TOR (28 entries) + 4 NAPOT (4 entries) == MAX_KERNEL_ENTRIES,
+        // spread over 18 regions (< MAX_KERNEL_REGIONS), so the entry budget
+        // (not the array bound) is the binding constraint.
+        let tor_count = 14;
+        let napot_count = 4;
+        assert_eq!(2 * tor_count + napot_count, MAX_KERNEL_ENTRIES);
+        assert!(tor_count + napot_count < MAX_KERNEL_REGIONS);
+
+        let mut list = PMPRegionList::new();
+        for _ in 0..tor_count {
+            list.add_region(tor()).unwrap();
+        }
+        for _ in 0..napot_count {
+            list.add_region(napot()).unwrap();
+        }
+        assert_eq!(list.total_entries(), MAX_KERNEL_ENTRIES);
+        assert_eq!(list.count(), tor_count + napot_count);
+    }
+
+    #[test]
+    fn rejects_region_after_budget_is_exactly_full() {
+        let (tor_count, napot_count) = (14usize, 4usize);
+        let mut list = PMPRegionList::new();
+        for _ in 0..tor_count {
+            list.add_region(tor()).unwrap();
+        }
+        for _ in 0..napot_count {
+            list.add_region(napot()).unwrap();
+        }
+        assert_eq!(list.total_entries(), MAX_KERNEL_ENTRIES);
+        let regions_before = list.count();
+
+        // Rejected purely by the entry budget while count < MAX_KERNEL_REGIONS.
+        assert!(list.add_region(napot()).is_err()); // would need 1 more entry
+        assert!(list.add_region(tor()).is_err()); // would need 2 more entries
+
+        // List is unchanged after the rejected adds.
+        assert_eq!(list.total_entries(), MAX_KERNEL_ENTRIES);
+        assert_eq!(list.count(), regions_before);
+    }
+
+    #[test]
+    fn total_entries_equals_sum_of_entry_counts() {
+        let mut list = PMPRegionList::new();
+        let plan = [tor(), napot(), tor(), napot(), napot(), tor()];
+        for region in plan.iter().copied() {
+            list.add_region(region).unwrap();
+            // Invariant holds after every successful addition.
+            let expected: usize = list.iter().map(PMPRegion::entry_count).sum();
+            assert_eq!(list.total_entries(), expected);
+        }
+        assert_eq!(list.count(), plan.len());
     }
 }


### PR DESCRIPTION
Fix #1265

## Summary
Refactors the kernel-side PMP region list (PMPRegionList) to track the
actual number of PMP hardware entries consumed (TOR=2, NAPOT=1) instead
of a worst-case count * 2 estimate. Frees PMP entries that were
over-reserved when NAPOT regions were used, and replaces the previous
hardcoded array size of 16 with MAX_KERNEL_REGIONS derived from the
hardware budget (MAX_KERNEL_ENTRIES = AVAILABLE_ENTRIES - MPU_REGIONS * 2).
Also tightens encapsulation so downstream code (VeeRProtectionMMLEPMP::new)
can rely on the total_entries == sum(region.entry_count()) invariant.
Scoped to runtime/kernel/veer/src/pmp.rs only; no other files change.
## Changes
runtime/kernel/veer/src/pmp.rs
- Add MAX_KERNEL_ENTRIES and MAX_KERNEL_REGIONS consts (module-private)
  that bound the kernel-side PMPRegionList — its array size and the PMP
  hardware entry budget.
- Add PMPRegion::entry_count() (const fn) reporting hardware entry cost
  per addressing mode (TOR=2, NAPOT=1).
- Make PMPRegionList fields private; add count() / total_entries()
  accessors, Default impl, and const fn new().
- Split add_region failure conditions into the array bound and the PMP
  entry budget for clarity.
- VeeRProtectionMMLEPMP::new now uses pmp_regions.total_entries()
  directly; the kernel start entry is computed precisely.
- Fix ReadOnlyRegion / DataRegion doc comments that incorrectly described
  them as NAPOT regions (they are TOR), and clarify ReadOnlyRegion's
  purpose post the CodeRegion → ReadOnlyRegion rename in #237.
## Test plan
- [ ] cargo xtask precheckin
- [ ] cargo xtask runtime

## Notes
- Boot stack: the PMPRegionList array grows 16→32 entries. (The earlier
  ~960 B figure also counted a platform-region buffer 32→64 change; that
  is no longer part of this PR since pmp_config.rs is unchanged, so the
  remaining increase is only the PMPRegionList growth.) Still a comfortable
  margin against the 8 KB emulator runtime stack.
- Public API additions: PMPRegion::entry_count(), PMPRegionList::count(),
  PMPRegionList::total_entries(), PMPRegionList::default().
  (MAX_KERNEL_ENTRIES / MAX_KERNEL_REGIONS are internal, not public.)
- Public API removals: PMPRegionList::regions / count / total_entries
  fields are no longer accessible directly (use accessors / iter()).