### PR TITLE
[auth-cmds] Add a command to get a challenge nonce

### DIFF
--- a/common/mcu-mbox/src/messages.rs
+++ b/common/mcu-mbox/src/messages.rs
@@ -120,6 +120,7 @@ impl CommandId {
     pub const MC_FUSE_LOCK_PARTITION: Self = Self(0x4946_504B); // "IFPK"
 
     // Authorized commands
+    pub const MC_GET_AUTH_CMD_CHALLENGE: Self = Self(0x4D414343); // "MACC"
     pub const MC_ROTATE_VENDOR_PK_HASH: Self = Self(0x4D56_504B); // "MVPK"
     pub const MC_FUSE_INCREASE_CALIPTRA_MIN_SVN: Self = Self(0x4D43_4D53); // "MCMS"
     pub const MC_FE_PROG: Self = Self(0x4D43_4650); // "MCFP"
@@ -189,6 +190,7 @@ pub enum McuMailboxReq {
     FuseLockPartition(FuseLockPartitionReq),
     FuseIncreaseCaliptraMinSvn(FuseIncreaseCaliptraMinSvnReq),
     FeProg(McuFeProgReq),
+    GetAuthCmdChallenge(GetAuthCmdChallengeReq),
     // Certificate commands
     ExportAttestedCsr(ExportAttestedCsrReq),
 }
@@ -240,6 +242,7 @@ impl McuMailboxReq {
             McuMailboxReq::FuseLockPartition(req) => Ok(req.as_bytes()),
             McuMailboxReq::FuseIncreaseCaliptraMinSvn(req) => Ok(req.as_bytes()),
             McuMailboxReq::FeProg(req) => Ok(req.as_bytes()),
+            McuMailboxReq::GetAuthCmdChallenge(req) => Ok(req.as_bytes()),
             McuMailboxReq::ExportAttestedCsr(req) => Ok(req.as_bytes()),
         }
     }
@@ -290,6 +293,7 @@ impl McuMailboxReq {
             McuMailboxReq::FuseLockPartition(req) => Ok(req.as_mut_bytes()),
             McuMailboxReq::FuseIncreaseCaliptraMinSvn(req) => Ok(req.as_mut_bytes()),
             McuMailboxReq::FeProg(req) => Ok(req.as_mut_bytes()),
+            McuMailboxReq::GetAuthCmdChallenge(req) => Ok(req.as_mut_bytes()),
             McuMailboxReq::ExportAttestedCsr(req) => Ok(req.as_mut_bytes()),
         }
     }
@@ -342,6 +346,7 @@ impl McuMailboxReq {
                 CommandId::MC_FUSE_INCREASE_CALIPTRA_MIN_SVN
             }
             McuMailboxReq::FeProg(_) => CommandId::MC_FE_PROG,
+            McuMailboxReq::GetAuthCmdChallenge(_) => CommandId::MC_GET_AUTH_CMD_CHALLENGE,
             McuMailboxReq::ExportAttestedCsr(_) => CommandId::MC_EXPORT_ATTESTED_CSR,
         }
     }
@@ -415,6 +420,7 @@ pub enum McuMailboxResp {
     FuseRead(FuseReadResp),
     FuseWrite(FuseWriteResp),
     FuseLockPartition(FuseLockPartitionResp),
+    GetAuthCmdChallenge(GetAuthCmdChallengeResp),
     // Certificate commands
     ExportAttestedCsr(ExportAttestedCsrResp),
 }
@@ -525,6 +531,7 @@ impl McuMailboxResp {
             McuMailboxResp::FuseRead(resp) => resp.as_bytes_partial(),
             McuMailboxResp::FuseWrite(resp) => Ok(resp.as_bytes()),
             McuMailboxResp::FuseLockPartition(resp) => Ok(resp.as_bytes()),
+            McuMailboxResp::GetAuthCmdChallenge(resp) => Ok(resp.as_bytes()),
             McuMailboxResp::ExportAttestedCsr(resp) => resp.as_bytes_partial(),
         }
     }
@@ -574,6 +581,7 @@ impl McuMailboxResp {
             McuMailboxResp::FuseRead(resp) => resp.as_bytes_partial_mut(),
             McuMailboxResp::FuseWrite(resp) => Ok(resp.as_mut_bytes()),
             McuMailboxResp::FuseLockPartition(resp) => Ok(resp.as_mut_bytes()),
+            McuMailboxResp::GetAuthCmdChallenge(resp) => Ok(resp.as_mut_bytes()),
             McuMailboxResp::ExportAttestedCsr(resp) => resp.as_bytes_partial_mut(),
         }
     }
@@ -1371,6 +1379,29 @@ pub struct FuseLockPartitionResp {
     pub hdr: MailboxRespHeader,
 }
 impl Response for FuseLockPartitionResp {}
