### PR TITLE
spdm-lib: Unify large request/response into shared LargeMessageCtx

### DIFF
--- a/firmware-bundler/reference/emulator/user-app.toml
+++ b/firmware-bundler/reference/emulator/user-app.toml
@@ -33,6 +33,6 @@ stack = 0x0_7000
 
 [[app]]
 name = "user-app"
-stack = 0xae00
+stack = 0xa000
 grant_space = 0x4000
 

--- a/platforms/emulator/runtime/userspace/apps/user/src/spdm/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/spdm/mod.rs
@@ -33,13 +33,11 @@ const SECURE_SPDM_VERSIONS: &[SpdmVersion] = &[SpdmVersion::V12];
 // Caliptra Crypto timeout exponent (2^20 us)
 const CALIPTRA_SPDM_CT_EXPONENT: u8 = 20;
 
-/// Shared buffer size for large SPDM responses (shared by both measurements and VDM chunking).
+/// Shared buffer size for large SPDM messages (request reassembly and response chunking).
+/// Only one direction is active at a time, so a single buffer is shared.
 /// Sized for ECC-P384 certificate chain + signature + overhead.
 /// TODO: Increase for ML-DSA support once memory optimization (static buffers) is implemented.
-const LARGE_RESP_BUF_SIZE: usize = 4096;
-
-/// Buffer size for reassembling large SPDM requests received via CHUNK_SEND.
-const MAX_SPDM_REQ_SIZE: usize = 2048;
+const LARGE_MSG_BUF_SIZE: usize = 4096;
 
 #[embassy_executor::task]
 pub(crate) async fn spdm_task(spawner: Spawner) {
@@ -93,7 +91,7 @@ async fn spdm_mctp_responder() {
         ct_exponent: CALIPTRA_SPDM_CT_EXPONENT,
         flags: CapabilityFlags::default(),
         data_transfer_size: max_mctp_spdm_msg_size,
-        max_spdm_msg_size: MAX_SPDM_REQ_SIZE as u32,
+        max_spdm_msg_size: LARGE_MSG_BUF_SIZE as u32,
     };
 
     let local_algorithms = LocalDeviceAlgorithms::default();
@@ -117,10 +115,9 @@ async fn spdm_mctp_responder() {
     let vdm_handlers: Option<&mut [&mut dyn caliptra_mcu_spdm_lib::vdm_handler::VdmHandler]> =
         Some(&mut handlers_array);
 
-    // Buffer for large SPDM responses (measurements + VDM chunking)
-    let mut large_resp_buf = [0u8; LARGE_RESP_BUF_SIZE];
-    // Buffer for reassembling large SPDM requests (CHUNK_SEND)
-    let mut large_req_buf = [0u8; MAX_SPDM_REQ_SIZE];
+    // Shared buffer for large SPDM messages (request reassembly + response chunking).
+    // Only one direction is active at a time, so a single buffer is shared.
+    let mut large_msg_buf = [0u8; LARGE_MSG_BUF_SIZE];
 
     let mut ctx = match SpdmContext::new(
         SPDM_VERSIONS,
@@ -131,8 +128,7 @@ async fn spdm_mctp_responder() {
         &shared_cert_store,
         device_measurements,
         vdm_handlers,
-        &mut large_resp_buf,
-        &mut large_req_buf,
+        &mut large_msg_buf,
     ) {
         Ok(ctx) => ctx,
         Err(e) => {
@@ -178,7 +174,7 @@ async fn spdm_doe_responder() {
         ct_exponent: CALIPTRA_SPDM_CT_EXPONENT,
         flags: doe_capability_flags,
         data_transfer_size: max_doe_spdm_msg_size,
-        max_spdm_msg_size: MAX_SPDM_REQ_SIZE as u32,
+        max_spdm_msg_size: LARGE_MSG_BUF_SIZE as u32,
     };
 
     let mut device_doe_algorithms = DeviceAlgorithms::default();
@@ -245,10 +241,8 @@ async fn spdm_doe_responder() {
     #[cfg(not(feature = "test-doe-spdm-tdisp-ide-validator"))]
     let vdm_handlers: Option<&mut [&mut dyn caliptra_mcu_spdm_lib::vdm_handler::VdmHandler]> = None;
 
-    // Shared buffer for large SPDM responses (measurements + VDM chunking)
-    let mut large_resp_buf = [0u8; LARGE_RESP_BUF_SIZE];
-    // Buffer for reassembling large SPDM requests (CHUNK_SEND)
-    let mut large_req_buf = [0u8; MAX_SPDM_REQ_SIZE];
+    // Shared buffer for large SPDM messages (request reassembly + response chunking).
+    let mut large_msg_buf = [0u8; LARGE_MSG_BUF_SIZE];
 
     let mut ctx = match SpdmContext::new(
         SPDM_VERSIONS,
@@ -259,8 +253,7 @@ async fn spdm_doe_responder() {
         &shared_cert_store,
         device_measurements,
         vdm_handlers,
-        &mut large_resp_buf,
-        &mut large_req_buf,
+        &mut large_msg_buf,
     ) {
         Ok(ctx) => ctx,
         Err(e) => {

--- a/runtime/userspace/api/spdm-lib/src/chunk_ctx.rs
+++ b/runtime/userspace/api/spdm-lib/src/chunk_ctx.rs
@@ -1,6 +1,5 @@
 // Licensed under the Apache-2.0 license
 
-use crate::codec::{CodecResult, MessageBuf};
 use crate::commands::certificate_rsp::CertificateResponse;
 
 #[derive(Debug, PartialEq)]
@@ -49,68 +48,129 @@ impl ChunkState {
 
 pub type ChunkResult<T> = Result<T, ChunkError>;
 
-/// Manages the context for an incoming large SPDM request sent with CHUNK_SEND.
-pub(crate) struct LargeRequestCtx<'a> {
-    chunk_state: ChunkState,
-    buffer: &'a mut [u8],
+/// Represents a large message response type that can be split into chunks.
+/// `Buffered` responses have their data pre-serialized in the shared buffer.
+/// `Certificate` responses stream from the certificate store.
+pub(crate) enum LargeResponse {
+    Certificate(CertificateResponse),
+    /// Pre-serialized data lives in `LargeMessageCtx.buf[..data_len]`.
+    /// Shared by both measurements and VDM large responses.
+    Buffered,
 }
 
-impl<'a> LargeRequestCtx<'a> {
-    /// Create a new context with the given app-provided buffer.
+/// Tracks which direction the shared buffer is currently being used for.
+enum LargeMessageMode {
+    /// Buffer is not in use.
+    Idle,
+    /// Buffer is being used to reassemble an incoming large request (CHUNK_SEND).
+    Request,
+    /// Buffer is being used to send a large response (CHUNK_GET).
+    Response(LargeResponse),
+}
+
+/// Manages the shared buffer for both large SPDM request reassembly (CHUNK_SEND)
+/// and large response chunking (CHUNK_GET).
+///
+/// Only one direction is active at a time: the SPDM protocol ensures that
+/// CHUNK_SEND rejects if a large response is in progress, and vice versa.
+///
+/// TODO: Refactor `buf` to use `MessageBuf` instead of raw `&mut [u8]` to align
+/// with the process_message pattern (reserve/put_data/encode) and simplify
+/// header construction in vendor_defined_rsp.rs.
+pub(crate) struct LargeMessageCtx<'a> {
+    chunk_state: ChunkState,
+    mode: LargeMessageMode,
+    /// Global handle counter for large responses (incremented on each response reset)
+    global_handle: u8,
+    /// Number of valid bytes in `buf` (used by buffered responses)
+    pub(crate) data_len: usize,
+    /// App-provided shared buffer for large message data
+    pub(crate) buf: &'a mut [u8],
+}
+
+impl<'a> LargeMessageCtx<'a> {
+    /// Create a new context with the given app-provided shared buffer.
     pub fn new(buf: &'a mut [u8]) -> Self {
         Self {
             chunk_state: ChunkState::default(),
-            buffer: buf,
+            mode: LargeMessageMode::Idle,
+            global_handle: 1,
+            data_len: 0,
+            buf,
         }
     }
 
-    pub fn reset(&mut self) {
+    /// Take the shared buffer, leaving an empty slice in its place.
+    /// The caller MUST call `replace_buf` to restore the buffer.
+    pub fn take_buf(&mut self) -> &'a mut [u8] {
+        core::mem::take(&mut self.buf)
+    }
+
+    /// Replace the shared buffer with the given one.
+    pub fn replace_buf(&mut self, buf: &'a mut [u8]) {
+        self.buf = buf;
+    }
+
+    // ── Request methods (CHUNK_SEND reassembly) ──
+
+    /// Reset the request context. The buffer returns to idle.
+    pub fn reset_request(&mut self) {
         self.chunk_state.reset();
+        self.mode = LargeMessageMode::Idle;
     }
 
-    pub fn capacity(&self) -> usize {
-        self.buffer.len()
+    /// Returns `true` if a large request reassembly is in progress.
+    pub fn request_in_progress(&self) -> bool {
+        matches!(self.mode, LargeMessageMode::Request) && self.chunk_state.in_use
     }
 
-    pub fn in_progress(&self) -> bool {
-        self.chunk_state.in_use
+    pub fn request_capacity(&self) -> usize {
+        self.buf.len()
     }
 
-    pub fn init(&mut self, handle: u8, large_msg_size: usize, chunk: &[u8]) -> ChunkResult<()> {
-        if large_msg_size > self.buffer.len() || chunk.len() > large_msg_size {
+    /// Initialize a large request reassembly with the first chunk.
+    pub fn init_request(
+        &mut self,
+        handle: u8,
+        large_msg_size: usize,
+        chunk: &[u8],
+    ) -> ChunkResult<()> {
+        if large_msg_size > self.buf.len() || chunk.len() > large_msg_size {
             return Err(ChunkError::LargeMessageInitError);
         }
 
+        self.mode = LargeMessageMode::Request;
         self.chunk_state.init(large_msg_size, handle);
-        self.buffer[..chunk.len()].copy_from_slice(chunk);
+        self.buf[..chunk.len()].copy_from_slice(chunk);
         self.chunk_state.bytes_transferred = chunk.len();
         Ok(())
     }
 
-    pub fn append_chunk(
+    /// Append a subsequent chunk to the in-progress large request.
+    pub fn append_request_chunk(
         &mut self,
         handle: u8,
         chunk_seq_num: u16,
         chunk: &[u8],
     ) -> ChunkResult<()> {
-        self.validate_chunk(handle, chunk_seq_num)?;
+        self.validate_request_chunk(handle, chunk_seq_num)?;
 
         let end = self
             .chunk_state
             .bytes_transferred
             .checked_add(chunk.len())
             .ok_or(ChunkError::InvalidMessageOffset)?;
-        if end > self.chunk_state.large_msg_size || end > self.buffer.len() {
+        if end > self.chunk_state.large_msg_size || end > self.buf.len() {
             return Err(ChunkError::InvalidMessageOffset);
         }
 
-        self.buffer[self.chunk_state.bytes_transferred..end].copy_from_slice(chunk);
+        self.buf[self.chunk_state.bytes_transferred..end].copy_from_slice(chunk);
         self.chunk_state.bytes_transferred = end;
         self.chunk_state.seq_num = self.chunk_state.seq_num.wrapping_add(1);
         Ok(())
     }
 
-    pub fn validate_chunk(&self, handle: u8, chunk_seq_num: u16) -> ChunkResult<()> {
+    pub fn validate_request_chunk(&self, handle: u8, chunk_seq_num: u16) -> ChunkResult<()> {
         if !self.chunk_state.in_use {
             return Err(ChunkError::NoLargeResponseInProgress);
         }
@@ -123,15 +183,15 @@ impl<'a> LargeRequestCtx<'a> {
         Ok(())
     }
 
-    pub fn large_request_size(&self) -> usize {
+    pub fn request_size(&self) -> usize {
         self.chunk_state.large_msg_size
     }
 
-    pub fn bytes_transferred(&self) -> usize {
+    pub fn request_bytes_transferred(&self) -> usize {
         self.chunk_state.bytes_transferred
     }
 
-    pub fn is_complete(&self) -> bool {
+    pub fn request_is_complete(&self) -> bool {
         self.chunk_state.in_use
             && self.chunk_state.bytes_transferred == self.chunk_state.large_msg_size
     }
@@ -140,81 +200,30 @@ impl<'a> LargeRequestCtx<'a> {
         if self.chunk_state.large_msg_size < 2 {
             return None;
         }
-        Some(self.buffer[1])
+        Some(self.buf[1])
     }
 
-    pub fn copy_message_to(&self, dst: &mut MessageBuf<'_>) -> CodecResult<()> {
-        let msg_len = self.chunk_state.large_msg_size;
-        dst.reset();
-        dst.put_data(msg_len)?;
-        dst.data_mut(msg_len)?
-            .copy_from_slice(&self.buffer[..msg_len]);
-        Ok(())
-    }
-}
+    // ── Response methods (CHUNK_GET chunking) ──
 
-/// Represents a large message response type that can be split into chunks.
-/// `Buffered` responses have their data pre-serialized in the shared buffer.
-/// `Certificate` responses stream from the certificate store.
-pub(crate) enum LargeResponse {
-    Certificate(CertificateResponse),
-    /// Pre-serialized data lives in `LargeResponseCtx.buf[..data_len]`.
-    /// Shared by both measurements and VDM large responses.
-    Buffered,
-}
-
-/// Manages the context for ongoing large message responses.
-///
-/// Holds an app-provided shared buffer used by `Buffered` large responses.
-/// Only one large response is active at a time, so the buffer is shared
-/// between measurements and VDM responses.
-///
-/// TODO: Refactor `buf` to use `MessageBuf` instead of raw `&mut [u8]` to align
-/// with the process_message pattern (reserve/put_data/encode) and simplify
-/// header construction in vendor_defined_rsp.rs.
-pub(crate) struct LargeResponseCtx<'a> {
-    chunk_state: ChunkState,
-    response: Option<LargeResponse>,
-    /// Global handle counter for large responses (incremented for each new response)
-    global_handle: u8,
-    /// App-provided shared buffer for pre-serialized large response data
-    pub(crate) buf: &'a mut [u8],
-    /// Number of valid bytes in `buf`
-    pub(crate) data_len: usize,
-}
-
-impl<'a> LargeResponseCtx<'a> {
-    /// Create a new context with the given app-provided shared buffer.
-    pub fn new(buf: &'a mut [u8]) -> Self {
-        Self {
-            chunk_state: ChunkState::default(),
-            response: None,
-            global_handle: 1,
-            buf,
-            data_len: 0,
-        }
-    }
-
-    /// Reset the context to its initial state.
-    /// This action increments the global handle for the next large response.
-    pub(crate) fn reset(&mut self) {
+    /// Reset the response context. Increments global handle for next response.
+    pub(crate) fn reset_response(&mut self) {
         self.chunk_state.reset();
-        self.response = None;
+        self.mode = LargeMessageMode::Idle;
         self.data_len = 0;
-        // Increment global handle for next large response
         self.global_handle = self.global_handle.wrapping_add(1);
     }
 
-    /// Initialize the context for a large response.
-    ///
-    /// # Arguments
-    /// * `large_rsp` - The large message response to be sent
-    /// * `large_rsp_size` - The size of the response message
+    /// Returns `true` if a large response chunking is in progress.
+    pub fn response_in_progress(&self) -> bool {
+        matches!(self.mode, LargeMessageMode::Response(_)) && self.chunk_state.in_use
+    }
+
+    /// Initialize the context for a large response (e.g., Certificate).
     ///
     /// # Returns
-    /// The handle(u8) for this large response
-    pub fn init(&mut self, large_rsp: LargeResponse, large_rsp_size: usize) -> u8 {
-        self.response = Some(large_rsp);
+    /// The handle for this large response.
+    pub fn init_response(&mut self, large_rsp: LargeResponse, large_rsp_size: usize) -> u8 {
+        self.mode = LargeMessageMode::Response(large_rsp);
         self.chunk_state.init(large_rsp_size, self.global_handle);
         self.global_handle
     }
@@ -222,17 +231,14 @@ impl<'a> LargeResponseCtx<'a> {
     /// Initialize a buffered large response.
     /// The caller must have already written `data_len` bytes into `self.buf`.
     ///
-    /// # Arguments
-    /// * `data_len` - Number of valid bytes written into the shared buffer
-    ///
     /// # Returns
     /// The handle for this large response, or error if data exceeds buffer capacity.
-    pub fn init_buffered(&mut self, data_len: usize) -> ChunkResult<u8> {
+    pub fn init_buffered_response(&mut self, data_len: usize) -> ChunkResult<u8> {
         if data_len > self.buf.len() {
             return Err(ChunkError::BufferCapacityExceeded);
         }
         self.data_len = data_len;
-        self.response = Some(LargeResponse::Buffered);
+        self.mode = LargeMessageMode::Response(LargeResponse::Buffered);
         self.chunk_state.init(data_len, self.global_handle);
         Ok(self.global_handle)
     }
@@ -243,23 +249,8 @@ impl<'a> LargeResponseCtx<'a> {
         &self.buf[..self.data_len]
     }
 
-    /// Is large message response in progress
-    ///
-    /// # Returns
-    /// Returns `true` if a large response is currently in progress, otherwise `false`
-    pub fn in_progress(&self) -> bool {
-        self.chunk_state.in_use
-    }
-
-    /// Validates that the provided chunk handle and sequence number match the expected values
-    ///
-    /// # Arguments
-    /// * `handle` - The chunk handle to validate
-    /// * `chunk_seq_num` - The sequence number to validate
-    ///
-    /// # Returns
-    /// `Ok(())` if valid, or a specific `ChunkError` if validation fails
-    pub fn validate_chunk(&self, handle: u8, chunk_seq_num: u16) -> ChunkResult<()> {
+    /// Validates that the provided chunk handle and sequence number match the expected values.
+    pub fn validate_response_chunk(&self, handle: u8, chunk_seq_num: u16) -> ChunkResult<()> {
         if !self.chunk_state.in_use {
             return Err(ChunkError::NoLargeResponseInProgress);
         }
@@ -272,30 +263,24 @@ impl<'a> LargeResponseCtx<'a> {
         Ok(())
     }
 
-    /// Returns the total size of the large response being transferred
-    pub fn large_response_size(&self) -> usize {
+    /// Returns the total size of the large response being transferred.
+    pub fn response_size(&self) -> usize {
         self.chunk_state.large_msg_size
     }
 
-    /// Records that a chunk has been sent and updates internal state
-    ///
-    /// # Arguments
-    /// * `chunk_size` - The size of the chunk that was sent
+    /// Records that a chunk has been sent and updates internal state.
     pub fn next_chunk_sent(&mut self, chunk_size: usize) {
         self.chunk_state.bytes_transferred += chunk_size;
         self.chunk_state.seq_num = self.chunk_state.seq_num.wrapping_add(1);
         if self.chunk_state.bytes_transferred == self.chunk_state.large_msg_size {
-            // Transfer complete - reset chunk state but keep global handle for next response
+            // Transfer complete
             self.chunk_state.reset();
-            self.response = None;
+            self.mode = LargeMessageMode::Idle;
             self.data_len = 0;
         }
     }
 
-    /// Gets information about the next chunk to be sent
-    ///
-    /// # Arguments
-    /// * `chunk_size` - Maximum size allowed for a single chunk
+    /// Gets information about the next chunk to be sent.
     ///
     /// # Returns
     /// `Ok((is_last_chunk, remaining_size))` or `Err` if no transfer is active
@@ -304,16 +289,17 @@ impl<'a> LargeResponseCtx<'a> {
             return Err(ChunkError::NoLargeResponseInProgress);
         }
         let rem_len = self.chunk_state.large_msg_size - self.chunk_state.bytes_transferred;
-
-        // Check if the last chunk is reached
         Ok((rem_len <= chunk_size, rem_len))
     }
 
     pub fn response(&self) -> Option<&LargeResponse> {
-        self.response.as_ref()
+        match &self.mode {
+            LargeMessageMode::Response(r) => Some(r),
+            _ => None,
+        }
     }
 
-    pub fn bytes_transferred(&self) -> usize {
+    pub fn response_bytes_transferred(&self) -> usize {
         self.chunk_state.bytes_transferred
     }
 }

--- a/runtime/userspace/api/spdm-lib/src/codec.rs
+++ b/runtime/userspace/api/spdm-lib/src/codec.rs
@@ -338,6 +338,11 @@ impl<'a> MessageBuf<'a> {
     pub fn msg_len(&self) -> usize {
         self.tail
     }
+
+    /// Consumes the MessageBuf and returns the underlying buffer.
+    pub fn into_inner(self) -> &'a mut [u8] {
+        self.buffer
+    }
 }
 
 #[cfg(test)]

--- a/runtime/userspace/api/spdm-lib/src/commands/certificate_rsp.rs
+++ b/runtime/userspace/api/spdm-lib/src/commands/certificate_rsp.rs
@@ -187,7 +187,7 @@ async fn generate_certificate_response<'a>(
     if portion_len > SPDM_MAX_CERT_CHAIN_PORTION_LEN {
         let large_rsp_len = CERTIFICATE_RESP_HEADER_SIZE + portion_len as usize;
         let large_rsp = LargeResponse::Certificate(rsp_ctx.clone());
-        let handle = ctx.large_resp_context.init(large_rsp, large_rsp_len);
+        let handle = ctx.large_msg_ctx.init_response(large_rsp, large_rsp_len);
         Err(ctx.generate_error_response(rsp, ErrorCode::LargeResponse, 0, Some(&[handle])))?;
     }
 

--- a/runtime/userspace/api/spdm-lib/src/commands/chunk_get_rsp.rs
+++ b/runtime/userspace/api/spdm-lib/src/commands/chunk_get_rsp.rs
@@ -75,7 +75,7 @@ fn compute_chunk_size(ctx: &SpdmContext, chunk_seq_num: u16) -> CommandResult<(u
         .saturating_sub(size_of::<ChunkResponseHdr>() + extra_field_size);
 
     let (is_last_chunk, remaining_len) = ctx
-        .large_resp_context
+        .large_msg_ctx
         .next_chunk_info(max_chunk_size)
         .map_err(|_| (false, CommandError::InvalidChunkContext))?;
 
@@ -103,8 +103,8 @@ fn process_chunk_get<'a>(
     })?;
 
     if ctx
-        .large_resp_context
-        .validate_chunk(chunk_get_req.handle, chunk_get_req.chunk_seq_num)
+        .large_msg_ctx
+        .validate_response_chunk(chunk_get_req.handle, chunk_get_req.chunk_seq_num)
         .is_err()
     {
         Err(ctx.generate_error_response(req_payload, ErrorCode::InvalidRequest, 0, None))?;
@@ -113,7 +113,7 @@ fn process_chunk_get<'a>(
     // compute max possible response size that can be transferred in chunks is less than the large response size
     let max_large_rsp_size = max_chunked_resp_size(ctx);
 
-    if ctx.large_resp_context.large_response_size() > max_large_rsp_size {
+    if ctx.large_msg_ctx.response_size() > max_large_rsp_size {
         Err(ctx.generate_error_response(req_payload, ErrorCode::ResponseTooLarge, 0, None))?;
     }
 
@@ -155,7 +155,7 @@ async fn encode_chunk_data(
     rsp: &mut MessageBuf<'_>,
 ) -> CommandResult<usize> {
     // Get the chunk data from the large response context
-    let offset = ctx.large_resp_context.bytes_transferred();
+    let offset = ctx.large_msg_ctx.response_bytes_transferred();
     rsp.put_data(chunk_size)
         .map_err(|e| (false, CommandError::Codec(e)))?;
 
@@ -163,7 +163,7 @@ async fn encode_chunk_data(
         .data_mut(chunk_size)
         .map_err(|e| (false, CommandError::Codec(e)))?;
 
-    let bytes_copied = if let Some(response) = ctx.large_resp_context.response() {
+    let bytes_copied = if let Some(response) = ctx.large_msg_ctx.response() {
         match response {
             LargeResponse::Certificate(cert_rsp) => {
                 // Get the chunk data from the certificate response
@@ -178,7 +178,7 @@ async fn encode_chunk_data(
             }
             LargeResponse::Buffered => {
                 // Simple memcpy from the pre-serialized shared buffer
-                let data = &ctx.large_resp_context.buf[..ctx.large_resp_context.data_len];
+                let data = &ctx.large_msg_ctx.buf[..ctx.large_msg_ctx.data_len];
                 let available = data.len().saturating_sub(offset);
                 let copy_len = chunk_buf.len().min(available);
                 chunk_buf[..copy_len].copy_from_slice(&data[offset..offset + copy_len]);
@@ -222,7 +222,7 @@ async fn generate_chunk_response<'a>(
         .map_err(|e| (false, CommandError::Codec(e)))?;
 
     let (chunk_size, last_chunk) = compute_chunk_size(ctx, chunk_seq_num)?;
-    if chunk_size > ctx.large_resp_context.large_response_size() {
+    if chunk_size > ctx.large_msg_ctx.response_size() {
         Err((false, CommandError::InvalidChunkContext))?;
     }
 
@@ -230,14 +230,13 @@ async fn generate_chunk_response<'a>(
     let actual_chunk_size = encode_chunk_data(ctx, chunk_size, rsp).await?;
 
     // Mark this chunk as sent with actual bytes transferred
-    ctx.large_resp_context.next_chunk_sent(actual_chunk_size);
+    ctx.large_msg_ctx.next_chunk_sent(actual_chunk_size);
 
     // Now prepend headers in reverse order (innermost first)
 
     // Prepend LargeResponseSize for the first chunk
     if chunk_seq_num == 0 {
-        let large_response_size =
-            LargeResponseSize(ctx.large_resp_context.large_response_size() as u32);
+        let large_response_size = LargeResponseSize(ctx.large_msg_ctx.response_size() as u32);
         large_response_size
             .encode(rsp)
             .map_err(|e| (false, CommandError::Codec(e)))?;
@@ -270,7 +269,7 @@ pub(crate) async fn handle_chunk_get<'a>(
     // 3. Check if a large response is in progress
     if ctx.state.connection_info.state() < ConnectionState::AfterCapabilities
         || ctx.local_capabilities.flags.chunk_cap() == 0
-        || !ctx.large_resp_context.in_progress()
+        || !ctx.large_msg_ctx.response_in_progress()
     {
         error_code = Some(ErrorCode::UnexpectedRequest);
     }

--- a/runtime/userspace/api/spdm-lib/src/commands/chunk_send_ack_rsp.rs
+++ b/runtime/userspace/api/spdm-lib/src/commands/chunk_send_ack_rsp.rs
@@ -2,7 +2,7 @@
 
 use crate::codec::{Codec, CommonCodec, DataKind, MessageBuf};
 use crate::commands::error_rsp::{encode_error_response, ErrorCode};
-use crate::context::{SpdmContext, MAX_SPDM_RESPONDER_BUF_SIZE};
+use crate::context::SpdmContext;
 use crate::error::{CommandError, CommandResult};
 use crate::protocol::*;
 use crate::state::ConnectionState;
@@ -141,7 +141,7 @@ fn validate_common(
 
     if ctx.state.connection_info.state() < ConnectionState::AfterCapabilities
         || !ctx.support_large_msg_chunking()
-        || ctx.large_resp_context.in_progress()
+        || ctx.large_msg_ctx.response_in_progress()
     {
         Err(ctx.generate_error_response(req, ErrorCode::UnexpectedRequest, 0, None))?;
     }
@@ -171,7 +171,7 @@ fn process_chunk_send(
 
     let invalid = if has_reserved_bits {
         true
-    } else if !ctx.large_req_context.in_progress() {
+    } else if !ctx.large_msg_ctx.request_in_progress() {
         if available_chunk_len < size_of::<u32>() {
             true
         } else {
@@ -190,7 +190,7 @@ fn process_chunk_send(
                 || chunk_size != available_chunk_len
                 || chunk_send_msg_len > ctx.local_capabilities.data_transfer_size as usize
                 || large_message_size > ctx.local_capabilities.max_spdm_msg_size as usize
-                || large_message_size > ctx.large_req_context.capacity()
+                || large_message_size > ctx.large_msg_ctx.request_capacity()
                 || large_message_size <= MIN_DATA_TRANSFER_SIZE_V12 as usize
                 || chunk_size > large_message_size;
 
@@ -198,8 +198,8 @@ fn process_chunk_send(
                 let chunk = req
                     .data(chunk_size)
                     .map_err(|e| (false, CommandError::Codec(e)))?;
-                ctx.large_req_context
-                    .init(handle, large_message_size, chunk)
+                ctx.large_msg_ctx
+                    .init_request(handle, large_message_size, chunk)
                     .is_err()
             } else {
                 true
@@ -209,16 +209,16 @@ fn process_chunk_send(
         let min_chunk_size = MIN_DATA_TRANSFER_SIZE_V12 as usize
             - size_of::<SpdmMsgHdr>()
             - size_of::<ChunkSendReq>();
-        let transferred = ctx.large_req_context.bytes_transferred();
-        let large_message_size = ctx.large_req_context.large_request_size();
+        let transferred = ctx.large_msg_ctx.request_bytes_transferred();
+        let large_message_size = ctx.large_msg_ctx.request_size();
         let end = transferred.saturating_add(chunk_size);
 
         let invalid = chunk_seq_num == 0
             || chunk_size != available_chunk_len
             || chunk_send_msg_len > ctx.local_capabilities.data_transfer_size as usize
             || ctx
-                .large_req_context
-                .validate_chunk(handle, chunk_seq_num)
+                .large_msg_ctx
+                .validate_request_chunk(handle, chunk_seq_num)
                 .is_err()
             || end > large_message_size
             || (last_chunk && end != large_message_size)
@@ -228,8 +228,8 @@ fn process_chunk_send(
             let chunk = req
                 .data(chunk_size)
                 .map_err(|e| (false, CommandError::Codec(e)))?;
-            ctx.large_req_context
-                .append_chunk(handle, chunk_seq_num, chunk)
+            ctx.large_msg_ctx
+                .append_request_chunk(handle, chunk_seq_num, chunk)
                 .is_err()
         } else {
             true
@@ -237,7 +237,7 @@ fn process_chunk_send(
     };
 
     if invalid {
-        ctx.large_req_context.reset();
+        ctx.large_msg_ctx.reset_request();
         return Ok(ChunkSendProcessResult::EarlyError {
             handle,
             chunk_seq_num,
@@ -247,49 +247,8 @@ fn process_chunk_send(
     Ok(ChunkSendProcessResult::Ack(ChunkSendInfo {
         handle,
         chunk_seq_num,
-        complete: ctx.large_req_context.is_complete(),
+        complete: ctx.large_msg_ctx.request_is_complete(),
     }))
-}
-
-async fn process_large_request<'a>(
-    ctx: &mut SpdmContext<'a>,
-    req: &mut MessageBuf<'a>,
-    response: &mut [u8],
-) -> CommandResult<usize> {
-    let version = ctx.state.connection_info.version_number();
-    let request_code = ctx.large_req_context.request_code();
-
-    if matches!(
-        request_code,
-        Some(code) if code == ReqRespCode::ChunkSend.into() || code == ReqRespCode::ChunkGet.into()
-    ) {
-        ctx.large_req_context.reset();
-        return encode_error_response_to_slice(version, ErrorCode::InvalidRequest, response);
-    }
-
-    if ctx.large_req_context.copy_message_to(req).is_err() {
-        ctx.large_req_context.reset();
-        return encode_error_response_to_slice(version, ErrorCode::RequestTooLarge, response);
-    }
-    ctx.large_req_context.reset();
-
-    match ctx.handle_large_request_payload(req).await {
-        Ok(()) => {}
-        Err((true, _)) => {}
-        Err((false, _)) => {
-            return encode_error_response_to_slice(version, ErrorCode::InvalidRequest, response);
-        }
-    }
-
-    let response_len = req.data_len();
-    if response_len > response.len() {
-        return encode_error_response_to_slice(version, ErrorCode::ResponseTooLarge, response);
-    }
-    let inner_response = req
-        .data(response_len)
-        .map_err(|e| (false, CommandError::Codec(e)))?;
-    response[..response_len].copy_from_slice(inner_response);
-    Ok(response_len)
 }
 
 async fn generate_chunk_send_ack<'a>(
@@ -298,24 +257,45 @@ async fn generate_chunk_send_ack<'a>(
     rsp: &mut MessageBuf<'a>,
 ) -> CommandResult<()> {
     let version = ctx.state.connection_info.version_number();
-    let mut response_to_large_request = [0u8; MAX_SPDM_RESPONDER_BUF_SIZE];
-    let response_to_large_request_len = if info.complete {
-        Some(process_large_request(ctx, rsp, &mut response_to_large_request).await?)
+
+    if info.complete {
+        // Validate request code before dispatch
+        let request_code = ctx.large_msg_ctx.request_code();
+        if matches!(
+            request_code,
+            Some(code) if code == ReqRespCode::ChunkSend.into() || code == ReqRespCode::ChunkGet.into()
+        ) {
+            ctx.large_msg_ctx.reset_request();
+            ctx.prepare_response_buffer(rsp)?;
+            let header_size = size_of::<ChunkSendAckHdr>();
+            rsp.reserve(header_size)
+                .map_err(|e| (false, CommandError::Codec(e)))?;
+            append_error_response(version, ErrorCode::InvalidRequest, rsp)?;
+            encode_chunk_send_ack_hdr(version, true, info.handle, info.chunk_seq_num, rsp)?;
+            return Ok(());
+        }
+
+        // Prepare response buffer: transport header + CHUNK_SEND_ACK header reserved
+        ctx.prepare_response_buffer(rsp)?;
+        let header_size = size_of::<ChunkSendAckHdr>();
+        rsp.reserve(header_size)
+            .map_err(|e| (false, CommandError::Codec(e)))?;
+
+        // Dispatch the large request — handler writes ResponseToLargeRequest into rsp
+        ctx.handle_large_request_payload(rsp).await?;
+
+        // Encode the CHUNK_SEND_ACK header (fills in the reserved space)
+        encode_chunk_send_ack_hdr(version, false, info.handle, info.chunk_seq_num, rsp)?;
+        Ok(())
     } else {
-        None
-    };
-
-    ctx.prepare_response_buffer(rsp)?;
-    let header_size = size_of::<ChunkSendAckHdr>();
-    rsp.reserve(header_size)
-        .map_err(|e| (false, CommandError::Codec(e)))?;
-
-    if let Some(len) = response_to_large_request_len {
-        append_bytes_without_advancing_data(rsp, &response_to_large_request[..len])?;
+        // Non-final chunk — just send CHUNK_SEND_ACK with no ResponseToLargeRequest
+        ctx.prepare_response_buffer(rsp)?;
+        let header_size = size_of::<ChunkSendAckHdr>();
+        rsp.reserve(header_size)
+            .map_err(|e| (false, CommandError::Codec(e)))?;
+        encode_chunk_send_ack_hdr(version, false, info.handle, info.chunk_seq_num, rsp)?;
+        Ok(())
     }
-
-    encode_chunk_send_ack_hdr(version, false, info.handle, info.chunk_seq_num, rsp)?;
-    Ok(())
 }
 
 fn generate_chunk_send_early_error_ack(
@@ -493,8 +473,7 @@ mod tests {
         transport: &'a mut TestTransport,
         cert_store: &'a TestCertStore,
         measurements: &'a mut TestMeasurements,
-        large_resp_buf: &'a mut [u8],
-        large_req_buf: &'a mut [u8],
+        large_msg_buf: &'a mut [u8],
     ) -> SpdmContext<'a> {
         let mut flags = CapabilityFlags::default();
         flags.set_chunk_cap(1);
@@ -514,8 +493,7 @@ mod tests {
             cert_store,
             crate::measurements::SpdmMeasurements::new(&[], measurements),
             None,
-            large_resp_buf,
-            large_req_buf,
+            large_msg_buf,
         )
         .expect("test context should be valid");
         ctx.state
@@ -570,14 +548,12 @@ mod tests {
         let mut transport = TestTransport;
         let cert_store = TestCertStore;
         let mut measurements = TestMeasurements;
-        let mut large_resp_buf = [0u8; 1024];
-        let mut large_req_buf = [0u8; 2048];
+        let mut large_msg_buf = [0u8; 2048];
         let mut ctx = test_context(
             &mut transport,
             &cert_store,
             &mut measurements,
-            &mut large_resp_buf,
-            &mut large_req_buf,
+            &mut large_msg_buf,
         );
 
         let first_chunk = [0xAA; 30];
@@ -596,7 +572,7 @@ mod tests {
             }
             ChunkSendProcessResult::EarlyError { .. } => panic!("unexpected early error"),
         }
-        assert_eq!(ctx.large_req_context.bytes_transferred(), 30);
+        assert_eq!(ctx.large_msg_ctx.request_bytes_transferred(), 30);
 
         let second_chunk = [0xBB; 50];
         let mut second_storage = [0u8; 96];
@@ -614,7 +590,7 @@ mod tests {
             }
             ChunkSendProcessResult::EarlyError { .. } => panic!("unexpected early error"),
         }
-        assert_eq!(ctx.large_req_context.bytes_transferred(), 80);
+        assert_eq!(ctx.large_msg_ctx.request_bytes_transferred(), 80);
     }
 
     #[test]
@@ -622,14 +598,12 @@ mod tests {
         let mut transport = TestTransport;
         let cert_store = TestCertStore;
         let mut measurements = TestMeasurements;
-        let mut large_resp_buf = [0u8; 1024];
-        let mut large_req_buf = [0u8; 2048];
+        let mut large_msg_buf = [0u8; 2048];
         let mut ctx = test_context(
             &mut transport,
             &cert_store,
             &mut measurements,
-            &mut large_resp_buf,
-            &mut large_req_buf,
+            &mut large_msg_buf,
         );
 
         let first_chunk = [0xAA; 30];
@@ -658,7 +632,7 @@ mod tests {
                 assert_eq!(chunk_seq_num, 2);
             }
         }
-        assert!(!ctx.large_req_context.in_progress());
+        assert!(!ctx.large_msg_ctx.request_in_progress());
     }
 
     #[test]
@@ -666,14 +640,12 @@ mod tests {
         let mut transport = TestTransport;
         let cert_store = TestCertStore;
         let mut measurements = TestMeasurements;
-        let mut large_resp_buf = [0u8; 1024];
-        let mut large_req_buf = [0u8; 2048];
+        let mut large_msg_buf = [0u8; 2048];
         let mut ctx = test_context(
             &mut transport,
             &cert_store,
             &mut measurements,
-            &mut large_resp_buf,
-            &mut large_req_buf,
+            &mut large_msg_buf,
         );
 
         let first_chunk = [0xAA; 30];
@@ -693,7 +665,7 @@ mod tests {
                 assert_eq!(chunk_seq_num, 0);
             }
         }
-        assert!(!ctx.large_req_context.in_progress());
+        assert!(!ctx.large_msg_ctx.request_in_progress());
     }
 
     #[test]
@@ -701,14 +673,12 @@ mod tests {
         let mut transport = TestTransport;
         let cert_store = TestCertStore;
         let mut measurements = TestMeasurements;
-        let mut large_resp_buf = [0u8; 1024];
-        let mut large_req_buf = [0u8; 2048];
+        let mut large_msg_buf = [0u8; 2048];
         let mut ctx = test_context(
             &mut transport,
             &cert_store,
             &mut measurements,
-            &mut large_resp_buf,
-            &mut large_req_buf,
+            &mut large_msg_buf,
         );
 
         let first_chunk = [0xAA; 30];
@@ -737,7 +707,7 @@ mod tests {
                 assert_eq!(chunk_seq_num, 0);
             }
         }
-        assert!(!ctx.large_req_context.in_progress());
+        assert!(!ctx.large_msg_ctx.request_in_progress());
     }
 
     #[test]
@@ -745,14 +715,12 @@ mod tests {
         let mut transport = TestTransport;
         let cert_store = TestCertStore;
         let mut measurements = TestMeasurements;
-        let mut large_resp_buf = [0u8; 1024];
-        let mut large_req_buf = [0u8; 2048];
+        let mut large_msg_buf = [0u8; 2048];
         let mut ctx = test_context(
             &mut transport,
             &cert_store,
             &mut measurements,
-            &mut large_resp_buf,
-            &mut large_req_buf,
+            &mut large_msg_buf,
         );
         let mut storage = [0u8; 64];
         let mut msg = MessageBuf::new(&mut storage);

--- a/runtime/userspace/api/spdm-lib/src/commands/measurements_rsp.rs
+++ b/runtime/userspace/api/spdm-lib/src/commands/measurements_rsp.rs
@@ -501,7 +501,7 @@ pub(crate) async fn generate_measurements_response<'a>(
 
     if rsp_len > ctx.min_data_transfer_size() {
         // Check buffer capacity before acquiring mutable borrows.
-        if rsp_len > ctx.large_resp_context.buf.len() {
+        if rsp_len > ctx.large_msg_ctx.buf.len() {
             Err(ctx.generate_error_response(rsp, ErrorCode::ResponseTooLarge, 0, None))?;
         }
 
@@ -515,7 +515,7 @@ pub(crate) async fn generate_measurements_response<'a>(
             None => None,
         };
 
-        let buf = &mut ctx.large_resp_context.buf[..rsp_len];
+        let buf = &mut ctx.large_msg_ctx.buf[..rsp_len];
         let payload_len = rsp_ctx
             .encode_response(
                 &mut ctx.measurements,
@@ -528,8 +528,8 @@ pub(crate) async fn generate_measurements_response<'a>(
             .await?;
 
         let handle = ctx
-            .large_resp_context
-            .init_buffered(payload_len)
+            .large_msg_ctx
+            .init_buffered_response(payload_len)
             .map_err(|e| (false, CommandError::Chunk(e)))?;
         Err(ctx.generate_error_response(rsp, ErrorCode::LargeResponse, 0, Some(&[handle])))?
     } else {

--- a/runtime/userspace/api/spdm-lib/src/commands/vendor_defined_rsp.rs
+++ b/runtime/userspace/api/spdm-lib/src/commands/vendor_defined_rsp.rs
@@ -267,11 +267,7 @@ async fn generate_vendor_defined_response<'a>(
     // Pass shared buffer sub-slice starting after the VendorDefRspHdr reservation.
     // The temporary borrow ends after the await, so we can re-borrow in the match arms.
     match vdm_handler
-        .handle_request(
-            vdm_req_buf,
-            rsp,
-            &mut ctx.large_resp_context.buf[resp_hdr_len..],
-        )
+        .handle_request(vdm_req_buf, rsp, &mut ctx.large_msg_ctx.buf[resp_hdr_len..])
         .await
     {
         Ok(len) => {
@@ -286,9 +282,9 @@ async fn generate_vendor_defined_response<'a>(
             // Now encode VendorDefRspHdr at the start of the shared buffer.
             let total_len = resp_hdr_len + payload_len;
             resp_hdr.set_resp_len(payload_len as u16);
-            // TODO: Refactor large_resp_context.buf to use MessageBuf directly,
+            // TODO: Refactor large_msg_ctx.buf to use MessageBuf directly,
             // eliminating this temporary MessageBuf + reserve dance.
-            let mut hdr_buf = MessageBuf::new(&mut ctx.large_resp_context.buf[..resp_hdr_len]);
+            let mut hdr_buf = MessageBuf::new(&mut ctx.large_msg_ctx.buf[..resp_hdr_len]);
             hdr_buf
                 .reserve(resp_hdr_len)
                 .map_err(|e| (false, CommandError::Codec(e)))?;
@@ -296,8 +292,8 @@ async fn generate_vendor_defined_response<'a>(
                 .encode(&mut hdr_buf)
                 .map_err(|e| (false, CommandError::Codec(e)))?;
             let handle = ctx
-                .large_resp_context
-                .init_buffered(total_len)
+                .large_msg_ctx
+                .init_buffered_response(total_len)
                 .map_err(|e| (false, CommandError::Chunk(e)))?;
             Err(ctx.generate_error_response(rsp, ErrorCode::LargeResponse, 0, Some(&[handle])))
         }

--- a/runtime/userspace/api/spdm-lib/src/context.rs
+++ b/runtime/userspace/api/spdm-lib/src/context.rs
@@ -1,7 +1,7 @@
 // Licensed under the Apache-2.0 license
 
 use crate::cert_store::*;
-use crate::chunk_ctx::{LargeRequestCtx, LargeResponseCtx};
+use crate::chunk_ctx::LargeMessageCtx;
 use crate::codec::{encode_u8_slice, Codec, MessageBuf};
 use crate::commands::error_rsp::{encode_error_response, ErrorCode};
 use crate::commands::{
@@ -38,8 +38,7 @@ pub struct SpdmContext<'a> {
     pub(crate) local_algorithms: LocalDeviceAlgorithms<'a>,
     pub(crate) device_certs_store: &'a dyn SpdmCertStore,
     pub(crate) measurements: SpdmMeasurements<'a>,
-    pub(crate) large_resp_context: LargeResponseCtx<'a>,
-    pub(crate) large_req_context: LargeRequestCtx<'a>,
+    pub(crate) large_msg_ctx: LargeMessageCtx<'a>,
     pub(crate) session_mgr: SessionManager,
     pub(crate) vdm_handlers: Option<&'a mut [&'a mut dyn VdmHandler]>,
 }
@@ -55,8 +54,7 @@ impl<'a> SpdmContext<'a> {
         device_certs_store: &'a dyn SpdmCertStore,
         measurements: SpdmMeasurements<'a>,
         vdm_handlers: Option<&'a mut [&'a mut dyn VdmHandler]>,
-        large_resp_buf: &'a mut [u8],
-        large_req_buf: &'a mut [u8],
+        large_msg_buf: &'a mut [u8],
     ) -> SpdmResult<Self> {
         validate_supported_versions(supported_versions)?;
 
@@ -72,8 +70,7 @@ impl<'a> SpdmContext<'a> {
             local_algorithms,
             device_certs_store,
             measurements,
-            large_resp_context: LargeResponseCtx::new(large_resp_buf),
-            large_req_context: LargeRequestCtx::new(large_req_buf),
+            large_msg_ctx: LargeMessageCtx::new(large_msg_buf),
             session_mgr: SessionManager::new(),
             vdm_handlers,
         })
@@ -135,17 +132,75 @@ impl<'a> SpdmContext<'a> {
         self.dispatch_request(req_msg_header, req_code, buf).await
     }
 
+    /// Handle a fully reassembled large request (from CHUNK_SEND).
+    ///
+    /// Detaches the large message buffer, creates a request MessageBuf from it,
+    /// dispatches to the appropriate handler, and writes the response into `rsp`.
+    /// The caller must have already reserved space for the CHUNK_SEND_ACK header in `rsp`.
     pub(crate) async fn handle_large_request_payload(
         &mut self,
-        buf: &mut MessageBuf<'a>,
+        rsp: &mut MessageBuf<'a>,
     ) -> CommandResult<()> {
-        let (req_msg_header, req_code) = self.decode_and_validate_request(buf)?;
+        let request_size = self.large_msg_ctx.request_size();
 
-        if req_code == ReqRespCode::ChunkSend {
-            return Err((false, CommandError::UnsupportedRequest));
+        // Take the buffer containing the reassembled request
+        let taken_buf = self.large_msg_ctx.take_buf();
+        self.large_msg_ctx.reset_request();
+
+        // Create a MessageBuf from the taken buffer with request data loaded
+        let mut req = MessageBuf::new(taken_buf);
+        if req.put_data(request_size).is_err() {
+            let buf = req.into_inner();
+            self.large_msg_ctx.replace_buf(buf);
+            return Err((false, CommandError::BufferTooSmall));
         }
 
-        self.dispatch_request(req_msg_header, req_code, buf).await
+        let (req_msg_header, req_code) = match self.decode_and_validate_request(&mut req) {
+            Ok(v) => v,
+            Err((_send, _e)) => {
+                let buf = req.into_inner();
+                self.large_msg_ctx.replace_buf(buf);
+                let version = self.state.connection_info.version_number();
+                encode_error_response(rsp, version, ErrorCode::InvalidRequest, 0, None);
+                return Ok(());
+            }
+        };
+
+        if req_code == ReqRespCode::ChunkSend || req_code == ReqRespCode::ChunkGet {
+            let buf = req.into_inner();
+            self.large_msg_ctx.replace_buf(buf);
+            let version = self.state.connection_info.version_number();
+            encode_error_response(rsp, version, ErrorCode::InvalidRequest, 0, None);
+            return Ok(());
+        }
+
+        let result = self
+            .dispatch_large_request(req_msg_header, req_code, &mut req, rsp)
+            .await;
+
+        let buf = req.into_inner();
+        self.large_msg_ctx.replace_buf(buf);
+
+        result
+    }
+
+    /// Dispatch a large request to the appropriate handler.
+    ///
+    /// Commands with dedicated large-request handlers read from `req` and write
+    /// their response directly into `rsp`. When a command gains large-request
+    /// support (e.g. SET_CERTIFICATE, VDM), add it as a match arm here.
+    async fn dispatch_large_request(
+        &mut self,
+        _req_msg_header: SpdmMsgHdr,
+        _req_code: ReqRespCode,
+        _req: &mut MessageBuf<'a>,
+        rsp: &mut MessageBuf<'a>,
+    ) -> CommandResult<()> {
+        // No commands currently support large-request handling.
+        // As handlers are implemented, add match arms here.
+        let version = self.state.connection_info.version_number();
+        encode_error_response(rsp, version, ErrorCode::UnsupportedRequest, 0, None);
+        Ok(())
     }
 
     fn decode_and_validate_request(
@@ -160,15 +215,15 @@ impl<'a> SpdmContext<'a> {
             .map_err(|_| (false, CommandError::UnsupportedRequest))?;
 
         if !matches!(req_code, ReqRespCode::ChunkGet | ReqRespCode::ChunkSend)
-            && self.large_resp_context.in_progress()
+            && self.large_msg_ctx.response_in_progress()
         {
             // Reset large response context if the request is not a CHUNK_GET/CHUNK_SEND.
-            self.large_resp_context.reset();
+            self.large_msg_ctx.reset_response();
         }
 
-        if req_code != ReqRespCode::ChunkSend && self.large_req_context.in_progress() {
+        if req_code != ReqRespCode::ChunkSend && self.large_msg_ctx.request_in_progress() {
             // Reset large request context if the next request is not a CHUNK_SEND.
-            self.large_req_context.reset();
+            self.large_msg_ctx.reset_request();
         }
 
         // Check for requests prohibited within session
@@ -250,8 +305,8 @@ impl<'a> SpdmContext<'a> {
 
     pub(crate) fn reset(&mut self) {
         self.state.reset();
-        self.large_resp_context.reset();
-        self.large_req_context.reset();
+        self.large_msg_ctx.reset_response();
+        self.large_msg_ctx.reset_request();
         self.session_mgr.reset();
     }
 


### PR DESCRIPTION
- Combine LargeRequestCtx and LargeResponseCtx into a single
      LargeMessageCtx using one app-provided buffer.
- Eliminate the 1KB intermediate buffer in chunk_send_ack response generation
- Reduce the user-app stack reservation (0xAE00 -> 0xA000) to address the Process load error