### PR TITLE
Add ExportIdevidCsr Caliptra VDM command

### DIFF
--- a/.github/workflows/caliptra-util-host-validator.yml
+++ b/.github/workflows/caliptra-util-host-validator.yml
@@ -184,9 +184,14 @@ jobs:
           cargo test --package caliptra-mcu-tests-integration --lib -- test_mctp_vdm_validator::test::test_caliptra_util_host_mctp_vdm_validator --nocapture --include-ignored
           sccache --show-stats
 
-      - name: Run Caliptra Util Host SPDM VDM validator tests
+      - name: Run Caliptra Util Host SPDM VDM validator tests (production mode)
         run: |
-          cargo test --package caliptra-mcu-tests-integration --lib -- test_caliptra_util_host_spdm_vdm_validator::test::test_caliptra_util_host_spdm_vdm_validator --nocapture --include-ignored
+          cargo test --package caliptra-mcu-tests-integration --lib -- test_caliptra_util_host_spdm_vdm_validator::test::test_caliptra_util_host_spdm_vdm_validator --exact --nocapture --include-ignored
+          sccache --show-stats
+
+      - name: Run Caliptra Util Host SPDM VDM validator tests (manufacturing mode)
+        run: |
+          cargo test --package caliptra-mcu-tests-integration --lib -- test_caliptra_util_host_spdm_vdm_validator::test::test_caliptra_util_host_spdm_vdm_validator_mfg_mode --exact --nocapture --include-ignored
           sccache --show-stats
 
       - name: Upload test results and logs

--- a/caliptra-util-host/apps/spdm/client/src/config.rs
+++ b/caliptra-util-host/apps/spdm/client/src/config.rs
@@ -6,8 +6,20 @@
 //! 1. Add a new config struct (e.g., `GetFirmwareVersionConfig`)
 //! 2. Add it as a `#[serde(default)]` field in `TestConfig`
 
+use clap::ValueEnum;
 use serde::Deserialize;
 use std::path::Path;
