### PR TITLE
fuses: emit each fuse entry as its own const

### DIFF
--- a/registers/fuses/src/codegen.rs
+++ b/registers/fuses/src/codegen.rs
@@ -174,14 +174,9 @@ pub fn generate_fuses(
     }
     output.push_str("];");
 
-    // Fuse entry lookup table — entries with partition info
-    output.push_str(
-        "/// Lookup table mapping (partition_num, entry_num) to OTP addresses and layout.\n",
-    );
-    output.push_str(
-        "/// Only populated for fields that have a partition assignment in fuses.hjson.\n",
-    );
-    output.push_str("pub const FUSE_ENTRY_TABLE: &[FuseEntryInfo] = &[");
+    // Fuse entries with partition info — emitted as standalone constants so the
+    // compiler can dead-code-eliminate unused entries instead of pulling in one
+    // big array.
     let partitions = spec.partitions.as_ref();
     for field in &spec.fields {
         if let Some(partition_name) = &field.partition {
@@ -219,24 +214,11 @@ pub fn generate_fuses(
             };
 
             let layout_str = layout_to_codegen(&field.layout, field.bits);
-            output.push_str(&format!(
-                "FuseEntryInfo {{ partition_num: {}, entry_num: {}, byte_offset: 0x{:x}, byte_size: {}, name: \"{}\", layout: {} }},",
-                part_idx, entry_num, byte_offset, byte_size, field.name, layout_str
-            ));
-        }
-    }
-    output.push_str("];");
-
-    // Named const references to individual entries
-    let mut entry_idx = 0usize;
-    for field in &spec.fields {
-        if field.partition.is_some() {
             let const_name = field.name.to_uppercase();
             output.push_str(&format!(
-                "/// Fuse entry for `{}`.\npub const {}: &FuseEntryInfo = &FUSE_ENTRY_TABLE[{}];",
-                field.name, const_name, entry_idx
+                "/// Fuse entry for `{}`.\npub const {}: &FuseEntryInfo = &FuseEntryInfo {{ partition_num: {}, entry_num: {}, byte_offset: 0x{:x}, byte_size: {}, name: \"{}\", layout: {} }};",
+                field.name, const_name, part_idx, entry_num, byte_offset, byte_size, field.name, layout_str
             ));
-            entry_idx += 1;
         }
     }
 
