### PR TITLE
Add PLDM firmware update restart capability

### DIFF
--- a/emulator/app/src/emulator.rs
+++ b/emulator/app/src/emulator.rs
@@ -1064,6 +1064,7 @@ impl Emulator {
                         update_sm_actions:
                             caliptra_mcu_pldm_ua::update_sm::DefaultActionsExitOnError {},
                         fd_tid: 0x01,
+                        rerun_count: 0,
                     },
                 );
             } else {
@@ -1074,6 +1075,7 @@ impl Emulator {
                         discovery_sm_actions: caliptra_mcu_pldm_ua::discovery_sm::DefaultActions {},
                         update_sm_actions: caliptra_mcu_pldm_ua::update_sm::DefaultActions {},
                         fd_tid: 0x01,
+                        rerun_count: 0,
                     },
                 );
             };

--- a/emulator/bmc/pldm-ua/src/daemon.rs
+++ b/emulator/bmc/pldm-ua/src/daemon.rs
@@ -76,6 +76,7 @@ impl<
                 socket_clone1.clone(),
                 opts.caliptra_mcu_pldm_fw_pkg.unwrap(),
                 event_queue_tx_clone4,
+                opts.rerun_count,
             ),
         )));
 
@@ -110,6 +111,21 @@ impl<
         if let Some(handle) = self.event_loop_handle.take() {
             handle.join().unwrap();
         }
+    }
+
+    /// Wait for the firmware update session to reach a terminal state (Done),
+    /// then stop the daemon. Use this when running sequential PLDM sessions.
+    pub fn wait_for_update_complete_and_stop(&mut self) {
+        loop {
+            {
+                let sm = self.update_sm.lock().unwrap();
+                if matches!(sm.state(), &update_sm::States::Done) {
+                    break;
+                }
+            }
+            std::thread::sleep(Duration::from_secs(5));
+        }
+        self.stop();
     }
 
     pub fn cancel_update(&mut self) {
@@ -237,15 +253,22 @@ pub struct Options<D: discovery_sm::StateMachineActions, U: update_sm::StateMach
     // Actions for the update state machine that can be customized as needed
     pub update_sm_actions: U,
     pub caliptra_mcu_pldm_fw_pkg: Option<FirmwareManifest>,
+    // The number of times to re-run the update cycle after the first one completes
+    pub rerun_count: u32,
 }
 
-impl Default for Options<discovery_sm::DefaultActions, update_sm::DefaultActions> {
+impl<D, U> Default for Options<D, U>
+where
+    D: discovery_sm::StateMachineActions + Default,
+    U: update_sm::StateMachineActions + Default,
+{
     fn default() -> Self {
         Self {
-            discovery_sm_actions: discovery_sm::DefaultActions {},
-            update_sm_actions: update_sm::DefaultActions {},
+            discovery_sm_actions: D::default(),
+            update_sm_actions: U::default(),
             caliptra_mcu_pldm_fw_pkg: None,
             fd_tid: 0,
+            rerun_count: 0,
         }
     }
 }

--- a/emulator/bmc/pldm-ua/src/discovery_sm.rs
+++ b/emulator/bmc/pldm-ua/src/discovery_sm.rs
@@ -46,7 +46,8 @@ statemachine! {
 
         GetPLDMCommandsType5Sent + GetPLDMCommandsResponse(pldm_packet::GetPldmCommandsResponse) [is_pldm_commands_response_type5_valid] / on_pldm_commands_response_type5 = Done,
 
-        _ + CancelDiscovery / on_cancel_discovery = Done
+        _ + CancelDiscovery / on_cancel_discovery = Done,
+        Done + StartDiscovery / on_start_discovery = SetTidSent
     }
 }
 
@@ -357,6 +358,7 @@ pub fn process_packet(packet: &RxPacket) -> Result<PldmEvents, ()> {
     }
 }
 // Implement the context struct
+#[derive(Default)]
 pub struct DefaultActions;
 impl StateMachineActions for DefaultActions {}
 

--- a/emulator/bmc/pldm-ua/src/update_sm.rs
+++ b/emulator/bmc/pldm-ua/src/update_sm.rs
@@ -85,7 +85,9 @@ statemachine! {
 
         _ + CancelUpdateComponentResponse(pldm_packet::request_cancel::CancelUpdateComponentResponse) / on_cancel_update_component_response = Idle,
         _ + StopUpdateOnError / on_stop_update_error = Done,
-        _ + StopUpdate / on_stop_update = Done
+        _ + StopUpdate / on_stop_update = Done,
+        Done + StartUpdate / on_start_update = QueryDeviceIdentifiersSent,
+        Activate + StartUpdate / on_start_update = QueryDeviceIdentifiersSent
     }
 }
 