+
+/// Device mode determines which test suite to run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, ValueEnum, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum DeviceMode {
+    /// Production mode: ExportAttestedCsr + ExportIdevidCsr(expect_fail)
+    #[default]
+    Production,
+    /// Manufacturing mode: ExportIdevidCsr only
+    Manufacturing,
+}
 
 #[derive(Debug, Clone, Deserialize, Default)]
 pub struct TestConfig {
@@ -16,8 +28,11 @@ pub struct TestConfig {
     #[serde(default)]
     pub spdm: SpdmTestConfig,
     #[serde(default)]
+    pub mode: DeviceMode,
+    #[serde(default)]
     pub export_attested_csr: ExportAttestedCsrConfig,
-    // Future commands: pub get_firmware_version: GetFirmwareVersionConfig,
+    #[serde(default)]
+    pub export_idevid_csr: ExportIdevidCsrConfig,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -74,5 +89,24 @@ impl TestConfig {
         let content = std::fs::read_to_string(path)?;
         let config: Self = toml::from_str(&content)?;
         Ok(config)
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ExportIdevidCsrConfig {
+    /// Algorithms to test (0x0001=ECC384, 0x0002=MLDSA87)
+    #[serde(default = "default_idevid_algorithms")]
+    pub algorithms: Vec<u32>,
+}
+
+fn default_idevid_algorithms() -> Vec<u32> {
+    vec![1] // ECC384 by default
+}
+
+impl Default for ExportIdevidCsrConfig {
+    fn default() -> Self {
+        Self {
+            algorithms: default_idevid_algorithms(),
+        }
     }
 }

--- a/caliptra-util-host/apps/spdm/client/src/lib.rs
+++ b/caliptra-util-host/apps/spdm/client/src/lib.rs
@@ -24,7 +24,9 @@ pub use config::TestConfig;
 pub use validator::{all_passed, print_summary, run_all, ValidationResult, ValidationStatus};
 
 use anyhow::Result;
-use caliptra_mcu_core_util_host_command_types::certificate::ExportAttestedCsrResponse;
+use caliptra_mcu_core_util_host_command_types::certificate::{
+    ExportAttestedCsrResponse, ExportIdevidCsrResponse,
+};
 use caliptra_mcu_core_util_host_command_types::{
     GetDeviceCapabilitiesResponse, GetDeviceIdResponse, GetDeviceInfoResponse,
     GetFirmwareVersionResponse,
@@ -33,7 +35,9 @@ use caliptra_mcu_core_util_host_transport::transports::spdm_vdm::transport::{
     SpdmVdmDriver, SpdmVdmTransport,
 };
 use caliptra_mcu_core_util_host_transport::Transport;
-use caliptra_util_host_commands::api::certificate::caliptra_cmd_export_attested_csr;
+use caliptra_util_host_commands::api::certificate::{
+    caliptra_cmd_export_attested_csr, caliptra_cmd_export_idevid_csr,
+};
 use caliptra_util_host_commands::api::device_info::{
     caliptra_cmd_get_device_capabilities, caliptra_cmd_get_device_id, caliptra_cmd_get_device_info,
     caliptra_cmd_get_firmware_version,
@@ -112,6 +116,16 @@ impl<'a> SpdmVdmClient<'a> {
         let mut session = self.create_session()?;
         caliptra_cmd_export_attested_csr(&mut session, device_key_id, algorithm, nonce)
             .map_err(|e| anyhow::anyhow!("ExportAttestedCsr failed: {:?}", e))
+    }
+
+    /// Execute the ExportIdevidCsr command (manufacturing mode only).
+    ///
+    /// # Parameters
+    /// - `algorithm`: Asymmetric algorithm (0x0001=ECC384, 0x0002=MLDSA87)
+    pub fn export_idevid_csr(&mut self, algorithm: u32) -> Result<ExportIdevidCsrResponse> {
+        let mut session = self.create_session()?;
+        caliptra_cmd_export_idevid_csr(&mut session, algorithm)
+            .map_err(|e| anyhow::anyhow!("ExportIdevidCsr failed: {:?}", e))
     }
 
     fn create_session(&mut self) -> Result<CaliptraSession> {

--- a/caliptra-util-host/apps/spdm/client/src/main.rs
+++ b/caliptra-util-host/apps/spdm/client/src/main.rs
@@ -9,7 +9,7 @@
 
 use anyhow::Result;
 use caliptra_spdm_requester::{SpdmConfig, SpdmRequester, SpdmSocketDeviceIo, SpdmVdmDriverImpl};
-use caliptra_spdm_vdm_client::config::{self, TestConfig};
+use caliptra_spdm_vdm_client::config::{self, DeviceMode, TestConfig};
 use caliptra_spdm_vdm_client::{validator, SpdmVdmClient};
 use clap::Parser;
 
@@ -29,6 +29,10 @@ struct Args {
     #[arg(long)]
     config: Option<String>,
 
+    /// Device mode: production or manufacturing
+    #[arg(long, value_enum, default_value_t = DeviceMode::Production)]
+    mode: DeviceMode,
+
     /// Key IDs to test for ExportAttestedCsr (comma-separated)
     #[arg(long)]
     key_ids: Option<String>,
@@ -36,6 +40,9 @@ struct Args {
     /// Algorithm ID for ExportAttestedCsr (1=EccP384, 2=MlDsa87)
     #[arg(long)]
     algorithm: Option<u32>,
+    /// Algorithm IDs for ExportIdevidCsr (comma-separated)
+    #[arg(long)]
+    idevid_algorithms: Option<String>,
 }
 
 impl Args {
@@ -51,20 +58,23 @@ impl Args {
                 spdm: config::SpdmTestConfig {
                     slot_id: self.slot_id,
                 },
+                mode: self.mode,
                 ..TestConfig::default()
             }
         };
 
-        // CLI args override config file values when explicitly provided.
-        if self.config.is_none() {
-            config.network.server_address = self.server;
-            config.spdm.slot_id = self.slot_id;
-        }
+        // CLI args always override config file values for server and mode.
+        config.network.server_address = self.server;
+        config.spdm.slot_id = self.slot_id;
+        config.mode = self.mode;
         if let Some(key_ids) = &self.key_ids {
             config.export_attested_csr.key_ids = parse_key_ids(key_ids)?;
         }
         if let Some(algorithm) = self.algorithm {
             config.export_attested_csr.algorithm = algorithm;
+        }
+        if let Some(algorithms) = &self.idevid_algorithms {
+            config.export_idevid_csr.algorithms = parse_key_ids(algorithms)?;
         }
 
         Ok(config)

--- a/caliptra-util-host/apps/spdm/client/src/validator.rs
+++ b/caliptra-util-host/apps/spdm/client/src/validator.rs
@@ -11,7 +11,7 @@
 //! 3. Call it from `run_all()`
 //! 4. Add a config section in `config.rs`
 
-use crate::config::TestConfig;
+use crate::config::{DeviceMode, TestConfig};
 use crate::SpdmVdmClient;
 use caliptra_mcu_core_util_host_command_types::certificate::AttestedCsrValidationError;
 
@@ -93,6 +93,10 @@ pub fn all_passed(results: &[ValidationResult]) -> bool {
 }
 
 /// Run all VDM command validations using the typed SpdmVdmClient.
+///
+/// Test suite depends on the configured DeviceMode:
+/// - Production: ExportAttestedCsr + ExportIdevidCsr(expect_fail)
+/// - Manufacturing: ExportIdevidCsr only
 pub fn run_all(
     client: &mut SpdmVdmClient,
     config: &TestConfig,
@@ -100,12 +104,28 @@ pub fn run_all(
 ) -> Vec<ValidationResult> {
     let mut results = Vec::new();
 
-    results.extend(run_export_attested_csr(
-        client,
-        &config.export_attested_csr.key_ids,
-        config.export_attested_csr.algorithm,
-        verbose,
-    ));
+    match config.mode {
+        DeviceMode::Production => {
+            results.extend(run_export_attested_csr(
+                client,
+                &config.export_attested_csr.key_ids,
+                config.export_attested_csr.algorithm,
+                verbose,
+            ));
+            results.extend(run_export_idevid_csr_expect_fail(
+                client,
+                &config.export_idevid_csr.algorithms,
+                verbose,
+            ));
+        }
+        DeviceMode::Manufacturing => {
+            results.extend(run_export_idevid_csr(
+                client,
+                &config.export_idevid_csr.algorithms,
+                verbose,
+            ));
+        }
+    }
 
     results
 }
@@ -146,6 +166,74 @@ pub fn run_export_attested_csr(
                         ValidationResult::fail(test_name, msg_str)
                     }
                 }
+            }
+        })
+        .collect()
+}
+
+/// Validate ExportIdevidCsr for each algorithm (manufacturing mode).
+pub fn run_export_idevid_csr(
+    client: &mut SpdmVdmClient,
+    algorithms: &[u32],
+    verbose: bool,
+) -> Vec<ValidationResult> {
+    algorithms
+        .iter()
+        .map(|&algorithm| {
+            let test_name = format!("ExportIdevidCsr(algorithm={})", algorithm);
+            match client.export_idevid_csr(algorithm) {
+                Ok(response) => match response.validate_csr_payload() {
+                    Ok(len) => {
+                        if verbose {
+                            println!("  csr: {} bytes", len);
+                        }
+                        ValidationResult::pass(test_name, format!("{} bytes", len))
+                    }
+                    Err(AttestedCsrValidationError::Empty) => {
+                        ValidationResult::fail(test_name, "CSR data is empty")
+                    }
+                    Err(AttestedCsrValidationError::TooLarge(len)) => ValidationResult::fail(
+                        test_name,
+                        format!("CSR data_len {} exceeds maximum", len),
+                    ),
+                },
+                Err(msg) => {
+                    let msg_str = format!("{}", msg);
+                    if msg_str.contains("NotSupported") {
+                        ValidationResult::skip(test_name, msg_str)
+                    } else {
+                        ValidationResult::fail(test_name, msg_str)
+                    }
+                }
+            }
+        })
+        .collect()
+}
+
+/// Negative test: ExportIdevidCsr should be rejected in production mode.
+pub fn run_export_idevid_csr_expect_fail(
+    client: &mut SpdmVdmClient,
+    algorithms: &[u32],
+    verbose: bool,
+) -> Vec<ValidationResult> {
+    algorithms
+        .iter()
+        .map(|&algorithm| {
+            let test_name = format!("ExportIdevidCsr(algorithm={},expect_fail)", algorithm);
+            match client.export_idevid_csr(algorithm) {
+                Ok(_response) => {
+                    if verbose {
+                        println!("  Expected rejection but got success");
+                    }
+                    ValidationResult::fail(
+                        test_name,
+                        "Expected device to reject ExportIdevidCsr in production mode",
+                    )
+                }
+                Err(_) => ValidationResult::pass(
+                    test_name,
+                    "Device correctly rejected ExportIdevidCsr in production mode",
+                ),
             }
         })
         .collect()

--- a/caliptra-util-host/apps/spdm/test-config.toml
+++ b/caliptra-util-host/apps/spdm/test-config.toml
@@ -2,6 +2,8 @@
 
 # SPDM Client Test Configuration
 
+mode = "production"
+
 [network]
 # Server address for the SPDM-over-MCTP bridge (emulator I3C controller socket)
 server_address = "127.0.0.1:63333"
@@ -15,6 +17,11 @@ timeout_seconds = 30
 verbose_output = false
 
 [export_attested_csr]
+# 1 = LDevID, 2 = FMC Alias, 3 = RT Alias
+key_ids = [1, 2, 3]
 # ECC384 = 1, MlDsa87 = 2
-key_ids = [0, 1, 2]
 algorithm = 1
+
+[export_idevid_csr]
+# ECC384 = 1, MlDsa87 = 2
+algorithms = [1]

--- a/caliptra-util-host/command-types/src/certificate.rs
+++ b/caliptra-util-host/command-types/src/certificate.rs
@@ -145,3 +145,53 @@ impl ExportAttestedCsrResponse {
         Ok(csr.len())
     }
 }
+
+// ============================================================================
+// ExportIdevidCsr Command
+// ============================================================================
+
+/// Export IDevID CSR request (manufacturing mode only)
+#[repr(C)]
+#[derive(Debug, Clone, IntoBytes, FromBytes, Immutable)]
+pub struct ExportIdevidCsrRequest {
+    /// Asymmetric algorithm (0x0001=ECC384, 0x0002=MLDSA87)
+    pub algorithm: u32,
+}
+
+/// Export IDevID CSR response
+#[repr(C)]
+#[derive(Debug, Clone, IntoBytes, FromBytes, Immutable)]
+pub struct ExportIdevidCsrResponse {
+    pub common: CommonResponse,
+    /// Length of CSR data
+    pub data_len: u32,
+    /// CSR data (variable length, up to MAX_CSR_DATA_SIZE)
+    pub csr_data: [u8; MAX_CSR_DATA_SIZE],
+}
+
+impl CommandRequest for ExportIdevidCsrRequest {
+    type Response = ExportIdevidCsrResponse;
+    const COMMAND_ID: CaliptraCommandId = CaliptraCommandId::ExportIdevidCsr;
+}
+
+impl CommandResponse for ExportIdevidCsrResponse {}
+
+impl ExportIdevidCsrResponse {
+    /// Returns the IDevID CSR payload as a byte slice.
+    pub fn csr_bytes(&self) -> &[u8] {
+        let len = (self.data_len as usize).min(MAX_CSR_DATA_SIZE);
+        &self.csr_data[..len]
+    }
+
+    /// Validates the CSR payload, returning Ok with the byte length on success.
+    pub fn validate_csr_payload(&self) -> Result<usize, AttestedCsrValidationError> {
+        let csr = self.csr_bytes();
+        if csr.is_empty() {
+            return Err(AttestedCsrValidationError::Empty);
+        }
+        if csr.len() > MAX_CSR_DATA_SIZE {
+            return Err(AttestedCsrValidationError::TooLarge(csr.len()));
+        }
+        Ok(csr.len())
+    }
+}

--- a/caliptra-util-host/command-types/src/lib.rs
+++ b/caliptra-util-host/command-types/src/lib.rs
@@ -56,6 +56,7 @@ pub enum CaliptraCommandId {
     GetFmcAliasCert = 0x1003,
     GetRtAliasCert = 0x1004,
     ExportAttestedCsr = 0x1005,
+    ExportIdevidCsr = 0x1006,
     GetCertChain = 0x1010,
     StoreCertificate = 0x1011,
     GetCertificate = 0x1012, // Generic get certificate

--- a/caliptra-util-host/commands/src/api/certificate.rs
+++ b/caliptra-util-host/commands/src/api/certificate.rs
@@ -6,7 +6,10 @@
 
 use crate::api::{CaliptraApiError, CaliptraResult};
 use caliptra_mcu_core_util_host_command_types::{
-    certificate::{ExportAttestedCsrRequest, ExportAttestedCsrResponse},
+    certificate::{
+        ExportAttestedCsrRequest, ExportAttestedCsrResponse, ExportIdevidCsrRequest,
+        ExportIdevidCsrResponse,
+    },
     CaliptraCommandId,
 };
 use caliptra_util_host_session::CaliptraSession;
@@ -38,4 +41,25 @@ pub fn caliptra_cmd_export_attested_csr(
     session
         .execute_command_with_id(CaliptraCommandId::ExportAttestedCsr, &request)
         .map_err(|_| CaliptraApiError::SessionError("ExportAttestedCsr command failed"))
+}
+
+/// Export an IDevID CSR from the device (manufacturing mode only)
+///
+/// # Parameters
+///
+/// - `session`: Mutable reference to CaliptraSession
+/// - `algorithm`: Asymmetric algorithm (0x0001=ECC384, 0x0002=MLDSA87)
+///
+/// # Returns
+///
+/// - `Ok(ExportIdevidCsrResponse)` on success
+/// - `Err(CaliptraApiError)` on failure
+pub fn caliptra_cmd_export_idevid_csr(
+    session: &mut CaliptraSession,
+    algorithm: u32,
+) -> CaliptraResult<ExportIdevidCsrResponse> {
+    let request = ExportIdevidCsrRequest { algorithm };
+    session
+        .execute_command_with_id(CaliptraCommandId::ExportIdevidCsr, &request)
+        .map_err(|_| CaliptraApiError::SessionError("ExportIdevidCsr command failed"))
 }

--- a/caliptra-util-host/transport/src/transports/spdm_vdm/commands.rs
+++ b/caliptra-util-host/transport/src/transports/spdm_vdm/commands.rs
@@ -15,6 +15,7 @@
 //! - DeviceCapabilities (0x02)
 //! - DeviceId (0x03)
 //! - DeviceInfo (0x04)
+//! - ExportIdevidCsr (0x0C)
 //! - ExportAttestedCsr (0x0F)
 
 use super::protocol::{
@@ -334,6 +335,59 @@ pub fn handle_export_attested_csr(
     csr_data[..copy_csr_len].copy_from_slice(&data[csr_start..csr_start + copy_csr_len]);
 
     let internal_resp = certificate::ExportAttestedCsrResponse {
+        common: CommonResponse { fips_status: 0 },
+        data_len: csr_len as u32,
+        csr_data,
+    };
+
+    let resp_bytes = internal_resp.as_bytes();
+    let copy_len = resp_bytes.len().min(response_buffer.len());
+    response_buffer[..copy_len].copy_from_slice(&resp_bytes[..copy_len]);
+    Ok(copy_len)
+}
+
+/// Handle ExportIdevidCsr command (manufacturing mode only).
+pub fn handle_export_idevid_csr(
+    payload: &[u8],
+    driver: &mut dyn SpdmVdmDriver,
+    response_buffer: &mut [u8],
+) -> Result<usize, TransportError> {
+    let req = certificate::ExportIdevidCsrRequest::from_bytes(payload)
+        .map_err(|_| TransportError::InvalidMessage)?;
+
+    // VDM payload: [algorithm(4)]
+    let vdm_payload = req.as_bytes();
+
+    let mut resp_buf = [0u8; MAX_VDM_RESPONSE_SIZE];
+    let resp_len = send_vdm_request(
+        CaliptraVdmCommand::ExportIdevidCsr,
+        vdm_payload,
+        driver,
+        &mut resp_buf,
+    )?;
+
+    let data = &resp_buf[VDM_RESPONSE_HEADER_SIZE..resp_len];
+
+    // Response data format: [data_len: u32 LE, csr_data...]
+    if data.len() < 4 {
+        return Err(TransportError::InvalidMessage);
+    }
+
+    let csr_len = u32::from_le_bytes([data[0], data[1], data[2], data[3]]) as usize;
+    let csr_start = 4;
+    let csr_end = csr_start + csr_len;
+
+    if csr_end > data.len() {
+        return Err(TransportError::BufferError(
+            "ExportIdevidCsr data_len exceeds response",
+        ));
+    }
+
+    let mut csr_data = [0u8; certificate::MAX_CSR_DATA_SIZE];
+    let copy_csr_len = csr_len.min(certificate::MAX_CSR_DATA_SIZE);
+    csr_data[..copy_csr_len].copy_from_slice(&data[csr_start..csr_start + copy_csr_len]);
+
+    let internal_resp = certificate::ExportIdevidCsrResponse {
         common: CommonResponse { fips_status: 0 },
         data_len: csr_len as u32,
         csr_data,

--- a/caliptra-util-host/transport/src/transports/spdm_vdm/dispatch.rs
+++ b/caliptra-util-host/transport/src/transports/spdm_vdm/dispatch.rs
@@ -31,6 +31,9 @@ pub fn get_command_handler(command_id: u32) -> Option<VdmCommandHandlerFn> {
         x if x == CaliptraCommandId::ExportAttestedCsr as u32 => {
             Some(commands::handle_export_attested_csr)
         }
+        x if x == CaliptraCommandId::ExportIdevidCsr as u32 => {
+            Some(commands::handle_export_idevid_csr)
+        }
         _ => None,
     }
 }

--- a/caliptra-util-host/transport/src/transports/spdm_vdm/protocol.rs
+++ b/caliptra-util-host/transport/src/transports/spdm_vdm/protocol.rs
@@ -155,6 +155,9 @@ pub fn command_id_to_vdm(command_id: u32) -> Option<CaliptraVdmCommand> {
         x if x == CaliptraCommandId::ExportAttestedCsr as u32 => {
             Some(CaliptraVdmCommand::ExportAttestedCsr)
         }
+        x if x == CaliptraCommandId::ExportIdevidCsr as u32 => {
+            Some(CaliptraVdmCommand::ExportIdevidCsr)
+        }
         _ => None,
     }
 }

--- a/platforms/emulator/runtime/userspace/apps/user/src/caliptra_cmd_handler/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/caliptra_cmd_handler/mod.rs
@@ -14,7 +14,7 @@ use caliptra_mcu_common_commands::{
     CaliptraCmdHandler, CaliptraCmdResult, CaliptraCompletionCode, DeviceCapabilities, DeviceId,
     DeviceInfo, FirmwareVersion,
 };
-use caliptra_mcu_libapi_caliptra::certificate::CertContext;
+use caliptra_mcu_libapi_caliptra::certificate::{CertContext, IDEV_ECC_CSR_MAX_SIZE};
 use caliptra_mcu_libapi_caliptra::crypto::asym::AsymAlgo;
 use caliptra_mcu_libapi_caliptra::error::CaliptraApiError;
 
@@ -75,5 +75,44 @@ impl CaliptraCmdHandler for CaliptraCmdBackend {
             })?;
 
         Ok(len)
+    }
+
+    async fn export_idevid_csr(
+        &self,
+        algorithm: u32,
+        csr_buf: &mut [u8],
+    ) -> CaliptraCmdResult<usize> {
+        let algo =
+            AsymAlgo::try_from_u32(algorithm).ok_or(CaliptraCompletionCode::InvalidParameter)?;
+
+        let mut cert_ctx = CertContext::new();
+
+        match algo {
+            AsymAlgo::EccP384 => {
+                let mut csr_der = [0u8; IDEV_ECC_CSR_MAX_SIZE];
+                let len = cert_ctx
+                    .get_idev_csr(&mut csr_der)
+                    .await
+                    .map_err(|e| match e {
+                        CaliptraApiError::MailboxBusy => {
+                            CaliptraCompletionCode::CaliptraMailboxBusy
+                        }
+                        CaliptraApiError::UnprovisionedCsr => CaliptraCompletionCode::InvalidState,
+                        CaliptraApiError::BufferTooSmall => {
+                            CaliptraCompletionCode::CaliptraBufferTooSmall
+                        }
+                        _ => CaliptraCompletionCode::GeneralError,
+                    })?;
+                if len > csr_buf.len() {
+                    return Err(CaliptraCompletionCode::CaliptraBufferTooSmall);
+                }
+                csr_buf[..len].copy_from_slice(&csr_der[..len]);
+                Ok(len)
+            }
+            AsymAlgo::MlDsa87 => {
+                // MLDSA IDevID CSR not yet supported at the mailbox level
+                Err(CaliptraCompletionCode::UnsupportedOperation)
+            }
+        }
     }
 }

--- a/platforms/emulator/runtime/userspace/apps/user/src/mcu_mbox/cmd_handler_mock.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/mcu_mbox/cmd_handler_mock.rs
@@ -101,4 +101,14 @@ impl CaliptraCmdHandler for NonCryptoCmdHandlerMock {
             .export_attested_csr(device_key_id, algorithm, nonce, csr_buf)
             .await
     }
+
+    async fn export_idevid_csr(
+        &self,
+        algorithm: u32,
+        csr_buf: &mut [u8],
+    ) -> CaliptraCmdResult<usize> {
+        // Delegate to real CaliptraCmdBackend for actual Caliptra mailbox interaction
+        let handler = CaliptraCmdBackend;
+        handler.export_idevid_csr(algorithm, csr_buf).await
+    }
 }

--- a/platforms/emulator/runtime/userspace/apps/user/src/vdm/cmd_handler_mock.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/vdm/cmd_handler_mock.rs
@@ -94,4 +94,12 @@ impl CaliptraCmdHandler for NonCryptoCmdHandlerMock {
     ) -> CaliptraCmdResult<usize> {
         Err(CaliptraCompletionCode::UnsupportedOperation)
     }
+
+    async fn export_idevid_csr(
+        &self,
+        _algorithm: u32,
+        _csr_buf: &mut [u8],
+    ) -> CaliptraCmdResult<usize> {
+        Err(CaliptraCompletionCode::UnsupportedOperation)
+    }
 }

