### PR TITLE
add concurrency check for workflows

### DIFF
--- a/.github/workflows/bitstream-build.yml
+++ b/.github/workflows/bitstream-build.yml
@@ -12,10 +12,14 @@ on:
 
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build-bitstream:
     runs-on: [bitstream-builder]
-    timeout-minutes: 1440 
+    timeout-minutes: 1440
     strategy:
       matrix:
         segmented: [true, false]
@@ -49,7 +53,7 @@ jobs:
           if [ "${{ matrix.segmented }}" = "true" ]; then
             SEGMENTED_ARG="--segmented"
           fi
-          
+
           # Find the xsa and pdi files in /tmp
           XSA_FILE=$(ls /tmp/*.xsa 2>/dev/null | head -n 1)
           PDI_FILE=$(ls /tmp/*.pdi 2>/dev/null | head -n 1)
@@ -61,7 +65,7 @@ jobs:
 
           # Leave a copy for the uploader
           mkdir manifest-bundle
-          
+
           caliptra-bitstream-downloader bundle-manifest \
             --repository "${{ github.repository }}" \
             --hw-major-version "2.0" \

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -7,6 +7,10 @@ on:
   workflow_call:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   precheckin:
     runs-on: ubuntu-latest

--- a/.github/workflows/fpga-spdm.yml
+++ b/.github/workflows/fpga-spdm.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build_test_binaries:
     runs-on: [ e2-standard-8-big-disk ]

--- a/.github/workflows/fpga.yml
+++ b/.github/workflows/fpga.yml
@@ -5,6 +5,11 @@ name: FPGA Tests
 on:
   pull_request:
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build_test_binaries:
     runs-on: [e2-standard-8-big-disk]


### PR DESCRIPTION
Added [concurrency flag](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency) into workflows with "pull_request" trigger.
We can narrow down the changes to only a couple of workflows.

(please ignore the extra "whitespace" changes showing)