### PR TITLE
[rom] remove read_fuses and its uses

### DIFF
--- a/rom/src/rom.rs
+++ b/rom/src/rom.rs
@@ -443,20 +443,12 @@ impl Soc {
             romtime::ocp_lock::PermaBitStatus::Unset
         };
 
-        let fuses = otp
-            .read_fuses()
-            .unwrap_or_else(|_| fatal_error(McuError::ROM_OTP_READ_ERROR));
+        let mut seeds = [[0u8; 48]; 8];
+        for (i, seed) in seeds.iter_mut().enumerate() {
+            otp.read_hek_seed(i, seed)
+                .unwrap_or_else(|_| fatal_error(McuError::ROM_OTP_READ_ERROR));
+        }
 
-        let seeds = [
-            &fuses.cptra_ss_lock_hek_prod_0,
-            &fuses.cptra_ss_lock_hek_prod_1,
-            &fuses.cptra_ss_lock_hek_prod_2,
-            &fuses.cptra_ss_lock_hek_prod_3,
-            &fuses.cptra_ss_lock_hek_prod_4,
-            &fuses.cptra_ss_lock_hek_prod_5,
-            &fuses.cptra_ss_lock_hek_prod_6,
-            &fuses.cptra_ss_lock_hek_prod_7,
-        ];
         let total_slots = seeds.len();
 
         let hek_seeds = romtime::ocp_lock::HekSeeds::new(&seeds[..]);

--- a/romtime/src/ocp_lock.rs
+++ b/romtime/src/ocp_lock.rs
@@ -61,11 +61,11 @@ impl AsRef<[u8]> for HekSeed<'_> {
 
 /// A collection of HEK Seed buffers
 pub struct HekSeeds<'a> {
-    bufs: &'a [&'a [u8; 48]],
+    bufs: &'a [[u8; 48]],
 }
 
 impl<'a> HekSeeds<'a> {
-    pub fn new(bufs: &'a [&'a [u8; 48]]) -> Self {
+    pub fn new(bufs: &'a [[u8; 48]]) -> Self {
         Self { bufs }
     }
 
@@ -78,7 +78,7 @@ impl<'a> HekSeeds<'a> {
     }
 
     pub fn get(&self, slot: usize) -> Option<&'a [u8; 48]> {
-        self.bufs.get(slot).copied()
+        self.bufs.get(slot)
     }
 }
 

--- a/romtime/src/otp.rs
+++ b/romtime/src/otp.rs
@@ -4,7 +4,7 @@ use crate::{HexBytes, HexWord, StaticRef};
 use core::fmt::Write;
 use mcu_error::{McuError, McuResult};
 use registers_generated::fuses;
-use registers_generated::fuses::{FuseEntryInfo, Fuses};
+use registers_generated::fuses::FuseEntryInfo;
 use registers_generated::otp_ctrl;
 use tock_registers::interfaces::{Readable, Writeable};
 
@@ -705,6 +705,16 @@ impl Otp {
         )
     }
 
+    /// Read a specific HEK seed partition from OTP.
+    /// index must be between 0 and 7.
+    pub fn read_hek_seed(&self, index: usize, data: &mut [u8; 48]) -> McuResult<()> {
+        if index > 7 {
+            return Err(McuError::ROM_OTP_INVALID_DATA_ERROR);
+        }
+        let offset = HEK_OFFSETS[index];
+        self.read_data(offset, data.len(), data)
+    }
+
     // -------------------------------------------------------------------------
     // Generic fuse entry read/write using generated FuseEntryInfo
     // -------------------------------------------------------------------------