@@ -208,6 +210,14 @@ pub trait StateMachineActions {
         &mut self,
         ctx: &mut InnerContext<impl PldmSocket + Send + 'static>,
     ) -> Result<(), ()> {
+        // Reset context for a fresh update cycle (important when restarting from Done state)
+        ctx.device_id = None;
+        ctx.components.clear();
+        ctx.component_response_codes.clear();
+        ctx.current_component_index = None;
+        ctx.transferred_bytes = 0;
+        ctx.transfer_start_time = None;
+
         send_message_helper(
             ctx,
             &pldm_packet::query_devid::QueryDeviceIdentifiersRequest::new(
@@ -623,6 +633,9 @@ pub trait StateMachineActions {
         &mut self,
         ctx: &mut InnerContext<impl PldmSocket + Send + 'static>,
     ) -> Result<(), ()> {
+        // Cancel the response timer from UpdateComponent — the FD will now
+        // initiate RequestFirmwareData at its own pace.
+        ctx.response_timer.cancel();
         // Reset transfer tracking for new download
         ctx.transferred_bytes = 0;
         ctx.transfer_start_time = None;
@@ -1043,10 +1056,16 @@ pub trait StateMachineActions {
                     ctx.event_queue.clone(),
                     |event_queue| Self::poll_activation_status(event_queue),
                 );
-            } else {
+            } else if ctx.rerun_count == 0 {
                 info!("ActivateFirmware response success, no activation needed");
                 ctx.event_queue
                     .send(PldmEvents::Update(Events::StopUpdate))
+                    .map_err(|_| ())?;
+            } else {
+                info!("Restarting update");
+                ctx.rerun_count -= 1;
+                ctx.event_queue
+                    .send(PldmEvents::Update(Events::StartUpdate))
                     .map_err(|_| ())?;
             }
 
@@ -1174,6 +1193,7 @@ pub fn process_packet(packet: &RxPacket) -> Result<PldmEvents, ()> {
 }
 
 // Implement the context struct
+#[derive(Default)]
 pub struct DefaultActions;
 impl StateMachineActions for DefaultActions {}
 
@@ -1211,6 +1231,7 @@ pub struct InnerContext<S: PldmSocket> {
     response_timer: Timer,
     retry_count: Arc<Mutex<u8>>,
     is_initiator: bool,
+    rerun_count: u32,
 }
 
 pub struct Context<T: StateMachineActions, S: PldmSocket> {
@@ -1224,6 +1245,7 @@ impl<T: StateMachineActions, S: PldmSocket> Context<T, S> {
         socket: S,
         caliptra_mcu_pldm_fw_pkg: FirmwareManifest,
         event_queue: Sender<PldmEvents>,
+        rerun_count: u32,
     ) -> Self {
         Self {
             inner: context,
@@ -1243,6 +1265,7 @@ impl<T: StateMachineActions, S: PldmSocket> Context<T, S> {
                 response_timer: Timer::new(),
                 retry_count: Arc::new(Mutex::new(0)),
                 is_initiator: true,
+                rerun_count,
             },
         }
     }

--- a/emulator/bmc/pldm-ua/tests/common.rs
+++ b/emulator/bmc/pldm-ua/tests/common.rs
@@ -295,6 +295,7 @@ impl<
 }
 
 /* Override the Discovery SM. Skip the discovery process by starting firmware update immediately when discovery is kicked-off */
+#[derive(Default)]
 pub struct CustomDiscoverySm {}
 impl discovery_sm::StateMachineActions for CustomDiscoverySm {
     fn on_start_discovery(
@@ -323,6 +324,7 @@ fn test_pldm_daemon_setup() {
         discovery_sm_actions: CustomDiscoverySm {},
         update_sm_actions: update_sm::DefaultActions {},
         fd_tid: 0x02,
+        ..Default::default()
     });
 
     let _: QueryDeviceIdentifiersRequest = setup.receive_request(&setup.fd_sock, 1u8).unwrap();

--- a/emulator/bmc/pldm-ua/tests/test_device_identifier.rs
+++ b/emulator/bmc/pldm-ua/tests/test_device_identifier.rs
@@ -65,6 +65,7 @@ fn test_valid_device_identifier_one_descriptor() {
         discovery_sm_actions: common::CustomDiscoverySm {},
         update_sm_actions: update_sm::DefaultActions {},
         fd_tid: 0x02,
+        ..Default::default()
     });
 
     // Receive QueryDeviceIdentifiers request
@@ -114,6 +115,7 @@ fn test_valid_device_identifier_not_matched() {
         discovery_sm_actions: common::CustomDiscoverySm {},
         update_sm_actions: update_sm::DefaultActions {},
         fd_tid: 0x02,
+        ..Default::default()
     });
 
     // Receive QueryDeviceIdentifiers request
@@ -177,6 +179,7 @@ fn test_multiple_device_identifiers() {
         discovery_sm_actions: common::CustomDiscoverySm {},
         update_sm_actions: update_sm::DefaultActions {},
         fd_tid: 0x02,
+        ..Default::default()
     });
 
     // Receive QueryDeviceIdentifiers request
@@ -234,6 +237,7 @@ fn test_send_get_fw_parameter_after_response() {
         ..Default::default()
     };
 
+    #[derive(Default)]
     struct UpdateSmIgnoreFirmwareParamsResponse {}
     impl update_sm::StateMachineActions for UpdateSmIgnoreFirmwareParamsResponse {
         fn on_get_firmware_parameters_response(
@@ -250,6 +254,7 @@ fn test_send_get_fw_parameter_after_response() {
         discovery_sm_actions: common::CustomDiscoverySm {},
         update_sm_actions: UpdateSmIgnoreFirmwareParamsResponse {},
         fd_tid: 0x02,
+        ..Default::default()
     });
 
     // Receive QueryDeviceIdentifiers request

--- a/emulator/bmc/pldm-ua/tests/test_discovery.rs
+++ b/emulator/bmc/pldm-ua/tests/test_discovery.rs
@@ -29,6 +29,7 @@ const COMPLETION_CODE_SUCCESSFUL: u8 = 0x00;
  * The on_start_update() method will set a flag to true to indicate that the Firmware Update SM has started.
  * When the Daemon is stopped the on_stop_update() method will be called and verify the flag is true.
  */
+#[derive(Default)]
 struct UpdateSmStopAfterRequest {
     is_fw_update_started: bool,
 }
@@ -62,6 +63,7 @@ fn test_discovery() {
             is_fw_update_started: false,
         },
         fd_tid: DEVICE_TID,
+        ..Default::default()
     });
 
     // TID to be assigned to the device