+
+/// MC_GET_AUTH_CMD_CHALLENGE request: Get a challenge nonce to prove freshness in auth commands
+#[repr(C)]
+#[derive(Debug, Default, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct GetAuthCmdChallengeReq {
+    pub hdr: MailboxReqHeader,
+    pub flags: u32,
+    pub reserved: u32,
+}
+impl Request for GetAuthCmdChallengeReq {
+    const ID: CommandId = CommandId::MC_GET_AUTH_CMD_CHALLENGE;
+    type Resp = GetAuthCmdChallengeResp;
+}
+
+/// MC_GET_AUTH_CMD_CHALLENGE response: Indicates success or failure.
+#[repr(C)]
+#[derive(Debug, Default, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct GetAuthCmdChallengeResp {
+    pub hdr: MailboxRespHeader,
+    pub reserved: u32,
+    pub challenge: [u8; 32],
+}
+impl Response for GetAuthCmdChallengeResp {}
 
 /// MC_FUSE_INCREASE_CALIPTRA_MIN_SVN request: Increases the Caliptra min bootable SVN
 #[repr(C)]

--- a/platforms/emulator/runtime/userspace/apps/user/src/mcu_mbox/cmd_auth_mock.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/mcu_mbox/cmd_auth_mock.rs
@@ -1,7 +1,10 @@
 // Licensed under the Apache-2.0 license
 use caliptra_mcu_external_cmds_common::CommandAuthorizer;
 
-pub struct MockCommandAuthorizer;
+#[derive(Default)]
+pub struct MockCommandAuthorizer {
+    challenge: Option<[u8; 32]>,
+}
 
 impl CommandAuthorizer for MockCommandAuthorizer {
     fn is_authorized<'a>(
@@ -10,5 +13,13 @@ impl CommandAuthorizer for MockCommandAuthorizer {
         req: &'a [u8],
     ) -> Result<&'a [u8], caliptra_mcu_external_cmds_common::AuthorizationError> {
         Ok(req)
+    }
+
+    fn take_challenge(&mut self) -> Option<[u8; 32]> {
+        self.challenge.take()
+    }
+
+    fn set_challenge(&mut self, challenge: [u8; 32]) {
+        self.challenge = Some(challenge)
     }
 }

--- a/platforms/emulator/runtime/userspace/apps/user/src/mcu_mbox/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/mcu_mbox/mod.rs
@@ -47,13 +47,13 @@ async fn start_mcu_mbox_service() -> Result<(), ErrorCode> {
     ))]
     {
         let handler = cmd_handler_mock::NonCryptoCmdHandlerMock::default();
-        let cmd_authorizer = cmd_auth_mock::MockCommandAuthorizer;
+        let mut cmd_authorizer = cmd_auth_mock::MockCommandAuthorizer::default();
         let mut transport = caliptra_mcu_mbox_lib::transport::McuMboxTransport::new(
             caliptra_mcu_libsyscall_caliptra::mcu_mbox::MCU_MBOX0_DRIVER_NUM,
         );
         let mut mcu_mbox_service = caliptra_mcu_mbox_lib::daemon::McuMboxService::init(
             &handler,
-            &cmd_authorizer,
+            &mut cmd_authorizer,
             &mut transport,
             crate::EXECUTOR.get().spawner(),
         );

--- a/runtime/userspace/api/external-cmds-common/src/lib.rs
+++ b/runtime/userspace/api/external-cmds-common/src/lib.rs
@@ -166,4 +166,12 @@ pub trait CommandAuthorizer {
         cmd_id: CommandId,
         req: &'a [u8],
     ) -> Result<&'a [u8], AuthorizationError>;
+
+    /// Get the challenge from the last call to `MC_GET_AUTH_CMD_CHALLENGE`.
+    ///
+    /// This consumes the challenge so it can only be used once.
+    fn take_challenge(&mut self) -> Option<[u8; 32]>;
+
+    /// Set the challenge nonce to be used on the next authorized command.
+    fn set_challenge(&mut self, challenge: [u8; 32]);
 }

--- a/runtime/userspace/api/mcu-mbox-lib/src/cmd_interface.rs
+++ b/runtime/userspace/api/mcu-mbox-lib/src/cmd_interface.rs
@@ -6,6 +6,7 @@ use caliptra_mcu_external_cmds_common::{
     AttestedCsrData, CommandAuthorizer, DeviceCapabilities, DeviceId, DeviceInfo, FirmwareVersion,
     UnifiedCommandHandler, MAX_UID_LEN,
 };
+use caliptra_mcu_libapi_caliptra::crypto::rng::Rng;
 use caliptra_mcu_libapi_caliptra::mailbox_api::execute_mailbox_cmd;
 use caliptra_mcu_libsyscall_caliptra::mcu_mbox::MbxCmdStatus;
 use caliptra_mcu_libsyscall_caliptra::otp;