--- a/runtime/userspace/api/caliptra-common-commands/src/lib.rs
+++ b/runtime/userspace/api/caliptra-common-commands/src/lib.rs
@@ -167,6 +167,20 @@ pub trait CaliptraCmdHandler: Send + Sync {
         nonce: &[u8; 32],
         csr_buf: &mut [u8],
     ) -> CaliptraCmdResult<usize>;
+
+    /// Exports an IDevID CSR (manufacturing mode only).
+    ///
+    /// # Arguments
+    /// * `algorithm` - The asymmetric algorithm (0x0001=ECC384, 0x0002=MLDSA87).
+    /// * `csr_buf` - Mutable buffer to write the CSR DER data into directly.
+    ///
+    /// # Returns
+    /// * `CaliptraCmdResult<usize>` - Number of bytes written on success, or an error.
+    async fn export_idevid_csr(
+        &self,
+        algorithm: u32,
+        csr_buf: &mut [u8],
+    ) -> CaliptraCmdResult<usize>;
 }
 
 pub struct AuthorizationError;

--- a/runtime/userspace/api/spdm-lib/src/vdm_handler/iana/ocp/caliptra_vdm/commands/export_idevid_csr.rs
+++ b/runtime/userspace/api/spdm-lib/src/vdm_handler/iana/ocp/caliptra_vdm/commands/export_idevid_csr.rs
@@ -1,0 +1,70 @@
+// Licensed under the Apache-2.0 license
+
+use crate::codec::{encode_u8_slice, Codec, CommonCodec, MessageBuf};
+use crate::vdm_handler::iana::ocp::caliptra_vdm::protocol::{
+    CaliptraCompletionCode, CaliptraVdmCmdResult, CaliptraVdmCommand, CaliptraVdmMsgHeader,
+    CALIPTRA_VDM_COMMAND_VERSION,
+};
+use crate::vdm_handler::{VdmError, VdmResult};
+use caliptra_mcu_common_commands::CaliptraCmdHandler;
+use core::mem::size_of;
+use zerocopy::{FromBytes, Immutable, IntoBytes};
+
+#[derive(FromBytes, IntoBytes, Immutable)]
+#[repr(C)]
+struct ExportIdevidCsrReq {
+    algorithm: u32,
+}
+
+impl CommonCodec for ExportIdevidCsrReq {}
+
+pub(crate) async fn handle_export_idevid_csr(
+    handler: &dyn CaliptraCmdHandler,
+    req_buf: &mut MessageBuf<'_>,
+    rsp_buf: &mut MessageBuf<'_>,
+    large_rsp_buf: &mut [u8],
+) -> VdmResult<CaliptraVdmCmdResult> {
+    let req = ExportIdevidCsrReq::decode(req_buf).map_err(VdmError::Codec)?;
+
+    // VDM large-response header: [command_version(1), response_code(1), status(1), data_len(4)]
+    let large_hdr_len = size_of::<CaliptraVdmMsgHeader>() + 1 + 4; // 7
+
+    if large_rsp_buf.len() < large_hdr_len {
+        return Ok(CaliptraVdmCmdResult::ErrorResponse(
+            CaliptraCompletionCode::InsufficientResources,
+        ));
+    }
+
+    // Use the tail of large_rsp_buf as scratch space for the CSR data.
+    let csr_buf = &mut large_rsp_buf[large_hdr_len..];
+    let data_len = match handler.export_idevid_csr(req.algorithm, csr_buf).await {
+        Ok(len) => len,
+        Err(e) => return Ok(CaliptraVdmCmdResult::ErrorResponse(e)),
+    };
+
+    // Normal-response VDM payload: [completion_code(1), data_len(4), csr_data...]
+    let normal_payload_len = 1 + 4 + data_len;
+
+    if normal_payload_len <= rsp_buf.tailroom() {
+        // Response fits in the normal SPDM message — no chunking needed.
+        let mut len = (CaliptraCompletionCode::Success as u8)
+            .encode(rsp_buf)
+            .map_err(VdmError::Codec)?;
+        len += (data_len as u32).encode(rsp_buf).map_err(VdmError::Codec)?;
+        len += encode_u8_slice(&csr_buf[..data_len], rsp_buf).map_err(VdmError::Codec)?;
+        Ok(CaliptraVdmCmdResult::Response(len))
+    } else {
+        // Too large — format in large_rsp_buf and return LargeResp for chunking.
+        let total_resp_len = large_hdr_len + data_len;
+        let mut offset = 0;
+        large_rsp_buf[offset] = CALIPTRA_VDM_COMMAND_VERSION;
+        offset += 1;
+        large_rsp_buf[offset] = CaliptraVdmCommand::ExportIdevidCsr.response_code();
+        offset += 1;
+        large_rsp_buf[offset] = CaliptraCompletionCode::Success as u8;
+        offset += 1;
+        large_rsp_buf[offset..offset + 4].copy_from_slice(&(data_len as u32).to_le_bytes());
+        // CSR data is already at large_rsp_buf[large_hdr_len..large_hdr_len + data_len]
+        Err(VdmError::LargeResp(total_resp_len))
+    }
+}

