### PR TITLE
fix 3c packet race condition

### DIFF
--- a/common/testing/src/mctp_transport.rs
+++ b/common/testing/src/mctp_transport.rs
@@ -32,7 +32,8 @@ pub struct MctpPldmSocket {
     target_addr: u8,
     msg_tag: u8,
     context: Arc<(Mutex<MctpPldmSocketData>, Condvar)>,
-    stream: BufferedStream,
+    rx_stream: Arc<Mutex<BufferedStream>>,
+    tx_stream: BufferedStream,
     response_msg_tag: Arc<Mutex<u8>>,
 }
 
@@ -53,40 +54,45 @@ impl PldmSocket for MctpPldmSocket {
         mctp_payload.push(mctp_common_header.0);
         mctp_payload.extend_from_slice(payload);
 
-        let mut stream = self
-            .stream
-            .try_clone()
-            .map_err(|_| PldmTransportError::Disconnected)?;
         let (context_lock, cvar) = &*self.context;
         let context = &mut *context_lock.lock().unwrap();
         if context.state == MctpPldmSocketState::Idle {
             /* If this is the first time we are sending a request,
              * we need to make sure that the responder is ready
-             * so we wait for a response for the first message
+             * so we wait for a response for the first message.
+             * Read through the shared rx_stream so any packets fill_buffer drains
+             * past the first response stay buffered for the rx_loop to consume.
              */
+            let mut rx = self.rx_stream.lock().unwrap();
             mctp_util.new_req(self.msg_tag);
             let response = mctp_util.wait_for_responder(
                 self.msg_tag,
                 mctp_payload.as_mut_slice(),
-                &mut stream,
+                &mut rx,
                 self.target_addr,
             );
             context.first_response.replace(response.unwrap());
             context.state = MctpPldmSocketState::FirstResponse;
             cvar.notify_all();
-        } else if payload[0] & 0x80 == 0x80 {
-            mctp_util.send_request(
-                self.msg_tag,
-                mctp_payload.as_mut_slice(),
-                &mut stream,
-                self.target_addr,
-            );
         } else {
-            let msg_tag = *self.response_msg_tag.lock().unwrap();
-            mctp_util.set_src_eid(self.dest.0);
-            mctp_util.set_dest_eid(self.source.0);
-            mctp_util.set_msg_tag(msg_tag & MCTP_TAG_MASK);
-            mctp_util.send_response(mctp_payload.as_mut_slice(), &mut stream, self.target_addr);
+            let mut stream = self
+                .tx_stream
+                .try_clone()
+                .map_err(|_| PldmTransportError::Disconnected)?;
+            if payload[0] & 0x80 == 0x80 {
+                mctp_util.send_request(
+                    self.msg_tag,
+                    mctp_payload.as_mut_slice(),
+                    &mut stream,
+                    self.target_addr,
+                );
+            } else {
+                let msg_tag = *self.response_msg_tag.lock().unwrap();
+                mctp_util.set_src_eid(self.dest.0);
+                mctp_util.set_dest_eid(self.source.0);
+                mctp_util.set_msg_tag(msg_tag & MCTP_TAG_MASK);
+                mctp_util.send_response(mctp_payload.as_mut_slice(), &mut stream, self.target_addr);
+            }
         }
 
         Ok(())
@@ -129,11 +135,8 @@ impl PldmSocket for MctpPldmSocket {
         // without waiting for the first response
         let mut mctp_util = MctpUtil::new();
         mctp_util.set_pkt_payload_size(MAX_PLDM_PAYLOAD_SIZE);
-        let mut stream = self
-            .stream
-            .try_clone()
-            .map_err(|_| PldmTransportError::Disconnected)?;
-        let raw_pkt: Vec<u8> = mctp_util.receive(&mut stream, self.target_addr, None);
+        let mut rx = self.rx_stream.lock().unwrap();
+        let raw_pkt: Vec<u8> = mctp_util.receive(&mut rx, self.target_addr, None);
         if raw_pkt.is_empty() {
             return Err(PldmTransportError::Underflow);
         }
@@ -165,7 +168,8 @@ impl PldmSocket for MctpPldmSocket {
             target_addr: self.target_addr,
             msg_tag: self.msg_tag,
             context: self.context.clone(),
-            stream: self.stream.try_clone().unwrap(),
+            rx_stream: self.rx_stream.clone(),
+            tx_stream: self.tx_stream.try_clone().unwrap(),
             response_msg_tag: self.response_msg_tag.clone(),
         }
     }
@@ -192,13 +196,17 @@ impl PldmTransport<MctpPldmSocket> for MctpTransport {
         let addr = SocketAddr::from(([127, 0, 0, 1], self.port));
         let stream = TcpStream::connect(addr).map_err(|_| PldmTransportError::Disconnected)?;
         let stream = BufferedStream::new(stream);
+        let tx_stream = stream
+            .try_clone()
+            .map_err(|_| PldmTransportError::Disconnected)?;
         let msg_tag = 0u8;
         Ok(MctpPldmSocket {
             source,
             dest,
             target_addr: self.target_addr.into(),
             msg_tag,
-            stream,
+            rx_stream: Arc::new(Mutex::new(stream)),
+            tx_stream,
             context: Arc::new((
                 Mutex::new(MctpPldmSocketData {
                     state: MctpPldmSocketState::Idle,

--- a/emulator/periph/src/i3c.rs
+++ b/emulator/periph/src/i3c.rs
@@ -23,6 +23,7 @@ use registers_generated::i3c::bits::{
 };
 use semver::Version;
 use std::collections::VecDeque;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc;
 use std::sync::Arc;
 use tock_registers::interfaces::{ReadWriteable, Readable, Writeable};
@@ -31,13 +32,12 @@ use zerocopy::FromBytes;
 const I3C_REC_INT_BYPASS_I3C_CORE: u32 = 0x0;
 const I3C_REC_INT_BYPASS_AXI_DIRECT: u32 = 0x1;
 struct PollScheduler {
-    timer: Timer,
+    pending: Arc<AtomicBool>,
 }
 
 impl I3cIncomingCommandClient for PollScheduler {
     fn incoming(&self) {
-        // trigger interrupt check next tick
-        self.timer.schedule_poll_in(1);
+        self.pending.store(true, Ordering::Relaxed);
     }
 }
 
@@ -90,6 +90,8 @@ pub struct I3c {
     events_from_caliptra: Option<mpsc::Receiver<Event>>,
     events_to_mcu: Option<mpsc::Sender<Event>>,
     events_from_mcu: Option<mpsc::Receiver<Event>>,
+
+    incoming_poll_pending: Arc<AtomicBool>,
 }
 
 impl I3c {
@@ -107,8 +109,9 @@ impl I3c {
         controller.attach_target(i3c_target.clone()).unwrap();
         let timer = Timer::new(clock);
         timer.schedule_poll_in(Self::HCI_TICKS);
+        let incoming_poll_pending = Arc::new(AtomicBool::new(false));
         let poll_scheduler = PollScheduler {
-            timer: timer.clone(),
+            pending: incoming_poll_pending.clone(),
         };
         i3c_target.set_incoming_command_client(Arc::new(poll_scheduler));
 
@@ -146,6 +149,7 @@ impl I3c {
             events_from_caliptra: None,
             events_to_mcu: None,
             events_from_mcu: None,
+            incoming_poll_pending,
         }
     }
 
@@ -996,7 +1000,12 @@ impl I3cPeripheral for I3c {
         self.check_interrupts();
         self.read_rx_data_into_buffer();
         self.write_tx_data_into_target();
-        self.timer.schedule_poll_in(Self::HCI_TICKS);
+        let next_poll = if self.incoming_poll_pending.swap(false, Ordering::Relaxed) {
+            1
+        } else {
+            Self::HCI_TICKS
+        };
+        self.timer.schedule_poll_in(next_poll);
 
         if let Some(events_from_caliptra) = &self.events_from_caliptra {
             // Collect all events first to avoid borrowing issues


### PR DESCRIPTION
Add patches to correct 2 race conditions found in firmware update tests.  One was causing false positives by crashing early due to a timer issue, the other was causing the test to stall by silently dropping i3c packets.  Both were within the testing infrastructure and do not impact firmware.