@@ -353,7 +335,6 @@ mod tests {
         assert!(generated_code.contains("pub const SECRET_VENDOR_FUSES:"));
         assert!(generated_code.contains("pub const NON_SECRET_VENDOR_FUSES:"));
         assert!(generated_code.contains("pub const FUSE_FIELDS:"));
-        assert!(generated_code.contains("pub const FUSE_ENTRY_TABLE:"));
         assert!(generated_code.contains("\"device_ownership_transfer\""));
         assert!(generated_code.contains("\"secret_vendor\""));
         assert!(generated_code.contains("\"example_key1\""));
@@ -392,7 +373,8 @@ mod tests {
 
         println!("Generated code:\n{}", generated_code);
 
-        assert!(generated_code.contains("FUSE_ENTRY_TABLE"));
+        assert!(generated_code.contains("pub const ECC_REVOCATION: &FuseEntryInfo"));
+        assert!(generated_code.contains("pub const SIMPLE_FIELD: &FuseEntryInfo"));
         assert!(generated_code.contains("partition_num: 5"));
         assert!(generated_code.contains("LinearMajorityVote"));
         assert!(generated_code.contains("duplication: 3"));

--- a/registers/generated-firmware/src/fuses.rs
+++ b/registers/generated-firmware/src/fuses.rs
@@ -775,931 +775,855 @@ pub const FUSE_FIELDS: &[FuseField] = &[
         bits: Bits(2),
     },
 ];
-/// Lookup table mapping (partition_num, entry_num) to OTP addresses and layout.
-/// Only populated for fields that have a partition assignment in fuses.hjson.
-pub const FUSE_ENTRY_TABLE: &[FuseEntryInfo] = &[
-    FuseEntryInfo {
-        partition_num: 14,
-        entry_num: 0,
-        byte_offset: 0xaa8,
-        byte_size: 32,
-        name: "dot_initialized",
-        layout: FuseLayoutType::LinearMajorityVote {
-            bits: 1,
-            duplication: 3,
-        },
-    },
-    FuseEntryInfo {
-        partition_num: 14,
-        entry_num: 1,
-        byte_offset: 0xac8,
-        byte_size: 32,
-        name: "dot_fuse_array",
-        layout: FuseLayoutType::OneHot { bits: 256 },
-    },
-    FuseEntryInfo {
-        partition_num: 14,
-        entry_num: 2,
-        byte_offset: 0xae8,
-        byte_size: 32,
-        name: "perma_hek_en",
-        layout: FuseLayoutType::LinearMajorityVote {
-            bits: 1,
-            duplication: 3,
-        },
-    },
-    FuseEntryInfo {
-        partition_num: 14,
-        entry_num: 3,
-        byte_offset: 0xb08,
-        byte_size: 32,
-        name: "cptra_itrng_health_test_window_size",
-        layout: FuseLayoutType::Single { bits: 16 },
-    },
-    FuseEntryInfo {
-        partition_num: 14,
-        entry_num: 4,
-        byte_offset: 0xb28,
-        byte_size: 32,
-        name: "cptra_itrng_entropy_config_0",
-        layout: FuseLayoutType::Single { bits: 32 },
-    },
-    FuseEntryInfo {
-        partition_num: 14,
-        entry_num: 5,
-        byte_offset: 0xb48,
-        byte_size: 32,
-        name: "cptra_itrng_entropy_config_1",
-        layout: FuseLayoutType::Single { bits: 32 },
-    },
-    FuseEntryInfo {
-        partition_num: 13,
-        entry_num: 0,
-        byte_offset: 0x898,
-        byte_size: 32,
-        name: "vendor_recovery_pk_hash",
-        layout: FuseLayoutType::Single { bits: 384 },
-    },
-    FuseEntryInfo {
-        partition_num: 11,
-        entry_num: 33,
-        byte_offset: 0x7a4,
-        byte_size: 16,
-        name: "vendor_pk_hash_valid",
-        layout: FuseLayoutType::LinearMajorityVote {
-            bits: 16,
-            duplication: 8,
-        },
-    },
-    FuseEntryInfo {
-        partition_num: 12,
-        entry_num: 3,
-        byte_offset: 0x7cc,
-        byte_size: 4,
-        name: "vendor_ecc_revocation_0",
-        layout: FuseLayoutType::LinearMajorityVote {
-            bits: 4,
-            duplication: 3,
-        },
-    },
-    FuseEntryInfo {
-        partition_num: 12,
-        entry_num: 5,
-        byte_offset: 0x7d4,
-        byte_size: 4,
-        name: "vendor_mldsa_revocation_0",
-        layout: FuseLayoutType::LinearMajorityVote {
-            bits: 4,
-            duplication: 3,
-        },
-    },
-    FuseEntryInfo {
-        partition_num: 12,
-        entry_num: 4,
-        byte_offset: 0x7d0,
-        byte_size: 4,
-        name: "vendor_lms_revocation_0",
-        layout: FuseLayoutType::LinearMajorityVote {
-            bits: 16,
-            duplication: 2,
-        },
-    },
-    FuseEntryInfo {
-        partition_num: 12,
-        entry_num: 6,
-        byte_offset: 0x7d8,
-        byte_size: 4,
-        name: "vendor_ecc_revocation_1",
-        layout: FuseLayoutType::LinearMajorityVote {
-            bits: 4,
-            duplication: 3,
-        },
-    },
-    FuseEntryInfo {
-        partition_num: 12,
-        entry_num: 8,
-        byte_offset: 0x7e0,
-        byte_size: 4,
-        name: "vendor_mldsa_revocation_1",
-        layout: FuseLayoutType::LinearMajorityVote {
-            bits: 4,
-            duplication: 3,
-        },
-    },
-    FuseEntryInfo {
-        partition_num: 12,
-        entry_num: 7,
-        byte_offset: 0x7dc,
-        byte_size: 4,
-        name: "vendor_lms_revocation_1",
-        layout: FuseLayoutType::LinearMajorityVote {
-            bits: 16,
-            duplication: 2,
-        },
-    },
-    FuseEntryInfo {
-        partition_num: 12,
-        entry_num: 9,
-        byte_offset: 0x7e4,
-        byte_size: 4,
-        name: "vendor_ecc_revocation_2",
-        layout: FuseLayoutType::LinearMajorityVote {
-            bits: 4,
-            duplication: 3,
-        },
-    },
-    FuseEntryInfo {
-        partition_num: 12,
-        entry_num: 11,
-        byte_offset: 0x7ec,
-        byte_size: 4,
-        name: "vendor_mldsa_revocation_2",
-        layout: FuseLayoutType::LinearMajorityVote {
-            bits: 4,
-            duplication: 3,
-        },
-    },
-    FuseEntryInfo {
-        partition_num: 12,
-        entry_num: 10,
-        byte_offset: 0x7e8,
-        byte_size: 4,
-        name: "vendor_lms_revocation_2",
-        layout: FuseLayoutType::LinearMajorityVote {
-            bits: 16,
-            duplication: 2,
-        },
-    },
-    FuseEntryInfo {
-        partition_num: 12,
-        entry_num: 12,
-        byte_offset: 0x7f0,
-        byte_size: 4,
-        name: "vendor_ecc_revocation_3",
-        layout: FuseLayoutType::LinearMajorityVote {
-            bits: 4,
-            duplication: 3,
-        },
-    },
-    FuseEntryInfo {
-        partition_num: 12,
-        entry_num: 14,
-        byte_offset: 0x7f8,
-        byte_size: 4,
-        name: "vendor_mldsa_revocation_3",
-        layout: FuseLayoutType::LinearMajorityVote {
-            bits: 4,
-            duplication: 3,
-        },
-    },
-    FuseEntryInfo {
-        partition_num: 12,
-        entry_num: 13,
-        byte_offset: 0x7f4,
-        byte_size: 4,
-        name: "vendor_lms_revocation_3",
-        layout: FuseLayoutType::LinearMajorityVote {
-            bits: 16,
-            duplication: 2,
-        },
-    },
-    FuseEntryInfo {
-        partition_num: 12,
-        entry_num: 15,
-        byte_offset: 0x7fc,
-        byte_size: 4,
-        name: "vendor_ecc_revocation_4",
-        layout: FuseLayoutType::LinearMajorityVote {
-            bits: 4,
-            duplication: 3,
-        },
-    },
-    FuseEntryInfo {
-        partition_num: 12,
-        entry_num: 17,
-        byte_offset: 0x804,
-        byte_size: 4,
-        name: "vendor_mldsa_revocation_4",
-        layout: FuseLayoutType::LinearMajorityVote {
-            bits: 4,
-            duplication: 3,
-        },
-    },
-    FuseEntryInfo {
-        partition_num: 12,
-        entry_num: 16,
-        byte_offset: 0x800,
-        byte_size: 4,
-        name: "vendor_lms_revocation_4",
-        layout: FuseLayoutType::LinearMajorityVote {
-            bits: 16,
-            duplication: 2,
-        },
-    },
-    FuseEntryInfo {
-        partition_num: 12,
-        entry_num: 18,
-        byte_offset: 0x808,
-        byte_size: 4,
-        name: "vendor_ecc_revocation_5",
-        layout: FuseLayoutType::LinearMajorityVote {
-            bits: 4,
-            duplication: 3,
-        },
-    },
-    FuseEntryInfo {
-        partition_num: 12,
-        entry_num: 20,
-        byte_offset: 0x810,
-        byte_size: 4,
-        name: "vendor_mldsa_revocation_5",
-        layout: FuseLayoutType::LinearMajorityVote {
-            bits: 4,
-            duplication: 3,
-        },
-    },
-    FuseEntryInfo {
-        partition_num: 12,
-        entry_num: 19,
-        byte_offset: 0x80c,
-        byte_size: 4,
-        name: "vendor_lms_revocation_5",
-        layout: FuseLayoutType::LinearMajorityVote {
-            bits: 16,
-            duplication: 2,
-        },
-    },
-    FuseEntryInfo {
-        partition_num: 12,
-        entry_num: 21,
-        byte_offset: 0x814,
-        byte_size: 4,
-        name: "vendor_ecc_revocation_6",
-        layout: FuseLayoutType::LinearMajorityVote {
-            bits: 4,
-            duplication: 3,
-        },
-    },
-    FuseEntryInfo {
-        partition_num: 12,
-        entry_num: 23,
-        byte_offset: 0x81c,
-        byte_size: 4,
-        name: "vendor_mldsa_revocation_6",
-        layout: FuseLayoutType::LinearMajorityVote {
-            bits: 4,
-            duplication: 3,
-        },
-    },
-    FuseEntryInfo {
-        partition_num: 12,
-        entry_num: 22,
-        byte_offset: 0x818,
-        byte_size: 4,
-        name: "vendor_lms_revocation_6",
-        layout: FuseLayoutType::LinearMajorityVote {
-            bits: 16,
-            duplication: 2,
-        },
-    },
-    FuseEntryInfo {
-        partition_num: 12,
-        entry_num: 24,
-        byte_offset: 0x820,
-        byte_size: 4,
-        name: "vendor_ecc_revocation_7",
-        layout: FuseLayoutType::LinearMajorityVote {
-            bits: 4,
-            duplication: 3,
-        },
-    },
-    FuseEntryInfo {
-        partition_num: 12,
-        entry_num: 26,
-        byte_offset: 0x828,
-        byte_size: 4,
-        name: "vendor_mldsa_revocation_7",
-        layout: FuseLayoutType::LinearMajorityVote {
-            bits: 4,
-            duplication: 3,
-        },
-    },
-    FuseEntryInfo {
-        partition_num: 12,
-        entry_num: 25,
-        byte_offset: 0x824,
-        byte_size: 4,
-        name: "vendor_lms_revocation_7",
-        layout: FuseLayoutType::LinearMajorityVote {
-            bits: 16,
-            duplication: 2,
-        },
-    },
-    FuseEntryInfo {
-        partition_num: 12,
-        entry_num: 27,
-        byte_offset: 0x82c,
-        byte_size: 4,
-        name: "vendor_ecc_revocation_8",
-        layout: FuseLayoutType::LinearMajorityVote {
-            bits: 4,
-            duplication: 3,
-        },
-    },
-    FuseEntryInfo {
-        partition_num: 12,
-        entry_num: 29,
-        byte_offset: 0x834,
-        byte_size: 4,
-        name: "vendor_mldsa_revocation_8",
-        layout: FuseLayoutType::LinearMajorityVote {
-            bits: 4,
-            duplication: 3,
-        },
-    },
-    FuseEntryInfo {
-        partition_num: 12,
-        entry_num: 28,
-        byte_offset: 0x830,
-        byte_size: 4,
-        name: "vendor_lms_revocation_8",
-        layout: FuseLayoutType::LinearMajorityVote {
-            bits: 16,
-            duplication: 2,
-        },
-    },
-    FuseEntryInfo {
-        partition_num: 12,
-        entry_num: 30,
-        byte_offset: 0x838,
-        byte_size: 4,
-        name: "vendor_ecc_revocation_9",
-        layout: FuseLayoutType::LinearMajorityVote {
-            bits: 4,
-            duplication: 3,
-        },
-    },
-    FuseEntryInfo {
-        partition_num: 12,
-        entry_num: 32,
-        byte_offset: 0x840,
-        byte_size: 4,
-        name: "vendor_mldsa_revocation_9",
-        layout: FuseLayoutType::LinearMajorityVote {
-            bits: 4,
-            duplication: 3,
-        },
-    },
-    FuseEntryInfo {
-        partition_num: 12,
-        entry_num: 31,
-        byte_offset: 0x83c,
-        byte_size: 4,
-        name: "vendor_lms_revocation_9",
-        layout: FuseLayoutType::LinearMajorityVote {
-            bits: 16,
-            duplication: 2,
-        },
-    },
-    FuseEntryInfo {
-        partition_num: 12,
-        entry_num: 33,
-        byte_offset: 0x844,
-        byte_size: 4,
-        name: "vendor_ecc_revocation_10",
-        layout: FuseLayoutType::LinearMajorityVote {
-            bits: 4,
-            duplication: 3,
-        },
-    },
-    FuseEntryInfo {
-        partition_num: 12,
-        entry_num: 35,
-        byte_offset: 0x84c,
-        byte_size: 4,
-        name: "vendor_mldsa_revocation_10",
-        layout: FuseLayoutType::LinearMajorityVote {
-            bits: 4,
-            duplication: 3,
-        },
-    },
-    FuseEntryInfo {
-        partition_num: 12,
-        entry_num: 34,
-        byte_offset: 0x848,
-        byte_size: 4,
-        name: "vendor_lms_revocation_10",
-        layout: FuseLayoutType::LinearMajorityVote {
-            bits: 16,
-            duplication: 2,
-        },
-    },
-    FuseEntryInfo {
-        partition_num: 12,
-        entry_num: 36,
-        byte_offset: 0x850,
-        byte_size: 4,
-        name: "vendor_ecc_revocation_11",
-        layout: FuseLayoutType::LinearMajorityVote {
-            bits: 4,
-            duplication: 3,
-        },
-    },
-    FuseEntryInfo {
-        partition_num: 12,
-        entry_num: 38,
-        byte_offset: 0x858,
-        byte_size: 4,
-        name: "vendor_mldsa_revocation_11",
-        layout: FuseLayoutType::LinearMajorityVote {
-            bits: 4,
-            duplication: 3,
-        },
-    },
-    FuseEntryInfo {
-        partition_num: 12,
-        entry_num: 37,
-        byte_offset: 0x854,
-        byte_size: 4,
-        name: "vendor_lms_revocation_11",
-        layout: FuseLayoutType::LinearMajorityVote {
-            bits: 16,
-            duplication: 2,
-        },
-    },
-    FuseEntryInfo {
-        partition_num: 12,
-        entry_num: 39,
-        byte_offset: 0x85c,
-        byte_size: 4,
-        name: "vendor_ecc_revocation_12",
-        layout: FuseLayoutType::LinearMajorityVote {
-            bits: 4,
-            duplication: 3,
-        },
-    },
-    FuseEntryInfo {
-        partition_num: 12,
-        entry_num: 41,
-        byte_offset: 0x864,
-        byte_size: 4,
-        name: "vendor_mldsa_revocation_12",
-        layout: FuseLayoutType::LinearMajorityVote {
-            bits: 4,
-            duplication: 3,
-        },
-    },
-    FuseEntryInfo {
-        partition_num: 12,
-        entry_num: 40,
-        byte_offset: 0x860,
-        byte_size: 4,
-        name: "vendor_lms_revocation_12",
-        layout: FuseLayoutType::LinearMajorityVote {
-            bits: 16,
-            duplication: 2,
-        },
-    },
-    FuseEntryInfo {
-        partition_num: 12,
-        entry_num: 42,
-        byte_offset: 0x868,
-        byte_size: 4,
-        name: "vendor_ecc_revocation_13",
-        layout: FuseLayoutType::LinearMajorityVote {
-            bits: 4,
-            duplication: 3,
-        },
-    },
-    FuseEntryInfo {
-        partition_num: 12,
-        entry_num: 44,
-        byte_offset: 0x870,
-        byte_size: 4,
-        name: "vendor_mldsa_revocation_13",
-        layout: FuseLayoutType::LinearMajorityVote {
-            bits: 4,
-            duplication: 3,
-        },
-    },
-    FuseEntryInfo {
-        partition_num: 12,
-        entry_num: 43,
-        byte_offset: 0x86c,
-        byte_size: 4,
-        name: "vendor_lms_revocation_13",
-        layout: FuseLayoutType::LinearMajorityVote {
-            bits: 16,
-            duplication: 2,
-        },
-    },
-    FuseEntryInfo {
-        partition_num: 12,
-        entry_num: 45,
-        byte_offset: 0x874,
-        byte_size: 4,
-        name: "vendor_ecc_revocation_14",
-        layout: FuseLayoutType::LinearMajorityVote {
-            bits: 4,
-            duplication: 3,
-        },
-    },
-    FuseEntryInfo {
-        partition_num: 12,
-        entry_num: 47,
-        byte_offset: 0x87c,
-        byte_size: 4,
-        name: "vendor_mldsa_revocation_14",
-        layout: FuseLayoutType::LinearMajorityVote {
-            bits: 4,
-            duplication: 3,
-        },
-    },
-    FuseEntryInfo {
-        partition_num: 12,
-        entry_num: 46,
-        byte_offset: 0x878,
-        byte_size: 4,
-        name: "vendor_lms_revocation_14",
-        layout: FuseLayoutType::LinearMajorityVote {
-            bits: 16,
-            duplication: 2,
-        },
-    },
-    FuseEntryInfo {
-        partition_num: 12,
-        entry_num: 48,
-        byte_offset: 0x880,
-        byte_size: 4,
-        name: "vendor_ecc_revocation_15",
-        layout: FuseLayoutType::LinearMajorityVote {
-            bits: 4,
-            duplication: 3,
-        },
-    },
-    FuseEntryInfo {
-        partition_num: 12,
-        entry_num: 50,
-        byte_offset: 0x888,
-        byte_size: 4,
-        name: "vendor_mldsa_revocation_15",
-        layout: FuseLayoutType::LinearMajorityVote {
-            bits: 4,
-            duplication: 3,
-        },
-    },
-    FuseEntryInfo {
-        partition_num: 12,
-        entry_num: 49,
-        byte_offset: 0x884,
-        byte_size: 4,
-        name: "vendor_lms_revocation_15",
-        layout: FuseLayoutType::LinearMajorityVote {
-            bits: 16,
-            duplication: 2,
-        },
-    },
-    FuseEntryInfo {
-        partition_num: 10,
-        entry_num: 1,
-        byte_offset: 0x450,
-        byte_size: 4,
-        name: "vendor_pqc_key_type_0",
-        layout: FuseLayoutType::OneHotLinearMajorityVote {
-            bits: 2,
-            duplication: 3,
-        },
-    },
-    FuseEntryInfo {
-        partition_num: 11,
-        entry_num: 4,
-        byte_offset: 0x4c8,
-        byte_size: 4,
-        name: "vendor_pqc_key_type_1",
-        layout: FuseLayoutType::OneHotLinearMajorityVote {
-            bits: 2,
-            duplication: 3,
-        },
-    },
-    FuseEntryInfo {
-        partition_num: 11,
-        entry_num: 6,
-        byte_offset: 0x4fc,
-        byte_size: 4,
-        name: "vendor_pqc_key_type_2",
-        layout: FuseLayoutType::OneHotLinearMajorityVote {
-            bits: 2,
-            duplication: 3,
-        },
-    },
-    FuseEntryInfo {
-        partition_num: 11,
-        entry_num: 8,
-        byte_offset: 0x530,
-        byte_size: 4,
-        name: "vendor_pqc_key_type_3",
-        layout: FuseLayoutType::OneHotLinearMajorityVote {
-            bits: 2,
-            duplication: 3,
-        },
-    },
-    FuseEntryInfo {
-        partition_num: 11,
-        entry_num: 10,
-        byte_offset: 0x564,
-        byte_size: 4,
-        name: "vendor_pqc_key_type_4",
-        layout: FuseLayoutType::OneHotLinearMajorityVote {
-            bits: 2,
-            duplication: 3,
-        },
-    },
-    FuseEntryInfo {
-        partition_num: 11,
-        entry_num: 12,
-        byte_offset: 0x598,
-        byte_size: 4,
-        name: "vendor_pqc_key_type_5",
-        layout: FuseLayoutType::OneHotLinearMajorityVote {
-            bits: 2,
-            duplication: 3,
-        },
-    },
-    FuseEntryInfo {
-        partition_num: 11,
-        entry_num: 14,
-        byte_offset: 0x5cc,
-        byte_size: 4,
-        name: "vendor_pqc_key_type_6",
-        layout: FuseLayoutType::OneHotLinearMajorityVote {
-            bits: 2,
-            duplication: 3,
-        },
-    },
-    FuseEntryInfo {
-        partition_num: 11,
-        entry_num: 16,
-        byte_offset: 0x600,
-        byte_size: 4,
-        name: "vendor_pqc_key_type_7",
-        layout: FuseLayoutType::OneHotLinearMajorityVote {
-            bits: 2,
-            duplication: 3,
-        },
-    },
-    FuseEntryInfo {
-        partition_num: 11,
-        entry_num: 18,
-        byte_offset: 0x634,
-        byte_size: 4,
-        name: "vendor_pqc_key_type_8",
-        layout: FuseLayoutType::OneHotLinearMajorityVote {
-            bits: 2,
-            duplication: 3,
-        },
-    },
-    FuseEntryInfo {
-        partition_num: 11,
-        entry_num: 20,
-        byte_offset: 0x668,
-        byte_size: 4,
-        name: "vendor_pqc_key_type_9",
-        layout: FuseLayoutType::OneHotLinearMajorityVote {
-            bits: 2,
-            duplication: 3,
-        },
-    },
-    FuseEntryInfo {
-        partition_num: 11,
-        entry_num: 22,
-        byte_offset: 0x69c,
-        byte_size: 4,
-        name: "vendor_pqc_key_type_10",
-        layout: FuseLayoutType::OneHotLinearMajorityVote {
-            bits: 2,
-            duplication: 3,
-        },
-    },
-    FuseEntryInfo {
-        partition_num: 11,
-        entry_num: 24,
-        byte_offset: 0x6d0,
-        byte_size: 4,
-        name: "vendor_pqc_key_type_11",
-        layout: FuseLayoutType::OneHotLinearMajorityVote {
-            bits: 2,
-            duplication: 3,
-        },
-    },
-    FuseEntryInfo {
-        partition_num: 11,
-        entry_num: 26,
-        byte_offset: 0x704,
-        byte_size: 4,
-        name: "vendor_pqc_key_type_12",
-        layout: FuseLayoutType::OneHotLinearMajorityVote {
-            bits: 2,
-            duplication: 3,
-        },
-    },
-    FuseEntryInfo {
-        partition_num: 11,
-        entry_num: 28,
-        byte_offset: 0x738,
-        byte_size: 4,
-        name: "vendor_pqc_key_type_13",
-        layout: FuseLayoutType::OneHotLinearMajorityVote {
-            bits: 2,
-            duplication: 3,
-        },
-    },
-    FuseEntryInfo {
-        partition_num: 11,
-        entry_num: 30,
-        byte_offset: 0x76c,
-        byte_size: 4,
-        name: "vendor_pqc_key_type_14",
-        layout: FuseLayoutType::OneHotLinearMajorityVote {
-            bits: 2,
-            duplication: 3,
-        },
-    },
-    FuseEntryInfo {
-        partition_num: 11,
-        entry_num: 32,
-        byte_offset: 0x7a0,
-        byte_size: 4,
-        name: "vendor_pqc_key_type_15",
-        layout: FuseLayoutType::OneHotLinearMajorityVote {
-            bits: 2,
-            duplication: 3,
-        },
-    },
-];
 /// Fuse entry for `dot_initialized`.
-pub const DOT_INITIALIZED: &FuseEntryInfo = &FUSE_ENTRY_TABLE[0];
+pub const DOT_INITIALIZED: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 14,
+    entry_num: 0,
+    byte_offset: 0xaa8,
+    byte_size: 32,
+    name: "dot_initialized",
+    layout: FuseLayoutType::LinearMajorityVote {
+        bits: 1,
+        duplication: 3,
+    },
+};
 /// Fuse entry for `dot_fuse_array`.
