### PR TITLE
Add revoke vendor PK hash mcu-mbox command

### DIFF
--- a/common/mcu-mbox/src/messages.rs
+++ b/common/mcu-mbox/src/messages.rs
@@ -126,6 +126,7 @@ impl CommandId {
     pub const MC_FUSE_INCREASE_CALIPTRA_MIN_SVN: Self = Self(0x4D43_4D53); // "MCMS"
     pub const MC_FE_PROG: Self = Self(0x4D43_4650); // "MCFP"
     pub const MC_FUSE_REVOKE_VENDOR_PUB_KEY: Self = Self(0x4D52_564B); // "MRVK"
+    pub const MC_FUSE_REVOKE_VENDOR_PK_HASH: Self = Self(0x5256_4b48); // "RVKH"
 
     // Certificate commands
     pub const MC_EXPORT_ATTESTED_CSR: Self = Self(0x4D45_4143); // "MEAC"
@@ -195,6 +196,7 @@ pub enum McuMailboxReq {
     GetAuthCmdChallenge(GetAuthCmdChallengeReq),
     FuseRevokeVendorPubKey(FuseRevokeVendorPubKeyReq),
     ProvisionVendorPkHash(ProvisionVendorPkHashReq),
+    FuseRevokeVendorPkHash(FuseRevokeVendorPkHashReq),
     // Certificate commands
     ExportAttestedCsr(ExportAttestedCsrReq),
 }
@@ -249,6 +251,7 @@ impl McuMailboxReq {
             McuMailboxReq::GetAuthCmdChallenge(req) => Ok(req.as_bytes()),
             McuMailboxReq::FuseRevokeVendorPubKey(req) => Ok(req.as_bytes()),
             McuMailboxReq::ProvisionVendorPkHash(req) => Ok(req.as_bytes()),
+            McuMailboxReq::FuseRevokeVendorPkHash(req) => Ok(req.as_bytes()),
             McuMailboxReq::ExportAttestedCsr(req) => Ok(req.as_bytes()),
         }
     }
@@ -302,6 +305,7 @@ impl McuMailboxReq {
             McuMailboxReq::GetAuthCmdChallenge(req) => Ok(req.as_mut_bytes()),
             McuMailboxReq::FuseRevokeVendorPubKey(req) => Ok(req.as_mut_bytes()),
             McuMailboxReq::ProvisionVendorPkHash(req) => Ok(req.as_mut_bytes()),
+            McuMailboxReq::FuseRevokeVendorPkHash(req) => Ok(req.as_mut_bytes()),
             McuMailboxReq::ExportAttestedCsr(req) => Ok(req.as_mut_bytes()),
         }
     }
@@ -357,6 +361,7 @@ impl McuMailboxReq {
             McuMailboxReq::GetAuthCmdChallenge(_) => CommandId::MC_GET_AUTH_CMD_CHALLENGE,
             McuMailboxReq::FuseRevokeVendorPubKey(_) => CommandId::MC_FUSE_REVOKE_VENDOR_PUB_KEY,
             McuMailboxReq::ProvisionVendorPkHash(_) => CommandId::MC_PROVISION_VENDOR_PK_HASH,
+            McuMailboxReq::FuseRevokeVendorPkHash(_) => CommandId::MC_FUSE_REVOKE_VENDOR_PK_HASH,
             McuMailboxReq::ExportAttestedCsr(_) => CommandId::MC_EXPORT_ATTESTED_CSR,
         }
     }
@@ -433,6 +438,7 @@ pub enum McuMailboxResp {
     GetAuthCmdChallenge(GetAuthCmdChallengeResp),
     FuseRevokeVendorPubKey(FuseRevokeVendorPubKeyResp),
     ProvisionVendorPkHash(ProvisionVendorPkHashResp),
+    FuseRevokeVendorPkHash(FuseRevokeVendorPkHashResp),
     // Certificate commands
     ExportAttestedCsr(ExportAttestedCsrResp),
 }
@@ -546,6 +552,7 @@ impl McuMailboxResp {
             McuMailboxResp::GetAuthCmdChallenge(resp) => Ok(resp.as_bytes()),
             McuMailboxResp::FuseRevokeVendorPubKey(resp) => Ok(resp.as_bytes()),
             McuMailboxResp::ProvisionVendorPkHash(resp) => Ok(resp.as_bytes()),
+            McuMailboxResp::FuseRevokeVendorPkHash(resp) => Ok(resp.as_bytes()),
             McuMailboxResp::ExportAttestedCsr(resp) => resp.as_bytes_partial(),
         }
     }
