### PR TITLE
Add ExportAttestedCsr command on MCU mailbox and SPDM-over-MCTP

### DIFF
--- a/caliptra-util-host/apps/mailbox/client/src/lib.rs
+++ b/caliptra-util-host/apps/mailbox/client/src/lib.rs
@@ -21,6 +21,7 @@ pub use caliptra_mcu_debug_unlock_signer::{
 pub use caliptra_mcu_core_util_host_mailbox_test_config::*;
 
 use anyhow::Result;
+use caliptra_mcu_core_util_host_command_types::certificate::ExportAttestedCsrResponse;
 use caliptra_mcu_core_util_host_command_types::crypto_aes::{
     AesMode, AES_GCM_IV_SIZE, AES_GCM_TAG_SIZE, AES_IV_SIZE,
 };
@@ -44,6 +45,7 @@ use caliptra_mcu_core_util_host_command_types::{
     GetFirmwareVersionResponse,
 };
 use caliptra_mcu_core_util_host_transport::Mailbox;
+use caliptra_util_host_commands::api::certificate::caliptra_cmd_export_attested_csr;
 use caliptra_util_host_commands::api::crypto_aes::{
     caliptra_aes_decrypt, caliptra_aes_encrypt, caliptra_aes_gcm_decrypt, caliptra_aes_gcm_encrypt,
     AesEncryptResult, AesGcmDecryptResult, AesGcmEncryptResult,
@@ -919,6 +921,38 @@ impl<'a> MailboxClient<'a> {
                     "Production debug unlock token command failed: {:?}",
                     e
                 ))
+            }
+        }
+    }
+
+    /// Export an attested CSR from the device
+    pub fn export_attested_csr(
+        &mut self,
+        device_key_id: u32,
+        algorithm: u32,
+        nonce: &[u8; 32],
+    ) -> Result<ExportAttestedCsrResponse> {
+        println!("Executing ExportAttestedCsr command...");
+
+        let mut session = CaliptraSession::new(
+            1,
+            &mut self.transport as &mut dyn caliptra_mcu_core_util_host_transport::Transport,
+        )
+        .map_err(|e| anyhow::anyhow!("Failed to create session: {:?}", e))?;
+
+        session
+            .connect()
+            .map_err(|e| anyhow::anyhow!("Failed to connect to device: {:?}", e))?;
+
+        match caliptra_cmd_export_attested_csr(&mut session, device_key_id, algorithm, nonce) {
+            Ok(response) => {
+                println!("✓ ExportAttestedCsr succeeded!");
+                println!("  CSR data length: {} bytes", response.data_len);
+                Ok(response)
+            }
+            Err(e) => {
+                eprintln!("✗ ExportAttestedCsr failed: {:?}", e);
+                Err(anyhow::anyhow!("ExportAttestedCsr command failed: {:?}", e))
             }
         }
     }

