### PR TITLE
rom: Remove dot blob debug output

### DIFF
--- a/rom/src/device_ownership_transfer.rs
+++ b/rom/src/device_ownership_transfer.rs
@@ -235,7 +235,6 @@ pub fn dot_flow(
         "[mcu-rom-dot] DOT raw blob: {}",
         romtime::HexBytes(blob.as_bytes())
     );
-    romtime::println!("[mcu-rom-dot] {:x?}", blob);
     env.mci
         .set_flow_checkpoint(McuRomBootStatus::DeviceOwnershipTransferStarted.into());
 


### PR DESCRIPTION
Remove the dot blob debug statement, saving ~3Kb in ROM imem.  The raw blob is still output and could be decoded, so information is not lost.