@@ -213,6 +215,7 @@ fn test_discovery_with_retry() {
             is_fw_update_started: false,
         },
         fd_tid: DEVICE_TID,
+        ..Default::default()
     });
 
     // TID to be assigned to the device

--- a/emulator/bmc/pldm-ua/tests/test_download.rs
+++ b/emulator/bmc/pldm-ua/tests/test_download.rs
@@ -39,6 +39,7 @@ pub const TEST_UUID: [u8; 16] = [
 const BASELINE_TRANSFER_SIZE: u32 = 32;
 
 /* Override the Update SM, go directly to UpdateComponent */
+#[derive(Default)]
 struct UpdateSmBypassed {}
 impl update_sm::StateMachineActions for UpdateSmBypassed {
     fn on_start_update(
@@ -195,6 +196,7 @@ fn test_download_size_divisible_by_transfer_size() {
         discovery_sm_actions: CustomDiscoverySm {},
         update_sm_actions: UpdateSmBypassed {},
         fd_tid: 0x01,
+        ..Default::default()
     });
 
     setup.wait_for_state_transition(update_sm::States::Download);
@@ -313,6 +315,7 @@ fn test_download_size_not_divisible_by_transfer_size() {
         discovery_sm_actions: CustomDiscoverySm {},
         update_sm_actions: UpdateSmBypassed {},
         fd_tid: 0x01,
+        ..Default::default()
     });
 
     setup.wait_for_state_transition(update_sm::States::Download);

--- a/emulator/bmc/pldm-ua/tests/test_get_fw_parameters.rs
+++ b/emulator/bmc/pldm-ua/tests/test_get_fw_parameters.rs
@@ -33,6 +33,7 @@ pub const TEST_UUID: [u8; 16] = [
 ];
 
 /* Override the Update SM, and bypass the QueryDeviceIdentifier exchange and go straight to GetFirmwareParameters */
+#[derive(Default)]
 struct UpdateSmBypassQueryDevId {
     expected_num_components_to_update: usize,
 }
@@ -214,6 +215,7 @@ fn test_caliptra_fw_update() {
             expected_num_components_to_update: 1,
         },
         fd_tid: 0x01,
+        ..Default::default()
     });
 
     // Receive QueryDeviceIdentifiers request
