### PR TITLE
[auth-cmds] Add authorization to mock implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5532,6 +5532,7 @@ dependencies = [
  "caliptra-mcu-romtime",
  "caliptra-mcu-spdm-lib",
  "caliptra-ocp-eat",
+ "constant_time_eq 0.4.2",
  "critical-section",
  "embassy-executor",
  "embassy-sync",

--- a/platforms/emulator/runtime/userspace/apps/user/Cargo.toml
+++ b/platforms/emulator/runtime/userspace/apps/user/Cargo.toml
@@ -10,6 +10,7 @@ edition.workspace = true
 arrayvec.workspace = true
 async-trait.workspace = true
 caliptra-api.workspace = true
+constant_time_eq.workspace = true
 caliptra-ocp-eat.workspace = true
 critical-section.workspace = true
 embassy-executor.workspace = true

--- a/platforms/emulator/runtime/userspace/apps/user/src/mcu_mbox/cmd_auth_mock.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/mcu_mbox/cmd_auth_mock.rs
@@ -1,18 +1,85 @@
 // Licensed under the Apache-2.0 license
-use caliptra_mcu_common_commands::{AuthorizationResult, CommandAuthorizer};
+use async_trait::async_trait;
+use caliptra_mcu_common_commands::{AuthorizationError, AuthorizationResult, CommandAuthorizer};
+use caliptra_mcu_libapi_caliptra::crypto::hmac::Hmac;
+use caliptra_mcu_libapi_caliptra::crypto::import::{CmKeyUsage, Import};
+use caliptra_mcu_mbox_common::messages::{
+    CommandId, FuseIncreaseCaliptraMinSvnReq, FuseRevokeVendorPubKeyReq, MailboxReqHeader,
+    McuFeProgReq,
+};
+use constant_time_eq::constant_time_eq;
+use core::mem::size_of;
+use zerocopy::IntoBytes;
+extern crate alloc;
+use alloc::boxed::Box;
+
+/// NOTE: because this is a symmetric secret, this should come from a provisioned secret from OTP
+/// instead of embedded into firmware. To keep the implementation generic, this does not add OTP
+/// syscalls to get this value, in case a platform chooses another verification method like
+/// asymmetric key verification.
+const TEST_AUTH_CMD_HMAC_KEY: [u8; 48] = [
+    0x72, 0xec, 0x12, 0x02, 0x77, 0x69, 0xb9, 0xdc, 0x04, 0xbd, 0xd0, 0xc0, 0x86, 0xca, 0x1b, 0x20,
+    0x2f, 0x47, 0x1e, 0xee, 0xf2, 0x8c, 0x2d, 0xa8, 0xc5, 0x4c, 0x75, 0xc2, 0x48, 0xa6, 0x80, 0x0a,
+    0x11, 0xbf, 0xd5, 0xcd, 0x09, 0xed, 0x57, 0x0c, 0xb4, 0xc2, 0xa1, 0x37, 0x6b, 0xa2, 0xcb, 0xcd,
+];
 
 #[derive(Default)]
 pub struct MockCommandAuthorizer {
     challenge: Option<[u8; 32]>,
 }
 
+#[async_trait(?Send)]
 impl CommandAuthorizer for MockCommandAuthorizer {
-    fn is_authorized<'a>(
-        &self,
-        _cmd_id: caliptra_mcu_mbox_common::messages::CommandId,
+    async fn is_authorized<'a>(
+        &mut self,
+        cmd_id: CommandId,
         req: &'a [u8],
     ) -> AuthorizationResult<&'a [u8]> {
-        Ok(req)
+        let cmd_len = match cmd_id {
+            CommandId::MC_ROTATE_VENDOR_PK_HASH => Err(AuthorizationError)?,
+            CommandId::MC_FUSE_INCREASE_CALIPTRA_MIN_SVN => {
+                size_of::<FuseIncreaseCaliptraMinSvnReq>()
+            }
+            CommandId::MC_FE_PROG => size_of::<McuFeProgReq>(),
+            CommandId::MC_FUSE_REVOKE_VENDOR_PUB_KEY => size_of::<FuseRevokeVendorPubKeyReq>(),
+            _ => Err(AuthorizationError)?,
+        };
+
+        let challenge = self.challenge.take().ok_or_else(|| AuthorizationError)?;
+
+        let received_mac = req
+            .get(cmd_len..cmd_len + 48)
+            .ok_or_else(|| AuthorizationError)?;
+
+        // Import the key using Caliptra API
+        let import_resp = Import::import(CmKeyUsage::Hmac, &TEST_AUTH_CMD_HMAC_KEY)
+            .await
+            .map_err(|_| AuthorizationError)?;
+        let cmk = import_resp.cmk;
+
+        // Reconstruct the buffer to hash: cmd_id + cmd_body + challenge
+        let mut buf = arrayvec::ArrayVec::<u8, 256>::new();
+        let cmd_id_bytes = u32::from(cmd_id).to_be_bytes();
+        let cmd_body = req
+            .get(size_of::<MailboxReqHeader>()..cmd_len)
+            .ok_or_else(|| AuthorizationError)?;
+
+        buf.extend(cmd_id_bytes);
+        buf.extend(cmd_body.iter().copied());
+        buf.extend(challenge.iter().copied());
+
+        // Compute HMAC using Caliptra API
+        let hmac_resp = Hmac::hmac(&cmk, buf.as_slice())
+            .await
+            .map_err(|_| AuthorizationError)?;
+
+        let computed_mac_all = hmac_resp.mac.as_bytes();
+        let computed_mac = &computed_mac_all[..48];
+
+        if !constant_time_eq(computed_mac, received_mac) {
+            Err(AuthorizationError)?;
+        }
+        Ok(&req[..cmd_len])
     }
 
     fn take_challenge(&mut self) -> Option<[u8; 32]> {

--- a/runtime/userspace/api/caliptra-common-commands/src/lib.rs
+++ b/runtime/userspace/api/caliptra-common-commands/src/lib.rs
@@ -173,6 +173,7 @@ pub struct AuthorizationError;
 
 pub type AuthorizationResult<T> = Result<T, AuthorizationError>;
 
+#[async_trait(?Send)]
 pub trait CommandAuthorizer {
     /// Validates if a message is authorized.
     ///
@@ -186,8 +187,8 @@ pub trait CommandAuthorizer {
     ///
     /// # Returns
     /// * `Result<&[u8], CommandError>` - Unpacked command or Error
-    fn is_authorized<'a>(
-        &self,
+    async fn is_authorized<'a>(
+        &mut self,
         cmd_id: CommandId,
         req: &'a [u8],
     ) -> Result<&'a [u8], AuthorizationError>;

--- a/runtime/userspace/api/mcu-mbox-lib/src/cmd_interface.rs
+++ b/runtime/userspace/api/mcu-mbox-lib/src/cmd_interface.rs
@@ -701,7 +701,7 @@ impl<'a> CmdInterface<'a> {
     }
 
     async fn handle_authorized_command<'r>(
-        &self,
+        &mut self,
         cmd_id: CommandId,
         req: &[u8],
         resp_buf: &'r mut [u8],
@@ -709,6 +709,7 @@ impl<'a> CmdInterface<'a> {
         let cmd = self
             .cmd_authorizer
             .is_authorized(cmd_id, req)
+            .await
             .map_err(|_| MsgHandlerError::UnauthorizedCommand)?;
         match cmd_id {
             CommandId::MC_ROTATE_VENDOR_PK_HASH => {

--- a/tests/integration/src/runtime/mod.rs
+++ b/tests/integration/src/runtime/mod.rs
@@ -1,4 +1,90 @@
 // Licensed under the Apache-2.0 license
 
+use anyhow::{anyhow, bail, Result};
+use caliptra_api::calc_checksum;
+use caliptra_api::mailbox::MailboxReqHeader;
+use caliptra_mcu_hw_model::McuHwModel;
+use caliptra_mcu_mbox_common::messages::GetAuthCmdChallengeReq;
+use core::mem::size_of;
+use hmac::{Hmac, Mac};
+use sha2::Sha384;
+use zerocopy::FromBytes;
+
 mod test_increase_caliptra_svn;
 mod test_mcu_mailbox;
+
+pub const TEST_AUTH_CMD_HMAC_KEY: [u8; 48] = [
+    0x72, 0xec, 0x12, 0x02, 0x77, 0x69, 0xb9, 0xdc, 0x04, 0xbd, 0xd0, 0xc0, 0x86, 0xca, 0x1b, 0x20,
+    0x2f, 0x47, 0x1e, 0xee, 0xf2, 0x8c, 0x2d, 0xa8, 0xc5, 0x4c, 0x75, 0xc2, 0x48, 0xa6, 0x80, 0x0a,
+    0x11, 0xbf, 0xd5, 0xcd, 0x09, 0xed, 0x57, 0x0c, 0xb4, 0xc2, 0xa1, 0x37, 0x6b, 0xa2, 0xcb, 0xcd,
+];
+
+pub fn get_auth_cmd_challenge(hw: &mut impl McuHwModel) -> Result<[u8; 32]> {
+    let cmd = GetAuthCmdChallengeReq::default();
+    let resp = hw.mailbox_execute_req(cmd)?;
+    Ok(resp.challenge)
+}
+
+pub fn sign_auth_cmd_challenge(challenge: &[u8; 32], cmd_id: u32, cmd: &[u8]) -> Result<[u8; 48]> {
+    type HmacSha384 = Hmac<Sha384>;
+    let mut mac = HmacSha384::new_from_slice(&TEST_AUTH_CMD_HMAC_KEY)?;
+    mac.update(&cmd_id.to_be_bytes());
+    mac.update(&cmd[size_of::<MailboxReqHeader>()..]);
+    mac.update(challenge);
+    Ok(mac.finalize().into_bytes().into())
+}
+
+pub fn authorize_cmd(hw: &mut impl McuHwModel, cmd_id: u32, cmd: &[u8]) -> Result<Vec<u8>> {
+    let challenge = get_auth_cmd_challenge(hw)?;
+    let mac = sign_auth_cmd_challenge(&challenge, cmd_id, cmd)?;
+    let mut auth_cmd = cmd.to_vec();
+    auth_cmd.extend_from_slice(&mac);
+    Ok(auth_cmd)
+}
+
+pub fn execute_authorized_req<R: caliptra_mcu_mbox_common::messages::Request>(
+    hw: &mut impl McuHwModel,
+    mut req: R,
+) -> Result<R::Resp> {
+    let req_bytes = req.as_mut_bytes();
+
+    // Authorize (sign)
+    let mut auth_cmd = authorize_cmd(hw, u32::from(R::ID), req_bytes)?;
+
+    // Populate the request checksum over body + MAC
+    let checksum = calc_checksum(R::ID.into(), &auth_cmd[size_of::<i32>()..]);
+    let hdr: &mut MailboxReqHeader =
+        MailboxReqHeader::mut_from_bytes(&mut auth_cmd[..size_of::<MailboxReqHeader>()]).unwrap();
+    hdr.chksum = checksum;
+
+    // Send the request to the mailbox
+    let mut response = hw
+        .mailbox_execute(R::ID.into(), &auth_cmd)?
+        .unwrap_or_default();
+
+    // Check the response checksum
+    if response.len() < 4 {
+        bail!("Response too short to contain checksum");
+    }
+    let received_chksum = u32::from_le_bytes(response[..4].try_into().unwrap());
+    let calculated_chksum = calc_checksum(0, &response[4..]);
+    if received_chksum != calculated_chksum {
+        bail!(
+            "Response checksum mismatch: expected {:08x}, calculated {:08x}",
+            received_chksum,
+            calculated_chksum
+        );
+    }
+
+    if response.len() < std::mem::size_of::<R::Resp>() {
+        response.resize(std::mem::size_of::<R::Resp>(), 0);
+    }
+    let response = R::Resp::read_from_bytes(&response).map_err(|_| {
+        anyhow!(
+            "Failed to read response into struct: expected len {}, response len {}",
+            std::mem::size_of::<R::Resp>(),
+            response.len()
+        )
+    })?;
+    Ok(response)
+}

--- a/tests/integration/src/runtime/test_increase_caliptra_svn.rs
+++ b/tests/integration/src/runtime/test_increase_caliptra_svn.rs
@@ -1,5 +1,6 @@
 // Licensed under the Apache-2.0 license
 
+use crate::runtime::execute_authorized_req;
 use crate::test::{compile_runtime, start_runtime_hw_model, CustomCaliptraFw, TestParams};
 use anyhow::Result;
 use caliptra_api::{calc_checksum, error::CaliptraError, mailbox::FwInfoResp, SocManager};
@@ -65,7 +66,7 @@ fn test_increase_caliptra_svn() -> Result<()> {
         svn: 0,
         ..Default::default()
     };
-    let result = hw.mailbox_execute_req(cmd);
+    let result = execute_authorized_req(&mut hw, cmd);
     assert!(result.is_err());
 
     // Check requesting to increase SVN past what is currently running returns an error.
@@ -74,7 +75,7 @@ fn test_increase_caliptra_svn() -> Result<()> {
         svn: 8,
         ..Default::default()
     };
-    let result = hw.mailbox_execute_req(cmd);
+    let result = execute_authorized_req(&mut hw, cmd);
     assert!(result.is_err());
 
     // Check trying to burn a value greater than 128 returns an error.
@@ -82,7 +83,7 @@ fn test_increase_caliptra_svn() -> Result<()> {
         svn: 129,
         ..Default::default()
     };
-    let result = hw.mailbox_execute_req(cmd);
+    let result = execute_authorized_req(&mut hw, cmd);
     assert!(result.is_err());
 
     // Send a command to increase the Caliptra minimum SVN fuses to 7.
@@ -90,14 +91,14 @@ fn test_increase_caliptra_svn() -> Result<()> {
         svn: 7,
         ..Default::default()
     };
-    let _resp = hw.mailbox_execute_req(cmd)?;
+    let _resp = execute_authorized_req(&mut hw, cmd)?;
 
     // Check requesting twice to burn the SVN of the value currently in fuses passes.
     let cmd = FuseIncreaseCaliptraMinSvnReq {
         svn: 7,
         ..Default::default()
     };
-    let _resp = hw.mailbox_execute_req(cmd)?;
+    let _resp = execute_authorized_req(&mut hw, cmd)?;
 
     // Read OTP memory so we can use the same config in later boots.
     let otp = hw.read_otp_memory();
@@ -139,7 +140,7 @@ fn test_increase_caliptra_svn() -> Result<()> {
         svn: 6,
         ..Default::default()
     };
-    let resp = hw.mailbox_execute_req(cmd);
+    let resp = execute_authorized_req(&mut hw, cmd);
     assert!(resp.is_err());
 
     // Step 3: Negative test. Build firmware with SVN = 0 (less than fuse value 7)
@@ -227,7 +228,7 @@ fn test_increase_caliptra_svn_max() -> Result<()> {
         svn: 128,
         ..Default::default()
     };
-    let _resp = hw.mailbox_execute_req(cmd)?;
+    let _resp = execute_authorized_req(&mut hw, cmd)?;
 
     // Read OTP memory immediately after the command to verify fuses were burned.
     let otp = hw.read_otp_memory();


### PR DESCRIPTION
This adds HMAC verification of authorized commands for the mock implementation. This also adds some testing helper functions to make it easier to call authorized commands from tests.

The implementation embeds an HMAC key in firmware which should not be done. Because this authorization process is up to the integrator, all other options would require partially implementing something unused by all other integrations. For example, if the HMAC secret were provisioned into OTP it would require adding an OTP syscall to retrieve the key. If another integrator wants to use asymmetric keys, this syscall would be implemented, but never used.