### PR TITLE
[reference only/not for merging] add proposals for DMA transfer trait and PLDM flash image loading

### DIFF
--- a/docs/proposals/flash-image-loader-dma-trait.md
+++ b/docs/proposals/flash-image-loader-dma-trait.md
@@ -1,0 +1,225 @@
+# Proposal: Generic DMA Transfer Trait for FlashImageLoader
+
+## Problem
+
+The current `FlashImageLoader` implementation in
+`runtime/userspace/api/caliptra-api/src/image_loading/flash_client.rs`
+performs image loading in a two-step copy per chunk:
+
+```
+Flash Storage → stack buffer [0u8; 128] → DMA → target AXI address
+```
+
+The `flash_load_image` function allocates a 128-byte stack buffer, reads
+from flash into it via `SpiFlash::read`, converts the buffer pointer to an
+AXI address, and then issues a DMA transfer from the buffer to the
+destination. This means every chunk is touched twice, and the transfer
+size is capped at 128 bytes, resulting in many small syscall round-trips
+for large images.
+
+```rust
+// Current implementation (simplified)
+while remaining_size > 0 {
+    let transfer_size = remaining_size.min(128);
+    let mut buffer = [0u8; 128];                       // temp buffer on stack
+    flash.read(current_offset, transfer_size, &mut buffer).await?;  // flash → buffer
+    let src = dma_mapping.mcu_sram_to_mcu_axi(buffer.as_ptr() as u32)?;
+    dma_syscall.xfer(&DMATransaction {
+        byte_count: transfer_size,
+        source: DMASource::Address(src),
+        dest_addr: current_address,
+    }).await?;                                          // buffer → destination
+    // advance offsets...
+}
+```
+
+On platforms with a DMA engine that can drive transfers directly from the
+flash controller's AXI interface to the target address, this intermediate
+copy is unnecessary and a performance bottleneck.
+
+## Goals
+
+1. Introduce a generic `DMATransfer` trait that abstracts a
+   source-to-destination DMA operation, allowing platforms to provide
+   optimized transfer implementations (e.g., direct flash-to-AXI DMA)
+   without the temporary buffer.
+2. Keep the existing buffered path as a fallback for platforms without
+   direct DMA capability.
+3. Minimize API surface change — the `ImageLoader` trait and its callers
+   should not need modification.
+4. Support larger transfer sizes when the hardware allows it.
+5. Keep the trait generic so it can be reused for other source-to-
+   destination transfer scenarios beyond flash (e.g., memory-to-memory,
+   peripheral-to-memory).
+
+## Proposed Design
+
+### New trait: `DMATransfer`
+
+Introduce a generic trait that abstracts a source-to-destination DMA
+transfer. The trait is not flash-specific — it describes any transfer
+from a source (identified by offset) to an AXI destination. Platforms
+implement this trait to provide optimized transfer paths.
+
+```rust
+// runtime/userspace/api/caliptra-api/src/image_loading/dma_transfer.rs
+
+use caliptra_mcu_libsyscall_caliptra::dma::AXIAddr;
+use caliptra_mcu_libtock_platform::ErrorCode;
+
+/// Generic trait for performing source-to-destination DMA transfers.
+///
+/// This trait abstracts the transfer of data from a source (identified
+/// by offset) to an AXI destination address. Implementations can use
+/// any transfer mechanism: direct DMA from a peripheral, buffered
+/// copy through SRAM, memory-to-memory DMA, etc.
+///
+/// For flash image loading, the source offset corresponds to a flash
+/// address, but the trait itself is not flash-specific.
+#[async_trait(?Send)]
+pub trait DMATransfer: Send + Sync {
+    /// The maximum number of bytes that can be transferred in a single
+    /// operation. The caller will chunk transfers to this size.
+    fn max_transfer_size(&self) -> usize;
+
+    /// Transfer `length` bytes starting at `src_offset` in the source
+    /// directly to `dest_addr` on the AXI bus.
+    async fn transfer(
+        &self,
+        src_offset: usize,
+        dest_addr: AXIAddr,
+        length: usize,
+    ) -> Result<(), ErrorCode>;
+}
+```
+
+### Fallback implementation: `BufferedFlashDMA`
+
+For platforms that do not have direct flash-to-AXI DMA, provide a
+flash-backed implementation that preserves the current behavior (read
+flash into buffer, then DMA from buffer to destination):
+
+```rust
+/// Flash-backed DMATransfer that buffers through SRAM, matching the
+/// current behavior. Reads from SPI flash into a stack buffer, then
+/// DMAs from the buffer to the destination.
+pub struct BufferedFlashDMA<'a, D: DMAMapping> {
+    flash: &'a FlashSyscall,
+    dma_mapping: &'a D,
+}
+
+impl<'a, D: DMAMapping> BufferedFlashDMA<'a, D> {
+    pub fn new(flash: &'a FlashSyscall, dma_mapping: &'a D) -> Self {
+        Self { flash, dma_mapping }
+    }
+}
+
+#[async_trait(?Send)]
+impl<D: DMAMapping> DMATransfer for BufferedFlashDMA<'_, D> {
+    fn max_transfer_size(&self) -> usize {
+        128 // matches current MAX_DMA_TRANSFER_SIZE
+    }
+
+    async fn transfer(
+        &self,
+        src_offset: usize,
+        dest_addr: AXIAddr,
+        length: usize,
+    ) -> Result<(), ErrorCode> {
+        let dma_syscall = DMASyscall::new();
+        let mut buffer = [0u8; 128];
+        self.flash
+            .read(src_offset, length, &mut buffer[..length])
+            .await?;
+        let source_address = self.dma_mapping
+            .mcu_sram_to_mcu_axi(buffer.as_ptr() as u32)?;
+        dma_syscall.xfer(&DMATransaction {
+            byte_count: length,
+            source: DMASource::Address(source_address),
+            dest_addr,
+        }).await
+    }
+}
+```
+
+### Updated `FlashImageLoader`
+
+`FlashImageLoader` becomes generic over the `DMATransfer` trait
+instead of only over `DMAMapping`:
+
+```rust
+pub struct FlashImageLoader<T: DMATransfer + 'static> {
+    mailbox: Mailbox,
+    flash: FlashSyscall,
+    dma_transfer: &'static T,
+}
+
+impl<T: DMATransfer + 'static> FlashImageLoader<T> {
+    pub fn new(flash_syscall: FlashSyscall, dma_transfer: &'static T) -> Self {
+        Self {
+            mailbox: Mailbox::new(),
+            flash: flash_syscall,
+            dma_transfer,
+        }
+    }
+}
+```
+
+### Updated `flash_load_image`
+
+The function is simplified to delegate to the trait:
+
+```rust
+pub async fn flash_load_image(
+    dma_transfer: &impl DMATransfer,
+    load_address: AXIAddr,
+    offset: usize,
+    img_size: usize,
+) -> Result<(), ErrorCode> {
+    let max_xfer = dma_transfer.max_transfer_size();
+    let mut remaining = img_size;
+    let mut current_offset = offset;
+    let mut current_addr = load_address;
+
+    while remaining > 0 {
+        let xfer_size = remaining.min(max_xfer);
+        dma_transfer.transfer(current_offset, current_addr, xfer_size).await?;
+        remaining -= xfer_size;
+        current_offset += xfer_size;
+        current_addr += xfer_size as u64;
+    }
+
+    Ok(())
+}
+```
+
+### Platform-specific direct DMA example
+
+A platform with a flash controller that supports DMA read to an AXI
+destination would implement the trait like this:
+
+```rust
+pub struct DirectFlashDMA {
+    // Platform-specific handles to flash controller + DMA engine
+}
+
+#[async_trait(?Send)]
+impl DMATransfer for DirectFlashDMA {
+    fn max_transfer_size(&self) -> usize {
+        4096 // platform can do larger transfers
+    }
+
+    async fn transfer(
+        &self,
+        src_offset: usize,
+        dest_addr: AXIAddr,
+        length: usize,
+    ) -> Result<(), ErrorCode> {
+        // Program flash controller to read from src_offset
+        // Program DMA engine destination to dest_addr
+        // Start transfer and wait for completion
+        // ... platform-specific implementation ...
+        Ok(())
+    }
+}
+```

