### PR TITLE
Add Caliptra VDM command handler for SPDM VDM transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1730,6 +1730,7 @@ dependencies = [
  "async-trait",
  "bitfield",
  "caliptra-api",
+ "caliptra-mcu-external-cmds-common",
  "caliptra-mcu-libapi-caliptra",
  "caliptra-mcu-libsyscall-caliptra",
  "caliptra-mcu-libtock_console",

--- a/runtime/userspace/api/external-cmds-common/src/lib.rs
+++ b/runtime/userspace/api/external-cmds-common/src/lib.rs
@@ -81,7 +81,7 @@ pub struct DeviceCapabilities {
 /// Each function represents a protocol-agnostic command handler. Implementors should provide
 /// the specific logic for each command as required by their application.
 #[async_trait]
-pub trait UnifiedCommandHandler {
+pub trait UnifiedCommandHandler: Send + Sync {
     /// Retrieves the firmware version for the given index.
     ///
     /// # Arguments

--- a/runtime/userspace/api/spdm-lib/Cargo.toml
+++ b/runtime/userspace/api/spdm-lib/Cargo.toml
@@ -12,6 +12,7 @@ async-trait.workspace = true
 bitfield.workspace = true
 caliptra-api.workspace = true
 constant_time_eq.workspace = true
+caliptra-mcu-external-cmds-common.workspace = true
 caliptra-mcu-libapi-caliptra.workspace = true
 caliptra-mcu-libsyscall-caliptra.workspace = true
 caliptra-mcu-libtock_platform.workspace = true

--- a/runtime/userspace/api/spdm-lib/src/vdm_handler/iana/ocp/caliptra_vdm/commands/device_capabilities.rs
+++ b/runtime/userspace/api/spdm-lib/src/vdm_handler/iana/ocp/caliptra_vdm/commands/device_capabilities.rs
@@ -1,0 +1,29 @@
+// Licensed under the Apache-2.0 license
+
+use crate::codec::{encode_u8_slice, Codec, MessageBuf};
+use crate::vdm_handler::iana::ocp::caliptra_vdm::protocol::{
+    CaliptraVdmCmdResult, CaliptraVdmError,
+};
+use crate::vdm_handler::{VdmError, VdmResult};
+use caliptra_mcu_external_cmds_common::{DeviceCapabilities, UnifiedCommandHandler};
+use zerocopy::IntoBytes;
+
+pub(crate) async fn handle_device_capabilities(
+    handler: &dyn UnifiedCommandHandler,
+    _req_buf: &mut MessageBuf<'_>,
+    rsp_buf: &mut MessageBuf<'_>,
+) -> VdmResult<CaliptraVdmCmdResult> {
+    let mut caps = DeviceCapabilities::default();
+    match handler.get_device_capabilities(&mut caps).await {
+        Ok(()) => {
+            let mut len = (CaliptraVdmError::Success as u8)
+                .encode(rsp_buf)
+                .map_err(VdmError::Codec)?;
+            len += encode_u8_slice(caps.as_bytes(), rsp_buf).map_err(VdmError::Codec)?;
+            Ok(CaliptraVdmCmdResult::Response(len))
+        }
+        Err(_) => Ok(CaliptraVdmCmdResult::ErrorResponse(
+            CaliptraVdmError::GeneralError,
+        )),
+    }
+}

--- a/runtime/userspace/api/spdm-lib/src/vdm_handler/iana/ocp/caliptra_vdm/commands/device_id.rs
+++ b/runtime/userspace/api/spdm-lib/src/vdm_handler/iana/ocp/caliptra_vdm/commands/device_id.rs
@@ -1,0 +1,43 @@
+// Licensed under the Apache-2.0 license
+
+use crate::codec::{Codec, MessageBuf};
+use crate::vdm_handler::iana::ocp::caliptra_vdm::protocol::{
+    CaliptraVdmCmdResult, CaliptraVdmError,
+};
+use crate::vdm_handler::{VdmError, VdmResult};
+use caliptra_mcu_external_cmds_common::{DeviceId, UnifiedCommandHandler};
+
+pub(crate) async fn handle_device_id(
+    handler: &dyn UnifiedCommandHandler,
+    _req_buf: &mut MessageBuf<'_>,
+    rsp_buf: &mut MessageBuf<'_>,
+) -> VdmResult<CaliptraVdmCmdResult> {
+    let mut device_id = DeviceId::default();
+    match handler.get_device_id(&mut device_id).await {
+        Ok(()) => {
+            let mut len = (CaliptraVdmError::Success as u8)
+                .encode(rsp_buf)
+                .map_err(VdmError::Codec)?;
+            len += device_id
+                .vendor_id
+                .encode(rsp_buf)
+                .map_err(VdmError::Codec)?;
+            len += device_id
+                .device_id
+                .encode(rsp_buf)
+                .map_err(VdmError::Codec)?;
+            len += device_id
+                .subsystem_vendor_id
+                .encode(rsp_buf)
+                .map_err(VdmError::Codec)?;
+            len += device_id
+                .subsystem_id
+                .encode(rsp_buf)
+                .map_err(VdmError::Codec)?;
+            Ok(CaliptraVdmCmdResult::Response(len))
+        }
+        Err(_) => Ok(CaliptraVdmCmdResult::ErrorResponse(
+            CaliptraVdmError::GeneralError,
+        )),
+    }
+}

--- a/runtime/userspace/api/spdm-lib/src/vdm_handler/iana/ocp/caliptra_vdm/commands/device_info.rs
+++ b/runtime/userspace/api/spdm-lib/src/vdm_handler/iana/ocp/caliptra_vdm/commands/device_info.rs
@@ -1,0 +1,42 @@
+// Licensed under the Apache-2.0 license
+
+use crate::codec::{encode_u8_slice, Codec, CommonCodec, MessageBuf};
+use crate::vdm_handler::iana::ocp::caliptra_vdm::protocol::{
+    CaliptraVdmCmdResult, CaliptraVdmError,
+};
+use crate::vdm_handler::{VdmError, VdmResult};
+use caliptra_mcu_external_cmds_common::{DeviceInfo, Uid, UnifiedCommandHandler, MAX_UID_LEN};
+use zerocopy::{FromBytes, Immutable, IntoBytes};
+
+#[derive(FromBytes, IntoBytes, Immutable)]
+#[repr(C)]
+struct DeviceInfoReq {
+    info_index: u32,
+}
+
+impl CommonCodec for DeviceInfoReq {}
+
+pub(crate) async fn handle_device_info(
+    handler: &dyn UnifiedCommandHandler,
+    req_buf: &mut MessageBuf<'_>,
+    rsp_buf: &mut MessageBuf<'_>,
+) -> VdmResult<CaliptraVdmCmdResult> {
+    let req = DeviceInfoReq::decode(req_buf).map_err(VdmError::Codec)?;
+
+    let mut info = DeviceInfo::Uid(Uid::default());
+    match handler.get_device_info(req.info_index, &mut info).await {
+        Ok(()) => {
+            let DeviceInfo::Uid(uid) = &info;
+            let data_len = uid.len.min(MAX_UID_LEN);
+            let mut len = (CaliptraVdmError::Success as u8)
+                .encode(rsp_buf)
+                .map_err(VdmError::Codec)?;
+            len += encode_u8_slice(&uid.unique_chip_id[..data_len], rsp_buf)
+                .map_err(VdmError::Codec)?;
+            Ok(CaliptraVdmCmdResult::Response(len))
+        }
+        Err(_) => Ok(CaliptraVdmCmdResult::ErrorResponse(
+            CaliptraVdmError::InvalidData,
+        )),
+    }
+}

--- a/runtime/userspace/api/spdm-lib/src/vdm_handler/iana/ocp/caliptra_vdm/commands/export_attested_csr.rs
+++ b/runtime/userspace/api/spdm-lib/src/vdm_handler/iana/ocp/caliptra_vdm/commands/export_attested_csr.rs
@@ -1,0 +1,56 @@
+// Licensed under the Apache-2.0 license
+
+use crate::codec::{encode_u8_slice, Codec, CommonCodec, MessageBuf};
+use crate::vdm_handler::iana::ocp::caliptra_vdm::protocol::{
+    CaliptraVdmCmdResult, CaliptraVdmError,
+};
+use crate::vdm_handler::{VdmError, VdmResult};
+use caliptra_mcu_external_cmds_common::{
+    AttestedCsrData, CommandError, UnifiedCommandHandler, MAX_ATTESTED_CSR_DATA_LEN,
+};
+use zerocopy::{FromBytes, Immutable, IntoBytes};
+
+#[derive(FromBytes, IntoBytes, Immutable)]
+#[repr(C)]
+struct ExportAttestedCsrReq {
+    device_key_id: u32,
+    algorithm: u32,
+}
+
+impl CommonCodec for ExportAttestedCsrReq {}
+
+pub(crate) async fn handle_export_attested_csr(
+    handler: &dyn UnifiedCommandHandler,
+    req_buf: &mut MessageBuf<'_>,
+    rsp_buf: &mut MessageBuf<'_>,
+) -> VdmResult<CaliptraVdmCmdResult> {
+    let req = ExportAttestedCsrReq::decode(req_buf).map_err(VdmError::Codec)?;
+
+    let mut csr_data = AttestedCsrData::default();
+    match handler
+        .export_attested_csr(req.device_key_id, req.algorithm, &mut csr_data)
+        .await
+    {
+        Ok(()) => {
+            let data_len = csr_data.len.min(MAX_ATTESTED_CSR_DATA_LEN);
+            let mut len = (CaliptraVdmError::Success as u8)
+                .encode(rsp_buf)
+                .map_err(VdmError::Codec)?;
+            len += (data_len as u32).encode(rsp_buf).map_err(VdmError::Codec)?;
+            len += encode_u8_slice(&csr_data.data[..data_len], rsp_buf).map_err(VdmError::Codec)?;
+            Ok(CaliptraVdmCmdResult::Response(len))
+        }
+        Err(CommandError::InvalidParams) => Ok(CaliptraVdmCmdResult::ErrorResponse(
+            CaliptraVdmError::InvalidData,
+        )),
+        Err(CommandError::NotSupported) => Ok(CaliptraVdmCmdResult::ErrorResponse(
+            CaliptraVdmError::InvalidCommand,
+        )),
+        Err(CommandError::Busy) => Ok(CaliptraVdmCmdResult::ErrorResponse(
+            CaliptraVdmError::NotReady,
+        )),
+        Err(_) => Ok(CaliptraVdmCmdResult::ErrorResponse(
+            CaliptraVdmError::GeneralError,
+        )),
+    }
+}

--- a/runtime/userspace/api/spdm-lib/src/vdm_handler/iana/ocp/caliptra_vdm/commands/firmware_version.rs
+++ b/runtime/userspace/api/spdm-lib/src/vdm_handler/iana/ocp/caliptra_vdm/commands/firmware_version.rs
@@ -1,0 +1,43 @@
+// Licensed under the Apache-2.0 license
+
+use crate::codec::{encode_u8_slice, Codec, CommonCodec, MessageBuf};
+use crate::vdm_handler::iana::ocp::caliptra_vdm::protocol::{
+    CaliptraVdmCmdResult, CaliptraVdmError,
+};
+use crate::vdm_handler::{VdmError, VdmResult};
+use caliptra_mcu_external_cmds_common::{FirmwareVersion, UnifiedCommandHandler};
+use zerocopy::{FromBytes, Immutable, IntoBytes};
+
+#[derive(FromBytes, IntoBytes, Immutable)]
+#[repr(C)]
+struct FirmwareVersionReq {
+    area_index: u32,
+}
+
+impl CommonCodec for FirmwareVersionReq {}
+
+pub(crate) async fn handle_firmware_version(
+    handler: &dyn UnifiedCommandHandler,
+    req_buf: &mut MessageBuf<'_>,
+    rsp_buf: &mut MessageBuf<'_>,
+) -> VdmResult<CaliptraVdmCmdResult> {
+    let req = FirmwareVersionReq::decode(req_buf).map_err(VdmError::Codec)?;
+
+    let mut version = FirmwareVersion::default();
+    match handler
+        .get_firmware_version(req.area_index, &mut version)
+        .await
+    {
+        Ok(()) => {
+            let mut len = (CaliptraVdmError::Success as u8)
+                .encode(rsp_buf)
+                .map_err(VdmError::Codec)?;
+            len += encode_u8_slice(&version.ver_str[..version.len], rsp_buf)
+                .map_err(VdmError::Codec)?;
+            Ok(CaliptraVdmCmdResult::Response(len))
+        }
+        Err(_) => Ok(CaliptraVdmCmdResult::ErrorResponse(
+            CaliptraVdmError::InvalidData,
+        )),
+    }
+}

--- a/runtime/userspace/api/spdm-lib/src/vdm_handler/iana/ocp/caliptra_vdm/commands/mod.rs
+++ b/runtime/userspace/api/spdm-lib/src/vdm_handler/iana/ocp/caliptra_vdm/commands/mod.rs
@@ -1,0 +1,7 @@
+// Licensed under the Apache-2.0 license
+
+pub(crate) mod device_capabilities;
+pub(crate) mod device_id;
+pub(crate) mod device_info;
+pub(crate) mod export_attested_csr;
+pub(crate) mod firmware_version;

--- a/runtime/userspace/api/spdm-lib/src/vdm_handler/iana/ocp/caliptra_vdm/mod.rs
+++ b/runtime/userspace/api/spdm-lib/src/vdm_handler/iana/ocp/caliptra_vdm/mod.rs
@@ -1,0 +1,105 @@
+// Licensed under the Apache-2.0 license
+
+extern crate alloc;
+
+use crate::codec::{Codec, MessageBuf};
+use crate::protocol::StandardsBodyId;
+use crate::vdm_handler::iana::ocp::caliptra_vdm::commands::{
+    device_capabilities, device_id, device_info, export_attested_csr, firmware_version,
+};
+use crate::vdm_handler::iana::ocp::caliptra_vdm::protocol::*;
+use crate::vdm_handler::{VdmError, VdmHandler, VdmRegistryMatcher, VdmResponder, VdmResult};
+use alloc::boxed::Box;
+use async_trait::async_trait;
+use caliptra_mcu_external_cmds_common::UnifiedCommandHandler;
+
+pub(crate) mod commands;
+pub mod protocol;
+
+pub struct CaliptraVdmHandler<'a> {
+    handler: &'a dyn UnifiedCommandHandler,
+}
+
+impl<'a> CaliptraVdmHandler<'a> {
+    #[allow(dead_code)]
+    pub fn new(handler: &'a dyn UnifiedCommandHandler) -> Self {
+        Self { handler }
+    }
+}
+
+impl VdmRegistryMatcher for CaliptraVdmHandler<'_> {
+    fn match_id(
+        &self,
+        standard_id: StandardsBodyId,
+        vendor_id: &[u8],
+        _secure_session: bool,
+    ) -> bool {
+        standard_id == StandardsBodyId::Iana
+            && vendor_id.len() == 2
+            && u16::from_le_bytes([vendor_id[0], vendor_id[1]]) == OCP_VENDOR_ID
+    }
+}
+
+#[async_trait]
+impl VdmResponder for CaliptraVdmHandler<'_> {
+    async fn handle_request(
+        &mut self,
+        req_buf: &mut MessageBuf<'_>,
+        rsp_buf: &mut MessageBuf<'_>,
+    ) -> VdmResult<usize> {
+        // Decode command header [command_version, command_code]
+        let hdr = CaliptraVdmMsgHeader::decode(req_buf).map_err(VdmError::Codec)?;
+
+        if hdr.command_version != CALIPTRA_VDM_COMMAND_VERSION {
+            return Err(VdmError::UnsupportedRequest);
+        }
+
+        let command = CaliptraVdmCommand::try_from(hdr.command_code)?;
+
+        // Reserve space for response header
+        let rsp_hdr_len = size_of::<CaliptraVdmMsgHeader>();
+        rsp_buf.reserve(rsp_hdr_len).map_err(VdmError::Codec)?;
+
+        let result = match command {
+            CaliptraVdmCommand::FirmwareVersion => {
+                firmware_version::handle_firmware_version(self.handler, req_buf, rsp_buf).await?
+            }
+            CaliptraVdmCommand::DeviceCapabilities => {
+                device_capabilities::handle_device_capabilities(self.handler, req_buf, rsp_buf)
+                    .await?
+            }
+            CaliptraVdmCommand::DeviceId => {
+                device_id::handle_device_id(self.handler, req_buf, rsp_buf).await?
+            }
+            CaliptraVdmCommand::DeviceInfo => {
+                device_info::handle_device_info(self.handler, req_buf, rsp_buf).await?
+            }
+            CaliptraVdmCommand::ExportAttestedCsr => {
+                export_attested_csr::handle_export_attested_csr(self.handler, req_buf, rsp_buf)
+                    .await?
+            }
+            _ => CaliptraVdmCmdResult::ErrorResponse(CaliptraVdmError::InvalidCommand),
+        };
+
+        let rsp_hdr = CaliptraVdmMsgHeader {
+            command_version: CALIPTRA_VDM_COMMAND_VERSION,
+            command_code: command.response_code(),
+        };
+
+        let len = match result {
+            CaliptraVdmCmdResult::Response(payload_len) => {
+                let hdr_len = rsp_hdr.encode(rsp_buf).map_err(VdmError::Codec)?;
+                payload_len + hdr_len
+            }
+            CaliptraVdmCmdResult::ErrorResponse(error) => {
+                let payload_len = (error as u8).encode(rsp_buf).map_err(VdmError::Codec)?;
+                let hdr_len = rsp_hdr.encode(rsp_buf).map_err(VdmError::Codec)?;
+                payload_len + hdr_len
+            }
+        };
+
+        Ok(len)
+    }
+}
+
+impl VdmHandler for CaliptraVdmHandler<'_> {}

--- a/runtime/userspace/api/spdm-lib/src/vdm_handler/iana/ocp/caliptra_vdm/protocol.rs
+++ b/runtime/userspace/api/spdm-lib/src/vdm_handler/iana/ocp/caliptra_vdm/protocol.rs
@@ -1,0 +1,132 @@
+// Licensed under the Apache-2.0 license
+
+use crate::codec::{CommonCodec, DataKind};
+use crate::vdm_handler::VdmError;
+use zerocopy::{FromBytes, Immutable, IntoBytes};
+
+/// OCP Vendor ID for Caliptra Working Group (IANA assigned).
+pub const OCP_VENDOR_ID: u16 = 42623; // 0xA67F
+
+/// Caliptra VDM command version (first byte of every VDM payload).
+pub const CALIPTRA_VDM_COMMAND_VERSION: u8 = 0x01;
+
+/// Caliptra VDM command codes as defined in the OCP registry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum CaliptraVdmCommand {
+    FirmwareVersion = 0x01,
+    DeviceCapabilities = 0x02,
+    DeviceId = 0x03,
+    DeviceInfo = 0x04,
+    GetDebugLog = 0x05,
+    ClearDebugLog = 0x06,
+    GetAttestationLog = 0x07,
+    ClearAttestationLog = 0x08,
+    GetAttestation = 0x09,
+    RequestDebugUnlock = 0x0A,
+    AuthorizeDebugUnlockToken = 0x0B,
+    ExportIdevidCsr = 0x0C,
+    SetSlot0Cert = 0x0D,
+    GetSlot0State = 0x0E,
+    ExportAttestedCsr = 0x0F,
+    ProgramFieldEntropy = 0x10,
+    DeviceOwnershipTransfer = 0x11,
+}
+
+impl TryFrom<u8> for CaliptraVdmCommand {
+    type Error = VdmError;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0x01 => Ok(Self::FirmwareVersion),
+            0x02 => Ok(Self::DeviceCapabilities),
+            0x03 => Ok(Self::DeviceId),
+            0x04 => Ok(Self::DeviceInfo),
+            0x05 => Ok(Self::GetDebugLog),
+            0x06 => Ok(Self::ClearDebugLog),
+            0x07 => Ok(Self::GetAttestationLog),
+            0x08 => Ok(Self::ClearAttestationLog),
+            0x09 => Ok(Self::GetAttestation),
+            0x0A => Ok(Self::RequestDebugUnlock),
+            0x0B => Ok(Self::AuthorizeDebugUnlockToken),
+            0x0C => Ok(Self::ExportIdevidCsr),
+            0x0D => Ok(Self::SetSlot0Cert),
+            0x0E => Ok(Self::GetSlot0State),
+            0x0F => Ok(Self::ExportAttestedCsr),
+            0x10 => Ok(Self::ProgramFieldEntropy),
+            0x11 => Ok(Self::DeviceOwnershipTransfer),
+            _ => Err(VdmError::InvalidVdmCommand),
+        }
+    }
+}
+
+impl CaliptraVdmCommand {
+    pub fn response_code(self) -> u8 {
+        self as u8
+    }
+}
+
+/// Caliptra VDM error codes (completion codes in response payload).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+#[allow(dead_code)]
+pub enum CaliptraVdmError {
+    Success = 0x00,
+    InvalidCommand = 0x01,
+    InvalidLength = 0x02,
+    NotReady = 0x03,
+    InvalidData = 0x04,
+    GeneralError = 0x05,
+}
+
+/// Caliptra VDM message header: [command_version, command_code].
+#[derive(FromBytes, IntoBytes, Immutable, Debug)]
+#[repr(C)]
+pub struct CaliptraVdmMsgHeader {
+    pub command_version: u8,
+    pub command_code: u8,
+}
+
+impl CommonCodec for CaliptraVdmMsgHeader {
+    const DATA_KIND: DataKind = DataKind::Header;
+}
+
+impl CaliptraVdmMsgHeader {
+    #[allow(dead_code)]
+    pub fn new_request(command: CaliptraVdmCommand) -> Self {
+        Self {
+            command_version: CALIPTRA_VDM_COMMAND_VERSION,
+            command_code: command as u8,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn new_response(command: CaliptraVdmCommand) -> Self {
+        Self {
+            command_version: CALIPTRA_VDM_COMMAND_VERSION,
+            command_code: command.response_code(),
+        }
+    }
+}
+
+/// Result type for individual command handlers.
+pub enum CaliptraVdmCmdResult {
+    Response(usize),
+    ErrorResponse(CaliptraVdmError),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_command_roundtrip() {
+        for code in 0x01u8..=0x11 {
+            let cmd = CaliptraVdmCommand::try_from(code).unwrap();
+            assert_eq!(cmd as u8, code);
+        }
+        assert!(CaliptraVdmCommand::try_from(0x00).is_err());
+        assert!(CaliptraVdmCommand::try_from(0x12).is_err());
+        assert!(CaliptraVdmCommand::try_from(0xFF).is_err());
+    }
+}

--- a/runtime/userspace/api/spdm-lib/src/vdm_handler/iana/ocp/mod.rs
+++ b/runtime/userspace/api/spdm-lib/src/vdm_handler/iana/ocp/mod.rs
@@ -1,4 +1,5 @@
 // Licensed under the Apache-2.0 license
 
+pub mod caliptra_vdm;
 pub(crate) mod envelope_signed_csr_rsp;
 pub(crate) mod get_eat_rsp;


### PR DESCRIPTION
- CaliptraVdmHandler matches IANA StandardID + OCP Vendor ID 42623 and dispatches CaliptraVdmCommand (0x01-0x11) to per-command handlers
- Each handler decodes the VDM request, delegates to UnifiedCommandHandler, and encodes the VDM response
- Implemented: firmware_version, device_capabilities, device_id, device_info, export_attested_csr