### PR TITLE
Move FIRMWARE_LOAD to ActivateFirmware phase

### DIFF
--- a/runtime/userspace/api/caliptra-api/src/firmware_update/mod.rs
+++ b/runtime/userspace/api/caliptra-api/src/firmware_update/mod.rs
@@ -109,15 +109,15 @@ impl<'a, D: DMAMapping> FirmwareUpdater<'a, D> {
         let img_len = pldm_total_component_size();
         self.staging_memory.image_valid(img_len).await?;
 
+        pldm_client::pldm_set_apply_result(ApplyResult::ApplySuccess);
+        pldm_client::pldm_wait(State::Activate).await?;
+
         // Update Caliptra
         let result = self.update_caliptra(&flash_header).await;
         if result.is_err() {
-            pldm_client::pldm_set_apply_result(ApplyResult::ApplyGenericError);
             // Abort firmware update
             return Err(ErrorCode::Fail);
         }
-        pldm_client::pldm_set_apply_result(ApplyResult::ApplySuccess);
-        pldm_client::pldm_wait(State::Activate).await?;
 
         self.set_auth_manifest().await?;
 


### PR DESCRIPTION
Move update_caliptra() (which issues the FIRMWARE_LOAD mailbox command) from the Apply phase to the Activate phase, matching the spec in docs/src/firmware_update.md.

The Apply phase now only marks the staging partition as valid and signals ApplySuccess. The FIRMWARE_LOAD, SET_AUTH_MANIFEST, and MCU update all execute after pldm_wait(State::Activate).

Fixes: #1336