-pub const DOT_FUSE_ARRAY: &FuseEntryInfo = &FUSE_ENTRY_TABLE[1];
+pub const DOT_FUSE_ARRAY: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 14,
+    entry_num: 1,
+    byte_offset: 0xac8,
+    byte_size: 32,
+    name: "dot_fuse_array",
+    layout: FuseLayoutType::OneHot { bits: 256 },
+};
 /// Fuse entry for `perma_hek_en`.
-pub const PERMA_HEK_EN: &FuseEntryInfo = &FUSE_ENTRY_TABLE[2];
+pub const PERMA_HEK_EN: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 14,
+    entry_num: 2,
+    byte_offset: 0xae8,
+    byte_size: 32,
+    name: "perma_hek_en",
+    layout: FuseLayoutType::LinearMajorityVote {
+        bits: 1,
+        duplication: 3,
+    },
+};
 /// Fuse entry for `cptra_itrng_health_test_window_size`.
-pub const CPTRA_ITRNG_HEALTH_TEST_WINDOW_SIZE: &FuseEntryInfo = &FUSE_ENTRY_TABLE[3];
+pub const CPTRA_ITRNG_HEALTH_TEST_WINDOW_SIZE: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 14,
+    entry_num: 3,
+    byte_offset: 0xb08,
+    byte_size: 32,
+    name: "cptra_itrng_health_test_window_size",
+    layout: FuseLayoutType::Single { bits: 16 },
+};
 /// Fuse entry for `cptra_itrng_entropy_config_0`.
