### PR TITLE
Add evidence decode, appraise command

### DIFF
--- a/.github/workflows/attestation.yml
+++ b/.github/workflows/attestation.yml
@@ -207,3 +207,15 @@ jobs:
           ./target/release/ocptoken authenticate \
             -e $EVIDENCE_DIR/measurement_block_fd.bin \
             -c $EVIDENCE_DIR/certificate_chain_slot_00.der
+
+      # ---- Appraise evidence against reference values (OCP EAT Verifier Algorithm) -------------------------------
+      - name: Appraise evidence against reference values
+        working-directory: ocp-eat-verifier
+        env:
+          EVIDENCE_DIR: ${{ github.workspace }}/attestation-artifacts/evidence
+          TA_STORE_PATH: ${{ github.workspace }}/attestation-artifacts/ta_store
+          SIGNED_REFVAL_CORIM_PATH: ${{ github.workspace }}/attestation-artifacts/signed-refval-corim
+        run: |
+          ./target/release/ocptoken appraise \
+            -e $EVIDENCE_DIR/measurement_block_fd.bin \
+            -c $EVIDENCE_DIR/certificate_chain_slot_00.der

--- a/ocp-eat-verifier/Cargo.toml
+++ b/ocp-eat-verifier/Cargo.toml
@@ -21,3 +21,4 @@ openssl = { version = "0.10", features = ["vendored"] }
 clap = { version = "4", features = ["derive"] }
 corim-rs = { git = "https://github.com/parvathib/corim-rs.git", branch = "pbhogaraju/add_coev" }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
+ciborium = "0.2"

--- a/ocp-eat-verifier/ocptoken-lib/Cargo.toml
+++ b/ocp-eat-verifier/ocptoken-lib/Cargo.toml
@@ -14,6 +14,7 @@ default = ["openssl"]
 openssl = ["dep:openssl"]
 
 [dependencies]
+ciborium.workspace = true
 coset.workspace = true
 hex.workspace = true
 thiserror.workspace = true

--- a/ocp-eat-verifier/ocptoken-lib/src/appraisal.rs
+++ b/ocp-eat-verifier/ocptoken-lib/src/appraisal.rs
@@ -1,0 +1,401 @@
+// Licensed under the Apache-2.0 license
+
+//! Appraisal engine: match evidence triples against CoRIM reference values.
+//!
+//! Implements a simplified version of the CoRIM-09 §9 Reference Verifier
+//! Algorithm:
+//!
+//! - **Phase 2** (Evidence Augmentation): evidence triples are collected.
+//! - **Phase 3** (Reference Values Corroboration): each reference triple is
+//!   matched against evidence; corroborated entries are recorded.
+//! - **Phase 5** (Verifier Augmentation): the Verifier checks freshness
+//!   (nonce) and debug status, augmenting the claims set with Verifier-
+//!   authority assertions.
+//! - **Phase 6** (Attestation Result): the final pass/fail result is
+//!   determined from all preceding phases.
+
+use corim_rs::{ConciseTagTypeChoice, MeasurementMap, ReferenceTripleRecord};
+
+use crate::corim::RefValCorims;
+use crate::token::claims::{DebugStatus, OcpEatClaims};
+
+// ── Result types ───────────────────────────────────────────────────
+
+/// Outcome of appraising a single reference triple.
+pub struct TripleResult {
+    /// Human-readable label for the environment.
+    pub env_label: String,
+    /// Whether a matching evidence triple was found.
+    pub env_matched: bool,
+    /// Per-measurement outcomes (populated only when `env_matched`).
+    pub measurements: Vec<MeasurementResult>,
+}
+
+impl TripleResult {
+    pub fn passed(&self) -> bool {
+        self.env_matched && self.measurements.iter().all(|m| m.matched)
+    }
+}
+
+/// Outcome of comparing one reference measurement against the evidence.
+pub struct MeasurementResult {
+    pub label: String,
+    pub matched: bool,
+    pub detail: String,
+}
+
+// ── Verifier-augmented claims (Phase 5) ────────────────────────────
+
+/// Result of a single verifier precondition check.
+pub struct VerifierCheck {
+    pub name: String,
+    pub passed: bool,
+    pub detail: String,
+}
+
+/// Overall appraisal report.
+pub struct AppraisalReport {
+    /// Phase 5: Verifier-augmented precondition checks.
+    pub verifier_checks: Vec<VerifierCheck>,
+    /// Phase 3: Per-reference-triple corroboration results.
+    pub results: Vec<TripleResult>,
+}
+
+impl AppraisalReport {
+    pub fn all_passed(&self) -> bool {
+        self.verifier_checks.iter().all(|c| c.passed)
+            && !self.results.is_empty()
+            && self.results.iter().all(|r| r.passed())
+    }
+}
+
+// ── Core appraisal logic ───────────────────────────────────────────
+
+/// Run appraisal: for every reference triple in the CoRIM, find the
+/// matching evidence triple and compare measurement values.
+///
+/// `expected_nonce` is the hex-encoded nonce the Verifier sent to the
+/// Attester via SPDM GET_MEASUREMENTS.  If `Some`, it is compared
+/// against the nonce in the evidence claims (Phase 5 freshness check).
+/// If `None`, the freshness check is skipped.
+pub fn appraise(
+    claims: &OcpEatClaims,
+    refval_corims: &RefValCorims,
+    expected_nonce: Option<&str>,
+) -> Result<AppraisalReport, String> {
+    // ── Phase 5: Verifier Augmentation ─────────────────────────────
+    let verifier_checks = verify_preconditions(claims, expected_nonce);
+
+    // 1. Collect reference triples from all CoRIM's CoMID tags.
+    let ref_triples: Vec<&ReferenceTripleRecord> = refval_corims
+        .iter()
+        .flat_map(|(_, corim_map)| {
+            corim_map.tags.iter().filter_map(|tag| {
+                if let ConciseTagTypeChoice::Mid(tagged_comid) = tag {
+                    tagged_comid.triples.reference_triples.as_deref()
+                } else {
+                    None
+                }
+            })
+        })
+        .flatten()
+        .collect();
+
+    if ref_triples.is_empty() {
+        return Err("No reference triples found in CoRIM files".into());
+    }
+
+    // 2. Collect evidence triples from decoded measurements.
+    let decoded = claims
+        .decode_measurements()
+        .map_err(|e| format!("Failed to decode measurements: {}", e))?;
+
+    let ev_triples: Vec<&ReferenceTripleRecord> = decoded
+        .iter()
+        .filter_map(|entry| entry.evidence.ev_triples.evidence_triples.as_deref())
+        .flatten()
+        .collect();
+
+    // 3. Appraise each reference triple against the evidence.
+    let mut results = Vec::with_capacity(ref_triples.len());
+
+    for ref_triple in &ref_triples {
+        let env_label = format_env(&ref_triple.ref_env);
+
+        // Find evidence triples whose environment matches the reference.
+        let matching_ev: Vec<&&ReferenceTripleRecord> = ev_triples
+            .iter()
+            .filter(|ev| ref_triple.ref_env.matches(&ev.ref_env))
+            .collect();
+
+        if matching_ev.is_empty() {
+            results.push(TripleResult {
+                env_label,
+                env_matched: false,
+                measurements: Vec::new(),
+            });
+            continue;
+        }
+
+        // Compare each reference measurement against the matched evidence.
+        let measurements = ref_triple
+            .ref_claims
+            .iter()
+            .map(|ref_meas| appraise_measurement(ref_meas, &matching_ev))
+            .collect();
+
+        results.push(TripleResult {
+            env_label,
+            env_matched: true,
+            measurements,
+        });
+    }
+
+    Ok(AppraisalReport {
+        verifier_checks,
+        results,
+    })
+}
+
+// ── Phase 5 helpers ────────────────────────────────────────────────
+
+/// Run verifier precondition checks (Phase 5: Verifier Augmentation).
+///
+/// These are claims generated by the Verifier itself — they do not come
+/// from reference values or endorsements.
+fn verify_preconditions(claims: &OcpEatClaims, expected_nonce: Option<&str>) -> Vec<VerifierCheck> {
+    let mut checks = Vec::new();
+
+    // 1. Freshness: compare the evidence nonce against the expected nonce
+    //    that the Verifier sent via SPDM GET_MEASUREMENTS.
+    if let Some(expected) = expected_nonce {
+        let evidence_nonce_hex = hex::encode(&claims.nonce);
+        let nonce_ok = evidence_nonce_hex.eq_ignore_ascii_case(expected);
+        checks.push(VerifierCheck {
+            name: "Freshness (nonce)".into(),
+            passed: nonce_ok,
+            detail: if nonce_ok {
+                let short = if evidence_nonce_hex.len() > 16 {
+                    format!(
+                        "{}…{}",
+                        &evidence_nonce_hex[..8],
+                        &evidence_nonce_hex[evidence_nonce_hex.len() - 8..]
+                    )
+                } else {
+                    evidence_nonce_hex.clone()
+                };
+                format!("nonce={} — evidence matches expected", short)
+            } else {
+                format!(
+                    "nonce mismatch: expected={}, evidence={}",
+                    expected, evidence_nonce_hex
+                )
+            },
+        });
+    }
+
+    // 2. Debug status: the evidence MUST NOT indicate debug is enabled.
+    let dbg_ok = claims.debug_status != DebugStatus::Enabled;
+    checks.push(VerifierCheck {
+        name: "Debug status".into(),
+        passed: dbg_ok,
+        detail: if dbg_ok {
+            format!("debug status is {} — acceptable", claims.debug_status)
+        } else {
+            "debug status is enabled (0) — NOT acceptable".into()
+        },
+    });
+
+    checks
+}
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+/// Compare a single reference measurement against all evidence measurements
+/// from the matching evidence triples.
+fn appraise_measurement(
+    ref_meas: &MeasurementMap,
+    matching_ev: &[&&ReferenceTripleRecord],
+) -> MeasurementResult {
+    let label = format_mkey(ref_meas);
+
+    for ev_triple in matching_ev {
+        for ev_meas in &ev_triple.ref_claims {
+            // If the reference measurement has a key, only compare with
+            // evidence measurements that carry the same key.
+            if let Some(ref rk) = ref_meas.mkey {
+                match &ev_meas.mkey {
+                    Some(ek) if ek == rk => {}
+                    _ => continue,
+                }
+            }
+
+            if ref_meas.mval.matches(&ev_meas.mval) {
+                return MeasurementResult {
+                    label,
+                    matched: true,
+                    detail: describe_match(&ref_meas.mval, &ev_meas.mval),
+                };
+            } else {
+                return MeasurementResult {
+                    label,
+                    matched: false,
+                    detail: describe_mismatch(&ref_meas.mval, &ev_meas.mval),
+                };
+            }
+        }
+    }
+
+    MeasurementResult {
+        label,
+        matched: false,
+        detail: "no evidence measurement found for this key".into(),
+    }
+}
+
+/// Produce a human-readable label for a measurement key.
+fn format_mkey(meas: &MeasurementMap) -> String {
+    match &meas.mkey {
+        Some(corim_rs::MeasuredElementTypeChoice::Tstr(s)) => s.to_string(),
+        Some(corim_rs::MeasuredElementTypeChoice::UInt(n)) => format!("{}", n),
+        Some(other) => format!("{:?}", other),
+        None => "(no key)".into(),
+    }
+}
+
+/// Produce a human-readable label for an environment.
+fn format_env(env: &corim_rs::EnvironmentMap) -> String {
+    let mut parts = Vec::new();
+    if let Some(ref class) = env.class {
+        if let Some(ref vendor) = class.vendor {
+            parts.push(format!("vendor={}", vendor));
+        }
+        if let Some(ref model) = class.model {
+            parts.push(format!("model={}", model));
+        }
+        if let Some(ref class_id) = class.class_id {
+            if let Some(bytes) = class_id.as_bytes() {
+                match std::str::from_utf8(bytes) {
+                    Ok(s) => parts.push(format!("class-id=\"{}\"", s)),
+                    Err(_) => parts.push(format!("class-id={}", hex::encode(bytes))),
+                }
+            }
+        }
+    }
+    if parts.is_empty() {
+        format!("{:?}", env)
+    } else {
+        parts.join(", ")
+    }
+}
+
+/// Describe which fields in the reference matched the evidence.
+fn describe_match(
+    ref_mval: &corim_rs::MeasurementValuesMap,
+    ev_mval: &corim_rs::MeasurementValuesMap,
+) -> String {
+    let mut matches = Vec::new();
+
+    if let Some(ref ref_digests) = ref_mval.digests {
+        if let Some(ref ev_digests) = ev_mval.digests {
+            for rd in ref_digests {
+                if let Some(ed) = ev_digests
+                    .iter()
+                    .find(|ed| ed.alg == rd.alg && ed.val == rd.val)
+                {
+                    let hex_val = hex::encode(&ed.val);
+                    let short = if hex_val.len() > 16 {
+                        format!("{}…{}", &hex_val[..8], &hex_val[hex_val.len() - 8..])
+                    } else {
+                        hex_val
+                    };
+                    matches.push(format!("digest({:?})={}", rd.alg, short));
+                }
+            }
+        }
+    }
+
+    if let Some(ref ref_svn) = ref_mval.svn {
+        if let Some(ref ev_svn) = ev_mval.svn {
+            if ref_svn.matches(ev_svn) {
+                matches.push(format!("svn={:?}", ev_svn));
+            }
+        }
+    }
+
+    if let Some(ref ref_ver) = ref_mval.version {
+        if let Some(ref ev_ver) = ev_mval.version {
+            if ref_ver.matches(ev_ver) {
+                matches.push(format!("version={:?}", ev_ver));
+            }
+        }
+    }
+
+    if matches.is_empty() {
+        "all specified values match".into()
+    } else {
+        matches.join("; ")
+    }
+}
+
+/// Describe which fields in the reference didn't match the evidence.
+fn describe_mismatch(
+    ref_mval: &corim_rs::MeasurementValuesMap,
+    ev_mval: &corim_rs::MeasurementValuesMap,
+) -> String {
+    let mut mismatches = Vec::new();
+
+    if let Some(ref ref_digests) = ref_mval.digests {
+        match &ev_mval.digests {
+            Some(ev_digests) => {
+                for rd in ref_digests {
+                    let found = ev_digests.iter().find(|ed| ed.alg == rd.alg);
+                    match found {
+                        Some(ed) if ed.val != rd.val => {
+                            mismatches.push(format!(
+                                "digest({:?}): ref={} ev={}",
+                                rd.alg,
+                                hex::encode(&rd.val),
+                                hex::encode(&ed.val),
+                            ));
+                        }
+                        None => {
+                            mismatches
+                                .push(format!("digest({:?}): not present in evidence", rd.alg));
+                        }
+                        _ => {} // matching
+                    }
+                }
+            }
+            None => mismatches.push("digests: not present in evidence".into()),
+        }
+    }
+
+    if let Some(ref ref_svn) = ref_mval.svn {
+        match &ev_mval.svn {
+            Some(ev_svn) => {
+                if !ref_svn.matches(ev_svn) {
+                    mismatches.push(format!("svn: ref={:?} ev={:?}", ref_svn, ev_svn));
+                }
+            }
+            None => mismatches.push("svn: not present in evidence".into()),
+        }
+    }
+
+    if let Some(ref ref_ver) = ref_mval.version {
+        match &ev_mval.version {
+            Some(ev_ver) => {
+                if !ref_ver.matches(ev_ver) {
+                    mismatches.push(format!("version: ref={:?} ev={:?}", ref_ver, ev_ver));
+                }
+            }
+            None => mismatches.push("version: not present in evidence".into()),
+        }
+    }
+
+    if mismatches.is_empty() {
+        "unknown mismatch".into()
+    } else {
+        mismatches.join("; ")
+    }
+}

