### PR TITLE
[auth-cmds] Add a command to revoke a vendor FW verification key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1371,6 +1371,7 @@ dependencies = [
  "caliptra-mcu-libtock_runtime",
  "caliptra-mcu-libtock_unittest",
  "caliptra-mcu-libtockasync",
+ "caliptra-mcu-mbox-common",
  "caliptra-mcu-registers-generated",
  "embassy-sync",
 ]

--- a/common/mcu-mbox/src/messages.rs
+++ b/common/mcu-mbox/src/messages.rs
@@ -124,6 +124,7 @@ impl CommandId {
     pub const MC_ROTATE_VENDOR_PK_HASH: Self = Self(0x4D56_504B); // "MVPK"
     pub const MC_FUSE_INCREASE_CALIPTRA_MIN_SVN: Self = Self(0x4D43_4D53); // "MCMS"
     pub const MC_FE_PROG: Self = Self(0x4D43_4650); // "MCFP"
+    pub const MC_FUSE_REVOKE_VENDOR_PUB_KEY: Self = Self(0x4D52_564B); // "MRVK"
 
     // Certificate commands
     pub const MC_EXPORT_ATTESTED_CSR: Self = Self(0x4D45_4143); // "MEAC"
@@ -191,6 +192,7 @@ pub enum McuMailboxReq {
     FuseIncreaseCaliptraMinSvn(FuseIncreaseCaliptraMinSvnReq),
     FeProg(McuFeProgReq),
     GetAuthCmdChallenge(GetAuthCmdChallengeReq),
+    FuseRevokeVendorPubKey(FuseRevokeVendorPubKeyReq),
     // Certificate commands
     ExportAttestedCsr(ExportAttestedCsrReq),
 }
@@ -243,6 +245,7 @@ impl McuMailboxReq {
             McuMailboxReq::FuseIncreaseCaliptraMinSvn(req) => Ok(req.as_bytes()),
             McuMailboxReq::FeProg(req) => Ok(req.as_bytes()),
             McuMailboxReq::GetAuthCmdChallenge(req) => Ok(req.as_bytes()),
+            McuMailboxReq::FuseRevokeVendorPubKey(req) => Ok(req.as_bytes()),
             McuMailboxReq::ExportAttestedCsr(req) => Ok(req.as_bytes()),
         }
     }
@@ -294,6 +297,7 @@ impl McuMailboxReq {
             McuMailboxReq::FuseIncreaseCaliptraMinSvn(req) => Ok(req.as_mut_bytes()),
             McuMailboxReq::FeProg(req) => Ok(req.as_mut_bytes()),
             McuMailboxReq::GetAuthCmdChallenge(req) => Ok(req.as_mut_bytes()),
+            McuMailboxReq::FuseRevokeVendorPubKey(req) => Ok(req.as_mut_bytes()),
             McuMailboxReq::ExportAttestedCsr(req) => Ok(req.as_mut_bytes()),
         }
     }
@@ -347,6 +351,7 @@ impl McuMailboxReq {
             }
             McuMailboxReq::FeProg(_) => CommandId::MC_FE_PROG,
             McuMailboxReq::GetAuthCmdChallenge(_) => CommandId::MC_GET_AUTH_CMD_CHALLENGE,
+            McuMailboxReq::FuseRevokeVendorPubKey(_) => CommandId::MC_FUSE_REVOKE_VENDOR_PUB_KEY,
             McuMailboxReq::ExportAttestedCsr(_) => CommandId::MC_EXPORT_ATTESTED_CSR,
         }
     }
@@ -421,6 +426,7 @@ pub enum McuMailboxResp {
     FuseWrite(FuseWriteResp),
     FuseLockPartition(FuseLockPartitionResp),
     GetAuthCmdChallenge(GetAuthCmdChallengeResp),
+    FuseRevokeVendorPubKey(FuseRevokeVendorPubKeyResp),
     // Certificate commands
     ExportAttestedCsr(ExportAttestedCsrResp),
 }
@@ -532,6 +538,7 @@ impl McuMailboxResp {
             McuMailboxResp::FuseWrite(resp) => Ok(resp.as_bytes()),
             McuMailboxResp::FuseLockPartition(resp) => Ok(resp.as_bytes()),
             McuMailboxResp::GetAuthCmdChallenge(resp) => Ok(resp.as_bytes()),
+            McuMailboxResp::FuseRevokeVendorPubKey(resp) => Ok(resp.as_bytes()),
             McuMailboxResp::ExportAttestedCsr(resp) => resp.as_bytes_partial(),
         }
     }