@@ -14,16 +15,17 @@ use caliptra_mcu_mbox_common::messages::{
     CommandId, DeviceCapsReq, DeviceCapsResp, DeviceIdReq, DeviceIdResp, DeviceInfoReq,
     DeviceInfoResp, ExportAttestedCsrReq, ExportAttestedCsrResp, FirmwareVersionReq,
     FirmwareVersionResp, FuseIncreaseCaliptraMinSvnReq, FuseIncreaseCaliptraMinSvnResp,
-    FuseWriteResp, MailboxRespHeader, MailboxRespHeaderVarSize, McuAesDecryptInitReq,
-    McuAesDecryptUpdateReq, McuAesEncryptInitReq, McuAesEncryptUpdateReq, McuAesGcmDecryptFinalReq,
-    McuAesGcmDecryptInitReq, McuAesGcmDecryptUpdateReq, McuAesGcmEncryptFinalReq,
-    McuAesGcmEncryptInitReq, McuAesGcmEncryptUpdateReq, McuCmDeleteReq, McuCmImportReq,
-    McuCmStatusReq, McuEcdhFinishReq, McuEcdhGenerateReq, McuEcdsaCmkPublicKeyReq,
-    McuEcdsaCmkSignReq, McuEcdsaCmkVerifyReq, McuFeProgReq, McuFipsSelfTestGetResultsReq,
-    McuFipsSelfTestStartReq, McuHkdfExpandReq, McuHkdfExtractReq, McuHmacKdfCounterReq, McuHmacReq,
-    McuProdDebugUnlockReqReq, McuProdDebugUnlockTokenReq, McuRandomGenerateReq, McuRandomStirReq,
-    McuResponseVarSize, McuShaFinalReq, McuShaInitReq, McuShaUpdateReq, DEVICE_CAPS_SIZE,
-    MAX_FW_VERSION_STR_LEN, MAX_RESP_DATA_SIZE,
+    FuseWriteResp, GetAuthCmdChallengeReq, GetAuthCmdChallengeResp, MailboxRespHeader,
+    MailboxRespHeaderVarSize, McuAesDecryptInitReq, McuAesDecryptUpdateReq, McuAesEncryptInitReq,
+    McuAesEncryptUpdateReq, McuAesGcmDecryptFinalReq, McuAesGcmDecryptInitReq,
+    McuAesGcmDecryptUpdateReq, McuAesGcmEncryptFinalReq, McuAesGcmEncryptInitReq,
+    McuAesGcmEncryptUpdateReq, McuCmDeleteReq, McuCmImportReq, McuCmStatusReq, McuEcdhFinishReq,
+    McuEcdhGenerateReq, McuEcdsaCmkPublicKeyReq, McuEcdsaCmkSignReq, McuEcdsaCmkVerifyReq,
+    McuFeProgReq, McuFipsSelfTestGetResultsReq, McuFipsSelfTestStartReq, McuHkdfExpandReq,
+    McuHkdfExtractReq, McuHmacKdfCounterReq, McuHmacReq, McuProdDebugUnlockReqReq,
+    McuProdDebugUnlockTokenReq, McuRandomGenerateReq, McuRandomStirReq, McuResponseVarSize,
+    McuShaFinalReq, McuShaInitReq, McuShaUpdateReq, DEVICE_CAPS_SIZE, MAX_FW_VERSION_STR_LEN,
+    MAX_RESP_DATA_SIZE,
 };
 #[cfg(feature = "periodic-fips-self-test")]
 use caliptra_mcu_mbox_common::messages::{
@@ -47,7 +49,7 @@ pub enum MsgHandlerError {
 pub struct CmdInterface<'a> {
     transport: &'a mut McuMboxTransport,
     non_crypto_cmds_handler: &'a dyn UnifiedCommandHandler,
-    cmd_authorizer: &'a dyn CommandAuthorizer,
+    cmd_authorizer: &'a mut dyn CommandAuthorizer,
     caliptra_mbox: caliptra_mcu_libsyscall_caliptra::mailbox::Mailbox, // Handle crypto commands via caliptra mailbox
     busy: AtomicBool,
 }
@@ -56,7 +58,7 @@ impl<'a> CmdInterface<'a> {
     pub fn new(
         transport: &'a mut McuMboxTransport,
         non_crypto_cmds_handler: &'a dyn UnifiedCommandHandler,
-        cmd_authorizer: &'a dyn CommandAuthorizer,
+        cmd_authorizer: &'a mut dyn CommandAuthorizer,
     ) -> Self {
         Self {
             transport,
@@ -415,6 +417,9 @@ impl<'a> CmdInterface<'a> {
                 )
                 .await
             }
+            CommandId::MC_GET_AUTH_CMD_CHALLENGE => {
+                self.handle_get_auth_cmd_challenge(req, resp_buf).await
+            }
             cmd_id @ CommandId::MC_ROTATE_VENDOR_PK_HASH
             | cmd_id @ CommandId::MC_FUSE_INCREASE_CALIPTRA_MIN_SVN
             | cmd_id @ CommandId::MC_FE_PROG => {
@@ -644,6 +649,27 @@ impl<'a> CmdInterface<'a> {
         resp_buf[..resp_bytes.len()].copy_from_slice(resp_bytes);
 
         Ok((&mut resp_buf[..resp_bytes.len()], mbox_cmd_status))
+    }
+
+    async fn handle_get_auth_cmd_challenge<'r>(
+        &mut self,
+        req: &[u8],
+        resp_buf: &'r mut [u8],
+    ) -> Result<(&'r mut [u8], MbxCmdStatus), MsgHandlerError> {
+        // Decode the request
+        let _req = GetAuthCmdChallengeReq::ref_from_bytes(req)
+            .map_err(|_| MsgHandlerError::InvalidParams)?;
+        let (resp, _) = GetAuthCmdChallengeResp::mut_from_prefix(resp_buf)
+            .map_err(|_| MsgHandlerError::InvalidParams)?;
+        *resp = GetAuthCmdChallengeResp::default();
+
+        Rng::generate_random_number(&mut resp.challenge)
+            .await
+            .map_err(|_| MsgHandlerError::McuMboxCommon)?;
+
+        self.cmd_authorizer.set_challenge(resp.challenge);
+        let len = size_of_val(resp);
+        Ok((&mut resp_buf[..len], MbxCmdStatus::Complete))
     }
 
     pub async fn handle_crypto_passthrough<'r, T: Default + IntoBytes + FromBytes>(

--- a/runtime/userspace/api/mcu-mbox-lib/src/daemon.rs
+++ b/runtime/userspace/api/mcu-mbox-lib/src/daemon.rs
@@ -33,7 +33,7 @@ pub struct McuMboxService<'a> {
 impl<'a> McuMboxService<'a> {
     pub fn init(
         non_crypto_cmd_handler: &'a dyn UnifiedCommandHandler,
-        cmd_authorizer: &'a dyn CommandAuthorizer,
+        cmd_authorizer: &'a mut dyn CommandAuthorizer,
         transport: &'a mut McuMboxTransport,
         spawner: Spawner,
     ) -> Self {

--- a/tests/integration/src/runtime/test_mcu_mailbox.rs
+++ b/tests/integration/src/runtime/test_mcu_mailbox.rs
@@ -3,7 +3,7 @@
 use crate::test::{start_runtime_hw_model, TestParams};
 use anyhow::Result;
 use caliptra_mcu_hw_model::McuHwModel;
-use caliptra_mcu_mbox_common::messages::FirmwareVersionReq;
+use caliptra_mcu_mbox_common::messages::{FirmwareVersionReq, GetAuthCmdChallengeReq};
 use caliptra_mcu_romtime::McuBootMilestones;
 
 #[test]
@@ -52,5 +52,34 @@ fn test_firmware_version_cmd() -> Result<()> {
     let resp_version_str = std::str::from_utf8(&resp.version[..resp.hdr.data_len as usize])
         .expect("Version string is not valid UTF-8");
     assert_eq!(resp_version_str, expected_version);
+    Ok(())
+}
+
+#[test]
+fn test_get_auth_cmd_challenge_cmd() -> Result<()> {
+    let mut hw = start_runtime_hw_model(TestParams {
+        feature: Some("test-mcu-mbox-cmds"),
+        ..Default::default()
+    });
+
+    // wait another little bit for the mailbox to come up after the runtime
+    hw.step_until(|hw| {
+        hw.mci_boot_milestones()
+            .contains(McuBootMilestones::FIRMWARE_MAILBOX_READY)
+    });
+
+    let cmd = GetAuthCmdChallengeReq::default();
+    let resp = hw.mailbox_execute_req(cmd)?;
+
+    assert_eq!(resp.challenge.len(), 32);
+    assert!(
+        resp.challenge
+            .iter()
+            .copied()
+            .reduce(|a, b| (a | b))
+            .unwrap()
+            != 0,
+        "Challenge should not be all-zeros"
+    );
     Ok(())
 }


### PR DESCRIPTION
This adds a new command `MC_GET_AUTH_CMD_CHALLENGE` which returns a 256 bit random nonce that can be used to prove freshness and block replay attacks. This nonce will be included in the authorized commands.

When an authorized command is sent, it zeroizes the stored challenge nonce.