### PR TITLE
Add state machine and timeout to support chunked mailbox requests

### DIFF
--- a/platforms/emulator/runtime/src/board.rs
+++ b/platforms/emulator/runtime/src/board.rs
@@ -493,6 +493,7 @@ pub unsafe fn main() {
         board_kernel,
         caliptra_mcu_capsules_runtime::mailbox::DRIVER_NUM,
         mux_alarm,
+        Some(100_000),
     )
     .finalize(mailbox_component_static!(
         InternalTimers<'static>,

--- a/platforms/emulator/runtime/userspace/apps/example/src/main.rs
+++ b/platforms/emulator/runtime/userspace/apps/example/src/main.rs
@@ -153,6 +153,8 @@ pub(crate) async fn async_main<S: Syscalls>() {
         test_caliptra_mailbox::test_caliptra_mailbox().await;
         test_caliptra_mailbox::test_caliptra_mailbox_bad_command().await;
         test_caliptra_mailbox::test_caliptra_mailbox_fail().await;
+        test_caliptra_mailbox::test_caliptra_mailbox_chunked().await;
+        test_caliptra_mailbox::test_caliptra_mailbox_chunked_timeout().await;
         System::exit(0);
     }
 

--- a/platforms/emulator/runtime/userspace/apps/example/src/test_caliptra_mailbox.rs
+++ b/platforms/emulator/runtime/userspace/apps/example/src/test_caliptra_mailbox.rs
@@ -2,6 +2,7 @@
 
 use caliptra_api::mailbox::{MailboxReqHeader, QuotePcrsEcc384Req, QuotePcrsEcc384Resp, Request};
 use caliptra_mcu_libsyscall_caliptra::mailbox::{Mailbox, MailboxError};
+use caliptra_mcu_libtock_platform::ErrorCode;
 use caliptra_mcu_romtime::{println, test_exit};
 use core::fmt::Write;
 use zerocopy::{FromBytes, IntoBytes};
@@ -127,4 +128,133 @@ pub(crate) async fn test_caliptra_mailbox_fail() {
             test_exit(1);
         }
     }
+}
+
+#[allow(unused)]
+pub(crate) async fn test_caliptra_mailbox_chunked() {
+    println!("Starting mailbox chunked test");
+
+    let mailbox: Mailbox = Mailbox::new();
+
+    let mut req = QuotePcrsEcc384Req {
+        hdr: MailboxReqHeader::default(),
+        nonce: [0x34; 32],
+    };
+    let req_data = req.as_mut_bytes();
+    mailbox
+        .populate_checksum(QuotePcrsEcc384Req::ID.into(), req_data)
+        .unwrap();
+
+    let response_buffer = &mut [0u8; core::mem::size_of::<QuotePcrsEcc384Resp>()];
+
+    println!("Initiating chunked QUOTE_PCRS command");
+
+    // Step 1: Initiate the request
+    if let Err(err) = mailbox
+        .start_chunked_request(QuotePcrsEcc384Req::ID.0, req_data.len())
+        .await
+    {
+        println!("start_chunked_request failed with err {:?}", err);
+        test_exit(1);
+    }
+
+    // Step 2: Send data in 4-byte chunks
+    for chunk in req_data.chunks(4) {
+        if let Err(err) = mailbox.send_chunk(chunk).await {
+            println!("send_chunk failed with err {:?}", err);
+            test_exit(1);
+        }
+    }
+
+    // Step 3: Execute the command
+    match mailbox
+        .execute_chunked_request(QuotePcrsEcc384Req::ID.0, response_buffer)
+        .await
+    {
+        Ok(_) => {}
+        Err(err) => {
+            println!("execute_chunked_request failed with err {:?}", err);
+            test_exit(1);
+        }
+    }
+
+    println!("Chunked mailbox command success");
+
+    if response_buffer.iter().all(|&x| x == 0) {
+        println!("Mailbox response all 0");
+        test_exit(1);
+    }
+
+    match QuotePcrsEcc384Resp::ref_from_bytes(response_buffer) {
+        Ok(resp) => {
+            if resp.nonce != req.nonce {
+                println!(
+                    "Nonce mismatch: expected {:x?}, got {:x?}",
+                    req.nonce, resp.nonce
+                );
+                test_exit(1);
+            }
+        }
+        Err(err) => {
+            println!("Failed to parse response: {:?}", err);
+            test_exit(1);
+        }
+    }
+    println!("Chunked test passed");
+}
+
+#[allow(unused)]
+pub(crate) async fn test_caliptra_mailbox_chunked_timeout() {
+    println!("Starting mailbox chunked timeout test");
+
+    let mailbox: Mailbox = Mailbox::new();
+
+    let req = QuotePcrsEcc384Req {
+        hdr: MailboxReqHeader::default(),
+        nonce: [0x34; 32],
+    };
+    let req_data = req.as_bytes();
+
+    println!("Initiating chunked request then waiting for timeout");
+
+    // Step 1: Initiate the request
+    if let Err(err) = mailbox
+        .start_chunked_request(QuotePcrsEcc384Req::ID.0, req_data.len())
+        .await
+    {
+        println!("start_chunked_request failed with err {:?}", err);
+        test_exit(1);
+    }
+
+    // Step 2: Delay long enough for the kernel timeout to fire and reset to idle.
+    // Use a busy loop to burn time without yielding to the kernel scheduler,
+    // then yield so the kernel can process the alarm callback.
+    for _ in 0..1_000_000u32 {
+        core::hint::black_box(0u32);
+    }
+    // Yield to let the kernel fire the alarm callback.
+    crate::sleep::<caliptra_mcu_libsyscall_caliptra::DefaultSyscalls>(
+        caliptra_mcu_libtock::alarm::Milliseconds(500),
+    )
+    .await;
+
+    // Step 3: Try to send a chunk — should fail because the timeout reset state to Idle.
+    match mailbox.send_chunk(req_data).await {
+        Err(MailboxError::ErrorCode(ErrorCode::Invalid)) => {
+            println!("send_chunk correctly rejected after timeout");
+        }
+        Ok(_) => {
+            println!("send_chunk should have failed after timeout but succeeded");
+            test_exit(1);
+        }
+        Err(err) => {
+            println!(
+                "send_chunk failed with unexpected error after timeout: {:?}",
+                err
+            );
+            test_exit(1);
+        }
+    }
+
+    println!("Chunked timeout test passed");
 }

