### PR TITLE
spdm: Convert VCA-only command handlers to sync

### DIFF
--- a/platforms/emulator/runtime/userspace/apps/user/src/spdm/device_measurements/ocp_eat/claims.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/spdm/device_measurements/ocp_eat/claims.rs
@@ -15,7 +15,6 @@ use caliptra_ocp_eat::{
     ClassIdTypeChoice, ClassMap, ConciseEvidence, ConciseEvidenceMap, DigestEntry, EnvironmentMap,
     EvTriplesMap, EvidenceTripleRecord, MeasurementMap, MeasurementValue, TaggedBytes, VersionMap,
 };
-use core::fmt::Write;
 use core::mem::MaybeUninit;
 use core::sync::atomic::{AtomicBool, Ordering};
 
@@ -257,12 +256,30 @@ pub async fn generate_claims(claims_buf: &mut [u8], nonce: &[u8]) -> Measurement
 }
 
 fn version_to_str(ver: u32) -> ArrayString<MAX_SEMVER_LEN> {
-    let major = (ver >> 16) & 0xFF;
-    let minor = (ver >> 8) & 0xFF;
-    let patch = ver & 0xFF;
+    let major = ((ver >> 16) & 0xFF) as u8;
+    let minor = ((ver >> 8) & 0xFF) as u8;
+    let patch = (ver & 0xFF) as u8;
     let mut s = ArrayString::<MAX_SEMVER_LEN>::new();
-    let _ = write!(&mut s, "{}.{}.{}", major, minor, patch);
+    push_decimal(&mut s, major);
+    let _ = s.try_push('.');
+    push_decimal(&mut s, minor);
+    let _ = s.try_push('.');
+    push_decimal(&mut s, patch);
     s
+}
+
+fn push_decimal(s: &mut ArrayString<MAX_SEMVER_LEN>, value: u8) {
+    if value >= 100 {
+        push_digit(s, value / 100);
+        push_digit(s, (value / 10) % 10);
+    } else if value >= 10 {
+        push_digit(s, value / 10);
+    }
+    push_digit(s, value % 10);
+}
+
+fn push_digit(s: &mut ArrayString<MAX_SEMVER_LEN>, digit: u8) {
+    let _ = s.try_push((b'0' + digit) as char);
 }
 
 fn digest_words_to_bytes(words: &[u32; SHA384_HASH_WORDS]) -> [u8; SHA384_HASH_SIZE] {
@@ -363,4 +380,44 @@ async fn fill_sw_config_info(
         raw_value_masks[i] = None; // or Some(ArrayVec::from_slice(&[...]).unwrap());
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_version_to_str_typical() {
+        let ver = (1 << 16) | (2 << 8) | 3;
+        assert_eq!(version_to_str(ver).as_str(), "1.2.3");
+    }
+
+    #[test]
+    fn test_version_to_str_zeros() {
+        assert_eq!(version_to_str(0).as_str(), "0.0.0");
+    }
+
+    #[test]
+    fn test_version_to_str_single_digits() {
+        let ver = (9 << 16) | (8 << 8) | 7;
+        assert_eq!(version_to_str(ver).as_str(), "9.8.7");
+    }
+
+    #[test]
+    fn test_version_to_str_double_digits() {
+        let ver = (10 << 16) | (20 << 8) | 99;
+        assert_eq!(version_to_str(ver).as_str(), "10.20.99");
+    }
+
+    #[test]
+    fn test_version_to_str_triple_digits() {
+        let ver = (255 << 16) | (100 << 8) | 200;
+        assert_eq!(version_to_str(ver).as_str(), "255.100.200");
+    }
+
+    #[test]
+    fn test_version_to_str_max() {
+        let ver = (255 << 16) | (255 << 8) | 255;
+        assert_eq!(version_to_str(ver).as_str(), "255.255.255");
+    }
 }

--- a/runtime/userspace/api/spdm-lib/src/commands/algorithms_rsp.rs
+++ b/runtime/userspace/api/spdm-lib/src/commands/algorithms_rsp.rs
@@ -6,7 +6,6 @@ use crate::context::SpdmContext;
 use crate::error::{CommandResult, SpdmError};
 use crate::protocol::*;
 use crate::state::ConnectionState;
-use crate::transcript::TranscriptContext;
 use bitfield::bitfield;
 use core::mem::size_of;
 use zerocopy::{FromBytes, Immutable, IntoBytes};
@@ -156,7 +155,7 @@ pub(crate) fn selected_measurement_specification(ctx: &SpdmContext) -> Measureme
     measurement_specification_sel
 }
 