--- a/docs/proposals/pldm-flash-image-loading.md
+++ b/docs/proposals/pldm-flash-image-loading.md
@@ -1,0 +1,185 @@
+# Proposal: Full Flash Image Loading to SPI Flash via PLDM
+
+## Problem
+
+When the system boots via streaming boot (PLDM), images are downloaded
+and loaded directly into memory at their target AXI addresses. However,
+the SPI flash is not updated with the streamed content. This means:
+
+1. If the system resets, it falls back to whatever was previously on
+   flash, which may be stale or empty.
+2. Flash and the running firmware are out of sync.
+
+The customer requirement (from meeting notes) is: **when doing streaming
+boot, the image should also be written back to SPI flash so flash stays
+consistent with the streamed image.** Flash should act as a "follower"
+copy of the booted image.
+
+Importantly, the unit of transfer is the **full flash image** — the
+complete binary blob containing the `FlashHeader`, all `ImageHeader`
+entries (TOC), and every image payload (Caliptra FMC/RT, SoC manifest,
+MCU RT, SoC images). This is the same layout that `FlashImageLoader`
+expects when booting from flash. Writing individual images is not
+sufficient; the entire flash image must be stored so that a subsequent
+flash boot produces the same result as the streaming boot that preceded
+it.
+
+## Goals
+
+1. Provide a mechanism to download the **complete flash image** (headers
+   + TOC + all image payloads) via PLDM and write it to SPI flash as a
+   single contiguous blob.
+2. Reuse the existing image loader and PLDM infrastructure as much as
+   possible.
+3. The recommended flow is: perform streaming boot first (load
+   individual images into memory for immediate execution), then
+   re-download the full flash image and store it to SPI flash so flash
+   is consistent for future flash-based boots.
+4. The solution should work with the existing `FdOps` / PLDM firmware
+   device model.
+
+## Current Architecture
+
+### Streaming Boot (`PldmImageLoader`)
+- Downloads header, TOC, and individual images via PLDM.
+- Each image is DMA'd directly to its target AXI load address.
+- Flash is never written.
+- Uses `StreamingFdOps` which implements `FdOps`.
+
+
+## Proposed Design
+
+### Approach: New `download_full_image` API on `PldmImageLoader` with a generic `ImageWriter` trait
+
+Add a new method to `PldmImageLoader` that downloads the full flash
+image (headers + TOC + all payloads) as a single contiguous blob via
+PLDM and writes each received chunk to a caller-provided `ImageWriter`.
+The `ImageWriter` trait is generic — it is not flash-specific — so
+different backends can be plugged in (SPI flash, memory buffer, etc.).
+
+### New method on `PldmImageLoader`: `download_full_image`
+
+Add a `download_full_image` method that reuses the existing PLDM
+infrastructure (`StreamingFdOps`, `pldm_client`) but instead of
+loading individual images to AXI load addresses, downloads the
+complete flash image blob and passes each chunk to the `ImageWriter`.
+
+This method operates on the same PLDM session that `PldmImageLoader`
+already manages. The UA sends the full flash image as a single PLDM
+component, and the FD writes each received chunk via the writer.
+
+```rust
+impl<'a, D: DMAMapping + 'static> PldmImageLoader<'a, D> {
+    /// Download the full flash image via PLDM and write it to the
+    /// provided `ImageWriter`.
+    ///
+    /// This downloads the complete flash image blob (FlashHeader +
+    /// all ImageHeaders + all image payloads) as a single contiguous
+    /// transfer and writes each received chunk to `writer`.
+    ///
+    /// This is typically called after streaming boot completes, to
+    /// persist the streamed image to SPI flash for future flash boots.
+    pub async fn download_full_image(
+        &self,
+        writer: &dyn ImageWriter,
+    ) -> Result<(), ErrorCode> {
+        // Initialize a new PLDM session for the full image download
+        pldm_client::initialize_pldm(
+            self.spawner,
+            self.params.descriptors,
+            self.params.fw_params,
+            self.dma_mapping,
+        )
+        .await?;
+
+        // Get the total image size from the PLDM component info
+        let total_size = pldm_client::pldm_get_total_component_size().await?;
+
+        // Prepare the writer (e.g., erase flash)
+        writer.prepare(total_size).await?;
+
+        // Download the full image blob, writing each chunk via the writer
+        let result = pldm_client::pldm_download_full_image(writer).await;
+
+        if result.is_err() {
+            self.finalize()?;
+            return Err(ErrorCode::Fail);
+        }
+
+        // Finalize the writer
+        writer.finalize().await?;
+
+        Ok(())
+    }
+}
+```
+
+### New trait: `ImageWriter`
+
+```rust
+// runtime/userspace/api/caliptra-api/src/image_loading/image_writer.rs
+
+use caliptra_mcu_libtock_platform::ErrorCode;
+
+/// A generic writer for receiving a full flash image blob.
+///
+/// Each call to `write` delivers a chunk of the image at the given
+/// offset. Implementations can write to flash, a memory buffer, or
+/// any other storage backend.
+#[async_trait(?Send)]
+pub trait ImageWriter: Send + Sync {
+    /// Prepare the writer for receiving an image of `total_size` bytes.
+    /// Called once before any `write` calls. Implementations can use
+    /// this to erase flash, allocate buffers, etc.
+    async fn prepare(&self, total_size: usize) -> Result<(), ErrorCode>;
+
+    /// Write `data` at `offset` within the image.
+    /// Offsets are relative to the start of the full flash image blob.
+    async fn write(&self, offset: usize, data: &[u8]) -> Result<(), ErrorCode>;
+
+    /// Called once after all data has been written. Implementations
+    /// can use this to finalize (e.g., verify checksums, write a
+    /// validity marker).
+    async fn finalize(&self) -> Result<(), ErrorCode>;
+}
+```
+
+### SPI flash implementation: `FlashImageWriter`
+
+### Recommended Flow: Streaming Boot, Then Full Flash Image Download
+
+The recommended combined flow is:
+
+```
+1. Streaming boot (PldmImageLoader::load_and_authorize)
+   ├── Download header + TOC via PLDM
+   ├── For each image: download via PLDM → DMA to AXI load address
+   ├── Authorize each image via Caliptra mailbox
+   └── System is now running from memory
+
+2. Full flash image download (PldmImageLoader::download_full_image)
+   ├── Initiate a new PLDM session
+   ├── Writer::prepare() — e.g., erase SPI flash target region
+   ├── Download the complete flash image (headers + TOC + all images)
+   │   as a single contiguous blob → Writer::write() for each chunk
+   ├── Writer::finalize()
+   └── SPI flash now contains the full image for future flash boots
+```
+
+Usage example:
+
+```rust
+// Phase 1: Streaming boot (existing flow, unchanged)
+let pldm_loader = PldmImageLoader::new(&pldm_params, spawner, &dma_mapping);
+for image_id in image_ids {
+    pldm_loader.load_and_authorize(image_id).await?;
+}
+pldm_loader.finalize()?;
+// System is now booted from streamed images
+
+// Phase 2: Persist the full flash image to SPI flash
+let flash = SpiFlash::new(FLASH_DRIVER_NUM);
+let writer = FlashImageWriter::new(flash, 0);
+pldm_loader.download_full_image(&writer).await?;
+// SPI flash now has the complete image for future flash boots
+```

