### PR TITLE
image_loading: introduce DmaTransfer trait for FlashImageLoader

### DIFF
--- a/platforms/emulator/runtime/userspace/apps/user/src/image_loader/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/image_loader/mod.rs
@@ -1,5 +1,8 @@
 // Licensed under the Apache-2.0 license
 
+extern crate alloc;
+use alloc::boxed::Box;
+
 #[cfg(any(
     feature = "test-pldm-discovery",
     feature = "test-pldm-fw-update",
@@ -9,6 +12,7 @@ mod pldm_fdops_mock;
 
 mod config;
 
+use async_trait::async_trait;
 use caliptra_api::mailbox::{
     ActivateFirmwareReq, ActivateFirmwareResp, CommandId, MailboxReqHeader,
 };
@@ -40,7 +44,8 @@ use core::fmt::Write;
 use crate::EXECUTOR;
 #[allow(unused)]
 use caliptra_mcu_libapi_caliptra::image_loading::{
-    FlashImageLoader, ImageLoader, PldmFirmwareDeviceParams, PldmImageLoader,
+    dma_transfer::DmaTransfer, FlashImageLoader, ImageLoader, PldmFirmwareDeviceParams,
+    PldmImageLoader,
 };
 use caliptra_mcu_libsyscall_caliptra::DefaultSyscalls;
 #[allow(unused)]
@@ -176,8 +181,10 @@ async fn image_loading<D: DMAMapping>(dma_mapping: &'static D) -> Result<(), Err
             active
         };
 
+        let buffered_dma =
+            FlashReaderDma::new(SpiFlash::new(load_partition.1.driver_num), dma_mapping);
         let flash_syscall = SpiFlash::new(load_partition.1.driver_num);
-        let flash_image_loader = FlashImageLoader::new(flash_syscall, dma_mapping);
+        let flash_image_loader = FlashImageLoader::new(flash_syscall, &buffered_dma);
 
         if let Some(pending) = pending {
             // Set the new Auth Manifest from the pending partition
@@ -279,3 +286,62 @@ impl DMAMapping for EmulatedDMAMap {
 
 #[allow(dead_code)]
 pub static EMULATED_DMA_MAPPING: EmulatedDMAMap = EmulatedDMAMap {};
+
+/// This is the size of the buffer used for DMA transfers.
+const MAX_DMA_TRANSFER_SIZE: usize = 128;
+
+/// Flash-backed DmaTransfer that buffers through SRAM.
+/// Reads from SPI flash into a stack buffer, then
+/// DMAs from the buffer to the destination.
+pub struct FlashReaderDma<D: DMAMapping + 'static> {
+    flash: SpiFlash,
+    dma_mapping: &'static D,
+}
+
+#[allow(dead_code)]
+impl<D: DMAMapping + 'static> FlashReaderDma<D> {
+    pub fn new(flash: SpiFlash, dma_mapping: &'static D) -> Self {
+        Self { flash, dma_mapping }
+    }
+}
+
+impl<D: DMAMapping + 'static> DMAMapping for FlashReaderDma<D> {
+    fn mcu_sram_to_mcu_axi(&self, sram_addr: u32) -> Result<AXIAddr, ErrorCode> {
+        self.dma_mapping.mcu_sram_to_mcu_axi(sram_addr)
+    }
+
+    fn cptra_axi_to_mcu_axi(&self, cptra_addr: u64) -> Result<AXIAddr, ErrorCode> {
+        self.dma_mapping.cptra_axi_to_mcu_axi(cptra_addr)
+    }
+}
+
+#[async_trait(?Send)]
+impl<D: DMAMapping + 'static> DmaTransfer for FlashReaderDma<D> {
+    fn max_transfer_size(&self) -> usize {
+        MAX_DMA_TRANSFER_SIZE
+    }
+
+    async fn transfer(
+        &self,
+        src_offset: usize,
+        dest_addr: AXIAddr,
+        length: usize,
+    ) -> Result<(), ErrorCode> {
+        use caliptra_mcu_libsyscall_caliptra::dma::{DMASource, DMATransaction, DMA as DMASyscall};
+        let dma_syscall: DMASyscall = DMASyscall::new();
+        let mut buffer = [0u8; MAX_DMA_TRANSFER_SIZE];
+        self.flash
+            .read(src_offset, length, &mut buffer[..length])
+            .await?;
+        let source_address = self
+            .dma_mapping
+            .mcu_sram_to_mcu_axi(buffer.as_ptr() as u32)?;
+        dma_syscall
+            .xfer(&DMATransaction {
+                byte_count: length,
+                source: DMASource::Address(source_address),
+                dest_addr,
+            })
+            .await
+    }
+}

