### PR TITLE
Hold Caliptra CPU until MCU ROM writes CPTRA_BOOT_GO

### DIFF
--- a/emulator/app/src/emulator.rs
+++ b/emulator/app/src/emulator.rs
@@ -47,6 +47,7 @@ use caliptra_mcu_testing_common::{MCU_RUNNING, MCU_RUNTIME_STARTED, MCU_TICKS, T
 use clap::{ArgAction, Parser};
 use clap_num::maybe_hex;
 use crossterm::event::{Event, KeyCode, KeyEvent};
+use std::cell::Cell;
 use std::cell::RefCell;
 use std::fs::File;
 use std::io::{self, IsTerminal, Read, Write};
@@ -318,6 +319,8 @@ pub struct Emulator {
     // Synchronizes cross-thread timer scheduling (I3C / DOE controller
     // threads) with the CPU step that advances the clock.
     pub step_lock: Arc<Mutex<()>>,
+    /// Caliptra CPU is held until MCU ROM writes CPTRA_BOOT_GO
+    pub cptra_boot_go: Rc<Cell<bool>>,
 }
 
 impl Emulator {
@@ -895,6 +898,8 @@ impl Emulator {
             )
         };
 
+        let cptra_boot_go = Rc::new(Cell::new(false));
+
         let mci = Mci::new(
             &clock.clone(),
             ext_mci,
@@ -903,6 +908,7 @@ impl Emulator {
             Some(mcu_mailbox1),
             Some(soc_ifc),
             [0, 0],
+            cptra_boot_go.clone(),
         );
 
         let mut auto_root_bus = AutoRootBus::new(
@@ -1096,6 +1102,7 @@ impl Emulator {
             Some(i3c_dynamic_address.into()),
             i3c_controller_join_handle,
             step_lock,
+            cptra_boot_go,
         ))
     }
 
@@ -1115,6 +1122,7 @@ impl Emulator {
         i3c_address: Option<u8>,
         i3c_controller_join_handle: Option<JoinHandle<()>>,
         step_lock: Arc<Mutex<()>>,
+        cptra_boot_go: Rc<Cell<bool>>,
     ) -> Self {
         // read from the console in a separate thread to prevent blocking
         let stdin_uart_clone = stdin_uart.clone();
@@ -1139,6 +1147,7 @@ impl Emulator {
             i3c_address,
             i3c_controller_join_handle,
             step_lock,
+            cptra_boot_go,
         }
     }
 
@@ -1198,25 +1207,27 @@ impl Emulator {
             MCU_RUNTIME_STARTED.store(true, Ordering::Relaxed);
         }
 
-        let caliptra_action = if self.trace_file.is_some() {
-            let caliptra_trace_fn: &mut dyn FnMut(u32, caliptra_emu_cpu::RvInstr) =
-                &mut |pc, instr| match instr {
-                    caliptra_emu_cpu::RvInstr::Instr32(instr32) => {
-                        println!("{{caliptra cpu}} {}", disassemble(pc, instr32));
-                    }
-                    caliptra_emu_cpu::RvInstr::Instr16(instr16) => {
-                        println!("{{caliptra cpu}} {}", disassemble(pc, instr16 as u32));
-                    }
-                };
-            self.caliptra_cpu.step(Some(caliptra_trace_fn))
-        } else {
-            self.caliptra_cpu.step(None)
-        };
+        if self.cptra_boot_go.get() {
+            let caliptra_action = if self.trace_file.is_some() {
+                let caliptra_trace_fn: &mut dyn FnMut(u32, caliptra_emu_cpu::RvInstr) =
+                    &mut |pc, instr| match instr {
+                        caliptra_emu_cpu::RvInstr::Instr32(instr32) => {
+                            println!("{{caliptra cpu}} {}", disassemble(pc, instr32));
+                        }
+                        caliptra_emu_cpu::RvInstr::Instr16(instr16) => {
+                            println!("{{caliptra cpu}} {}", disassemble(pc, instr16 as u32));
+                        }
+                    };
+                self.caliptra_cpu.step(Some(caliptra_trace_fn))
+            } else {
+                self.caliptra_cpu.step(None)
+            };
 
-        match caliptra_action {
-            StepAction::Continue => {}
-            _ => {
-                println!("Caliptra CPU Halted");
+            match caliptra_action {
+                StepAction::Continue => {}
+                _ => {
+                    println!("Caliptra CPU Halted");
+                }
             }
         }
 

--- a/emulator/periph/src/mci.rs
+++ b/emulator/periph/src/mci.rs
@@ -12,7 +12,7 @@ use caliptra_mcu_registers_generated::mci::bits::{
     SecurityState, WdtStatus, WdtTimer1Ctrl, WdtTimer1En, WdtTimer2Ctrl, WdtTimer2En,
 };
 use caliptra_registers::soc_ifc::RegisterBlock;
-use std::{cell::RefCell, rc::Rc};
+use std::{cell::Cell, cell::RefCell, rc::Rc};
 use tock_registers::interfaces::{ReadWriteable, Readable};
 
 const RESET_STATUS_MCU_RESET_MASK: u32 = 0x2;
@@ -48,9 +48,13 @@ pub struct Mci {
     soc_regs: Option<RegisterBlock<BusMmio<SocToCaliptraBus>>>,
 
     reset_requested: bool,
+
+    /// Shared flag: Caliptra CPU is held until MCU ROM writes CPTRA_BOOT_GO
+    cptra_boot_go: Rc<Cell<bool>>,
 }
 
 impl Mci {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         clock: &Clock,
         ext_mci_regs: caliptra_emu_periph::mci::Mci,
@@ -59,6 +63,7 @@ impl Mci {
         mcu_mailbox1: Option<McuMailbox0Internal>,
         soc_regs: Option<RegisterBlock<BusMmio<SocToCaliptraBus>>>,
         generic_input_wires: [u32; 2],
+        cptra_boot_go: Rc<Cell<bool>>,
     ) -> Self {
         // Clear the reset status, MCU and Caiptra are out of reset
         ext_mci_regs.regs.borrow_mut().reset_status = 0;
@@ -92,6 +97,8 @@ impl Mci {
             op_mtimecmp_due_action: None,
             mcu_mailbox1,
             soc_regs,
+
+            cptra_boot_go,
         }
     }
 
@@ -162,6 +169,19 @@ impl Mci {
 impl MciPeripheral for Mci {
     fn generated(&mut self) -> Option<&mut MciGenerated> {
         Some(&mut self.generated)
+    }
+
+    fn write_mci_reg_cptra_boot_go(
+        &mut self,
+        val: caliptra_emu_bus::ReadWriteRegister<
+            u32,
+            caliptra_mcu_registers_generated::mci::bits::Go::Register,
+        >,
+    ) {
+        if let Some(generated) = self.generated() {
+            generated.write_mci_reg_cptra_boot_go(val);
+        }
+        self.cptra_boot_go.set(true);
     }
 
     fn read_mci_reg_generic_input_wires(&mut self, index: usize) -> caliptra_emu_types::RvData {
@@ -1417,6 +1437,7 @@ mod tests {
             None,
             None,
             [0, 0],
+            Rc::new(Cell::new(true)),
         );
         let mut mci_bus = MciBus {
             periph: Box::new(mci_reg),
@@ -1512,6 +1533,7 @@ mod tests {
             None,
             None,
             [0, 0],
+            Rc::new(Cell::new(true)),
         );
         let mut mcu_mailbox = mci_reg.mcu_mailbox0.clone().unwrap();
         let mut mci_bus = MciBus {
@@ -1551,6 +1573,7 @@ mod tests {
             None,
             None,
             [0, 0],
+            Rc::new(Cell::new(true)),
         );
 
         let hi: u32 = 0x0022_3344;
@@ -1581,6 +1604,7 @@ mod tests {
             None,
             None,
             [0, 0],
+            Rc::new(Cell::new(true)),
         );
 
         let lo: u32 = 0x0000_FFFF;
@@ -1611,6 +1635,7 @@ mod tests {
             None,
             None,
             [0, 0],
+            Rc::new(Cell::new(true)),
         );
 
         // Seed a known value.
@@ -1639,6 +1664,7 @@ mod tests {
             None,
             None,
             [0, 0],
+            Rc::new(Cell::new(true)),
         );
 
         // use a safe 48-bit range: 0x0000_DEAD_FFFF_FFFE
@@ -1683,6 +1709,7 @@ mod tests {
             None,
             None,
             [0, 0],
+            Rc::new(Cell::new(true)),
         );
 
         // Step 1: Cold boot - reset_reason should be 0x0
@@ -1742,6 +1769,7 @@ mod tests {
             None,
             None,
             [0, 0],
+            Rc::new(Cell::new(true)),
         );
 
         // Cold boot: reset_reason = 0x0
@@ -1773,6 +1801,7 @@ mod tests {
             None,
             None,
             [0, 0],
+            Rc::new(Cell::new(true)),
         );
 
         // Initial time is 0
@@ -1800,6 +1829,7 @@ mod tests {
             None,
             None,
             [0, 0],
+            Rc::new(Cell::new(true)),
         );
 
         // Move time to a known value.
@@ -1836,6 +1866,7 @@ mod tests {
             None,
             None,
             [0, 0],
+            Rc::new(Cell::new(true)),
         );
 
         // Advance by 2^32 + 1 -> high = 1, low = 1, as clock start at 0

--- a/emulator/periph/src/mcu_mbox0.rs
+++ b/emulator/periph/src/mcu_mbox0.rs
@@ -467,7 +467,7 @@ impl MciMailboxImpl {
 
 #[cfg(test)]
 mod tests {
-    use std::{cell::RefCell, rc::Rc};
+    use std::{cell::Cell, cell::RefCell, rc::Rc};
 
     use super::*;
     use crate::mci::Mci;
@@ -510,6 +510,7 @@ mod tests {
             None,
             None,
             [0, 0],
+            Rc::new(Cell::new(true)),
         );
         AutoRootBus::new(
             vec![],

--- a/hw/model/src/model_emulated.rs
+++ b/hw/model/src/model_emulated.rs
@@ -345,6 +345,7 @@ impl McuHwModel for ModelEmulated {
             Some(mcu_mailbox1),
             None,
             mci_generic_input_wires,
+            Rc::new(Cell::new(true)),
         );
 
         let delegates: Vec<Box<dyn caliptra_emu_bus::Bus>> =


### PR DESCRIPTION
On real hardware, Caliptra Core is held in reset until MCU ROM writes the CPTRA_BOOT_GO register in MCI. The emulator did not enforce this, stepping both CPUs unconditionally from the first cycle.

Wire the MCI CPTRA_BOOT_GO register write to a shared flag and skip the Caliptra CPU step until the flag is set. This applies to both the standalone emulator and SVP (which calls the same step path via the C binding).