-pub const CPTRA_ITRNG_ENTROPY_CONFIG_0: &FuseEntryInfo = &FUSE_ENTRY_TABLE[4];
+pub const CPTRA_ITRNG_ENTROPY_CONFIG_0: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 14,
+    entry_num: 4,
+    byte_offset: 0xb28,
+    byte_size: 32,
+    name: "cptra_itrng_entropy_config_0",
+    layout: FuseLayoutType::Single { bits: 32 },
+};
 /// Fuse entry for `cptra_itrng_entropy_config_1`.
-pub const CPTRA_ITRNG_ENTROPY_CONFIG_1: &FuseEntryInfo = &FUSE_ENTRY_TABLE[5];
+pub const CPTRA_ITRNG_ENTROPY_CONFIG_1: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 14,
+    entry_num: 5,
+    byte_offset: 0xb48,
+    byte_size: 32,
+    name: "cptra_itrng_entropy_config_1",
+    layout: FuseLayoutType::Single { bits: 32 },
+};
 /// Fuse entry for `vendor_recovery_pk_hash`.
-pub const VENDOR_RECOVERY_PK_HASH: &FuseEntryInfo = &FUSE_ENTRY_TABLE[6];
+pub const VENDOR_RECOVERY_PK_HASH: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 13,
+    entry_num: 0,
+    byte_offset: 0x898,
+    byte_size: 32,
+    name: "vendor_recovery_pk_hash",
+    layout: FuseLayoutType::Single { bits: 384 },
+};
 /// Fuse entry for `vendor_pk_hash_valid`.
-pub const VENDOR_PK_HASH_VALID: &FuseEntryInfo = &FUSE_ENTRY_TABLE[7];
+pub const VENDOR_PK_HASH_VALID: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 11,
+    entry_num: 33,
+    byte_offset: 0x7a4,
+    byte_size: 16,
+    name: "vendor_pk_hash_valid",
+    layout: FuseLayoutType::LinearMajorityVote {
+        bits: 16,
+        duplication: 8,
+    },
+};
 /// Fuse entry for `vendor_ecc_revocation_0`.
-pub const VENDOR_ECC_REVOCATION_0: &FuseEntryInfo = &FUSE_ENTRY_TABLE[8];
+pub const VENDOR_ECC_REVOCATION_0: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 12,
+    entry_num: 3,
+    byte_offset: 0x7cc,
+    byte_size: 4,
+    name: "vendor_ecc_revocation_0",
+    layout: FuseLayoutType::LinearMajorityVote {
+        bits: 4,
+        duplication: 3,
+    },
+};
 /// Fuse entry for `vendor_mldsa_revocation_0`.
-pub const VENDOR_MLDSA_REVOCATION_0: &FuseEntryInfo = &FUSE_ENTRY_TABLE[9];
+pub const VENDOR_MLDSA_REVOCATION_0: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 12,
+    entry_num: 5,
+    byte_offset: 0x7d4,
+    byte_size: 4,
+    name: "vendor_mldsa_revocation_0",
+    layout: FuseLayoutType::LinearMajorityVote {
+        bits: 4,
+        duplication: 3,
+    },
+};
 /// Fuse entry for `vendor_lms_revocation_0`.
-pub const VENDOR_LMS_REVOCATION_0: &FuseEntryInfo = &FUSE_ENTRY_TABLE[10];
+pub const VENDOR_LMS_REVOCATION_0: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 12,
+    entry_num: 4,
+    byte_offset: 0x7d0,
+    byte_size: 4,
+    name: "vendor_lms_revocation_0",
+    layout: FuseLayoutType::LinearMajorityVote {
+        bits: 16,
+        duplication: 2,
+    },
+};
 /// Fuse entry for `vendor_ecc_revocation_1`.