--- a/runtime/userspace/api/spdm-lib/src/vdm_handler/iana/ocp/caliptra_vdm/commands/mod.rs
+++ b/runtime/userspace/api/spdm-lib/src/vdm_handler/iana/ocp/caliptra_vdm/commands/mod.rs
@@ -4,4 +4,5 @@ pub(crate) mod device_capabilities;
 pub(crate) mod device_id;
 pub(crate) mod device_info;
 pub(crate) mod export_attested_csr;
+pub(crate) mod export_idevid_csr;
 pub(crate) mod firmware_version;

--- a/runtime/userspace/api/spdm-lib/src/vdm_handler/iana/ocp/caliptra_vdm/mod.rs
+++ b/runtime/userspace/api/spdm-lib/src/vdm_handler/iana/ocp/caliptra_vdm/mod.rs
@@ -5,7 +5,8 @@ extern crate alloc;
 use crate::codec::{Codec, MessageBuf};
 use crate::protocol::StandardsBodyId;
 use crate::vdm_handler::iana::ocp::caliptra_vdm::commands::{
-    device_capabilities, device_id, device_info, export_attested_csr, firmware_version,
+    device_capabilities, device_id, device_info, export_attested_csr, export_idevid_csr,
+    firmware_version,
 };
 use crate::vdm_handler::iana::ocp::caliptra_vdm::protocol::*;
 use crate::vdm_handler::{VdmError, VdmHandler, VdmRegistryMatcher, VdmResponder, VdmResult};