-async fn process_negotiate_algorithms_request<'a>(
+fn process_negotiate_algorithms_request<'a>(
     ctx: &mut SpdmContext<'a>,
     spdm_hdr: SpdmMsgHdr,
     req_payload: &mut MessageBuf<'a>,
@@ -277,11 +276,10 @@ async fn process_negotiate_algorithms_request<'a>(
         .set_peer_algorithms(peer_algorithms);
 
     // Append NEGOTIATE_ALGORITHMS to the transcript VCA context
-    ctx.append_message_to_transcript(req_payload, TranscriptContext::Vca, None)
-        .await
+    ctx.append_message_to_vca_transcript(req_payload)
 }
 
-async fn generate_algorithms_response<'a>(
+fn generate_algorithms_response<'a>(
     ctx: &mut SpdmContext<'a>,
     rsp: &mut MessageBuf<'a>,
 ) -> CommandResult<()> {
@@ -368,8 +366,7 @@ async fn generate_algorithms_response<'a>(
     payload_len += encode_alg_struct_table(ctx, rsp, num_alg_struct_tables)?;
 
     // Add the ALGORITHMS to the transcript VCA context
-    ctx.append_message_to_transcript(rsp, TranscriptContext::Vca, None)
-        .await?;
+    ctx.append_message_to_vca_transcript(rsp)?;
 
     rsp.push_data(payload_len)
         .map_err(|_| ctx.generate_error_response(rsp, ErrorCode::InvalidRequest, 0, None))?;
@@ -468,7 +465,7 @@ fn encode_alg_struct_table(
     Ok(len)
 }
 
-pub(crate) async fn handle_negotiate_algorithms<'a>(
+pub(crate) fn handle_negotiate_algorithms<'a>(
     ctx: &mut SpdmContext<'a>,
     spdm_hdr: SpdmMsgHdr,
     req_payload: &mut MessageBuf<'a>,
@@ -479,11 +476,11 @@ pub(crate) async fn handle_negotiate_algorithms<'a>(
     }
 
     // Process NEGOTIATE_ALGORITHMS request
-    process_negotiate_algorithms_request(ctx, spdm_hdr, req_payload).await?;
+    process_negotiate_algorithms_request(ctx, spdm_hdr, req_payload)?;
 
     // Generate ALGORITHMS response
     ctx.prepare_response_buffer(req_payload)?;
-    generate_algorithms_response(ctx, req_payload).await?;
+    generate_algorithms_response(ctx, req_payload)?;
 
     // Set the negotiated asymmetric algorithm in the measurements module
     let asym_algo = ctx.validate_negotiated_base_asym_algo(req_payload)?;

--- a/runtime/userspace/api/spdm-lib/src/commands/capabilities_rsp.rs
+++ b/runtime/userspace/api/spdm-lib/src/commands/capabilities_rsp.rs
@@ -5,7 +5,6 @@ use crate::context::SpdmContext;
 use crate::error::{CommandError, CommandResult};
 use crate::protocol::*;
 use crate::state::ConnectionState;
-use crate::transcript::TranscriptContext;
 use zerocopy::{FromBytes, Immutable, IntoBytes};
 
 #[derive(IntoBytes, FromBytes, Immutable, Default)]
@@ -141,7 +140,7 @@ fn req_flag_compatible(version: SpdmVersion, flags: &CapabilityFlags) -> bool {
     true
 }
 
-async fn process_get_capabilities<'a>(
+fn process_get_capabilities<'a>(
     ctx: &mut SpdmContext<'a>,
     spdm_hdr: SpdmMsgHdr,
     req_payload: &mut MessageBuf<'a>,
@@ -242,11 +241,10 @@ async fn process_get_capabilities<'a>(
     ctx.measurements.set_spdm_version(spdm_version);
 
     // Append GET_CAPABILITIES to the transcript VCA context
-    ctx.append_message_to_transcript(req_payload, TranscriptContext::Vca, None)
-        .await
+    ctx.append_message_to_vca_transcript(req_payload)
 }
 
