### PR TITLE
[github] remove --no-capture from CI tests

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -350,5 +350,4 @@ jobs:
             --workspace-remap . \
             --test-threads=1 \
             --profile=nightly-emulator \
-            --no-capture \
             --partition hash:${{ matrix.shard }}/4


### PR DESCRIPTION
Cleans up CI output by removing logging of intermediate build steps and console logs on passing tests