### PR TITLE
[auth-cmds] Add command to increase the Caliptra minimum SVN

### DIFF
--- a/builder/src/all.rs
+++ b/builder/src/all.rs
@@ -180,6 +180,8 @@ fn create_default_soc_images() -> (Vec<ImageCfg>, Vec<PathBuf>) {
 pub struct FirmwareBinaries {
     pub caliptra_rom: Vec<u8>,
     pub caliptra_fw: Vec<u8>,
+    pub caliptra_fw_svn7: Vec<u8>,
+    pub caliptra_fw_svn128: Vec<u8>,
     pub mcu_rom: Vec<u8>,
     pub mcu_runtime: Vec<u8>,
     pub mcu_bare_metal_runtime: Vec<u8>,
@@ -197,6 +199,8 @@ pub struct FirmwareBinaries {
 impl FirmwareBinaries {
     const CALIPTRA_ROM_NAME: &'static str = "caliptra_rom.bin";
     const CALIPTRA_FW_NAME: &'static str = "caliptra_fw.bin";
+    const CALIPTRA_FW_SVN7_NAME: &'static str = "caliptra_fw_svn7.bin";
+    const CALIPTRA_FW_SVN128_NAME: &'static str = "caliptra_fw_svn128.bin";
     const MCU_ROM_NAME: &'static str = "mcu_rom.bin";
     const MCU_RUNTIME_NAME: &'static str = "mcu_runtime.bin";
     const MCU_BARE_METAL_RUNTIME_NAME: &'static str = "mcu_bare_metal_runtime.bin";
@@ -237,6 +241,8 @@ impl FirmwareBinaries {
             match name.as_str() {
                 Self::CALIPTRA_ROM_NAME => binaries.caliptra_rom = data,
                 Self::CALIPTRA_FW_NAME => binaries.caliptra_fw = data,
+                Self::CALIPTRA_FW_SVN7_NAME => binaries.caliptra_fw_svn7 = data,
+                Self::CALIPTRA_FW_SVN128_NAME => binaries.caliptra_fw_svn128 = data,
                 Self::MCU_ROM_NAME => binaries.mcu_rom = data,
                 Self::MCU_RUNTIME_NAME => binaries.mcu_runtime = data,
                 Self::MCU_BARE_METAL_RUNTIME_NAME => binaries.mcu_bare_metal_runtime = data,
@@ -597,6 +603,20 @@ pub fn all_build(args: AllBuildArgs) -> Result<()> {
     let vendor_pk_hash = caliptra_builder.get_vendor_pk_hash()?.to_string();
     println!("Vendor PK hash: {:x?}", vendor_pk_hash);
     let soc_manifest = caliptra_builder.get_soc_manifest(None)?;
+
+    let mut builder_svn7 = crate::CaliptraBuilder::new(&CaliptraBuildArgs {
+        fpga: platform == "fpga",
+        svn: Some(7),
+        ..Default::default()
+    });
+    let caliptra_fw_svn7 = builder_svn7.get_caliptra_fw()?;
+
+    let mut builder_svn128 = crate::CaliptraBuilder::new(&CaliptraBuildArgs {
+        fpga: platform == "fpga",
+        svn: Some(128),
+        ..Default::default()
+    });
+    let caliptra_fw_svn128 = builder_svn128.get_caliptra_fw()?;
     let flash_image = create_flash_image(
         Some(caliptra_fw.clone()),
         Some(soc_manifest.clone()),
@@ -824,6 +844,18 @@ pub fn all_build(args: AllBuildArgs) -> Result<()> {
     add_to_zip(
         &caliptra_fw,
         FirmwareBinaries::CALIPTRA_FW_NAME,
+        &mut zip,
+        options,
+    )?;
+    add_to_zip(
+        &caliptra_fw_svn7,
+        FirmwareBinaries::CALIPTRA_FW_SVN7_NAME,
+        &mut zip,
+        options,
+    )?;
+    add_to_zip(
+        &caliptra_fw_svn128,
+        FirmwareBinaries::CALIPTRA_FW_SVN128_NAME,
         &mut zip,
         options,
     )?;

--- a/builder/src/caliptra.rs
+++ b/builder/src/caliptra.rs
@@ -86,6 +86,7 @@ pub struct CaliptraBuilder {
     /// Optional custom owner configuration for re-signing auth manifests (SoC manifest).
     /// If provided, the auth manifest will be signed with these owner keys.
     auth_manifest_owner_config: Option<AuthManifestOwnerConfig>,
+    svn: Option<u16>,
 }
 
 use crate::CaliptraBuildArgs;
@@ -113,6 +114,7 @@ impl CaliptraBuilder {
                 .unwrap_or_else(|| "Caliptra-SS".to_string()),
             owner_config: None,
             auth_manifest_owner_config: None,
+            svn: args.svn,
         }
     }
 
@@ -157,7 +159,7 @@ impl CaliptraBuilder {
             }
             caliptra_firmware.clone()
         } else {
-            let (path, vendor_pk_hash) = Self::compile_caliptra_fw_cached(self.fpga)?;
+            let (path, vendor_pk_hash) = Self::compile_caliptra_fw_cached(self.fpga, self.svn)?;
             self.vendor_pk_hash = Some(vendor_pk_hash);
             self.caliptra_firmware = Some(path.clone());
             path
@@ -484,11 +486,14 @@ impl CaliptraBuilder {
         Ok(path)
     }
 
-    fn compile_caliptra_fw_cached(fpga: bool) -> Result<(PathBuf, String)> {
+    fn compile_caliptra_fw_cached(fpga: bool, svn: Option<u16>) -> Result<(PathBuf, String)> {
         let platform = if fpga { "fpga" } else { "emulator" };
         if let Some(version) = Self::caliptra_version() {
-            let path =
-                target_dir().join(format!("caliptra-fw-bundle-{}-{}.bin", version, platform));
+            let svn_or_default = svn.unwrap_or_default();
+            let path = target_dir().join(format!(
+                "caliptra-fw-bundle-{}-{}-{}.bin",
+                version, platform, svn_or_default
+            ));
             if path.exists() {
                 println!("Using cached Caliptra FW bundle at {:?}", path);
                 return Self::parse_fw_bundle(path);
@@ -497,12 +502,15 @@ impl CaliptraBuilder {
                 "Caliptra FW bundle version {} not found in cache, compiling...",
                 version
             );
-            let compiled_fw_bundle = Self::compile_caliptra_fw_uncached(fpga)?.0;
-            std::fs::copy(compiled_fw_bundle, &path)?;
+            let compiled_fw_bundle = Self::compile_caliptra_fw_uncached(fpga, svn)?.0;
+            // std::fs::copy truncates the file to 0 bytes if both paths are the same
+            if compiled_fw_bundle != path {
+                std::fs::copy(compiled_fw_bundle, &path)?;
+            }
             Self::parse_fw_bundle(path)
         } else {
             println!("Caliptra version not found so cannot use cached FW bundle");
-            Self::compile_caliptra_fw_uncached(fpga)
+            Self::compile_caliptra_fw_uncached(fpga, svn)
         }
     }
 
@@ -618,9 +626,10 @@ impl CaliptraBuilder {
         Ok((new_bundle, vendor_hash, owner_hash))
     }
 
-    fn compile_caliptra_fw_uncached(fpga: bool) -> Result<(PathBuf, String)> {
+    fn compile_caliptra_fw_uncached(fpga: bool, svn: Option<u16>) -> Result<(PathBuf, String)> {
         let opts = caliptra_builder::ImageOptions {
             pqc_key_type: FwVerificationPqcKeyType::LMS,
+            fw_svn: svn.unwrap_or(0) as u32,
             ..Default::default()
         };
 
@@ -638,7 +647,13 @@ impl CaliptraBuilder {
             )?
         };
         let fw_bytes = bundle.to_bytes()?;
-        let path = target_dir().join("caliptra-fw-bundle.bin");
+        let platform = if fpga { "fpga" } else { "emulator" };
+        let version = Self::caliptra_version().unwrap_or("no_version".to_string());
+        let svn_or_default = svn.unwrap_or_default();
+        let path = target_dir().join(format!(
+            "caliptra-fw-bundle-{}-{}-{}.bin",
+            version, platform, svn_or_default
+        ));
         std::fs::write(&path, fw_bytes)?;
         Ok((path, Self::vendor_pk_hash_str(bundle.manifest)?))
     }

--- a/common/mcu-mbox/src/messages.rs
+++ b/common/mcu-mbox/src/messages.rs
@@ -119,6 +119,7 @@ impl CommandId {
 
     // Authorized commands
     pub const MC_ROTATE_VENDOR_PK_HASH: Self = Self(0x4D56_504B); // "MVPK"
+    pub const MC_FUSE_INCREASE_CALIPTRA_MIN_SVN: Self = Self(0x4D43_4D53); // "MCMS"
 }
 
 impl From<u32> for CommandId {
@@ -180,6 +181,7 @@ pub enum McuMailboxReq {
     FuseRead(FuseReadReq),
     FuseWrite(FuseWriteReq),
     FuseLockPartition(FuseLockPartitionReq),
+    FuseIncreaseCaliptraMinSvn(FuseIncreaseCaliptraMinSvnReq),
 }
 
 impl McuMailboxReq {
@@ -227,6 +229,7 @@ impl McuMailboxReq {
             McuMailboxReq::FuseRead(req) => Ok(req.as_bytes()),
             McuMailboxReq::FuseWrite(req) => req.as_bytes_partial(),
             McuMailboxReq::FuseLockPartition(req) => Ok(req.as_bytes()),
+            McuMailboxReq::FuseIncreaseCaliptraMinSvn(req) => Ok(req.as_bytes()),
         }
     }
 
@@ -274,6 +277,7 @@ impl McuMailboxReq {
             McuMailboxReq::FuseRead(req) => Ok(req.as_mut_bytes()),
             McuMailboxReq::FuseWrite(req) => req.as_bytes_partial_mut(),
             McuMailboxReq::FuseLockPartition(req) => Ok(req.as_mut_bytes()),
+            McuMailboxReq::FuseIncreaseCaliptraMinSvn(req) => Ok(req.as_mut_bytes()),
         }
     }
 
@@ -321,6 +325,9 @@ impl McuMailboxReq {
             McuMailboxReq::FuseRead(_) => CommandId::MC_FUSE_READ,
             McuMailboxReq::FuseWrite(_) => CommandId::MC_FUSE_WRITE,
             McuMailboxReq::FuseLockPartition(_) => CommandId::MC_FUSE_LOCK_PARTITION,
+            McuMailboxReq::FuseIncreaseCaliptraMinSvn(_) => {
+                CommandId::MC_FUSE_INCREASE_CALIPTRA_MIN_SVN
+            }
         }
     }
 
@@ -1345,6 +1352,27 @@ pub struct FuseLockPartitionResp {
     pub hdr: MailboxRespHeader,
 }
 impl Response for FuseLockPartitionResp {}
+
+/// MC_FUSE_INCREASE_CALIPTRA_MIN_SVN request: Increases the Caliptra min bootable SVN
+#[repr(C)]
+#[derive(Debug, Default, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct FuseIncreaseCaliptraMinSvnReq {
+    pub hdr: MailboxReqHeader,
+    pub flags: u32,
+    pub svn: u32,
+}
+impl Request for FuseIncreaseCaliptraMinSvnReq {
+    const ID: CommandId = CommandId::MC_FUSE_INCREASE_CALIPTRA_MIN_SVN;
+    type Resp = FuseIncreaseCaliptraMinSvnResp;
+}
+
+/// MC_FUSE_INCREASE_CALIPTRA_MIN_SVN response: Indicates success or failure.
+#[repr(C)]
+#[derive(Debug, Default, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct FuseIncreaseCaliptraMinSvnResp {
+    pub hdr: MailboxRespHeader,
+}
+impl Response for FuseIncreaseCaliptraMinSvnResp {}
 
 #[cfg(test)]
 mod tests {

--- a/runtime/userspace/api/mcu-mbox-lib/src/cmd_interface.rs
+++ b/runtime/userspace/api/mcu-mbox-lib/src/cmd_interface.rs
@@ -7,20 +7,22 @@ use caliptra_mcu_external_cmds_common::{
     UnifiedCommandHandler, MAX_UID_LEN,
 };
 use caliptra_mcu_libapi_caliptra::mailbox_api::execute_mailbox_cmd;
-use caliptra_mcu_libsyscall_caliptra::mailbox::Mailbox;
 use caliptra_mcu_libsyscall_caliptra::mcu_mbox::MbxCmdStatus;
+use caliptra_mcu_libsyscall_caliptra::otp;
+use caliptra_mcu_libsyscall_caliptra::{mailbox::Mailbox, DefaultSyscalls};
 use caliptra_mcu_mbox_common::messages::{
     CommandId, DeviceCapsReq, DeviceCapsResp, DeviceIdReq, DeviceIdResp, DeviceInfoReq,
-    DeviceInfoResp, FirmwareVersionReq, FirmwareVersionResp, MailboxRespHeader,
-    MailboxRespHeaderVarSize, McuAesDecryptInitReq, McuAesDecryptUpdateReq, McuAesEncryptInitReq,
-    McuAesEncryptUpdateReq, McuAesGcmDecryptFinalReq, McuAesGcmDecryptInitReq,
-    McuAesGcmDecryptUpdateReq, McuAesGcmEncryptFinalReq, McuAesGcmEncryptInitReq,
-    McuAesGcmEncryptUpdateReq, McuCmDeleteReq, McuCmImportReq, McuCmStatusReq, McuEcdhFinishReq,
-    McuEcdhGenerateReq, McuEcdsaCmkPublicKeyReq, McuEcdsaCmkSignReq, McuEcdsaCmkVerifyReq,
-    McuFipsSelfTestGetResultsReq, McuFipsSelfTestStartReq, McuHkdfExpandReq, McuHkdfExtractReq,
-    McuHmacKdfCounterReq, McuHmacReq, McuProdDebugUnlockReqReq, McuProdDebugUnlockTokenReq,
-    McuRandomGenerateReq, McuRandomStirReq, McuResponseVarSize, McuShaFinalReq, McuShaInitReq,
-    McuShaUpdateReq, DEVICE_CAPS_SIZE, MAX_FW_VERSION_STR_LEN,
+    DeviceInfoResp, FirmwareVersionReq, FirmwareVersionResp, FuseIncreaseCaliptraMinSvnReq,
+    FuseIncreaseCaliptraMinSvnResp, MailboxRespHeader, MailboxRespHeaderVarSize,
+    McuAesDecryptInitReq, McuAesDecryptUpdateReq, McuAesEncryptInitReq, McuAesEncryptUpdateReq,
+    McuAesGcmDecryptFinalReq, McuAesGcmDecryptInitReq, McuAesGcmDecryptUpdateReq,
+    McuAesGcmEncryptFinalReq, McuAesGcmEncryptInitReq, McuAesGcmEncryptUpdateReq, McuCmDeleteReq,
+    McuCmImportReq, McuCmStatusReq, McuEcdhFinishReq, McuEcdhGenerateReq, McuEcdsaCmkPublicKeyReq,
+    McuEcdsaCmkSignReq, McuEcdsaCmkVerifyReq, McuFipsSelfTestGetResultsReq,
+    McuFipsSelfTestStartReq, McuHkdfExpandReq, McuHkdfExtractReq, McuHmacKdfCounterReq, McuHmacReq,
+    McuProdDebugUnlockReqReq, McuProdDebugUnlockTokenReq, McuRandomGenerateReq, McuRandomStirReq,
+    McuResponseVarSize, McuShaFinalReq, McuShaInitReq, McuShaUpdateReq, DEVICE_CAPS_SIZE,
+    MAX_FW_VERSION_STR_LEN,
 };
 #[cfg(feature = "periodic-fips-self-test")]
 use caliptra_mcu_mbox_common::messages::{
@@ -412,7 +414,8 @@ impl<'a> CmdInterface<'a> {
                 )
                 .await
             }
-            cmd_id @ CommandId::MC_ROTATE_VENDOR_PK_HASH => {
+            cmd_id @ CommandId::MC_ROTATE_VENDOR_PK_HASH
+            | cmd_id @ CommandId::MC_FUSE_INCREASE_CALIPTRA_MIN_SVN => {
                 self.handle_authorized_command(cmd_id, req, resp_buf).await
             }
             // TODO: add more command handlers.
@@ -638,6 +641,9 @@ impl<'a> CmdInterface<'a> {
             CommandId::MC_ROTATE_VENDOR_PK_HASH => {
                 self.handle_rotate_vendor_pk_hash(cmd, resp_buf).await
             }
+            CommandId::MC_FUSE_INCREASE_CALIPTRA_MIN_SVN => {
+                self.handle_increase_caliptra_min_svn(cmd, resp_buf).await
+            }
             _ => Err(MsgHandlerError::UnsupportedCommand),
         }
     }
@@ -649,6 +655,125 @@ impl<'a> CmdInterface<'a> {
     ) -> Result<(&'r mut [u8], MbxCmdStatus), MsgHandlerError> {
         // TODO
         Err(MsgHandlerError::UnsupportedCommand)
+    }
+
+    async fn handle_increase_caliptra_min_svn<'r>(
+        &self,
+        req: &[u8],
+        resp_buf: &'r mut [u8],
+    ) -> Result<(&'r mut [u8], MbxCmdStatus), MsgHandlerError> {
+        if resp_buf.len() < core::mem::size_of::<FuseIncreaseCaliptraMinSvnResp>() {
+            return Err(MsgHandlerError::InvalidParams);
+        }
+
+        // Decode the request
+        let req = FuseIncreaseCaliptraMinSvnReq::ref_from_bytes(req)
+            .map_err(|_| MsgHandlerError::InvalidParams)?;
+
+        // Check the request has a valid SVN value
+        if req.svn == 0 {
+            return Err(MsgHandlerError::InvalidParams);
+        }
+        if req.svn > 128 {
+            return Err(MsgHandlerError::InvalidParams);
+        }
+
+        let caliptra_fw_info = self.get_caliptra_fw_info().await?;
+
+        // Ensure the requested SVN will allow current Caliptra firmware to run
+        if req.svn > caliptra_fw_info.fw_svn {
+            return Err(MsgHandlerError::InvalidParams);
+        }
+
+        // Get the minimum SVN set in fuses
+        let otp: otp::Otp<DefaultSyscalls> = otp::Otp::new();
+        let mut current_fuses = [0u32; 4];
+        for (i, fuse) in current_fuses.iter_mut().enumerate() {
+            *fuse = otp
+                .read(otp::reg::CALIPTRA_FW_SVN, i as u32)
+                .map_err(|_| MsgHandlerError::McuMboxCommon)?;
+        }
+
+        // Convert the fuses to the SVN value
+        let fused_min_svn = {
+            // Value is take as the most significant bit set in fuses
+            let fuse: u128 = u128::from_le_bytes(current_fuses.as_bytes().try_into().unwrap());
+            128 - fuse.leading_zeros()
+        };
+
+        // Ensure we are not trying to decrease the SVN
+        if req.svn < fused_min_svn {
+            return Err(MsgHandlerError::InvalidParams);
+        }
+
+        // We are done, if the fuses already match the requested SVN.
+        if fused_min_svn == req.svn {
+            let resp = FuseIncreaseCaliptraMinSvnResp::default();
+            let resp_bytes = resp.as_bytes();
+            resp_buf[..resp_bytes.len()].copy_from_slice(resp_bytes);
+            return Ok((&mut resp_buf[..resp_bytes.len()], MbxCmdStatus::Complete));
+        }
+
+        let new_fuse_svn = if req.svn == 128 {
+            u128::MAX
+        } else {
+            !(u128::MAX << req.svn)
+        };
+
+        for (i, (current, new_bytes)) in current_fuses
+            .iter()
+            .zip(new_fuse_svn.as_bytes().chunks_exact(4))
+            .enumerate()
+        {
+            let new_svn_word = u32::from_le_bytes(new_bytes.try_into().unwrap());
+            if *current != new_svn_word {
+                otp.write(otp::reg::CALIPTRA_FW_SVN, i as u32, new_svn_word)
+                    .map_err(|_| MsgHandlerError::InvalidParams)?;
+            }
+        }
+
+        let resp = FuseIncreaseCaliptraMinSvnResp::default();
+        let resp_bytes = resp.as_bytes();
+        resp_buf[..resp_bytes.len()].copy_from_slice(resp_bytes);
+        Ok((&mut resp_buf[..resp_bytes.len()], MbxCmdStatus::Complete))
+    }
+
+    async fn get_caliptra_fw_info(
+        &self,
+    ) -> Result<caliptra_api::mailbox::FwInfoResp, MsgHandlerError> {
+        let mut req = caliptra_api::mailbox::MailboxReqHeader::default();
+        let mut caliptra_info = caliptra_api::mailbox::FwInfoResp {
+            hdr: Default::default(),
+            pl0_pauser: Default::default(),
+            fw_svn: Default::default(),
+            min_fw_svn: Default::default(),
+            cold_boot_fw_svn: Default::default(),
+            attestation_disabled: Default::default(),
+            rom_revision: Default::default(),
+            fmc_revision: Default::default(),
+            runtime_revision: Default::default(),
+            rom_sha256_digest: Default::default(),
+            fmc_sha384_digest: Default::default(),
+            runtime_sha384_digest: Default::default(),
+            owner_pub_key_hash: Default::default(),
+            authman_sha384_digest: Default::default(),
+            most_recent_fw_error: Default::default(),
+        };
+
+        // Invoke Caliptra mailbox API
+        let len = execute_mailbox_cmd(
+            &self.caliptra_mbox,
+            caliptra_api::mailbox::CommandId::FW_INFO.into(),
+            req.as_mut_bytes(),
+            caliptra_info.as_mut_bytes(),
+        )
+        .await
+        .map_err(|_| MsgHandlerError::McuMboxCommon)?;
+
+        if len < size_of_val(&caliptra_info) {
+            return Err(MsgHandlerError::McuMboxCommon);
+        }
+        Ok(caliptra_info)
     }
 
     #[cfg(feature = "periodic-fips-self-test")]

--- a/tests/integration/src/runtime/mod.rs
+++ b/tests/integration/src/runtime/mod.rs
@@ -1,3 +1,4 @@
 // Licensed under the Apache-2.0 license
 
+mod test_increase_caliptra_svn;
 mod test_mcu_mailbox;

--- a/tests/integration/src/runtime/test_increase_caliptra_svn.rs
+++ b/tests/integration/src/runtime/test_increase_caliptra_svn.rs
@@ -1,0 +1,274 @@
+// Licensed under the Apache-2.0 license
+
+use crate::test::{compile_runtime, start_runtime_hw_model, CustomCaliptraFw, TestParams};
+use anyhow::Result;
+use caliptra_api::{calc_checksum, error::CaliptraError, mailbox::FwInfoResp, SocManager};
+use caliptra_mcu_builder::{CaliptraBuildArgs, CaliptraBuilder, FirmwareBinaries};
+use caliptra_mcu_hw_model::{LifecycleControllerState, McuHwModel};
+use caliptra_mcu_mbox_common::messages::FuseIncreaseCaliptraMinSvnReq;
+use caliptra_mcu_romtime::McuBootMilestones;
+use zerocopy::{FromBytes, IntoBytes};
+
+#[test]
+fn test_increase_caliptra_svn() -> Result<()> {
+    // Step 1: Compile runtime with specific features and build initial Caliptra
+    // firmware with SVN = 0 and SVN = 7.
+    let mcu_runtime_path = compile_runtime(Some("test-mcu-mbox-cmds"), false);
+    let (caliptra_fw_svn0, caliptra_fw_svn7, vendor_pk_hash_arr, soc_manifest) =
+        if let Ok(binaries) = FirmwareBinaries::from_env() {
+            let fw_svn0 = binaries.caliptra_fw.clone();
+            let fw_svn7 = binaries.caliptra_fw_svn7.clone();
+            let pk_hash = binaries.vendor_pk_hash().unwrap();
+            let manifest = binaries.test_soc_manifest("test-mcu-mbox-cmds").unwrap();
+            (fw_svn0, fw_svn7, pk_hash, manifest)
+        } else {
+            let mut builder = CaliptraBuilder::new(&CaliptraBuildArgs {
+                svn: Some(0),
+                mcu_firmware: Some(mcu_runtime_path.clone()),
+                ..Default::default()
+            });
+            let fw_svn0 = std::fs::read(builder.get_caliptra_fw()?).unwrap();
+            let mut builder = CaliptraBuilder::new(&CaliptraBuildArgs {
+                svn: Some(7),
+                mcu_firmware: Some(mcu_runtime_path),
+                ..Default::default()
+            });
+            let fw_svn7 = std::fs::read(builder.get_caliptra_fw()?).unwrap();
+            let pk_hash_str = builder.get_vendor_pk_hash()?.to_string();
+            let pk_hash = hex::decode(&pk_hash_str).unwrap();
+            let mut pk_hash_arr = [0u8; 48];
+            pk_hash_arr.copy_from_slice(&pk_hash);
+            let manifest = std::fs::read(builder.get_soc_manifest(None)?).unwrap();
+            (fw_svn0, fw_svn7, pk_hash_arr, manifest)
+        };
+
+    // Start the hardware model with the custom Caliptra firmware (SVN 7).
+    let mut hw = start_runtime_hw_model(TestParams {
+        feature: Some("test-mcu-mbox-cmds"),
+        custom_caliptra_fw: Some(CustomCaliptraFw {
+            fw_bytes: caliptra_fw_svn7.clone(),
+            vendor_pk_hash: vendor_pk_hash_arr,
+            soc_manifest: soc_manifest.clone(),
+        }),
+        lifecycle_controller_state: Some(LifecycleControllerState::Prod),
+        ..Default::default()
+    });
+
+    // Wait for the mailbox to become ready, indicating the runtime has booted.
+    hw.step_until(|hw| {
+        hw.mci_boot_milestones()
+            .contains(McuBootMilestones::FIRMWARE_MAILBOX_READY)
+    });
+
+    // Check setting the SVN to 0 fails
+    let cmd = FuseIncreaseCaliptraMinSvnReq {
+        svn: 0,
+        ..Default::default()
+    };
+    let result = hw.mailbox_execute_req(cmd);
+    assert!(result.is_err());
+
+    // Check requesting to increase SVN past what is currently running returns an error.
+    // Running SVN is 7, so requesting 8 should fail.
+    let cmd = FuseIncreaseCaliptraMinSvnReq {
+        svn: 8,
+        ..Default::default()
+    };
+    let result = hw.mailbox_execute_req(cmd);
+    assert!(result.is_err());
+
+    // Check trying to burn a value greater than 128 returns an error.
+    let cmd = FuseIncreaseCaliptraMinSvnReq {
+        svn: 129,
+        ..Default::default()
+    };
+    let result = hw.mailbox_execute_req(cmd);
+    assert!(result.is_err());
+
+    // Send a command to increase the Caliptra minimum SVN fuses to 7.
+    let cmd = FuseIncreaseCaliptraMinSvnReq {
+        svn: 7,
+        ..Default::default()
+    };
+    let _resp = hw.mailbox_execute_req(cmd)?;
+
+    // Check requesting twice to burn the SVN of the value currently in fuses passes.
+    let cmd = FuseIncreaseCaliptraMinSvnReq {
+        svn: 7,
+        ..Default::default()
+    };
+    let _resp = hw.mailbox_execute_req(cmd)?;
+
+    // Read OTP memory so we can use the same config in later boots.
+    let otp = hw.read_otp_memory();
+
+    // Step 2: Cold boot with the burned fuses and verify the firmware with SVN 7 can still boot.
+    let mut hw = start_runtime_hw_model(TestParams {
+        feature: Some("test-mcu-mbox-cmds"),
+        custom_caliptra_fw: Some(CustomCaliptraFw {
+            fw_bytes: caliptra_fw_svn7,
+            vendor_pk_hash: vendor_pk_hash_arr,
+            soc_manifest: soc_manifest.clone(),
+        }),
+        otp_memory: Some(otp.clone()),
+        ..Default::default()
+    });
+
+    // Wait for mailbox ready again.
+    hw.step_until(|hw| {
+        hw.mci_boot_milestones()
+            .contains(McuBootMilestones::FIRMWARE_MAILBOX_READY)
+    });
+
+    // Query FW_INFO to check if the reported min_fw_svn matches the burned fuses.
+    let fw_info_id = caliptra_api::mailbox::CommandId::FW_INFO.into();
+    let payload = caliptra_api::mailbox::MailboxReqHeader {
+        chksum: calc_checksum(fw_info_id, &[]),
+    };
+
+    let resp = hw
+        .caliptra_mailbox_execute(fw_info_id, payload.as_bytes())
+        .unwrap()
+        .unwrap();
+    let caliptra_fw_info = FwInfoResp::read_from_bytes(&resp).unwrap();
+    assert_eq!(caliptra_fw_info.min_fw_svn, 7);
+
+    // Check trying to burn a lower SVN returns an error.
+    // Current fuses are 7, so trying to burn 6 should fail.
+    let cmd = FuseIncreaseCaliptraMinSvnReq {
+        svn: 6,
+        ..Default::default()
+    };
+    let resp = hw.mailbox_execute_req(cmd);
+    assert!(resp.is_err());
+
+    // Step 3: Negative test. Build firmware with SVN = 0 (less than fuse value 7)
+    // and verify that boot fails with the expected error.
+
+    // We use `rom_only: true` here to prevent the emulator initialization from
+    // blocking or crashing while waiting for a successful boot that will never happen.
+    let mut hw = start_runtime_hw_model(TestParams {
+        feature: Some("test-mcu-mbox-cmds"),
+        custom_caliptra_fw: Some(CustomCaliptraFw {
+            fw_bytes: caliptra_fw_svn0.clone(),
+            vendor_pk_hash: vendor_pk_hash_arr,
+            soc_manifest,
+        }),
+        otp_memory: Some(otp),
+        rom_only: true,
+        ..Default::default()
+    });
+
+    // Step the model until a fatal error is reported by Caliptra.
+    hw.step_until(|hw| {
+        hw.caliptra_soc_manager()
+            .soc_ifc()
+            .cptra_fw_error_fatal()
+            .read()
+            != 0
+    });
+
+    // Verify that the fatal error corresponds to the SVN being less than the fuse value.
+    assert_eq!(
+        hw.caliptra_soc_manager()
+            .soc_ifc()
+            .cptra_fw_error_fatal()
+            .read(),
+        u32::from(CaliptraError::IMAGE_VERIFIER_ERR_FIRMWARE_SVN_LESS_THAN_FUSE)
+    );
+    Ok(())
+}
+
+#[test]
+fn test_increase_caliptra_svn_max() -> Result<()> {
+    // Compile runtime with specific features and build Caliptra firmware with max SVN (128).
+    let mcu_runtime_path = compile_runtime(Some("test-mcu-mbox-cmds"), false);
+    let (caliptra_fw_svn128, vendor_pk_hash_arr, soc_manifest) =
+        if let Ok(binaries) = FirmwareBinaries::from_env() {
+            let fw = binaries.caliptra_fw_svn128.clone();
+            let pk_hash = binaries.vendor_pk_hash().unwrap();
+            let manifest = binaries.test_soc_manifest("test-mcu-mbox-cmds").unwrap();
+            (fw, pk_hash, manifest)
+        } else {
+            let mut builder = CaliptraBuilder::new(&CaliptraBuildArgs {
+                svn: Some(128),
+                mcu_firmware: Some(mcu_runtime_path.clone()),
+                ..Default::default()
+            });
+            let fw = std::fs::read(builder.get_caliptra_fw()?).unwrap();
+            let pk_hash_str = builder.get_vendor_pk_hash()?.to_string();
+            let pk_hash = hex::decode(&pk_hash_str).unwrap();
+            let mut pk_hash_arr = [0u8; 48];
+            pk_hash_arr.copy_from_slice(&pk_hash);
+            let manifest = std::fs::read(builder.get_soc_manifest(None)?).unwrap();
+            (fw, pk_hash_arr, manifest)
+        };
+
+    // Start the hardware model with the custom Caliptra firmware (SVN 128).
+    let mut hw = start_runtime_hw_model(TestParams {
+        feature: Some("test-mcu-mbox-cmds"),
+        custom_caliptra_fw: Some(CustomCaliptraFw {
+            fw_bytes: caliptra_fw_svn128.clone(),
+            vendor_pk_hash: vendor_pk_hash_arr,
+            soc_manifest: soc_manifest.clone(),
+        }),
+        lifecycle_controller_state: Some(LifecycleControllerState::Prod),
+        ..Default::default()
+    });
+
+    // Wait for the mailbox to become ready, indicating the runtime has booted.
+    hw.step_until(|hw| {
+        hw.mci_boot_milestones()
+            .contains(McuBootMilestones::FIRMWARE_MAILBOX_READY)
+    });
+
+    // Send a command to increase the Caliptra minimum SVN fuses to 128.
+    let cmd = FuseIncreaseCaliptraMinSvnReq {
+        svn: 128,
+        ..Default::default()
+    };
+    let _resp = hw.mailbox_execute_req(cmd)?;
+
+    // Read OTP memory immediately after the command to verify fuses were burned.
+    let otp = hw.read_otp_memory();
+
+    // Check SVN value at offset 0x394 using specific decoding logic.
+    // The SVN is represented as a bitmask where the number of set bits is the SVN.
+    let svn_bytes = &otp[0x394..0x394 + 16];
+    let fuse = u128::from_le_bytes(svn_bytes.try_into().unwrap());
+    let svn = 128 - fuse.leading_zeros();
+    assert_eq!(svn, 128);
+
+    // Verify persistence across cold boot.
+    let mut hw = start_runtime_hw_model(TestParams {
+        feature: Some("test-mcu-mbox-cmds"),
+        custom_caliptra_fw: Some(CustomCaliptraFw {
+            fw_bytes: caliptra_fw_svn128,
+            vendor_pk_hash: vendor_pk_hash_arr,
+            soc_manifest: soc_manifest.clone(),
+        }),
+        otp_memory: Some(otp.clone()),
+        ..Default::default()
+    });
+
+    // Wait for mailbox ready again.
+    hw.step_until(|hw| {
+        hw.mci_boot_milestones()
+            .contains(McuBootMilestones::FIRMWARE_MAILBOX_READY)
+    });
+
+    // Query FW_INFO to check if the reported min_fw_svn matches the burned fuses (128).
+    let fw_info_id = caliptra_api::mailbox::CommandId::FW_INFO.into();
+    let payload = caliptra_api::mailbox::MailboxReqHeader {
+        chksum: calc_checksum(fw_info_id, &[]),
+    };
+
+    let resp = hw
+        .caliptra_mailbox_execute(fw_info_id, payload.as_bytes())
+        .unwrap()
+        .unwrap();
+    let caliptra_fw_info = FwInfoResp::read_from_bytes(&resp).unwrap();
+    assert_eq!(caliptra_fw_info.min_fw_svn, 128);
+
+    Ok(())
+}


### PR DESCRIPTION
This command will take a parameter for the value to set in fuses. To prevent Caliptra from getting into a position where the SVN is too high, it will only allow fusing up to the currently running FW SVN value.