### PR TITLE
[syscall] Add a syscall/capsule for Caliptra registers

### DIFF
--- a/platforms/emulator/runtime/src/board.rs
+++ b/platforms/emulator/runtime/src/board.rs
@@ -146,6 +146,7 @@ struct VeeR {
         'static,
         VirtualMuxAlarm<'static, InternalTimers<'static>>,
     >,
+    caliptra: &'static caliptra_mcu_capsules_runtime::caliptra::Caliptra,
     dma: &'static caliptra_mcu_capsules_emulator::dma::Dma<'static>,
     logging_flash:
         &'static caliptra_mcu_capsules_emulator::logging::driver::LoggingFlashDriver<'static>,
@@ -188,6 +189,7 @@ impl SyscallDriverLookup for VeeR {
                 f(Some(self.doe_spdm))
             }
             caliptra_mcu_capsules_runtime::mailbox::DRIVER_NUM => f(Some(self.mailbox)),
+            caliptra_mcu_capsules_runtime::caliptra::DRIVER_NUM => f(Some(self.caliptra)),
             caliptra_mcu_capsules_emulator::dma::DMA_CTRL_DRIVER_NUM => f(Some(self.dma)),
             caliptra_mcu_capsules_runtime::mci::DRIVER_NUM => f(Some(self.mci)),
             caliptra_mcu_config_emulator::flash::DRIVER_NUM_START
@@ -490,6 +492,26 @@ pub unsafe fn main() {
     ));
     mailbox.alarm.set_alarm_client(mailbox);
 
+    let caliptra_soc = static_init!(
+        caliptra_mcu_romtime::CaliptraSoC,
+        caliptra_mcu_romtime::CaliptraSoC::new(
+            Some(MCU_MEMORY_MAP.soc_offset),
+            Some(MCU_MEMORY_MAP.soc_offset),
+            Some(MCU_MEMORY_MAP.mbox_offset)
+        )
+    );
+
+    let caliptra = static_init!(
+        caliptra_mcu_capsules_runtime::caliptra::Caliptra,
+        caliptra_mcu_capsules_runtime::caliptra::Caliptra::new(
+            board_kernel.create_grant(
+                caliptra_mcu_capsules_runtime::caliptra::DRIVER_NUM,
+                &memory_allocation_cap
+            ),
+            caliptra_soc,
+        )
+    );
+
     let mci_regs = unsafe {
         caliptra_mcu_romtime::StaticRef::new(MCU_MEMORY_MAP.mci_offset as *const mci::regs::Mci)
     };
@@ -768,6 +790,7 @@ pub unsafe fn main() {
             doe_spdm,
             flash_partitions,
             mailbox,
+            caliptra,
             dma,
             logging_flash,
             mci,

--- a/romtime/src/soc_manager.rs
+++ b/romtime/src/soc_manager.rs
@@ -353,6 +353,10 @@ impl CaliptraSoC {
             _ => Err(CaliptraApiError::MailboxNoResponseData),
         }
     }
+
+    pub fn read_vendor_pk_hash(&mut self) -> [u32; 12] {
+        self.soc_ifc().fuse_vendor_pk_hash().read()
+    }
 }
 
 pub struct CaliptraMailboxResponse<'a> {