--- a/docs/proposals/pldm-flash-image-loading.md
+++ b/docs/proposals/pldm-flash-image-loading.md
@@ -10,7 +10,7 @@ the SPI flash is not updated with the streamed content. This means:
    flash, which may be stale or empty.
 2. Flash and the running firmware are out of sync.
 
-The customer requirement (from meeting notes) is: **when doing streaming
+The customer requirement is: **when doing streaming
 boot, the image should also be written back to SPI flash so flash stays
 consistent with the streamed image.** Flash should act as a "follower"
 copy of the booted image.
@@ -29,144 +29,229 @@ it.
 1. Provide a mechanism to download the **complete flash image** (headers
    + TOC + all image payloads) via PLDM and write it to SPI flash as a
    single contiguous blob.
-2. Reuse the existing image loader and PLDM infrastructure as much as
-   possible.
-3. The recommended flow is: perform streaming boot first (load
-   individual images into memory for immediate execution), then
-   re-download the full flash image and store it to SPI flash so flash
-   is consistent for future flash-based boots.
-4. The solution should work with the existing `FdOps` / PLDM firmware
-   device model.
-
-## Current Architecture
-
-### Streaming Boot (`PldmImageLoader`)
-- Downloads header, TOC, and individual images via PLDM.
-- Each image is DMA'd directly to its target AXI load address.
-- Flash is never written.
-- Uses `StreamingFdOps` which implements `FdOps`.
-
+2. Ensure that the image written to flash is the same as the current tunning one
 
 ## Proposed Design
 