@@ -257,6 +259,7 @@ fn test_caliptra_fw_update_with_timeout() {
             expected_num_components_to_update: 1,
         },
         fd_tid: 0x01,
+        ..Default::default()
     });
 
     // Receive QueryDeviceIdentifiers request
@@ -306,6 +309,7 @@ fn test_caliptra_fw_incorrect_id() {
             expected_num_components_to_update: 0,
         },
         fd_tid: 0x01,
+        ..Default::default()
     });
 
     // Receive QueryDeviceIdentifiers request
@@ -351,6 +355,7 @@ fn test_caliptra_fw_update_same_version() {
             expected_num_components_to_update: 0,
         },
         fd_tid: 0x01,
+        ..Default::default()
     });
 
     // Receive QueryDeviceIdentifiers request
@@ -395,6 +400,7 @@ fn test_caliptra_fw_caliptra_and_manifest() {
             expected_num_components_to_update: 2,
         },
         fd_tid: 0x01,
+        ..Default::default()
     });
 
     // Receive QueryDeviceIdentifiers request
@@ -440,6 +446,7 @@ fn test_caliptra_fw_caliptra_same_version_and_manifest_diff_version() {
             expected_num_components_to_update: 1,
         },
         fd_tid: 0x01,
+        ..Default::default()
     });
 
     // Receive QueryDeviceIdentifiers request

--- a/emulator/bmc/pldm-ua/tests/test_pass_component_table.rs
+++ b/emulator/bmc/pldm-ua/tests/test_pass_component_table.rs
@@ -28,6 +28,7 @@ pub const TEST_UUID: [u8; 16] = [
 ];
 
 /* Override the Update SM, go directly to PassComponents */
+#[derive(Default)]
 struct UpdateSmBypassed {}
 impl update_sm::StateMachineActions for UpdateSmBypassed {
     fn on_start_update(
@@ -142,6 +143,7 @@ fn test_pass_one_component() {
         discovery_sm_actions: CustomDiscoverySm {},
         update_sm_actions: UpdateSmBypassed {},
         fd_tid: 0x01,
+        ..Default::default()
     });
 
     // Receive PassComponent request
@@ -206,6 +208,7 @@ fn test_pass_two_components() {
         discovery_sm_actions: CustomDiscoverySm {},
         update_sm_actions: UpdateSmBypassed {},
         fd_tid: 0x01,
+        ..Default::default()
     });
 
     // Receive PassComponent request
@@ -280,6 +283,7 @@ fn test_pass_three_components() {
         discovery_sm_actions: CustomDiscoverySm {},
         update_sm_actions: UpdateSmBypassed {},
         fd_tid: 0x01,
+        ..Default::default()
     });
 
     // Receive PassComponent request

--- a/emulator/bmc/pldm-ua/tests/test_post_download.rs
+++ b/emulator/bmc/pldm-ua/tests/test_post_download.rs
@@ -43,6 +43,7 @@ const SELF_ACTIVATION_FIELD_BIT: u16 = 0x0001;
 const SELF_ACTIVATION_FIELD_MASK: u16 = 0x0001;
 
 /* Override the Update SM, go directly to TransferComplete */
+#[derive(Default)]
 struct UpdateSmBypassed {}
 impl update_sm::StateMachineActions for UpdateSmBypassed {
     fn on_start_update(
@@ -185,6 +186,7 @@ fn test_one_component_activate() {
         discovery_sm_actions: CustomDiscoverySm {},
         update_sm_actions: UpdateSmBypassed {},
         fd_tid: 0x01,
+        ..Default::default()
     });
 
     setup.wait_for_state_transition(update_sm::States::Verify);
@@ -306,6 +308,7 @@ fn test_one_component_verify_failed() {
         discovery_sm_actions: CustomDiscoverySm {},
         update_sm_actions: UpdateSmBypassed {},
         fd_tid: 0x01,
+        ..Default::default()
     });
 
     setup.wait_for_state_transition(update_sm::States::Verify);