@@ -582,6 +589,7 @@ impl McuMailboxResp {
             McuMailboxResp::FuseWrite(resp) => Ok(resp.as_mut_bytes()),
             McuMailboxResp::FuseLockPartition(resp) => Ok(resp.as_mut_bytes()),
             McuMailboxResp::GetAuthCmdChallenge(resp) => Ok(resp.as_mut_bytes()),
+            McuMailboxResp::FuseRevokeVendorPubKey(resp) => Ok(resp.as_mut_bytes()),
             McuMailboxResp::ExportAttestedCsr(resp) => resp.as_bytes_partial_mut(),
         }
     }
@@ -1434,6 +1442,55 @@ pub struct McuFeProgReq {
 impl Request for McuFeProgReq {
     const ID: CommandId = CommandId::MC_FE_PROG;
     type Resp = FuseWriteResp; // Reuse FuseWriteResp as it only contains header
+}
+
+/// MC_FUSE_REVOKE_VENDOR_PUB_KEY request: Revoke a vendor firmware verification key.
+#[repr(C)]
+#[derive(Debug, Default, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct FuseRevokeVendorPubKeyReq {
+    pub hdr: MailboxReqHeader,
+    pub reserved: u32,
+    pub vendor_pk_hash_slot: u32,
+    pub key_type: u32,
+    pub key_index: u32,
+}
+impl Request for FuseRevokeVendorPubKeyReq {
+    const ID: CommandId = CommandId::MC_FUSE_REVOKE_VENDOR_PUB_KEY;
+    type Resp = FuseRevokeVendorPubKeyResp;
+}
+
+/// MC_FUSE_LOCK_PARTITION response: Indicates success or failure.
+#[repr(C)]
+#[derive(Debug, Default, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct FuseRevokeVendorPubKeyResp {
+    pub hdr: MailboxRespHeader,
+}
+impl Response for FuseRevokeVendorPubKeyResp {}
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum RevokeVendorPubKeyType {
+    Ecdsa384,
+    Lms,
+    Mldsa87,
+}
+
+impl TryFrom<u32> for RevokeVendorPubKeyType {
+    type Error = ();
+
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Self::Ecdsa384),
+            1 => Ok(Self::Lms),
+            2 => Ok(Self::Mldsa87),
+            _ => Err(()),
+        }
+    }
+}
+
+impl From<RevokeVendorPubKeyType> for u32 {
+    fn from(value: RevokeVendorPubKeyType) -> Self {
+        value as u32
+    }
 }
 
 // ============================================================================

--- a/romtime/src/otp.rs
+++ b/romtime/src/otp.rs
@@ -512,7 +512,8 @@ impl Otp {
 
     /// Read vendor public key hash valid.
     pub fn read_vendor_pk_hash_valid(&self) -> McuResult<u32> {
-        self.read_entry(fuses::VENDOR_PK_HASH_VALID)
+        let val = self.read_entry_multi::<1>(fuses::VENDOR_PK_HASH_VALID)?;
+        Ok(val[0])
     }
 
     /// Read cptra_core_runtime_svn (16 bytes).
@@ -565,6 +566,24 @@ impl Otp {
     pub fn read_vendor_mldsa_revocation(&self, index: usize) -> McuResult<u32> {
         let entry = vendor_mldsa_revocation_entry(index)?;
         self.read_entry(entry)
+    }
+
+    /// Write vendor ECC revocation (4 bytes).
+    pub fn write_vendor_ecc_revocation(&self, index: usize, value: u32) -> McuResult<()> {
+        let entry = vendor_ecc_revocation_entry(index)?;
+        self.write_entry(entry, value)
+    }
+
+    /// Write vendor LMS revocation (4 bytes).
+    pub fn write_vendor_lms_revocation(&self, index: usize, value: u32) -> McuResult<()> {
+        let entry = vendor_lms_revocation_entry(index)?;
+        self.write_entry(entry, value)
+    }
+
+    /// Write vendor MLDSA revocation (4 bytes).
+    pub fn write_vendor_mldsa_revocation(&self, index: usize, value: u32) -> McuResult<()> {
+        let entry = vendor_mldsa_revocation_entry(index)?;
+        self.write_entry(entry, value)
     }
 
     /// Read cptra_ss_owner_pk_hash (48 bytes).

--- a/runtime/kernel/capsules/src/otp.rs
+++ b/runtime/kernel/capsules/src/otp.rs
@@ -94,6 +94,10 @@ pub mod reg {
             _ => None,
         }
     }
+
+    pub const VENDOR_ECC_REVOCATION: u32 = 27;
+    pub const VENDOR_LMS_REVOCATION: u32 = 28;
+    pub const VENDOR_MLDSA_REVOCATION: u32 = 29;
 }
 
 #[derive(Default)]