-### Approach: New `download_full_image` API on `PldmImageLoader` with a generic `ImageWriter` trait
+### Approach: Use `FirmwareUpdater` and skip activation
 
-Add a new method to `PldmImageLoader` that downloads the full flash
-image (headers + TOC + all payloads) as a single contiguous blob via
-PLDM and writes each received chunk to a caller-provided `ImageWriter`.
-The `ImageWriter` trait is generic — it is not flash-specific — so
-different backends can be plugged in (SPI flash, memory buffer, etc.).
+The existing `FirmwareUpdater` already handles downloading a complete
+flash image blob via PLDM into a `StagingMemory` backend, followed by
+verification and activation. The key insight is that `StagingMemory` is
+a trait — by providing an implementation backed by SPI flash, the
+`FirmwareUpdater` can write the full image directly to flash.
 
-### New method on `PldmImageLoader`: `download_full_image`
+For the streaming boot + flash persistence use case, the system has
+already booted from memory and does not want to activate (reboot) after
+writing to flash. A new `skip_activation` option on `FirmwareUpdater`
+controls whether the activation step (update Caliptra, update MCU,
+reboot) is executed or skipped.
 
-Add a `download_full_image` method that reuses the existing PLDM
-infrastructure (`StreamingFdOps`, `pldm_client`) but instead of
-loading individual images to AXI load addresses, downloads the
-complete flash image blob and passes each chunk to the `ImageWriter`.
+Additionally, a `verify_same_image` option enables the updater to
+confirm that the downloaded image matches the currently running
+firmware before writing to flash. This is useful for the streaming
+boot + flash persistence flow where the intent is to persist the
+*same* image that was just streamed, not to update to a different one.
 