--- a/caliptra-util-host/apps/mailbox/client/src/validator.rs
+++ b/caliptra-util-host/apps/mailbox/client/src/validator.rs
@@ -185,6 +185,10 @@ impl Validator {
         let debug_unlock_result = self.validate_prod_debug_unlock(&mut client);
         results.push(debug_unlock_result);
 
+        // Run ExportAttestedCsr validation tests for all key IDs and algorithms
+        let export_csr_results = self.validate_export_attested_csr_all(&mut client);
+        results.extend(export_csr_results);
+
         if self.verbose {
             self.print_summary(&results);
         }
@@ -1593,6 +1597,103 @@ impl Validator {
                     test_name,
                     passed: true,
                     error_message: None,
+                }
+            }
+        }
+    }
+
+    /// Validate ExportAttestedCsr command
+    fn validate_export_attested_csr_all(
+        &self,
+        client: &mut MailboxClient,
+    ) -> Vec<ValidationResult> {
+        const KEY_IDS: &[(u32, &str)] = &[
+            (0x0001, "LDevID"),
+            (0x0002, "FMC Alias"),
+            (0x0003, "RT Alias"),
+        ];
+        const ALGORITHMS: &[(u32, &str)] = &[
+            (0x0001, "ECC384"),
+            // TODO: enable MLDSA87 when support is verified in emulator
+            // (0x0002, "MLDSA87"),
+        ];
+
+        let mut results = Vec::new();
+        let nonce: [u8; 32] = [0x42; 32];
+
+        for &(key_id, key_name) in KEY_IDS {
+            for &(algorithm, algo_name) in ALGORITHMS {
+                let result = self.validate_export_attested_csr(
+                    client, key_id, key_name, algorithm, algo_name, &nonce,
+                );
+                results.push(result);
+            }
+        }
+
+        results
+    }
+
+    fn validate_export_attested_csr(
+        &self,
+        client: &mut MailboxClient,
+        device_key_id: u32,
+        key_name: &str,
+        algorithm: u32,
+        algo_name: &str,
+        nonce: &[u8; 32],
+    ) -> ValidationResult {
+        let test_name = format!("ExportAttestedCsr({}/{})", key_name, algo_name);
+
+        if self.verbose {
+            println!(
+                "\n=== Validating ExportAttestedCsr: {} {} ===",
+                key_name, algo_name
+            );
+        }
+
+        match client.export_attested_csr(device_key_id, algorithm, nonce) {
+            Ok(response) => {
+                if response.data_len == 0 {
+                    let error_msg = "attested CSR data_len is 0".to_string();
+                    eprintln!("✗ {} validation FAILED: {}", test_name, error_msg);
+                    return ValidationResult {
+                        test_name,
+                        passed: false,
+                        error_message: Some(error_msg),
+                    };
+                }
+
+                if response.data_len as usize
+                    > caliptra_mcu_core_util_host_command_types::certificate::MAX_CSR_DATA_SIZE
+                {
+                    let error_msg = format!(
+                        "attested CSR data_len {} exceeds maximum",
+                        response.data_len
+                    );
+                    eprintln!("✗ {} validation FAILED: {}", test_name, error_msg);
+                    return ValidationResult {
+                        test_name,
+                        passed: false,
+                        error_message: Some(error_msg),
+                    };
+                }
+
+                println!(
+                    "✓ {} validation PASSED (attested CSR size: {} bytes)",
+                    test_name, response.data_len
+                );
+                ValidationResult {
+                    test_name,
+                    passed: true,
+                    error_message: None,
+                }
+            }
+            Err(e) => {
+                eprintln!("✗ {} validation FAILED: {}", test_name, e);
+                ValidationResult {
+                    test_name,
+                    passed: false,
+                    error_message: Some(e.to_string()),
                 }
             }
         }

--- a/caliptra-util-host/command-types/src/certificate.rs
+++ b/caliptra-util-host/command-types/src/certificate.rs
@@ -79,3 +79,48 @@ impl CommandRequest for SetCertificateRequest {
 }
 
 impl CommandResponse for SetCertificateResponse {}
+
+// ============================================================================
+// ExportAttestedCsr Command
+// ============================================================================
+
+/// Maximum CSR data size (matches MAX_RESP_DATA_SIZE on MCU side)
+pub const MAX_CSR_DATA_SIZE: usize = 4 * 1024;
+
+/// Export Attested CSR request
+#[repr(C)]
+#[derive(Debug, Clone, IntoBytes, FromBytes, Immutable)]
+pub struct ExportAttestedCsrRequest {
+    /// Device key identifier (0x0001=LDevID, 0x0002=FMC Alias, 0x0003=RT Alias)
+    pub device_key_id: u32,
+    /// Asymmetric algorithm (0x0001=ECC384, 0x0002=MLDSA87)
+    pub algorithm: u32,
+    /// 32-byte nonce for freshness
+    pub nonce: [u8; 32],
+}
+
+/// Export Attested CSR response
+#[repr(C)]
+#[derive(Debug, Clone, IntoBytes, FromBytes, Immutable)]
+pub struct ExportAttestedCsrResponse {
+    pub common: CommonResponse,
+    /// Length of CSR data
+    pub data_len: u32,
+    /// CSR data (variable length, up to MAX_CSR_DATA_SIZE)
+    pub csr_data: [u8; MAX_CSR_DATA_SIZE],
+}
+
+impl CommandRequest for ExportAttestedCsrRequest {
+    type Response = ExportAttestedCsrResponse;
+    const COMMAND_ID: CaliptraCommandId = CaliptraCommandId::ExportAttestedCsr;
+}
+
+impl CommandResponse for ExportAttestedCsrResponse {}
+
+impl ExportAttestedCsrResponse {
+    /// Returns the attested CSR payload as a byte slice (CoseSign1 structure).
+    pub fn csr_bytes(&self) -> &[u8] {
+        let len = (self.data_len as usize).min(MAX_CSR_DATA_SIZE);
+        &self.csr_data[..len]
+    }
+}

--- a/caliptra-util-host/command-types/src/lib.rs
+++ b/caliptra-util-host/command-types/src/lib.rs
@@ -55,6 +55,7 @@ pub enum CaliptraCommandId {
     GetLdevidCert = 0x1002,
     GetFmcAliasCert = 0x1003,
     GetRtAliasCert = 0x1004,
+    ExportAttestedCsr = 0x1005,
     GetCertChain = 0x1010,
     StoreCertificate = 0x1011,
     GetCertificate = 0x1012, // Generic get certificate

--- a/caliptra-util-host/commands/src/api/certificate.rs
+++ b/caliptra-util-host/commands/src/api/certificate.rs
@@ -1,0 +1,41 @@
+// Licensed under the Apache-2.0 license
+
+//! Certificate API functions
+//!
+//! High-level functions for certificate operations with Caliptra.
+
+use crate::api::{CaliptraApiError, CaliptraResult};
+use caliptra_mcu_core_util_host_command_types::{
+    certificate::{ExportAttestedCsrRequest, ExportAttestedCsrResponse},
+    CaliptraCommandId,
+};
+use caliptra_util_host_session::CaliptraSession;
+
+/// Export an attested CSR from the device
+///
+/// # Parameters
+///
+/// - `session`: Mutable reference to CaliptraSession
+/// - `device_key_id`: Device key identifier (0x0001=LDevID, 0x0002=FMC Alias, 0x0003=RT Alias)
+/// - `algorithm`: Asymmetric algorithm (0x0001=ECC384, 0x0002=MLDSA87)
+/// - `nonce`: 32-byte nonce for freshness
+///
+/// # Returns
+///
+/// - `Ok(ExportAttestedCsrResponse)` on success
+/// - `Err(CaliptraApiError)` on failure
+pub fn caliptra_cmd_export_attested_csr(
+    session: &mut CaliptraSession,
+    device_key_id: u32,
+    algorithm: u32,
+    nonce: &[u8; 32],
+) -> CaliptraResult<ExportAttestedCsrResponse> {
+    let request = ExportAttestedCsrRequest {
+        device_key_id,
+        algorithm,
+        nonce: *nonce,
+    };
+    session
+        .execute_command_with_id(CaliptraCommandId::ExportAttestedCsr, &request)
+        .map_err(|_| CaliptraApiError::SessionError("ExportAttestedCsr command failed"))
+}

--- a/caliptra-util-host/commands/src/api/mod.rs
+++ b/caliptra-util-host/commands/src/api/mod.rs
@@ -9,6 +9,7 @@
 // Re-export types that API consumers might need
 // Note: These imports might appear unused but are used by other modules or re-exports
 
+pub mod certificate;
 pub mod crypto_aes;
 pub mod crypto_asymmetric;
 pub mod crypto_delete;
@@ -19,6 +20,7 @@ pub mod debug_unlock;
 pub mod device_info;
 
 pub use caliptra_util_host_session::CommandSession;
+pub use certificate::*;
 pub use crypto_aes::*;
 pub use crypto_asymmetric::*;
 pub use crypto_delete::*;

--- a/caliptra-util-host/transport/src/transports/mailbox/certificate.rs
+++ b/caliptra-util-host/transport/src/transports/mailbox/certificate.rs
@@ -1,0 +1,137 @@
+// Licensed under the Apache-2.0 license
+
+//! Certificate commands for mailbox transport
+//!
+//! This module provides command definitions and implementations for certificate
+//! commands using the mailbox transport protocol.
+
+use super::checksum::calc_checksum;
+use super::command_traits::*;
+use caliptra_mcu_core_util_host_command_types::certificate::{
+    ExportAttestedCsrRequest, ExportAttestedCsrResponse, MAX_CSR_DATA_SIZE,
+};
+use caliptra_mcu_core_util_host_command_types::CommonResponse;
+use zerocopy::{FromBytes, Immutable, IntoBytes};
+
+pub use super::command_traits::{process_command, process_command_with_metadata};
+
+// ============================================================================
+// MC_EXPORT_ATTESTED_CSR Command (0x4D45_4143 - "MEAC")
+// ============================================================================
+
+/// External command: Export attested CSR request
+#[repr(C)]
+#[derive(Debug, Clone, IntoBytes, FromBytes, Immutable)]
+pub struct ExtCmdExportAttestedCsrRequest {
+    /// Checksum over input data
+    pub chksum: u32,
+    /// Device key identifier
+    pub device_key_id: u32,
+    /// Asymmetric algorithm
+    pub algorithm: u32,
+    /// 32-byte nonce for freshness
+    pub nonce: [u8; 32],
+}
+
+/// External command: Export attested CSR response
+#[repr(C)]
+#[derive(Debug, Clone, IntoBytes, FromBytes, Immutable)]
+pub struct ExtCmdExportAttestedCsrResponse {
+    /// Checksum field
+    pub chksum: u32,
+    /// FIPS approved or an error
+    pub fips_status: u32,
+    /// Length of CSR data
+    pub data_len: u32,
+    /// CSR data (variable length)
+    pub csr_data: [u8; MAX_CSR_DATA_SIZE],
+}
+
+impl FromInternalRequest<ExportAttestedCsrRequest> for ExtCmdExportAttestedCsrRequest {
+    fn from_internal(internal: &ExportAttestedCsrRequest, command_code: u32) -> Self {
+        let chksum = calc_checksum(command_code, internal.as_bytes());
+        Self {
+            chksum,
+            device_key_id: internal.device_key_id,
+            algorithm: internal.algorithm,
+            nonce: internal.nonce,
+        }
+    }
+}
+
+impl ToInternalResponse<ExportAttestedCsrResponse> for ExtCmdExportAttestedCsrResponse {
+    fn to_internal(&self) -> ExportAttestedCsrResponse {
+        let mut csr_data = [0u8; MAX_CSR_DATA_SIZE];
+        let data_len = (self.data_len as usize).min(MAX_CSR_DATA_SIZE);
+        csr_data[..data_len].copy_from_slice(&self.csr_data[..data_len]);
+
+        ExportAttestedCsrResponse {
+            common: CommonResponse {
+                fips_status: self.fips_status,
+            },
+            data_len: self.data_len,
+            csr_data,
+        }
+    }
+}
+
+impl VariableSizeBytes for ExtCmdExportAttestedCsrRequest {}
+
+impl VariableSizeBytes for ExtCmdExportAttestedCsrResponse {
+    fn from_bytes_variable(bytes: &[u8]) -> Result<Self, crate::TransportError> {
+        if bytes.len() < 12 {
+            return Err(crate::TransportError::InvalidMessage);
+        }
+
+        let chksum = u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+        let fips_status = u32::from_le_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]);
+        let data_len = u32::from_le_bytes([bytes[8], bytes[9], bytes[10], bytes[11]]);
+
+        let data_len_usize = data_len as usize;
+        if data_len_usize > MAX_CSR_DATA_SIZE || bytes.len() < 12 + data_len_usize {
+            return Err(crate::TransportError::InvalidMessage);
+        }
+
+        let mut csr_data = [0u8; MAX_CSR_DATA_SIZE];
+        csr_data[..data_len_usize].copy_from_slice(&bytes[12..12 + data_len_usize]);
+
+        Ok(ExtCmdExportAttestedCsrResponse {
+            chksum,
+            fips_status,
+            data_len,
+            csr_data,
+        })
+    }
+
+    fn to_bytes_variable(&self, buffer: &mut [u8]) -> usize {
+        let header_size = 12;
+        let actual_len = (self.data_len as usize).min(MAX_CSR_DATA_SIZE);
+        let total_size = header_size + actual_len;
+
+        if buffer.len() < total_size {
+            return 0;
+        }
+
+        buffer[0..4].copy_from_slice(&self.chksum.to_le_bytes());
+        buffer[4..8].copy_from_slice(&self.fips_status.to_le_bytes());
+        buffer[8..12].copy_from_slice(&self.data_len.to_le_bytes());
+        buffer[12..12 + actual_len].copy_from_slice(&self.csr_data[..actual_len]);
+
+        total_size
+    }
+}
+
+// ============================================================================
+// Command Metadata Definition
+// ============================================================================
+
+use crate::define_command;
+
+define_command!(
+    ExportAttestedCsrCmd,
+    0x4D45_4143, // MC_EXPORT_ATTESTED_CSR - "MEAC"
+    ExportAttestedCsrRequest,
+    ExportAttestedCsrResponse,
+    ExtCmdExportAttestedCsrRequest,
+    ExtCmdExportAttestedCsrResponse
+);