--- a/platforms/fpga/runtime/src/board.rs
+++ b/platforms/fpga/runtime/src/board.rs
@@ -479,6 +479,7 @@ pub unsafe fn main() {
         board_kernel,
         caliptra_mcu_capsules_runtime::mailbox::DRIVER_NUM,
         mux_alarm,
+        Some(100_000),
     )
     .finalize(caliptra_mcu_components::mailbox_component_static!(
         InternalTimers<'static>,

--- a/romtime/src/soc_manager.rs
+++ b/romtime/src/soc_manager.rs
@@ -178,6 +178,11 @@ impl CaliptraSoC {
         Ok(())
     }
 
+    /// Aborts a mailbox request by clearing the execute bit, releasing the HW lock.
+    pub fn abort_request(&mut self) {
+        self.soc_mbox().execute().write(|w| w.execute(false));
+    }
+
     /// Finished a mailbox request, validating the checksum of the response.
     pub fn finish_mailbox_resp(
         &mut self,

--- a/runtime/kernel/capsules/src/mailbox.rs
+++ b/runtime/kernel/capsules/src/mailbox.rs
@@ -92,6 +92,17 @@ mod rw_allow {
     pub const COUNT: u8 = 1;
 }
 
+/// State machine for the chunked mailbox command flow (commands 2/3/4).
+#[derive(Clone, Copy, PartialEq)]
+enum MailboxState {
+    /// No mailbox operation in progress.
+    Idle,
+    /// After initiate_request (command 2), waiting for data chunks and execute.
+    Initiated,
+    /// After execute (command 4) or enqueue_command (command 1), polling for response.
+    Executing,
+}
+
 #[derive(Default)]
 pub struct App {}
 
@@ -108,6 +119,11 @@ pub struct Mailbox<'a, A: Alarm<'a>> {
     >,
     // Which app is currently using the storage.
     current_app: OptionalCell<ProcessId>,
+    // Current state of the mailbox state machine.
+    state: Cell<MailboxState>,
+    // Timeout ticks for the initiated state before auto-resetting to idle.
+    // If None, no timeout is enforced.
+    timeout_ticks: Option<u32>,
     resp_min_size: Cell<usize>,
     resp_size: Cell<usize>,
 }
@@ -122,12 +138,15 @@ impl<'a, A: Alarm<'a>> Mailbox<'a, A> {
             AllowRwCount<{ rw_allow::COUNT }>,
         >,
         driver: &'static mut CaliptraSoC,
+        timeout_ticks: Option<u32>,
     ) -> Mailbox<'a, A> {
         Mailbox {
             alarm,
             driver: TakeCell::new(driver),
             apps: grant,
             current_app: OptionalCell::empty(),
+            state: Cell::new(MailboxState::Idle),
+            timeout_ticks,
             resp_min_size: Cell::new(0),
             resp_size: Cell::new(0),
         }
@@ -138,7 +157,7 @@ impl<'a, A: Alarm<'a>> Mailbox<'a, A> {
     // command is completed.
     fn enqueue_command(&self, command: u32, processid: ProcessId) -> Result<(), ErrorCode> {
         // Check if we're already executing a mailbox command.
-        if self.current_app.is_some() {
+        if self.state.get() != MailboxState::Idle {
             return Err(ErrorCode::BUSY);
         }
         self.apps.enter(processid, |_app, kernel_data| {
@@ -178,6 +197,7 @@ impl<'a, A: Alarm<'a>> Mailbox<'a, A> {
         app_buffer: &ReadableProcessSlice,
     ) -> Result<(), ErrorCode> {
         self.current_app.set(processid);
+        self.state.set(MailboxState::Executing);
 
         // App buffer contains the full payload
         match driver.start_mailbox_req(
@@ -195,6 +215,8 @@ impl<'a, A: Alarm<'a>> Mailbox<'a, A> {
             }
             Err(err) => {
                 log_caliptra_error(&err);
+                self.state.set(MailboxState::Idle);
+                self.current_app.take();
                 Err(ErrorCode::FAIL)
             }
         }
@@ -207,23 +229,32 @@ impl<'a, A: Alarm<'a>> Mailbox<'a, A> {
         processid: ProcessId,
     ) -> Result<(), ErrorCode> {
         // Check if we're already executing a mailbox command.
-        if self.current_app.is_some() {
+        if self.state.get() != MailboxState::Idle {
             return Err(ErrorCode::BUSY);
         }
         self.current_app.set(processid);
+        self.state.set(MailboxState::Initiated);
         self.driver
-            .map(|driver| {
-                driver
-                    .initiate_request(command, payload_size)
-                    .map_err(|_| ErrorCode::FAIL)
-            })
+            .map(
+                |driver| match driver.initiate_request(command, payload_size) {
+                    Ok(()) => {
+                        self.schedule_initiate_timeout();
+                        Ok(())
+                    }
+                    Err(_) => {
+                        self.state.set(MailboxState::Idle);
+                        self.current_app.take();
+                        Err(ErrorCode::FAIL)
+                    }
+                },
+            )
             .ok_or(ErrorCode::RESERVE)?
     }
 
     fn send_next_chunk(&self, processid: ProcessId) -> Result<(), ErrorCode> {
-        // Check if we're already executing a mailbox command.
-        if self.current_app.is_none() {
-            return Err(ErrorCode::CANCEL);
+        // Only allowed after initiate_request (command 2).
+        if self.state.get() != MailboxState::Initiated {
+            return Err(ErrorCode::INVAL);
         }
         self.apps.enter(processid, |_app, kernel_data| {
             // copy the request so we can write async
@@ -249,6 +280,8 @@ impl<'a, A: Alarm<'a>> Mailbox<'a, A> {
                             ErrorCode::FAIL
                         })?
                 })?;
+            // Reset the timeout since the user is actively sending data.
+            self.schedule_initiate_timeout();
             kernel_data
                 .schedule_upcall(upcall::COMMAND_DONE, (0, 0, 0))
                 .map_err(|err| {
@@ -279,17 +312,22 @@ impl<'a, A: Alarm<'a>> Mailbox<'a, A> {
     }
 
     fn execute(&self) -> Result<(), ErrorCode> {
-        // Check if we're already executing a mailbox command.
-        if self.current_app.is_none() {
-            return Err(ErrorCode::CANCEL);
+        // Only allowed after initiate_request (command 2).
+        if self.state.get() != MailboxState::Initiated {
+            return Err(ErrorCode::INVAL);
         }
+        self.state.set(MailboxState::Executing);
         self.driver
             .map(|driver| match driver.execute_command() {
                 Ok(()) => {
                     self.schedule_alarm();
                     Ok(())
                 }
-                Err(_err) => Err(ErrorCode::FAIL),
+                Err(_err) => {
+                    self.state.set(MailboxState::Idle);
+                    self.current_app.take();
+                    Err(ErrorCode::FAIL)
+                }
             })
             .unwrap_or(Err(ErrorCode::FAIL))
     }
@@ -381,27 +419,50 @@ impl<'a, A: Alarm<'a>> Mailbox<'a, A> {
         let dt = A::Ticks::from(10000);
         self.alarm.set_alarm(now, dt);
     }
+
+    fn schedule_initiate_timeout(&self) {
+        if let Some(ticks) = self.timeout_ticks {
+            let now = self.alarm.now();
+            let dt = A::Ticks::from(ticks);
+            self.alarm.set_alarm(now, dt);
+        }
+    }
 }
 
 impl<'a, A: Alarm<'a>> AlarmClient for Mailbox<'a, A> {
     fn alarm(&self) {
-        let reschedule = self
-            .driver
-            .map(|driver| {
-                if driver.is_mailbox_busy() {
-                    true
-                } else {
-                    self.try_complete_request(driver);
-                    false
-                }
-            })
-            .unwrap_or_default();
+        match self.state.get() {
+            MailboxState::Initiated => {
+                // Timeout: user didn't complete the chunked send in time.
+                debug!("Mailbox initiate timeout: resetting to idle");
+                let _ = self.alarm.disarm();
+                self.state.set(MailboxState::Idle);
+                self.current_app.take();
+            }
+            MailboxState::Executing => {
+                let reschedule = self
+                    .driver
+                    .map(|driver| {
+                        if driver.is_mailbox_busy() {
+                            true
+                        } else {
+                            self.try_complete_request(driver);
+                            false
+                        }
+                    })
+                    .unwrap_or_default();
 
-        if reschedule {
-            self.schedule_alarm();
-        } else {
-            let _ = self.alarm.disarm();
-            self.current_app.take(); // clear the current app so another app can use the mailbox
+                if reschedule {
+                    self.schedule_alarm();
+                } else {
+                    let _ = self.alarm.disarm();
+                    self.state.set(MailboxState::Idle);
+                    self.current_app.take();
+                }
+            }
+            MailboxState::Idle => {
+                let _ = self.alarm.disarm();
+            }
         }
     }
 }

--- a/runtime/kernel/capsules/src/mailbox.rs
+++ b/runtime/kernel/capsules/src/mailbox.rs
@@ -256,6 +256,10 @@ impl<'a, A: Alarm<'a>> Mailbox<'a, A> {
         if self.state.get() != MailboxState::Initiated {
             return Err(ErrorCode::INVAL);
         }
+        // Verify that the caller is the app that initiated the request.
+        if self.current_app.get() != Some(processid) {
+            return Err(ErrorCode::INVAL);
+        }
         self.apps.enter(processid, |_app, kernel_data| {
             // copy the request so we can write async
             kernel_data
@@ -311,9 +315,13 @@ impl<'a, A: Alarm<'a>> Mailbox<'a, A> {
         Ok(())
     }
 
-    fn execute(&self) -> Result<(), ErrorCode> {
+    fn execute(&self, processid: ProcessId) -> Result<(), ErrorCode> {
         // Only allowed after initiate_request (command 2).
         if self.state.get() != MailboxState::Initiated {
+            return Err(ErrorCode::INVAL);
+        }
+        // Verify that the caller is the app that initiated the request.
+        if self.current_app.get() != Some(processid) {
             return Err(ErrorCode::INVAL);
         }
         self.state.set(MailboxState::Executing);
@@ -434,8 +442,12 @@ impl<'a, A: Alarm<'a>> AlarmClient for Mailbox<'a, A> {
         match self.state.get() {
             MailboxState::Initiated => {
                 // Timeout: user didn't complete the chunked send in time.
-                debug!("Mailbox initiate timeout: resetting to idle");
+                capsule_debug!("MBOX", "Mailbox initiate timeout: resetting to idle");
                 let _ = self.alarm.disarm();
+                // Release the HW mailbox lock by clearing the execute bit.
+                self.driver.map(|driver| {
+                    driver.abort_request();
+                });
                 self.state.set(MailboxState::Idle);
                 self.current_app.take();
             }
@@ -517,7 +529,7 @@ impl<'a, A: Alarm<'a>> SyscallDriver for Mailbox<'a, A> {
 
             4 => {
                 // Execute the command
-                let res = self.execute();
+                let res = self.execute(processid);
                 match res {
                     Ok(()) => CommandReturn::success(),
                     Err(e) => CommandReturn::failure(e),

--- a/runtime/kernel/components/src/mailbox.rs
+++ b/runtime/kernel/components/src/mailbox.rs
@@ -28,6 +28,7 @@ pub struct MailboxComponent<A: Alarm<'static> + 'static> {
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
     mux_alarm: &'static MuxAlarm<'static, A>,
+    timeout_ticks: Option<u32>,
 }
 
 impl<A: Alarm<'static>> MailboxComponent<A> {
@@ -35,11 +36,13 @@ impl<A: Alarm<'static>> MailboxComponent<A> {
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
         mux_alarm: &'static MuxAlarm<'static, A>,
+        timeout_ticks: Option<u32>,
     ) -> Self {
         Self {
             board_kernel,
             driver_num,
             mux_alarm,
+            timeout_ticks,
         }
     }
 }
@@ -73,6 +76,7 @@ impl<A: Alarm<'static>> Component for MailboxComponent<A> {
                     mux_alarm,
                     self.board_kernel.create_grant(self.driver_num, &grant_cap),
                     caliptra_soc,
+                    self.timeout_ticks,
                 ));
         mailbox
     }

--- a/runtime/userspace/syscall/src/mailbox.rs
+++ b/runtime/userspace/syscall/src/mailbox.rs
@@ -127,6 +127,13 @@ impl<S: Syscalls> Mailbox<S> {
     ///
     /// Call this first, then send data with [`send_chunk`](Self::send_chunk),
     /// and finally call [`execute_chunked_request`](Self::execute_chunked_request).
+    ///
+    /// **Concurrency:** The kernel enforces ordering via a state machine and
+    /// verifies the calling process ID, so different processes cannot
+    /// interleave chunked flows. Within a single process with multiple async
+    /// tasks, callers should either use [`execute_with_payload_stream`](Self::execute_with_payload_stream)
+    /// (which holds the global mailbox mutex) or acquire `MAILBOX_MUTEX`
+    /// externally before calling this method.
     pub async fn start_chunked_request(
         &self,
         command: u32,

--- a/runtime/userspace/syscall/src/mailbox.rs
+++ b/runtime/userspace/syscall/src/mailbox.rs
@@ -123,18 +123,15 @@ impl<S: Syscalls> Mailbox<S> {
         }
     }
 
-    pub async fn execute_with_payload_stream(
+    /// Initiates a chunked mailbox request.
+    ///
+    /// Call this first, then send data with [`send_chunk`](Self::send_chunk),
+    /// and finally call [`execute_chunked_request`](Self::execute_chunked_request).
+    pub async fn start_chunked_request(
         &self,
         command: u32,
-        header: Option<&[u8]>,
-        payload: &mut dyn PayloadStream,
-        response_buffer: &mut [u8],
-    ) -> Result<usize, MailboxError> {
-        let mutex = MAILBOX_MUTEX.lock().await;
-
-        let request_len = payload.size() + header.map_or(0, |h| h.len());
-
-        // Send the command to initiate mailbox request
+        request_len: usize,
+    ) -> Result<(), MailboxError> {
         S::command(
             self.driver_num,
             mailbox_cmd::START_CHUNKED_REQUEST,
@@ -142,70 +139,11 @@ impl<S: Syscalls> Mailbox<S> {
             request_len as u32,
         )
         .to_result::<(), ErrorCode>()
-        .map_err(MailboxError::ErrorCode)?;
-
-        // Send the header if provided
-        let mut buffer = [0u8; PAYLOAD_CHUNK_SIZE];
-        if let Some(header) = header {
-            // If a header is provided, write it to the buffer first
-            buffer[..header.len()].copy_from_slice(header);
-            self.send_chunk(buffer[..header.len()].as_ref()).await?;
-        }
-
-        // Send the payload in chunks
-        loop {
-            // Read a chunk of data from the payload stream
-            let sz = payload
-                .read(&mut buffer)
-                .await
-                .map_err(MailboxError::ErrorCode)?;
-            if sz == 0 {
-                break; // No more data to read
-            }
-            self.send_chunk(buffer[..sz].as_ref()).await?;
-        }
-
-        // Execute the command
-        let result = share::scope::<(), _, _>(|_handle| {
-            let mut sub = TockSubscribe::subscribe_allow_rw::<S, DefaultConfig>(
-                self.driver_num,
-                mailbox_subscribe::COMMAND_DONE,
-                mailbox_rw_buffer::RESPONSE,
-                response_buffer,
-            );
-
-            // Issue the command to the kernel
-            match S::command(
-                self.driver_num,
-                mailbox_cmd::EXECUTE_CHUNKED_REQUEST,
-                command,
-                0,
-            )
-            .to_result::<(), ErrorCode>()
-            {
-                Ok(()) => Ok(TockSubscribe::subscribe_finish(sub)),
-                Err(err) => {
-                    S::unallow_rw(self.driver_num, mailbox_rw_buffer::RESPONSE);
-                    sub.cancel();
-                    Err(MailboxError::ErrorCode(err))
-                }
-            }
-        })?
-        .await;
-        black_box(*mutex); // Ensure the mutex is not optimized away
-        match result {
-            Ok((bytes, error_code, _)) => {
-                if error_code != 0 {
-                    Err(MailboxError::MailboxError(error_code))
-                } else {
-                    Ok(bytes as usize)
-                }
-            }
-            Err(err) => Err(MailboxError::ErrorCode(err)),
-        }
+        .map_err(MailboxError::ErrorCode)
     }
 
-    async fn send_chunk(&self, buffer: &[u8]) -> Result<(u32, u32, u32), MailboxError> {
+    /// Sends a chunk of data for a previously started chunked mailbox request.
+    pub async fn send_chunk(&self, buffer: &[u8]) -> Result<(u32, u32, u32), MailboxError> {
         share::scope::<(), _, _>(|_handle| {
             let mut sub = TockSubscribe::subscribe_allow_ro::<S, DefaultConfig>(
                 self.driver_num,
@@ -228,6 +166,88 @@ impl<S: Syscalls> Mailbox<S> {
         })?
         .await
         .map_err(MailboxError::ErrorCode)
+    }
+
+    /// Executes a previously started chunked mailbox request and returns the response.
+    pub async fn execute_chunked_request(
+        &self,
+        command: u32,
+        response_buffer: &mut [u8],
+    ) -> Result<usize, MailboxError> {
+        let result = share::scope::<(), _, _>(|_handle| {
+            let mut sub = TockSubscribe::subscribe_allow_rw::<S, DefaultConfig>(
+                self.driver_num,
+                mailbox_subscribe::COMMAND_DONE,
+                mailbox_rw_buffer::RESPONSE,
+                response_buffer,
+            );
+
+            match S::command(
+                self.driver_num,
+                mailbox_cmd::EXECUTE_CHUNKED_REQUEST,
+                command,
+                0,
+            )
+            .to_result::<(), ErrorCode>()
+            {
+                Ok(()) => Ok(TockSubscribe::subscribe_finish(sub)),
+                Err(err) => {
+                    S::unallow_rw(self.driver_num, mailbox_rw_buffer::RESPONSE);
+                    sub.cancel();
+                    Err(MailboxError::ErrorCode(err))
+                }
+            }
+        })?
+        .await;
+        match result {
+            Ok((bytes, error_code, _)) => {
+                if error_code != 0 {
+                    Err(MailboxError::MailboxError(error_code))
+                } else {
+                    Ok(bytes as usize)
+                }
+            }
+            Err(err) => Err(MailboxError::ErrorCode(err)),
+        }
+    }
+
+    pub async fn execute_with_payload_stream(
+        &self,
+        command: u32,
+        header: Option<&[u8]>,
+        payload: &mut dyn PayloadStream,
+        response_buffer: &mut [u8],
+    ) -> Result<usize, MailboxError> {
+        let mutex = MAILBOX_MUTEX.lock().await;
+
+        let request_len = payload.size() + header.map_or(0, |h| h.len());
+
+        self.start_chunked_request(command, request_len).await?;
+
+        // Send the header if provided
+        let mut buffer = [0u8; PAYLOAD_CHUNK_SIZE];
+        if let Some(header) = header {
+            // If a header is provided, write it to the buffer first
+            buffer[..header.len()].copy_from_slice(header);
+            self.send_chunk(buffer[..header.len()].as_ref()).await?;
+        }
+
+        // Send the payload in chunks
+        loop {
+            // Read a chunk of data from the payload stream
+            let sz = payload
+                .read(&mut buffer)
+                .await
+                .map_err(MailboxError::ErrorCode)?;
+            if sz == 0 {
+                break; // No more data to read
+            }
+            self.send_chunk(buffer[..sz].as_ref()).await?;
+        }
+
+        let result = self.execute_chunked_request(command, response_buffer).await;
+        black_box(*mutex); // Ensure the mutex is not optimized away
+        result
     }
 }
 #[async_trait(?Send)]


### PR DESCRIPTION
Enforce ordering for the chunked mailbox flow (initiate -> send chunks -> execute) via a MailboxState enum. Requests issued out of order are rejected with INVAL. A configurable timeout resets the mailbox to idle if the user stalls between steps, preventing one app from blocking others indefinitely.

Also adds integration tests for the chunked path and timeout behavior.