### PR TITLE
spdm-lib: Remove measurement staging buffer, use shared large msg buf

### DIFF
--- a/firmware-bundler/reference/emulator/user-app.toml
+++ b/firmware-bundler/reference/emulator/user-app.toml
@@ -33,6 +33,6 @@ stack = 0x0_7000
 
 [[app]]
 name = "user-app"
-stack = 0xa000
+stack = 0xae00
 grant_space = 0x4000
 

--- a/runtime/userspace/api/spdm-lib/src/commands/challenge_auth_rsp.rs
+++ b/runtime/userspace/api/spdm-lib/src/commands/challenge_auth_rsp.rs
@@ -219,8 +219,13 @@ pub(crate) async fn encode_measurement_summary_hash<'a>(
     rsp: &mut MessageBuf<'a>,
 ) -> CommandResult<usize> {
     let mut meas_summary_hash = [0u8; SHA384_HASH_SIZE];
+    // Borrow-split to access measurements and large_msg_ctx.buf simultaneously
     ctx.measurements
-        .measurement_summary_hash(meas_summary_hash_type, &mut meas_summary_hash)
+        .measurement_summary_hash(
+            meas_summary_hash_type,
+            &mut meas_summary_hash,
+            ctx.large_msg_ctx.buf,
+        )
         .await
         .map_err(|e| (false, CommandError::Measurement(e)))?;
 

--- a/runtime/userspace/api/spdm-lib/src/commands/measurements_rsp.rs
+++ b/runtime/userspace/api/spdm-lib/src/commands/measurements_rsp.rs
@@ -94,17 +94,23 @@ pub(crate) struct MeasurementsResponse {
 }
 
 impl MeasurementsResponse {
+    /// Encode the measurements response into `resp_buf`.
+    ///
+    /// `resp_buf` also serves as the measurement scratch buffer — measurement
+    /// data is fetched into it by `measurement_block_size`/`measurement_block`,
+    /// then the full response (header + record + trailer + signature) is
+    /// assembled in-place.
     pub async fn encode_response(
         &self,
         measurements: &mut SpdmMeasurements<'_>,
         shared_transcript: &mut Transcript,
         cert_store: &dyn SpdmCertStore,
         offset: usize,
-        chunk_buf: &mut [u8],
+        resp_buf: &mut [u8],
         mut session_info: Option<&mut SessionInfo>,
     ) -> CommandResult<usize> {
         // Calculate the size of the response
-        let response_size = self.response_size(measurements).await?;
+        let response_size = self.response_size(measurements, resp_buf).await?;
 
         // Check if the offset is valid
         if offset >= response_size {
@@ -112,12 +118,12 @@ impl MeasurementsResponse {
         }
 
         // Calculate the size of the chunk to return
-        let mut rem_len = (response_size - offset).min(chunk_buf.len());
+        let mut rem_len = (response_size - offset).min(resp_buf.len());
 
         let raw_bitstream_requested = self.req_attr.raw_bitstream_requested() == 1;
 
         let measurement_record_len = measurements
-            .measurement_block_size(self.meas_op, raw_bitstream_requested)
+            .measurement_block_size(self.meas_op, raw_bitstream_requested, resp_buf)
             .await
             .map_err(|e| (false, CommandError::Measurement(e)))?;
 
@@ -147,26 +153,20 @@ impl MeasurementsResponse {
             let start = offset;
             let end = (RESPONSE_FIXED_FIELDS_SIZE).min(start + rem_len);
             let copy_len = end - start;
-            chunk_buf[copied..copied + copy_len].copy_from_slice(&fixed_fields[start..end]);
+            resp_buf[copied..copied + copy_len].copy_from_slice(&fixed_fields[start..end]);
             copied += copy_len;
             rem_len -= copy_len;
         }
 
-        // 2. Copy from the measurement record
+        // 2. Measurement record data is at resp_buf[RESPONSE_FIXED_FIELDS_SIZE..]
+        // (fetched there by response_size/measurement_block_size).
         if rem_len > 0 && offset + copied < record_end {
             let meas_block_offset = (offset + copied).saturating_sub(record_start);
             let bytes_to_copy = (measurement_record_len - meas_block_offset).min(rem_len);
-            let bytes_filled = measurements
-                .measurement_block(
-                    self.meas_op,
-                    raw_bitstream_requested,
-                    meas_block_offset,
-                    &mut chunk_buf[copied..copied + bytes_to_copy],
-                )
-                .await
-                .map_err(|e| (false, CommandError::Measurement(e)))?;
-            copied += bytes_filled;
-            rem_len -= bytes_filled;
+            let src_offset = RESPONSE_FIXED_FIELDS_SIZE + meas_block_offset;
+            resp_buf.copy_within(src_offset..src_offset + bytes_to_copy, copied);
+            copied += bytes_to_copy;
+            rem_len -= bytes_to_copy;
         }
 
         // 3. Copy from the variable/trailer fields
@@ -177,7 +177,7 @@ impl MeasurementsResponse {
             let trailer_offset = (offset + copied) - trailer_start;
             let end = (trailer_len).min(trailer_offset + rem_len);
             let copy_len = end - trailer_offset;
-            chunk_buf[copied..copied + copy_len]
+            resp_buf[copied..copied + copy_len]
                 .copy_from_slice(&variable_fields[trailer_offset..end]);
             copied += copy_len;
             rem_len -= copy_len;
@@ -187,7 +187,7 @@ impl MeasurementsResponse {
             .append(
                 TranscriptContext::L1,
                 session_info.as_deref_mut(),
-                &chunk_buf[..copied],
+                &resp_buf[..copied],
             )
             .await
             .map_err(|e| (false, CommandError::Transcript(e)))?;
@@ -205,7 +205,7 @@ impl MeasurementsResponse {
 
             let sig_offset = (offset + copied) - signature_start;
             let copy_len = (ECC_P384_SIGNATURE_SIZE - sig_offset).min(rem_len);
-            chunk_buf[copied..copied + copy_len]
+            resp_buf[copied..copied + copy_len]
                 .copy_from_slice(&signature[sig_offset..sig_offset + copy_len]);
             copied += copy_len;
         }
@@ -215,7 +215,7 @@ impl MeasurementsResponse {
 
     async fn response_fixed_fields(
         &self,
-        measurements: &mut SpdmMeasurements<'_>,
+        measurements: &SpdmMeasurements<'_>,
     ) -> CommandResult<[u8; RESPONSE_FIXED_FIELDS_SIZE]> {
         let mut fixed_rsp_fields = [0u8; RESPONSE_FIXED_FIELDS_SIZE];
         let mut fixed_rsp_buf = MessageBuf::new(&mut fixed_rsp_fields);
@@ -228,12 +228,10 @@ impl MeasurementsResponse {
     async fn encode_response_fixed_fields(
         &self,
         buf: &mut MessageBuf<'_>,
-        measurements: &mut SpdmMeasurements<'_>,
+        measurements: &SpdmMeasurements<'_>,
     ) -> CommandResult<usize> {
-        let measurement_record_size = measurements
-            .measurement_block_size(self.meas_op, self.req_attr.raw_bitstream_requested() == 1)
-            .await
-            .map_err(|e| (false, CommandError::Measurement(e)))?;
+        // Measurement data must already be fetched before calling this.
+        let measurement_record_size = measurements.measurement_record_len();
         let total_measurement_count = measurements.total_measurement_count() as u8;
 
         let (total_meas_indices, num_of_meas_blocks_in_record, meas_record_len) = match self.meas_op
@@ -386,14 +384,18 @@ impl MeasurementsResponse {
         Ok(signature.len())
     }
 
-    async fn response_size(&self, measurements: &mut SpdmMeasurements<'_>) -> CommandResult<usize> {
+    async fn response_size(
+        &self,
+        measurements: &mut SpdmMeasurements<'_>,
+        meas_buf: &mut [u8],
+    ) -> CommandResult<usize> {
         // Calculate the size of the response based on the request attributes
         let mut rsp_size = RESPONSE_FIXED_FIELDS_SIZE;
 
         if self.meas_op > 0 {
             // return the size of a measurement block or all measurement blocks
             rsp_size += measurements
-                .measurement_block_size(self.meas_op, false)
+                .measurement_block_size(self.meas_op, false, meas_buf)
                 .await
                 .map_err(|e| (false, CommandError::Measurement(e)))?;
         };
@@ -491,7 +493,11 @@ pub(crate) async fn generate_measurements_response<'a>(
     rsp_ctx: MeasurementsResponse,
     rsp: &mut MessageBuf<'a>,
 ) -> CommandResult<()> {
-    let rsp_len = match rsp_ctx.response_size(&mut ctx.measurements).await {
+    // Fetch measurement data at RESPONSE_FIXED_FIELDS_SIZE offset so it's
+    // already at its final position in the response layout:
+    //   [header (fixed fields) | measurement record | trailer | signature]
+    let meas_buf = &mut ctx.large_msg_ctx.buf[RESPONSE_FIXED_FIELDS_SIZE..];
+    let rsp_len = match rsp_ctx.response_size(&mut ctx.measurements, meas_buf).await {
         Ok(len) => len,
         Err((_, CommandError::Measurement(MeasurementsError::InvalidIndex))) => {
             Err(ctx.generate_error_response(rsp, ErrorCode::InvalidRequest, 0, None))?
@@ -500,13 +506,46 @@ pub(crate) async fn generate_measurements_response<'a>(
     };
 
     if rsp_len > ctx.min_data_transfer_size() {
-        // Check buffer capacity before acquiring mutable borrows.
+        // Check buffer capacity.
         if rsp_len > ctx.large_msg_ctx.buf.len() {
             Err(ctx.generate_error_response(rsp, ErrorCode::ResponseTooLarge, 0, None))?;
         }
 
-        // Pre-serialize the full response into the shared buffer.
-        // Use borrow splitting to access disjoint fields of ctx simultaneously.
+        let session_info = match ctx.session_mgr.active_session_id() {
+            Some(session_id) => match ctx.session_mgr.session_info_mut(session_id) {
+                Ok(info) => Some(info),
+                Err(e) => Err((false, CommandError::Session(e)))?,
+            },
+            None => None,
+        };
+
+        // For large responses, the measurement data is already in large_msg_ctx.buf
+        // from the response_size call above. encode_response serializes the full
+        // response (header + measurement record + trailer) into the same buffer.
+        let buf = &mut ctx.large_msg_ctx.buf[..rsp_len];
+        let payload_len = rsp_ctx
+            .encode_response(
+                &mut ctx.measurements,
+                &mut ctx.shared_transcript,
+                ctx.device_certs_store,
+                0,
+                buf,
+                session_info,
+            )
+            .await?;
+
+        let handle = ctx
+            .large_msg_ctx
+            .init_buffered_response(payload_len)
+            .map_err(|e| (false, CommandError::Chunk(e)))?;
+        Err(ctx.generate_error_response(rsp, ErrorCode::LargeResponse, 0, Some(&[handle])))?
+    } else {
+        // For small responses, encode into large_msg_ctx.buf (measurement data is
+        // already there from response_size), then copy the result to rsp.
+        if rsp_len > ctx.large_msg_ctx.buf.len() {
+            Err(ctx.generate_error_response(rsp, ErrorCode::ResponseTooLarge, 0, None))?;
+        }
+
         let session_info = match ctx.session_mgr.active_session_id() {
             Some(session_id) => match ctx.session_mgr.session_info_mut(session_id) {
                 Ok(info) => Some(info),
@@ -526,44 +565,19 @@ pub(crate) async fn generate_measurements_response<'a>(
                 session_info,
             )
             .await?;
-
-        let handle = ctx
-            .large_msg_ctx
-            .init_buffered_response(payload_len)
-            .map_err(|e| (false, CommandError::Chunk(e)))?;
-        Err(ctx.generate_error_response(rsp, ErrorCode::LargeResponse, 0, Some(&[handle])))?
-    } else {
-        let session_info = match ctx.session_mgr.active_session_id() {
-            Some(session_id) => match ctx.session_mgr.session_info_mut(session_id) {
-                Ok(info) => Some(info),
-                Err(e) => Err((false, CommandError::Session(e)))?,
-            },
-            None => None,
-        };
-
-        // If the response fits in a single message, prepare it directly
-        // Encode the response fixed fields
-        rsp.put_data(rsp_len)
-            .map_err(|e| (false, CommandError::Codec(e)))?;
-        let rsp_buf = rsp
-            .data_mut(rsp_len)
-            .map_err(|e| (false, CommandError::Codec(e)))?;
-        let payload_len = rsp_ctx
-            .encode_response(
-                &mut ctx.measurements,
-                &mut ctx.shared_transcript,
-                ctx.device_certs_store,
-                0,
-                rsp_buf,
-                session_info,
-            )
-            .await?;
         if rsp_len != payload_len {
             Err((
                 false,
                 CommandError::Measurement(MeasurementsError::InvalidBuffer),
             ))?;
         }
+        // Copy the encoded response into the transport buffer
+        rsp.put_data(payload_len)
+            .map_err(|e| (false, CommandError::Codec(e)))?;
+        let rsp_buf = rsp
+            .data_mut(payload_len)
+            .map_err(|e| (false, CommandError::Codec(e)))?;
+        rsp_buf.copy_from_slice(&ctx.large_msg_ctx.buf[..payload_len]);
         rsp.pull_data(payload_len)
             .map_err(|e| (false, CommandError::Codec(e)))?;
 

--- a/runtime/userspace/api/spdm-lib/src/context.rs
+++ b/runtime/userspace/api/spdm-lib/src/context.rs
@@ -243,11 +243,14 @@ impl<'a> SpdmContext<'a> {
         req: &mut MessageBuf<'a>,
     ) -> CommandResult<()> {
         // Acquire the shared large message buffer for commands that may need it
-        // (large responses or chunk operations). The buffer is released after
-        // the response is fully sent (in process_message) if no chunking is active.
+        // (large responses, chunk operations, or measurement summary hashes).
+        // The buffer is released after the response is fully sent (in process_message)
+        // if no chunking is active.
         match req_code {
             ReqRespCode::GetCertificate
             | ReqRespCode::GetMeasurements
+            | ReqRespCode::Challenge
+            | ReqRespCode::KeyExchange
             | ReqRespCode::ChunkGet
             | ReqRespCode::VendorDefinedRequest => {
                 self.large_msg_ctx

--- a/runtime/userspace/api/spdm-lib/src/measurements.rs
+++ b/runtime/userspace/api/spdm-lib/src/measurements.rs
@@ -22,9 +22,6 @@ use caliptra_mcu_libapi_caliptra::error::CaliptraApiError;
 use caliptra_mcu_libapi_caliptra::mailbox_api::MAX_CRYPTO_MBOX_DATA_SIZE;
 use zerocopy::IntoBytes;
 
-// Needs to be adjusted based on actual max size of measurement record when PQC is added
-const MAX_MEASUREMENT_RECORD_BUF_SIZE: usize = 4096;
-
 #[derive(Debug, PartialEq)]
 pub enum MeasurementsError {
     InvalidIndex,
@@ -148,22 +145,11 @@ pub struct SpdmMeasurements<'a> {
     measurement_record: MeasurementRecord,
 }
 
+#[derive(Default)]
 struct MeasurementRecord {
-    data: [u8; MAX_MEASUREMENT_RECORD_BUF_SIZE], // Fixed-size array
     length: usize,
     current_index: u8,
     valid: bool,
-}
-
-impl Default for MeasurementRecord {
-    fn default() -> Self {
-        MeasurementRecord {
-            data: [0u8; MAX_MEASUREMENT_RECORD_BUF_SIZE],
-            length: 0,
-            current_index: 0,
-            valid: false,
-        }
-    }
 }
 
 impl MeasurementRecord {
@@ -171,15 +157,22 @@ impl MeasurementRecord {
         self.current_index == index && self.length > 0 && self.valid
     }
 
-    fn reset(&mut self) {
+    fn reset(&mut self, buf: &mut [u8]) {
         self.length = 0;
         self.current_index = 0;
         self.valid = false;
-        self.data.fill(0);
+        buf.fill(0);
+    }
+
+    fn invalidate(&mut self) {
+        self.length = 0;
+        self.current_index = 0;
+        self.valid = false;
     }
 
     fn add_measurement_block(
         &mut self,
+        buf: &mut [u8],
         index: u8,
         is_dgst: bool,
         value_type: MeasurementValueType,
@@ -187,14 +180,14 @@ impl MeasurementRecord {
     ) -> MeasurementsResult<()> {
         let offset = self.length;
         let needed = MEAS_BLOCK_METADATA_SIZE + value_len;
-        if self.data.len().saturating_sub(offset) < needed {
+        if buf.len().saturating_sub(offset) < needed {
             return Err(MeasurementsError::BufferTooSmall);
         }
 
         let metadata =
             DmtfMeasurementBlockMetadata::new(index, value_len as u16, is_dgst, value_type)
                 .ok_or(MeasurementsError::InvalidIndex)?;
-        self.data[offset..offset + MEAS_BLOCK_METADATA_SIZE].copy_from_slice(metadata.as_bytes());
+        buf[offset..offset + MEAS_BLOCK_METADATA_SIZE].copy_from_slice(metadata.as_bytes());
 
         self.length += needed;
 
@@ -233,7 +226,7 @@ impl<'a> SpdmMeasurements<'a> {
     /// Sets the nonce to be included in the measurement value.
     pub(crate) fn set_nonce(&mut self, nonce: [u8; SPDM_NONCE_LEN]) {
         self.nonce = Some(nonce);
-        self.measurement_record.valid = false;
+        self.measurement_record.invalidate();
     }
 
     pub(crate) fn set_spdm_version(&mut self, version: SpdmVersion) {
@@ -266,21 +259,19 @@ impl<'a> SpdmMeasurements<'a> {
         &mut self,
         index: u8,
         _raw_bit_stream: bool,
+        buf: &mut [u8],
     ) -> MeasurementsResult<usize> {
         if index == 0 {
             return Ok(0);
         }
 
         let len = if self.measurement_record.is_valid(index) {
-            // Special case for freeform manifest
             self.measurement_record.length
         } else {
             if index == 0xFF {
-                // Size of all measurement blocks
-                self.fetch_all_measurement_blocks().await?;
+                self.fetch_all_measurement_blocks(buf).await?;
             } else {
-                // Size of specific measurement block
-                self.fetch_measurement_block(index, false).await?;
+                self.fetch_measurement_block(index, false, buf).await?;
             }
             self.measurement_record.length
         };
@@ -288,46 +279,11 @@ impl<'a> SpdmMeasurements<'a> {
         Ok(len)
     }
 
-    /// Returns the measurement block for the given index.
-    ///
-    /// # Arguments
-    /// * `asym_algo` - The asymmetric algorithm negotiated.
-    /// * `index` - The index of the measurement block. Should be between 1 and 0xFE.
-    /// * `raw_bit_stream` - If true, returns the raw bit stream.
-    /// * `offset` - The offset to start reading from.
-    /// * `measurement_chunk` - The buffer to store the measurement block.
-    ///
-    /// # Returns
-    /// A result indicating success or failure.
-    pub(crate) async fn measurement_block(
-        &mut self,
-        index: u8,
-        _raw_bit_stream: bool,
-        offset: usize,
-        measurement_chunk: &mut [u8],
-    ) -> MeasurementsResult<usize> {
-        if !self.measurement_record.is_valid(index) {
-            if index == 0xFF {
-                // Fetch all measurement blocks
-                self.fetch_all_measurement_blocks().await?;
-            } else {
-                // Fetch specific measurement block
-                self.fetch_measurement_block(index, false).await?;
-            }
-        }
-
-        if offset >= self.measurement_record.length {
-            return Err(MeasurementsError::InvalidOffset);
-        }
-
-        let end = self
-            .measurement_record
-            .length
-            .min(offset + measurement_chunk.len());
-
-        let chunk_size = end - offset;
-        measurement_chunk[..chunk_size].copy_from_slice(&self.measurement_record.data[offset..end]);
-        Ok(chunk_size)
+    /// Returns the size of valid measurement data for the given index.
+    /// The data itself is already in the buffer passed to `measurement_block_size`
+    /// or `fetch_measurement_block`. The caller can read it directly from that buffer.
+    pub(crate) fn measurement_record_len(&self) -> usize {
+        self.measurement_record.length
     }
 
     /// Returns the measurement summary hash.
@@ -346,24 +302,25 @@ impl<'a> SpdmMeasurements<'a> {
         &mut self,
         measurement_summary_hash_type: u8,
         hash: &mut [u8; SHA384_HASH_SIZE],
+        buf: &mut [u8],
     ) -> MeasurementsResult<()> {
         if measurement_summary_hash_type != 1 && measurement_summary_hash_type != 0xFF {
             return Err(MeasurementsError::InvalidParam);
         }
 
         // Fetch the required measurement blocks freshly for summary hash
-        self.measurement_record.reset();
+        self.measurement_record.reset(buf);
 
         if measurement_summary_hash_type == 1 {
             // Only TCB measurements
             for measurement_info in self.meas_value_info.iter() {
                 if measurement_info.is_tcb {
-                    self.fetch_measurement_block(measurement_info.meas_index, true)
+                    self.fetch_measurement_block(measurement_info.meas_index, true, buf)
                         .await?;
                 }
             }
         } else {
-            self.fetch_all_measurement_blocks().await?;
+            self.fetch_all_measurement_blocks(buf).await?;
         }
 
         let mut hash_ctx = HashContext::new();
@@ -375,14 +332,11 @@ impl<'a> SpdmMeasurements<'a> {
 
             if offset == 0 {
                 hash_ctx
-                    .init(
-                        HashAlgoType::SHA384,
-                        Some(&self.measurement_record.data[..chunk_size]),
-                    )
+                    .init(HashAlgoType::SHA384, Some(&buf[..chunk_size]))
                     .await
                     .map_err(MeasurementsError::CaliptraApi)?;
             } else {
-                let chunk = &self.measurement_record.data[offset..offset + chunk_size];
+                let chunk = &buf[offset..offset + chunk_size];
                 hash_ctx
                     .update(chunk)
                     .await
@@ -406,7 +360,12 @@ impl<'a> SpdmMeasurements<'a> {
             .ok_or(MeasurementsError::InvalidIndex)
     }
 
-    async fn fetch_measurement_block(&mut self, index: u8, append: bool) -> MeasurementsResult<()> {
+    async fn fetch_measurement_block(
+        &mut self,
+        index: u8,
+        append: bool,
+        buf: &mut [u8],
+    ) -> MeasurementsResult<()> {
         let asym_algo = self
             .asym_algo
             .ok_or(MeasurementsError::MissingParam("AsymAlgo"))?;
@@ -429,21 +388,16 @@ impl<'a> SpdmMeasurements<'a> {
         };
 
         if !append {
-            self.measurement_record.reset();
+            self.measurement_record.reset(buf);
         }
 
         let offset = self.measurement_record.length;
         let meas_value_offset = offset + MEAS_BLOCK_METADATA_SIZE;
-        let remaining = self
-            .measurement_record
-            .data
-            .len()
-            .saturating_sub(meas_value_offset);
+        let remaining = buf.len().saturating_sub(meas_value_offset);
         if remaining == 0 {
             Err(MeasurementsError::BufferTooSmall)?;
         }
-        let meas_value_slice =
-            &mut self.measurement_record.data[meas_value_offset..meas_value_offset + remaining];
+        let meas_value_slice = &mut buf[meas_value_offset..meas_value_offset + remaining];
 
         let meas_value_size = self
             .meas_value
@@ -454,16 +408,14 @@ impl<'a> SpdmMeasurements<'a> {
             Err(MeasurementsError::BufferTooSmall)?;
         }
 
-        // Add spdm measurement block metadata and update length.
         self.measurement_record.add_measurement_block(
+            buf,
             meas_info.meas_index,
             meas_info.is_dgst,
             meas_value_type,
             meas_value_size,
         )?;
 
-        // Set current_index/valid so is_valid() reflects the freshly filled record.
-        // - For single-block fetches (append == false) mark the record valid for that index so future calls can reuse.
         if !append {
             self.measurement_record.set_valid(meas_info.meas_index);
         }
@@ -471,10 +423,11 @@ impl<'a> SpdmMeasurements<'a> {
         Ok(())
     }
 
-    async fn fetch_all_measurement_blocks(&mut self) -> MeasurementsResult<()> {
-        self.measurement_record.reset();
+    async fn fetch_all_measurement_blocks(&mut self, buf: &mut [u8]) -> MeasurementsResult<()> {
+        self.measurement_record.reset(buf);
         for info in self.meas_value_info.iter() {
-            self.fetch_measurement_block(info.meas_index, true).await?;
+            self.fetch_measurement_block(info.meas_index, true, buf)
+                .await?;
         }
         self.measurement_record.set_valid(0xFF);
 


### PR DESCRIPTION
Remove the 4 KB MeasurementRecord::data inline buffer from SpdmContext. Measurements are now fetched directly into large_msg_ctx.buf, which is already acquired for GetMeasurements. Also acquire the buffer for Challenge and KeyExchange (measurement summary hash).

.bss savings: 4,072 B per responder task.
Increase user-app stack from 0xa000 to 0xae00, enabled by the savings.