### PR TITLE
[auth-cmds] Add authorized command for Caliptra FeProgReq

### DIFF
--- a/common/mcu-mbox/src/messages.rs
+++ b/common/mcu-mbox/src/messages.rs
@@ -122,6 +122,7 @@ impl CommandId {
     // Authorized commands
     pub const MC_ROTATE_VENDOR_PK_HASH: Self = Self(0x4D56_504B); // "MVPK"
     pub const MC_FUSE_INCREASE_CALIPTRA_MIN_SVN: Self = Self(0x4D43_4D53); // "MCMS"
+    pub const MC_FE_PROG: Self = Self(0x4D43_4650); // "MCFP"
 
     // Certificate commands
     pub const MC_EXPORT_ATTESTED_CSR: Self = Self(0x4D45_4143); // "MEAC"
@@ -187,6 +188,7 @@ pub enum McuMailboxReq {
     FuseWrite(FuseWriteReq),
     FuseLockPartition(FuseLockPartitionReq),
     FuseIncreaseCaliptraMinSvn(FuseIncreaseCaliptraMinSvnReq),
+    FeProg(McuFeProgReq),
     // Certificate commands
     ExportAttestedCsr(ExportAttestedCsrReq),
 }
@@ -237,6 +239,7 @@ impl McuMailboxReq {
             McuMailboxReq::FuseWrite(req) => req.as_bytes_partial(),
             McuMailboxReq::FuseLockPartition(req) => Ok(req.as_bytes()),
             McuMailboxReq::FuseIncreaseCaliptraMinSvn(req) => Ok(req.as_bytes()),
+            McuMailboxReq::FeProg(req) => Ok(req.as_bytes()),
             McuMailboxReq::ExportAttestedCsr(req) => Ok(req.as_bytes()),
         }
     }
@@ -286,6 +289,7 @@ impl McuMailboxReq {
             McuMailboxReq::FuseWrite(req) => req.as_bytes_partial_mut(),
             McuMailboxReq::FuseLockPartition(req) => Ok(req.as_mut_bytes()),
             McuMailboxReq::FuseIncreaseCaliptraMinSvn(req) => Ok(req.as_mut_bytes()),
+            McuMailboxReq::FeProg(req) => Ok(req.as_mut_bytes()),
             McuMailboxReq::ExportAttestedCsr(req) => Ok(req.as_mut_bytes()),
         }
     }
@@ -337,6 +341,7 @@ impl McuMailboxReq {
             McuMailboxReq::FuseIncreaseCaliptraMinSvn(_) => {
                 CommandId::MC_FUSE_INCREASE_CALIPTRA_MIN_SVN
             }
+            McuMailboxReq::FeProg(_) => CommandId::MC_FE_PROG,
             McuMailboxReq::ExportAttestedCsr(_) => CommandId::MC_EXPORT_ATTESTED_CSR,
         }
     }
@@ -1387,6 +1392,18 @@ pub struct FuseIncreaseCaliptraMinSvnResp {
     pub hdr: MailboxRespHeader,
 }
 impl Response for FuseIncreaseCaliptraMinSvnResp {}
+
+/// MC_FE_PROG request: Program field entropy.
+#[repr(C)]
+#[derive(Debug, Default, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct McuFeProgReq {
+    pub hdr: MailboxReqHeader,
+    pub partition: u32,
+}
+impl Request for McuFeProgReq {
+    const ID: CommandId = CommandId::MC_FE_PROG;
+    type Resp = FuseWriteResp; // Reuse FuseWriteResp as it only contains header
+}
 
 // ============================================================================
 // MC_EXPORT_ATTESTED_CSR Command (0x4D45_4143 - "MEAC")

