### PR TITLE
Add ProdDebugUnlock support to SPDM VDM host validator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2864,7 +2864,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4527,7 +4527,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5019,7 +5019,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5406,9 +5406,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "ufmt"
@@ -5747,7 +5747,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/caliptra-util-host/Cargo.lock
+++ b/caliptra-util-host/Cargo.lock
@@ -669,6 +669,7 @@ dependencies = [
  "anyhow",
  "caliptra-mcu-core-util-host-command-types",
  "caliptra-mcu-core-util-host-transport",
+ "caliptra-mcu-debug-unlock-signer",
  "caliptra-spdm-requester",
  "caliptra-util-host-commands",
  "caliptra-util-host-session",

--- a/caliptra-util-host/apps/spdm/client/Cargo.toml
+++ b/caliptra-util-host/apps/spdm/client/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/main.rs"
 caliptra-spdm-requester.workspace = true
 caliptra-mcu-core-util-host-transport.workspace = true
 caliptra-mcu-core-util-host-command-types.workspace = true
+caliptra-mcu-debug-unlock-signer.workspace = true
 caliptra-util-host-commands.workspace = true
 caliptra-util-host-session.workspace = true
 anyhow.workspace = true

--- a/caliptra-util-host/apps/spdm/client/src/config.rs
+++ b/caliptra-util-host/apps/spdm/client/src/config.rs
@@ -33,6 +33,8 @@ pub struct TestConfig {
     pub export_attested_csr: ExportAttestedCsrConfig,
     #[serde(default)]
     pub export_idevid_csr: ExportIdevidCsrConfig,
+    #[serde(default)]
+    pub debug_unlock: DebugUnlockConfig,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -107,6 +109,27 @@ impl Default for ExportIdevidCsrConfig {
     fn default() -> Self {
         Self {
             algorithms: default_idevid_algorithms(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct DebugUnlockConfig {
+    #[serde(default = "default_unlock_level")]
+    pub unlock_level: u8,
+    #[serde(default)]
+    pub enabled: bool,
+}
+
+fn default_unlock_level() -> u8 {
+    1
+}
+
+impl Default for DebugUnlockConfig {
+    fn default() -> Self {
+        Self {
+            unlock_level: default_unlock_level(),
+            enabled: true,
         }
     }
 }

--- a/caliptra-util-host/apps/spdm/client/src/lib.rs
+++ b/caliptra-util-host/apps/spdm/client/src/lib.rs
@@ -23,9 +23,17 @@ pub mod validator;
 pub use config::TestConfig;
 pub use validator::{all_passed, print_summary, run_all, ValidationResult, ValidationStatus};
 
+// Re-export the debug unlock signer trait and types from the common crate
+pub use caliptra_mcu_debug_unlock_signer::{
+    DebugUnlockKeys, DebugUnlockSigner, LocalDebugUnlockSigner,
+};
+
 use anyhow::Result;
 use caliptra_mcu_core_util_host_command_types::certificate::{
     ExportAttestedCsrResponse, ExportIdevidCsrResponse,
+};
+use caliptra_mcu_core_util_host_command_types::debug_unlock::{
+    ProdDebugUnlockReqResponse, ProdDebugUnlockTokenRequest, ProdDebugUnlockTokenResponse,
 };
 use caliptra_mcu_core_util_host_command_types::{
     GetDeviceCapabilitiesResponse, GetDeviceIdResponse, GetDeviceInfoResponse,
@@ -37,6 +45,9 @@ use caliptra_mcu_core_util_host_transport::transports::spdm_vdm::transport::{
 use caliptra_mcu_core_util_host_transport::Transport;
 use caliptra_util_host_commands::api::certificate::{
     caliptra_cmd_export_attested_csr, caliptra_cmd_export_idevid_csr,
+};
+use caliptra_util_host_commands::api::debug_unlock::{
+    caliptra_cmd_prod_debug_unlock_req, caliptra_cmd_prod_debug_unlock_token,
 };
 use caliptra_util_host_commands::api::device_info::{
     caliptra_cmd_get_device_capabilities, caliptra_cmd_get_device_id, caliptra_cmd_get_device_info,
@@ -126,6 +137,32 @@ impl<'a> SpdmVdmClient<'a> {
         let mut session = self.create_session()?;
         caliptra_cmd_export_idevid_csr(&mut session, algorithm)
             .map_err(|e| anyhow::anyhow!("ExportIdevidCsr failed: {:?}", e))
+    }
+
+    /// Request a production debug unlock challenge.
+    ///
+    /// # Parameters
+    /// - `unlock_level`: The debug unlock level requested (1-8)
+    pub fn prod_debug_unlock_req(
+        &mut self,
+        unlock_level: u8,
+    ) -> Result<ProdDebugUnlockReqResponse> {
+        let mut session = self.create_session()?;
+        caliptra_cmd_prod_debug_unlock_req(&mut session, unlock_level)
+            .map_err(|e| anyhow::anyhow!("ProdDebugUnlockReq failed: {:?}", e))
+    }
+
+    /// Submit a production debug unlock token.
+    ///
+    /// # Parameters
+    /// - `request`: The fully populated debug unlock token request
+    pub fn prod_debug_unlock_token(
+        &mut self,
+        request: &ProdDebugUnlockTokenRequest,
+    ) -> Result<ProdDebugUnlockTokenResponse> {
+        let mut session = self.create_session()?;
+        caliptra_cmd_prod_debug_unlock_token(&mut session, request)
+            .map_err(|e| anyhow::anyhow!("ProdDebugUnlockToken failed: {:?}", e))
     }
 
     fn create_session(&mut self) -> Result<CaliptraSession> {

--- a/caliptra-util-host/apps/spdm/client/src/main.rs
+++ b/caliptra-util-host/apps/spdm/client/src/main.rs
@@ -10,7 +10,9 @@
 use anyhow::Result;
 use caliptra_spdm_requester::{SpdmConfig, SpdmRequester, SpdmSocketDeviceIo, SpdmVdmDriverImpl};
 use caliptra_spdm_vdm_client::config::{self, DeviceMode, TestConfig};
-use caliptra_spdm_vdm_client::{validator, SpdmVdmClient};
+use caliptra_spdm_vdm_client::{
+    validator, DebugUnlockKeys, DebugUnlockSigner, LocalDebugUnlockSigner, SpdmVdmClient,
+};
 use clap::Parser;
 
 #[derive(Parser, Debug)]
@@ -43,6 +45,14 @@ struct Args {
     /// Algorithm IDs for ExportIdevidCsr (comma-separated)
     #[arg(long)]
     idevid_algorithms: Option<String>,
+
+    /// Path to a binary file containing debug unlock keys (written by DebugUnlockKeys::save_to_file)
+    #[arg(long)]
+    debug_unlock_keys_file: Option<String>,
+
+    /// Debug unlock level (1-8)
+    #[arg(long)]
+    unlock_level: Option<u8>,
 }
 
 impl Args {
@@ -76,6 +86,9 @@ impl Args {
         if let Some(algorithms) = &self.idevid_algorithms {
             config.export_idevid_csr.algorithms = parse_key_ids(algorithms)?;
         }
+        if let Some(unlock_level) = self.unlock_level {
+            config.debug_unlock.unlock_level = unlock_level;
+        }
 
         Ok(config)
     }
@@ -88,7 +101,16 @@ fn main() -> Result<()> {
         .init()
         .ok();
 
-    let config = Args::parse().into_config()?;
+    let args = Args::parse();
+    let debug_unlock_signer: Option<Box<dyn DebugUnlockSigner>> =
+        if let Some(keys_path) = &args.debug_unlock_keys_file {
+            let keys = DebugUnlockKeys::load_from_file(std::path::Path::new(keys_path))?;
+            println!("[caliptra-spdm-validator] Loaded debug unlock keys from {}", keys_path);
+            Some(Box::new(LocalDebugUnlockSigner::new(keys)))
+        } else {
+            None
+        };
+    let config = args.into_config()?;
 
     println!(
         "[caliptra-spdm-validator] Connecting to bridge at {}",
@@ -114,7 +136,12 @@ fn main() -> Result<()> {
     let results = {
         let mut vdm = SpdmVdmDriverImpl::new(&mut requester, None);
         let mut client = SpdmVdmClient::new(&mut vdm);
-        validator::run_all(&mut client, &config, true)
+        validator::run_all(
+            &mut client,
+            &config,
+            debug_unlock_signer.as_deref(),
+            true,
+        )
     };
     validator::print_summary(&results);
 

--- a/caliptra-util-host/apps/spdm/client/src/main.rs
+++ b/caliptra-util-host/apps/spdm/client/src/main.rs
@@ -105,7 +105,10 @@ fn main() -> Result<()> {
     let debug_unlock_signer: Option<Box<dyn DebugUnlockSigner>> =
         if let Some(keys_path) = &args.debug_unlock_keys_file {
             let keys = DebugUnlockKeys::load_from_file(std::path::Path::new(keys_path))?;
-            println!("[caliptra-spdm-validator] Loaded debug unlock keys from {}", keys_path);
+            println!(
+                "[caliptra-spdm-validator] Loaded debug unlock keys from {}",
+                keys_path
+            );
             Some(Box::new(LocalDebugUnlockSigner::new(keys)))
         } else {
             None
@@ -136,12 +139,7 @@ fn main() -> Result<()> {
     let results = {
         let mut vdm = SpdmVdmDriverImpl::new(&mut requester, None);
         let mut client = SpdmVdmClient::new(&mut vdm);
-        validator::run_all(
-            &mut client,
-            &config,
-            debug_unlock_signer.as_deref(),
-            true,
-        )
+        validator::run_all(&mut client, &config, debug_unlock_signer.as_deref(), true)
     };
     validator::print_summary(&results);
 

--- a/caliptra-util-host/apps/spdm/client/src/validator.rs
+++ b/caliptra-util-host/apps/spdm/client/src/validator.rs
@@ -320,21 +320,7 @@ pub fn run_prod_debug_unlock(
                     }
                 }
             } else {
-                // No signer — send zeroed token (expected to be rejected)
-                let token_req = ProdDebugUnlockTokenRequest::default();
-                match client.prod_debug_unlock_token(&token_req) {
-                    Ok(_) => {
-                        if verbose {
-                            println!("  Token accepted (unexpected in test mode)");
-                        }
-                    }
-                    Err(_) => {
-                        if verbose {
-                            println!("  Token correctly rejected (no valid signature) ✓");
-                        }
-                    }
-                }
-                ValidationResult::pass(test_name, "challenge received, command dispatch works")
+                ValidationResult::fail(test_name, "no signer provided")
             }
         }
         Err(e) => {
@@ -345,12 +331,7 @@ pub fn run_prod_debug_unlock(
                     msg
                 );
             }
-            // The command was dispatched — the device rejected it, which is OK
-            // (e.g., wrong lifecycle state).
-            ValidationResult::pass(
-                test_name,
-                format!("command dispatched, rejected by device: {}", msg),
-            )
+            ValidationResult::fail(test_name, format!("debug unlock request failed: {}", msg))
         }
     }
 }

--- a/caliptra-util-host/apps/spdm/client/src/validator.rs
+++ b/caliptra-util-host/apps/spdm/client/src/validator.rs
@@ -14,6 +14,7 @@
 use crate::config::{DeviceMode, TestConfig};
 use crate::SpdmVdmClient;
 use caliptra_mcu_core_util_host_command_types::certificate::AttestedCsrValidationError;
+use caliptra_mcu_debug_unlock_signer::{DebugUnlockSigner, ProdDebugUnlockChallenge};
 
 /// Result of a single validation check.
 #[derive(Debug, Clone)]
@@ -100,6 +101,7 @@ pub fn all_passed(results: &[ValidationResult]) -> bool {
 pub fn run_all(
     client: &mut SpdmVdmClient,
     config: &TestConfig,
+    debug_unlock_signer: Option<&dyn DebugUnlockSigner>,
     verbose: bool,
 ) -> Vec<ValidationResult> {
     let mut results = Vec::new();
@@ -125,6 +127,15 @@ pub fn run_all(
                 verbose,
             ));
         }
+    }
+
+    if config.debug_unlock.enabled {
+        results.push(run_prod_debug_unlock(
+            client,
+            config.debug_unlock.unlock_level,
+            debug_unlock_signer,
+            verbose,
+        ));
     }
 
     results
@@ -237,4 +248,109 @@ pub fn run_export_idevid_csr_expect_fail(
             }
         })
         .collect()
+}
+
+/// Validate Production Debug Unlock via SPDM VDM.
+///
+/// When a [`DebugUnlockSigner`] is provided, performs a full end-to-end flow:
+/// request challenge → sign token → submit token.
+///
+/// Without a signer, sends a zeroed token (expected to be rejected) to confirm
+/// command dispatch works.
+pub fn run_prod_debug_unlock(
+    client: &mut SpdmVdmClient,
+    unlock_level: u8,
+    signer: Option<&dyn DebugUnlockSigner>,
+    verbose: bool,
+) -> ValidationResult {
+    use caliptra_mcu_core_util_host_command_types::debug_unlock::ProdDebugUnlockTokenRequest;
+
+    let test_name = "ProdDebugUnlock".to_string();
+
+    if verbose {
+        println!("\n=== Validating Production Debug Unlock (SPDM VDM) ===");
+    }
+
+    match client.prod_debug_unlock_req(unlock_level) {
+        Ok(response) => {
+            if verbose {
+                println!("  Got challenge response:");
+                println!(
+                    "    UDI: {:02X?}...",
+                    &response.unique_device_identifier[..8]
+                );
+                println!("    Challenge: {:02X?}...", &response.challenge[..8]);
+            }
+
+            if let Some(signer) = signer {
+                // Full end-to-end: sign a real token
+                if verbose {
+                    println!("  Signing token with provided signer...");
+                }
+
+                let challenge = ProdDebugUnlockChallenge {
+                    unique_device_identifier: response.unique_device_identifier,
+                    challenge: response.challenge,
+                };
+
+                let token = match signer.sign_debug_unlock_token(&challenge, unlock_level) {
+                    Ok(t) => ProdDebugUnlockTokenRequest {
+                        length: t.length,
+                        unique_device_identifier: t.unique_device_identifier,
+                        unlock_level: t.unlock_level,
+                        reserved: t.reserved,
+                        challenge: t.challenge,
+                        ecc_public_key: t.ecc_public_key,
+                        mldsa_public_key: t.mldsa_public_key,
+                        ecc_signature: t.ecc_signature,
+                        mldsa_signature: t.mldsa_signature,
+                    },
+                    Err(e) => {
+                        return ValidationResult::fail(
+                            test_name,
+                            format!("Failed to sign token: {}", e),
+                        );
+                    }
+                };
+
+                match client.prod_debug_unlock_token(&token) {
+                    Ok(_) => ValidationResult::pass(test_name, "token accepted"),
+                    Err(e) => {
+                        ValidationResult::fail(test_name, format!("Signed token rejected: {}", e))
+                    }
+                }
+            } else {
+                // No signer — send zeroed token (expected to be rejected)
+                let token_req = ProdDebugUnlockTokenRequest::default();
+                match client.prod_debug_unlock_token(&token_req) {
+                    Ok(_) => {
+                        if verbose {
+                            println!("  Token accepted (unexpected in test mode)");
+                        }
+                    }
+                    Err(_) => {
+                        if verbose {
+                            println!("  Token correctly rejected (no valid signature) ✓");
+                        }
+                    }
+                }
+                ValidationResult::pass(test_name, "challenge received, command dispatch works")
+            }
+        }
+        Err(e) => {
+            let msg = format!("{}", e);
+            if verbose {
+                println!(
+                    "  Debug unlock request returned error: {} (may be expected due to lifecycle)",
+                    msg
+                );
+            }
+            // The command was dispatched — the device rejected it, which is OK
+            // (e.g., wrong lifecycle state).
+            ValidationResult::pass(
+                test_name,
+                format!("command dispatched, rejected by device: {}", msg),
+            )
+        }
+    }
 }

--- a/caliptra-util-host/transport/src/transports/spdm_vdm/commands.rs
+++ b/caliptra-util-host/transport/src/transports/spdm_vdm/commands.rs
@@ -16,6 +16,8 @@
 //! - DeviceId (0x03)
 //! - DeviceInfo (0x04)
 //! - ExportIdevidCsr (0x0C)
+//! - RequestDebugUnlock (0x0A)
+//! - AuthorizeDebugUnlockToken (0x0B)
 //! - ExportAttestedCsr (0x0F)
 
 use super::protocol::{
@@ -24,8 +26,15 @@ use super::protocol::{
 };
 use super::transport::{SpdmVdmDriver, SpdmVdmError};
 use crate::TransportError;
+use caliptra_mcu_core_util_host_command_types::debug_unlock::{
+    ProdDebugUnlockReqRequest, ProdDebugUnlockReqResponse, ProdDebugUnlockTokenRequest,
+    ProdDebugUnlockTokenResponse, DEBUG_UNLOCK_CHALLENGE_SIZE, UNIQUE_DEVICE_ID_SIZE,
+};
 use caliptra_mcu_core_util_host_command_types::*;
 use zerocopy::IntoBytes;
+
+/// Caliptra RT mailbox command ID for PRODUCTION_AUTH_DEBUG_UNLOCK_TOKEN.
+const CALIPTRA_RT_CMD_PROD_DEBUG_UNLOCK_TOKEN: u32 = 0x5044_5554; // "PDUT"
 
 // ---------------------------------------------------------------------------
 // Helper: build VDM request, send via driver, validate response header
@@ -391,6 +400,103 @@ pub fn handle_export_idevid_csr(
         common: CommonResponse { fips_status: 0 },
         data_len: csr_len as u32,
         csr_data,
+    };
+
+    let resp_bytes = internal_resp.as_bytes();
+    let copy_len = resp_bytes.len().min(response_buffer.len());
+    response_buffer[..copy_len].copy_from_slice(&resp_bytes[..copy_len]);
+    Ok(copy_len)
+}
+
+// ---------------------------------------------------------------------------
+// RequestDebugUnlock (CaliptraCommandId::ProdDebugUnlockReq)
+// ---------------------------------------------------------------------------
+
+pub fn handle_prod_debug_unlock_req(
+    payload: &[u8],
+    driver: &mut dyn SpdmVdmDriver,
+    response_buffer: &mut [u8],
+) -> Result<usize, TransportError> {
+    let req = ProdDebugUnlockReqRequest::from_bytes(payload)
+        .map_err(|_| TransportError::InvalidMessage)?;
+
+    // VDM payload: [unlock_level(1)]
+    let vdm_payload = [req.unlock_level];
+    let mut resp_buf = [0u8; MAX_VDM_RESPONSE_SIZE];
+    let resp_len = send_vdm_request(
+        CaliptraVdmCommand::RequestDebugUnlock,
+        &vdm_payload,
+        driver,
+        &mut resp_buf,
+    )?;
+
+    let data = &resp_buf[VDM_RESPONSE_HEADER_SIZE..resp_len];
+
+    // Response data: [unique_device_identifier(32), challenge(48)]
+    if data.len() < UNIQUE_DEVICE_ID_SIZE + DEBUG_UNLOCK_CHALLENGE_SIZE {
+        return Err(TransportError::InvalidMessage);
+    }
+
+    let mut unique_device_identifier = [0u8; UNIQUE_DEVICE_ID_SIZE];
+    unique_device_identifier.copy_from_slice(&data[..UNIQUE_DEVICE_ID_SIZE]);
+
+    let mut challenge = [0u8; DEBUG_UNLOCK_CHALLENGE_SIZE];
+    challenge.copy_from_slice(
+        &data[UNIQUE_DEVICE_ID_SIZE..UNIQUE_DEVICE_ID_SIZE + DEBUG_UNLOCK_CHALLENGE_SIZE],
+    );
+
+    let internal_resp = ProdDebugUnlockReqResponse {
+        common: CommonResponse { fips_status: 0 },
+        length: 0,
+        unique_device_identifier,
+        challenge,
+    };
+
+    let resp_bytes = internal_resp.as_bytes();
+    let copy_len = resp_bytes.len().min(response_buffer.len());
+    response_buffer[..copy_len].copy_from_slice(&resp_bytes[..copy_len]);
+    Ok(copy_len)
+}
+
+// ---------------------------------------------------------------------------
+// AuthorizeDebugUnlockToken (CaliptraCommandId::ProdDebugUnlockToken)
+// ---------------------------------------------------------------------------
+
+pub fn handle_prod_debug_unlock_token(
+    payload: &[u8],
+    driver: &mut dyn SpdmVdmDriver,
+    response_buffer: &mut [u8],
+) -> Result<usize, TransportError> {
+    use crate::transports::mailbox::checksum::calc_checksum;
+    use alloc::vec;
+
+    let req = ProdDebugUnlockTokenRequest::from_bytes(payload)
+        .map_err(|_| TransportError::InvalidMessage)?;
+
+    // Build VDM payload in Caliptra RT mailbox format:
+    // [MailboxReqHeader(chksum: u32) | token_struct_bytes...]
+    // The MCU streams this directly to the Caliptra mailbox FIFO.
+    let token_bytes = req.as_bytes();
+    let hdr_size = core::mem::size_of::<u32>(); // MailboxReqHeader = chksum(u32)
+    let total_len = hdr_size + token_bytes.len();
+
+    // Build the payload with zeroed checksum first, then compute
+    let mut mbox_payload = vec![0u8; total_len];
+    mbox_payload[hdr_size..].copy_from_slice(token_bytes);
+    let chksum = calc_checksum(CALIPTRA_RT_CMD_PROD_DEBUG_UNLOCK_TOKEN, &mbox_payload);
+    mbox_payload[..hdr_size].copy_from_slice(&chksum.to_le_bytes());
+
+    let mut resp_buf = [0u8; MAX_VDM_RESPONSE_SIZE];
+    let _resp_len = send_vdm_request(
+        CaliptraVdmCommand::AuthorizeDebugUnlockToken,
+        &mbox_payload,
+        driver,
+        &mut resp_buf,
+    )?;
+
+    // Response is just completion code (already validated by send_vdm_request)
+    let internal_resp = ProdDebugUnlockTokenResponse {
+        common: CommonResponse { fips_status: 0 },
     };
 
     let resp_bytes = internal_resp.as_bytes();

--- a/caliptra-util-host/transport/src/transports/spdm_vdm/dispatch.rs
+++ b/caliptra-util-host/transport/src/transports/spdm_vdm/dispatch.rs
@@ -34,6 +34,12 @@ pub fn get_command_handler(command_id: u32) -> Option<VdmCommandHandlerFn> {
         x if x == CaliptraCommandId::ExportIdevidCsr as u32 => {
             Some(commands::handle_export_idevid_csr)
         }
+        x if x == CaliptraCommandId::ProdDebugUnlockReq as u32 => {
+            Some(commands::handle_prod_debug_unlock_req)
+        }
+        x if x == CaliptraCommandId::ProdDebugUnlockToken as u32 => {
+            Some(commands::handle_prod_debug_unlock_token)
+        }
         _ => None,
     }
 }

--- a/caliptra-util-host/transport/src/transports/spdm_vdm/protocol.rs
+++ b/caliptra-util-host/transport/src/transports/spdm_vdm/protocol.rs
@@ -158,6 +158,12 @@ pub fn command_id_to_vdm(command_id: u32) -> Option<CaliptraVdmCommand> {
         x if x == CaliptraCommandId::ExportIdevidCsr as u32 => {
             Some(CaliptraVdmCommand::ExportIdevidCsr)
         }
+        x if x == CaliptraCommandId::ProdDebugUnlockReq as u32 => {
+            Some(CaliptraVdmCommand::RequestDebugUnlock)
+        }
+        x if x == CaliptraCommandId::ProdDebugUnlockToken as u32 => {
+            Some(CaliptraVdmCommand::AuthorizeDebugUnlockToken)
+        }
         _ => None,
     }
 }

--- a/common/debug-unlock-signer/src/local.rs
+++ b/common/debug-unlock-signer/src/local.rs
@@ -59,6 +59,15 @@ impl DebugUnlockKeys {
         let mut len_buf = [0u8; 4];
         file.read_exact(&mut len_buf)?;
         let mldsa_priv_len = u32::from_le_bytes(len_buf) as usize;
+        // ML-DSA-87 private keys are always exactly 4896 bytes.
+        const MLDSA_PRIVATE_KEY_SIZE: usize = 4896;
+        if mldsa_priv_len != MLDSA_PRIVATE_KEY_SIZE {
+            return Err(anyhow::anyhow!(
+                "Invalid MLDSA private key size: expected {}, got {}",
+                MLDSA_PRIVATE_KEY_SIZE,
+                mldsa_priv_len
+            ));
+        }
         let mut mldsa_private_key_bytes = vec![0u8; mldsa_priv_len];
         file.read_exact(&mut mldsa_private_key_bytes)?;
 

--- a/common/debug-unlock-signer/src/local.rs
+++ b/common/debug-unlock-signer/src/local.rs
@@ -5,6 +5,8 @@ use crate::{
     MLDSA_PUBLIC_KEY_WORD_SIZE, MLDSA_SIGNATURE_WORD_SIZE,
 };
 use anyhow::Result;
+use std::io::{Read, Write};
+use std::path::Path;
 
 use crate::DebugUnlockSigner;
 
@@ -19,6 +21,61 @@ pub struct DebugUnlockKeys {
     pub mldsa_private_key_bytes: Vec<u8>,
     /// ML-DSA-87 public key as little-endian u32 words.
     pub mldsa_public_key: [u32; MLDSA_PUBLIC_KEY_WORD_SIZE],
+}
+
+impl DebugUnlockKeys {
+    /// Serialize keys to a binary file.
+    ///
+    /// Format: `[ecc_priv: 48][ecc_pub: 96][mldsa_priv_len: 4][mldsa_priv: N][mldsa_pub: 2592]`
+    pub fn save_to_file(&self, path: &Path) -> Result<()> {
+        let mut file = std::fs::File::create(path)?;
+        file.write_all(&self.ecc_private_key_bytes)?;
+        for word in &self.ecc_public_key {
+            file.write_all(&word.to_le_bytes())?;
+        }
+        let mldsa_priv_len = self.mldsa_private_key_bytes.len() as u32;
+        file.write_all(&mldsa_priv_len.to_le_bytes())?;
+        file.write_all(&self.mldsa_private_key_bytes)?;
+        for word in &self.mldsa_public_key {
+            file.write_all(&word.to_le_bytes())?;
+        }
+        Ok(())
+    }
+
+    /// Deserialize keys from a binary file written by [`save_to_file`].
+    pub fn load_from_file(path: &Path) -> Result<Self> {
+        let mut file = std::fs::File::open(path)?;
+
+        let mut ecc_private_key_bytes = [0u8; 48];
+        file.read_exact(&mut ecc_private_key_bytes)?;
+
+        let mut ecc_public_key = [0u32; ECC_PUBLIC_KEY_WORD_SIZE];
+        for word in &mut ecc_public_key {
+            let mut buf = [0u8; 4];
+            file.read_exact(&mut buf)?;
+            *word = u32::from_le_bytes(buf);
+        }
+
+        let mut len_buf = [0u8; 4];
+        file.read_exact(&mut len_buf)?;
+        let mldsa_priv_len = u32::from_le_bytes(len_buf) as usize;
+        let mut mldsa_private_key_bytes = vec![0u8; mldsa_priv_len];
+        file.read_exact(&mut mldsa_private_key_bytes)?;
+
+        let mut mldsa_public_key = [0u32; MLDSA_PUBLIC_KEY_WORD_SIZE];
+        for word in &mut mldsa_public_key {
+            let mut buf = [0u8; 4];
+            file.read_exact(&mut buf)?;
+            *word = u32::from_le_bytes(buf);
+        }
+
+        Ok(Self {
+            ecc_private_key_bytes,
+            ecc_public_key,
+            mldsa_private_key_bytes,
+            mldsa_public_key,
+        })
+    }
 }
 
 /// A [`DebugUnlockSigner`] that signs tokens locally using in-memory keys.


### PR DESCRIPTION
Add RequestDebugUnlock and AuthorizeDebugUnlockToken VDM commands to the host-side SPDM validator client. The token command builds the mailbox payload with a proper checksum header so Caliptra RT can verify it.

Also adds key serialization/deserialization to DebugUnlockKeys for persisting generated keys between validator invocations.