### PR TITLE
rom: replace `{:?}` error prints with HexWord codes to shrink ROM

### DIFF
--- a/rom/src/cold_boot.rs
+++ b/rom/src/cold_boot.rs
@@ -590,8 +590,8 @@ impl ColdBoot {
         if let Err(err) = lc.transition(LifecycleControllerState::Scrap, &LifecycleToken([0u8; 16]))
         {
             romtime::println!(
-                "[mcu-rom] FIPS zeroization: LC SCRAP transition failed: {:?}",
-                err
+                "[mcu-rom] FIPS zeroization: LC SCRAP transition failed: {}",
+                HexWord(err.into())
             );
             fatal_error(McuError::ROM_FIPS_ZEROIZATION_LC_TRANSITION_ERROR);
         }
@@ -808,7 +808,10 @@ impl BootFlow for ColdBoot {
         if let Some((state, token)) = params.lifecycle_transition {
             mci.set_flow_checkpoint(McuRomBootStatus::LifecycleTransitionStarted.into());
             if let Err(err) = lc.transition(state, &token) {
-                romtime::println!("[mcu-rom] Error transitioning lifecycle: {:?}", err);
+                romtime::println!(
+                    "[mcu-rom] Error transitioning lifecycle: {}",
+                    HexWord(err.into())
+                );
                 fatal_error(err);
             }
             romtime::println!("Lifecycle transition successful; halting");
@@ -840,8 +843,8 @@ impl BootFlow for ColdBoot {
 
             if let Err(err) = otp.burn_lifecycle_tokens(tokens) {
                 romtime::println!(
-                    "[mcu-rom] Error burning lifecycle tokens {:?}; OTP status: {}",
-                    err,
+                    "[mcu-rom] Error burning lifecycle tokens {}; OTP status: {}",
+                    HexWord(err.into()),
                     HexWord(otp.status())
                 );
                 otp.print_errors();
@@ -1165,7 +1168,10 @@ impl BootFlow for ColdBoot {
                     romtime::println!("[mcu-rom] Error sending mailbox command: {}", HexWord(code));
                 }
                 _ => {
-                    romtime::println!("[mcu-rom] Error sending mailbox command: {:?}", err);
+                    romtime::println!(
+                        "[mcu-rom] Error sending mailbox command: {}",
+                        HexWord(Self::err_code(&err))
+                    );
                 }
             }
             fatal_error(McuError::ROM_COLD_BOOT_START_RI_DOWNLOAD_ERROR);

--- a/rom/src/device_ownership_transfer.rs
+++ b/rom/src/device_ownership_transfer.rs
@@ -21,6 +21,7 @@ use caliptra_api::mailbox::{
 };
 use mcu_error::{McuError, McuResult};
 use romtime::otp::Otp;
+use romtime::HexWord;
 use romtime::McuRomBootStatus;
 use zerocopy::{transmute, FromBytes, Immutable, IntoBytes, KnownLayout};
 
@@ -314,14 +315,20 @@ fn cm_derive_stable_key(
     req.hdr.chksum = chksum;
 
     if let Err(err) = env.soc_manager.start_mailbox_req_bytes(cmd, req.as_bytes()) {
-        romtime::println!("[mcu-rom] Error deriving DOT stable key: {:?}", err);
+        romtime::println!(
+            "[mcu-rom] Error deriving DOT stable key: {}",
+            HexWord(crate::err_code(&err))
+        );
         return Err(McuError::ROM_COLD_BOOT_DOT_ERROR);
     }
 
     // CmDeriveStableKeyResp = hdr(8) + cmk(128) = 136 bytes
     let mut resp_buf = [0u8; core::mem::size_of::<CmDeriveStableKeyResp>()];
     if let Err(err) = env.soc_manager.finish_mailbox_resp_bytes(&mut resp_buf) {
-        romtime::println!("[mcu-rom] Error deriving DOT stable key: {:?}", err);
+        romtime::println!(
+            "[mcu-rom] Error deriving DOT stable key: {}",
+            HexWord(crate::err_code(&err))
+        );
         return Err(McuError::ROM_COLD_BOOT_DOT_ERROR);
     }
 
@@ -404,14 +411,20 @@ fn cm_hmac(env: &mut RomEnv, key: &Cmk, data: &[u8]) -> McuResult<[u32; 16]> {
         None => return Err(McuError::ROM_COLD_BOOT_DOT_ERROR),
     };
     if let Err(err) = env.soc_manager.start_mailbox_req_bytes(cmd, req_bytes) {
-        romtime::println!("[mcu-rom] Error computing HMAC: {:?}", err);
+        romtime::println!(
+            "[mcu-rom] Error computing HMAC: {}",
+            HexWord(crate::err_code(&err))
+        );
         return Err(McuError::ROM_COLD_BOOT_DOT_ERROR);
     }
 
     // Read response – CmHmacResp is MailboxRespHeaderVarSize(12) + mac(64) = 76 bytes.
     let mut resp_buf = [0u8; core::mem::size_of::<CmHmacResp>()];
     if let Err(err) = env.soc_manager.finish_mailbox_resp_bytes(&mut resp_buf) {
-        romtime::println!("[mcu-rom] Error computing HMAC: {:?}", err);
+        romtime::println!(
+            "[mcu-rom] Error computing HMAC: {}",
+            HexWord(crate::err_code(&err))
+        );
         return Err(McuError::ROM_COLD_BOOT_DOT_ERROR);
     }
 
@@ -996,7 +1009,10 @@ fn cm_sha384(env: &mut RomEnv, data_parts: &[&[u32]]) -> McuResult<[u8; SHA384_D
         data_parts,
         &mut resp32,
     ) {
-        romtime::println!("[mcu-rom-dot] CM_SHA failed: {:?}", err);
+        romtime::println!(
+            "[mcu-rom-dot] CM_SHA failed: {}",
+            HexWord(crate::err_code(&err))
+        );
         return Err(McuError::ROM_DOT_OVERRIDE_CHALLENGE_FAILED);
     }
 
@@ -1055,7 +1071,10 @@ fn cm_random_generate(env: &mut RomEnv) -> McuResult<[u8; 48]> {
         &mut req32,
         &mut resp32,
     ) {
-        romtime::println!("[mcu-rom-dot] CM_RANDOM_GENERATE failed: {:?}", err);
+        romtime::println!(
+            "[mcu-rom-dot] CM_RANDOM_GENERATE failed: {}",
+            HexWord(crate::err_code(&err))
+        );
         return Err(McuError::ROM_DOT_OVERRIDE_CHALLENGE_FAILED);
     }
     let resp: CmRandomResp = transmute!(resp32);
@@ -1103,7 +1122,10 @@ fn cm_ecdsa384_verify(
         &mut req32,
         &mut resp32,
     ) {
-        romtime::println!("[mcu-rom-dot] ECDSA384_SIGNATURE_VERIFY failed: {:?}", err);
+        romtime::println!(
+            "[mcu-rom-dot] ECDSA384_SIGNATURE_VERIFY failed: {}",
+            HexWord(crate::err_code(&err))
+        );
         return Err(McuError::ROM_DOT_OVERRIDE_SIG_VERIFY_FAILED);
     }
     Ok(())
@@ -1155,7 +1177,10 @@ fn cm_mldsa87_verify(
         data_parts,
         &mut resp32,
     ) {
-        romtime::println!("[mcu-rom-dot] MLDSA87_SIGNATURE_VERIFY failed: {:?}", err);
+        romtime::println!(
+            "[mcu-rom-dot] MLDSA87_SIGNATURE_VERIFY failed: {}",
+            HexWord(crate::err_code(&err))
+        );
         return Err(McuError::ROM_DOT_OVERRIDE_SIG_VERIFY_FAILED);
     }
     Ok(())
@@ -1219,8 +1244,8 @@ pub fn dot_recovery_flow(
     // Write authenticated blob to flash
     if let Err(err) = dot_flash.write(&backup_blob_bytes, 0) {
         romtime::println!(
-            "[mcu-rom-dot] Failed to write recovery blob to flash: {:?}",
-            err
+            "[mcu-rom-dot] Failed to write recovery blob to flash: {}",
+            HexWord(usize::from(err) as u32)
         );
         env.mci
             .set_flow_checkpoint(McuRomBootStatus::DotRecoveryFailed.into());


### PR DESCRIPTION
`Result::unwrap` and `"{:?}"` formatting pull in each error enum's `Debug` impl plus its variant-name strings and the shared `core::fmt` machinery. Converting the 13 error-print sites in `cold_boot.rs` and `device_ownership_transfer.rs` to `HexWord(err.into())` / `HexWord(crate::err_code(&err))` / `HexWord(usize::from(err) as u32)` lets the linker drop `<CaliptraApiError as Debug>::fmt` (~644 B), `<McuError as Debug>::fmt`, `<FlashDrvError as Debug>::fmt`, and all their variant-name strings.

`mcu-rom-emulator --features hw-2-1` .text: 72,364 → 70,704 B (saved 1,660 B / 1.62 KB).