@@ -781,95 +791,6 @@ impl Otp {
     pub fn set_hek_perma(&self) -> McuResult<()> {
         self.write_entry(fuses::PERMA_HEK_EN, 1)?;
         Ok(())
-    }
-
-    pub fn read_fuses(&self) -> McuResult<Fuses> {
-        let mut fuses = Fuses::default();
-
-        crate::println!("[mcu-rom-otp] Reading partitions");
-        self.read_data(
-            fuses::SW_TEST_UNLOCK_PARTITION_BYTE_OFFSET,
-            fuses::SW_TEST_UNLOCK_PARTITION_BYTE_SIZE,
-            &mut fuses.sw_test_unlock_partition,
-        )?;
-        self.read_data(
-            fuses::SW_MANUF_PARTITION_BYTE_OFFSET,
-            fuses::SW_MANUF_PARTITION_BYTE_SIZE,
-            &mut fuses.sw_manuf_partition,
-        )?;
-        self.read_data(
-            fuses::SVN_PARTITION_BYTE_OFFSET,
-            fuses::SVN_PARTITION_BYTE_SIZE,
-            &mut fuses.svn_partition,
-        )?;
-        self.read_data(
-            fuses::VENDOR_TEST_PARTITION_BYTE_OFFSET,
-            fuses::VENDOR_TEST_PARTITION_BYTE_SIZE,
-            &mut fuses.vendor_test_partition,
-        )?;
-        self.read_data(
-            fuses::VENDOR_HASHES_MANUF_PARTITION_BYTE_OFFSET,
-            fuses::VENDOR_HASHES_MANUF_PARTITION_BYTE_SIZE,
-            &mut fuses.vendor_hashes_manuf_partition,
-        )?;
-        // TODO: read these again when the offsets are fixed
-        self.read_data(
-            fuses::VENDOR_HASHES_PROD_PARTITION_BYTE_OFFSET,
-            fuses::VENDOR_HASHES_PROD_PARTITION_BYTE_SIZE,
-            &mut fuses.vendor_hashes_prod_partition,
-        )?;
-        self.read_data(
-            fuses::VENDOR_REVOCATIONS_PROD_PARTITION_BYTE_OFFSET,
-            fuses::VENDOR_REVOCATIONS_PROD_PARTITION_BYTE_SIZE,
-            &mut fuses.vendor_revocations_prod_partition,
-        )?;
-        self.read_data(
-            fuses::CPTRA_SS_LOCK_HEK_PROD_0_BYTE_OFFSET,
-            fuses::CPTRA_SS_LOCK_HEK_PROD_0_BYTE_SIZE,
-            &mut fuses.cptra_ss_lock_hek_prod_0,
-        )?;
-        self.read_data(
-            fuses::CPTRA_SS_LOCK_HEK_PROD_1_BYTE_OFFSET,
-            fuses::CPTRA_SS_LOCK_HEK_PROD_1_BYTE_SIZE,
-            &mut fuses.cptra_ss_lock_hek_prod_1,
-        )?;
-        self.read_data(
-            fuses::CPTRA_SS_LOCK_HEK_PROD_2_BYTE_OFFSET,
-            fuses::CPTRA_SS_LOCK_HEK_PROD_2_BYTE_SIZE,
-            &mut fuses.cptra_ss_lock_hek_prod_2,
-        )?;
-        self.read_data(
-            fuses::CPTRA_SS_LOCK_HEK_PROD_3_BYTE_OFFSET,
-            fuses::CPTRA_SS_LOCK_HEK_PROD_3_BYTE_SIZE,
-            &mut fuses.cptra_ss_lock_hek_prod_3,
-        )?;
-        self.read_data(
-            fuses::CPTRA_SS_LOCK_HEK_PROD_4_BYTE_OFFSET,
-            fuses::CPTRA_SS_LOCK_HEK_PROD_4_BYTE_SIZE,
-            &mut fuses.cptra_ss_lock_hek_prod_4,
-        )?;
-        self.read_data(
-            fuses::CPTRA_SS_LOCK_HEK_PROD_5_BYTE_OFFSET,
-            fuses::CPTRA_SS_LOCK_HEK_PROD_5_BYTE_SIZE,
-            &mut fuses.cptra_ss_lock_hek_prod_5,
-        )?;
-        self.read_data(
-            fuses::CPTRA_SS_LOCK_HEK_PROD_6_BYTE_OFFSET,
-            fuses::CPTRA_SS_LOCK_HEK_PROD_6_BYTE_SIZE,
-            &mut fuses.cptra_ss_lock_hek_prod_6,
-        )?;
-        self.read_data(
-            fuses::CPTRA_SS_LOCK_HEK_PROD_7_BYTE_OFFSET,
-            fuses::CPTRA_SS_LOCK_HEK_PROD_7_BYTE_SIZE,
-            &mut fuses.cptra_ss_lock_hek_prod_7,
-        )?;
-        crate::println!("[mcu-rom-otp] Reading vendor non-secret production partition");
-        self.read_data(
-            fuses::VENDOR_NON_SECRET_PROD_PARTITION_BYTE_OFFSET,
-            fuses::VENDOR_NON_SECRET_PROD_PARTITION_BYTE_SIZE,
-            &mut fuses.vendor_non_secret_prod_partition,
-        )?;
-        Ok(fuses)
     }
 
     /// Compute the software digest of an OTP partition by reading its data


### PR DESCRIPTION
this function allocates many OTP fields onto the stack, using several kilobytes and causing overflows in several test cases