### PR TITLE
rom: DOT header should be processed during FW update; add docs

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -55,7 +55,8 @@ default-filter = """
 (package(caliptra-mcu-tests-integration) and test(test_bootfsm_timeout)) |
 (package(caliptra-mcu-tests-integration) and test(test_lc_ctrl)) |
 (package(caliptra-mcu-tests-integration) and test(test_raw_lifecycle_boot)) |
-(package(caliptra-mcu-tests-integration) and test(test_rom_hooks_fire_in_order))
+(package(caliptra-mcu-tests-integration) and test(test_rom_hooks_fire_in_order)) |
+(package(caliptra-mcu-tests-integration) and test(test_fw_manifest_dot_hitless_lock))
 """
 # disabled for now due to flakiness of firmware update
 # (package(caliptra-mcu-tests-integration) and test(test_firmware_update_streaming_fpga)) |

--- a/builder/src/features.rs
+++ b/builder/src/features.rs
@@ -66,6 +66,7 @@ pub const FPGA_RUNTIME_TEST_FEATURES: &[&str] = &[
 pub const ROM_ONLY_TEST_FEATURES: &[&str] = &[
     "test-i3c-services",
     "test-fw-manifest-dot",
+    "test-fw-manifest-dot-hitless",
     "test-dot-recovery",
     "test-rom-hooks",
 ];

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -7,6 +7,7 @@
         - [DOT I3C Recovery Protocol](./dot_i3c.md)
     - [ROM Fuses](./rom-fuses.md)
 - [Runtime Specification](./runtime.md)
+    - [Firmware Format](./firmware_format.md)
     - [PLDM Package](./pldm_package.md)
     - [Flash Layout](./flash_layout.md)
     - [Flash Controller](./flash_controller.md)

--- a/docs/src/firmware_format.md
+++ b/docs/src/firmware_format.md
@@ -1,0 +1,229 @@
+# MCU Firmware Format
+
+This document describes optional headers that may be prepended to the MCU
+runtime firmware image. These headers sit **in front of** the firmware's
+reset vector in MCU SRAM and give the ROM a way to act on instructions
+carried by the firmware image itself.
+
+All headers described here are **optional**. A firmware image that does
+not include any of them still boots normally; the ROM detects each header
+by its magic value and silently skips any header that is absent.
+
+## Purpose
+
+The ROM is the trusted component of the MCU. The MCU runtime firmware is
+authenticated against the code-signing keys (via the Caliptra
+SoC manifest) before the ROM jumps to it, which means any bytes that the
+ROM consumes from the start of the firmware image inherit the same
+authorization guarantees as the firmware itself.
+
+An integrator may desire that some operations — burning fuses, advancing
+ownership state, and similar one-way platform changes — are performed
+by immutable code. 
+
+Firmware headers give the runtime an **easy, signed, idempotent path** to
+ask the ROM to perform a well-defined set of privileged operations on
+its behalf. The model is:
+
+* The firmware image author (the signer who holds the owner code-signing
+  key) decides which operations need to happen on the next boot.
+* Those operations are encoded as a fixed-format header and prepended to
+  the firmware image before signing.
+* The ROM authenticates the whole image as usual, then — before jumping
+  to the firmware — inspects the header, executes the requested
+  operations, and advances the firmware entry offset past the header.
+* Every command is idempotent: if the requested state change has
+  already been applied on a previous boot, the command is a no-op. This
+  makes it safe to leave the header in place across resets and hitless
+  updates.
+
+This keeps the set of operations the ROM will perform small, auditable,
+and explicitly authorized, while avoiding the need to implement
+privileged paths in the runtime firmware.
+
+## Image Layout
+
+When one or more headers are present, they are concatenated at the start
+of the MCU image, in front of the firmware's reset vector:
+
+```
++-----------------------------------------+ <- MCU_MEMORY_MAP.sram_offset
+| Optional header #1 (e.g. DOT manifest)  |
++-----------------------------------------+
+| Optional header #2 (future)             |
++-----------------------------------------+
+| ...                                     |
++-----------------------------------------+
+| MCU runtime firmware (reset vector, ...)|
++-----------------------------------------+
+```
+
+Each header starts with a 32-bit little-endian magic value. The ROM
+checks the magic at the expected offset; if it does not match, the ROM
+assumes no header of that type is present and does not advance the
+firmware entry offset for it. The firmware entry offset the ROM jumps
+to is:
+
+```
+entry = sram_offset + mcu_image_header_size + sum(size_of(present headers))
+```
+
+Each supported header type also carries its own integrity check (e.g. a
+checksum) and a version field so the format can evolve without breaking
+older ROMs.
+
+Header processing is gated both at compile time (by a ROM Cargo
+feature) and at runtime (by a field in `RomParameters`), so integrators
+opt in explicitly per platform. A ROM built without the feature pays no
+code-size cost and ignores any such header.
+
+## Firmware Manifest DOT Section
+
+The first header defined in this format is the **firmware manifest DOT
+section**, used to request [Device Ownership Transfer](./dot.md) state
+changes (lock, unlock, rotate, disable) during firmware updates.
+
+### Summary
+
+* **Magic:** `FW_MANIFEST_DOT_MAGIC = 0x444F_5443` (u32). Stored
+  little-endian, the four bytes on disk at offset `0x00` are
+  `0x43 0x54 0x4F 0x44` — i.e. the ASCII string `"CTOD"`. The source
+  code comment spells this magic as `"DOTC"` because the hex digits
+  of the constant, read most-significant byte first, are `44 4F 54 43`;
+  the actual byte order in the image file is the reverse.
+* **Size:** 128 bytes, naturally aligned
+* **Version:** 1
+* **Cargo feature:** `fw-manifest-dot` on the ROM crate
+* **Runtime gate:** `RomParameters::fw_manifest_dot_enabled`
+* **Source of truth:** `FwManifestDotSection` in
+  [`rom/src/device_ownership_transfer.rs`](https://github.com/chipsalliance/caliptra-mcu-sw/blob/main/rom/src/device_ownership_transfer.rs)
+
+### Layout
+
+```text
+offset  size  field          description
+------  ----  -------------  -------------------------------------------------
+ 0x00     4   magic          FW_MANIFEST_DOT_MAGIC = 0x444F_5443 (u32).
+                              On disk (little-endian): 43 54 4F 44 ("CTOD").
+ 0x04     4   checksum       ones-complement of the u32 sum of bytes[8..end]
+ 0x08     4   version        format version (must be 1)
+ 0x0C     4   num_commands   number of valid entries in `commands` (<= 8)
+ 0x10     4   min_fuse_count ROTATE idempotency threshold (ignored otherwise)
+ 0x14     8   commands       up to 8 command bytes, executed in order
+ 0x1C    48   cak            Code Authentication Key for LOCK/ROTATE (12x u32)
+ 0x4C    48   lak            Lock Authentication Key for LOCK/DISABLE (12x u32)
+ 0x7C     4   _reserved      must be zero
+```
+
+The `checksum` is a ones-complement over every byte after the magic and
+checksum fields. It protects against accidental image corruption. It is
+**not** a substitute for authentication — the real authentication comes
+from the firmware image signature verified by the SoC manifest flow.
+
+### Commands
+
+Each byte in `commands` encodes one of the following operations. All
+commands re-read the current DOT fuse state from OTP before acting and
+skip themselves if the requested transition has already been applied,
+so the header is safe to leave in place across reboots.
+
+| Value | Name     | Meaning                                                                                 |
+|-------|----------|-----------------------------------------------------------------------------------------|
+| `0`   | NOP      | Padding / no-op.                                                                        |
+| `1`   | LOCK     | Transition from unlocked (EVEN) to locked (ODD), using `cak` and `lak`.                 |
+| `2`   | UNLOCK   | Transition from locked (ODD) to unlocked (EVEN).                                        |
+| `3`   | ROTATE   | Burn two DOT fuses to advance the effective key while preserving lock/unlock parity. Idempotency is controlled by `min_fuse_count`: rotation is applied only when the currently burned count is below this threshold. |
+| `4`   | DISABLE  | Ensure the device is in ODD (locked/disabled) state. Equivalent at the fuse level to LOCK, but the associated DOT blob contains no CAK. |
+
+Unknown command values cause the ROM to fail the firmware boot with
+`ROM_COLD_BOOT_FW_MANIFEST_DOT_ERROR`. Version mismatches are treated
+the same way.
+
+### ROM Processing
+
+The header is consumed by the ROM as part of the Firmware Boot Flow
+(see the [Reference ROM Specification](./rom.md)):
+
+1. During cold boot, firmware in MCU SRAM is always decrypted by the
+   time the Firmware Boot Flow runs, so the ROM can read the header
+   in place.
+2. The ROM looks for `FW_MANIFEST_DOT_MAGIC` at `sram_offset`. If the
+   magic is absent, no DOT header processing is done and the firmware
+   entry offset is unchanged.
+3. If the magic is present, the ROM verifies the checksum and version,
+   then executes the commands in order against the live DOT fuse/blob
+   state.
+4. On success, the ROM advances the firmware entry offset by the size
+   of the section and jumps to the firmware's reset vector.
+5. Any error in header validation or command execution is fatal and
+   halts the boot.
+
+During the **Hitless Firmware Update Flow**, the ROM performs the same
+manifest detection and command execution as during cold boot — a new
+firmware image delivered via hitless update may carry a different DOT
+header, and its owner-signed commands are applied on this boot rather
+than deferred to the next cold reset.
+
+### DOT Blob Updates and Power-Loss Behavior
+
+Every command that changes DOT fuse state must also leave a consistent
+DOT blob on flash, otherwise the next boot will see fuse state that
+does not match the sealed blob and the part will be unbootable via the
+DOT path. The exact sequence the ROM uses per command is:
+
+* **LOCK / DISABLE** (EVEN → ODD): the ROM first re-seals the DOT blob
+  with the new CAK/LAK (LOCK) or zero CAK + new LAK (DISABLE) against
+  the *current* fuse-derived effective key, writes it to DOT flash,
+  and only then burns the lock fuse. If power is lost between the
+  blob write and the fuse burn, the fuses still report "unlocked" on
+  the next boot and the command is re-attempted idempotently.
+* **UNLOCK** (ODD → EVEN): the ROM pre-computes the *post-burn* fuse
+  state, seals a new unlock blob against that future effective key,
+  writes it to DOT flash, and then burns the unlock fuse. If power is
+  lost between the blob write and the fuse burn, the already-written
+  blob is sealed against a key that the device cannot yet derive, so
+  the next boot will see a valid-looking but HMAC-failing blob and
+  must recover via a DOT recovery handler (see [DOT](./dot.md)).
+* **ROTATE**: the ROM burns both rotation fuses first and only then
+  re-seals the DOT blob against the rotated effective key. If power
+  is lost after the first fuse burn but before the blob is re-sealed,
+  the next boot will again see a stale blob that no longer matches
+  the current fuse-derived key and must recover via a DOT recovery
+  handler.
+* **NOP**: nothing is written.
+
+In all cases, the DOT blob is written **before** the irreversible fuse
+burn whenever possible, so that the most common failure window leaves
+the device in the pre-command state. The remaining windows — between
+individual fuse burns inside ROTATE, and between the pre-computed
+UNLOCK blob and its fuse burn — cannot be closed by code alone: once
+fuses are partially burned there is no way to roll back. A power
+interruption in those windows may leave the device in a state that
+requires a DOT recovery flow on the next boot, and in the worst case
+may leave the part unbootable via DOT until such a recovery succeeds.
+
+This risk is inherent to mixing single-shot fuse burns with flash
+updates. It can be reduced — though not fully eliminated — by
+platform-level mitigations outside the scope of this format, for
+example:
+
+* Maintaining redundant backup copies of both the *current* and *next*
+  DOT blob in flash, so that a partially-updated primary copy can
+  always be reconciled against a known-good backup.
+* Using more sophisticated sequence locks backed by fuses (e.g., a
+  small monotonic counter burned in a defined order) so that the ROM
+  can unambiguously determine which step of a multi-step transition
+  was in progress when power was lost, and either roll it forward or
+  fall back to a backup blob.
+
+Integrators who need stronger power-loss guarantees should layer such
+mechanisms on top of the firmware manifest DOT section; the format
+itself intentionally keeps the ROM-side logic minimal.
+
+## Future Headers
+
+Additional headers of the same shape — magic, version, checksum,
+payload — can be added in the same image area (before the firmware
+reset vector). Each new header will define its own magic and be
+independently detected and skipped by the ROM, subject to its own
+compile-time and runtime opt-in gates.

--- a/docs/src/rom.md
+++ b/docs/src/rom.md
@@ -138,7 +138,7 @@ This flow is used to boot the MCU into the MCU Runtime Firmware following either
 1. Check the MCI `RESET_REASON` register for MCU status (it should be in firmware boot reset mode `FirmwareBootReset`).
 1. Set flow checkpoint to indicate firmware boot flow has started.
 1. Compute the firmware entry offset starting from the MCU image header size.
-1. If the DOT manifests are enabled and `fw_manifest_dot_enabled` is set, look for a firmware-manifest DOT section at the start of MCU SRAM. If found (identified by its magic value):
+1. If the DOT manifests are enabled and `fw_manifest_dot_enabled` is set, look for a firmware-manifest DOT section at the start of MCU SRAM (see [MCU Firmware Format](./firmware_format.md)). If found (identified by its magic value):
     1. Advance the firmware entry offset past the DOT manifest section.
     1. Process the DOT commands contained in the manifest section (see [DOT documentation](./dot.md)). A fatal error is raised if DOT processing fails.
 1. Validate that firmware is present by checking that the first word at the computed firmware entry point (`sram_offset + firmware_offset`) is non-zero. A fatal error (`ROM_FW_BOOT_INVALID_FIRMWARE`) is raised otherwise.
@@ -170,7 +170,7 @@ Hitless Update Flow is triggered when MCU runtime FW requests an update of the M
 1. Check the MCI `RESET_REASON` register for reset status (it should be `FirmwareHitlessUpdate`).
 1. Release the Caliptra mailbox by completing the response to the original `ACTIVATE_FIRMWARE` command. This is required because the mailbox is still held by the command that triggered this reset. A fatal error (`ROM_FW_HITLESS_UPDATE_CLEAR_MB_ERROR`) is raised if the mailbox cannot be released.
 1. Wait for Caliptra to indicate that MCU firmware is ready in SRAM (i.e., Caliptra has finished copying the new image).
-1. Compute the firmware entry offset starting from the MCU image header size. If the DOT manifests feature is enabled and `fw_manifest_dot_enabled` is set, and a DOT firmware manifest section is present at the start of SRAM (identified by its magic value), advance the entry offset past that section. Note that unlike the Firmware Boot Flow, the hitless update flow does **not** re-process the DOT manifest commands — it only skips past the section so that the entry point lands on the firmware reset vector.
+1. Compute the firmware entry offset starting from the MCU image header size. If the DOT manifests feature is enabled and `fw_manifest_dot_enabled` is set, and a DOT firmware manifest section is present at the start of SRAM (identified by its magic value), advance the entry offset past that section **and** process the DOT commands contained in the manifest, mirroring the Firmware Boot Flow. This lets a hitless-updated firmware carry new DOT commands that take effect on this boot. A fatal error is raised if DOT processing fails. See [MCU Firmware Format](./firmware_format.md) for the section layout.
 1. Jump directly to runtime firmware at the computed SRAM entry point.
 
 ```mermaid
@@ -182,6 +182,7 @@ sequenceDiagram
     end
     alt DOT manifest enabled and DOT section present
         note right of mcu: advance entry offset past DOT section
+        note right of mcu: process firmware-manifest DOT commands
     end
     note right of mcu: jump to runtime firmware
 ```

--- a/platforms/emulator/rom/Cargo.toml
+++ b/platforms/emulator/rom/Cargo.toml
@@ -39,6 +39,10 @@ test-mcu-svn-gt-fuse = []
 test-mcu-svn-lt-fuse = []
 test-flash-based-boot = ["hw-2-1"]
 test-fw-manifest-dot = ["caliptra-mcu-rom-common/fw-manifest-dot"]
+test-fw-manifest-dot-hitless = [
+    "caliptra-mcu-rom-common/fw-manifest-dot",
+    "caliptra-mcu-rom-common/test-force-hitless-update",
+]
 test-pldm-streaming-boot = []
 active-i3c1 = ["caliptra-mcu-config-emulator/active-i3c1"]
 test-i3c-services = []

--- a/platforms/emulator/rom/src/riscv.rs
+++ b/platforms/emulator/rom/src/riscv.rs
@@ -254,7 +254,10 @@ pub extern "C" fn rom_entry() -> ! {
             ..Default::default()
         };
         caliptra_mcu_rom_common::rom_start(rom_parameters);
-    } else if cfg!(feature = "test-fw-manifest-dot") {
+    } else if cfg!(any(
+        feature = "test-fw-manifest-dot",
+        feature = "test-fw-manifest-dot-hitless"
+    )) {
         caliptra_mcu_rom_common::rom_start(RomParameters {
             dot_flash: Some(dot_flash),
             fw_manifest_dot_enabled: true,

--- a/rom/Cargo.toml
+++ b/rom/Cargo.toml
@@ -34,3 +34,8 @@ default = []   # default is 2.0
 hw-2-1 = []
 core_test = ["caliptra-mcu-romtime/core_test"]
 fw-manifest-dot = []
+# Test-only: at the end of cold boot, rewrite the reset-reason register to
+# force the next boot entry to `FirmwareHitlessUpdate` instead of
+# `FirmwareBootReset`. Used by the DOT manifest hitless-update integration
+# test to exercise `FwHitlessUpdate::run` without a real PLDM update flow.
+test-force-hitless-update = []

--- a/rom/src/cold_boot.rs
+++ b/rom/src/cold_boot.rs
@@ -892,6 +892,23 @@ impl BootFlow for ColdBoot {
         mci.set_flow_checkpoint(McuRomBootStatus::ColdBootFlowComplete.into());
         mci.set_flow_milestone(McuBootMilestones::COLD_BOOT_FLOW_COMPLETE.into());
         crate::call_hook(params.hooks, |h| h.post_cold_boot());
+
+        #[cfg(feature = "test-force-hitless-update")]
+        {
+            use caliptra_mcu_registers_generated::mci::bits::ResetReason;
+            use tock_registers::interfaces::ReadWriteable;
+            // Replace FwBootUpdReset with FwHitlessUpdReset so the emulator
+            // preserves the hitless bit across this MCU reset and the ROM
+            // re-enters as `FirmwareHitlessUpdate`. Only used by the
+            // fw-manifest-dot hitless integration test.
+            caliptra_mcu_romtime::println!(
+                "[mcu-rom] test-force-hitless-update: forcing hitless reset reason"
+            );
+            mci.registers
+                .mci_reg_reset_reason
+                .modify(ResetReason::FwBootUpdReset::CLEAR + ResetReason::FwHitlessUpdReset::SET);
+        }
+
         mci.trigger_warm_reset();
         caliptra_mcu_romtime::println!("[mcu-rom] ERROR: Still running after reset request!");
         fatal_error(McuError::ROM_COLD_BOOT_RESET_ERROR);

--- a/rom/src/fw_hitless_update.rs
+++ b/rom/src/fw_hitless_update.rs
@@ -14,16 +14,22 @@ Abstract:
 
 #![allow(clippy::empty_loop)]
 
-#[cfg(target_arch = "riscv32")]
+#[cfg(all(target_arch = "riscv32", feature = "fw-manifest-dot"))]
 use crate::device_ownership_transfer;
 #[cfg(target_arch = "riscv32")]
 use crate::MCU_MEMORY_MAP;
 use crate::{fatal_error, BootFlow, RomEnv, RomParameters};
+#[cfg(not(feature = "test-force-hitless-update"))]
 use caliptra_api::{mailbox::MailboxRespHeader, CaliptraApiError};
+#[cfg(not(feature = "test-force-hitless-update"))]
 use caliptra_mcu_error::McuError;
 use caliptra_mcu_romtime::HexWord;
-use core::fmt::Write;
 #[cfg(target_arch = "riscv32")]
+use caliptra_mcu_romtime::McuBootMilestones;
+#[cfg(all(target_arch = "riscv32", feature = "fw-manifest-dot"))]
+use caliptra_mcu_romtime::McuRomBootStatus;
+use core::fmt::Write;
+#[cfg(all(target_arch = "riscv32", feature = "fw-manifest-dot"))]
 use zerocopy::FromBytes;
 
 pub struct FwHitlessUpdate {}
@@ -38,6 +44,7 @@ impl BootFlow for FwHitlessUpdate {
         let soc = &env.soc;
 
         // Release mailbox from activate command before device reboot
+        #[cfg(not(feature = "test-force-hitless-update"))]
         if let Err(err) = soc_manager.finish_mailbox_resp(
             core::mem::size_of::<MailboxRespHeader>(),
             core::mem::size_of::<MailboxRespHeader>(),
@@ -56,7 +63,16 @@ impl BootFlow for FwHitlessUpdate {
             fatal_error(McuError::ROM_FW_HITLESS_UPDATE_CLEAR_MB_ERROR);
         };
 
+        #[cfg(not(feature = "test-force-hitless-update"))]
         while !soc.fw_ready() {}
+
+        // Silence unused-variable warnings when the test feature elides the
+        // mailbox release and fw-ready wait above.
+        #[cfg(feature = "test-force-hitless-update")]
+        {
+            let _ = soc_manager;
+            let _ = soc;
+        }
 
         // Jump to firmware
         caliptra_mcu_romtime::println!("[mcu-rom] Jumping to firmware");
@@ -64,10 +80,15 @@ impl BootFlow for FwHitlessUpdate {
 
         #[cfg(target_arch = "riscv32")]
         unsafe {
+            #[cfg_attr(not(feature = "fw-manifest-dot"), allow(unused_mut))]
             let mut firmware_offset = _params.mcu_image_header_size as u32;
 
-            // Dynamically skip past DOT manifest section if present.
-            if cfg!(feature = "fw-manifest-dot") && _params.fw_manifest_dot_enabled {
+            // Process optional firmware manifest DOT section, mirroring the
+            // cold-boot FwBoot path so that a hitless update carrying a new
+            // DOT header applies its commands on this boot rather than
+            // deferring them to the next cold reset.
+            #[cfg(feature = "fw-manifest-dot")]
+            if _params.fw_manifest_dot_enabled {
                 let manifest_size =
                     core::mem::size_of::<device_ownership_transfer::FwManifestDotSection>();
                 let sram = core::slice::from_raw_parts(
@@ -79,9 +100,32 @@ impl BootFlow for FwHitlessUpdate {
                 {
                     if section.magic == device_ownership_transfer::FW_MANIFEST_DOT_MAGIC {
                         firmware_offset += manifest_size as u32;
+
+                        env.mci.set_flow_checkpoint(
+                            McuRomBootStatus::FwManifestDotProcessingStarted.into(),
+                        );
+                        if let Err(err) =
+                            device_ownership_transfer::process_fw_manifest_dot_commands(
+                                env,
+                                section,
+                                _params.dot_flash,
+                            )
+                        {
+                            caliptra_mcu_romtime::println!(
+                                "[mcu-rom] Error in firmware manifest DOT: {}",
+                                HexWord(err.into())
+                            );
+                            fatal_error(err);
+                        }
+                        env.mci.set_flow_checkpoint(
+                            McuRomBootStatus::FwManifestDotProcessingComplete.into(),
+                        );
                     }
                 }
             }
+
+            env.mci
+                .set_flow_milestone(McuBootMilestones::FIRMWARE_BOOT_FLOW_COMPLETE.into());
 
             let firmware_entry = MCU_MEMORY_MAP.sram_offset + firmware_offset;
             core::arch::asm!(

--- a/tests/integration/src/lib.rs
+++ b/tests/integration/src/lib.rs
@@ -84,6 +84,11 @@ mod test {
         pub custom_mcu_rom: Option<Vec<u8>>,
         /// Optional bytes to prepend to the MCU firmware image (e.g., a manifest header).
         pub firmware_prefix: Option<Vec<u8>>,
+        /// If true (with `firmware_prefix` set), use the DOT hitless-update
+        /// test ROM which forces the cold-boot warm reset to come back as
+        /// `FirmwareHitlessUpdate` so `FwHitlessUpdate::run` processes the
+        /// manifest instead of `FwBoot::run`.
+        pub fw_manifest_dot_hitless: bool,
         pub vendor_pqc_type: Option<caliptra_image_types::FwVerificationPqcKeyType>,
         /// Assert the debug intent strap.
         pub debug_intent: bool,
@@ -107,6 +112,7 @@ mod test {
                 lifecycle_controller_state: None,
                 custom_mcu_rom: None,
                 firmware_prefix: None,
+                fw_manifest_dot_hitless: false,
                 vendor_pqc_type: Some(caliptra_image_types::FwVerificationPqcKeyType::LMS),
                 debug_intent: false,
                 prod_dbg_unlock_keypairs: Vec::new(),
@@ -155,6 +161,9 @@ mod test {
     pub static ROM: LazyLock<PathBuf> = LazyLock::new(|| get_or_compile_rom(""));
     pub static ROM_FW_MANIFEST_DOT: LazyLock<Vec<u8>> =
         LazyLock::new(|| std::fs::read(get_or_compile_rom("test-fw-manifest-dot")).unwrap());
+    pub static ROM_FW_MANIFEST_DOT_HITLESS: LazyLock<Vec<u8>> = LazyLock::new(|| {
+        std::fs::read(get_or_compile_rom("test-fw-manifest-dot-hitless")).unwrap()
+    });
 
     pub static TEST_LOCK: LazyLock<Mutex<AtomicU32>> =
         LazyLock::new(|| Mutex::new(AtomicU32::new(0)));
@@ -357,7 +366,11 @@ mod test {
         .unwrap();
 
         let mcu_rom = if params.firmware_prefix.is_some() {
-            ROM_FW_MANIFEST_DOT.clone()
+            if params.fw_manifest_dot_hitless {
+                ROM_FW_MANIFEST_DOT_HITLESS.clone()
+            } else {
+                ROM_FW_MANIFEST_DOT.clone()
+            }
         } else if let Some(rf) = params.rom_feature {
             let rom_path = get_rom_with_feature(rf);
             std::fs::read(rom_path).unwrap()

--- a/tests/integration/src/test_dot.rs
+++ b/tests/integration/src/test_dot.rs
@@ -1732,6 +1732,92 @@ mod test {
         lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     }
 
+    /// Test: Firmware manifest DOT commands are applied on a hitless firmware
+    /// update boot path.
+    ///
+    /// This is a scaled-down test: rather than running a full PLDM firmware
+    /// update cycle (which the integration harness cannot exercise while
+    /// retaining OTP/flash observability), the ROM is built with the
+    /// `test-fw-manifest-dot-hitless` feature. That feature causes the
+    /// end-of-cold-boot warm reset to come back as `FirmwareHitlessUpdate`
+    /// instead of `FirmwareBootReset`, so `FwHitlessUpdate::run` is the path
+    /// that sees the SRAM firmware image + DOT manifest prefix and executes
+    /// the manifest commands.
+    ///
+    /// Setup:
+    /// - DOT enabled in fuses, EVEN state (burned=0)
+    /// - Valid DOT blob with CAK only (no LAK)
+    /// - Firmware manifest with LOCK command
+    ///
+    /// Expected: On the hitless path, the manifest LOCK command still burns
+    /// the lock fuse (EVEN → ODD) and the boot completes successfully.
+    #[test]
+    fn test_fw_manifest_dot_hitless_lock() {
+        use caliptra_mcu_registers_generated::fuses;
+        use caliptra_mcu_rom_common::FW_MANIFEST_DOT_CMD_LOCK;
+
+        let lock = TEST_LOCK.lock().unwrap();
+        lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
+        let owner_pk_hash = get_owner_pk_hash();
+        let blob = create_valid_dot_blob(owner_pk_hash, [0u32; 12]);
+        let dot_flash = blob.to_flash_contents();
+
+        let manifest =
+            create_manifest_section(&[FW_MANIFEST_DOT_CMD_LOCK], 0, owner_pk_hash, test_lak());
+
+        let mut hw = start_runtime_hw_model(TestParams {
+            firmware_prefix: Some(manifest),
+            fw_manifest_dot_hitless: true,
+            dot_flash_initial_contents: Some(dot_flash),
+            dot_enabled: true,
+            rom_only: true,
+            ..Default::default()
+        });
+
+        hw.step_until(|m| {
+            m.mci_boot_milestones()
+                .contains(McuBootMilestones::FIRMWARE_BOOT_FLOW_COMPLETE)
+                || m.mci_fw_fatal_error().is_some()
+                || m.cycle_count() > 100_000_000
+        });
+
+        let fatal_error = hw.mci_fw_fatal_error();
+        assert!(
+            fatal_error.is_none(),
+            "Hitless manifest LOCK test failed with fatal error: 0x{:x}",
+            fatal_error.unwrap_or(0)
+        );
+
+        assert!(
+            hw.mci_boot_milestones()
+                .contains(McuBootMilestones::FIRMWARE_BOOT_FLOW_COMPLETE),
+            "Hitless boot did not complete within cycle budget"
+        );
+
+        let otp_memory = hw.read_otp_memory();
+        let fuse_byte = otp_memory[fuses::DOT_FUSE_ARRAY.byte_offset];
+        assert!(
+            fuse_byte & 0x01 != 0,
+            "Hitless manifest LOCK should have burned the lock fuse, got 0x{:02x}",
+            fuse_byte
+        );
+
+        let fuse_array = &otp_memory[fuses::DOT_FUSE_ARRAY.byte_offset
+            ..fuses::DOT_FUSE_ARRAY.byte_offset + fuses::DOT_FUSE_ARRAY.byte_size];
+        let burned: u32 = fuse_array.iter().map(|b| b.count_ones()).sum();
+        assert_eq!(
+            burned, 1,
+            "Expected 1 fuse burned by hitless manifest LOCK, found {}",
+            burned
+        );
+
+        println!(
+            "[TEST] Hitless-path firmware manifest LOCK command successfully burned lock fuse"
+        );
+        lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+
     /// Test: LOCK command is idempotent when device is already in ODD (locked) state.
     ///
     /// Setup:


### PR DESCRIPTION
Adds docs/src/firmware_format.md describing the optional DOT header used by ROM for authorized, idempotent fuse and ownership-transfer actions, and links it from rom.md and SUMMARY.md.

Fixes the hitless firmware update path so it also processes a DOT manifest and sets FIRMWARE_BOOT_FLOW_COMPLETE before jumping to firmware, matching the cold-boot flow.

Adds an integration test (test_fw_manifest_dot_hitless_lock) that forces the ROM to re-enter via the hitless path and verifies DOT command processing still burns fuses. Uses a new ROM-only test-force-hitless-update feature to rewrite reset_reason at the end of cold boot. Enabled in the nightly-ci nextest filter.