@@ -598,6 +605,7 @@ impl McuMailboxResp {
             McuMailboxResp::GetAuthCmdChallenge(resp) => Ok(resp.as_mut_bytes()),
             McuMailboxResp::FuseRevokeVendorPubKey(resp) => Ok(resp.as_mut_bytes()),
             McuMailboxResp::ProvisionVendorPkHash(resp) => Ok(resp.as_mut_bytes()),
+            McuMailboxResp::FuseRevokeVendorPkHash(resp) => Ok(resp.as_mut_bytes()),
             McuMailboxResp::ExportAttestedCsr(resp) => resp.as_bytes_partial_mut(),
         }
     }
@@ -1500,6 +1508,27 @@ impl From<RevokeVendorPubKeyType> for u32 {
         value as u32
     }
 }
+
+/// MC_FUSE_REVOKE_VENDOR_PK_HASH request: Request revokation of a vendor PK hash.
+#[repr(C)]
+#[derive(Debug, Default, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct FuseRevokeVendorPkHashReq {
+    pub hdr: MailboxReqHeader,
+    pub reserved: u32,
+    pub vendor_pk_hash_slot: u32,
+}
+impl Request for FuseRevokeVendorPkHashReq {
+    const ID: CommandId = CommandId::MC_FUSE_REVOKE_VENDOR_PK_HASH;
+    type Resp = FuseRevokeVendorPubKeyResp;
+}
+
+/// MC_FUSE_REVOKE_VENDOR_PK_HASH response: Indicates success or failure.
+#[repr(C)]
+#[derive(Debug, Default, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct FuseRevokeVendorPkHashResp {
+    pub hdr: MailboxRespHeader,
+}
+impl Response for FuseRevokeVendorPkHashResp {}
 
 // ============================================================================
 // MC_EXPORT_ATTESTED_CSR Command (0x4D45_4143 - "MEAC")

--- a/docs/src/external_mailbox_cmds.md
+++ b/docs/src/external_mailbox_cmds.md
@@ -84,6 +84,7 @@ These commands support a wide range of functionalities, including querying devic
 | MC_FUSE_WRITE                     | 0x4946_5057 ("IFPW") | See [fuses spec](fuses.md) for details |
 | MC_FUSE_LOCK_PARTITION            | 0x4946_504B ("IFPK") | See [fuses spec](fuses.md) for details |
 | MC_PROVISION_VENDOR_PK_HASH       | 0x5056_504b ("PVPK") | See [fuses spec](fuses.md) for details |
+| MC_FUSE_REVOKE_VENDOR_PK_HASH     | 0x5256_4b48 ("RVKH") | See [fuses spec](fuses.md) for details |
 
 ## Command Format
 

--- a/docs/src/fuse_api_cmd.md
+++ b/docs/src/fuse_api_cmd.md
@@ -96,3 +96,27 @@ Command Code: `0x5056_504b` ("PVPK")
 
 Caveats:
 * Fails if the slot already contains data
+
+### MC_FUSE_REVOKE_VENDOR_PK_HASH
+
+Revoke a vendor PK hash.
+Marks a vendor PK hash as invalid, revoking all of the associated keys.
+
+Command Code: `0x5256_4b48` ("RVKH")
+
+*Table: `MC_FUSE_REVOKE_VENDOR_PK_HASH` input arguments*
+| **Name**             | **Type**       | **Description**               |
+| -------------------- | -------------- | ----------------------------- |
+| chksum               |  u32           |                               |
+| vendor_pk_hash_slot  |  u32           | Vendor PK hash slot to revoke |
+
+
+*Table: `MC_FUSE_REVOKE_VENDOR_PK_HASH` output arguments*
+| **Name**      | **Type**       | **Description**                         |
+| ------------- | -------------- | --------------------------------------- |
+| chksum        |  u32           |                                         |
+| fips_status   |  u32           | FIPS approved or an error               |
+
+Caveats:
+* This command is **idempotent**, so that revoking a slot twice has no effect.
+* Trying to revoke an empty slot will result in an error

