### PR TITLE
[Handoff]: Partially address comments from previous PR

### DIFF
--- a/builder/src/rom.rs
+++ b/builder/src/rom.rs
@@ -202,6 +202,9 @@ SECTIONS
         PROVIDE(ESTACK_START = . );
     }
 
+    /* We reserve 1 KB at the end of DCCM for the handoff table.
+       This must be 1KB aligned because the runtime requires DCCM regions
+       to be 1KB aligned for MEIVT (Machine External Interrupt Vector Table). */
     .handoff (NOLOAD) :
     {
         KEEP(*(.handoff))

--- a/firmware-bundler/data/default-rom-layout.ld
+++ b/firmware-bundler/data/default-rom-layout.ld
@@ -64,7 +64,6 @@ SECTIONS
     /* We reserve 1 KB at the end of DCCM for the handoff table.
        This must be 1KB aligned because the runtime requires DCCM regions
        to be 1KB aligned for MEIVT (Machine External Interrupt Vector Table). */
-    . = HANDOFF_ADDR;
     .handoff (NOLOAD) :
     {
         KEEP(*(.handoff))


### PR DESCRIPTION
Fixes: https://github.com/chipsalliance/caliptra-mcu-sw/issues/1361.

Feedback item: Align linker script between `builder/src/rom.rs` and `default-rom-layout.ld`.