-async fn generate_capabilities_response<'a>(
+fn generate_capabilities_response<'a>(
     ctx: &mut SpdmContext<'a>,
     rsp_buf: &mut MessageBuf<'a>,
 ) -> CommandResult<()> {
@@ -282,8 +280,7 @@ async fn generate_capabilities_response<'a>(
     }
 
     // Append CAPABILITIES to the transcript VCA context
-    ctx.append_message_to_transcript(rsp_buf, TranscriptContext::Vca, None)
-        .await?;
+    ctx.append_message_to_vca_transcript(rsp_buf)?;
 
     rsp_buf
         .push_data(payload_len)
@@ -291,7 +288,7 @@ async fn generate_capabilities_response<'a>(
     Ok(())
 }
 
-pub(crate) async fn handle_get_capabilities<'a>(
+pub(crate) fn handle_get_capabilities<'a>(
     ctx: &mut SpdmContext<'a>,
     spdm_hdr: SpdmMsgHdr,
     req_payload: &mut MessageBuf<'a>,
@@ -301,11 +298,11 @@ pub(crate) async fn handle_get_capabilities<'a>(
     }
 
     // Process GET_CAPABILITIES request
-    process_get_capabilities(ctx, spdm_hdr, req_payload).await?;
+    process_get_capabilities(ctx, spdm_hdr, req_payload)?;
 
     // Generate CAPABILITIES response
     ctx.prepare_response_buffer(req_payload)?;
-    generate_capabilities_response(ctx, req_payload).await?;
+    generate_capabilities_response(ctx, req_payload)?;
 
     // Set handshake_in_the_clear flag based on local and peer capabilities
     let local_flags = ctx.local_capabilities.flags;

--- a/runtime/userspace/api/spdm-lib/src/commands/end_session_ack_rsp.rs
+++ b/runtime/userspace/api/spdm-lib/src/commands/end_session_ack_rsp.rs
@@ -79,7 +79,7 @@ fn generate_end_session_response(
     Ok(())
 }
 
-pub(crate) async fn handle_end_session<'a>(
+pub(crate) fn handle_end_session<'a>(
     ctx: &mut SpdmContext<'a>,
     spdm_hdr: SpdmMsgHdr,
     req_payload: &mut MessageBuf<'a>,

--- a/runtime/userspace/api/spdm-lib/src/commands/version_rsp.rs
+++ b/runtime/userspace/api/spdm-lib/src/commands/version_rsp.rs
@@ -6,7 +6,6 @@ use crate::context::SpdmContext;
 use crate::error::{CommandError, CommandResult};
 use crate::protocol::{ReqRespCode, SpdmMsgHdr, SpdmVersion};
 use crate::state::ConnectionState;
-use crate::transcript::TranscriptContext;
 use bitfield::bitfield;
 use zerocopy::{FromBytes, Immutable, IntoBytes};
 
@@ -78,7 +77,7 @@ impl VersionNumberEntry<[u8; VERSION_ENTRY_SIZE]> {
 
 impl CommonCodec for VersionNumberEntry<[u8; VERSION_ENTRY_SIZE]> {}
 
-async fn generate_version_response<'a>(
+fn generate_version_response<'a>(
     ctx: &mut SpdmContext<'a>,
     rsp_buf: &mut MessageBuf<'a>,
     supported_versions: &[SpdmVersion],
@@ -103,9 +102,8 @@ async fn generate_version_response<'a>(
             .map_err(|_| (false, CommandError::BufferTooSmall))?;
     }
 
-    // Append response to VCA transcript
-    ctx.append_message_to_transcript(rsp_buf, TranscriptContext::Vca, None)
-        .await?;
+    // Append response to VCA transcript (sync — no hash needed)
+    ctx.append_message_to_vca_transcript(rsp_buf)?;
 
     // Push data offset up by total payload length
     rsp_buf
@@ -114,7 +112,7 @@ async fn generate_version_response<'a>(
     Ok(())
 }
 
-async fn process_get_version<'a>(
+fn process_get_version<'a>(
     ctx: &mut SpdmContext<'a>,
     spdm_hdr: SpdmMsgHdr,
     req_payload: &mut MessageBuf<'a>,
@@ -131,22 +129,21 @@ async fn process_get_version<'a>(
     // Reset Transcript
     ctx.shared_transcript.reset();
 
-    // Append request to VCA transcript
-    ctx.append_message_to_transcript(req_payload, TranscriptContext::Vca, None)
-        .await
+    // Append request to VCA transcript (sync — no hash needed)
+    ctx.append_message_to_vca_transcript(req_payload)
 }
 
