### PR TITLE
rom: clarify cold_boot module abstract

### DIFF
--- a/rom/src/cold_boot.rs
+++ b/rom/src/cold_boot.rs
@@ -8,7 +8,8 @@ File Name:
 
 Abstract:
 
-    Cold Boot Flow - Handles initial boot when MCU powers on
+    Cold Boot Flow - Handles initial boot when MCU powers on.
+    Entry point for the MCU reset vector on power-on-reset.
 
 --*/
 


### PR DESCRIPTION
Expands the abstract comment to state that cold_boot.rs is the entry point for the MCU reset vector on power-on-reset, which is not obvious from the function names alone.