--- a/caliptra-util-host/transport/src/transports/mailbox/dispatch.rs
+++ b/caliptra-util-host/transport/src/transports/mailbox/dispatch.rs
@@ -13,6 +13,7 @@ use super::aes::{
     AesGcmDecryptFinalCmd, AesGcmDecryptInitCmd, AesGcmDecryptUpdateCmd, AesGcmEncryptFinalCmd,
     AesGcmEncryptInitCmd, AesGcmEncryptUpdateCmd,
 };
+use super::certificate::ExportAttestedCsrCmd;
 use super::crypto_asymmetric::{
     EcdhFinishCmd, EcdhGenerateCmd, EcdsaPublicKeyCmd, EcdsaSignCmd, EcdsaVerifyCmd,
 };
@@ -79,6 +80,8 @@ pub fn get_command_handler(command_id: u32) -> Option<CommandHandlerFn> {
         // Debug Unlock Commands (0x7010-0x7011)
         0x7010 => Some(process_command_with_metadata::<ProdDebugUnlockReqCmd>), // ProdDebugUnlockReq
         0x7011 => Some(process_command_with_metadata::<ProdDebugUnlockTokenCmd>), // ProdDebugUnlockToken
+        // Certificate Commands (0x1005)
+        0x1005 => Some(process_command_with_metadata::<ExportAttestedCsrCmd>), // ExportAttestedCsr
         _ => None,
     }
 }
@@ -130,6 +133,8 @@ pub fn get_external_cmd_code(command_id: u32) -> Option<u32> {
         // Debug Unlock Commands
         0x7010 => Some(0x4D50_5552), // ProdDebugUnlockReq -> MC_PROD_DEBUG_UNLOCK_REQ ("MPUR")
         0x7011 => Some(0x4D50_5554), // ProdDebugUnlockToken -> MC_PROD_DEBUG_UNLOCK_TOKEN ("MPUT")
+        // Certificate Commands
+        0x1005 => Some(0x4D45_4143), // ExportAttestedCsr -> MC_EXPORT_ATTESTED_CSR ("MEAC")
         _ => None,
     }
 }