@@ -193,6 +197,33 @@ impl Otp {
                     hash[offset..offset + 4].try_into().unwrap(),
                 ))
             }
+            reg::VENDOR_ECC_REVOCATION => {
+                match self
+                    .driver
+                    .read_vendor_ecc_revocation(app.reg_index as usize)
+                {
+                    Ok(val) => CommandReturn::success_u32(val),
+                    Err(_) => CommandReturn::failure(ErrorCode::INVAL),
+                }
+            }
+            reg::VENDOR_LMS_REVOCATION => {
+                match self
+                    .driver
+                    .read_vendor_lms_revocation(app.reg_index as usize)
+                {
+                    Ok(val) => CommandReturn::success_u32(val),
+                    Err(_) => CommandReturn::failure(ErrorCode::INVAL),
+                }
+            }
+            reg::VENDOR_MLDSA_REVOCATION => {
+                match self
+                    .driver
+                    .read_vendor_mldsa_revocation(app.reg_index as usize)
+                {
+                    Ok(val) => CommandReturn::success_u32(val),
+                    Err(_) => CommandReturn::failure(ErrorCode::INVAL),
+                }
+            }
             _ => CommandReturn::failure(ErrorCode::NOSUPPORT),
         }) {
             Ok(ret) => ret,
@@ -262,6 +293,33 @@ impl Otp {
                 match self.driver.write_word(word_addr, value) {
                     Ok(_) => CommandReturn::success(),
                     Err(_) => CommandReturn::failure(ErrorCode::FAIL),
+                }
+            }
+            reg::VENDOR_ECC_REVOCATION => {
+                match self
+                    .driver
+                    .write_vendor_ecc_revocation(app.reg_index as usize, value)
+                {
+                    Ok(()) => CommandReturn::success(),
+                    Err(_) => CommandReturn::failure(ErrorCode::INVAL),
+                }
+            }
+            reg::VENDOR_LMS_REVOCATION => {
+                match self
+                    .driver
+                    .write_vendor_lms_revocation(app.reg_index as usize, value)
+                {
+                    Ok(()) => CommandReturn::success(),
+                    Err(_) => CommandReturn::failure(ErrorCode::INVAL),
+                }
+            }
+            reg::VENDOR_MLDSA_REVOCATION => {
+                match self
+                    .driver
+                    .write_vendor_mldsa_revocation(app.reg_index as usize, value)
+                {
+                    Ok(()) => CommandReturn::success(),
+                    Err(_) => CommandReturn::failure(ErrorCode::INVAL),
                 }
             }
             _ => CommandReturn::failure(ErrorCode::NOSUPPORT),

--- a/runtime/userspace/api/mcu-mbox-lib/src/cmd_interface.rs
+++ b/runtime/userspace/api/mcu-mbox-lib/src/cmd_interface.rs
@@ -9,23 +9,23 @@ use caliptra_mcu_external_cmds_common::{
 use caliptra_mcu_libapi_caliptra::crypto::rng::Rng;
 use caliptra_mcu_libapi_caliptra::mailbox_api::execute_mailbox_cmd;
 use caliptra_mcu_libsyscall_caliptra::mcu_mbox::MbxCmdStatus;
-use caliptra_mcu_libsyscall_caliptra::otp;
+use caliptra_mcu_libsyscall_caliptra::{caliptra, otp};
 use caliptra_mcu_libsyscall_caliptra::{mailbox::Mailbox, DefaultSyscalls};
 use caliptra_mcu_mbox_common::messages::{
     CommandId, DeviceCapsReq, DeviceCapsResp, DeviceIdReq, DeviceIdResp, DeviceInfoReq,
     DeviceInfoResp, ExportAttestedCsrReq, ExportAttestedCsrResp, FirmwareVersionReq,
     FirmwareVersionResp, FuseIncreaseCaliptraMinSvnReq, FuseIncreaseCaliptraMinSvnResp,
-    FuseWriteResp, GetAuthCmdChallengeReq, GetAuthCmdChallengeResp, MailboxRespHeader,
-    MailboxRespHeaderVarSize, McuAesDecryptInitReq, McuAesDecryptUpdateReq, McuAesEncryptInitReq,
-    McuAesEncryptUpdateReq, McuAesGcmDecryptFinalReq, McuAesGcmDecryptInitReq,
-    McuAesGcmDecryptUpdateReq, McuAesGcmEncryptFinalReq, McuAesGcmEncryptInitReq,
-    McuAesGcmEncryptUpdateReq, McuCmDeleteReq, McuCmImportReq, McuCmStatusReq, McuEcdhFinishReq,
-    McuEcdhGenerateReq, McuEcdsaCmkPublicKeyReq, McuEcdsaCmkSignReq, McuEcdsaCmkVerifyReq,
-    McuFeProgReq, McuFipsSelfTestGetResultsReq, McuFipsSelfTestStartReq, McuHkdfExpandReq,
-    McuHkdfExtractReq, McuHmacKdfCounterReq, McuHmacReq, McuProdDebugUnlockReqReq,
-    McuProdDebugUnlockTokenReq, McuRandomGenerateReq, McuRandomStirReq, McuResponseVarSize,
-    McuShaFinalReq, McuShaInitReq, McuShaUpdateReq, DEVICE_CAPS_SIZE, MAX_FW_VERSION_STR_LEN,
-    MAX_RESP_DATA_SIZE,
+    FuseRevokeVendorPubKeyReq, FuseRevokeVendorPubKeyResp, FuseWriteResp, GetAuthCmdChallengeReq,
+    GetAuthCmdChallengeResp, MailboxRespHeader, MailboxRespHeaderVarSize, McuAesDecryptInitReq,
+    McuAesDecryptUpdateReq, McuAesEncryptInitReq, McuAesEncryptUpdateReq, McuAesGcmDecryptFinalReq,
+    McuAesGcmDecryptInitReq, McuAesGcmDecryptUpdateReq, McuAesGcmEncryptFinalReq,
+    McuAesGcmEncryptInitReq, McuAesGcmEncryptUpdateReq, McuCmDeleteReq, McuCmImportReq,
+    McuCmStatusReq, McuEcdhFinishReq, McuEcdhGenerateReq, McuEcdsaCmkPublicKeyReq,
+    McuEcdsaCmkSignReq, McuEcdsaCmkVerifyReq, McuFeProgReq, McuFipsSelfTestGetResultsReq,
+    McuFipsSelfTestStartReq, McuHkdfExpandReq, McuHkdfExtractReq, McuHmacKdfCounterReq, McuHmacReq,
+    McuProdDebugUnlockReqReq, McuProdDebugUnlockTokenReq, McuRandomGenerateReq, McuRandomStirReq,
+    McuResponseVarSize, McuShaFinalReq, McuShaInitReq, McuShaUpdateReq, RevokeVendorPubKeyType,
+    DEVICE_CAPS_SIZE, MAX_FW_VERSION_STR_LEN, MAX_RESP_DATA_SIZE,
 };
 #[cfg(feature = "periodic-fips-self-test")]
 use caliptra_mcu_mbox_common::messages::{
@@ -422,7 +422,8 @@ impl<'a> CmdInterface<'a> {
             }
             cmd_id @ CommandId::MC_ROTATE_VENDOR_PK_HASH
             | cmd_id @ CommandId::MC_FUSE_INCREASE_CALIPTRA_MIN_SVN
-            | cmd_id @ CommandId::MC_FE_PROG => {
+            | cmd_id @ CommandId::MC_FE_PROG
+            | cmd_id @ CommandId::MC_FUSE_REVOKE_VENDOR_PUB_KEY => {
                 self.handle_authorized_command(cmd_id, req, resp_buf).await
             }
             // Certificate commands
@@ -721,6 +722,9 @@ impl<'a> CmdInterface<'a> {
                 self.handle_increase_caliptra_min_svn(cmd, resp_buf).await
             }
             CommandId::MC_FE_PROG => self.handle_fe_prog(cmd, resp_buf).await,
+            CommandId::MC_FUSE_REVOKE_VENDOR_PUB_KEY => {
+                self.handle_revoke_vendor_pub_key(cmd, resp_buf).await
+            }
             _ => Err(MsgHandlerError::UnsupportedCommand),
         }
     }
@@ -848,6 +852,71 @@ impl<'a> CmdInterface<'a> {
         *resp = FuseWriteResp::default();
         let resp_len = resp.as_bytes().len();
         Ok((&mut resp_buf[..resp_len], MbxCmdStatus::Complete))
+    }
+
+    async fn handle_revoke_vendor_pub_key<'r>(
+        &self,
+        req: &[u8],
+        resp_buf: &'r mut [u8],
+    ) -> Result<(&'r mut [u8], MbxCmdStatus), MsgHandlerError> {
+        let req = FuseRevokeVendorPubKeyReq::ref_from_bytes(req)
+            .map_err(|_| MsgHandlerError::InvalidParams)?;
+        let (resp, _) = FuseRevokeVendorPubKeyResp::mut_from_prefix(resp_buf)
+            .map_err(|_| MsgHandlerError::InvalidParams)?;
+        let key_type = RevokeVendorPubKeyType::try_from(req.key_type)
+            .map_err(|_| MsgHandlerError::InvalidParams)?;
+
+        // Check the given slot has a valid PK hash provisioned
+        let otp = otp::Otp::<DefaultSyscalls>::new();
+        if !otp.valid_vendor_pk_hash_slot(req.vendor_pk_hash_slot) {
+            Err(MsgHandlerError::InvalidParams)?;
+        }
+
+        let caliptra_info = self.get_caliptra_fw_info().await?;
+
+        // Check if the key to be revoked was a key used to boot. If so, return an error as a form
+        // of proof of possession for other keys.
+        let same_key_used_to_boot = || {
+            let caliptra_soc = caliptra::Caliptra::<DefaultSyscalls>::new();
+            let booted_pk_hash = caliptra_soc
+                .read_vendor_pk_hash()
+                .map_err(|_| MsgHandlerError::McuMboxCommon)?;
+            let pk_hash_from_slot = otp
+                .read_vendor_pk_hash(req.vendor_pk_hash_slot)
+                .map_err(|_| MsgHandlerError::McuMboxCommon)?;
+
+            // Check if the requested slot was the one used to boot
+            if booted_pk_hash != pk_hash_from_slot {
+                return Ok(false);
+            }
+
+            const FW_VERIFICATION_PQC_TYPE_MLDSA: u32 = 1;
+            const FW_VERIFICATION_PQC_TYPE_LMS: u32 = 3;
+            let same_key = match (key_type, caliptra_info.image_manifest_pqc_type) {
+                (RevokeVendorPubKeyType::Ecdsa384, _) => {
+                    req.key_index == caliptra_info.vendor_ecc384_pub_key_index
+                }
+                // Same PQC type
+                (RevokeVendorPubKeyType::Lms, FW_VERIFICATION_PQC_TYPE_LMS)
+                | (RevokeVendorPubKeyType::Mldsa87, FW_VERIFICATION_PQC_TYPE_MLDSA) => {
+                    req.key_index == caliptra_info.vendor_pqc_pub_key_index
+                }
+                // Different PQC types
+                _ => false,
+            };
+            Ok(same_key)
+        };
+
+        if same_key_used_to_boot()? {
+            Err(MsgHandlerError::InvalidParams)?;
+        }
+
+        otp.revoke_vendor_pub_key(req.vendor_pk_hash_slot, key_type, req.key_index)
+            .map_err(|_| MsgHandlerError::McuMboxCommon)?;
+
+        *resp = FuseRevokeVendorPubKeyResp::default();
+        let len = size_of_val(resp);
+        Ok((&mut resp_buf[..len], MbxCmdStatus::Complete))
     }
 
     async fn get_caliptra_fw_info(

--- a/runtime/userspace/syscall/Cargo.toml
+++ b/runtime/userspace/syscall/Cargo.toml
@@ -14,6 +14,7 @@ caliptra-mcu-libtock_console.workspace = true
 caliptra-mcu-libtock_platform.workspace = true
 caliptra-mcu-libtockasync.workspace = true
 caliptra-mcu-libtock_runtime.workspace = true
+caliptra-mcu-mbox-common.workspace = true
 caliptra-mcu-registers-generated.workspace = true
 
 [target.'cfg(not(target_arch = "riscv32"))'.dependencies]

--- a/runtime/userspace/syscall/src/otp.rs
+++ b/runtime/userspace/syscall/src/otp.rs
@@ -4,10 +4,15 @@
 
 use crate::DefaultSyscalls;
 use caliptra_mcu_libtock_platform::{ErrorCode, Syscalls};
+use caliptra_mcu_mbox_common::messages::RevokeVendorPubKeyType;
 use core::marker::PhantomData;
 
 pub const VENDOR_PK_HASH_SIZE: usize =
     caliptra_mcu_registers_generated::fuses::OTP_CPTRA_CORE_VENDOR_PK_HASH_0.byte_size;
+pub const MAX_NUM_VENDOR_PK_HASH: usize = 16;
+pub const VENDOR_ECC_MAX_KEY_COUNT: u32 = 4;
+pub const VENDOR_LMS_MAX_KEY_COUNT: u32 = 32;
+pub const VENDOR_MLDSA_MAX_KEY_COUNT: u32 = 4;
 
 pub struct Otp<S: Syscalls = DefaultSyscalls> {
     syscall: PhantomData<S>,
@@ -44,14 +49,15 @@ impl<S: Syscalls> Otp<S> {
 
     /// Check whether a given slot has a valid PK hash
     pub fn valid_vendor_pk_hash_slot(&self, slot: u32) -> bool {
-        if slot >= 16 {
+        if slot as usize >= MAX_NUM_VENDOR_PK_HASH {
             return false;
         }
 
         let Ok(valid_mask) = self.read(reg::VENDOR_PK_HASH_VALID, 0) else {
             return false;
         };
-        (valid_mask & (1 << slot)) != 0
+        // Bit value `1` means revoked
+        (valid_mask & (1 << slot)) == 0
     }
 
     /// Read a vendor PK hash from fuses
@@ -70,6 +76,47 @@ impl<S: Syscalls> Otp<S> {
 
         Ok(fuse_value)
     }
+
+    /// Revoke an individual key within a PK hash slot
+    pub fn revoke_vendor_pub_key(
+        &self,
+        vendor_pk_hash_slot: u32,
+        key_type: RevokeVendorPubKeyType,
+        key_index: u32,
+    ) -> Result<(), ErrorCode> {
+        if !self.valid_vendor_pk_hash_slot(vendor_pk_hash_slot) {
+            Err(ErrorCode::Invalid)?;
+        }
+
+        // Check the index is valid.
+        // NOTE: the last index can not be revoked per Caliptra
+        match key_type {
+            RevokeVendorPubKeyType::Ecdsa384 => {
+                if key_index >= VENDOR_ECC_MAX_KEY_COUNT - 1 {
+                    Err(ErrorCode::Invalid)?;
+                }
+            }
+            RevokeVendorPubKeyType::Lms => {
+                if key_index >= VENDOR_LMS_MAX_KEY_COUNT - 1 {
+                    Err(ErrorCode::Invalid)?;
+                }
+            }
+            RevokeVendorPubKeyType::Mldsa87 => {
+                if key_index >= VENDOR_MLDSA_MAX_KEY_COUNT - 1 {
+                    Err(ErrorCode::Invalid)?;
+                }
+            }
+        }
+
+        let reg_offset = reg::vendor_revocation_by_type(key_type);
+        let current = self.read(reg_offset, vendor_pk_hash_slot)?;
+        let to_write = current | (1 << key_index);
+        if current == to_write {
+            return Ok(());
+        }
+
+        self.write(reg_offset, vendor_pk_hash_slot, to_write)
+    }
 }
 
 // -----------------------------------------------------------------------------
@@ -86,6 +133,8 @@ pub mod cmd {
 }
 
 pub mod reg {
+    use super::*;
+
     pub const LOCK_TOTAL_HEKS: u32 = 0;
     pub const LOCK_HEK_PROD_0: u32 = 1;
     pub const LOCK_HEK_PROD_1: u32 = 2;
@@ -146,6 +195,18 @@ pub mod reg {
             14 => Some(VENDOR_PK_HASH_14),
             15 => Some(VENDOR_PK_HASH_15),
             _ => None,
+        }
+    }
+
+    pub const VENDOR_ECC_REVOCATION: u32 = 27;
+    pub const VENDOR_LMS_REVOCATION: u32 = 28;
+    pub const VENDOR_MLDSA_REVOCATION: u32 = 29;
+
+    pub(super) fn vendor_revocation_by_type(key_type: RevokeVendorPubKeyType) -> u32 {
+        match key_type {
+            RevokeVendorPubKeyType::Ecdsa384 => VENDOR_ECC_REVOCATION,
+            RevokeVendorPubKeyType::Lms => VENDOR_LMS_REVOCATION,
+            RevokeVendorPubKeyType::Mldsa87 => VENDOR_MLDSA_REVOCATION,
         }
     }
 }


### PR DESCRIPTION
This checks the key to be revoked was not used for boot. This is a form of proof of possession check to ensure other PKs are valid before revocation.

Tests will be added in a follow-on change.