--- a/runtime/userspace/api/mcu-mbox-lib/src/cmd_interface.rs
+++ b/runtime/userspace/api/mcu-mbox-lib/src/cmd_interface.rs
@@ -16,9 +16,10 @@ use caliptra_mcu_mbox_common::messages::{
     CommandId, DeviceCapsReq, DeviceCapsResp, DeviceIdReq, DeviceIdResp, DeviceInfoReq,
     DeviceInfoResp, ExportAttestedCsrReq, ExportAttestedCsrResp, FirmwareVersionReq,
     FirmwareVersionResp, FuseIncreaseCaliptraMinSvnReq, FuseIncreaseCaliptraMinSvnResp,
-    FuseRevokeVendorPubKeyReq, FuseRevokeVendorPubKeyResp, FuseWriteResp, GetAuthCmdChallengeReq,
-    GetAuthCmdChallengeResp, MailboxRespHeader, MailboxRespHeaderVarSize, McuAesDecryptInitReq,
-    McuAesDecryptUpdateReq, McuAesEncryptInitReq, McuAesEncryptUpdateReq, McuAesGcmDecryptFinalReq,
+    FuseRevokeVendorPkHashReq, FuseRevokeVendorPkHashResp, FuseRevokeVendorPubKeyReq,
+    FuseRevokeVendorPubKeyResp, FuseWriteResp, GetAuthCmdChallengeReq, GetAuthCmdChallengeResp,
+    MailboxRespHeader, MailboxRespHeaderVarSize, McuAesDecryptInitReq, McuAesDecryptUpdateReq,
+    McuAesEncryptInitReq, McuAesEncryptUpdateReq, McuAesGcmDecryptFinalReq,
     McuAesGcmDecryptInitReq, McuAesGcmDecryptUpdateReq, McuAesGcmEncryptFinalReq,
     McuAesGcmEncryptInitReq, McuAesGcmEncryptUpdateReq, McuCmDeleteReq, McuCmImportReq,
     McuCmStatusReq, McuEcdhFinishReq, McuEcdhGenerateReq, McuEcdsaCmkPublicKeyReq,
@@ -425,6 +426,7 @@ impl<'a> CmdInterface<'a> {
             cmd_id @ CommandId::MC_PROVISION_VENDOR_PK_HASH
             | cmd_id @ CommandId::MC_FUSE_INCREASE_CALIPTRA_MIN_SVN
             | cmd_id @ CommandId::MC_FE_PROG
+            | cmd_id @ CommandId::MC_FUSE_REVOKE_VENDOR_PK_HASH
             | cmd_id @ CommandId::MC_FUSE_REVOKE_VENDOR_PUB_KEY => {
                 self.handle_authorized_command(cmd_id, req, resp_buf).await
             }
@@ -724,6 +726,9 @@ impl<'a> CmdInterface<'a> {
             CommandId::MC_FUSE_REVOKE_VENDOR_PUB_KEY => {
                 self.handle_revoke_vendor_pub_key(cmd, resp_buf).await
             }
+            CommandId::MC_FUSE_REVOKE_VENDOR_PK_HASH => {
+                self.handle_revoke_vendor_pk_hash(cmd, resp_buf).await
+            }
             _ => Err(MsgHandlerError::UnsupportedCommand),
         }
     }
@@ -925,6 +930,46 @@ impl<'a> CmdInterface<'a> {
         *resp = FuseRevokeVendorPubKeyResp::default();
         let len = size_of_val(resp);
         Ok((&mut resp_buf[..len], MbxCmdStatus::Complete))
+    }
+
+    async fn handle_revoke_vendor_pk_hash<'r>(
+        &self,
+        req: &[u8],
+        resp_buf: &'r mut [u8],
+    ) -> Result<(&'r mut [u8], MbxCmdStatus), MsgHandlerError> {
+        // Decode the request
+        let req = FuseRevokeVendorPkHashReq::ref_from_bytes(req)
+            .map_err(|_| MsgHandlerError::InvalidParams)?;
+        let (resp, _) = FuseRevokeVendorPkHashResp::mut_from_prefix(resp_buf)
+            .map_err(|_| MsgHandlerError::InvalidParams)?;
+
+        let otp = otp::Otp::<DefaultSyscalls>::new();
+
+        // Check if the PK hash to be revoked was used to boot. If so, return an error as a form
+        // of proof of possession for other keys.
+        let same_key_used_to_boot = || {
+            let caliptra_soc = caliptra::Caliptra::<DefaultSyscalls>::new();
+            let booted_pk_hash = caliptra_soc
+                .read_vendor_pk_hash()
+                .map_err(|_| MsgHandlerError::McuMboxCommon)?;
+            let pk_hash_from_slot = otp
+                .read_vendor_pk_hash(req.vendor_pk_hash_slot)
+                .map_err(|_| MsgHandlerError::McuMboxCommon)?;
+
+            // Check if the requested slot was the one used to boot
+            Ok(booted_pk_hash == pk_hash_from_slot)
+        };
+
+        if same_key_used_to_boot()? {
+            Err(MsgHandlerError::InvalidParams)?;
+        }
+
+        otp.revoke_vendor_pk_hash(req.vendor_pk_hash_slot)
+            .map_err(|_| MsgHandlerError::McuMboxCommon)?;
+
+        *resp = FuseRevokeVendorPkHashResp::default();
+        let resp_len = resp.as_bytes().len();
+        Ok((&mut resp_buf[..resp_len], MbxCmdStatus::Complete))
     }
 
     async fn get_caliptra_fw_info(

--- a/runtime/userspace/syscall/src/otp.rs
+++ b/runtime/userspace/syscall/src/otp.rs
@@ -47,11 +47,9 @@ impl<S: Syscalls> Otp<S> {
         S::command(self.driver_num, cmd::OTP_WRITE, value, 0).to_result::<(), ErrorCode>()
     }
 
-    /// Check whether a given slot has a valid PK hash
+    /// Check whether a given vendor pk hash slot is marked valid (has not been marked invalid).
     ///
-    /// # Returns
-    /// - `true` if the slot is valid
-    /// - `false` if the slot has been marked as revoked
+    /// Also returns `false` if the slot ID is invalid or reading of the mask fails.
     pub fn valid_vendor_pk_hash_slot(&self, slot: u32) -> bool {
         if slot as usize >= MAX_NUM_VENDOR_PK_HASH {
             return false;
@@ -165,6 +163,12 @@ impl<S: Syscalls> Otp<S> {
     }
 
     /// Revoke a vendor PK hash
+    ///
+    /// Idempotent: revoking a slot twice has no effect and is a no-op.
+    ///
+    /// # Errors
+    /// - Returns `Invalid` when the slot is invalid
+    /// - Returns `Fail` when writing the fuse failed
     pub fn revoke_vendor_pk_hash(&self, vendor_pk_hash_slot: u32) -> Result<(), ErrorCode> {
         if vendor_pk_hash_slot as usize >= MAX_NUM_VENDOR_PK_HASH {
             Err(ErrorCode::Invalid)?

--- a/runtime/userspace/syscall/src/otp.rs
+++ b/runtime/userspace/syscall/src/otp.rs
@@ -163,6 +163,30 @@ impl<S: Syscalls> Otp<S> {
 
         Ok(())
     }
+
+    /// Revoke a vendor PK hash
+    pub fn revoke_vendor_pk_hash(&self, vendor_pk_hash_slot: u32) -> Result<(), ErrorCode> {
+        if vendor_pk_hash_slot as usize >= MAX_NUM_VENDOR_PK_HASH {
+            Err(ErrorCode::Invalid)?
+        }
+
+        if !self.valid_vendor_pk_hash_slot(vendor_pk_hash_slot) {
+            // Return early if the slot is already marked invalid
+            Ok(())?;
+        }
+
+        // Check if the slot is provisioned to not burn an empty slot
+        let pk_hash = self.read_vendor_pk_hash(vendor_pk_hash_slot)?;
+        if pk_hash.iter().eq(repeat(&0)) {
+            Err(ErrorCode::Invalid)?
+        }
+
+        let valid_mask = self.read(reg::VENDOR_PK_HASH_VALID, 0)?;
+
+        let valid_mask = valid_mask | (1 << vendor_pk_hash_slot);
+
+        self.write(reg::VENDOR_PK_HASH_VALID, 0, valid_mask)
+    }
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
Adds a MC_FUSE_REVOKE_VENDOR_PK_HASH ("RVKH") command to invalidate a specific vendor PK hash slot.
If the a slot is not provisioned with a hash an error is returned.

Part of #544.