--- a/caliptra-util-host/transport/src/transports/mailbox/mod.rs
+++ b/caliptra-util-host/transport/src/transports/mailbox/mod.rs
@@ -5,6 +5,7 @@
 //! This module provides mailbox transport implementation with external mailbox protocol support.
 
 pub mod aes;
+pub mod certificate;
 pub mod checksum;
 pub mod command_traits;
 pub mod crypto_asymmetric;
@@ -28,6 +29,7 @@ pub use command_traits::{
 
 // Re-export external command types for testing
 pub use aes::*;
+pub use certificate::*;
 pub use crypto_asymmetric::*;
 pub use debug_unlock::*;
 pub use delete::*;

--- a/common/mcu-mbox/src/messages.rs
+++ b/common/mcu-mbox/src/messages.rs
@@ -122,6 +122,9 @@ impl CommandId {
     // Authorized commands
     pub const MC_ROTATE_VENDOR_PK_HASH: Self = Self(0x4D56_504B); // "MVPK"
     pub const MC_FUSE_INCREASE_CALIPTRA_MIN_SVN: Self = Self(0x4D43_4D53); // "MCMS"
+
+    // Certificate commands
+    pub const MC_EXPORT_ATTESTED_CSR: Self = Self(0x4D45_4143); // "MEAC"
 }
 
 impl From<u32> for CommandId {
@@ -184,6 +187,8 @@ pub enum McuMailboxReq {
     FuseWrite(FuseWriteReq),
     FuseLockPartition(FuseLockPartitionReq),
     FuseIncreaseCaliptraMinSvn(FuseIncreaseCaliptraMinSvnReq),
+    // Certificate commands
+    ExportAttestedCsr(ExportAttestedCsrReq),
 }
 
 impl McuMailboxReq {
@@ -232,6 +237,7 @@ impl McuMailboxReq {
             McuMailboxReq::FuseWrite(req) => req.as_bytes_partial(),
             McuMailboxReq::FuseLockPartition(req) => Ok(req.as_bytes()),
             McuMailboxReq::FuseIncreaseCaliptraMinSvn(req) => Ok(req.as_bytes()),
+            McuMailboxReq::ExportAttestedCsr(req) => Ok(req.as_bytes()),
         }
     }
 
@@ -280,6 +286,7 @@ impl McuMailboxReq {
             McuMailboxReq::FuseWrite(req) => req.as_bytes_partial_mut(),
             McuMailboxReq::FuseLockPartition(req) => Ok(req.as_mut_bytes()),
             McuMailboxReq::FuseIncreaseCaliptraMinSvn(req) => Ok(req.as_mut_bytes()),
+            McuMailboxReq::ExportAttestedCsr(req) => Ok(req.as_mut_bytes()),
         }
     }
 
@@ -330,6 +337,7 @@ impl McuMailboxReq {
             McuMailboxReq::FuseIncreaseCaliptraMinSvn(_) => {
                 CommandId::MC_FUSE_INCREASE_CALIPTRA_MIN_SVN
             }
+            McuMailboxReq::ExportAttestedCsr(_) => CommandId::MC_EXPORT_ATTESTED_CSR,
         }
     }
 
@@ -402,6 +410,8 @@ pub enum McuMailboxResp {
     FuseRead(FuseReadResp),
     FuseWrite(FuseWriteResp),
     FuseLockPartition(FuseLockPartitionResp),
+    // Certificate commands
+    ExportAttestedCsr(ExportAttestedCsrResp),
 }
 
 /// A trait for responses with variable size data.
@@ -510,6 +520,7 @@ impl McuMailboxResp {
             McuMailboxResp::FuseRead(resp) => resp.as_bytes_partial(),
             McuMailboxResp::FuseWrite(resp) => Ok(resp.as_bytes()),
             McuMailboxResp::FuseLockPartition(resp) => Ok(resp.as_bytes()),
+            McuMailboxResp::ExportAttestedCsr(resp) => resp.as_bytes_partial(),
         }
     }
 
@@ -558,6 +569,7 @@ impl McuMailboxResp {
             McuMailboxResp::FuseRead(resp) => resp.as_bytes_partial_mut(),
             McuMailboxResp::FuseWrite(resp) => Ok(resp.as_mut_bytes()),
             McuMailboxResp::FuseLockPartition(resp) => Ok(resp.as_mut_bytes()),
+            McuMailboxResp::ExportAttestedCsr(resp) => resp.as_bytes_partial_mut(),
         }
     }
 
@@ -1375,6 +1387,42 @@ pub struct FuseIncreaseCaliptraMinSvnResp {
     pub hdr: MailboxRespHeader,
 }
 impl Response for FuseIncreaseCaliptraMinSvnResp {}