--- a/ocp-eat-verifier/ocptoken-lib/src/error.rs
+++ b/ocp-eat-verifier/ocptoken-lib/src/error.rs
@@ -18,6 +18,14 @@ pub enum OcpEatError {
     /// Trust anchor store error
     #[error("Trust anchor: {0}")]
     TrustAnchor(#[from] crate::ta_store::TrustAnchorError),
+
+    /// Claims decoding error
+    #[error("Claims decode: {0}")]
+    ClaimsDecode(#[from] coset::CoseError),
+
+    /// Measurements decoding error
+    #[error("Measurements decode: {0}")]
+    MeasurementsDecode(String),
 }
 
 /// Result type for OCP EAT operations

--- a/ocp-eat-verifier/ocptoken-lib/src/lib.rs
+++ b/ocp-eat-verifier/ocptoken-lib/src/lib.rs
@@ -1,5 +1,6 @@
 // Licensed under the Apache-2.0 license
 
+pub mod appraisal;
 pub mod corim;
 pub mod cose_verify;
 pub mod error;

--- a/ocp-eat-verifier/ocptoken-lib/src/token/claims.rs
+++ b/ocp-eat-verifier/ocptoken-lib/src/token/claims.rs
@@ -1,0 +1,358 @@
+// Licensed under the Apache-2.0 license
+
+//! OCP EAT profile claims.
+//!
+//! Defines the mandatory and optional claims for the OCP EAT profile
+//! and provides validation that all mandatory claims are present.
+
+use crate::error::{OcpEatError, OcpEatResult};
+use corim_rs::coev::TaggedConciseEvidence;
+use coset::cbor::value::Value;
+use coset::cwt::{ClaimName, ClaimsSet};
+
+// ── Claim key constants (CBOR map keys) ────────────────────────────
+
+// Mandatory
+pub const CLAIM_KEY_NONCE: i64 = 10;
+pub const CLAIM_KEY_DEBUG_STATUS: i64 = 263;
+pub const CLAIM_KEY_EAT_PROFILE: i64 = 265;
+pub const CLAIM_KEY_MEASUREMENTS: i64 = 273;
+
+// Optional
+pub const CLAIM_KEY_UEID: i64 = 256;
+pub const CLAIM_KEY_SUEID: i64 = 257;
+pub const CLAIM_KEY_OEMID: i64 = 258;
+pub const CLAIM_KEY_HW_MODEL: i64 = 259;
+pub const CLAIM_KEY_UPTIME: i64 = 261;
+pub const CLAIM_KEY_BOOT_COUNT: i64 = 267;
+pub const CLAIM_KEY_BOOT_SEED: i64 = 268;
+pub const CLAIM_KEY_DLOAS: i64 = 269;
+pub const CLAIM_KEY_CORIM_LOCATORS: i64 = -70001;
+
+/// OCP EAT profile OID in dotted notation: 1.3.6.1.4.1.42623.1.3
+pub const OCP_EAT_PROFILE_OID_STR: &str = "1.3.6.1.4.1.42623.1.3";
+
+/// OCP EAT profile OID as ASN.1 DER TLV bytes.
+pub const OCP_EAT_PROFILE_OID: &[u8] = &[
+    0x06, 0x0a, 0x2b, 0x06, 0x01, 0x04, 0x01, 0x82, 0x4d, 0x1f, 0x01, 0x03,
+];
+
+/// OCP EAT profile OID as raw content bytes (without ASN.1 tag+length),
+/// matching the CBOR `~oid` (tag 111) encoding.
+pub const OCP_EAT_PROFILE_OID_RAW: &[u8] = &[
+    0x2b, 0x06, 0x01, 0x04, 0x01, 0x82, 0x4d, 0x1f, 0x01, 0x03,
+];
+
+// ── OCP EAT Claims ────────────────────────────────────────────────
+
+/// Debug status values per RFC 9711 §4.2.9.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DebugStatus {
+    Enabled,
+    Disabled,
+    DisabledSinceBoot,
+    DisabledPermanently,
+    DisabledFullyAndPermanently,
+}
+
+impl DebugStatus {
+    /// Decode from a CBOR integer value.
+    pub fn from_cbor(value: &Value) -> OcpEatResult<Self> {
+        match value {
+            Value::Integer(i) => {
+                let v: i128 = (*i).into();
+                match v {
+                    0 => Ok(DebugStatus::Enabled),
+                    1 => Ok(DebugStatus::Disabled),
+                    2 => Ok(DebugStatus::DisabledSinceBoot),
+                    3 => Ok(DebugStatus::DisabledPermanently),
+                    4 => Ok(DebugStatus::DisabledFullyAndPermanently),
+                    _ => Err(OcpEatError::InvalidToken("Unknown debug-status value")),
+                }
+            }
+            _ => Err(OcpEatError::InvalidToken("debug-status must be an integer")),
+        }
+    }
+}
+
+impl std::fmt::Display for DebugStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DebugStatus::Enabled => write!(f, "enabled (0)"),
+            DebugStatus::Disabled => write!(f, "disabled (1)"),
+            DebugStatus::DisabledSinceBoot => write!(f, "disabled-since-boot (2)"),
+            DebugStatus::DisabledPermanently => write!(f, "disabled-permanently (3)"),
+            DebugStatus::DisabledFullyAndPermanently => {
+                write!(f, "disabled-fully-and-permanently (4)")
+            }
+        }
+    }
+}
+
+/// Parsed OCP EAT claims, split into mandatory, optional, and private.
+pub struct OcpEatClaims {
+    // ── Mandatory ──
+    /// Nonce (key 10): bstr .size (8..64)
+    pub nonce: Vec<u8>,
+    /// Debug status (key 263): dbgstat-type per RFC 9711
+    pub debug_status: DebugStatus,
+    /// EAT Profile OID (key 265): ~oid 1.3.6.1.4.1.42623.1.3
+    pub eat_profile: String,
+    /// Measurements (key 273): bstr (CBOR-encoded measurements-type)
+    pub measurements: Vec<u8>,
+
+    // ── Optional ──
+    /// Issuer (key 1): tstr
+    pub issuer: Option<String>,
+    /// CWT ID (key 7): bstr .size (8..64)
+    pub cwt_id: Option<Vec<u8>>,
+    /// UEID (key 256): bstr .size (7..33)
+    pub ueid: Option<Vec<u8>>,
+    /// SUEID (key 257): bstr .size (7..33)
+    pub sueid: Option<Vec<u8>>,
+    /// OEM ID (key 258): oemid-type per RFC 9711
+    pub oemid: Option<Value>,
+    /// Hardware model (key 259): bytes .size (1..32)
+    pub hw_model: Option<Vec<u8>>,
+    /// Uptime (key 261): uint
+    pub uptime: Option<u64>,
+    /// Boot count (key 267): uint
+    pub boot_count: Option<u64>,
+    /// Boot seed (key 268): bstr .size (32..64)
+    pub boot_seed: Option<Vec<u8>>,
+    /// DLOAs (key 269): [ + dloa-type ]
+    pub dloas: Option<Value>,
+    /// CoRIM locators (key -70001): [ + corim-locator-map ]
+    pub corim_locators: Option<Value>,
+
+    // ── Private claims ──
+    /// Remaining claims not covered above.
+    pub private_claims: Vec<(ClaimName, Value)>,
+}
+
+impl OcpEatClaims {
+    /// Parse and validate an `OcpEatClaims` from a `ClaimsSet`.
+    ///
+    /// Returns an error if any mandatory claim is missing.
+    pub fn from_claims_set(cs: ClaimsSet) -> OcpEatResult<Self> {
+        let mut nonce: Option<Vec<u8>> = None;
+        let mut debug_status: Option<DebugStatus> = None;
+        let mut eat_profile: Option<String> = None;
+        let mut measurements: Option<Vec<u8>> = None;
+
+        let mut ueid: Option<Vec<u8>> = None;
+        let mut sueid: Option<Vec<u8>> = None;
+        let mut oemid: Option<Value> = None;
+        let mut hw_model: Option<Vec<u8>> = None;
+        let mut uptime: Option<u64> = None;
+        let mut boot_count: Option<u64> = None;
+        let mut boot_seed: Option<Vec<u8>> = None;
+        let mut dloas: Option<Value> = None;
+        let mut corim_locators: Option<Value> = None;
+        let mut private_claims: Vec<(ClaimName, Value)> = Vec::new();
+
+        for (name, value) in cs.rest {
+            match &name {
+                ClaimName::Assigned(n) => match n.to_i64() {
+                    CLAIM_KEY_NONCE => nonce = Some(value_to_bstr(value, "nonce")?),
+                    CLAIM_KEY_DEBUG_STATUS => debug_status = Some(DebugStatus::from_cbor(&value)?),
+                    CLAIM_KEY_EAT_PROFILE => {
+                        let oid_bytes = value_to_oid(value, "eat_profile")?;
+                        // Try UTF-8 text first, then dotted notation is already text
+                        let oid_str = String::from_utf8(oid_bytes)
+                            .map_err(|_| OcpEatError::InvalidToken("eat_profile is not valid UTF-8 or OID"))?;
+                        eat_profile = Some(oid_str);
+                    }
+                    CLAIM_KEY_MEASUREMENTS => {
+                        measurements = Some(value_to_measurements(value)?);
+                    }
+                    CLAIM_KEY_UEID => ueid = Some(value_to_bstr(value, "ueid")?),
+                    CLAIM_KEY_SUEID => sueid = Some(value_to_bstr(value, "sueid")?),
+                    CLAIM_KEY_OEMID => oemid = Some(value),
+                    CLAIM_KEY_HW_MODEL => hw_model = Some(value_to_bstr(value, "hwmodel")?),
+                    CLAIM_KEY_UPTIME => uptime = Some(value_to_uint(value, "uptime")?),
+                    CLAIM_KEY_BOOT_COUNT => boot_count = Some(value_to_uint(value, "bootcount")?),
+                    CLAIM_KEY_BOOT_SEED => boot_seed = Some(value_to_bstr(value, "bootseed")?),
+                    CLAIM_KEY_DLOAS => dloas = Some(value),
+                    _ => private_claims.push((name, value)),
+                },
+                ClaimName::PrivateUse(n) => match *n {
+                    CLAIM_KEY_CORIM_LOCATORS => corim_locators = Some(value),
+                    _ => private_claims.push((name, value)),
+                },
+                _ => private_claims.push((name, value)),
+            }
+        }
+
+        // ── Validate mandatory claims ──
+        let nonce = nonce.ok_or(OcpEatError::InvalidToken("Missing mandatory claim: nonce (10)"))?;
+        let debug_status = debug_status
+            .ok_or(OcpEatError::InvalidToken("Missing mandatory claim: dbgstat (263)"))?;
+        let eat_profile = eat_profile
+            .ok_or(OcpEatError::InvalidToken("Missing mandatory claim: eat_profile (265)"))?;
+
+        // Validate that eat_profile matches the OCP EAT profile OID.
+        if eat_profile != OCP_EAT_PROFILE_OID_STR {
+            return Err(OcpEatError::InvalidToken(
+                "eat_profile does not match OCP EAT profile OID (1.3.6.1.4.1.42623.1.3)",
+            ));
+        }
+
+        let measurements = measurements
+            .ok_or(OcpEatError::InvalidToken("Missing mandatory claim: measurements (273)"))?;
+
+        Ok(OcpEatClaims {
+            nonce,
+            debug_status,
+            eat_profile,
+            measurements,
+            issuer: cs.issuer,
+            cwt_id: cs.cwt_id,
+            ueid,
+            sueid,
+            oemid,
+            hw_model,
+            uptime,
+            boot_count,
+            boot_seed,
+            dloas,
+            corim_locators,
+            private_claims,
+        })
+    }
+
+    /// Decode the measurements bytes as a TaggedConciseEvidence (CBOR tag 571).
+    ///
+    /// The measurements field is a CBOR array of `[content-type, content-value]`
+    /// entries. Each content-value is decoded as a `TaggedConciseEvidence`.
+    pub fn decode_measurements(&self) -> OcpEatResult<Vec<DecodedMeasurement>> {
+        let value: Value = ciborium::from_reader(self.measurements.as_slice())
+            .map_err(|e| OcpEatError::MeasurementsDecode(format!("CBOR parse: {}", e)))?;
+
+        let entries = match value {
+            Value::Array(arr) => arr,
+            _ => {
+                return Err(OcpEatError::MeasurementsDecode(
+                    "measurements is not a CBOR array".into(),
+                ))
+            }
+        };
+
+        let mut result = Vec::with_capacity(entries.len());
+        for (i, entry) in entries.iter().enumerate() {
+            let pair = match entry {
+                Value::Array(a) if a.len() == 2 => a,
+                _ => {
+                    return Err(OcpEatError::MeasurementsDecode(format!(
+                        "entry[{}] is not a 2-element array",
+                        i
+                    )))
+                }
+            };
+
+            let content_type = match &pair[0] {
+                Value::Integer(n) => {
+                    let v: i128 = (*n).into();
+                    u64::try_from(v).map_err(|_| {
+                        OcpEatError::MeasurementsDecode(format!(
+                            "entry[{}] content-type out of range",
+                            i
+                        ))
+                    })?
+                }
+                _ => {
+                    return Err(OcpEatError::MeasurementsDecode(format!(
+                        "entry[{}] content-type is not uint",
+                        i
+                    )))
+                }
+            };
+
+            let content_bytes = match &pair[1] {
+                Value::Bytes(b) => b.as_slice(),
+                _ => {
+                    return Err(OcpEatError::MeasurementsDecode(format!(
+                        "entry[{}] content-value is not bstr",
+                        i
+                    )))
+                }
+            };
+
+            let evidence =
+                TaggedConciseEvidence::from_cbor(content_bytes).map_err(|e| {
+                    OcpEatError::MeasurementsDecode(format!("entry[{}] decode: {}", i, e))
+                })?;
+
+            result.push(DecodedMeasurement {
+                content_type,
+                evidence,
+            });
+        }
+
+        Ok(result)
+    }
+}
+
+/// A decoded measurement entry from the measurements array.
+pub struct DecodedMeasurement {
+    /// CoAP content-type (e.g. 10571 for concise-evidence).
+    pub content_type: u64,
+    /// The decoded TaggedConciseEvidence (CBOR tag 571).
+    pub evidence: TaggedConciseEvidence<'static>,
+}
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+/// CBOR tag for OID (RFC 9090).
+const CBOR_TAG_OID: u64 = 111;
+
+use coset::iana::EnumI64;
+
+fn value_to_bstr(value: Value, field: &'static str) -> OcpEatResult<Vec<u8>> {
+    match value {
+        Value::Bytes(b) => Ok(b),
+        _ => Err(OcpEatError::InvalidToken(field)),
+    }
+}
+
+/// Extract OID bytes from a CBOR value that is either:
+/// - `Value::Bytes(b)` — unwrapped OID (`~oid`)
+/// - `Value::Tag(111, Value::Bytes(b))` — tagged OID (`#6.111(bstr)`)
+fn value_to_oid(value: Value, field: &'static str) -> OcpEatResult<Vec<u8>> {
+    match value {
+        Value::Bytes(b) => Ok(b),
+        Value::Tag(CBOR_TAG_OID, inner) => match *inner {
+            Value::Bytes(b) => Ok(b),
+            _ => Err(OcpEatError::InvalidToken(field)),
+        },
+        _ => Err(OcpEatError::InvalidToken(field)),
+    }
+}
+
+fn value_to_uint(value: Value, field: &'static str) -> OcpEatResult<u64> {
+    match value {
+        Value::Integer(i) => {
+            let val: i128 = i.into();
+            u64::try_from(val).map_err(|_| OcpEatError::InvalidToken(field))
+        }
+        _ => Err(OcpEatError::InvalidToken(field)),
+    }
+}
+
+/// Extract measurements bytes from a CBOR value.
+///
+/// Per the OCP EAT CDDL, `measurements-type` can be:
+///   - `bstr .cbor concise-evidence`  → already a byte string
+///   - `concise-evidence` (a CBOR Array) → re-encode to CBOR bytes
+fn value_to_measurements(value: Value) -> OcpEatResult<Vec<u8>> {
+    match value {
+        Value::Bytes(b) => Ok(b),
+        Value::Array(_) => {
+            let mut buf = Vec::new();
+            ciborium::into_writer(&value, &mut buf)
+                .map_err(|_| OcpEatError::InvalidToken("measurements: failed to re-encode CBOR array"))?;
+            Ok(buf)
+        }
+        _ => Err(OcpEatError::InvalidToken("measurements must be bstr or array")),
+    }
+}