@@ -363,6 +366,7 @@ fn test_one_component_apply_failed() {
         discovery_sm_actions: CustomDiscoverySm {},
         update_sm_actions: UpdateSmBypassed {},
         fd_tid: 0x01,
+        ..Default::default()
     });
 
     setup.wait_for_state_transition(update_sm::States::Verify);
@@ -435,6 +439,7 @@ fn test_apply_complete_with_activation_modification() {
         discovery_sm_actions: CustomDiscoverySm {},
         update_sm_actions: UpdateSmBypassed {},
         fd_tid: 0x01,
+        ..Default::default()
     });
 
     setup.wait_for_state_transition(update_sm::States::Verify);
@@ -521,6 +526,7 @@ fn test_two_components_activate() {
         discovery_sm_actions: CustomDiscoverySm {},
         update_sm_actions: UpdateSmBypassed {},
         fd_tid: 0x01,
+        ..Default::default()
     });
 
     setup.wait_for_state_transition(update_sm::States::Verify);
@@ -701,6 +707,7 @@ fn test_two_components_no_self_activation() {
         discovery_sm_actions: CustomDiscoverySm {},
         update_sm_actions: UpdateSmBypassed {},
         fd_tid: 0x01,
+        ..Default::default()
     });
 
     setup.wait_for_state_transition(update_sm::States::Verify);
@@ -822,6 +829,7 @@ fn test_two_components_one_activate() {
         discovery_sm_actions: CustomDiscoverySm {},
         update_sm_actions: UpdateSmBypassed {},
         fd_tid: 0x01,
+        ..Default::default()
     });
 
     setup.wait_for_state_transition(update_sm::States::Verify);

--- a/emulator/bmc/pldm-ua/tests/test_request_update.rs
+++ b/emulator/bmc/pldm-ua/tests/test_request_update.rs
@@ -27,6 +27,7 @@ pub const TEST_UUID: [u8; 16] = [
 ];
 
 /* Override the Update SM, bypass QueryDeviceIdentifiers and GetFirmwareParameters */
+#[derive(Default)]
 struct UpdateSmBypassed {}
 impl update_sm::StateMachineActions for UpdateSmBypassed {
     fn on_start_update(
@@ -136,6 +137,7 @@ fn test_request_update_receive_ok() {
         discovery_sm_actions: CustomDiscoverySm {},
         update_sm_actions: UpdateSmBypassed {},
         fd_tid: 0x01,
+        ..Default::default()
     });
 
     // Receive RequestUpdate request
@@ -173,6 +175,7 @@ fn test_request_update_receive_fail() {
         discovery_sm_actions: CustomDiscoverySm {},
         update_sm_actions: UpdateSmBypassed {},
         fd_tid: 0x01,
+        ..Default::default()
     });
 
     // Receive RequestUpdate request

--- a/emulator/bmc/pldm-ua/tests/test_update_component.rs
+++ b/emulator/bmc/pldm-ua/tests/test_update_component.rs
@@ -28,6 +28,7 @@ pub const TEST_UUID: [u8; 16] = [
 ];
 
 /* Override the Update SM, go directly to UpdateComponent */
+#[derive(Default)]
 struct UpdateSmBypassed {}
 impl update_sm::StateMachineActions for UpdateSmBypassed {
     fn on_start_update(
@@ -164,6 +165,7 @@ fn test_update_one_component() {
         discovery_sm_actions: CustomDiscoverySm {},
         update_sm_actions: UpdateSmBypassed {},
         fd_tid: 0x01,
+        ..Default::default()
     });
 
     // Receive UpdateComponent request
@@ -229,6 +231,7 @@ fn test_update_two_components() {
         discovery_sm_actions: CustomDiscoverySm {},
         update_sm_actions: UpdateSmBypassed {},
         fd_tid: 0x01,
+        ..Default::default()
     });
 
     // Receive UpdateComponent request

--- a/runtime/userspace/api/caliptra-api/src/image_loading/mod.rs
+++ b/runtime/userspace/api/caliptra-api/src/image_loading/mod.rs
@@ -167,6 +167,11 @@ impl<'a, D: DMAMapping + 'static> PldmImageLoader<'a, D> {
     pub fn finalize(&self) -> Result<(), ErrorCode> {
         pldm_client::finalize(VerifyResult::VerifySuccess)
     }
