### PR TITLE
spdm-lib: Share large message buffer via static pool

### DIFF
--- a/platforms/emulator/runtime/userspace/apps/user/src/spdm/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/spdm/mod.rs
@@ -6,6 +6,7 @@ mod device_measurements;
 mod endorsement_certs;
 #[cfg(feature = "test-doe-spdm-tdisp-ide-validator")]
 mod integration_example;
+pub(crate) mod shared_large_msg_buf;
 
 use crate::spdm::device_measurements::ocp_eat::init_target_env_claims;
 use caliptra_mcu_libsyscall_caliptra::doe;
@@ -33,16 +34,13 @@ const SECURE_SPDM_VERSIONS: &[SpdmVersion] = &[SpdmVersion::V12];
 // Caliptra Crypto timeout exponent (2^20 us)
 const CALIPTRA_SPDM_CT_EXPONENT: u8 = 20;
 
-/// Shared buffer size for large SPDM messages (request reassembly and response chunking).
-/// Only one direction is active at a time, so a single buffer is shared.
-/// Sized for ECC-P384 certificate chain + signature + overhead.
-/// TODO: Increase for ML-DSA support once memory optimization (static buffers) is implemented.
-const LARGE_MSG_BUF_SIZE: usize = 4096;
-
 #[embassy_executor::task]
 pub(crate) async fn spdm_task(spawner: Spawner) {
     let mut console_writer = Console::<DefaultSyscalls>::writer();
     writeln!(console_writer, "SPDM_TASK: Running SPDM-TASK...").unwrap();
+
+    // Initialize the shared large message buffer (once, before spawning responders)
+    shared_large_msg_buf::init();
 
     // Initialize the shared certificate store
     if let Err(e) = initialize_cert_store().await {
@@ -91,7 +89,7 @@ async fn spdm_mctp_responder() {
         ct_exponent: CALIPTRA_SPDM_CT_EXPONENT,
         flags: CapabilityFlags::default(),
         data_transfer_size: max_mctp_spdm_msg_size,
-        max_spdm_msg_size: LARGE_MSG_BUF_SIZE as u32,
+        max_spdm_msg_size: shared_large_msg_buf::LARGE_MSG_BUF_SIZE as u32,
     };
 
     let local_algorithms = LocalDeviceAlgorithms::default();
@@ -115,9 +113,8 @@ async fn spdm_mctp_responder() {
     let vdm_handlers: Option<&mut [&mut dyn caliptra_mcu_spdm_lib::vdm_handler::VdmHandler]> =
         Some(&mut handlers_array);
 
-    // Shared buffer for large SPDM messages (request reassembly + response chunking).
-    // Only one direction is active at a time, so a single buffer is shared.
-    let mut large_msg_buf = [0u8; LARGE_MSG_BUF_SIZE];
+    // Large message buffer provider — shared across MCTP and DOE transports.
+    let large_msg_buf_provider = shared_large_msg_buf::SharedLargeMsgBuf::new();
 
     let mut ctx = match SpdmContext::new(
         SPDM_VERSIONS,
@@ -128,7 +125,7 @@ async fn spdm_mctp_responder() {
         &shared_cert_store,
         device_measurements,
         vdm_handlers,
-        &mut large_msg_buf,
+        &large_msg_buf_provider,
     ) {
         Ok(ctx) => ctx,
         Err(e) => {
@@ -174,7 +171,7 @@ async fn spdm_doe_responder() {
         ct_exponent: CALIPTRA_SPDM_CT_EXPONENT,
         flags: doe_capability_flags,
         data_transfer_size: max_doe_spdm_msg_size,
-        max_spdm_msg_size: LARGE_MSG_BUF_SIZE as u32,
+        max_spdm_msg_size: shared_large_msg_buf::LARGE_MSG_BUF_SIZE as u32,
     };
 
     let mut device_doe_algorithms = DeviceAlgorithms::default();
@@ -241,8 +238,8 @@ async fn spdm_doe_responder() {
     #[cfg(not(feature = "test-doe-spdm-tdisp-ide-validator"))]
     let vdm_handlers: Option<&mut [&mut dyn caliptra_mcu_spdm_lib::vdm_handler::VdmHandler]> = None;
 
-    // Shared buffer for large SPDM messages (request reassembly + response chunking).
-    let mut large_msg_buf = [0u8; LARGE_MSG_BUF_SIZE];
+    // Large message buffer provider — shared across MCTP and DOE transports.
+    let large_msg_buf_provider = shared_large_msg_buf::SharedLargeMsgBuf::new();
 
     let mut ctx = match SpdmContext::new(
         SPDM_VERSIONS,
@@ -253,7 +250,7 @@ async fn spdm_doe_responder() {
         &shared_cert_store,
         device_measurements,
         vdm_handlers,
-        &mut large_msg_buf,
+        &large_msg_buf_provider,
     ) {
         Ok(ctx) => ctx,
         Err(e) => {

--- a/platforms/emulator/runtime/userspace/apps/user/src/spdm/shared_large_msg_buf.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/spdm/shared_large_msg_buf.rs
@@ -1,0 +1,57 @@
+// Licensed under the Apache-2.0 license
+
+//! Shared large message buffer for SPDM responders.
+//!
+//! MCTP and DOE responders share a single static buffer for large message
+//! operations (CHUNK_SEND reassembly and CHUNK_GET response chunking).
+
+use caliptra_mcu_spdm_lib::chunk_ctx::LargeMsgBufProvider;
+use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+use embassy_sync::blocking_mutex::Mutex;
+use static_cell::StaticCell;
+
+/// Buffer size for large SPDM messages.
+/// TODO: Increase to ~14 KB for ML-DSA support.
+pub const LARGE_MSG_BUF_SIZE: usize = 4096;
+
+/// Backing storage (allocated once in `.bss`).
+static LARGE_MSG_BUF_STORAGE: StaticCell<[u8; LARGE_MSG_BUF_SIZE]> = StaticCell::new();
+
+/// Holds the buffer when it is not checked out by a responder.
+/// `Some(buf)` = available, `None` = in use by a responder.
+static SHARED_BUF: Mutex<CriticalSectionRawMutex, core::cell::RefCell<Option<&'static mut [u8]>>> =
+    Mutex::new(core::cell::RefCell::new(None));
+
+/// Initialize the shared buffer. Must be called once before spawning responders.
+pub fn init() {
+    let buf = LARGE_MSG_BUF_STORAGE.init([0u8; LARGE_MSG_BUF_SIZE]);
+    SHARED_BUF.lock(|cell| {
+        *cell.borrow_mut() = Some(buf);
+    });
+}
+
+/// Zero-size wrapper that implements `LargeMsgBufProvider` by delegating
+/// to the module-level static mutex. Follows the same pattern as `SharedCertStore`.
+pub struct SharedLargeMsgBuf;
+
+impl SharedLargeMsgBuf {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl LargeMsgBufProvider for SharedLargeMsgBuf {
+    fn acquire(&self) -> Option<&'static mut [u8]> {
+        SHARED_BUF.lock(|cell| cell.borrow_mut().take())
+    }
+
+    fn release(&self, buf: &'static mut [u8]) {
+        SHARED_BUF.lock(|cell| {
+            *cell.borrow_mut() = Some(buf);
+        });
+    }
+
+    fn capacity(&self) -> usize {
+        LARGE_MSG_BUF_SIZE
+    }
+}

--- a/runtime/userspace/api/spdm-lib/src/chunk_ctx.rs
+++ b/runtime/userspace/api/spdm-lib/src/chunk_ctx.rs
@@ -16,6 +16,25 @@ pub enum ChunkError {
     InvalidMessageOffset,
     /// Response data exceeds the shared buffer capacity
     BufferCapacityExceeded,
+    /// Shared large message buffer is not available (in use by another transport)
+    BufUnavailable,
+}
+
+/// Provider for the shared large message buffer.
+///
+/// Both SPDM transports (MCTP, DOE) share a single buffer for large message
+/// operations. Implementors manage the underlying static buffer and serialize
+/// access across concurrent responder tasks.
+///
+/// Methods are synchronous (non-blocking try-lock) to avoid adding async await
+/// points that inflate the responder task future state machine.
+pub trait LargeMsgBufProvider {
+    /// Acquire the shared buffer. Returns `None` if already in use.
+    fn acquire(&self) -> Option<&'static mut [u8]>;
+    /// Return the buffer to the shared pool.
+    fn release(&self, buf: &'static mut [u8]);
+    /// Maximum buffer capacity (used for capabilities negotiation).
+    fn capacity(&self) -> usize;
 }
 
 /// Stores state and metadata for managing ongoing large message requests and responses.
@@ -74,6 +93,10 @@ enum LargeMessageMode {
 /// Only one direction is active at a time: the SPDM protocol ensures that
 /// CHUNK_SEND rejects if a large response is in progress, and vice versa.
 ///
+/// The buffer is acquired on demand from a `LargeMsgBufProvider` and released
+/// when the chunking operation completes. This allows multiple transports
+/// to share a single static buffer.
+///
 /// TODO: Refactor `buf` to use `MessageBuf` instead of raw `&mut [u8]` to align
 /// with the process_message pattern (reserve/put_data/encode) and simplify
 /// header construction in vendor_defined_rsp.rs.
@@ -84,31 +107,75 @@ pub(crate) struct LargeMessageCtx<'a> {
     global_handle: u8,
     /// Number of valid bytes in `buf` (used by buffered responses)
     pub(crate) data_len: usize,
-    /// App-provided shared buffer for large message data
-    pub(crate) buf: &'a mut [u8],
+    /// Shared buffer for large message data (static lifetime for pool-based sharing)
+    pub(crate) buf: &'static mut [u8],
+    /// Provider for acquiring/releasing the shared buffer
+    buf_provider: &'a dyn LargeMsgBufProvider,
 }
 
 impl<'a> LargeMessageCtx<'a> {
-    /// Create a new context with the given app-provided shared buffer.
-    pub fn new(buf: &'a mut [u8]) -> Self {
+    /// Create a new context with the given buffer provider.
+    /// Starts with no buffer — it will be acquired on demand.
+    pub fn new(buf_provider: &'a dyn LargeMsgBufProvider) -> Self {
         Self {
             chunk_state: ChunkState::default(),
             mode: LargeMessageMode::Idle,
             global_handle: 1,
             data_len: 0,
-            buf,
+            buf: &mut [],
+            buf_provider,
         }
+    }
+
+    /// Acquire the shared buffer from the provider.
+    /// Returns `Ok(())` if acquired (or already held), `Err` if unavailable.
+    pub fn acquire_buf(&mut self) -> ChunkResult<()> {
+        if !self.buf.is_empty() {
+            return Ok(()); // Already have it
+        }
+        match self.buf_provider.acquire() {
+            Some(buf) => {
+                self.buf = buf;
+                Ok(())
+            }
+            None => Err(ChunkError::BufUnavailable),
+        }
+    }
+
+    /// Release the shared buffer back to the provider (if held and idle).
+    pub fn release_buf(&mut self) {
+        if !self.buf.is_empty() && self.is_idle() {
+            let buf = core::mem::take(&mut self.buf);
+            self.buf_provider.release(buf);
+        }
+    }
+
+    /// Returns the maximum buffer capacity from the provider.
+    #[allow(dead_code)]
+    pub fn buf_capacity(&self) -> usize {
+        self.buf_provider.capacity()
     }
 
     /// Take the shared buffer, leaving an empty slice in its place.
     /// The caller MUST call `replace_buf` to restore the buffer.
-    pub fn take_buf(&mut self) -> &'a mut [u8] {
+    pub fn take_buf(&mut self) -> &'static mut [u8] {
         core::mem::take(&mut self.buf)
     }
 
     /// Replace the shared buffer with the given one.
-    pub fn replace_buf(&mut self, buf: &'a mut [u8]) {
+    pub fn replace_buf(&mut self, buf: &'static mut [u8]) {
         self.buf = buf;
+    }
+
+    /// Returns `true` if no chunking operation is in progress.
+    pub fn is_idle(&self) -> bool {
+        matches!(self.mode, LargeMessageMode::Idle)
+    }
+
+    /// Returns `true` if a buffer is currently attached (non-empty).
+    #[allow(dead_code)]
+    pub fn has_buf(&self) -> bool {
+        !self.buf.is_empty()
     }
 
     // ── Request methods (CHUNK_SEND reassembly) ──
@@ -125,7 +192,11 @@ impl<'a> LargeMessageCtx<'a> {
     }
 
     pub fn request_capacity(&self) -> usize {
-        self.buf.len()
+        if self.buf.is_empty() {
+            self.buf_provider.capacity()
+        } else {
+            self.buf.len()
+        }
     }
 
     /// Initialize a large request reassembly with the first chunk.

--- a/runtime/userspace/api/spdm-lib/src/commands/chunk_send_ack_rsp.rs
+++ b/runtime/userspace/api/spdm-lib/src/commands/chunk_send_ack_rsp.rs
@@ -318,6 +318,11 @@ pub(crate) async fn handle_chunk_send<'a>(
     spdm_hdr: SpdmMsgHdr,
     req: &mut MessageBuf<'a>,
 ) -> CommandResult<()> {
+    // Acquire the shared buffer before processing (needed for request reassembly)
+    ctx.large_msg_ctx
+        .acquire_buf()
+        .map_err(|_| ctx.generate_error_response(req, ErrorCode::Busy, 0, None))?;
+
     let result = process_chunk_send(ctx, spdm_hdr, req)?;
 
     ctx.prepare_response_buffer(req)?;
@@ -340,6 +345,7 @@ mod tests {
     use crate::protocol::algorithms::LocalDeviceAlgorithms;
     use crate::transport::common::{SpdmTransport, TransportError, TransportResult};
     use alloc::boxed::Box;
+    use alloc::vec;
     use async_trait::async_trait;
     use caliptra_mcu_libapi_caliptra::crypto::asym::{AsymAlgo, ECC_P384_SIGNATURE_SIZE};
     use caliptra_mcu_libapi_caliptra::crypto::hash::SHA384_HASH_SIZE;
@@ -488,11 +494,37 @@ mod tests {
         }
     }
 
+    /// Test buffer provider that owns a leaked buffer.
+    /// Acquire always returns the buffer; release is a no-op (test only).
+    struct TestBufProvider {
+        capacity: usize,
+    }
+
+    impl TestBufProvider {
+        fn new(capacity: usize) -> Self {
+            Self { capacity }
+        }
+    }
+
+    impl crate::chunk_ctx::LargeMsgBufProvider for TestBufProvider {
+        fn acquire(&self) -> Option<&'static mut [u8]> {
+            // In tests, just leak a fresh buffer each time
+            let buf = vec![0u8; self.capacity].into_boxed_slice();
+            Some(Box::leak(buf))
+        }
+        fn release(&self, _buf: &'static mut [u8]) {
+            // Leak in tests — no-op
+        }
+        fn capacity(&self) -> usize {
+            self.capacity
+        }
+    }
+
     fn test_context<'a>(
         transport: &'a mut TestTransport,
         cert_store: &'a TestCertStore,
         measurements: &'a mut TestMeasurements,
-        large_msg_buf: &'a mut [u8],
+        buf_provider: &'a TestBufProvider,
     ) -> SpdmContext<'a> {
         let mut flags = CapabilityFlags::default();
         flags.set_chunk_cap(1);
@@ -512,7 +544,7 @@ mod tests {
             cert_store,
             crate::measurements::SpdmMeasurements::new(&[], measurements),
             None,
-            large_msg_buf,
+            buf_provider,
         )
         .expect("test context should be valid");
         ctx.state
@@ -567,13 +599,18 @@ mod tests {
         let mut transport = TestTransport;
         let cert_store = TestCertStore;
         let mut measurements = TestMeasurements;
-        let mut large_msg_buf = [0u8; 2048];
+        let buf_provider = TestBufProvider::new(2048);
         let mut ctx = test_context(
             &mut transport,
             &cert_store,
             &mut measurements,
-            &mut large_msg_buf,
+            &buf_provider,
         );
+
+        // Acquire the shared buffer (as handle_chunk_send would do)
+        ctx.large_msg_ctx
+            .acquire_buf()
+            .expect("buffer should be available");
 
         let first_chunk = [0xAA; 30];
         let mut first_storage = [0u8; 96];
@@ -617,13 +654,18 @@ mod tests {
         let mut transport = TestTransport;
         let cert_store = TestCertStore;
         let mut measurements = TestMeasurements;
-        let mut large_msg_buf = [0u8; 2048];
+        let buf_provider = TestBufProvider::new(2048);
         let mut ctx = test_context(
             &mut transport,
             &cert_store,
             &mut measurements,
-            &mut large_msg_buf,
+            &buf_provider,
         );
+
+        // Acquire the shared buffer (as handle_chunk_send would do)
+        ctx.large_msg_ctx
+            .acquire_buf()
+            .expect("buffer should be available");
 
         let first_chunk = [0xAA; 30];
         let mut first_storage = [0u8; 96];
@@ -659,12 +701,12 @@ mod tests {
         let mut transport = TestTransport;
         let cert_store = TestCertStore;
         let mut measurements = TestMeasurements;
-        let mut large_msg_buf = [0u8; 2048];
+        let buf_provider = TestBufProvider::new(2048);
         let mut ctx = test_context(
             &mut transport,
             &cert_store,
             &mut measurements,
-            &mut large_msg_buf,
+            &buf_provider,
         );
 
         let first_chunk = [0xAA; 30];
@@ -692,12 +734,12 @@ mod tests {
         let mut transport = TestTransport;
         let cert_store = TestCertStore;
         let mut measurements = TestMeasurements;
-        let mut large_msg_buf = [0u8; 2048];
+        let buf_provider = TestBufProvider::new(2048);
         let mut ctx = test_context(
             &mut transport,
             &cert_store,
             &mut measurements,
-            &mut large_msg_buf,
+            &buf_provider,
         );
 
         let first_chunk = [0xAA; 30];
@@ -734,12 +776,12 @@ mod tests {
         let mut transport = TestTransport;
         let cert_store = TestCertStore;
         let mut measurements = TestMeasurements;
-        let mut large_msg_buf = [0u8; 2048];
+        let buf_provider = TestBufProvider::new(2048);
         let mut ctx = test_context(
             &mut transport,
             &cert_store,
             &mut measurements,
-            &mut large_msg_buf,
+            &buf_provider,
         );
         let mut storage = [0u8; 64];
         let mut msg = MessageBuf::new(&mut storage);

--- a/runtime/userspace/api/spdm-lib/src/context.rs
+++ b/runtime/userspace/api/spdm-lib/src/context.rs
@@ -1,7 +1,7 @@
 // Licensed under the Apache-2.0 license
 
 use crate::cert_store::*;
-use crate::chunk_ctx::LargeMessageCtx;
+use crate::chunk_ctx::{LargeMessageCtx, LargeMsgBufProvider};
 use crate::codec::{encode_u8_slice, Codec, MessageBuf};
 use crate::commands::error_rsp::{encode_error_response, ErrorCode};
 use crate::commands::{
@@ -54,7 +54,7 @@ impl<'a> SpdmContext<'a> {
         device_certs_store: &'a dyn SpdmCertStore,
         measurements: SpdmMeasurements<'a>,
         vdm_handlers: Option<&'a mut [&'a mut dyn VdmHandler]>,
-        large_msg_buf: &'a mut [u8],
+        large_msg_buf_provider: &'a dyn LargeMsgBufProvider,
     ) -> SpdmResult<Self> {
         validate_supported_versions(supported_versions)?;
 
@@ -70,7 +70,7 @@ impl<'a> SpdmContext<'a> {
             local_algorithms,
             device_certs_store,
             measurements,
-            large_msg_ctx: LargeMessageCtx::new(large_msg_buf),
+            large_msg_ctx: LargeMessageCtx::new(large_msg_buf_provider),
             session_mgr: SessionManager::new(),
             vdm_handlers,
         })
@@ -114,9 +114,14 @@ impl<'a> SpdmContext<'a> {
                         .await
                         .inspect_err(|_| {})?;
                 }
+                // Release buffer on error if no chunking is in progress
+                self.large_msg_ctx.release_buf();
                 Err(SpdmError::Command(command_error))?;
             }
         }
+
+        // Release the shared buffer if no multi-message chunking is in progress
+        self.large_msg_ctx.release_buf();
 
         Ok(())
     }
@@ -193,7 +198,7 @@ impl<'a> SpdmContext<'a> {
         &mut self,
         _req_msg_header: SpdmMsgHdr,
         _req_code: ReqRespCode,
-        _req: &mut MessageBuf<'a>,
+        _req: &mut MessageBuf<'_>,
         rsp: &mut MessageBuf<'a>,
     ) -> CommandResult<()> {
         // No commands currently support large-request handling.
@@ -205,7 +210,7 @@ impl<'a> SpdmContext<'a> {
 
     fn decode_and_validate_request(
         &mut self,
-        req: &mut MessageBuf<'a>,
+        req: &mut MessageBuf<'_>,
     ) -> CommandResult<(SpdmMsgHdr, ReqRespCode)> {
         let req_msg_header: SpdmMsgHdr =
             SpdmMsgHdr::decode(req).map_err(|e| (false, CommandError::Codec(e)))?;
@@ -237,6 +242,21 @@ impl<'a> SpdmContext<'a> {
         req_code: ReqRespCode,
         req: &mut MessageBuf<'a>,
     ) -> CommandResult<()> {
+        // Acquire the shared large message buffer for commands that may need it
+        // (large responses or chunk operations). The buffer is released after
+        // the response is fully sent (in process_message) if no chunking is active.
+        match req_code {
+            ReqRespCode::GetCertificate
+            | ReqRespCode::GetMeasurements
+            | ReqRespCode::ChunkGet
+            | ReqRespCode::VendorDefinedRequest => {
+                self.large_msg_ctx
+                    .acquire_buf()
+                    .map_err(|_| self.generate_error_response(req, ErrorCode::Busy, 0, None))?;
+            }
+            _ => {}
+        }
+
         match req_code {
             ReqRespCode::GetVersion => {
                 version_rsp::handle_get_version(self, req_msg_header, req).await?
@@ -554,7 +574,7 @@ impl<'a> SpdmContext<'a> {
     fn validate_request_in_session_context(
         &self,
         req_code: ReqRespCode,
-        req: &mut MessageBuf<'a>,
+        req: &mut MessageBuf<'_>,
     ) -> CommandResult<()> {
         let Some(session_id) = self.session_mgr.active_session_id() else {
             return Ok(());


### PR DESCRIPTION
Replace per-task inline buffer with a shared static pool using the LargeMsgBufProvider trait. MCTP and DOE responders acquire the buffer on demand and release when idle. Saves ~4 KB .bss when both transports are enabled.