--- a/ocp-eat-verifier/ocptoken-lib/src/token/evidence.rs
+++ b/ocp-eat-verifier/ocptoken-lib/src/token/evidence.rs
@@ -1,11 +1,15 @@
 // Licensed under the Apache-2.0 license
 
-use crate::cose_verify::{CoseSign1Verifier, CryptoBackend, DecodedCoseSign1};
+use crate::cose_verify::authenticate::{HeaderSelection, SignerIdMethod};
+use crate::cose_verify::{
+    authenticate_signer, AuthenticateOptions, CoseSign1Verifier, CryptoBackend, DecodedCoseSign1,
+};
 use crate::error::{OcpEatError, OcpEatResult};
 use crate::ta_store::TrustAnchorStore;
-use coset::cbor::value::Value;
+use crate::token::claims::OcpEatClaims;
+use coset::cwt::ClaimsSet;
 use coset::iana::Algorithm;
-use coset::{Header, Label};
+use coset::CborSerializable;
 
 pub const OCP_EAT_CLAIMS_KEY_ID: &str = "";
 pub const CBOR_TAG_CBOR: u64 = 55799;
@@ -23,6 +27,7 @@ pub const OCP_EAT_TAGS: &[u64] = &[CBOR_TAG_CBOR, CBOR_TAG_CWT, CBOR_TAG_COSE_SI
 pub struct Evidence<'a> {
     decoded: DecodedCoseSign1,
     ta_store: &'a dyn TrustAnchorStore,
+    claims: OcpEatClaims,
 }
 
 impl<'a> Evidence<'a> {
@@ -32,8 +37,15 @@ impl<'a> Evidence<'a> {
         let decoded = DecodedCoseSign1::decode(slice, OCP_EAT_TAGS)?;
 
         verify_eat_protected_header(decoded.protected_header())?;
+        verify_eat_unprotected_header(decoded.unprotected_header())?;
 
-        Ok(Evidence { decoded, ta_store })
+        let claims = Self::decode_claims_from_payload(&decoded)?;
+
+        Ok(Evidence {
+            decoded,
+            ta_store,
+            claims,
+        })
     }
 
     /// Authenticate the signing key against the Trust Anchor Store.
@@ -51,27 +63,30 @@ impl<'a> Evidence<'a> {
     ///
     /// Returns the DER-encoded authenticated leaf certificate on success.
     pub fn authenticate(&self, cert_chain_blob: &[u8]) -> OcpEatResult<Vec<u8>> {
-        let x5chain = extract_x5chain(self.decoded.unprotected_header())?;
-
-        let full_chain = if cert_chain_blob.is_empty() {
-            // No external chain — use x5chain as the full chain
-            x5chain
-        } else {
-            // Split the blob into individual certs (root-to-leaf order)
-            let mut chain_certs = split_der_certs(cert_chain_blob)?;
-            // Drop the device leaf (last cert)
-            if !chain_certs.is_empty() {
-                chain_certs.pop();
-            }
-            // Reverse to leaf-to-root order, then prepend x5chain
-            chain_certs.reverse();
-            let mut full = x5chain;
-            full.extend(chain_certs);
-            full
+        let options = AuthenticateOptions {
+            header: HeaderSelection::Unprotected,
+            method: SignerIdMethod::X5chain,
         };
+        Ok(authenticate_signer(
+            &self.decoded,
+            self.ta_store,
+            cert_chain_blob,
+            &options,
+        )?)
+    }
 
-        let authenticated_leaf = self.ta_store.authenticate_chain(&full_chain)?;
-        Ok(authenticated_leaf)
+    /// Decode the EAT claims from the COSE_Sign1 payload.
+    fn decode_claims_from_payload(decoded: &DecodedCoseSign1) -> OcpEatResult<OcpEatClaims> {
+        let payload = decoded
+            .payload()
+            .ok_or(OcpEatError::InvalidToken("Missing payload"))?;
+        let claims_set = ClaimsSet::from_slice(payload)?;
+        OcpEatClaims::from_claims_set(claims_set)
+    }
+
+    /// Access the decoded OCP EAT claims.
+    pub fn claims(&self) -> &OcpEatClaims {
+        &self.claims
     }
 
     /// Authenticate the signing key and cryptographically verify
@@ -90,97 +105,21 @@ impl<'a> Evidence<'a> {
     }
 }
 
-/// COSE header parameter label for x5chain (RFC 9360, label 33).
+/// COSE header label for x5chain (RFC 9360).
 const COSE_HDR_PARAM_X5CHAIN: i64 = 33;
 
-/// Extract x5chain certificate chain from a COSE header (label 33).
-/// Returns DER-encoded certificates ordered leaf-first.
-fn extract_x5chain(header: &Header) -> OcpEatResult<Vec<Vec<u8>>> {
-    let value = header
+/// Verify that the unprotected header contains an x5chain (label 33).
+fn verify_eat_unprotected_header(unprotected: &coset::Header) -> OcpEatResult<()> {
+    let has_x5chain = unprotected
         .rest
         .iter()
-        .find_map(|(l, v)| {
-            if *l == Label::Int(COSE_HDR_PARAM_X5CHAIN) {
-                Some(v)
-            } else {
-                None
-            }
-        })
-        .ok_or(OcpEatError::InvalidToken(
-            "Missing x5chain (label 33) in unprotected header",
-        ))?;
-
-    match value {
-        // x5chain can be a single bstr (one cert) or an array of bstr
-        Value::Bytes(bytes) => Ok(vec![bytes.clone()]),
-        Value::Array(arr) => {
-            let certs: Vec<Vec<u8>> = arr
-                .iter()
-                .filter_map(|v| match v {
-                    Value::Bytes(b) => Some(b.clone()),
-                    _ => None,
-                })
-                .collect();
-            if certs.is_empty() {
-                Err(OcpEatError::InvalidToken("x5chain array contains no certificates"))
-            } else {
-                Ok(certs)
-            }
-        }
-        _ => Err(OcpEatError::InvalidToken(
-            "x5chain (label 33) has unexpected CBOR type",
-        )),
-    }
-}
-
-/// Split a concatenated DER blob into individual DER-encoded certificates.
-fn split_der_certs(blob: &[u8]) -> OcpEatResult<Vec<Vec<u8>>> {
-    let mut certs = Vec::new();
-    let mut offset = 0;
-
-    while offset < blob.len() {
-        if blob[offset] != 0x30 {
-            return Err(OcpEatError::Certificate(format!(
-                "Expected SEQUENCE tag (0x30) at offset {}, found 0x{:02x}",
-                offset, blob[offset]
-            )));
-        }
-        let (content_len, header_len) = parse_der_length(&blob[offset + 1..])?;
-        let total_len = 1 + header_len + content_len;
-        if offset + total_len > blob.len() {
-            return Err(OcpEatError::Certificate(format!(
-                "DER certificate at offset {} extends beyond input",
-                offset
-            )));
-        }
-        certs.push(blob[offset..offset + total_len].to_vec());
-        offset += total_len;
-    }
-
-    Ok(certs)
-}
-
-/// Parse a DER length field. Returns (content_length, header_bytes_consumed).
-fn parse_der_length(data: &[u8]) -> OcpEatResult<(usize, usize)> {
-    if data.is_empty() {
-        return Err(OcpEatError::Certificate(
-            "Truncated DER length".into(),
+        .any(|(label, _)| *label == coset::Label::Int(COSE_HDR_PARAM_X5CHAIN));
+    if !has_x5chain {
+        return Err(OcpEatError::InvalidToken(
+            "x5chain not found in unprotected header",
         ));
     }
-    if data[0] < 0x80 {
-        return Ok((data[0] as usize, 1));
-    }
-    let num_bytes = (data[0] & 0x7f) as usize;
-    if num_bytes == 0 || num_bytes > 4 || data.len() < 1 + num_bytes {
-        return Err(OcpEatError::Certificate(
-            "Invalid DER length encoding".into(),
-        ));
-    }
-    let mut len = 0usize;
-    for i in 0..num_bytes {
-        len = (len << 8) | (data[1 + i] as usize);
-    }
-    Ok((len, 1 + num_bytes))
+    Ok(())
 }
 
 /// EAT-specific protected header checks (algorithm + content-type).

--- a/ocp-eat-verifier/ocptoken-lib/src/token/mod.rs
+++ b/ocp-eat-verifier/ocptoken-lib/src/token/mod.rs
@@ -1,3 +1,4 @@
 // Licensed under the Apache-2.0 license
 
+pub mod claims;
 pub mod evidence;

--- a/ocp-eat-verifier/ocptoken-lib/tests/test_evidence.rs
+++ b/ocp-eat-verifier/ocptoken-lib/tests/test_evidence.rs
@@ -5,6 +5,8 @@ use coset::{
 };
 
 use openssl::{
+    asn1::Asn1Time,
+    bn::BigNum,
     ec::{EcGroup, EcKey},
     ecdsa::EcdsaSig,
     hash::MessageDigest,
@@ -15,7 +17,12 @@ use openssl::{
 };
 
 use ocptoken::cose_verify::{CoseSign1Verifier, OpenSslBackend};
+use ocptoken::error::OcpEatError;
 use ocptoken::ta_store::{TrustAnchorError, TrustAnchorStore};
+use ocptoken::token::claims::{
+    CLAIM_KEY_DEBUG_STATUS, CLAIM_KEY_EAT_PROFILE, CLAIM_KEY_MEASUREMENTS, CLAIM_KEY_NONCE,
+    OCP_EAT_PROFILE_OID_STR,
+};
 use ocptoken::token::evidence::Evidence;
 
 /// In-memory Trust Anchor Store for tests.
@@ -50,146 +57,119 @@ impl TrustAnchorStore for TestTrustAnchorStore {
     }
 }
 
-#[test]
-fn decode_and_verify_ecc_p384_cose_sign1() {
-    // 1 Generate ECC P-384 key pair
+// ── Helpers ────────────────────────────────────────────────────────
+
+/// Build a valid OCP EAT CWT ClaimsSet payload (CBOR bytes).
+///
+/// Contains all four mandatory claims with sensible defaults.
+/// Use `build_claims_set_custom` to override individual claims.
+fn build_valid_cwt_payload() -> Vec<u8> {
+    build_cwt_payload_with(None, None, None, None)
+}
+
+/// Build a CWT payload (CBOR map) with optional overrides for each mandatory claim.
+/// Pass `Some(value)` to override, `None` for the default.
+fn build_cwt_payload_with(
+    nonce: Option<Value>,
+    debug_status: Option<Value>,
+    eat_profile: Option<Value>,
+    measurements: Option<Value>,
+) -> Vec<u8> {
+    let nonce_val = nonce.unwrap_or_else(|| Value::Bytes(vec![0xAA; 32]));
+    let debug_val = debug_status.unwrap_or_else(|| Value::Integer(1.into())); // disabled
+    let profile_val =
+        eat_profile.unwrap_or_else(|| Value::Bytes(OCP_EAT_PROFILE_OID_STR.as_bytes().to_vec()));
+    let meas_val = measurements.unwrap_or_else(|| Value::Bytes(vec![0xBB; 16]));
+
+    let map = Value::Map(vec![
+        (Value::Integer(CLAIM_KEY_NONCE.into()), nonce_val),
+        (Value::Integer(CLAIM_KEY_DEBUG_STATUS.into()), debug_val),
+        (Value::Integer(CLAIM_KEY_EAT_PROFILE.into()), profile_val),
+        (Value::Integer(CLAIM_KEY_MEASUREMENTS.into()), meas_val),
+    ]);
+
+    let mut buf = Vec::new();
+    ciborium::into_writer(&map, &mut buf).unwrap();
+    buf
+}
+
+/// Build a CWT payload that omits a specific claim key.
+fn build_cwt_payload_without(omit_key: i64) -> Vec<u8> {
+    let all_claims: Vec<(i64, Value)> = vec![
+        (CLAIM_KEY_NONCE, Value::Bytes(vec![0xAA; 32])),
+        (CLAIM_KEY_DEBUG_STATUS, Value::Integer(1.into())),
+        (
+            CLAIM_KEY_EAT_PROFILE,
+            Value::Bytes(OCP_EAT_PROFILE_OID_STR.as_bytes().to_vec()),
+        ),
+        (CLAIM_KEY_MEASUREMENTS, Value::Bytes(vec![0xBB; 16])),
+    ];
+
+    let map = Value::Map(
+        all_claims
+            .into_iter()
+            .filter(|(k, _)| *k != omit_key)
+            .map(|(k, v)| (Value::Integer(k.into()), v))
+            .collect(),
+    );
+
+    let mut buf = Vec::new();
+    ciborium::into_writer(&map, &mut buf).unwrap();
+    buf
+}
+
+/// Generate an ECC P-384 key pair and self-signed X.509 certificate.
+/// Returns (PKey, DER-encoded cert).
+fn generate_key_and_cert(cn: &str) -> (PKey<openssl::pkey::Private>, Vec<u8>) {
     let group = EcGroup::from_curve_name(Nid::SECP384R1).unwrap();
     let ec_key = EcKey::generate(&group).unwrap();
     let pkey = PKey::from_ec_key(ec_key).unwrap();
 
-    use openssl::asn1::Asn1Time;
-    use openssl::bn::BigNum;
-
-    // 2 Create self-signed X.509 certificate
     let mut name = X509NameBuilder::new().unwrap();
-    name.append_entry_by_text("CN", "test-cert").unwrap();
+    name.append_entry_by_text("CN", cn).unwrap();
     let name = name.build();
 
-    let mut cert_builder = X509::builder().unwrap();
-
-    cert_builder.set_version(2).unwrap();
-
-    // serial number
+    let mut builder = X509::builder().unwrap();
+    builder.set_version(2).unwrap();
     let mut serial = BigNum::new().unwrap();
     serial
         .rand(64, openssl::bn::MsbOption::MAYBE_ZERO, false)
         .unwrap();
-    let serial = serial.to_asn1_integer().unwrap();
-    cert_builder.set_serial_number(&serial).unwrap();
+    builder
+        .set_serial_number(&serial.to_asn1_integer().unwrap())
+        .unwrap();
+    builder.set_subject_name(&name).unwrap();
+    builder.set_issuer_name(&name).unwrap();
+    builder
+        .set_not_before(&Asn1Time::days_from_now(0).unwrap())
+        .unwrap();
+    builder
+        .set_not_after(&Asn1Time::days_from_now(365).unwrap())
+        .unwrap();
+    builder.set_pubkey(&pkey).unwrap();
+    builder.sign(&pkey, MessageDigest::sha384()).unwrap();
 
-    // Subject / issuer
-    cert_builder.set_subject_name(&name).unwrap();
-    cert_builder.set_issuer_name(&name).unwrap();
+    let cert_der = builder.build().to_der().unwrap();
+    (pkey, cert_der)
+}
 
-    // validity
-    let not_before = Asn1Time::days_from_now(0).unwrap();
-    let not_after = Asn1Time::days_from_now(365).unwrap();
-    cert_builder.set_not_before(&not_before).unwrap();
-    cert_builder.set_not_after(&not_after).unwrap();
-
-    // Public key
-    cert_builder.set_pubkey(&pkey).unwrap();
-
-    // Sign certificate
-    cert_builder.sign(&pkey, MessageDigest::sha384()).unwrap();
-
-    let cert = cert_builder.build();
-    let cert_der = cert.to_der().unwrap();
-
-    // 3 Create Trust Anchor Store with the self-signed cert as root
-    let ta_store = TestTrustAnchorStore::new(vec![cert_der.clone()]);
-
-    // Dummy payload
-    let payload = b"dummy payload for COSE signature";
-
-    // 4 Create COSE_Sign1 structure
+/// Build a COSE_Sign1 (CBOR bytes) with the given payload, signed with `pkey`,
+/// and the cert in the x5chain unprotected header.
+fn build_signed_cose(
+    payload: &[u8],
+    pkey: &PKey<openssl::pkey::Private>,
+    cert_der: &[u8],
+) -> Vec<u8> {
     let cose = CoseSign1Builder::new()
         .payload(payload.to_vec())
         .protected(HeaderBuilder::new().algorithm(Algorithm::ES384).build())
         .unprotected(
             HeaderBuilder::new()
-                // x5chain = label 33
-                .value(33, Value::Array(vec![Value::Bytes(cert_der.clone())]))
+                .value(33, Value::Array(vec![Value::Bytes(cert_der.to_vec())]))
                 .build(),
         )
         .create_signature(&[], |msg| {
-            let mut signer = Signer::new(MessageDigest::sha384(), &pkey).unwrap();
-            signer.update(msg).unwrap();
-
-            let der_sig = signer.sign_to_vec().unwrap();
-
-            // DER → raw r||s (COSE format)
-            let sig = EcdsaSig::from_der(&der_sig).unwrap();
-            let r = sig.r().to_vec_padded(48).unwrap();
-            let s = sig.s().to_vec_padded(48).unwrap();
-            [r, s].concat()
-        })
-        .build();
-
-    // 5 Encode to CBOR
-    let encoded = cose.to_vec().unwrap();
-
-    // 6 Decode
-    let evidence =
-        Evidence::decode(&encoded, &ta_store).expect("Evidence::decode should succeed");
-
-    // 7 Verify
-    let verifier = CoseSign1Verifier::new(OpenSslBackend);
-    evidence
-        .verify(&[], &verifier)
-        .expect("COSE_Sign1 signature verification should succeed");
-}
-
-#[test]
-fn reject_untrusted_cert_chain() {
-    // Generate a key + self-signed cert
-    let group = EcGroup::from_curve_name(Nid::SECP384R1).unwrap();
-    let ec_key = EcKey::generate(&group).unwrap();
-    let pkey = PKey::from_ec_key(ec_key).unwrap();
-
-    use openssl::asn1::Asn1Time;
-    use openssl::bn::BigNum;
-
-    let mut name = X509NameBuilder::new().unwrap();
-    name.append_entry_by_text("CN", "untrusted-cert").unwrap();
-    let name = name.build();
-
-    let mut cert_builder = X509::builder().unwrap();
-    cert_builder.set_version(2).unwrap();
-    let mut serial = BigNum::new().unwrap();
-    serial
-        .rand(64, openssl::bn::MsbOption::MAYBE_ZERO, false)
-        .unwrap();
-    cert_builder
-        .set_serial_number(&serial.to_asn1_integer().unwrap())
-        .unwrap();
-    cert_builder.set_subject_name(&name).unwrap();
-    cert_builder.set_issuer_name(&name).unwrap();
-    cert_builder
-        .set_not_before(&Asn1Time::days_from_now(0).unwrap())
-        .unwrap();
-    cert_builder
-        .set_not_after(&Asn1Time::days_from_now(365).unwrap())
-        .unwrap();
-    cert_builder.set_pubkey(&pkey).unwrap();
-    cert_builder.sign(&pkey, MessageDigest::sha384()).unwrap();
-
-    let cert = cert_builder.build();
-    let cert_der = cert.to_der().unwrap();
-
-    // TA store has NO trusted roots -- empty
-    let ta_store = TestTrustAnchorStore::new(vec![]);
-
-    let cose = CoseSign1Builder::new()
-        .payload(b"payload".to_vec())
-        .protected(HeaderBuilder::new().algorithm(Algorithm::ES384).build())
-        .unprotected(
-            HeaderBuilder::new()
-                .value(33, Value::Array(vec![Value::Bytes(cert_der.clone())]))
-                .build(),
-        )
-        .create_signature(&[], |msg| {
-            let mut signer = Signer::new(MessageDigest::sha384(), &pkey).unwrap();
+            let mut signer = Signer::new(MessageDigest::sha384(), pkey).unwrap();
             signer.update(msg).unwrap();
             let der_sig = signer.sign_to_vec().unwrap();
             let sig = EcdsaSig::from_der(&der_sig).unwrap();
@@ -198,19 +178,48 @@ fn reject_untrusted_cert_chain() {
             [r, s].concat()
         })
         .build();
-
-    let encoded = cose.to_vec().unwrap();
-    let evidence = Evidence::decode(&encoded, &ta_store).unwrap();
-
-    // Verify should fail because the cert is not trusted
-    let verifier = CoseSign1Verifier::new(OpenSslBackend);
-    assert!(
-        evidence.verify(&[], &verifier).is_err(),
-        "Verification should fail with untrusted certificate chain"
-    );
+    cose.to_vec().unwrap()
 }
 
-mod tag_order_tests {
+mod cose_verify_tests {
+    use super::*;
+
+    #[test]
+    fn decode_and_verify_ecc_p384_cose_sign1() {
+        let (pkey, cert_der) = generate_key_and_cert("test-cert");
+        let ta_store = TestTrustAnchorStore::new(vec![cert_der.clone()]);
+        let payload = build_valid_cwt_payload();
+        let encoded = build_signed_cose(&payload, &pkey, &cert_der);
+
+        let evidence =
+            Evidence::decode(&encoded, &ta_store).expect("Evidence::decode should succeed");
+
+        let verifier = CoseSign1Verifier::new(OpenSslBackend);
+        evidence
+            .verify(&[], &verifier)
+            .expect("COSE_Sign1 signature verification should succeed");
+    }
+
+    #[test]
+    fn reject_untrusted_cert_chain() {
+        let (pkey, cert_der) = generate_key_and_cert("untrusted-cert");
+
+        // TA store has NO trusted roots -- empty
+        let ta_store = TestTrustAnchorStore::new(vec![]);
+        let payload = build_valid_cwt_payload();
+        let encoded = build_signed_cose(&payload, &pkey, &cert_der);
+        let evidence = Evidence::decode(&encoded, &ta_store).unwrap();
+
+        // Verify should fail because the cert is not trusted
+        let verifier = CoseSign1Verifier::new(OpenSslBackend);
+        assert!(
+            evidence.verify(&[], &verifier).is_err(),
+            "Verification should fail with untrusted certificate chain"
+        );
+    }
+}
+
+mod eat_tag_order_tests {
     use super::*;
     use coset::cbor::value::Value;
     use ocptoken::error::OcpEatError;
@@ -307,5 +316,219 @@ mod tag_order_tests {
             Ok(_) => panic!("Unexpected success with missing required CBOR tag"),
             Err(e) => panic!("Unexpected error variant: {:?}", e),
         }
+    }
+}
+
+// ── Claims validation corner-case tests ────────────────────────────
+
+mod eat_claims_tests {
+    use super::*;
+    use ocptoken::token::claims::DebugStatus;
+
+    fn ta_store_for(cert_der: &[u8]) -> TestTrustAnchorStore {
+        TestTrustAnchorStore::new(vec![cert_der.to_vec()])
+    }
+
+    // ── Happy path ──
+
+    #[test]
+    fn decode_valid_claims_mandatory_only() {
+        let (pkey, cert_der) = generate_key_and_cert("valid-claims");
+        let ta = ta_store_for(&cert_der);
+        let payload = build_valid_cwt_payload();
+        let encoded = build_signed_cose(&payload, &pkey, &cert_der);
+
+        let ev = Evidence::decode(&encoded, &ta).expect("decode should succeed");
+        let c = ev.claims();
+        assert_eq!(c.nonce, vec![0xAA; 32]);
+        assert_eq!(c.debug_status, DebugStatus::Disabled);
+        assert_eq!(c.eat_profile, "1.3.6.1.4.1.42623.1.3");
+        assert_eq!(c.measurements.len(), 16);
+    }
+
+    #[test]
+    fn measurements_as_cbor_array_accepted() {
+        let meas_array = Value::Array(vec![Value::Integer(1.into()), Value::Bytes(vec![0xCC; 8])]);
+        let (pkey, cert_der) = generate_key_and_cert("meas-array");
+        let ta = ta_store_for(&cert_der);
+        let payload = build_cwt_payload_with(None, None, None, Some(meas_array));
+        let encoded = build_signed_cose(&payload, &pkey, &cert_der);
+
+        let ev = Evidence::decode(&encoded, &ta).expect("array measurements should decode");
+        assert!(!ev.claims().measurements.is_empty());
+    }
+
+    // ── Missing mandatory claims ──
+
+    #[test]
+    fn reject_missing_nonce() {
+        let (pkey, cert_der) = generate_key_and_cert("no-nonce");
+        let ta = ta_store_for(&cert_der);
+        let payload = build_cwt_payload_without(CLAIM_KEY_NONCE);
+        let encoded = build_signed_cose(&payload, &pkey, &cert_der);
+
+        match Evidence::decode(&encoded, &ta) {
+            Err(OcpEatError::InvalidToken(msg)) => {
+                assert!(msg.contains("nonce"), "expected nonce error, got: {msg}");
+            }
+            Err(e) => panic!("Expected missing-nonce error, got: {e}"),
+            Ok(_) => panic!("Expected missing-nonce error, got Ok"),
+        }
+    }
+
+    #[test]
+    fn reject_missing_debug_status() {
+        let (pkey, cert_der) = generate_key_and_cert("no-dbg");
+        let ta = ta_store_for(&cert_der);
+        let payload = build_cwt_payload_without(CLAIM_KEY_DEBUG_STATUS);
+        let encoded = build_signed_cose(&payload, &pkey, &cert_der);
+
+        match Evidence::decode(&encoded, &ta) {
+            Err(OcpEatError::InvalidToken(msg)) => {
+                assert!(
+                    msg.contains("dbgstat"),
+                    "expected dbgstat error, got: {msg}"
+                );
+            }
+            Err(e) => panic!("Expected missing-dbgstat error, got: {e}"),
+            Ok(_) => panic!("Expected missing-dbgstat error, got Ok"),
+        }
+    }
+
+    #[test]
+    fn reject_missing_eat_profile() {
+        let (pkey, cert_der) = generate_key_and_cert("no-profile");
+        let ta = ta_store_for(&cert_der);
+        let payload = build_cwt_payload_without(CLAIM_KEY_EAT_PROFILE);
+        let encoded = build_signed_cose(&payload, &pkey, &cert_der);
+
+        match Evidence::decode(&encoded, &ta) {
+            Err(OcpEatError::InvalidToken(msg)) => {
+                assert!(
+                    msg.contains("eat_profile"),
+                    "expected eat_profile error, got: {msg}"
+                );
+            }
+            Err(e) => panic!("Expected missing-eat_profile error, got: {e}"),
+            Ok(_) => panic!("Expected missing-eat_profile error, got Ok"),
+        }
+    }
+
+    #[test]
+    fn reject_missing_measurements() {
+        let (pkey, cert_der) = generate_key_and_cert("no-meas");
+        let ta = ta_store_for(&cert_der);
+        let payload = build_cwt_payload_without(CLAIM_KEY_MEASUREMENTS);
+        let encoded = build_signed_cose(&payload, &pkey, &cert_der);
+
+        match Evidence::decode(&encoded, &ta) {
+            Err(OcpEatError::InvalidToken(msg)) => {
+                assert!(
+                    msg.contains("measurements"),
+                    "expected measurements error, got: {msg}"
+                );
+            }
+            Err(e) => panic!("Expected missing-measurements error, got: {e}"),
+            Ok(_) => panic!("Expected missing-measurements error, got Ok"),
+        }
+    }
+
+    // ── Wrong eat_profile OID ──
+
+    #[test]
+    fn reject_wrong_eat_profile_oid() {
+        let wrong_oid = Value::Bytes(b"1.2.3.4.5".to_vec());
+        let (pkey, cert_der) = generate_key_and_cert("wrong-oid");
+        let ta = ta_store_for(&cert_der);
+        let payload = build_cwt_payload_with(None, None, Some(wrong_oid), None);
+        let encoded = build_signed_cose(&payload, &pkey, &cert_der);
+
+        match Evidence::decode(&encoded, &ta) {
+            Err(OcpEatError::InvalidToken(msg)) => {
+                assert!(
+                    msg.contains("does not match"),
+                    "expected OID mismatch error, got: {msg}"
+                );
+            }
+            Err(e) => panic!("Expected wrong-OID error, got: {e}"),
+            Ok(_) => panic!("Expected wrong-OID error, got Ok"),
+        }
+    }
+
+    // ── Invalid debug_status value ──
+
+    #[test]
+    fn reject_invalid_debug_status() {
+        let bad_dbg = Value::Integer(99.into());
+        let (pkey, cert_der) = generate_key_and_cert("bad-dbg");
+        let ta = ta_store_for(&cert_der);
+        let payload = build_cwt_payload_with(None, Some(bad_dbg), None, None);
+        let encoded = build_signed_cose(&payload, &pkey, &cert_der);
+
+        match Evidence::decode(&encoded, &ta) {
+            Err(OcpEatError::InvalidToken(msg)) => {
+                assert!(
+                    msg.contains("debug-status"),
+                    "expected debug-status error, got: {msg}"
+                );
+            }
+            Err(e) => panic!("Expected bad debug-status error, got: {e}"),
+            Ok(_) => panic!("Expected bad debug-status error, got Ok"),
+        }
+    }
+
+    // ── All five debug-status values accepted ──
+
+    #[test]
+    fn all_debug_status_values_accepted() {
+        for (val, expected) in [
+            (0, DebugStatus::Enabled),
+            (1, DebugStatus::Disabled),
+            (2, DebugStatus::DisabledSinceBoot),
+            (3, DebugStatus::DisabledPermanently),
+            (4, DebugStatus::DisabledFullyAndPermanently),
+        ] {
+            let (pkey, cert_der) = generate_key_and_cert("dbg-val");
+            let ta = ta_store_for(&cert_der);
+            let payload =
+                build_cwt_payload_with(None, Some(Value::Integer(val.into())), None, None);
+            let encoded = build_signed_cose(&payload, &pkey, &cert_der);
+
+            let ev = Evidence::decode(&encoded, &ta)
+                .unwrap_or_else(|e| panic!("debug_status={val} should succeed: {e}"));
+            assert_eq!(ev.claims().debug_status, expected, "debug_status={val}");
+        }
+    }
+
+    // ── Nonce wrong type ──
+
+    #[test]
+    fn reject_nonce_wrong_type() {
+        let bad_nonce = Value::Text("not bytes".into());
+        let (pkey, cert_der) = generate_key_and_cert("bad-nonce");
+        let ta = ta_store_for(&cert_der);
+        let payload = build_cwt_payload_with(Some(bad_nonce), None, None, None);
+        let encoded = build_signed_cose(&payload, &pkey, &cert_der);
+
+        assert!(
+            Evidence::decode(&encoded, &ta).is_err(),
+            "nonce with wrong type should fail"
+        );
+    }
+
+    // ── Measurements wrong type ──
+
+    #[test]
+    fn reject_measurements_wrong_type() {
+        let bad_meas = Value::Text("not-measurements".into());
+        let (pkey, cert_der) = generate_key_and_cert("bad-meas");
+        let ta = ta_store_for(&cert_der);
+        let payload = build_cwt_payload_with(None, None, None, Some(bad_meas));
+        let encoded = build_signed_cose(&payload, &pkey, &cert_der);
+
+        assert!(
+            Evidence::decode(&encoded, &ta).is_err(),
+            "measurements with wrong type should fail"
+        );
     }
 }

--- a/ocp-eat-verifier/ocptoken/src/appraise.rs
+++ b/ocp-eat-verifier/ocptoken/src/appraise.rs
@@ -1,0 +1,98 @@
+// Licensed under the Apache-2.0 license
+
+//! The `appraise` subcommand: authenticate all inputs, decode EAT claims,
+//! appraise evidence against CoRIM reference values, run verifier checks,
+//! and produce the final attestation result.
+
+use std::env;
+
+use ocptoken::appraisal;
+use ocptoken::cose_verify::{CoseSign1Verifier, CryptoBackend};
+use ocptoken::ta_store::TrustAnchorStore;
+
+use crate::authenticate::{self, AuthenticateArgs};
+use crate::common::SIGNED_REFVAL_CORIM_PATH;
+use crate::display::{print_claims, print_corim_payload};
+
+/// Environment variable for the SPDM nonce (hex-encoded).
+const SPDM_NONCE: &str = "SPDM_NONCE";
+
+pub(crate) fn run(
+    args: &AuthenticateArgs,
+    ta_store: &dyn TrustAnchorStore,
+    verifier: &CoseSign1Verifier<impl CryptoBackend>,
+) {
+    // Phase 1: Input Validation & Transformation
+    println!("Phase 1: Input Validation & Transformation");
+    let result = authenticate::authenticate(args, ta_store, verifier);
+    println!("All inputs validated and authenticated.");
+
+    // Phase 2: Evidence Augmentation (decode EAT claims)
+    println!("\nPhase 2: Evidence Augmentation (Appraisal Claim Set Initialization)");
+    println!("Initializing Appraisal Claims Set with evidence claims...");
+    print_claims(result.evidence.claims());
+
+    // Phase 3: Reference Values Corroboration
+    println!("\nPhase 3: Reference Values Corroboration");
+    let refval_corims = match result.refval_corims {
+        Some(ref c) if !c.is_empty() => c,
+        _ => {
+            eprintln!(
+                "No CoRIM reference values loaded (set {} to enable appraisal)",
+                SIGNED_REFVAL_CORIM_PATH
+            );
+            std::process::exit(1);
+        }
+    };
+
+    println!("Loaded reference values:");
+    for (file_name, corim_map) in refval_corims.iter() {
+        print_corim_payload(file_name, corim_map);
+    }
+
+    println!("\nCorroborating evidence against reference values...");
+
+    let expected_nonce = env::var(SPDM_NONCE).ok();
+
+    let report = match appraisal::appraise(
+        result.evidence.claims(),
+        refval_corims,
+        expected_nonce.as_deref(),
+    ) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("Appraisal error: {}", e);
+            std::process::exit(1);
+        }
+    };
+
+    for triple_result in &report.results {
+        let mark = if triple_result.passed() { "PASS" } else { "FAIL" };
+        println!("  [{}] {}", mark, triple_result.env_label);
+        if !triple_result.env_matched {
+            println!("         No matching evidence environment found");
+        } else {
+            for m in &triple_result.measurements {
+                let mark = if m.matched { "PASS" } else { "FAIL" };
+                println!("      [{}] {}: {}", mark, m.label, m.detail);
+            }
+        }
+    }
+
+    // Phase 5: Verifier Augmentation
+    println!("\nPhase 5: Verifier Augmentation");
+    println!("Running Verifier-generated checks (freshness, debug status)...");
+    for check in &report.verifier_checks {
+        let mark = if check.passed { "PASS" } else { "FAIL" };
+        println!("  [{}] {}: {}", mark, check.name, check.detail);
+    }
+
+    // Phase 6: Attestation Result
+    println!("\nPhase 6: Attestation Result");
+    if report.all_passed() {
+        println!("ATTESTATION RESULT: PASS — all phases completed successfully.");
+    } else {
+        println!("ATTESTATION RESULT: FAIL — one or more checks did not pass.");
+        std::process::exit(1);
+    }
+}

--- a/ocp-eat-verifier/ocptoken/src/authenticate.rs
+++ b/ocp-eat-verifier/ocptoken/src/authenticate.rs
@@ -16,8 +16,7 @@ use ocptoken::token::evidence::Evidence;
 use crate::common::load_evidence;
 use crate::display::print_corim_payload;
 
-/// Environment variable for the signed reference-value CoRIM directory path.
-const SIGNED_REFVAL_CORIM_PATH: &str = "SIGNED_REFVAL_CORIM_PATH";
+use crate::common::SIGNED_REFVAL_CORIM_PATH;
 
 #[derive(Parser, Debug)]
 pub(crate) struct AuthenticateArgs {
@@ -120,19 +119,32 @@ fn authenticate_evidence<'a>(
 
 /// Authenticate and verify signed reference-value CoRIM files from
 /// the SIGNED_REFVAL_CORIM_PATH environment variable directory.
-/// Returns `None` if the environment variable is not set.
-/// Exits the process on failure.
+/// Returns `None` if the environment variable is not set, the path
+/// does not exist, or the directory contains no files.
 fn authenticate_refval_corims(
     ta_store: &dyn TrustAnchorStore,
     verifier: &CoseSign1Verifier<impl CryptoBackend>,
 ) -> Option<RefValCorims> {
-    let corims_path = match env::var(SIGNED_REFVAL_CORIM_PATH) {
-        Ok(p) => p,
-        Err(_) => return None,
-    };
+    let corims_path = env::var(SIGNED_REFVAL_CORIM_PATH).ok().filter(|p| !p.is_empty());
+    let corims_dir = corims_path.map(PathBuf::from);
 
-    let corims_dir = PathBuf::from(corims_path);
-    println!("\nAuthenticating Signed CoRIMs ...");
+    let has_files = corims_dir.as_ref().map_or(false, |dir| {
+        dir.is_dir()
+            && fs::read_dir(dir)
+                .ok()
+                .map_or(false, |mut e| e.any(|e| e.ok().map_or(false, |e| e.path().is_file())))
+    });
+
+    if !has_files {
+        println!("No signed reference CoRIMs found; skipping CoRIM authentication.");
+        return None;
+    }
+
+    let corims_dir = corims_dir.unwrap();
+    println!(
+        "\nAuthenticating Signed CoRIMs from '{}' ...",
+        corims_dir.display()
+    );
     match RefValCorims::decode_and_verify(&corims_dir, ta_store, verifier) {
         Ok(refval_corims) => {
             for (name, _) in refval_corims.iter() {

--- a/ocp-eat-verifier/ocptoken/src/common.rs
+++ b/ocp-eat-verifier/ocptoken/src/common.rs
@@ -11,6 +11,9 @@ use ocptoken::ta_store::{FsTrustAnchorStore, TrustAnchorStore};
 /// Environment variable for the trust anchor store path.
 const TA_STORE_PATH_ENV: &str = "TA_STORE_PATH";
 
+/// Environment variable for the signed reference-value CoRIM directory path.
+pub(crate) const SIGNED_REFVAL_CORIM_PATH: &str = "SIGNED_REFVAL_CORIM_PATH";
+
 /// Load the Trust Anchor Store from a local directory specified by
 /// the TA_STORE_PATH environment variable.  Exits the process on failure.
 pub(crate) fn load_fs_ta_store() -> Box<dyn TrustAnchorStore> {

--- a/ocp-eat-verifier/ocptoken/src/display.rs
+++ b/ocp-eat-verifier/ocptoken/src/display.rs
@@ -1,6 +1,8 @@
 // Licensed under the Apache-2.0 license
 
-//! CoRIM display helpers for pretty-printing decoded CoRIM payloads.
+//! Display helpers for pretty-printing decoded CoRIM payloads and EAT claims.
+
+use ocptoken::token::claims::OcpEatClaims;
 
 fn format_unix_timestamp(secs: i128) -> String {
     use chrono::DateTime;
@@ -56,8 +58,8 @@ fn print_comid_triples(triples: &corim_rs::TriplesMap) {
             println!("        [{}] Environment:", i);
             print_environment(&triple.ref_env);
             println!("            Measurements ({}):", triple.ref_claims.len());
-            for (j, meas) in triple.ref_claims.iter().enumerate() {
-                print_measurement(j, meas);
+            for meas in triple.ref_claims.iter() {
+                print_measurement(meas);
             }
         }
     }
@@ -114,7 +116,7 @@ fn print_environment(env: &corim_rs::EnvironmentMap) {
     }
 }
 
-fn print_measurement(_idx: usize, meas: &corim_rs::MeasurementMap) {
+fn print_measurement(meas: &corim_rs::MeasurementMap) {
     let mval = &meas.mval;
     if let Some(ref ver) = mval.version {
         println!("                    Version:  {:?}", ver);
@@ -133,5 +135,123 @@ fn print_measurement(_idx: usize, meas: &corim_rs::MeasurementMap) {
     }
     if let Some(ref raw) = mval.raw {
         println!("                    Raw:      {:?}", raw);
+    }
+}
+
+/// Print decoded OCP EAT claims.
+pub(crate) fn print_claims(claims: &OcpEatClaims) {
+    println!("\n=== OCP EAT Claims ===");
+
+    println!("  [Mandatory]");
+    println!("  Nonce:           {}", hex::encode(&claims.nonce));
+    println!("  Debug Status:    {}", claims.debug_status);
+    println!("  EAT Profile:     {}", claims.eat_profile);
+    println!("  Measurements:    {} bytes", claims.measurements.len());
+
+    // Decode and print evidence triples from measurements
+    print_measurements(claims);
+
+    println!("  [Optional]");
+    if let Some(ref iss) = claims.issuer {
+        println!("  Issuer:          {}", iss);
+    }
+    if let Some(ref cti) = claims.cwt_id {
+        println!("  CWT ID:          {}", hex::encode(cti));
+    }
+    if let Some(ref ueid) = claims.ueid {
+        println!("  UEID:            {}", hex::encode(ueid));
+    }
+    if let Some(ref sueid) = claims.sueid {
+        println!("  SUEID:           {}", hex::encode(sueid));
+    }
+    if let Some(ref oemid) = claims.oemid {
+        println!("  OEM ID:          {:?}", oemid);
+    }
+    if let Some(ref hw_model) = claims.hw_model {
+        println!("  HW Model:        {}", hex::encode(hw_model));
+    }
+    if let Some(uptime) = claims.uptime {
+        println!("  Uptime:          {}", uptime);
+    }
+    if let Some(boot_count) = claims.boot_count {
+        println!("  Boot Count:      {}", boot_count);
+    }
+    if let Some(ref boot_seed) = claims.boot_seed {
+        println!("  Boot Seed:       {}", hex::encode(boot_seed));
+    }
+    if let Some(ref dloas) = claims.dloas {
+        println!("  DLOAs:           {:?}", dloas);
+    }
+    if let Some(ref locs) = claims.corim_locators {
+        println!("  CoRIM Locators:  {:?}", locs);
+    }
+
+    if !claims.private_claims.is_empty() {
+        println!("  [Private]");
+        for (name, value) in &claims.private_claims {
+            println!("  {:?}: {:?}", name, value);
+        }
+    }
+
+    println!("======================\n");
+}
+
+/// Decode and print evidence triples from the measurements claim.
+fn print_measurements(claims: &OcpEatClaims) {
+    let entries = match claims.decode_measurements() {
+        Ok(e) => e,
+        Err(e) => {
+            println!("    (failed to decode measurements: {})", e);
+            return;
+        }
+    };
+
+    for (idx, entry) in entries.iter().enumerate() {
+        println!(
+            "    [{}] Content-Type: {} (concise-evidence)",
+            idx, entry.content_type
+        );
+        let coev = &entry.evidence;
+
+        if let Some(ref eid) = coev.evidence_id {
+            println!("        Evidence ID:     {:?}", eid);
+        }
+
+        if let Some(ref profile) = coev.profile {
+            println!("        Profile:         {:?}", profile);
+        }
+
+        if let Some(ref triples) = coev.ev_triples.evidence_triples {
+            println!("        Evidence Triples ({}):", triples.len());
+            for (i, triple) in triples.iter().enumerate() {
+                println!("          [{}] Environment:", i);
+                print_environment(&triple.ref_env);
+                println!("              Measurements ({}):", triple.ref_claims.len());
+                for meas in triple.ref_claims.iter() {
+                    print_measurement(meas);
+                }
+            }
+        }
+
+        if let Some(ref triples) = coev.ev_triples.identity_triples {
+            println!("        Identity Triples ({}):", triples.len());
+            for (i, triple) in triples.iter().enumerate() {
+                println!("          [{}] {:?}", i, triple);
+            }
+        }
+
+        if let Some(ref triples) = coev.ev_triples.dependency_triples {
+            println!("        Dependency Triples ({}):", triples.len());
+            for (i, triple) in triples.iter().enumerate() {
+                println!("          [{}] {:?}", i, triple);
+            }
+        }
+
+        if let Some(ref triples) = coev.ev_triples.membership_triples {
+            println!("        Membership Triples ({}):", triples.len());
+            for (i, triple) in triples.iter().enumerate() {
+                println!("          [{}] {:?}", i, triple);
+            }
+        }
     }
 }

--- a/ocp-eat-verifier/ocptoken/src/main.rs
+++ b/ocp-eat-verifier/ocptoken/src/main.rs
@@ -1,5 +1,6 @@
 // Licensed under the Apache-2.0 license
 
+mod appraise;
 mod authenticate;
 mod common;
 mod display;
@@ -31,6 +32,9 @@ enum Commands {
 
     /// Authenticate the evidence with the Trust Anchor Store and verify the COSE_Sign1 signature
     Authenticate(authenticate::AuthenticateArgs),
+
+    /// Authenticate, verify, and appraise evidence against CoRIM reference values
+    Appraise(authenticate::AuthenticateArgs),
 }
 
 fn main() {
@@ -42,6 +46,10 @@ fn main() {
         Commands::Authenticate(args) => {
             let ta_store = load_fs_ta_store();
             authenticate::run(&args, ta_store.as_ref(), &verifier);
+        }
+        Commands::Appraise(args) => {
+            let ta_store = load_fs_ta_store();
+            appraise::run(&args, ta_store.as_ref(), &verifier);
         }
     }
 }

--- a/xtask/src/corim.rs
+++ b/xtask/src/corim.rs
@@ -25,7 +25,6 @@ const DEFAULT_TEST_KEY_SEED: &str = "caliptra-corim-default-test-signing-key";
 /// See platforms/emulator/runtime/userspace/apps/user/src/soc_env.rs
 const CLASS_ID_FMC: &str = "FMC_INFO";
 const CLASS_ID_RT: &str = "RT_INFO";
-const CLASS_ID_SOC_MANIFEST: &str = "SOC_MANIFEST";
 
 /// MCU runtime firmware identifier.
 /// See common/flash-image/src/lib.rs: MCU_RT_IDENTIFIER = 0x00000002
@@ -165,10 +164,8 @@ struct EvidenceComponent {
     model: Option<String>,
     /// Pre-formatted digest string (e.g. "sha-384:base64...").
     digest: String,
-    /// Firmware version string.
-    version: String,
-    /// Security Version Number.
-    svn: u32,
+    /// Security Version Number (omitted for SoC firmware components).
+    svn: Option<u32>,
 }
 
 /// Compute SHA-256 digest and return as "sha-256:<base64>" string.
@@ -202,14 +199,22 @@ fn sha384_raw_to_digest_str(digest: &[u8; 48]) -> String {
 /// Returns components matching the OCP EAT evidence structure:
 ///   mkey 0: FMC_INFO      - Caliptra FMC binary (from caliptra_fw.bin)
 ///   mkey 1: RT_INFO        - Caliptra Runtime binary (from caliptra_fw.bin)
-///   mkey 2: SOC_MANIFEST   - SoC manifest / Authorization Manifest
-///   mkey 3+: SoC firmware  - Auto-discovered from AuthManifest metadata
+///   mkey 2+: SoC firmware  - Auto-discovered from AuthManifest metadata
 fn read_evidence_components(
     bundle_path: &Path,
     config: &CorimConfig,
+    feature: Option<&str>,
 ) -> Result<Vec<EvidenceComponent>> {
     let file = std::fs::File::open(bundle_path)?;
     let mut zip = zip::ZipArchive::new(file)?;
+
+    // When a feature is specified, prefer per-feature entries over generic ones.
+    let soc_manifest_name = feature
+        .map(|f| format!("mcu-test-soc-manifest-{}.bin", f))
+        .unwrap_or_else(|| SOC_MANIFEST_NAME.to_string());
+    let mcu_runtime_name = feature
+        .map(|f| format!("mcu-test-runtime-{}.bin", f))
+        .unwrap_or_else(|| MCU_RUNTIME_NAME.to_string());
 
     let mut caliptra_fw_data: Option<Vec<u8>> = None;
     let mut soc_manifest_data: Option<Vec<u8>> = None;
@@ -221,18 +226,19 @@ fn read_evidence_components(
         let mut data = Vec::new();
         file.read_to_end(&mut data)?;
 
-        match name.as_str() {
-            CALIPTRA_FW_NAME => caliptra_fw_data = Some(data),
-            SOC_MANIFEST_NAME => soc_manifest_data = Some(data),
-            MCU_RUNTIME_NAME => mcu_runtime_data = Some(data),
-            _ => {}
+        if name == CALIPTRA_FW_NAME {
+            caliptra_fw_data = Some(data);
+        } else if name == soc_manifest_name {
+            soc_manifest_data = Some(data);
+        } else if name == mcu_runtime_name {
+            mcu_runtime_data = Some(data);
         }
     }
 
     let caliptra_fw = caliptra_fw_data
         .ok_or_else(|| anyhow::anyhow!("{} not found in bundle", CALIPTRA_FW_NAME))?;
     let soc_manifest = soc_manifest_data
-        .ok_or_else(|| anyhow::anyhow!("{} not found in bundle", SOC_MANIFEST_NAME))?;
+        .ok_or_else(|| anyhow::anyhow!("{} not found in bundle", soc_manifest_name))?;
 
     // Decompose caliptra_fw.bin into FMC and Runtime
     if caliptra_fw.len() < IMAGE_MANIFEST_BYTE_SIZE {
@@ -262,10 +268,8 @@ fn read_evidence_components(
     let fmc_content = &caliptra_fw[fmc_offset..fmc_offset + fmc_size];
     let rt_content = &caliptra_fw[rt_offset..rt_offset + rt_size];
 
-    // Extract version and SVN from the Caliptra image manifest header
+    // Extract SVN from the Caliptra image manifest header
     let caliptra_fw_svn = image_manifest.header.svn;
-    let fmc_version = image_manifest.fmc.version;
-    let rt_version = image_manifest.runtime.version;
 
     // Parse AuthManifest to get preamble version/SVN and per-image metadata
     let auth_manifest = AuthorizationManifest::read_from_bytes(&soc_manifest).map_err(|e| {
@@ -274,7 +278,7 @@ fn read_evidence_components(
             e
         )
     })?;
-    // Build the fixed evidence components (mkeys 0-2)
+    // Build the fixed evidence components (mkeys 0-1)
     let mut components = vec![
         EvidenceComponent {
             class_id: CLASS_ID_FMC.to_string(),
@@ -282,8 +286,7 @@ fn read_evidence_components(
             vendor: None,
             model: None,
             digest: compute_digest(fmc_content, &config.hash_algo),
-            version: format!("{}", fmc_version),
-            svn: caliptra_fw_svn,
+            svn: Some(caliptra_fw_svn),
         },
         EvidenceComponent {
             class_id: CLASS_ID_RT.to_string(),
@@ -291,18 +294,7 @@ fn read_evidence_components(
             vendor: None,
             model: None,
             digest: compute_digest(rt_content, &config.hash_algo),
-            version: format!("{}", rt_version),
-            svn: caliptra_fw_svn,
-        },
-        // SOC_MANIFEST: version/SVN not available per-image in AuthManifestImageMetadata
-        EvidenceComponent {
-            class_id: CLASS_ID_SOC_MANIFEST.to_string(),
-            mkey: 2,
-            vendor: None,
-            model: None,
-            digest: compute_digest(&soc_manifest, &config.hash_algo),
-            version: "0".to_string(),
-            svn: 0,
+            svn: Some(caliptra_fw_svn),
         },
     ];
 
@@ -314,12 +306,17 @@ fn read_evidence_components(
         }
         let metadata = &auth_manifest.image_metadata_col.image_metadata_list[i];
 
-        // For MCU runtime, compute digest from the raw binary in the ZIP
-        // (allows using the configured hash algorithm).
+        // For MCU runtime, compute digest from the binary in the ZIP,
+        // padded to match the flash image alignment used at runtime.
+        // The flash image builder pads images to 256-byte boundaries, and
+        // Caliptra's AUTHORIZE_AND_STASH hashes the padded data.
         // For other SoC images, use the SHA-384 digest from the manifest metadata.
         let digest = if metadata.fw_id == MCU_RT_FW_ID {
             if let Some(ref mcu_rt) = mcu_runtime_data {
-                compute_digest(mcu_rt, &config.hash_algo)
+                let padded_len = mcu_rt.len().next_multiple_of(256);
+                let mut padded = mcu_rt.clone();
+                padded.resize(padded_len, 0);
+                compute_digest(&padded, &config.hash_algo)
             } else {
                 sha384_raw_to_digest_str(&metadata.digest)
             }
@@ -329,13 +326,11 @@ fn read_evidence_components(
 
         components.push(EvidenceComponent {
             class_id: format!("0x{:08X}", metadata.fw_id),
-            mkey: 3 + i,
+            mkey: 2 + i,
             vendor: Some(config.vendor.clone()),
             model: Some(config.model.clone()),
             digest,
-            // Per-image version/SVN not available in AuthManifestImageMetadata
-            version: "0".to_string(),
-            svn: 0,
+            svn: None,
         });
     }
 
@@ -346,7 +341,7 @@ fn read_evidence_components(
 /// the OCP EAT evidence triples from the device.
 ///
 /// Each evidence component gets its own environment (class-id) and measurement
-/// entry with version, svn, and digests fields.
+/// entry with svn and digests fields.
 fn generate_comid_template(components: &[EvidenceComponent]) -> serde_json::Value {
     let tag_id = uuid::Uuid::new_v4().to_string().to_uppercase();
 
@@ -379,6 +374,16 @@ fn generate_comid_template(components: &[EvidenceComponent]) -> serde_json::Valu
                 class_map["model"] = serde_json::json!(model);
             }
 
+            let mut meas_value = serde_json::json!({
+                "digests": [comp.digest]
+            });
+            if let Some(svn) = comp.svn {
+                meas_value["svn"] = serde_json::json!({
+                    "type": "exact-value",
+                    "value": svn
+                });
+            }
+
             serde_json::json!({
                 "environment": {
                     "class": class_map
@@ -389,17 +394,7 @@ fn generate_comid_template(components: &[EvidenceComponent]) -> serde_json::Valu
                             "type": "uint",
                             "value": comp.mkey
                         },
-                        "value": {
-                            "version": {
-                                "value": comp.version,
-                                "scheme": "multipartnumeric"
-                            },
-                            "svn": {
-                                "type": "exact-value",
-                                "value": comp.svn
-                            },
-                            "digests": [comp.digest]
-                        }
+                        "value": meas_value
                     }
                 ]
             })
@@ -460,6 +455,18 @@ fn generate_test_keys(
 ) -> Result<(PathBuf, PathBuf)> {
     std::fs::create_dir_all(keys_dir)?;
 
+    let jwk_path = keys_dir.join("signing-key.jwk");
+    let cert_path = keys_dir.join("signing-cert.der");
+
+    // Skip regeneration if both key and certificate already exist
+    if jwk_path.exists() && cert_path.exists() {
+        println!(
+            "  Reusing existing test signing keys in {}",
+            keys_dir.display()
+        );
+        return Ok((jwk_path, cert_path));
+    }
+
     let secret_key = p384::SecretKey::from_bytes(seed[..].into())
         .map_err(|e| anyhow::anyhow!("Failed to create P-384 key from seed: {}", e))?;
 
@@ -481,7 +488,6 @@ fn generate_test_keys(
         "y": URL_SAFE_NO_PAD.encode(&y_bytes[..]),
         "d": URL_SAFE_NO_PAD.encode(&seed[..])
     });
-    let jwk_path = keys_dir.join("signing-key.jwk");
     std::fs::write(&jwk_path, serde_json::to_string_pretty(&jwk)?)?;
 
     // Write PKCS#8 PEM (for openssl certificate generation)
@@ -499,7 +505,6 @@ fn generate_test_keys(
     std::fs::write(&pem_path, pem_string.as_bytes())?;
 
     // Generate self-signed X.509 certificate in DER format using openssl
-    let cert_path = keys_dir.join("signing-cert.der");
     let openssl_result = Command::new("openssl")
         .args([
             "req",
@@ -560,15 +565,14 @@ fn generate_meta_template(output_dir: &Path) -> Result<PathBuf> {
 ///
 ///   mkey 0: FMC_INFO      - Caliptra FMC digest
 ///   mkey 1: RT_INFO        - Caliptra Runtime digest
-///   mkey 2: SOC_MANIFEST   - Authorization Manifest digest
-///   mkey 3+: SoC FW        - Auto-discovered from AuthManifest metadata
+///   mkey 2+: SoC FW        - Auto-discovered from AuthManifest metadata
 ///
-/// Each measurement includes version, svn, and digest fields.
+/// Each measurement includes svn and digest fields.
 ///
 /// Note: integrity-registers (journey PCR values) are runtime-computed and
 /// cannot be pre-determined from static build artifacts. They are not included
 /// in the reference values.
-pub fn generate(bundle: &str, config: CorimConfig) -> Result<()> {
+pub fn generate(bundle: &str, config: CorimConfig, feature: Option<&str>) -> Result<()> {
     let bundle_path = Path::new(bundle);
     if !bundle_path.exists() {
         bail!(
@@ -582,7 +586,7 @@ pub fn generate(bundle: &str, config: CorimConfig) -> Result<()> {
 
     // Step 1: Read and decompose firmware binaries to match evidence structure
     println!("Reading firmware binaries from: {}", bundle);
-    let components = read_evidence_components(bundle_path, &config)?;
+    let components = read_evidence_components(bundle_path, &config, feature)?;
     for comp in &components {
         println!(
             "  [mkey {}] {} ({})",

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -468,6 +468,13 @@ EXAMPLES:
         /// Path to JSON config file (vendor, model, hash_algo, signing, etc.)
         #[arg(long, value_name = "CONFIG")]
         config: Option<String>,
+
+        /// Feature name to select per-feature entries from the bundle
+        /// (e.g. "test-mctp-spdm-attestation").
+        /// When set, reads mcu-test-runtime-<feature>.bin and
+        /// mcu-test-soc-manifest-<feature>.bin instead of the generic entries.
+        #[arg(long, value_name = "FEATURE")]
+        feature: Option<String>,
     },
     /// Print a sample JSON config file with all fields documented
     SampleConfig,
@@ -618,10 +625,12 @@ fn main() {
             AuthManifestCommands::Parse { file } => auth_manifest::parse(file),
         },
         Commands::Corim { subcommand } => match subcommand {
-            CorimCommands::GenRefval { bundle, config } => {
-                corim::CorimConfig::load(config.as_deref())
-                    .and_then(|cfg| corim::generate(bundle, cfg))
-            }
+            CorimCommands::GenRefval {
+                bundle,
+                config,
+                feature,
+            } => corim::CorimConfig::load(config.as_deref())
+                .and_then(|cfg| corim::generate(bundle, cfg, feature.as_deref())),
             CorimCommands::SampleConfig => {
                 corim::CorimConfig::print_sample();
                 Ok(())


### PR DESCRIPTION
Fixes #992 

- Add appraise subcommand to ocptoken CLI
- Add EAT claims and evidence triple decoding
- Fix CoRIM reference value generation (version, padding, mkey)
- Update attestation workflow with appraise step