+
+    /// Wait for the PLDM service to fully stop (protocol complete, tasks exited).
+    pub async fn wait_for_service_stopped(&self) {
+        caliptra_mcu_pldm_lib::daemon::wait_until_stopped().await;
+    }
 }
 
 #[async_trait(?Send)]

--- a/runtime/userspace/api/pldm-lib/src/cmd_interface.rs
+++ b/runtime/userspace/api/pldm-lib/src/cmd_interface.rs
@@ -16,6 +16,15 @@ use core::sync::atomic::{AtomicBool, Ordering};
 
 pub type PldmCompletionErrorCode = u8;
 
+/// Action the responder loop should take after handling a message.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResponderAction {
+    /// Continue processing messages.
+    Continue,
+    /// The PLDM session is complete (e.g. activation received); exit the loop.
+    Complete,
+}
+
 // Helper function to write a failure response message into payload
 pub(crate) fn generate_failure_response(
     payload: &mut [u8],
@@ -52,7 +61,7 @@ impl<'a> CmdInterface<'a> {
         &self,
         transport: &mut MctpTransport,
         msg_buf: &mut [u8],
-    ) -> Result<(), MsgHandlerError> {
+    ) -> Result<ResponderAction, MsgHandlerError> {
         // Receive msg from mctp transport
         transport
             .receive_request(msg_buf)
@@ -60,13 +69,15 @@ impl<'a> CmdInterface<'a> {
             .map_err(MsgHandlerError::Transport)?;
 
         // Process the request
-        let resp_len = self.process_request(msg_buf).await?;
+        let (resp_len, action) = self.process_request(msg_buf).await?;
 
         // Send the response
         transport
             .send_response(&msg_buf[..resp_len])
             .await
-            .map_err(MsgHandlerError::Transport)
+            .map_err(MsgHandlerError::Transport)?;
+
+        Ok(action)
     }
 
     pub async fn handle_initiator_msg(
@@ -145,7 +156,10 @@ impl<'a> CmdInterface<'a> {
         self.fd_ctx.ops()
     }
 
-    async fn process_request(&self, msg_buf: &mut [u8]) -> Result<usize, MsgHandlerError> {
+    async fn process_request(
+        &self,
+        msg_buf: &mut [u8],
+    ) -> Result<(usize, ResponderAction), MsgHandlerError> {
         // Check if the handler is busy processing a request
         if self.busy.load(Ordering::SeqCst) {
             return Err(MsgHandlerError::NotReady);
@@ -161,12 +175,15 @@ impl<'a> CmdInterface<'a> {
             Ok(result) => result,
             Err(e) => {
                 self.busy.store(false, Ordering::SeqCst);
-                return Ok(reserved_len + generate_failure_response(payload, e)?);
+                let len = reserved_len + generate_failure_response(payload, e)?;
+                return Ok((len, ResponderAction::Continue));
             }
         };
 
-        let resp_len = match pldm_type {
-            PldmSupportedType::Base => self.process_control_cmd(cmd_opcode, payload),
+        let result = match pldm_type {
+            PldmSupportedType::Base => self
+                .process_control_cmd(cmd_opcode, payload)
+                .map(|len| (len, ResponderAction::Continue)),
             PldmSupportedType::FwUpdate => self.process_fw_update_cmd(cmd_opcode, payload).await,
             _ => {
                 unreachable!()
@@ -175,10 +192,8 @@ impl<'a> CmdInterface<'a> {
 
         self.busy.store(false, Ordering::SeqCst);
 
-        match resp_len {
-            Ok(bytes) => Ok(reserved_len + bytes),
-            Err(e) => Err(e),
-        }
+        let (resp_len, action) = result?;
+        Ok((reserved_len + resp_len, action))
     }
 
     fn process_control_cmd(
@@ -204,30 +219,64 @@ impl<'a> CmdInterface<'a> {
         &self,
         cmd_opcode: u8,
         payload: &mut [u8],
-    ) -> Result<usize, MsgHandlerError> {
+    ) -> Result<(usize, ResponderAction), MsgHandlerError> {
         match FwUpdateCmd::try_from(cmd_opcode) {
             Ok(cmd) => match cmd {
-                FwUpdateCmd::QueryDeviceIdentifiers => self.fd_ctx.query_devid_rsp(payload).await,
-                FwUpdateCmd::GetFirmwareParameters => {
-                    self.fd_ctx.get_firmware_parameters_rsp(payload).await
-                }
-                FwUpdateCmd::RequestUpdate => self.fd_ctx.request_update_rsp(payload).await,
-                FwUpdateCmd::PassComponentTable => self.fd_ctx.pass_component_rsp(payload).await,
-                FwUpdateCmd::UpdateComponent => self.fd_ctx.update_component_rsp(payload).await,
+                FwUpdateCmd::QueryDeviceIdentifiers => self
+                    .fd_ctx
+                    .query_devid_rsp(payload)
+                    .await
+                    .map(|len| (len, ResponderAction::Continue)),
+                FwUpdateCmd::GetFirmwareParameters => self
+                    .fd_ctx
+                    .get_firmware_parameters_rsp(payload)
+                    .await
+                    .map(|len| (len, ResponderAction::Continue)),
+                FwUpdateCmd::RequestUpdate => self
+                    .fd_ctx
+                    .request_update_rsp(payload)
+                    .await
+                    .map(|len| (len, ResponderAction::Continue)),
+                FwUpdateCmd::PassComponentTable => self
+                    .fd_ctx
+                    .pass_component_rsp(payload)
+                    .await
+                    .map(|len| (len, ResponderAction::Continue)),
+                FwUpdateCmd::UpdateComponent => self
+                    .fd_ctx
+                    .update_component_rsp(payload)
+                    .await
+                    .map(|len| (len, ResponderAction::Continue)),
 
-                FwUpdateCmd::ActivateFirmware => self.fd_ctx.activate_firmware_rsp(payload).await,
-                FwUpdateCmd::CancelUpdateComponent => {
-                    self.fd_ctx.cancel_update_component_rsp(payload).await
-                }
-                FwUpdateCmd::CancelUpdate => self.fd_ctx.cancel_update_rsp(payload).await,
-                FwUpdateCmd::GetStatus => self.fd_ctx.get_status_rsp(payload).await,
+                FwUpdateCmd::ActivateFirmware => self
+                    .fd_ctx
+                    .activate_firmware_rsp(payload)
+                    .await
+                    .map(|len| (len, ResponderAction::Complete)),
+                FwUpdateCmd::CancelUpdateComponent => self
+                    .fd_ctx
+                    .cancel_update_component_rsp(payload)
+                    .await
+                    .map(|len| (len, ResponderAction::Continue)),
+                FwUpdateCmd::CancelUpdate => self
+                    .fd_ctx
+                    .cancel_update_rsp(payload)
+                    .await
+                    .map(|len| (len, ResponderAction::Complete)),
+                FwUpdateCmd::GetStatus => self
+                    .fd_ctx
+                    .get_status_rsp(payload)
+                    .await
+                    .map(|len| (len, ResponderAction::Continue)),
                 _ => generate_failure_response(
                     payload,
                     PldmBaseCompletionCode::UnsupportedPldmCmd as u8,
-                ),
+                )
+                .map(|len| (len, ResponderAction::Continue)),
             },
             Err(_) => {
                 generate_failure_response(payload, PldmBaseCompletionCode::UnsupportedPldmCmd as u8)
+                    .map(|len| (len, ResponderAction::Continue))
             }
         }
     }

--- a/runtime/userspace/api/pldm-lib/src/daemon.rs
+++ b/runtime/userspace/api/pldm-lib/src/daemon.rs
@@ -90,6 +90,9 @@ impl<'a> PldmService<'a> {
             return Err(PldmServiceError::StartError);
         }
 
+        // Reset the stopped signal to prevent stale Signaled state from a
+        // previous cycle causing wait_until_stopped() to return immediately.
+        self.stopped_signal.reset();
         self.running.store(true, Ordering::SeqCst);
 
         let cmd_interface: &'static CmdInterface<'static> =

--- a/runtime/userspace/api/pldm-lib/src/daemon.rs
+++ b/runtime/userspace/api/pldm-lib/src/daemon.rs
@@ -52,6 +52,20 @@ pub struct PldmService<'a> {
     cmd_interface: CmdInterface<'a>,
     running: &'static AtomicBool,
     initiator_signal: &'static Signal<CriticalSectionRawMutex, ()>,
+    stopped_signal: &'static Signal<CriticalSectionRawMutex, ()>,
+}
+
+static RUNNING: AtomicBool = AtomicBool::new(false);
+static INITIATOR_SIGNAL: Signal<CriticalSectionRawMutex, ()> = Signal::new();
+static STOPPED_SIGNAL: Signal<CriticalSectionRawMutex, ()> = Signal::new();
+
+/// Wait until the PLDM service has fully stopped (responder task exited).
+/// Can be called without a PldmService instance.
+pub async fn wait_until_stopped() {
+    if !RUNNING.load(Ordering::SeqCst) {
+        return;
+    }
+    STOPPED_SIGNAL.wait().await;
 }
 
 // Note: This implementation is a starting point for integration testing.
@@ -65,14 +79,9 @@ impl<'a> PldmService<'a> {
         Self {
             spawner,
             cmd_interface,
-            running: {
-                static RUNNING: AtomicBool = AtomicBool::new(false);
-                &RUNNING
-            },
-            initiator_signal: {
-                static INITIATOR_SIGNAL: Signal<CriticalSectionRawMutex, ()> = Signal::new();
-                &INITIATOR_SIGNAL
-            },
+            running: &RUNNING,
+            initiator_signal: &INITIATOR_SIGNAL,
+            stopped_signal: &STOPPED_SIGNAL,
         }
     }
 
@@ -91,6 +100,7 @@ impl<'a> PldmService<'a> {
                 cmd_interface,
                 self.running,
                 self.initiator_signal,
+                self.stopped_signal,
             ))
             .unwrap();
 
@@ -123,8 +133,10 @@ pub async fn pldm_responder_task(
     cmd_interface: &'static CmdInterface<'static>,
     running: &'static AtomicBool,
     initiator_signal: &'static Signal<CriticalSectionRawMutex, ()>,
+    stopped_signal: &'static Signal<CriticalSectionRawMutex, ()>,
 ) {
     pldm_responder(cmd_interface, running, initiator_signal).await;
+    stopped_signal.signal(());
 }
 
 pub async fn pldm_initiator(
@@ -233,7 +245,8 @@ pub async fn pldm_responder(
             .handle_responder_msg(&mut transport, &mut msg_buffer)
             .await
         {
-            Ok(_) => {}
+            Ok(crate::cmd_interface::ResponderAction::Complete) => break,
+            Ok(crate::cmd_interface::ResponderAction::Continue) => {}
             Err(e) => {
                 writeln!(
                     console_writer,
@@ -249,6 +262,10 @@ pub async fn pldm_responder(
             initiator_signal.signal(());
         }
     }
+
+    // Clear running flag and signal initiator so it can also exit
+    running.store(false, Ordering::SeqCst);
+    initiator_signal.signal(());
 }
 
 /// Optimized download loop that uses a local TransferSession to minimize mutex acquisitions.

--- a/runtime/userspace/api/pldm-lib/src/firmware_device/fd_context.rs
+++ b/runtime/userspace/api/pldm-lib/src/firmware_device/fd_context.rs
@@ -657,6 +657,12 @@ impl<'a> FirmwareDeviceContext<'a> {
             _ => Err(MsgHandlerError::FdInitiatorModeError),
         }?;
 
+        // Refresh T1 timestamp after verify/apply operations which may block
+        // for extended periods while the firmware update task processes.
+        if fd_state == FirmwareDeviceState::Verify || fd_state == FirmwareDeviceState::Apply {
+            self.set_fd_t1_ts().await;
+        }
+
         let now = self.ops.now();
         let ts = self.internal.get_fd_t1_update_ts();
         let elapsed = now.saturating_sub(ts);

--- a/tests/integration/src/test_pldm_fw_update.rs
+++ b/tests/integration/src/test_pldm_fw_update.rs
@@ -204,6 +204,7 @@ pub mod test {
                         discovery_sm_actions: discovery_sm::DefaultActions {},
                         update_sm_actions: update_sm::DefaultActions {},
                         fd_tid: 0x01,
+                        rerun_count: 0,
                     },
                 )
                 .map_err(|_| ())?,


### PR DESCRIPTION
- Allow PLDM tasks to be restarted. The use-case is to do streaming boot and then firmware update. In this case PLDM task needs to be restarted to give it a new set of FdOps.
- Fix MCI stale firmware update reason detection (reason_at_cycle_complete)