-This method operates on the same PLDM session that `PldmImageLoader`
-already manages. The UA sends the full flash image as a single PLDM
-component, and the FD writes each received chunk via the writer.
+### Changes to `FirmwareUpdater`
+
+Add `skip_activation` and `verify_same_image` fields that control
+the post-download behavior:
 
 ```rust
-impl<'a, D: DMAMapping + 'static> PldmImageLoader<'a, D> {
-    /// Download the full flash image via PLDM and write it to the
-    /// provided `ImageWriter`.
-    ///
-    /// This downloads the complete flash image blob (FlashHeader +
-    /// all ImageHeaders + all image payloads) as a single contiguous
-    /// transfer and writes each received chunk to `writer`.
-    ///
-    /// This is typically called after streaming boot completes, to
-    /// persist the streamed image to SPI flash for future flash boots.
-    pub async fn download_full_image(
-        &self,
-        writer: &dyn ImageWriter,
-    ) -> Result<(), ErrorCode> {
-        // Initialize a new PLDM session for the full image download
-        pldm_client::initialize_pldm(
-            self.spawner,
-            self.params.descriptors,
-            self.params.fw_params,
-            self.dma_mapping,
-        )
-        .await?;
+pub struct FirmwareUpdater<'a, D: DMAMapping> {
+    staging_memory: &'static dyn StagingMemory,
+    mailbox: Mailbox,
+    params: &'a PldmFirmwareDeviceParams,
+    dma_mapping: &'a D,
+    spawner: Spawner,
+    skip_activation: bool,    // NEW
+    verify_same_image: bool,  // NEW
+}
 
-        // Get the total image size from the PLDM component info
-        let total_size = pldm_client::pldm_get_total_component_size().await?;
+```
 
-        // Prepare the writer (e.g., erase flash)
-        writer.prepare(total_size).await?;
+#### Sequence Diagram
 