-pub const VENDOR_ECC_REVOCATION_1: &FuseEntryInfo = &FUSE_ENTRY_TABLE[11];
+pub const VENDOR_ECC_REVOCATION_1: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 12,
+    entry_num: 6,
+    byte_offset: 0x7d8,
+    byte_size: 4,
+    name: "vendor_ecc_revocation_1",
+    layout: FuseLayoutType::LinearMajorityVote {
+        bits: 4,
+        duplication: 3,
+    },
+};
 /// Fuse entry for `vendor_mldsa_revocation_1`.
-pub const VENDOR_MLDSA_REVOCATION_1: &FuseEntryInfo = &FUSE_ENTRY_TABLE[12];
+pub const VENDOR_MLDSA_REVOCATION_1: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 12,
+    entry_num: 8,
+    byte_offset: 0x7e0,
+    byte_size: 4,
+    name: "vendor_mldsa_revocation_1",
+    layout: FuseLayoutType::LinearMajorityVote {
+        bits: 4,
+        duplication: 3,
+    },
+};
 /// Fuse entry for `vendor_lms_revocation_1`.
-pub const VENDOR_LMS_REVOCATION_1: &FuseEntryInfo = &FUSE_ENTRY_TABLE[13];
+pub const VENDOR_LMS_REVOCATION_1: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 12,
+    entry_num: 7,
+    byte_offset: 0x7dc,
+    byte_size: 4,
+    name: "vendor_lms_revocation_1",
+    layout: FuseLayoutType::LinearMajorityVote {
+        bits: 16,
+        duplication: 2,
+    },
+};
 /// Fuse entry for `vendor_ecc_revocation_2`.
-pub const VENDOR_ECC_REVOCATION_2: &FuseEntryInfo = &FUSE_ENTRY_TABLE[14];
+pub const VENDOR_ECC_REVOCATION_2: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 12,
+    entry_num: 9,
+    byte_offset: 0x7e4,
+    byte_size: 4,
+    name: "vendor_ecc_revocation_2",
+    layout: FuseLayoutType::LinearMajorityVote {
+        bits: 4,
+        duplication: 3,
+    },
+};
 /// Fuse entry for `vendor_mldsa_revocation_2`.
-pub const VENDOR_MLDSA_REVOCATION_2: &FuseEntryInfo = &FUSE_ENTRY_TABLE[15];
+pub const VENDOR_MLDSA_REVOCATION_2: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 12,
+    entry_num: 11,
+    byte_offset: 0x7ec,
+    byte_size: 4,
+    name: "vendor_mldsa_revocation_2",
+    layout: FuseLayoutType::LinearMajorityVote {
+        bits: 4,
+        duplication: 3,
+    },
+};
 /// Fuse entry for `vendor_lms_revocation_2`.
-pub const VENDOR_LMS_REVOCATION_2: &FuseEntryInfo = &FUSE_ENTRY_TABLE[16];
+pub const VENDOR_LMS_REVOCATION_2: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 12,
+    entry_num: 10,
+    byte_offset: 0x7e8,
+    byte_size: 4,
+    name: "vendor_lms_revocation_2",
+    layout: FuseLayoutType::LinearMajorityVote {
+        bits: 16,
+        duplication: 2,
+    },
+};
 /// Fuse entry for `vendor_ecc_revocation_3`.
-pub const VENDOR_ECC_REVOCATION_3: &FuseEntryInfo = &FUSE_ENTRY_TABLE[17];
+pub const VENDOR_ECC_REVOCATION_3: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 12,
+    entry_num: 12,
+    byte_offset: 0x7f0,
+    byte_size: 4,
+    name: "vendor_ecc_revocation_3",
+    layout: FuseLayoutType::LinearMajorityVote {
+        bits: 4,
+        duplication: 3,
+    },
+};
 /// Fuse entry for `vendor_mldsa_revocation_3`.
-pub const VENDOR_MLDSA_REVOCATION_3: &FuseEntryInfo = &FUSE_ENTRY_TABLE[18];
+pub const VENDOR_MLDSA_REVOCATION_3: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 12,
+    entry_num: 14,
+    byte_offset: 0x7f8,
+    byte_size: 4,
+    name: "vendor_mldsa_revocation_3",
+    layout: FuseLayoutType::LinearMajorityVote {
+        bits: 4,
+        duplication: 3,
+    },
+};
 /// Fuse entry for `vendor_lms_revocation_3`.
-pub const VENDOR_LMS_REVOCATION_3: &FuseEntryInfo = &FUSE_ENTRY_TABLE[19];
+pub const VENDOR_LMS_REVOCATION_3: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 12,
+    entry_num: 13,
+    byte_offset: 0x7f4,
+    byte_size: 4,
+    name: "vendor_lms_revocation_3",
+    layout: FuseLayoutType::LinearMajorityVote {
+        bits: 16,
+        duplication: 2,
+    },
+};
 /// Fuse entry for `vendor_ecc_revocation_4`.
-pub const VENDOR_ECC_REVOCATION_4: &FuseEntryInfo = &FUSE_ENTRY_TABLE[20];
+pub const VENDOR_ECC_REVOCATION_4: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 12,
+    entry_num: 15,
+    byte_offset: 0x7fc,
+    byte_size: 4,
+    name: "vendor_ecc_revocation_4",
+    layout: FuseLayoutType::LinearMajorityVote {
+        bits: 4,
+        duplication: 3,
+    },
+};
 /// Fuse entry for `vendor_mldsa_revocation_4`.
-pub const VENDOR_MLDSA_REVOCATION_4: &FuseEntryInfo = &FUSE_ENTRY_TABLE[21];
+pub const VENDOR_MLDSA_REVOCATION_4: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 12,
+    entry_num: 17,
+    byte_offset: 0x804,
+    byte_size: 4,
+    name: "vendor_mldsa_revocation_4",
+    layout: FuseLayoutType::LinearMajorityVote {
+        bits: 4,
+        duplication: 3,
+    },
+};
 /// Fuse entry for `vendor_lms_revocation_4`.
-pub const VENDOR_LMS_REVOCATION_4: &FuseEntryInfo = &FUSE_ENTRY_TABLE[22];
+pub const VENDOR_LMS_REVOCATION_4: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 12,
+    entry_num: 16,
+    byte_offset: 0x800,
+    byte_size: 4,
+    name: "vendor_lms_revocation_4",
+    layout: FuseLayoutType::LinearMajorityVote {
+        bits: 16,
+        duplication: 2,
+    },
+};
 /// Fuse entry for `vendor_ecc_revocation_5`.
-pub const VENDOR_ECC_REVOCATION_5: &FuseEntryInfo = &FUSE_ENTRY_TABLE[23];
+pub const VENDOR_ECC_REVOCATION_5: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 12,
+    entry_num: 18,
+    byte_offset: 0x808,
+    byte_size: 4,
+    name: "vendor_ecc_revocation_5",
+    layout: FuseLayoutType::LinearMajorityVote {
+        bits: 4,
+        duplication: 3,
+    },
+};
 /// Fuse entry for `vendor_mldsa_revocation_5`.
-pub const VENDOR_MLDSA_REVOCATION_5: &FuseEntryInfo = &FUSE_ENTRY_TABLE[24];
+pub const VENDOR_MLDSA_REVOCATION_5: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 12,
+    entry_num: 20,
+    byte_offset: 0x810,
+    byte_size: 4,
+    name: "vendor_mldsa_revocation_5",
+    layout: FuseLayoutType::LinearMajorityVote {
+        bits: 4,
+        duplication: 3,
+    },
+};
 /// Fuse entry for `vendor_lms_revocation_5`.
-pub const VENDOR_LMS_REVOCATION_5: &FuseEntryInfo = &FUSE_ENTRY_TABLE[25];
+pub const VENDOR_LMS_REVOCATION_5: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 12,
+    entry_num: 19,
+    byte_offset: 0x80c,
+    byte_size: 4,
+    name: "vendor_lms_revocation_5",
+    layout: FuseLayoutType::LinearMajorityVote {
+        bits: 16,
+        duplication: 2,
+    },
+};
 /// Fuse entry for `vendor_ecc_revocation_6`.
-pub const VENDOR_ECC_REVOCATION_6: &FuseEntryInfo = &FUSE_ENTRY_TABLE[26];
+pub const VENDOR_ECC_REVOCATION_6: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 12,
+    entry_num: 21,
+    byte_offset: 0x814,
+    byte_size: 4,
+    name: "vendor_ecc_revocation_6",
+    layout: FuseLayoutType::LinearMajorityVote {
+        bits: 4,
+        duplication: 3,
+    },
+};
 /// Fuse entry for `vendor_mldsa_revocation_6`.
