### PR TITLE
regs: Disable stub warning by default

### DIFF
--- a/registers/generated-emulator/src/stub_warnings.rs
+++ b/registers/generated-emulator/src/stub_warnings.rs
@@ -5,7 +5,7 @@
 
 use std::sync::atomic::{AtomicBool, Ordering};
 
-static WARN_ON_STUB: AtomicBool = AtomicBool::new(true);
+static WARN_ON_STUB: AtomicBool = AtomicBool::new(false);
 
 /// Enable or disable warning logs when auto-generated register stubs
 /// handle a read/write that was not overridden by the peripheral implementation.

--- a/xtask/src/registers.rs
+++ b/xtask/src/registers.rs
@@ -324,7 +324,7 @@ fn generate_emulator_types(
     let stub_warnings_code = r#"
 use std::sync::atomic::{AtomicBool, Ordering};
 
-static WARN_ON_STUB: AtomicBool = AtomicBool::new(true);
+static WARN_ON_STUB: AtomicBool = AtomicBool::new(false);
 
 /// Enable or disable warning logs when auto-generated register stubs
 /// handle a read/write that was not overridden by the peripheral implementation.


### PR DESCRIPTION
The emulator app disables stubwarnings by default, but tests which directly invoke the emulator default to true based on the constant value.  This can result in large amounts of spurious warnings for registers whose default behavior does not need to change, but are often written or read from.

Adjust the default constant to match the emulator invocation.