+
+// ============================================================================
+// MC_EXPORT_ATTESTED_CSR Command (0x4D45_4143 - "MEAC")
+// ============================================================================
+
+#[repr(C)]
+#[derive(Debug, Default, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
+pub struct ExportAttestedCsrReq {
+    pub hdr: MailboxReqHeader,
+    /// Device key identifier (0x0001=LDevID, 0x0002=FMC Alias, 0x0003=RT Alias)
+    pub device_key_id: u32,
+    /// Asymmetric algorithm (0x0001=ECC384, 0x0002=MLDSA87)
+    pub algorithm: u32,
+    /// 32-byte nonce for freshness
+    pub nonce: [u8; 32],
+}
+impl Request for ExportAttestedCsrReq {
+    const ID: CommandId = CommandId::MC_EXPORT_ATTESTED_CSR;
+    type Resp = ExportAttestedCsrResp;
+}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
+pub struct ExportAttestedCsrResp {
+    pub hdr: MailboxRespHeaderVarSize,
+    pub data: [u8; MAX_RESP_DATA_SIZE],
+}
+impl Default for ExportAttestedCsrResp {
+    fn default() -> Self {
+        Self {
+            hdr: MailboxRespHeaderVarSize::default(),
+            data: [0u8; MAX_RESP_DATA_SIZE],
+        }
+    }
+}
+impl McuResponseVarSize for ExportAttestedCsrResp {}
 
 #[cfg(test)]
 mod tests {

--- a/docs/src/external_mailbox_cmds.md
+++ b/docs/src/external_mailbox_cmds.md
@@ -41,6 +41,7 @@ These commands support a wide range of functionalities, including querying devic
 | MC_DEVICE_INFO                    | 0x4D44_494E ("MDIN") | Retrieves information about the target device.                                                     |
 | MC_EXPORT_IDEV_CSR                | 0x4D49_4352 ("MICR") | Exports the IDEVID Self-Signed Certificate Signing Request.                                        |
 | MC_IMPORT_IDEV_CERT               | 0x4D49_4943 ("MIIC") | Allows SoC to import DER-encoded IDevId certificate on every boot.                                 |
+| MC_EXPORT_ATTESTED_CSR            | 0x4D45_4143 ("MEAC") | Exports an attested CSR for a specified device key, wrapped in a CoseSign1 structure.              |
 | MC_GET_LOG                        | 0x4D47_4C47 ("MGLG") | Retrieves the internal log for the RoT.                                                            |
 | MC_CLEAR_LOG                      | 0x4D43_4C47 ("MCLG") | Clears the log in the RoT subsystem.                                                               |
 | MC_FIPS_SELF_TEST_START           | 0x4D46_5354 ("MFST") | Starts the FIPS self-test to exercise the crypto engine.                                           |
@@ -213,6 +214,33 @@ Command Code: `0x4D49_4943` ("MIIC")
 |-------------|----------------|------------------------------|
 | chksum      | u32            |                              |
 | fips_status | u32            | FIPS approved or an error.   |
+
+### MC_EXPORT_ATTESTED_CSR
+
+Exports an attested Certificate Signing Request (CSR) for a specified device key. The CSR is wrapped in a CoseSign1 structure for attestation integrity. A 32-byte nonce is included for freshness.
+
+Command Code: `0x4D45_4143` ("MEAC")
+
+*Table: `MC_EXPORT_ATTESTED_CSR` input arguments*
+| **Name**       | **Type** | **Description**                                |
+| -------------- | -------- | ---------------------------------------------- |
+| chksum         | u32      |                                                |
+| device_key_id  | u32      | Device key identifier:                         |
+|                |          | - `0x0001` = LDevID                            |
+|                |          | - `0x0002` = FMC Alias                         |
+|                |          | - `0x0003` = RT Alias                          |
+| algorithm      | u32      | Asymmetric algorithm:                          |
+|                |          | - `0x0001` = ECC384                            |
+|                |          | - `0x0002` = MLDSA87                           |
+| nonce          | u8[32]   | 32-byte nonce for freshness.                   |
+
+*Table: `MC_EXPORT_ATTESTED_CSR` output arguments*
+| **Name**    | **Type**       | **Description**                                           |
+| ----------- | -------------- | --------------------------------------------------------- |
+| chksum      | u32            |                                                           |
+| fips_status | u32            | FIPS approved or an error.                                |
+| data_len    | u32            | Length in bytes of the valid data in the data field.       |
+| csr_data    | u8[data_len]   | Attested CSR payload (CoseSign1 structure).               |
 
 ### MC_GET_LOG
 

--- a/docs/src/unified_external_command_handling.md
+++ b/docs/src/unified_external_command_handling.md
@@ -18,7 +18,7 @@ The Caliptra MCU firmware provides two external command interfaces: [MCTP VDM ex
 | Clear Log                         | MC_CLEAR_LOG                           | Clears the log in the RoT subsystem.                    |
 | Request Debug Unlock              | MC_PRODUCTION_DEBUG_UNLOCK_REQ         | Requests debug unlock in a production environment.       |
 | Authorize Debug Unlock Token      | MC_PRODUCTION_DEBUG_UNLOCK_TOKEN       | Sends the debug unlock token for authorization.         |
-| Export Attested CSR               | -                                      | Exports attested CSR for a specified device key.        |
+| Export Attested CSR               | MC_EXPORT_ATTESTED_CSR                 | Exports attested CSR for a specified device key.        |
 
 To ensure consistent command behavior and maximize code reuse, we define a protocol-agnostic command handler trait with unified command IDs and input/output types. Both MCTP VDM and MCI mailbox frontends parse their protocol, map to the unified command and call the same backend handler, ensuring code reuse and consistent behavior.
 

--- a/platforms/emulator/runtime/userspace/apps/user/src/caliptra_cmd_handler/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/caliptra_cmd_handler/mod.rs
@@ -1,0 +1,83 @@
+// Licensed under the Apache-2.0 license
+
+//! Baseline Caliptra MCU implementation of `UnifiedCommandHandler`.
+//!
+//! This module provides the production command handler backed by the Caliptra
+//! mailbox API. It is consumed by both the SPDM VDM handler and the MCU
+//! mailbox command interface.
+
+extern crate alloc;
+
+use alloc::boxed::Box;
+use async_trait::async_trait;
+use caliptra_mcu_external_cmds_common::{
+    AttestedCsrData, CommandError, DeviceCapabilities, DeviceId, DeviceInfo, FirmwareVersion,
+    UnifiedCommandHandler,
+};
+use caliptra_mcu_libapi_caliptra::certificate::CertContext;
+use caliptra_mcu_libapi_caliptra::crypto::asym::AsymAlgo;
+use caliptra_mcu_libapi_caliptra::error::CaliptraApiError;
+
+/// Production command handler that delegates to the Caliptra mailbox API.
+///
+/// Currently only `export_attested_csr` is implemented; all other commands
+/// return `NotSupported` until their backend integrations are complete.
+pub struct CaliptraCmdHandler;
+
+#[async_trait]
+impl UnifiedCommandHandler for CaliptraCmdHandler {
+    async fn get_firmware_version(
+        &self,
+        _index: u32,
+        _version: &mut FirmwareVersion,
+    ) -> Result<(), CommandError> {
+        Err(CommandError::NotSupported)
+    }
+
+    async fn get_device_id(&self, _device_id: &mut DeviceId) -> Result<(), CommandError> {
+        Err(CommandError::NotSupported)
+    }
+
+    async fn get_device_info(
+        &self,
+        _index: u32,
+        _info: &mut DeviceInfo,
+    ) -> Result<(), CommandError> {
+        Err(CommandError::NotSupported)
+    }
+
+    async fn get_device_capabilities(
+        &self,
+        _capabilities: &mut DeviceCapabilities,
+    ) -> Result<(), CommandError> {
+        Err(CommandError::NotSupported)
+    }
+
+    async fn export_attested_csr(
+        &self,
+        device_key_id: u32,
+        algorithm: u32,
+        nonce: &[u8; 32],
+        csr_data: &mut AttestedCsrData,
+    ) -> Result<(), CommandError> {
+        let algo = AsymAlgo::try_from_u32(algorithm).ok_or(CommandError::InvalidParams)?;
+
+        let mut cert_ctx = CertContext::new();
+
+        // Write directly into csr_data.data to avoid a redundant 12800-byte
+        // buffer that would inflate the boxed async_trait future beyond the
+        // MCU heap budget.
+        let len = cert_ctx
+            .get_attested_csr(algo, device_key_id, nonce, &mut csr_data.data)
+            .await
+            .map_err(|e| match e {
+                CaliptraApiError::MailboxBusy => CommandError::Busy,
+                CaliptraApiError::InvalidArgument(_) => CommandError::InvalidParams,
+                CaliptraApiError::AsymAlgoUnsupported => CommandError::InvalidParams,
+                _ => CommandError::InternalError,
+            })?;
+
+        csr_data.len = len;
+        Ok(())
+    }
+}

--- a/platforms/emulator/runtime/userspace/apps/user/src/main.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/main.rs
@@ -11,6 +11,7 @@ use caliptra_mcu_libtockasync::TockExecutor;
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 #[allow(unused)]
 use embassy_sync::{lazy_lock::LazyLock, signal::Signal};
+mod caliptra_cmd_handler;
 #[cfg(any(
     feature = "test-firmware-update-streaming",
     feature = "test-firmware-update-flash"

--- a/platforms/emulator/runtime/userspace/apps/user/src/mcu_mbox/cmd_handler_mock.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/mcu_mbox/cmd_handler_mock.rs
@@ -10,6 +10,9 @@ use caliptra_mcu_external_cmds_common::{
 };
 use caliptra_mcu_mbox_common::config;
 
+use crate::caliptra_cmd_handler::CaliptraCmdHandler;
+
+// TODO: Remove this mock and use CaliptraCmdHandler directly.
 #[derive(Default)]
 pub struct NonCryptoCmdHandlerMock;
 
@@ -87,10 +90,15 @@ impl UnifiedCommandHandler for NonCryptoCmdHandlerMock {
 
     async fn export_attested_csr(
         &self,
-        _device_key_id: u32,
-        _algorithm: u32,
-        _csr_data: &mut AttestedCsrData,
+        device_key_id: u32,
+        algorithm: u32,
+        nonce: &[u8; 32],
+        csr_data: &mut AttestedCsrData,
     ) -> Result<(), CommandError> {
-        Err(CommandError::NotSupported)
+        // Delegate to real CaliptraCmdHandler for actual Caliptra mailbox interaction
+        let handler = CaliptraCmdHandler;
+        handler
+            .export_attested_csr(device_key_id, algorithm, nonce, csr_data)
+            .await
     }
 }

--- a/platforms/emulator/runtime/userspace/apps/user/src/spdm/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/spdm/mod.rs
@@ -98,6 +98,17 @@ async fn spdm_mctp_responder() {
         device_measurements::ocp_eat::create_manifest_with_ocp_eat();
     let device_measurements = SpdmMeasurements::new(&meas_value_info, &mut device_ocp_eat);
 
+    // Caliptra VDM handler for SPDM over MCTP transport
+    let caliptra_cmd_handler = crate::caliptra_cmd_handler::CaliptraCmdHandler;
+    let mut caliptra_vdm_handler =
+        caliptra_mcu_spdm_lib::vdm_handler::iana::ocp::caliptra_vdm::CaliptraVdmHandler::new(
+            &caliptra_cmd_handler,
+        );
+    let mut handlers_array: [&mut dyn caliptra_mcu_spdm_lib::vdm_handler::VdmHandler; 1] =
+        [&mut caliptra_vdm_handler as &mut dyn caliptra_mcu_spdm_lib::vdm_handler::VdmHandler];
+    let vdm_handlers: Option<&mut [&mut dyn caliptra_mcu_spdm_lib::vdm_handler::VdmHandler]> =
+        Some(&mut handlers_array);
+
     let mut ctx = match SpdmContext::new(
         SPDM_VERSIONS,
         SECURE_SPDM_VERSIONS,
@@ -106,7 +117,7 @@ async fn spdm_mctp_responder() {
         local_algorithms,
         &shared_cert_store,
         device_measurements,
-        None, // VDM handlers are not supported for MCTP transport in this configuration
+        vdm_handlers,
     ) {
         Ok(ctx) => ctx,
         Err(e) => {

--- a/platforms/emulator/runtime/userspace/apps/user/src/vdm/cmd_handler_mock.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/vdm/cmd_handler_mock.rs
@@ -89,6 +89,7 @@ impl UnifiedCommandHandler for NonCryptoCmdHandlerMock {
         &self,
         _device_key_id: u32,
         _algorithm: u32,
+        _nonce: &[u8; 32],
         _csr_data: &mut AttestedCsrData,
     ) -> Result<(), CommandError> {
         Err(CommandError::NotSupported)

--- a/runtime/userspace/api/external-cmds-common/src/lib.rs
+++ b/runtime/userspace/api/external-cmds-common/src/lib.rs
@@ -132,6 +132,7 @@ pub trait UnifiedCommandHandler: Send + Sync {
     /// # Arguments
     /// * `device_key_id` - The device key identifier (0x0001=LDevID, 0x0002=FMC Alias, 0x0003=RT Alias).
     /// * `algorithm` - The asymmetric algorithm (0x0001=ECC384, 0x0002=MLDSA87).
+    /// * `nonce` - A 32-byte nonce provided by the requester for freshness.
     /// * `csr_data` - Mutable reference to store the attested CSR data.
     ///
     /// # Returns
@@ -140,6 +141,7 @@ pub trait UnifiedCommandHandler: Send + Sync {
         &self,
         device_key_id: u32,
         algorithm: u32,
+        nonce: &[u8; 32],
         csr_data: &mut AttestedCsrData,
     ) -> Result<(), CommandError>;
 }

--- a/runtime/userspace/api/mctp-vdm-lib/src/cmd_interface.rs
+++ b/runtime/userspace/api/mctp-vdm-lib/src/cmd_interface.rs
@@ -3,13 +3,12 @@
 use crate::error::VdmLibError;
 use crate::transport::MctpVdmTransport;
 use caliptra_mcu_external_cmds_common::{
-    AttestedCsrData, CommandError, DeviceCapabilities, DeviceId, DeviceInfo, FirmwareVersion, Uid,
-    UnifiedCommandHandler, MAX_ATTESTED_CSR_DATA_LEN, MAX_UID_LEN,
+    DeviceCapabilities, DeviceId, DeviceInfo, FirmwareVersion, Uid, UnifiedCommandHandler,
+    MAX_UID_LEN,
 };
 use caliptra_mcu_mctp_vdm_common::codec::VdmCodec;
 use caliptra_mcu_mctp_vdm_common::message::{
-    AsymAlgorithm, DeviceCapabilitiesResponse, DeviceIdResponse, DeviceInfoRequest,
-    DeviceInfoResponse, ExportAttestedCsrRequest, ExportAttestedCsrResponse,
+    DeviceCapabilitiesResponse, DeviceIdResponse, DeviceInfoRequest, DeviceInfoResponse,
     FirmwareVersionRequest, FirmwareVersionResponse, DEVICE_CAPS_SIZE,
 };
 use caliptra_mcu_mctp_vdm_common::protocol::{
@@ -120,9 +119,6 @@ impl<'a> CmdInterface<'a> {
             }
             VdmCommand::DeviceId => self.handle_device_id(msg_buf, vdm_req_len).await,
             VdmCommand::DeviceInfo => self.handle_device_info(msg_buf, vdm_req_len).await,
-            VdmCommand::ExportAttestedCsr => {
-                self.handle_export_attested_csr(msg_buf, vdm_req_len).await
-            }
             _ => self.send_error_response(
                 msg_buf,
                 hdr.command_code,
@@ -300,75 +296,6 @@ impl<'a> CmdInterface<'a> {
         &self,
         msg_buf: &mut [u8],
         resp: &DeviceInfoResponse,
-    ) -> Result<usize, VdmLibError> {
-        // Construct MCTP header and get VDM message slice.
-        let vdm_msg = construct_mctp_vdm_msg(msg_buf).map_err(|_| VdmLibError::EncodingError)?;
-
-        // Encode the response.
-        let resp_len = resp
-            .encode(vdm_msg)
-            .map_err(|_| VdmLibError::EncodingError)?;
-
-        // Return total MCTP payload length (1 byte MCTP header + VDM response).
-        Ok(VDM_MSG_OFFSET + resp_len)
-    }
-
-    /// Handle Export Attested CSR command.
-    async fn handle_export_attested_csr(
-        &self,
-        msg_buf: &mut [u8],
-        req_len: usize,
-    ) -> Result<usize, VdmLibError> {
-        // Extract VDM message portion.
-        let vdm_msg = extract_vdm_msg(msg_buf).map_err(|_| VdmLibError::DecodingError)?;
-
-        // Decode the request.
-        let req = ExportAttestedCsrRequest::decode(&vdm_msg[..req_len])
-            .map_err(|_| VdmLibError::DecodingError)?;
-
-        let device_key_id = req.device_key_id;
-        let algorithm = req.algorithm;
-
-        // Validate algorithm at protocol layer since ECC384 and MLDSA-87
-        // map to different Caliptra backend commands.
-        if AsymAlgorithm::try_from(algorithm).is_err() {
-            let resp = ExportAttestedCsrResponse::new(VdmCompletionCode::InvalidData as u32, &[]);
-            return self.encode_export_attested_csr_response(msg_buf, &resp);
-        }
-
-        // Get the attested CSR using the unified handler.
-        // device_key_id validation is delegated to the Caliptra backend.
-        let mut csr_data = AttestedCsrData::default();
-        let result = self
-            .unified_handler
-            .export_attested_csr(device_key_id, algorithm, &mut csr_data)
-            .await;
-
-        // Build the response with appropriate completion code per error type.
-        let (completion_code, data) = match result {
-            Ok(()) => {
-                let len = csr_data.len.min(MAX_ATTESTED_CSR_DATA_LEN);
-                (VdmCompletionCode::Success, csr_data.data[..len].to_vec())
-            }
-            Err(CommandError::InvalidParams) => (VdmCompletionCode::InvalidData, alloc::vec![]),
-            Err(CommandError::NotSupported) => {
-                (VdmCompletionCode::UnsupportedCommand, alloc::vec![])
-            }
-            Err(CommandError::Busy) => (VdmCompletionCode::NotReady, alloc::vec![]),
-            Err(_) => (VdmCompletionCode::GeneralError, alloc::vec![]),
-        };
-
-        let resp = ExportAttestedCsrResponse::new(completion_code as u32, &data);
-
-        // Encode the response into the MCTP payload.
-        self.encode_export_attested_csr_response(msg_buf, &resp)
-    }
-
-    /// Encode an ExportAttestedCsrResponse (variable length) into the MCTP payload buffer.
-    fn encode_export_attested_csr_response(
-        &self,
-        msg_buf: &mut [u8],
-        resp: &ExportAttestedCsrResponse,
     ) -> Result<usize, VdmLibError> {
         // Construct MCTP header and get VDM message slice.
         let vdm_msg = construct_mctp_vdm_msg(msg_buf).map_err(|_| VdmLibError::EncodingError)?;

--- a/runtime/userspace/api/mcu-mbox-lib/src/cmd_interface.rs
+++ b/runtime/userspace/api/mcu-mbox-lib/src/cmd_interface.rs
@@ -3,7 +3,7 @@
 use crate::transport::McuMboxTransport;
 use caliptra_api::mailbox::{populate_checksum, CommandId as CaliptraCommandId, MailboxReqHeader};
 use caliptra_mcu_external_cmds_common::{
-    CommandAuthorizer, DeviceCapabilities, DeviceId, DeviceInfo, FirmwareVersion,
+    AttestedCsrData, CommandAuthorizer, DeviceCapabilities, DeviceId, DeviceInfo, FirmwareVersion,
     UnifiedCommandHandler, MAX_UID_LEN,
 };
 use caliptra_mcu_libapi_caliptra::mailbox_api::execute_mailbox_cmd;
@@ -12,17 +12,18 @@ use caliptra_mcu_libsyscall_caliptra::otp;
 use caliptra_mcu_libsyscall_caliptra::{mailbox::Mailbox, DefaultSyscalls};
 use caliptra_mcu_mbox_common::messages::{
     CommandId, DeviceCapsReq, DeviceCapsResp, DeviceIdReq, DeviceIdResp, DeviceInfoReq,
-    DeviceInfoResp, FirmwareVersionReq, FirmwareVersionResp, FuseIncreaseCaliptraMinSvnReq,
-    FuseIncreaseCaliptraMinSvnResp, MailboxRespHeader, MailboxRespHeaderVarSize,
-    McuAesDecryptInitReq, McuAesDecryptUpdateReq, McuAesEncryptInitReq, McuAesEncryptUpdateReq,
-    McuAesGcmDecryptFinalReq, McuAesGcmDecryptInitReq, McuAesGcmDecryptUpdateReq,
-    McuAesGcmEncryptFinalReq, McuAesGcmEncryptInitReq, McuAesGcmEncryptUpdateReq, McuCmDeleteReq,
-    McuCmImportReq, McuCmStatusReq, McuEcdhFinishReq, McuEcdhGenerateReq, McuEcdsaCmkPublicKeyReq,
+    DeviceInfoResp, ExportAttestedCsrReq, ExportAttestedCsrResp, FirmwareVersionReq,
+    FirmwareVersionResp, FuseIncreaseCaliptraMinSvnReq, FuseIncreaseCaliptraMinSvnResp,
+    MailboxRespHeader, MailboxRespHeaderVarSize, McuAesDecryptInitReq, McuAesDecryptUpdateReq,
+    McuAesEncryptInitReq, McuAesEncryptUpdateReq, McuAesGcmDecryptFinalReq,
+    McuAesGcmDecryptInitReq, McuAesGcmDecryptUpdateReq, McuAesGcmEncryptFinalReq,
+    McuAesGcmEncryptInitReq, McuAesGcmEncryptUpdateReq, McuCmDeleteReq, McuCmImportReq,
+    McuCmStatusReq, McuEcdhFinishReq, McuEcdhGenerateReq, McuEcdsaCmkPublicKeyReq,
     McuEcdsaCmkSignReq, McuEcdsaCmkVerifyReq, McuFipsSelfTestGetResultsReq,
     McuFipsSelfTestStartReq, McuHkdfExpandReq, McuHkdfExtractReq, McuHmacKdfCounterReq, McuHmacReq,
     McuProdDebugUnlockReqReq, McuProdDebugUnlockTokenReq, McuRandomGenerateReq, McuRandomStirReq,
     McuResponseVarSize, McuShaFinalReq, McuShaInitReq, McuShaUpdateReq, DEVICE_CAPS_SIZE,
-    MAX_FW_VERSION_STR_LEN,
+    MAX_FW_VERSION_STR_LEN, MAX_RESP_DATA_SIZE,
 };
 #[cfg(feature = "periodic-fips-self-test")]
 use caliptra_mcu_mbox_common::messages::{
@@ -418,6 +419,10 @@ impl<'a> CmdInterface<'a> {
             | cmd_id @ CommandId::MC_FUSE_INCREASE_CALIPTRA_MIN_SVN => {
                 self.handle_authorized_command(cmd_id, req, resp_buf).await
             }
+            // Certificate commands
+            CommandId::MC_EXPORT_ATTESTED_CSR => {
+                self.handle_export_attested_csr(req, resp_buf).await
+            }
             // TODO: add more command handlers.
             // TODO: DOT runtime commands (DOT_CAK_INSTALL, DOT_LOCK, DOT_DISABLE,
             // DOT_UNLOCK_CHALLENGE, DOT_UNLOCK) are not yet handled here. These require
@@ -587,6 +592,50 @@ impl<'a> CmdInterface<'a> {
         };
 
         // Encode the response and copy to resp_buf.
+        let resp_bytes = resp
+            .as_bytes_partial()
+            .map_err(|_| MsgHandlerError::McuMboxCommon)?;
+
+        resp_buf[..resp_bytes.len()].copy_from_slice(resp_bytes);
+
+        Ok((&mut resp_buf[..resp_bytes.len()], mbox_cmd_status))
+    }
+
+    async fn handle_export_attested_csr<'r>(
+        &self,
+        req: &[u8],
+        resp_buf: &'r mut [u8],
+    ) -> Result<(&'r mut [u8], MbxCmdStatus), MsgHandlerError> {
+        let req = ExportAttestedCsrReq::ref_from_bytes(req)
+            .map_err(|_| MsgHandlerError::InvalidParams)?;
+
+        let mut csr_data = AttestedCsrData::default();
+        let ret = self
+            .non_crypto_cmds_handler
+            .export_attested_csr(req.device_key_id, req.algorithm, &req.nonce, &mut csr_data)
+            .await;
+
+        let mbox_cmd_status = if ret.is_ok() {
+            MbxCmdStatus::Complete
+        } else {
+            MbxCmdStatus::Failure
+        };
+
+        let resp = if mbox_cmd_status == MbxCmdStatus::Complete {
+            let data_len = csr_data.len.min(MAX_RESP_DATA_SIZE);
+            let mut data = [0u8; MAX_RESP_DATA_SIZE];
+            data[..data_len].copy_from_slice(&csr_data.data[..data_len]);
+            ExportAttestedCsrResp {
+                hdr: MailboxRespHeaderVarSize {
+                    data_len: data_len as u32,
+                    ..Default::default()
+                },
+                data,
+            }
+        } else {
+            ExportAttestedCsrResp::default()
+        };
+
         let resp_bytes = resp
             .as_bytes_partial()
             .map_err(|_| MsgHandlerError::McuMboxCommon)?;

--- a/runtime/userspace/api/spdm-lib/src/vdm_handler/iana/mod.rs
+++ b/runtime/userspace/api/spdm-lib/src/vdm_handler/iana/mod.rs
@@ -1,3 +1,3 @@
 // Licensed under the Apache-2.0 license
 
-pub(crate) mod ocp;
+pub mod ocp;

--- a/runtime/userspace/api/spdm-lib/src/vdm_handler/iana/ocp/caliptra_vdm/commands/export_attested_csr.rs
+++ b/runtime/userspace/api/spdm-lib/src/vdm_handler/iana/ocp/caliptra_vdm/commands/export_attested_csr.rs
@@ -15,6 +15,7 @@ use zerocopy::{FromBytes, Immutable, IntoBytes};
 struct ExportAttestedCsrReq {
     device_key_id: u32,
     algorithm: u32,
+    nonce: [u8; 32],
 }
 
 impl CommonCodec for ExportAttestedCsrReq {}
@@ -28,7 +29,7 @@ pub(crate) async fn handle_export_attested_csr(
 
     let mut csr_data = AttestedCsrData::default();
     match handler
-        .export_attested_csr(req.device_key_id, req.algorithm, &mut csr_data)
+        .export_attested_csr(req.device_key_id, req.algorithm, &req.nonce, &mut csr_data)
         .await
     {
         Ok(()) => {


### PR DESCRIPTION
- Add baseline `CaliptraCmdHandler` implementation in app space backed by Caliptra mailbox API
- Support `ExportAttestedCsr` on MCU mailbox and SPDM-over-MCTP, remove from legacy MCTP VDM
- Fix nonce parameter missing from UnifiedCommandHandler trait
- Add host-side command-types, mailbox transport, API, client, and basic validator