--- a/runtime/userspace/api/mcu-mbox-lib/src/cmd_interface.rs
+++ b/runtime/userspace/api/mcu-mbox-lib/src/cmd_interface.rs
@@ -14,12 +14,12 @@ use caliptra_mcu_mbox_common::messages::{
     CommandId, DeviceCapsReq, DeviceCapsResp, DeviceIdReq, DeviceIdResp, DeviceInfoReq,
     DeviceInfoResp, ExportAttestedCsrReq, ExportAttestedCsrResp, FirmwareVersionReq,
     FirmwareVersionResp, FuseIncreaseCaliptraMinSvnReq, FuseIncreaseCaliptraMinSvnResp,
-    MailboxRespHeader, MailboxRespHeaderVarSize, McuAesDecryptInitReq, McuAesDecryptUpdateReq,
-    McuAesEncryptInitReq, McuAesEncryptUpdateReq, McuAesGcmDecryptFinalReq,
+    FuseWriteResp, MailboxRespHeader, MailboxRespHeaderVarSize, McuAesDecryptInitReq,
+    McuAesDecryptUpdateReq, McuAesEncryptInitReq, McuAesEncryptUpdateReq, McuAesGcmDecryptFinalReq,
     McuAesGcmDecryptInitReq, McuAesGcmDecryptUpdateReq, McuAesGcmEncryptFinalReq,
     McuAesGcmEncryptInitReq, McuAesGcmEncryptUpdateReq, McuCmDeleteReq, McuCmImportReq,
     McuCmStatusReq, McuEcdhFinishReq, McuEcdhGenerateReq, McuEcdsaCmkPublicKeyReq,
-    McuEcdsaCmkSignReq, McuEcdsaCmkVerifyReq, McuFipsSelfTestGetResultsReq,
+    McuEcdsaCmkSignReq, McuEcdsaCmkVerifyReq, McuFeProgReq, McuFipsSelfTestGetResultsReq,
     McuFipsSelfTestStartReq, McuHkdfExpandReq, McuHkdfExtractReq, McuHmacKdfCounterReq, McuHmacReq,
     McuProdDebugUnlockReqReq, McuProdDebugUnlockTokenReq, McuRandomGenerateReq, McuRandomStirReq,
     McuResponseVarSize, McuShaFinalReq, McuShaInitReq, McuShaUpdateReq, DEVICE_CAPS_SIZE,
@@ -416,7 +416,8 @@ impl<'a> CmdInterface<'a> {
                 .await
             }
             cmd_id @ CommandId::MC_ROTATE_VENDOR_PK_HASH
-            | cmd_id @ CommandId::MC_FUSE_INCREASE_CALIPTRA_MIN_SVN => {
+            | cmd_id @ CommandId::MC_FUSE_INCREASE_CALIPTRA_MIN_SVN
+            | cmd_id @ CommandId::MC_FE_PROG => {
                 self.handle_authorized_command(cmd_id, req, resp_buf).await
             }
             // Certificate commands
@@ -693,6 +694,7 @@ impl<'a> CmdInterface<'a> {
             CommandId::MC_FUSE_INCREASE_CALIPTRA_MIN_SVN => {
                 self.handle_increase_caliptra_min_svn(cmd, resp_buf).await
             }
+            CommandId::MC_FE_PROG => self.handle_fe_prog(cmd, resp_buf).await,
             _ => Err(MsgHandlerError::UnsupportedCommand),
         }
     }
@@ -785,6 +787,41 @@ impl<'a> CmdInterface<'a> {
         let resp_bytes = resp.as_bytes();
         resp_buf[..resp_bytes.len()].copy_from_slice(resp_bytes);
         Ok((&mut resp_buf[..resp_bytes.len()], MbxCmdStatus::Complete))
+    }
+
+    async fn handle_fe_prog<'r>(
+        &self,
+        req: &[u8],
+        resp_buf: &'r mut [u8],
+    ) -> Result<(&'r mut [u8], MbxCmdStatus), MsgHandlerError> {
+        // Decode the request
+        let req = McuFeProgReq::ref_from_bytes(req).map_err(|_| MsgHandlerError::InvalidParams)?;
+        let (resp, _) =
+            FuseWriteResp::mut_from_prefix(resp_buf).map_err(|_| MsgHandlerError::InvalidParams)?;
+
+        // Prepare Caliptra request
+        let mut caliptra_req = caliptra_api::mailbox::FeProgReq {
+            partition: req.partition,
+            ..Default::default()
+        };
+
+        // Calculate checksum
+        caliptra_req.hdr.chksum =
+            caliptra_api::calc_checksum(CaliptraCommandId::FE_PROG.into(), caliptra_req.as_bytes());
+
+        // Invoke Caliptra mailbox API
+        let _caliptra_resp_len = execute_mailbox_cmd(
+            &self.caliptra_mbox,
+            CaliptraCommandId::FE_PROG.into(),
+            caliptra_req.as_mut_bytes(),
+            resp.as_mut_bytes(),
+        )
+        .await
+        .map_err(|_| MsgHandlerError::McuMboxCommon)?;
+
+        *resp = FuseWriteResp::default();
+        let resp_len = resp.as_bytes().len();
+        Ok((&mut resp_buf[..resp_len], MbxCmdStatus::Complete))
     }
 
     async fn get_caliptra_fw_info(


### PR DESCRIPTION
Defines `MC_FE_PROG` command ID and `McuFeProgReq` struct in `common/mcu-mbox`. Implements `handle_fe_prog` in `mcu-mbox-lib` to pass the command to Caliptra.