-pub const VENDOR_MLDSA_REVOCATION_6: &FuseEntryInfo = &FUSE_ENTRY_TABLE[27];
+pub const VENDOR_MLDSA_REVOCATION_6: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 12,
+    entry_num: 23,
+    byte_offset: 0x81c,
+    byte_size: 4,
+    name: "vendor_mldsa_revocation_6",
+    layout: FuseLayoutType::LinearMajorityVote {
+        bits: 4,
+        duplication: 3,
+    },
+};
 /// Fuse entry for `vendor_lms_revocation_6`.
-pub const VENDOR_LMS_REVOCATION_6: &FuseEntryInfo = &FUSE_ENTRY_TABLE[28];
+pub const VENDOR_LMS_REVOCATION_6: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 12,
+    entry_num: 22,
+    byte_offset: 0x818,
+    byte_size: 4,
+    name: "vendor_lms_revocation_6",
+    layout: FuseLayoutType::LinearMajorityVote {
+        bits: 16,
+        duplication: 2,
+    },
+};
 /// Fuse entry for `vendor_ecc_revocation_7`.
-pub const VENDOR_ECC_REVOCATION_7: &FuseEntryInfo = &FUSE_ENTRY_TABLE[29];
+pub const VENDOR_ECC_REVOCATION_7: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 12,
+    entry_num: 24,
+    byte_offset: 0x820,
+    byte_size: 4,
+    name: "vendor_ecc_revocation_7",
+    layout: FuseLayoutType::LinearMajorityVote {
+        bits: 4,
+        duplication: 3,
+    },
+};
 /// Fuse entry for `vendor_mldsa_revocation_7`.
-pub const VENDOR_MLDSA_REVOCATION_7: &FuseEntryInfo = &FUSE_ENTRY_TABLE[30];
+pub const VENDOR_MLDSA_REVOCATION_7: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 12,
+    entry_num: 26,
+    byte_offset: 0x828,
+    byte_size: 4,
+    name: "vendor_mldsa_revocation_7",
+    layout: FuseLayoutType::LinearMajorityVote {
+        bits: 4,
+        duplication: 3,
+    },
+};
 /// Fuse entry for `vendor_lms_revocation_7`.
-pub const VENDOR_LMS_REVOCATION_7: &FuseEntryInfo = &FUSE_ENTRY_TABLE[31];
+pub const VENDOR_LMS_REVOCATION_7: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 12,
+    entry_num: 25,
+    byte_offset: 0x824,
+    byte_size: 4,
+    name: "vendor_lms_revocation_7",
+    layout: FuseLayoutType::LinearMajorityVote {
+        bits: 16,
+        duplication: 2,
+    },
+};
 /// Fuse entry for `vendor_ecc_revocation_8`.
-pub const VENDOR_ECC_REVOCATION_8: &FuseEntryInfo = &FUSE_ENTRY_TABLE[32];
+pub const VENDOR_ECC_REVOCATION_8: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 12,
+    entry_num: 27,
+    byte_offset: 0x82c,
+    byte_size: 4,
+    name: "vendor_ecc_revocation_8",
+    layout: FuseLayoutType::LinearMajorityVote {
+        bits: 4,
+        duplication: 3,
+    },
+};
 /// Fuse entry for `vendor_mldsa_revocation_8`.
-pub const VENDOR_MLDSA_REVOCATION_8: &FuseEntryInfo = &FUSE_ENTRY_TABLE[33];
+pub const VENDOR_MLDSA_REVOCATION_8: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 12,
+    entry_num: 29,
+    byte_offset: 0x834,
+    byte_size: 4,
+    name: "vendor_mldsa_revocation_8",
+    layout: FuseLayoutType::LinearMajorityVote {
+        bits: 4,
+        duplication: 3,
+    },
+};
 /// Fuse entry for `vendor_lms_revocation_8`.
-pub const VENDOR_LMS_REVOCATION_8: &FuseEntryInfo = &FUSE_ENTRY_TABLE[34];
+pub const VENDOR_LMS_REVOCATION_8: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 12,
+    entry_num: 28,
+    byte_offset: 0x830,
+    byte_size: 4,
+    name: "vendor_lms_revocation_8",
+    layout: FuseLayoutType::LinearMajorityVote {
+        bits: 16,
+        duplication: 2,
+    },
+};
 /// Fuse entry for `vendor_ecc_revocation_9`.
-pub const VENDOR_ECC_REVOCATION_9: &FuseEntryInfo = &FUSE_ENTRY_TABLE[35];
+pub const VENDOR_ECC_REVOCATION_9: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 12,
+    entry_num: 30,
+    byte_offset: 0x838,
+    byte_size: 4,
+    name: "vendor_ecc_revocation_9",
+    layout: FuseLayoutType::LinearMajorityVote {
+        bits: 4,
+        duplication: 3,
+    },
+};
 /// Fuse entry for `vendor_mldsa_revocation_9`.
-pub const VENDOR_MLDSA_REVOCATION_9: &FuseEntryInfo = &FUSE_ENTRY_TABLE[36];
+pub const VENDOR_MLDSA_REVOCATION_9: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 12,
+    entry_num: 32,
+    byte_offset: 0x840,
+    byte_size: 4,
+    name: "vendor_mldsa_revocation_9",
+    layout: FuseLayoutType::LinearMajorityVote {
+        bits: 4,
+        duplication: 3,
+    },
+};
 /// Fuse entry for `vendor_lms_revocation_9`.
-pub const VENDOR_LMS_REVOCATION_9: &FuseEntryInfo = &FUSE_ENTRY_TABLE[37];
+pub const VENDOR_LMS_REVOCATION_9: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 12,
+    entry_num: 31,
+    byte_offset: 0x83c,
+    byte_size: 4,
+    name: "vendor_lms_revocation_9",
+    layout: FuseLayoutType::LinearMajorityVote {
+        bits: 16,
+        duplication: 2,
+    },
+};
 /// Fuse entry for `vendor_ecc_revocation_10`.
-pub const VENDOR_ECC_REVOCATION_10: &FuseEntryInfo = &FUSE_ENTRY_TABLE[38];
+pub const VENDOR_ECC_REVOCATION_10: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 12,
+    entry_num: 33,
+    byte_offset: 0x844,
+    byte_size: 4,
+    name: "vendor_ecc_revocation_10",
+    layout: FuseLayoutType::LinearMajorityVote {
+        bits: 4,
+        duplication: 3,
+    },
+};
 /// Fuse entry for `vendor_mldsa_revocation_10`.
-pub const VENDOR_MLDSA_REVOCATION_10: &FuseEntryInfo = &FUSE_ENTRY_TABLE[39];
+pub const VENDOR_MLDSA_REVOCATION_10: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 12,
+    entry_num: 35,
+    byte_offset: 0x84c,
+    byte_size: 4,
+    name: "vendor_mldsa_revocation_10",
+    layout: FuseLayoutType::LinearMajorityVote {
+        bits: 4,
+        duplication: 3,
+    },
+};
 /// Fuse entry for `vendor_lms_revocation_10`.
-pub const VENDOR_LMS_REVOCATION_10: &FuseEntryInfo = &FUSE_ENTRY_TABLE[40];
+pub const VENDOR_LMS_REVOCATION_10: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 12,
+    entry_num: 34,
+    byte_offset: 0x848,
+    byte_size: 4,
+    name: "vendor_lms_revocation_10",
+    layout: FuseLayoutType::LinearMajorityVote {
+        bits: 16,
+        duplication: 2,
+    },
+};
 /// Fuse entry for `vendor_ecc_revocation_11`.
-pub const VENDOR_ECC_REVOCATION_11: &FuseEntryInfo = &FUSE_ENTRY_TABLE[41];
+pub const VENDOR_ECC_REVOCATION_11: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 12,
+    entry_num: 36,
+    byte_offset: 0x850,
+    byte_size: 4,
+    name: "vendor_ecc_revocation_11",
+    layout: FuseLayoutType::LinearMajorityVote {
+        bits: 4,
+        duplication: 3,
+    },
+};
 /// Fuse entry for `vendor_mldsa_revocation_11`.