-        // Download the full image blob, writing each chunk via the writer
-        let result = pldm_client::pldm_download_full_image(writer).await;
+```mermaid
+sequenceDiagram
+    participant UA as PLDM Update Agent
+    participant MCU as MCU
+    participant Flash as SPI Flash
+    participant Caliptra as Caliptra
 
-        if result.is_err() {
-            self.finalize()?;
-            return Err(ErrorCode::Fail);
+    Note over UA,Caliptra: Runtime SoC Image Loading (streaming boot) completes first
+
+    MCU->>Flash: erase(base_offset, capacity)
+
+    Note over MCU: Start PLDM Download
+    MCU->>UA: initialize_pldm(staging_memory)
+    loop For each PLDM chunk
+        UA->>MCU: firmware data chunk
+        MCU->>Flash: write(base_offset + offset, data)
+    end
+
+    Note over MCU: Download complete
+
+    MCU->>MCU: verify() — validate image integrity
+    MCU->>Flash: read image hashes
+    MCU->>Caliptra: FIRMWARE_VERIFY, VERIFY_AUTH_MANIFEST
+
+    rect rgb(65, 93, 117)
+        Note over MCU,Caliptra: verify_same_image = true
+        MCU->>Flash: read ImageManifest from Caliptra bundle
+        MCU->>MCU: Extract fmc.digest, runtime.digest
+
+        MCU->>Caliptra: FW_INFO command
+        Caliptra-->>MCU: FwInfoResp (fmc_sha384_digest, runtime_sha384_digest)
+        MCU->>MCU: Compare FMC digests
+        MCU->>MCU: Compare RT digests
+
+        loop For each MCU RT / SoC image
+            MCU->>Flash: read image chunks
+            MCU->>MCU: SHA-384 hash image
+            MCU->>MCU: Compare with active auth manifest digest
+        end
+    end
+
+    MCU->>UA: set_verification_result(VerifySuccess)
+    MCU->>UA: pldm_wait(Apply)
+    MCU->>Flash: image_valid(img_len)
+
+    rect rgb(65, 93, 117)
+        Note over MCU: skip_activation = true
+        MCU->>UA: set_apply_result(ApplySuccess)
+        Note over MCU: Return Ok — no activation, no reboot
+    end
+
+    Note over Flash: SPI flash now contains the<br/>verified flash image
+```
+
+### Running Image Verification (`verify_same_image`)
+
+When `verify_same_image` is `true`, the updater compares the downloaded
+images against the currently running firmware to ensure they are
+identical. This check runs after the standard `verify()` step (which
+already validates image integrity) and before the apply step.
+
+#### How digests are obtained for each image type
+
+**Caliptra FMC+RT Bundle:**
+
+The Caliptra FMC+RT bundle contains an `ImageManifest` header (from
+the `caliptra-image-types` crate) which includes `ImageTocEntry`
+fields for both FMC and Runtime, each containing a SHA-384 `digest`
+field:
+
+```rust
+// From caliptra-image-types (already available in the workspace)
+pub struct ImageManifest {
+    pub marker: u32,
+    pub preamble: ImagePreamble,
+    pub header: ImageHeader,
+    pub fmc: ImageTocEntry,     // contains .digest: [u32; 12]
+    pub runtime: ImageTocEntry, // contains .digest: [u32; 12]
+}
+```
+
+The `FW_INFO` mailbox command returns `FwInfoResp` which contains the
+currently running firmware's digests:
+
+```rust
+pub struct FwInfoResp {
+    // ...
+    pub fmc_sha384_digest: [u32; 12],      // running FMC digest
+    pub runtime_sha384_digest: [u32; 12],  // running RT digest
+    // ...
+}
+```
+
+The comparison logic:
+
+1. Read the `ImageManifest` from the downloaded Caliptra FMC+RT bundle
+   in staging memory (the first `IMAGE_MANIFEST_BYTE_SIZE` bytes at
+   the bundle's offset in the flash image).
+2. Extract `manifest.fmc.digest` and `manifest.runtime.digest`.
+3. Call `DeviceState::fw_info()` (which sends the `FW_INFO` mailbox
+   command) to get `fmc_sha384_digest` and `runtime_sha384_digest`
+   from the running Caliptra.
+4. Compare: downloaded FMC digest == running FMC digest, and
+   downloaded RT digest == running RT digest.
+
+**MCU RT and SoC Images:**
+
+The existing `verify()` step already computes SHA-384 hashes of the
+downloaded MCU RT and SoC images (via `verify_mcu_or_soc_image`) and
+compares them against digests in the authorization manifest. For the
+running image comparison, the same computed hashes are compared against
+the digests stored in the currently active authorization manifest on
+Caliptra. The active auth manifest reflects the streaming-boot images,
+so this comparison confirms the downloaded images are identical to what
+was streamed.
+
+
+### New `StagingMemory` implementation: `SpiFlashStagingMemory`
+
+```rust
+// runtime/userspace/api/caliptra-api/src/firmware_update/flash_staging.rs
+
+use caliptra_mcu_libsyscall_caliptra::flash::SpiFlash as FlashSyscall;
+use caliptra_mcu_libtock_platform::ErrorCode;
+use super::StagingMemory;
+
+/// A `StagingMemory` implementation backed by SPI flash.
+///
+/// PLDM firmware data is written directly to flash. This allows the
+/// `FirmwareUpdater` to program a full flash image via the standard
+/// PLDM firmware update flow.
+#[derive(Debug)]
+pub struct SpiFlashStagingMemory {
+    flash: FlashSyscall,
+    base_offset: usize,
+    capacity: usize,
+}
+
+impl SpiFlashStagingMemory {
+    pub fn new(flash: FlashSyscall, base_offset: usize, capacity: usize) -> Self {
+        Self {
+            flash,
+            base_offset,
+            capacity,
         }
+    }
 
-        // Finalize the writer
-        writer.finalize().await?;
+    /// Erase the flash region before starting the download.
+    /// Must be called before `FirmwareUpdater::start()`.
+    pub async fn erase(&self) -> Result<(), ErrorCode> {
+        self.flash.erase(self.base_offset, self.capacity).await
+    }
+}
 
+#[async_trait]
+impl StagingMemory for SpiFlashStagingMemory {
+    async fn write(&self, offset: usize, data: &[u8]) -> Result<(), ErrorCode> {
+        let flash_addr = self.base_offset + offset;
+        self.flash.write(flash_addr, data.len(), data).await
+    }
+
+    async fn read(&self, offset: usize, data: &mut [u8]) -> Result<(), ErrorCode> {
+        let flash_addr = self.base_offset + offset;
+        self.flash.read(flash_addr, data.len(), data).await
+    }
+
+    async fn image_valid(&self, _img_sz: usize) -> Result<(), ErrorCode> {
+        // No-op for flash — validity is confirmed by the
+        // FirmwareUpdater's verification step.
         Ok(())
+    }
+
+    fn size(&self) -> usize {
+        self.capacity
     }
 }
 ```
 
-### New trait: `ImageWriter`
-
-```rust
-// runtime/userspace/api/caliptra-api/src/image_loading/image_writer.rs
-
-use caliptra_mcu_libtock_platform::ErrorCode;
-
-/// A generic writer for receiving a full flash image blob.
-///
-/// Each call to `write` delivers a chunk of the image at the given
-/// offset. Implementations can write to flash, a memory buffer, or
-/// any other storage backend.
-#[async_trait(?Send)]
-pub trait ImageWriter: Send + Sync {
-    /// Prepare the writer for receiving an image of `total_size` bytes.
-    /// Called once before any `write` calls. Implementations can use
-    /// this to erase flash, allocate buffers, etc.
-    async fn prepare(&self, total_size: usize) -> Result<(), ErrorCode>;
-
-    /// Write `data` at `offset` within the image.
-    /// Offsets are relative to the start of the full flash image blob.
-    async fn write(&self, offset: usize, data: &[u8]) -> Result<(), ErrorCode>;
-
-    /// Called once after all data has been written. Implementations
-    /// can use this to finalize (e.g., verify checksums, write a
-    /// validity marker).
-    async fn finalize(&self) -> Result<(), ErrorCode>;
-}
-```
-
-### SPI flash implementation: `FlashImageWriter`
-
 ### Recommended Flow: Streaming Boot, Then Full Flash Image Download
-
-The recommended combined flow is:
-
-```
-1. Streaming boot (PldmImageLoader::load_and_authorize)
-   ├── Download header + TOC via PLDM
-   ├── For each image: download via PLDM → DMA to AXI load address
-   ├── Authorize each image via Caliptra mailbox
-   └── System is now running from memory
-
-2. Full flash image download (PldmImageLoader::download_full_image)
-   ├── Initiate a new PLDM session
-   ├── Writer::prepare() — e.g., erase SPI flash target region
-   ├── Download the complete flash image (headers + TOC + all images)
-   │   as a single contiguous blob → Writer::write() for each chunk
-   ├── Writer::finalize()
-   └── SPI flash now contains the full image for future flash boots
-```
-
-Usage example:
 
 ```rust
 // Phase 1: Streaming boot (existing flow, unchanged)
@@ -179,7 +264,18 @@ pldm_loader.finalize()?;
 
 // Phase 2: Persist the full flash image to SPI flash
 let flash = SpiFlash::new(FLASH_DRIVER_NUM);
-let writer = FlashImageWriter::new(flash, 0);
-pldm_loader.download_full_image(&writer).await?;
-// SPI flash now has the complete image for future flash boots
+let flash_capacity = flash.get_capacity()?.0 as usize;
+let staging = SpiFlashStagingMemory::new(flash, 0, flash_capacity);
+staging.erase().await?;
+
+let mut updater = FirmwareUpdater::new(
+    &staging,
+    &pldm_params,
+    &dma_mapping,
+    spawner,
+);
+updater.set_skip_activation(true);
+updater.set_verify_same_image(true);
+updater.start().await?;
+// SPI flash now has the same image that was streamed
 ```

--- a/docs/proposals/pldm-flash-image-loading.md
+++ b/docs/proposals/pldm-flash-image-loading.md
@@ -127,6 +127,42 @@ sequenceDiagram
     Note over Flash: SPI flash now contains the<br/>verified flash image
 ```
 
+#### SDK Layers Sequence Diagram
+
+The following diagram shows the flow from the application's perspective
+using MCU SDK components. After Runtime SoC Image Loading completes,
+the application has two options:
+
+1. **Flash persistence (streaming boot + write-back)**: Call
+   `FirmwareUpdater` with `SpiFlashStagingMemory` to re-download the
+   full image and write it to flash.
+2. **Hitless update (no flash write)**: Call `FirmwareUpdater` with a
+   custom `StagingMemory` implementation (e.g., `NullStagingMemory`)
+   that discards writes, so the update is applied in-memory without
+   touching flash.
+
+```mermaid
+sequenceDiagram
+    participant App as Application
+    participant IL as ImageLoading
+    participant FU as FirmwareUpdater
+    participant Flash as Flash
+
+    Note over App,Flash: Phase 1: Runtime SoC Image Loading
+
+    Note over App: System is now running from streamed images
+
+        Note over App,Flash: Phase 2a: Re-download full image to flash
+        App->>FU: FirmwareUpdater::new(SpiFlashStagingMemory, skip_activation=true, verify_same_image=true)
+        App->>FU: start()
+        FU->>Flash: write chunks (via StagingMemory trait)
+        FU->>FU: verify()
+        FU->>FU: verify_running_image_match()
+        FU-->>App: Ok
+        Note over Flash: Flash now matches running firmware
+
+```
+
 ### Running Image Verification (`verify_same_image`)
 
 When `verify_same_image` is `true`, the updater compares the downloaded


### PR DESCRIPTION
Add two design proposal documents:

- flash-image-loader-dma-trait.md: Introduces a generic DMATransfer
  trait to allow direct source-to-destination DMA transfers, eliminating
  the intermediate stack buffer copy in FlashImageLoader. Includes a
  BufferedFlashDMA fallback for platforms without direct DMA capability.

- pldm-flash-image-loading.md: Adds a download_full_image API to
  PldmImageLoader with a generic ImageWriter trait, enabling the full
  flash image (headers + TOC + all payloads) to be downloaded via PLDM
  and written to SPI flash after streaming boot. Includes a
  FlashImageWriter implementation for SPI flash.