--- a/runtime/userspace/api/caliptra-api/src/image_loading/dma_transfer.rs
+++ b/runtime/userspace/api/caliptra-api/src/image_loading/dma_transfer.rs
@@ -1,0 +1,30 @@
+// Licensed under the Apache-2.0 license
+
+extern crate alloc;
+use alloc::boxed::Box;
+
+use async_trait::async_trait;
+use caliptra_mcu_libsyscall_caliptra::dma::{AXIAddr, DMAMapping};
+use caliptra_mcu_libtock_platform::ErrorCode;
+
+/// Generic trait for performing source-to-destination DMA transfers.
+///
+/// This trait abstracts the transfer of data from a source (identified
+/// by offset) to an AXI destination address. Implementations can use
+/// any transfer mechanism: direct DMA from a peripheral, buffered
+/// copy through SRAM, memory-to-memory DMA, etc.
+#[async_trait(?Send)]
+pub trait DmaTransfer: DMAMapping {
+    /// The maximum number of bytes that can be transferred in a single
+    /// operation. The caller will chunk transfers to this size.
+    fn max_transfer_size(&self) -> usize;
+
+    /// Transfer `length` bytes starting at `src_offset` in the source
+    /// directly to `dest_addr` on the AXI bus.
+    async fn transfer(
+        &self,
+        src_offset: usize,
+        dest_addr: AXIAddr,
+        length: usize,
+    ) -> Result<(), ErrorCode>;
+}

--- a/runtime/userspace/api/caliptra-api/src/image_loading/flash_client.rs
+++ b/runtime/userspace/api/caliptra-api/src/image_loading/flash_client.rs
@@ -1,16 +1,13 @@
 // Licensed under the Apache-2.0 license
 
 use caliptra_mcu_flash_image::{FlashHeader, ImageHeader};
-use caliptra_mcu_libsyscall_caliptra::dma::{
-    AXIAddr, DMAMapping, DMASource, DMATransaction, DMA as DMASyscall,
-};
+use caliptra_mcu_libsyscall_caliptra::dma::AXIAddr;
 use caliptra_mcu_libtock_platform::ErrorCode;
 use zerocopy::FromBytes;
 
 use caliptra_mcu_libsyscall_caliptra::flash::SpiFlash as FlashSyscall;
 
-/// This is the size of the buffer used for DMA transfers.
-const MAX_DMA_TRANSFER_SIZE: usize = 128;
+use super::dma_transfer::DmaTransfer;
 
 const FLASH_HEADER_OFFSET: usize = 0;
 