-pub(crate) async fn handle_get_version<'a>(
+pub(crate) fn handle_get_version<'a>(
     ctx: &mut SpdmContext<'a>,
     spdm_hdr: SpdmMsgHdr,
     req_payload: &mut MessageBuf<'a>,
 ) -> CommandResult<()> {
     // Process GET_VERSION request
-    process_get_version(ctx, spdm_hdr, req_payload).await?;
+    process_get_version(ctx, spdm_hdr, req_payload)?;
 
     // Generate VERSION response
     ctx.prepare_response_buffer(req_payload)?;
-    generate_version_response(ctx, req_payload, ctx.supported_versions).await?;
+    generate_version_response(ctx, req_payload, ctx.supported_versions)?;
 
     // Invalidate state and reset session info
     ctx.reset();

--- a/runtime/userspace/api/spdm-lib/src/context.rs
+++ b/runtime/userspace/api/spdm-lib/src/context.rs
@@ -261,14 +261,12 @@ impl<'a> SpdmContext<'a> {
         }
 
         match req_code {
-            ReqRespCode::GetVersion => {
-                version_rsp::handle_get_version(self, req_msg_header, req).await?
-            }
+            ReqRespCode::GetVersion => version_rsp::handle_get_version(self, req_msg_header, req)?,
             ReqRespCode::GetCapabilities => {
-                capabilities_rsp::handle_get_capabilities(self, req_msg_header, req).await?
+                capabilities_rsp::handle_get_capabilities(self, req_msg_header, req)?
             }
             ReqRespCode::NegotiateAlgorithms => {
-                algorithms_rsp::handle_negotiate_algorithms(self, req_msg_header, req).await?
+                algorithms_rsp::handle_negotiate_algorithms(self, req_msg_header, req)?
             }
             ReqRespCode::GetDigests => {
                 digests_rsp::handle_get_digests(self, req_msg_header, req).await?
@@ -290,7 +288,7 @@ impl<'a> SpdmContext<'a> {
             }
             ReqRespCode::Finish => finish_rsp::handle_finish(self, req_msg_header, req).await?,
             ReqRespCode::EndSession => {
-                end_session_ack_rsp::handle_end_session(self, req_msg_header, req).await?
+                end_session_ack_rsp::handle_end_session(self, req_msg_header, req)?
             }
             ReqRespCode::VendorDefinedRequest => {
                 vendor_defined_rsp::handle_vendor_defined_request(self, req_msg_header, req).await?
@@ -437,6 +435,20 @@ impl<'a> SpdmContext<'a> {
 
         self.append_slice_to_transcript(msg, transcript_context, session_id)
             .await
+    }
+
+    /// Synchronous VCA transcript append — no mailbox call needed.
+    pub(crate) fn append_message_to_vca_transcript(
+        &mut self,
+        msg_buf: &mut MessageBuf<'_>,
+    ) -> CommandResult<()> {
+        let data_offset = msg_buf.data_offset();
+        let msg = msg_buf
+            .message_slice(data_offset)
+            .map_err(|e| (false, CommandError::Codec(e)))?;
+        self.shared_transcript
+            .append_vca(msg)
+            .map_err(|e| (false, CommandError::Transcript(e)))
     }
 
     pub(crate) async fn append_slice_to_transcript(

--- a/runtime/userspace/api/spdm-lib/src/transcript.rs
+++ b/runtime/userspace/api/spdm-lib/src/transcript.rs
@@ -222,7 +222,7 @@ impl Transcript {
         }
     }
 
-    fn append_vca(&mut self, data: &[u8]) -> TranscriptResult<()> {
+    pub(crate) fn append_vca(&mut self, data: &[u8]) -> TranscriptResult<()> {
         self.vca_buf
             .try_extend_from_slice(data)
             .map_err(|_| TranscriptError::BufferOverflow)


### PR DESCRIPTION
- Convert handle_get_version, handle_get_capabilities,
  handle_negotiate_algorithms, and handle_end_session to sync functions.
  These only use VCA transcript appends (synchronous buffer copies).
- Add sync append_message_to_vca_transcript() on SpdmContext.
- Replace write!() formatting in version_to_str with manual decimal
  encoding to avoid pulling in core::fmt machinery.

Saves ~2.8 KB .text in user-app.