-pub const VENDOR_MLDSA_REVOCATION_11: &FuseEntryInfo = &FUSE_ENTRY_TABLE[42];
+pub const VENDOR_MLDSA_REVOCATION_11: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 12,
+    entry_num: 38,
+    byte_offset: 0x858,
+    byte_size: 4,
+    name: "vendor_mldsa_revocation_11",
+    layout: FuseLayoutType::LinearMajorityVote {
+        bits: 4,
+        duplication: 3,
+    },
+};
 /// Fuse entry for `vendor_lms_revocation_11`.
-pub const VENDOR_LMS_REVOCATION_11: &FuseEntryInfo = &FUSE_ENTRY_TABLE[43];
+pub const VENDOR_LMS_REVOCATION_11: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 12,
+    entry_num: 37,
+    byte_offset: 0x854,
+    byte_size: 4,
+    name: "vendor_lms_revocation_11",
+    layout: FuseLayoutType::LinearMajorityVote {
+        bits: 16,
+        duplication: 2,
+    },
+};
 /// Fuse entry for `vendor_ecc_revocation_12`.
-pub const VENDOR_ECC_REVOCATION_12: &FuseEntryInfo = &FUSE_ENTRY_TABLE[44];
+pub const VENDOR_ECC_REVOCATION_12: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 12,
+    entry_num: 39,
+    byte_offset: 0x85c,
+    byte_size: 4,
+    name: "vendor_ecc_revocation_12",
+    layout: FuseLayoutType::LinearMajorityVote {
+        bits: 4,
+        duplication: 3,
+    },
+};
 /// Fuse entry for `vendor_mldsa_revocation_12`.
-pub const VENDOR_MLDSA_REVOCATION_12: &FuseEntryInfo = &FUSE_ENTRY_TABLE[45];
+pub const VENDOR_MLDSA_REVOCATION_12: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 12,
+    entry_num: 41,
+    byte_offset: 0x864,
+    byte_size: 4,
+    name: "vendor_mldsa_revocation_12",
+    layout: FuseLayoutType::LinearMajorityVote {
+        bits: 4,
+        duplication: 3,
+    },
+};
 /// Fuse entry for `vendor_lms_revocation_12`.
-pub const VENDOR_LMS_REVOCATION_12: &FuseEntryInfo = &FUSE_ENTRY_TABLE[46];
+pub const VENDOR_LMS_REVOCATION_12: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 12,
+    entry_num: 40,
+    byte_offset: 0x860,
+    byte_size: 4,
+    name: "vendor_lms_revocation_12",
+    layout: FuseLayoutType::LinearMajorityVote {
+        bits: 16,
+        duplication: 2,
+    },
+};
 /// Fuse entry for `vendor_ecc_revocation_13`.
-pub const VENDOR_ECC_REVOCATION_13: &FuseEntryInfo = &FUSE_ENTRY_TABLE[47];
+pub const VENDOR_ECC_REVOCATION_13: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 12,
+    entry_num: 42,
+    byte_offset: 0x868,
+    byte_size: 4,
+    name: "vendor_ecc_revocation_13",
+    layout: FuseLayoutType::LinearMajorityVote {
+        bits: 4,
+        duplication: 3,
+    },
+};
 /// Fuse entry for `vendor_mldsa_revocation_13`.
-pub const VENDOR_MLDSA_REVOCATION_13: &FuseEntryInfo = &FUSE_ENTRY_TABLE[48];
+pub const VENDOR_MLDSA_REVOCATION_13: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 12,
+    entry_num: 44,
+    byte_offset: 0x870,
+    byte_size: 4,
+    name: "vendor_mldsa_revocation_13",
+    layout: FuseLayoutType::LinearMajorityVote {
+        bits: 4,
+        duplication: 3,
+    },
+};
 /// Fuse entry for `vendor_lms_revocation_13`.
-pub const VENDOR_LMS_REVOCATION_13: &FuseEntryInfo = &FUSE_ENTRY_TABLE[49];
+pub const VENDOR_LMS_REVOCATION_13: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 12,
+    entry_num: 43,
+    byte_offset: 0x86c,
+    byte_size: 4,
+    name: "vendor_lms_revocation_13",
+    layout: FuseLayoutType::LinearMajorityVote {
+        bits: 16,
+        duplication: 2,
+    },
+};
 /// Fuse entry for `vendor_ecc_revocation_14`.
-pub const VENDOR_ECC_REVOCATION_14: &FuseEntryInfo = &FUSE_ENTRY_TABLE[50];
+pub const VENDOR_ECC_REVOCATION_14: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 12,
+    entry_num: 45,
+    byte_offset: 0x874,
+    byte_size: 4,
+    name: "vendor_ecc_revocation_14",
+    layout: FuseLayoutType::LinearMajorityVote {
+        bits: 4,
+        duplication: 3,
+    },
+};
 /// Fuse entry for `vendor_mldsa_revocation_14`.
-pub const VENDOR_MLDSA_REVOCATION_14: &FuseEntryInfo = &FUSE_ENTRY_TABLE[51];
+pub const VENDOR_MLDSA_REVOCATION_14: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 12,
+    entry_num: 47,
+    byte_offset: 0x87c,
+    byte_size: 4,
+    name: "vendor_mldsa_revocation_14",
+    layout: FuseLayoutType::LinearMajorityVote {
+        bits: 4,
+        duplication: 3,
+    },
+};
 /// Fuse entry for `vendor_lms_revocation_14`.
-pub const VENDOR_LMS_REVOCATION_14: &FuseEntryInfo = &FUSE_ENTRY_TABLE[52];
+pub const VENDOR_LMS_REVOCATION_14: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 12,
+    entry_num: 46,
+    byte_offset: 0x878,
+    byte_size: 4,
+    name: "vendor_lms_revocation_14",
+    layout: FuseLayoutType::LinearMajorityVote {
+        bits: 16,
+        duplication: 2,
+    },
+};
 /// Fuse entry for `vendor_ecc_revocation_15`.
-pub const VENDOR_ECC_REVOCATION_15: &FuseEntryInfo = &FUSE_ENTRY_TABLE[53];
+pub const VENDOR_ECC_REVOCATION_15: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 12,
+    entry_num: 48,
+    byte_offset: 0x880,
+    byte_size: 4,
+    name: "vendor_ecc_revocation_15",
+    layout: FuseLayoutType::LinearMajorityVote {
+        bits: 4,
+        duplication: 3,
+    },
+};
 /// Fuse entry for `vendor_mldsa_revocation_15`.
-pub const VENDOR_MLDSA_REVOCATION_15: &FuseEntryInfo = &FUSE_ENTRY_TABLE[54];
+pub const VENDOR_MLDSA_REVOCATION_15: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 12,
+    entry_num: 50,
+    byte_offset: 0x888,
+    byte_size: 4,
+    name: "vendor_mldsa_revocation_15",
+    layout: FuseLayoutType::LinearMajorityVote {
+        bits: 4,
+        duplication: 3,
+    },
+};
 /// Fuse entry for `vendor_lms_revocation_15`.
-pub const VENDOR_LMS_REVOCATION_15: &FuseEntryInfo = &FUSE_ENTRY_TABLE[55];
+pub const VENDOR_LMS_REVOCATION_15: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 12,
+    entry_num: 49,
+    byte_offset: 0x884,
+    byte_size: 4,
+    name: "vendor_lms_revocation_15",
+    layout: FuseLayoutType::LinearMajorityVote {
+        bits: 16,
+        duplication: 2,
+    },
+};
 /// Fuse entry for `vendor_pqc_key_type_0`.
-pub const VENDOR_PQC_KEY_TYPE_0: &FuseEntryInfo = &FUSE_ENTRY_TABLE[56];
+pub const VENDOR_PQC_KEY_TYPE_0: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 10,
+    entry_num: 1,
+    byte_offset: 0x450,
+    byte_size: 4,
+    name: "vendor_pqc_key_type_0",
+    layout: FuseLayoutType::OneHotLinearMajorityVote {
+        bits: 2,
+        duplication: 3,
+    },
+};
 /// Fuse entry for `vendor_pqc_key_type_1`.
-pub const VENDOR_PQC_KEY_TYPE_1: &FuseEntryInfo = &FUSE_ENTRY_TABLE[57];
+pub const VENDOR_PQC_KEY_TYPE_1: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 11,
+    entry_num: 4,
+    byte_offset: 0x4c8,
+    byte_size: 4,
+    name: "vendor_pqc_key_type_1",
+    layout: FuseLayoutType::OneHotLinearMajorityVote {
+        bits: 2,
+        duplication: 3,
+    },
+};
 /// Fuse entry for `vendor_pqc_key_type_2`.