@@ -76,6 +77,15 @@ impl VdmResponder for CaliptraVdmHandler<'_> {
             }
             CaliptraVdmCommand::ExportAttestedCsr => {
                 export_attested_csr::handle_export_attested_csr(
+                    self.handler,
+                    req_buf,
+                    rsp_buf,
+                    large_rsp_buf,
+                )
+                .await?
+            }
+            CaliptraVdmCommand::ExportIdevidCsr => {
+                export_idevid_csr::handle_export_idevid_csr(
                     self.handler,
                     req_buf,
                     rsp_buf,

--- a/tests/integration/src/test_caliptra_util_host_spdm_vdm_validator.rs
+++ b/tests/integration/src/test_caliptra_util_host_spdm_vdm_validator.rs
@@ -174,6 +174,20 @@ mod test {
 
     // --- Test cases ---
 
+    /// Path to test-config.toml relative to the repository root.
+    fn test_config_path() -> String {
+        let manifest_dir = env!("CARGO_MANIFEST_DIR");
+        let repo_root = std::path::Path::new(manifest_dir)
+            .parent()
+            .unwrap()
+            .parent()
+            .unwrap();
+        repo_root
+            .join("caliptra-util-host/apps/spdm/test-config.toml")
+            .to_string_lossy()
+            .to_string()
+    }
+
     #[ignore]
     #[test]
     fn test_caliptra_util_host_spdm_vdm_validator() {
@@ -188,11 +202,41 @@ mod test {
 
         hw.start_i3c_controller();
 
+        let config_path = test_config_path();
         run_spdm_vdm_test(
             hw.i3c_port().unwrap(),
             hw.i3c_address().unwrap().into(),
             Duration::from_secs(120),
-            &["--key-ids", "1,2,3", "--algorithm", "1"],
+            &["--config", &config_path],
+        );
+
+        let test = finish_runtime_hw_model(&mut hw);
+        assert_eq!(0, test);
+
+        lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    #[ignore]
+    #[test]
+    fn test_caliptra_util_host_spdm_vdm_validator_mfg_mode() {
+        let lock = TEST_LOCK.lock().unwrap();
+        lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
+        let mut hw = start_runtime_hw_model(TestParams {
+            i3c_port: Some(PortPicker::new().pick().unwrap()),
+            use_strap_secrets: true,
+            lifecycle_controller_state: Some(caliptra_mcu_hw_model::LifecycleControllerState::Dev),
+            ..Default::default()
+        });
+
+        hw.start_i3c_controller();
+
+        let config_path = test_config_path();
+        run_spdm_vdm_test(
+            hw.i3c_port().unwrap(),
+            hw.i3c_address().unwrap().into(),
+            Duration::from_secs(120),
+            &["--config", &config_path, "--mode", "manufacturing"],
         );
 
         let test = finish_runtime_hw_model(&mut hw);


### PR DESCRIPTION
Add a new Caliptra VDM command (ExportIdevidCsr) that exports the IDevID CSR over the SPDM VDM transport, using the large response chunking infrastructure.

Manufacturing mode: returns IDevID CSR for requested algorithm.
Production mode: rejects with error (negative test).