--- a/runtime/kernel/capsules/src/caliptra.rs
+++ b/runtime/kernel/capsules/src/caliptra.rs
@@ -1,0 +1,99 @@
+// Licensed under the Apache-2.0 license
+
+//! This provides the Caliptra capsule that handles syscalls for reading registers.
+
+use caliptra_mcu_romtime::CaliptraSoC;
+use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
+use kernel::syscall::{CommandReturn, SyscallDriver};
+use kernel::utilities::cells::TakeCell;
+use kernel::{ErrorCode, ProcessId};
+
+/// The driver number for Caliptra commands.
+pub const DRIVER_NUM: usize = 0x8000_0011;
+
+mod cmd {
+    pub const CALIPTRA_READ: u32 = 1;
+    pub const CALIPTRA_SET_REGISTER: u32 = 3;
+}
+
+pub mod reg {
+    pub const VENDOR_PK_HASH: u32 = 0x260;
+}
+
+#[derive(Default)]
+pub struct App {
+    pub reg_offset: u32,
+    pub reg_index: u32,
+}
+
+pub struct Caliptra {
+    // The underlying Caliptra API SoC interface
+    driver: TakeCell<'static, CaliptraSoC>,
+    // Per-app state.
+    apps: Grant<App, UpcallCount<0>, AllowRoCount<0>, AllowRwCount<0>>,
+}
+
+impl Caliptra {
+    pub fn new(
+        grant: Grant<App, UpcallCount<0>, AllowRoCount<0>, AllowRwCount<0>>,
+        driver: &'static mut CaliptraSoC,
+    ) -> Caliptra {
+        Caliptra {
+            driver: TakeCell::new(driver),
+            apps: grant,
+        }
+    }
+
+    fn read_reg(&self, processid: ProcessId) -> CommandReturn {
+        match self.apps.enter(processid, |app, _| match app.reg_offset {
+            reg::VENDOR_PK_HASH => self
+                .driver
+                .map(
+                    |driver| match driver.read_vendor_pk_hash().get(app.reg_index as usize) {
+                        Some(word) => CommandReturn::success_u32(*word),
+                        None => CommandReturn::failure(ErrorCode::INVAL),
+                    },
+                )
+                .ok_or(ErrorCode::RESERVE)
+                .unwrap_or_else(CommandReturn::failure),
+            _ => CommandReturn::failure(ErrorCode::NOSUPPORT),
+        }) {
+            Ok(ret) => ret,
+            Err(_) => CommandReturn::failure(ErrorCode::FAIL),
+        }
+    }
+
+    fn set_reg(&self, reg: u32, index: u32, processid: ProcessId) -> CommandReturn {
+        if self
+            .apps
+            .enter(processid, |app, _| {
+                app.reg_offset = reg;
+                app.reg_index = index;
+            })
+            .is_err()
+        {
+            return CommandReturn::failure(ErrorCode::FAIL);
+        }
+        CommandReturn::success()
+    }
+}
+
+impl SyscallDriver for Caliptra {
+    fn command(
+        &self,
+        caliptra_cmd: usize,
+        arg1: usize,
+        arg2: usize,
+        processid: ProcessId,
+    ) -> CommandReturn {
+        match caliptra_cmd as u32 {
+            cmd::CALIPTRA_READ => self.read_reg(processid),
+            cmd::CALIPTRA_SET_REGISTER => self.set_reg(arg1 as u32, arg2 as u32, processid),
+            _ => CommandReturn::failure(ErrorCode::NOSUPPORT),
+        }
+    }
+
+    fn allocate_grant(&self, processid: ProcessId) -> Result<(), kernel::process::Error> {
+        self.apps.enter(processid, |_, _| {})
+    }
+}

--- a/runtime/kernel/capsules/src/lib.rs
+++ b/runtime/kernel/capsules/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod test;
 
+pub mod caliptra;
 pub mod doe;
 pub mod flash_partition;
 pub mod mailbox;

--- a/runtime/userspace/syscall/src/caliptra.rs
+++ b/runtime/userspace/syscall/src/caliptra.rs
@@ -1,0 +1,72 @@
+// Licensed under the Apache-2.0 license
+
+//! # Caliptra Interface
+extern crate alloc;
+use crate::DefaultSyscalls;
+use caliptra_mcu_libtock_platform::{ErrorCode, Syscalls};
+use core::marker::PhantomData;
+
+/// Caliptra interface user interface.
+///
+/// # Generics
+/// - `S`: The syscall implementation.
+pub struct Caliptra<S: Syscalls = DefaultSyscalls> {
+    _syscall: PhantomData<S>,
+    driver_num: u32,
+}
+
+impl<S: Syscalls> Default for Caliptra<S> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<S: Syscalls> Caliptra<S> {
+    pub fn new() -> Self {
+        Self {
+            _syscall: PhantomData,
+            driver_num: CALIPTRA_DRIVER_NUM,
+        }
+    }
+
+    pub fn read(&self, reg_offset: u32, index: u32) -> Result<u32, ErrorCode> {
+        S::command(
+            self.driver_num,
+            cmd::CALIPTRA_SET_REGISTER,
+            reg_offset,
+            index,
+        )
+        .to_result::<(), ErrorCode>()?;
+
+        S::command(self.driver_num, cmd::CALIPTRA_READ, reg_offset, index)
+            .to_result::<u32, ErrorCode>()
+    }
+
+    /// Reads the vendor PK hash from the Caliptra fuses.
+    pub fn read_vendor_pk_hash(&self) -> Result<[u8; 48], ErrorCode> {
+        let mut fuse_value = [0u8; 48];
+        for (i, chunk) in fuse_value.chunks_exact_mut(4).enumerate() {
+            let word = self.read(reg::VENDOR_PK_HASH, i as u32)?;
+            let bytes = word.to_le_bytes();
+            chunk.copy_from_slice(&bytes);
+        }
+        Ok(fuse_value)
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Command IDs and Caliptra-specific constants
+// -----------------------------------------------------------------------------
+
+// Driver number for the Caliptra interface
+pub const CALIPTRA_DRIVER_NUM: u32 = 0x8000_0011;
+
+pub mod cmd {
+    pub const CALIPTRA_READ: u32 = 1;
+    pub const CALIPTRA_WRITE: u32 = 2;
+    pub const CALIPTRA_SET_REGISTER: u32 = 3;
+}
+
+pub mod reg {
+    pub const VENDOR_PK_HASH: u32 = 0x260;
+}

--- a/runtime/userspace/syscall/src/lib.rs
+++ b/runtime/userspace/syscall/src/lib.rs
@@ -2,6 +2,7 @@
 
 #![no_std]
 
+pub mod caliptra;
 pub mod dma;
 pub mod doe;
 pub mod flash;


### PR DESCRIPTION
The only register added currently is the Vendor PK hash register. This will be used for some authorized commands.