-pub const VENDOR_PQC_KEY_TYPE_2: &FuseEntryInfo = &FUSE_ENTRY_TABLE[58];
+pub const VENDOR_PQC_KEY_TYPE_2: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 11,
+    entry_num: 6,
+    byte_offset: 0x4fc,
+    byte_size: 4,
+    name: "vendor_pqc_key_type_2",
+    layout: FuseLayoutType::OneHotLinearMajorityVote {
+        bits: 2,
+        duplication: 3,
+    },
+};
 /// Fuse entry for `vendor_pqc_key_type_3`.
-pub const VENDOR_PQC_KEY_TYPE_3: &FuseEntryInfo = &FUSE_ENTRY_TABLE[59];
+pub const VENDOR_PQC_KEY_TYPE_3: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 11,
+    entry_num: 8,
+    byte_offset: 0x530,
+    byte_size: 4,
+    name: "vendor_pqc_key_type_3",
+    layout: FuseLayoutType::OneHotLinearMajorityVote {
+        bits: 2,
+        duplication: 3,
+    },
+};
 /// Fuse entry for `vendor_pqc_key_type_4`.
-pub const VENDOR_PQC_KEY_TYPE_4: &FuseEntryInfo = &FUSE_ENTRY_TABLE[60];
+pub const VENDOR_PQC_KEY_TYPE_4: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 11,
+    entry_num: 10,
+    byte_offset: 0x564,
+    byte_size: 4,
+    name: "vendor_pqc_key_type_4",
+    layout: FuseLayoutType::OneHotLinearMajorityVote {
+        bits: 2,
+        duplication: 3,
+    },
+};
 /// Fuse entry for `vendor_pqc_key_type_5`.
-pub const VENDOR_PQC_KEY_TYPE_5: &FuseEntryInfo = &FUSE_ENTRY_TABLE[61];
+pub const VENDOR_PQC_KEY_TYPE_5: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 11,
+    entry_num: 12,
+    byte_offset: 0x598,
+    byte_size: 4,
+    name: "vendor_pqc_key_type_5",
+    layout: FuseLayoutType::OneHotLinearMajorityVote {
+        bits: 2,
+        duplication: 3,
+    },
+};
 /// Fuse entry for `vendor_pqc_key_type_6`.
-pub const VENDOR_PQC_KEY_TYPE_6: &FuseEntryInfo = &FUSE_ENTRY_TABLE[62];
+pub const VENDOR_PQC_KEY_TYPE_6: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 11,
+    entry_num: 14,
+    byte_offset: 0x5cc,
+    byte_size: 4,
+    name: "vendor_pqc_key_type_6",
+    layout: FuseLayoutType::OneHotLinearMajorityVote {
+        bits: 2,
+        duplication: 3,
+    },
+};
 /// Fuse entry for `vendor_pqc_key_type_7`.
-pub const VENDOR_PQC_KEY_TYPE_7: &FuseEntryInfo = &FUSE_ENTRY_TABLE[63];
+pub const VENDOR_PQC_KEY_TYPE_7: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 11,
+    entry_num: 16,
+    byte_offset: 0x600,
+    byte_size: 4,
+    name: "vendor_pqc_key_type_7",
+    layout: FuseLayoutType::OneHotLinearMajorityVote {
+        bits: 2,
+        duplication: 3,
+    },
+};
 /// Fuse entry for `vendor_pqc_key_type_8`.
-pub const VENDOR_PQC_KEY_TYPE_8: &FuseEntryInfo = &FUSE_ENTRY_TABLE[64];
+pub const VENDOR_PQC_KEY_TYPE_8: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 11,
+    entry_num: 18,
+    byte_offset: 0x634,
+    byte_size: 4,
+    name: "vendor_pqc_key_type_8",
+    layout: FuseLayoutType::OneHotLinearMajorityVote {
+        bits: 2,
+        duplication: 3,
+    },
+};
 /// Fuse entry for `vendor_pqc_key_type_9`.
-pub const VENDOR_PQC_KEY_TYPE_9: &FuseEntryInfo = &FUSE_ENTRY_TABLE[65];
+pub const VENDOR_PQC_KEY_TYPE_9: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 11,
+    entry_num: 20,
+    byte_offset: 0x668,
+    byte_size: 4,
+    name: "vendor_pqc_key_type_9",
+    layout: FuseLayoutType::OneHotLinearMajorityVote {
+        bits: 2,
+        duplication: 3,
+    },
+};
 /// Fuse entry for `vendor_pqc_key_type_10`.
-pub const VENDOR_PQC_KEY_TYPE_10: &FuseEntryInfo = &FUSE_ENTRY_TABLE[66];
+pub const VENDOR_PQC_KEY_TYPE_10: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 11,
+    entry_num: 22,
+    byte_offset: 0x69c,
+    byte_size: 4,
+    name: "vendor_pqc_key_type_10",
+    layout: FuseLayoutType::OneHotLinearMajorityVote {
+        bits: 2,
+        duplication: 3,
+    },
+};
 /// Fuse entry for `vendor_pqc_key_type_11`.
-pub const VENDOR_PQC_KEY_TYPE_11: &FuseEntryInfo = &FUSE_ENTRY_TABLE[67];
+pub const VENDOR_PQC_KEY_TYPE_11: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 11,
+    entry_num: 24,
+    byte_offset: 0x6d0,
+    byte_size: 4,
+    name: "vendor_pqc_key_type_11",
+    layout: FuseLayoutType::OneHotLinearMajorityVote {
+        bits: 2,
+        duplication: 3,
+    },
+};
 /// Fuse entry for `vendor_pqc_key_type_12`.
-pub const VENDOR_PQC_KEY_TYPE_12: &FuseEntryInfo = &FUSE_ENTRY_TABLE[68];
+pub const VENDOR_PQC_KEY_TYPE_12: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 11,
+    entry_num: 26,
+    byte_offset: 0x704,
+    byte_size: 4,
+    name: "vendor_pqc_key_type_12",
+    layout: FuseLayoutType::OneHotLinearMajorityVote {
+        bits: 2,
+        duplication: 3,
+    },
+};
 /// Fuse entry for `vendor_pqc_key_type_13`.
-pub const VENDOR_PQC_KEY_TYPE_13: &FuseEntryInfo = &FUSE_ENTRY_TABLE[69];
+pub const VENDOR_PQC_KEY_TYPE_13: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 11,
+    entry_num: 28,
+    byte_offset: 0x738,
+    byte_size: 4,
+    name: "vendor_pqc_key_type_13",
+    layout: FuseLayoutType::OneHotLinearMajorityVote {
+        bits: 2,
+        duplication: 3,
+    },
+};
 /// Fuse entry for `vendor_pqc_key_type_14`.
-pub const VENDOR_PQC_KEY_TYPE_14: &FuseEntryInfo = &FUSE_ENTRY_TABLE[70];
+pub const VENDOR_PQC_KEY_TYPE_14: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 11,
+    entry_num: 30,
+    byte_offset: 0x76c,
+    byte_size: 4,
+    name: "vendor_pqc_key_type_14",
+    layout: FuseLayoutType::OneHotLinearMajorityVote {
+        bits: 2,
+        duplication: 3,
+    },
+};
 /// Fuse entry for `vendor_pqc_key_type_15`.
-pub const VENDOR_PQC_KEY_TYPE_15: &FuseEntryInfo = &FUSE_ENTRY_TABLE[71];
+pub const VENDOR_PQC_KEY_TYPE_15: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 11,
+    entry_num: 32,
+    byte_offset: 0x7a0,
+    byte_size: 4,
+    name: "vendor_pqc_key_type_15",
+    layout: FuseLayoutType::OneHotLinearMajorityVote {
+        bits: 2,
+        duplication: 3,
+    },
+};
 /// OTP item entry for `CPTRA_SS_MANUF_DEBUG_UNLOCK_TOKEN`.
 pub const OTP_CPTRA_SS_MANUF_DEBUG_UNLOCK_TOKEN: &FuseEntryInfo = &FuseEntryInfo {
     partition_num: 0,


### PR DESCRIPTION
Replace the single FUSE_ENTRY_TABLE array with one standalone &FuseEntryInfo const per entry so the linker can drop unreferenced entries. Saves ~916 bytes of .text in the emulator ROM (hw-2-1).