### PR TITLE
Add the support for MCU mailbox MLDSA sign/verify commands

### DIFF
--- a/common/mcu-mbox/src/messages.rs
+++ b/common/mcu-mbox/src/messages.rs
@@ -12,7 +12,8 @@ pub use caliptra_api::mailbox::{
     CmEcdhGenerateReq, CmEcdhGenerateResp, CmEcdsaPublicKeyReq, CmEcdsaPublicKeyResp,
     CmEcdsaSignReq, CmEcdsaSignResp, CmEcdsaVerifyReq, CmHkdfExpandReq, CmHkdfExpandResp,
     CmHkdfExtractReq, CmHkdfExtractResp, CmHmacKdfCounterReq, CmHmacKdfCounterResp, CmHmacReq,
-    CmHmacResp, CmImportReq, CmImportResp, CmKeyUsage, CmRandomGenerateReq, CmRandomGenerateResp,
+    CmHmacResp, CmImportReq, CmImportResp, CmKeyUsage, CmMldsaPublicKeyReq, CmMldsaPublicKeyResp,
+    CmMldsaSignReq, CmMldsaSignResp, CmMldsaVerifyReq, CmRandomGenerateReq, CmRandomGenerateResp,
     CmRandomStirReq, CmShaFinalReq, CmShaFinalResp, CmShaInitReq, CmShaInitResp, CmShaUpdateReq,
     CmStatusResp, Cmk, MailboxReqHeader, MailboxRespHeader, MailboxRespHeaderVarSize,
     ProductionAuthDebugUnlockChallenge, ProductionAuthDebugUnlockReq,
@@ -111,6 +112,11 @@ impl CommandId {
     pub const MC_ECDSA_CMK_SIGN: Self = Self(0x4D43_4553); // "MCES"
     pub const MC_ECDSA_CMK_VERIFY: Self = Self(0x4D43_4556); // "MCEV"
 
+    // MLDSA CMK commands (MML prefix avoids collision with MC_FUSE_INCREASE_CALIPTRA_MIN_SVN "MCMS")
+    pub const MC_MLDSA_CMK_PUBLIC_KEY: Self = Self(0x4D4D_4C50); // "MMLP"
+    pub const MC_MLDSA_CMK_SIGN: Self = Self(0x4D4D_4C53); // "MMLS"
+    pub const MC_MLDSA_CMK_VERIFY: Self = Self(0x4D4D_4C56); // "MMLV"
+
     // Debug Unlock commands
     pub const MC_PROD_DEBUG_UNLOCK_REQ: Self = Self(0x4D50_5552); // "MPUR"
     pub const MC_PROD_DEBUG_UNLOCK_TOKEN: Self = Self(0x4D50_5554); // "MPUT"
@@ -184,6 +190,9 @@ pub enum McuMailboxReq {
     EcdsaCmkPublicKey(McuEcdsaCmkPublicKeyReq),
     EcdsaCmkSign(McuEcdsaCmkSignReq),
     EcdsaCmkVerify(McuEcdsaCmkVerifyReq),
+    MldsaCmkPublicKey(McuMldsaCmkPublicKeyReq),
+    MldsaCmkSign(McuMldsaCmkSignReq),
+    MldsaCmkVerify(McuMldsaCmkVerifyReq),
     // Debug Unlock
     ProdDebugUnlockReq(McuProdDebugUnlockReqReq),
     ProdDebugUnlockToken(McuProdDebugUnlockTokenReq),
@@ -241,6 +250,9 @@ impl McuMailboxReq {
             McuMailboxReq::EcdsaCmkPublicKey(req) => Ok(req.as_bytes()),
             McuMailboxReq::EcdsaCmkSign(req) => req.as_bytes_partial(),
             McuMailboxReq::EcdsaCmkVerify(req) => req.as_bytes_partial(),
+            McuMailboxReq::MldsaCmkPublicKey(req) => Ok(req.as_bytes()),
+            McuMailboxReq::MldsaCmkSign(req) => req.as_bytes_partial(),
+            McuMailboxReq::MldsaCmkVerify(req) => req.as_bytes_partial(),
             McuMailboxReq::ProdDebugUnlockReq(req) => Ok(req.as_bytes()),
             McuMailboxReq::ProdDebugUnlockToken(req) => Ok(req.as_bytes()),
             McuMailboxReq::FuseRead(req) => Ok(req.as_bytes()),
@@ -295,6 +307,9 @@ impl McuMailboxReq {
             McuMailboxReq::EcdsaCmkPublicKey(req) => Ok(req.as_mut_bytes()),
             McuMailboxReq::EcdsaCmkSign(req) => req.as_bytes_partial_mut(),
             McuMailboxReq::EcdsaCmkVerify(req) => req.as_bytes_partial_mut(),
+            McuMailboxReq::MldsaCmkPublicKey(req) => Ok(req.as_mut_bytes()),
+            McuMailboxReq::MldsaCmkSign(req) => req.as_bytes_partial_mut(),
+            McuMailboxReq::MldsaCmkVerify(req) => req.as_bytes_partial_mut(),
             McuMailboxReq::ProdDebugUnlockReq(req) => Ok(req.as_mut_bytes()),
             McuMailboxReq::ProdDebugUnlockToken(req) => Ok(req.as_mut_bytes()),
             McuMailboxReq::FuseRead(req) => Ok(req.as_mut_bytes()),
@@ -349,6 +364,9 @@ impl McuMailboxReq {
             McuMailboxReq::EcdsaCmkPublicKey(_) => CommandId::MC_ECDSA_CMK_PUBLIC_KEY,
             McuMailboxReq::EcdsaCmkSign(_) => CommandId::MC_ECDSA_CMK_SIGN,
             McuMailboxReq::EcdsaCmkVerify(_) => CommandId::MC_ECDSA_CMK_VERIFY,
+            McuMailboxReq::MldsaCmkPublicKey(_) => CommandId::MC_MLDSA_CMK_PUBLIC_KEY,
+            McuMailboxReq::MldsaCmkSign(_) => CommandId::MC_MLDSA_CMK_SIGN,
+            McuMailboxReq::MldsaCmkVerify(_) => CommandId::MC_MLDSA_CMK_VERIFY,
             McuMailboxReq::ProdDebugUnlockReq(_) => CommandId::MC_PROD_DEBUG_UNLOCK_REQ,
             McuMailboxReq::ProdDebugUnlockToken(_) => CommandId::MC_PROD_DEBUG_UNLOCK_TOKEN,
             McuMailboxReq::FuseRead(_) => CommandId::MC_FUSE_READ,
@@ -428,6 +446,9 @@ pub enum McuMailboxResp {
     EcdsaCmkPublicKey(McuEcdsaCmkPublicKeyResp),
     EcdsaCmkSign(McuEcdsaCmkSignResp),
     EcdsaCmkVerify(McuEcdsaCmkVerifyResp),
+    MldsaCmkPublicKey(McuMldsaCmkPublicKeyResp),
+    MldsaCmkSign(McuMldsaCmkSignResp),
+    MldsaCmkVerify(McuMldsaCmkVerifyResp),
     // Debug Unlock
     ProdDebugUnlockReq(McuProdDebugUnlockReqResp),
     ProdDebugUnlockToken(McuProdDebugUnlockTokenResp),
@@ -544,6 +565,9 @@ impl McuMailboxResp {
             McuMailboxResp::EcdsaCmkPublicKey(resp) => Ok(resp.as_bytes()),
             McuMailboxResp::EcdsaCmkSign(resp) => Ok(resp.as_bytes()),
             McuMailboxResp::EcdsaCmkVerify(resp) => Ok(resp.as_bytes()),
+            McuMailboxResp::MldsaCmkPublicKey(resp) => Ok(resp.as_bytes()),
+            McuMailboxResp::MldsaCmkSign(resp) => Ok(resp.as_bytes()),
+            McuMailboxResp::MldsaCmkVerify(resp) => Ok(resp.as_bytes()),
             McuMailboxResp::ProdDebugUnlockReq(resp) => Ok(resp.as_bytes()),
             McuMailboxResp::ProdDebugUnlockToken(resp) => Ok(resp.as_bytes()),
             McuMailboxResp::FuseRead(resp) => resp.as_bytes_partial(),
@@ -597,6 +621,9 @@ impl McuMailboxResp {
             McuMailboxResp::EcdsaCmkPublicKey(resp) => Ok(resp.as_mut_bytes()),
             McuMailboxResp::EcdsaCmkSign(resp) => Ok(resp.as_mut_bytes()),
             McuMailboxResp::EcdsaCmkVerify(resp) => Ok(resp.as_mut_bytes()),
+            McuMailboxResp::MldsaCmkPublicKey(resp) => Ok(resp.as_mut_bytes()),
+            McuMailboxResp::MldsaCmkSign(resp) => Ok(resp.as_mut_bytes()),
+            McuMailboxResp::MldsaCmkVerify(resp) => Ok(resp.as_mut_bytes()),
             McuMailboxResp::ProdDebugUnlockReq(resp) => Ok(resp.as_mut_bytes()),
             McuMailboxResp::ProdDebugUnlockToken(resp) => Ok(resp.as_mut_bytes()),
             McuMailboxResp::FuseRead(resp) => resp.as_bytes_partial_mut(),
@@ -1237,6 +1264,48 @@ impl_mcu_request_varsize!(McuEcdsaCmkVerifyReq, CmEcdsaVerifyReq);
 #[derive(Debug, Default, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
 pub struct McuEcdsaCmkVerifyResp(pub MailboxRespHeader);
 impl Response for McuEcdsaCmkVerifyResp {}
+
+// ---- MLDSA CMK wrappers ----
+#[repr(C)]
+#[derive(Debug, Default, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct McuMldsaCmkPublicKeyReq(pub CmMldsaPublicKeyReq);
+impl Request for McuMldsaCmkPublicKeyReq {
+    const ID: CommandId = CommandId::MC_MLDSA_CMK_PUBLIC_KEY;
+    type Resp = McuMldsaCmkPublicKeyResp;
+}
+
+#[repr(C)]
+#[derive(Debug, Default, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct McuMldsaCmkPublicKeyResp(pub CmMldsaPublicKeyResp);
+impl Response for McuMldsaCmkPublicKeyResp {}
+
+#[repr(C)]
+#[derive(Debug, Default, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct McuMldsaCmkSignReq(pub CmMldsaSignReq);
+impl Request for McuMldsaCmkSignReq {
+    const ID: CommandId = CommandId::MC_MLDSA_CMK_SIGN;
+    type Resp = McuMldsaCmkSignResp;
+}
+impl_mcu_request_varsize!(McuMldsaCmkSignReq, CmMldsaSignReq);
+
+#[repr(C)]
+#[derive(Debug, Default, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct McuMldsaCmkSignResp(pub CmMldsaSignResp);
+impl Response for McuMldsaCmkSignResp {}
+
+#[repr(C)]
+#[derive(Debug, Default, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct McuMldsaCmkVerifyReq(pub CmMldsaVerifyReq);
+impl Request for McuMldsaCmkVerifyReq {
+    const ID: CommandId = CommandId::MC_MLDSA_CMK_VERIFY;
+    type Resp = McuMldsaCmkVerifyResp;
+}
+impl_mcu_request_varsize!(McuMldsaCmkVerifyReq, CmMldsaVerifyReq);
+
+#[repr(C)]
+#[derive(Debug, Default, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct McuMldsaCmkVerifyResp(pub MailboxRespHeader);
+impl Response for McuMldsaCmkVerifyResp {}
 
 // ---- Debug Unlock ----
 

--- a/runtime/kernel/capsules/src/mcu_mbox.rs
+++ b/runtime/kernel/capsules/src/mcu_mbox.rs
@@ -30,9 +30,9 @@ mod upcall {
     pub const COUNT: u8 = 2;
 }
 
-// Adjust as needed - must be large enough for CmShaInitReq (4108 bytes = 1027 dwords)
+// Adjust as needed - must be large enough for CmMldsaVerifyReq (8740 bytes = 2185 dwords)
 // but small enough to fit in the Tock Grant per-process memory
-const MAX_DATA_SIZE_DWORDS: usize = 2048;
+const MAX_DATA_SIZE_DWORDS: usize = 2304;
 struct BufferedMessage {
     pub command: u32,
     pub data: [u32; MAX_DATA_SIZE_DWORDS],

--- a/runtime/userspace/api/mcu-mbox-lib/src/cmd_interface.rs
+++ b/runtime/userspace/api/mcu-mbox-lib/src/cmd_interface.rs
@@ -25,8 +25,9 @@ use caliptra_mcu_mbox_common::messages::{
     McuCmStatusReq, McuEcdhFinishReq, McuEcdhGenerateReq, McuEcdsaCmkPublicKeyReq,
     McuEcdsaCmkSignReq, McuEcdsaCmkVerifyReq, McuFeProgReq, McuFipsSelfTestGetResultsReq,
     McuFipsSelfTestStartReq, McuHkdfExpandReq, McuHkdfExtractReq, McuHmacKdfCounterReq, McuHmacReq,
-    McuProdDebugUnlockReqReq, McuProdDebugUnlockTokenReq, McuRandomGenerateReq, McuRandomStirReq,
-    McuResponseVarSize, McuShaFinalReq, McuShaInitReq, McuShaUpdateReq, ProvisionVendorPkHashReq,
+    McuMldsaCmkPublicKeyReq, McuMldsaCmkSignReq, McuMldsaCmkVerifyReq, McuProdDebugUnlockReqReq,
+    McuProdDebugUnlockTokenReq, McuRandomGenerateReq, McuRandomStirReq, McuResponseVarSize,
+    McuShaFinalReq, McuShaInitReq, McuShaUpdateReq, ProvisionVendorPkHashReq,
     ProvisionVendorPkHashResp, RevokeVendorPubKeyType, DEVICE_CAPS_SIZE, MAX_FW_VERSION_STR_LEN,
     MAX_RESP_DATA_SIZE,
 };
@@ -399,6 +400,31 @@ impl<'a> CmdInterface<'a> {
                 self.handle_crypto_passthrough::<McuEcdsaCmkVerifyReq>(
                     req,
                     CaliptraCommandId::CM_ECDSA_VERIFY.into(),
+                    resp_buf,
+                )
+                .await
+            }
+            // MLDSA CMK commands (passthrough to Caliptra mailbox)
+            CommandId::MC_MLDSA_CMK_PUBLIC_KEY => {
+                self.handle_crypto_passthrough::<McuMldsaCmkPublicKeyReq>(
+                    req,
+                    CaliptraCommandId::CM_MLDSA_PUBLIC_KEY.into(),
+                    resp_buf,
+                )
+                .await
+            }
+            CommandId::MC_MLDSA_CMK_SIGN => {
+                self.handle_crypto_passthrough::<McuMldsaCmkSignReq>(
+                    req,
+                    CaliptraCommandId::CM_MLDSA_SIGN.into(),
+                    resp_buf,
+                )
+                .await
+            }
+            CommandId::MC_MLDSA_CMK_VERIFY => {
+                self.handle_crypto_passthrough::<McuMldsaCmkVerifyReq>(
+                    req,
+                    CaliptraCommandId::CM_MLDSA_VERIFY.into(),
                     resp_buf,
                 )
                 .await

--- a/tests/integration/src/test_mcu_mbox.rs
+++ b/tests/integration/src/test_mcu_mbox.rs
@@ -19,10 +19,11 @@ pub mod test {
         CmAesMode, CmAesRespHeader, CmDeleteReq, CmEcdhFinishReq, CmEcdhGenerateReq,
         CmEcdhGenerateResp, CmEcdsaPublicKeyReq, CmEcdsaSignReq, CmEcdsaVerifyReq, CmHkdfExpandReq,
         CmHkdfExtractReq, CmHmacKdfCounterReq, CmHmacReq, CmImportReq, CmKeyUsage,
-        CmRandomGenerateReq, CmRandomStirReq, CmShaFinalReq, CmShaFinalResp, CmShaInitReq,
-        CmShaUpdateReq, Cmk, DeviceCapsReq, DeviceCapsResp, DeviceIdReq, DeviceIdResp,
-        DeviceInfoReq, DeviceInfoResp, FirmwareVersionReq, FirmwareVersionResp, MailboxReqHeader,
-        MailboxRespHeader, MailboxRespHeaderVarSize, McuAesDecryptInitReq, McuAesDecryptUpdateReq,
+        CmMldsaPublicKeyReq, CmMldsaSignReq, CmMldsaVerifyReq, CmRandomGenerateReq,
+        CmRandomStirReq, CmShaFinalReq, CmShaFinalResp, CmShaInitReq, CmShaUpdateReq, Cmk,
+        DeviceCapsReq, DeviceCapsResp, DeviceIdReq, DeviceIdResp, DeviceInfoReq, DeviceInfoResp,
+        FirmwareVersionReq, FirmwareVersionResp, MailboxReqHeader, MailboxRespHeader,
+        MailboxRespHeaderVarSize, McuAesDecryptInitReq, McuAesDecryptUpdateReq,
         McuAesEncryptInitReq, McuAesEncryptUpdateReq, McuAesGcmDecryptFinalReq,
         McuAesGcmDecryptInitReq, McuAesGcmDecryptUpdateReq, McuAesGcmEncryptFinalReq,
         McuAesGcmEncryptInitReq, McuAesGcmEncryptUpdateReq, McuCmDeleteReq, McuCmImportReq,
@@ -33,9 +34,11 @@ pub mod test {
         McuFipsSelfTestGetResultsReq, McuFipsSelfTestStartReq, McuFipsSelfTestStartResp,
         McuHkdfExpandReq, McuHkdfExpandResp, McuHkdfExtractReq, McuHkdfExtractResp,
         McuHmacKdfCounterReq, McuHmacKdfCounterResp, McuHmacReq, McuMailboxReq, McuMailboxResp,
-        McuProdDebugUnlockReqReq, McuProdDebugUnlockTokenReq, McuRandomGenerateReq,
-        McuRandomStirReq, McuShaFinalReq, McuShaFinalResp, McuShaInitReq, McuShaInitResp,
-        McuShaUpdateReq, ProductionAuthDebugUnlockChallenge, ProductionAuthDebugUnlockReq,
+        McuMldsaCmkPublicKeyReq, McuMldsaCmkPublicKeyResp, McuMldsaCmkSignReq, McuMldsaCmkSignResp,
+        McuMldsaCmkVerifyReq, McuMldsaCmkVerifyResp, McuProdDebugUnlockReqReq,
+        McuProdDebugUnlockTokenReq, McuRandomGenerateReq, McuRandomStirReq, McuShaFinalReq,
+        McuShaFinalResp, McuShaInitReq, McuShaInitResp, McuShaUpdateReq,
+        ProductionAuthDebugUnlockChallenge, ProductionAuthDebugUnlockReq,
         ProductionAuthDebugUnlockToken, CMB_AES_GCM_ENCRYPTED_CONTEXT_SIZE,
         CMB_ECDH_EXCHANGE_DATA_MAX_SIZE, DEVICE_CAPS_SIZE, MAX_CMB_DATA_SIZE,
     };
@@ -44,13 +47,15 @@ pub mod test {
         emulator_ticks_elapsed, get_emulator_ticks, sleep_emulator_ticks, wait_for_runtime_start,
         MCU_RUNNING,
     };
-    use fips204::traits::SerDes;
+    use fips204::ml_dsa_87;
+    use fips204::traits::Signer;
     use hkdf::Hkdf;
     use hmac::{Hmac, Mac};
     use p384::ecdsa::signature::hazmat::PrehashSigner;
     use p384::ecdsa::{Signature, SigningKey};
     use rand::prelude::*;
     use rand::rngs::StdRng;
+    use rand::{CryptoRng, RngCore};
     use random_port::PortPicker;
     use sha2::{Digest, Sha384, Sha512};
     use std::process::exit;
@@ -385,6 +390,7 @@ pub mod test {
                 self.add_aes_gcm_encrypt_decrypt_tests()?;
                 self.add_ecdh_tests()?;
                 self.add_ecdsa_tests()?;
+                self.add_mldsa_tests()?;
                 self.add_hmac_tests()?;
                 self.add_hmac_kdf_counter_tests()?;
                 self.add_hkdf_tests()?;
@@ -1920,6 +1926,207 @@ pub mod test {
             }
         }
 
+        /// Test MLDSA operations: public key extraction, sign, and verify.
+        /// Similar to ECDSA tests but using ML-DSA-87 (FIPS 204).
+        /// 1. Import an MLDSA key seed
+        /// 2. Get the public key and verify it matches the deterministic expected value
+        /// 3. Sign random messages via mailbox and compare against fips204 reference
+        /// 4. Verify via mailbox with correct message (should succeed)
+        /// 5. Verify via mailbox with modified message (should fail)
+        fn add_mldsa_tests(&mut self) -> Result<(), ()> {
+            println!("Running MLDSA tests");
+
+            // Import a 32-byte seed for MLDSA
+            let seed_bytes: [u8; 32] = [
+                0x63, 0x1a, 0xfc, 0x2a, 0x36, 0xa5, 0x7e, 0x1d, 0x09, 0x0d, 0xad, 0xc2, 0x79, 0x1d,
+                0x48, 0x6d, 0x72, 0xc6, 0x9a, 0x9a, 0xab, 0xf9, 0x79, 0x90, 0xc5, 0x73, 0x21, 0x48,
+                0x46, 0xfe, 0x5b, 0x64,
+            ];
+            let cmk = self.import_key(&seed_bytes, CmKeyUsage::Mldsa)?;
+            println!("  Imported MLDSA key");
+
+            // Generate private key using fips204 for comparison
+            let mut rng = SeedOnlyRng::new(seed_bytes);
+            let (_, privkey) = ml_dsa_87::try_keygen_with_rng(&mut rng).unwrap();
+
+            // Get public key
+            let pub_key = self.mldsa_public_key(&cmk)?;
+            println!("  Got public key: first 8 bytes={:02x?}", &pub_key[..8]);
+
+            // Expected public key first bytes (deterministic from the seed above)
+            let expected_first_bytes: [u8; 8] = [0x57, 0x34, 0x49, 0xae, 0x17, 0x72, 0x43, 0x0d];
+            assert_eq!(
+                &pub_key[..8],
+                &expected_first_bytes,
+                "Public key first bytes should match"
+            );
+
+            // Seed RNG for random test messages
+            let seed_rng_bytes = [1u8; 32];
+            let mut seeded_rng = StdRng::from_seed(seed_rng_bytes);
+
+            // Use fewer iterations than caliptra-sw due to larger signature sizes
+            for i in 0..5 {
+                // Generate random message length and data (smaller than MAX_CMB_DATA_SIZE)
+                let len = seeded_rng.gen_range(1..MAX_CMB_DATA_SIZE / 4);
+                let mut data = vec![0u8; len];
+                seeded_rng.fill_bytes(&mut data);
+
+                println!(
+                    "  Testing MLDSA sign/verify iteration {} with message length: {}",
+                    i, len
+                );
+
+                // Sign the message via mailbox
+                let signature = self.mldsa_sign(&cmk, &data)?;
+                println!("    Mailbox signed: first 8 bytes={:02x?}", &signature[..8]);
+
+                // Sign with fips204 to verify
+                let sign_seed = [0u8; 32];
+                let fips204_sig = privkey.try_sign_with_seed(&sign_seed, &data, &[]).unwrap();
+
+                // Verify signatures match between mailbox and fips204.
+                // Mailbox returns the full MLDSA-87 fixed-size buffer; fips204
+                // returns the canonical signature; the trailing buffer bytes
+                // must be zero-padded.
+                assert_eq!(
+                    signature.len(),
+                    fips204_sig.len() + 1,
+                    "MLDSA-87 mailbox signature length"
+                );
+                assert_eq!(
+                    &signature[..fips204_sig.len()],
+                    &fips204_sig[..],
+                    "Signature should match fips204"
+                );
+                assert_eq!(
+                    signature[fips204_sig.len()],
+                    0,
+                    "Trailing signature byte should be zero padding"
+                );
+                println!("    Signatures match between mailbox and fips204");
+
+                // Verify via mailbox with correct message (should succeed)
+                let verify_result = self.mldsa_verify(&cmk, &data, &signature)?;
+                assert!(
+                    verify_result,
+                    "Signature verification should succeed with correct message"
+                );
+                println!("    Mailbox verification with correct message succeeded");
+
+                // Verify with modified message (should fail)
+                let mut modified_data = data.clone();
+                let modify_idx = seeded_rng.gen_range(0..len);
+                modified_data[modify_idx] ^= seeded_rng.gen_range(1..=255u8);
+
+                let verify_fail_result = self.mldsa_verify(&cmk, &modified_data, &signature);
+                assert!(
+                    verify_fail_result.is_err(),
+                    "Signature verification should fail with modified message"
+                );
+                println!("    Mailbox verification with modified message failed as expected");
+            }
+
+            // Clean up
+            self.delete_key(&cmk)?;
+            println!("MLDSA tests passed");
+            Ok(())
+        }
+
+        /// Get the public key for an MLDSA CMK. Returns the raw bytes.
+        fn mldsa_public_key(&mut self, cmk: &Cmk) -> Result<Vec<u8>, ()> {
+            let mut req =
+                McuMailboxReq::MldsaCmkPublicKey(McuMldsaCmkPublicKeyReq(CmMldsaPublicKeyReq {
+                    hdr: MailboxReqHeader::default(),
+                    cmk: cmk.clone(),
+                }));
+            req.populate_chksum().unwrap();
+
+            let resp = self
+                .process_message(req.cmd_code().0, req.as_bytes().unwrap())
+                .map_err(|_| ())?;
+
+            let pub_key_resp =
+                McuMldsaCmkPublicKeyResp::read_from_bytes(&resp.data).map_err(|_| ())?;
+
+            assert_eq!(
+                pub_key_resp.0.hdr.fips_status,
+                MailboxRespHeader::FIPS_STATUS_APPROVED,
+                "FIPS status should be approved"
+            );
+
+            Ok(pub_key_resp.0.public_key.to_vec())
+        }
+
+        /// Sign a message using an MLDSA CMK. Returns the raw signature bytes.
+        fn mldsa_sign(&mut self, cmk: &Cmk, message: &[u8]) -> Result<Vec<u8>, ()> {
+            let mut sign_req = CmMldsaSignReq {
+                hdr: MailboxReqHeader::default(),
+                cmk: cmk.clone(),
+                message_size: message.len() as u32,
+                ..Default::default()
+            };
+            sign_req.message[..message.len()].copy_from_slice(message);
+
+            let mut req = McuMailboxReq::MldsaCmkSign(McuMldsaCmkSignReq(sign_req));
+            req.populate_chksum().unwrap();
+
+            let resp = self
+                .process_message(req.cmd_code().0, req.as_bytes().unwrap())
+                .map_err(|_| ())?;
+
+            let sign_resp = McuMldsaCmkSignResp::read_from_bytes(&resp.data).map_err(|_| ())?;
+
+            assert_eq!(
+                sign_resp.0.hdr.fips_status,
+                MailboxRespHeader::FIPS_STATUS_APPROVED,
+                "FIPS status should be approved"
+            );
+
+            Ok(sign_resp.0.signature.to_vec())
+        }
+
+        /// Verify a signature using an MLDSA CMK.
+        fn mldsa_verify(
+            &mut self,
+            cmk: &Cmk,
+            message: &[u8],
+            signature: &[u8],
+        ) -> Result<bool, ()> {
+            let mut verify_req = CmMldsaVerifyReq {
+                hdr: MailboxReqHeader::default(),
+                cmk: cmk.clone(),
+                message_size: message.len() as u32,
+                ..Default::default()
+            };
+            assert_eq!(
+                signature.len(),
+                verify_req.signature.len(),
+                "MLDSA signature length mismatch"
+            );
+            verify_req.signature.copy_from_slice(signature);
+            verify_req.message[..message.len()].copy_from_slice(message);
+
+            let mut req = McuMailboxReq::MldsaCmkVerify(McuMldsaCmkVerifyReq(verify_req));
+            req.populate_chksum().unwrap();
+
+            let result = self.process_message(req.cmd_code().0, req.as_bytes().unwrap());
+
+            match result {
+                Ok(resp) => {
+                    let verify_resp =
+                        McuMldsaCmkVerifyResp::read_from_bytes(&resp.data).map_err(|_| ())?;
+                    assert_eq!(
+                        verify_resp.0.fips_status,
+                        MailboxRespHeader::FIPS_STATUS_APPROVED,
+                        "FIPS status should be approved"
+                    );
+                    Ok(true)
+                }
+                Err(_) => Err(()), // Verification failed (signature mismatch)
+            }
+        }
+
         /// Test FIPS self-test start and get results commands.
         /// This test exercises the FIPS KAT (Known Answer Test) passthrough functionality.
         /// Follows the polling pattern from caliptra-sw's exec_cmd_self_test_get_results.
@@ -2727,4 +2934,47 @@ pub mod test {
             _ => panic!("Invalid hash algorithm"),
         }
     }
+
+    /// Deterministic RNG that hands `fips204` exactly the supplied 32-byte
+    /// seed in a single `fill_bytes` call. This is the contract
+    /// `ml_dsa_87::try_keygen_with_rng` relies on; do not generalize it.
+    struct SeedOnlyRng {
+        seed: [u8; 32],
+        called: bool,
+    }
+
+    impl SeedOnlyRng {
+        fn new(seed: [u8; 32]) -> Self {
+            Self {
+                seed,
+                called: false,
+            }
+        }
+    }
+
+    impl RngCore for SeedOnlyRng {
+        fn next_u32(&mut self) -> u32 {
+            unimplemented!()
+        }
+
+        fn next_u64(&mut self) -> u64 {
+            unimplemented!()
+        }
+
+        fn fill_bytes(&mut self, out: &mut [u8]) {
+            if self.called {
+                panic!("Can only call fill_bytes once");
+            }
+            assert_eq!(out.len(), 32);
+            out.copy_from_slice(&self.seed[..32]);
+            self.called = true;
+        }
+
+        fn try_fill_bytes(&mut self, out: &mut [u8]) -> Result<(), rand::Error> {
+            self.fill_bytes(out);
+            Ok(())
+        }
+    }
+
+    impl CryptoRng for SeedOnlyRng {}
 }


### PR DESCRIPTION
E2E support for three MCU mailbox crypto commands. Validated on FPGA. 
- MC_MLDSA_CMK_PUBLIC_KEY (0x4D4D_4C50, "MMLP")
- MC_MLDSA_CMK_SIGN      (0x4D4D_4C53, "MMLS")
- MC_MLDSA_CMK_VERIFY    (0x4D4D_4C56, "MMLV")