@@ -52,31 +49,21 @@ pub async fn flash_read_toc(
 }
 
 pub async fn flash_load_image(
-    flash: &FlashSyscall,
+    dma_transfer: &impl DmaTransfer,
     load_address: AXIAddr,
     offset: usize,
     img_size: usize,
-    dma_mapping: &impl DMAMapping,
 ) -> Result<(), ErrorCode> {
-    let dma_syscall: DMASyscall = DMASyscall::new();
+    let max_xfer = dma_transfer.max_transfer_size();
     let mut remaining_size = img_size;
     let mut current_offset = offset;
     let mut current_address = load_address;
 
     while remaining_size > 0 {
-        let transfer_size = remaining_size.min(MAX_DMA_TRANSFER_SIZE);
-        let mut buffer = [0; MAX_DMA_TRANSFER_SIZE];
-        flash
-            .read(current_offset, transfer_size, &mut buffer)
+        let transfer_size = remaining_size.min(max_xfer);
+        dma_transfer
+            .transfer(current_offset, current_address, transfer_size)
             .await?;
-
-        let source_address = dma_mapping.mcu_sram_to_mcu_axi(buffer.as_ptr() as u32)?;
-        let transaction = DMATransaction {
-            byte_count: transfer_size,
-            source: DMASource::Address(source_address),
-            dest_addr: current_address,
-        };
-        dma_syscall.xfer(&transaction).await?;
         remaining_size -= transfer_size;
         current_offset += transfer_size;
         current_address += transfer_size as u64;

--- a/runtime/userspace/api/caliptra-api/src/image_loading/mod.rs
+++ b/runtime/userspace/api/caliptra-api/src/image_loading/mod.rs
@@ -1,6 +1,7 @@
 // Licensed under the Apache-2.0 license
 
 extern crate alloc;
+pub mod dma_transfer;
 mod flash_client;
 mod pldm_client;
 mod pldm_context;
@@ -18,11 +19,13 @@ use caliptra_mcu_libsyscall_caliptra::flash::SpiFlash as FlashSyscall;
 use caliptra_mcu_libsyscall_caliptra::mailbox::{MailboxError, PayloadStream};
 use caliptra_mcu_libsyscall_caliptra::{dma::AXIAddr, mailbox::Mailbox};
 use caliptra_mcu_libtock_platform::ErrorCode;
+
 use caliptra_mcu_libtockasync::TockExecutor;
 use caliptra_mcu_pldm_common::message::firmware_update::get_fw_params::FirmwareParameters;
 use caliptra_mcu_pldm_common::message::firmware_update::verify_complete::VerifyResult;
 use caliptra_mcu_pldm_common::protocol::firmware_update::Descriptor;
 use caliptra_mcu_pldm_lib::daemon::PldmService;
+use dma_transfer::DmaTransfer;
 use embassy_executor::Spawner;
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
@@ -46,10 +49,10 @@ pub trait ImageLoader {
     async fn load_and_authorize(&self, image_id: u32) -> Result<(), ErrorCode>;
 }
 
-pub struct FlashImageLoader<D: DMAMapping + 'static> {
+pub struct FlashImageLoader<'a, T: DmaTransfer> {
     mailbox: Mailbox,
     flash: FlashSyscall,
-    dma_mapping: &'static D,
+    dma_transfer: &'a T,
 }
 
 pub struct PldmImageLoader<'a, D: DMAMapping + 'static> {
@@ -65,22 +68,22 @@ pub struct PldmFirmwareDeviceParams<'a> {
     pub fw_params: &'a FirmwareParameters,
 }
 
-impl<D: DMAMapping + 'static> FlashImageLoader<D> {
-    pub fn new(flash_syscall: FlashSyscall, dma_mapping: &'static D) -> Self {
+impl<'a, T: DmaTransfer> FlashImageLoader<'a, T> {
+    pub fn new(flash_syscall: FlashSyscall, dma_transfer: &'a T) -> Self {
         Self {
             mailbox: Mailbox::new(),
             flash: flash_syscall,
-            dma_mapping,
+            dma_transfer,
         }
     }
 }
 
 #[async_trait(?Send)]
-impl<D: DMAMapping + 'static> ImageLoader for FlashImageLoader<D> {
+impl<T: DmaTransfer> ImageLoader for FlashImageLoader<'_, T> {
     async fn load_and_authorize(&self, image_id: u32) -> Result<(), ErrorCode> {
         let image_info = get_image_info(&self.mailbox, image_id).await?;
         let load_address = convert_dma_cptra_addr_to_mcu_addr(
-            self.dma_mapping,
+            self.dma_transfer,
             ((image_info.image_load_address_high as u64) << 32)
                 | (image_info.image_load_address_low as u64),
         )?;
@@ -90,11 +93,10 @@ impl<D: DMAMapping + 'static> ImageLoader for FlashImageLoader<D> {
         let (offset, size) =
             flash_client::flash_read_toc(&self.flash, &header, image_info.component_id).await?;
         flash_client::flash_load_image(
-            &self.flash,
+            self.dma_transfer,
             load_address,
             offset as usize,
             size as usize,
-            self.dma_mapping,
         )
         .await?;
         authorize_image(&self.mailbox, image_id, size).await?;
@@ -102,7 +104,7 @@ impl<D: DMAMapping + 'static> ImageLoader for FlashImageLoader<D> {
     }
 }
 
-impl<D: DMAMapping + 'static> FlashImageLoader<D> {
+impl<T: DmaTransfer> FlashImageLoader<'_, T> {
     pub async fn set_auth_manifest(&self) -> Result<(), ErrorCode> {
         let mut header: [u8; core::mem::size_of::<FlashHeader>()] =
             [0; core::mem::size_of::<FlashHeader>()];


### PR DESCRIPTION
- Add DmaTransfer trait in dma_transfer.rs that abstracts source-to- destination DMA transfers, with DMAMapping as supertrait
- Update FlashImageLoader to be generic over DmaTransfer instead of DMAMapping, and simplify flash_load_image to delegate to the trait
- Add FlashReaderDma implementation in the emulator platform that preserves the existing buffered behavior (flash -> stack buffer -> DMA -> destination)
- Platforms with direct flash-to-AXI DMA can implement DmaTransfer with larger transfer sizes and no intermediate copy