### PR TITLE
Add VDM streaming for ProdDebugUnlock on MCU side

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2864,7 +2864,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4527,7 +4527,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5019,7 +5019,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5406,9 +5406,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "ufmt"
@@ -5747,7 +5747,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/caliptra-util-host/Cargo.lock
+++ b/caliptra-util-host/Cargo.lock
@@ -669,6 +669,7 @@ dependencies = [
  "anyhow",
  "caliptra-mcu-core-util-host-command-types",
  "caliptra-mcu-core-util-host-transport",
+ "caliptra-mcu-debug-unlock-signer",
  "caliptra-spdm-requester",
  "caliptra-util-host-commands",
  "caliptra-util-host-session",

--- a/caliptra-util-host/apps/spdm/client/Cargo.toml
+++ b/caliptra-util-host/apps/spdm/client/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/main.rs"
 caliptra-spdm-requester.workspace = true
 caliptra-mcu-core-util-host-transport.workspace = true
 caliptra-mcu-core-util-host-command-types.workspace = true
+caliptra-mcu-debug-unlock-signer.workspace = true
 caliptra-util-host-commands.workspace = true
 caliptra-util-host-session.workspace = true
 anyhow.workspace = true

--- a/caliptra-util-host/apps/spdm/client/src/config.rs
+++ b/caliptra-util-host/apps/spdm/client/src/config.rs
@@ -33,6 +33,8 @@ pub struct TestConfig {
     pub export_attested_csr: ExportAttestedCsrConfig,
     #[serde(default)]
     pub export_idevid_csr: ExportIdevidCsrConfig,
+    #[serde(default)]
+    pub debug_unlock: DebugUnlockConfig,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -107,6 +109,27 @@ impl Default for ExportIdevidCsrConfig {
     fn default() -> Self {
         Self {
             algorithms: default_idevid_algorithms(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct DebugUnlockConfig {
+    #[serde(default = "default_unlock_level")]
+    pub unlock_level: u8,
+    #[serde(default)]
+    pub enabled: bool,
+}
+
+fn default_unlock_level() -> u8 {
+    1
+}
+
+impl Default for DebugUnlockConfig {
+    fn default() -> Self {
+        Self {
+            unlock_level: default_unlock_level(),
+            enabled: true,
         }
     }
 }

--- a/caliptra-util-host/apps/spdm/client/src/lib.rs
+++ b/caliptra-util-host/apps/spdm/client/src/lib.rs
@@ -23,9 +23,17 @@ pub mod validator;
 pub use config::TestConfig;
 pub use validator::{all_passed, print_summary, run_all, ValidationResult, ValidationStatus};
 
+// Re-export the debug unlock signer trait and types from the common crate
+pub use caliptra_mcu_debug_unlock_signer::{
+    DebugUnlockKeys, DebugUnlockSigner, LocalDebugUnlockSigner,
+};
+
 use anyhow::Result;
 use caliptra_mcu_core_util_host_command_types::certificate::{
     ExportAttestedCsrResponse, ExportIdevidCsrResponse,
+};
+use caliptra_mcu_core_util_host_command_types::debug_unlock::{
+    ProdDebugUnlockReqResponse, ProdDebugUnlockTokenRequest, ProdDebugUnlockTokenResponse,
 };
 use caliptra_mcu_core_util_host_command_types::{
     GetDeviceCapabilitiesResponse, GetDeviceIdResponse, GetDeviceInfoResponse,
@@ -37,6 +45,9 @@ use caliptra_mcu_core_util_host_transport::transports::spdm_vdm::transport::{
 use caliptra_mcu_core_util_host_transport::Transport;
 use caliptra_util_host_commands::api::certificate::{
     caliptra_cmd_export_attested_csr, caliptra_cmd_export_idevid_csr,
+};
+use caliptra_util_host_commands::api::debug_unlock::{
+    caliptra_cmd_prod_debug_unlock_req, caliptra_cmd_prod_debug_unlock_token,
 };
 use caliptra_util_host_commands::api::device_info::{
     caliptra_cmd_get_device_capabilities, caliptra_cmd_get_device_id, caliptra_cmd_get_device_info,
@@ -126,6 +137,32 @@ impl<'a> SpdmVdmClient<'a> {
         let mut session = self.create_session()?;
         caliptra_cmd_export_idevid_csr(&mut session, algorithm)
             .map_err(|e| anyhow::anyhow!("ExportIdevidCsr failed: {:?}", e))
+    }
+
+    /// Request a production debug unlock challenge.
+    ///
+    /// # Parameters
+    /// - `unlock_level`: The debug unlock level requested (1-8)
+    pub fn prod_debug_unlock_req(
+        &mut self,
+        unlock_level: u8,
+    ) -> Result<ProdDebugUnlockReqResponse> {
+        let mut session = self.create_session()?;
+        caliptra_cmd_prod_debug_unlock_req(&mut session, unlock_level)
+            .map_err(|e| anyhow::anyhow!("ProdDebugUnlockReq failed: {:?}", e))
+    }
+
+    /// Submit a production debug unlock token.
+    ///
+    /// # Parameters
+    /// - `request`: The fully populated debug unlock token request
+    pub fn prod_debug_unlock_token(
+        &mut self,
+        request: &ProdDebugUnlockTokenRequest,
+    ) -> Result<ProdDebugUnlockTokenResponse> {
+        let mut session = self.create_session()?;
+        caliptra_cmd_prod_debug_unlock_token(&mut session, request)
+            .map_err(|e| anyhow::anyhow!("ProdDebugUnlockToken failed: {:?}", e))
     }
 
     fn create_session(&mut self) -> Result<CaliptraSession> {

--- a/caliptra-util-host/apps/spdm/client/src/main.rs
+++ b/caliptra-util-host/apps/spdm/client/src/main.rs
@@ -10,7 +10,9 @@
 use anyhow::Result;
 use caliptra_spdm_requester::{SpdmConfig, SpdmRequester, SpdmSocketDeviceIo, SpdmVdmDriverImpl};
 use caliptra_spdm_vdm_client::config::{self, DeviceMode, TestConfig};
-use caliptra_spdm_vdm_client::{validator, SpdmVdmClient};
+use caliptra_spdm_vdm_client::{
+    validator, DebugUnlockKeys, DebugUnlockSigner, LocalDebugUnlockSigner, SpdmVdmClient,
+};
 use clap::Parser;
 
 #[derive(Parser, Debug)]
@@ -43,6 +45,14 @@ struct Args {
     /// Algorithm IDs for ExportIdevidCsr (comma-separated)
     #[arg(long)]
     idevid_algorithms: Option<String>,
+
+    /// Path to a binary file containing debug unlock keys (written by DebugUnlockKeys::save_to_file)
+    #[arg(long)]
+    debug_unlock_keys_file: Option<String>,
+
+    /// Debug unlock level (1-8)
+    #[arg(long)]
+    unlock_level: Option<u8>,
 }
 
 impl Args {
@@ -76,6 +86,9 @@ impl Args {
         if let Some(algorithms) = &self.idevid_algorithms {
             config.export_idevid_csr.algorithms = parse_key_ids(algorithms)?;
         }
+        if let Some(unlock_level) = self.unlock_level {
+            config.debug_unlock.unlock_level = unlock_level;
+        }
 
         Ok(config)
     }
@@ -88,7 +101,16 @@ fn main() -> Result<()> {
         .init()
         .ok();
 
-    let config = Args::parse().into_config()?;
+    let args = Args::parse();
+    let debug_unlock_signer: Option<Box<dyn DebugUnlockSigner>> =
+        if let Some(keys_path) = &args.debug_unlock_keys_file {
+            let keys = DebugUnlockKeys::load_from_file(std::path::Path::new(keys_path))?;
+            println!("[caliptra-spdm-validator] Loaded debug unlock keys from {}", keys_path);
+            Some(Box::new(LocalDebugUnlockSigner::new(keys)))
+        } else {
+            None
+        };
+    let config = args.into_config()?;
 
     println!(
         "[caliptra-spdm-validator] Connecting to bridge at {}",
@@ -114,7 +136,12 @@ fn main() -> Result<()> {
     let results = {
         let mut vdm = SpdmVdmDriverImpl::new(&mut requester, None);
         let mut client = SpdmVdmClient::new(&mut vdm);
-        validator::run_all(&mut client, &config, true)
+        validator::run_all(
+            &mut client,
+            &config,
+            debug_unlock_signer.as_deref(),
+            true,
+        )
     };
     validator::print_summary(&results);
 

--- a/caliptra-util-host/apps/spdm/client/src/main.rs
+++ b/caliptra-util-host/apps/spdm/client/src/main.rs
@@ -105,7 +105,10 @@ fn main() -> Result<()> {
     let debug_unlock_signer: Option<Box<dyn DebugUnlockSigner>> =
         if let Some(keys_path) = &args.debug_unlock_keys_file {
             let keys = DebugUnlockKeys::load_from_file(std::path::Path::new(keys_path))?;
-            println!("[caliptra-spdm-validator] Loaded debug unlock keys from {}", keys_path);
+            println!(
+                "[caliptra-spdm-validator] Loaded debug unlock keys from {}",
+                keys_path
+            );
             Some(Box::new(LocalDebugUnlockSigner::new(keys)))
         } else {
             None
@@ -136,12 +139,7 @@ fn main() -> Result<()> {
     let results = {
         let mut vdm = SpdmVdmDriverImpl::new(&mut requester, None);
         let mut client = SpdmVdmClient::new(&mut vdm);
-        validator::run_all(
-            &mut client,
-            &config,
-            debug_unlock_signer.as_deref(),
-            true,
-        )
+        validator::run_all(&mut client, &config, debug_unlock_signer.as_deref(), true)
     };
     validator::print_summary(&results);
 

--- a/caliptra-util-host/apps/spdm/client/src/validator.rs
+++ b/caliptra-util-host/apps/spdm/client/src/validator.rs
@@ -320,21 +320,7 @@ pub fn run_prod_debug_unlock(
                     }
                 }
             } else {
-                // No signer — send zeroed token (expected to be rejected)
-                let token_req = ProdDebugUnlockTokenRequest::default();
-                match client.prod_debug_unlock_token(&token_req) {
-                    Ok(_) => {
-                        if verbose {
-                            println!("  Token accepted (unexpected in test mode)");
-                        }
-                    }
-                    Err(_) => {
-                        if verbose {
-                            println!("  Token correctly rejected (no valid signature) ✓");
-                        }
-                    }
-                }
-                ValidationResult::pass(test_name, "challenge received, command dispatch works")
+                ValidationResult::fail(test_name, "no signer provided")
             }
         }
         Err(e) => {
@@ -345,12 +331,7 @@ pub fn run_prod_debug_unlock(
                     msg
                 );
             }
-            // The command was dispatched — the device rejected it, which is OK
-            // (e.g., wrong lifecycle state).
-            ValidationResult::pass(
-                test_name,
-                format!("command dispatched, rejected by device: {}", msg),
-            )
+            ValidationResult::fail(test_name, format!("debug unlock request failed: {}", msg))
         }
     }
 }

--- a/caliptra-util-host/apps/spdm/client/src/validator.rs
+++ b/caliptra-util-host/apps/spdm/client/src/validator.rs
@@ -14,6 +14,7 @@
 use crate::config::{DeviceMode, TestConfig};
 use crate::SpdmVdmClient;
 use caliptra_mcu_core_util_host_command_types::certificate::AttestedCsrValidationError;
+use caliptra_mcu_debug_unlock_signer::{DebugUnlockSigner, ProdDebugUnlockChallenge};
 
 /// Result of a single validation check.
 #[derive(Debug, Clone)]
@@ -100,6 +101,7 @@ pub fn all_passed(results: &[ValidationResult]) -> bool {
 pub fn run_all(
     client: &mut SpdmVdmClient,
     config: &TestConfig,
+    debug_unlock_signer: Option<&dyn DebugUnlockSigner>,
     verbose: bool,
 ) -> Vec<ValidationResult> {
     let mut results = Vec::new();
@@ -125,6 +127,15 @@ pub fn run_all(
                 verbose,
             ));
         }
+    }
+
+    if config.debug_unlock.enabled {
+        results.push(run_prod_debug_unlock(
+            client,
+            config.debug_unlock.unlock_level,
+            debug_unlock_signer,
+            verbose,
+        ));
     }
 
     results
@@ -237,4 +248,109 @@ pub fn run_export_idevid_csr_expect_fail(
             }
         })
         .collect()
+}
+
+/// Validate Production Debug Unlock via SPDM VDM.
+///
+/// When a [`DebugUnlockSigner`] is provided, performs a full end-to-end flow:
+/// request challenge → sign token → submit token.
+///
+/// Without a signer, sends a zeroed token (expected to be rejected) to confirm
+/// command dispatch works.
+pub fn run_prod_debug_unlock(
+    client: &mut SpdmVdmClient,
+    unlock_level: u8,
+    signer: Option<&dyn DebugUnlockSigner>,
+    verbose: bool,
+) -> ValidationResult {
+    use caliptra_mcu_core_util_host_command_types::debug_unlock::ProdDebugUnlockTokenRequest;
+
+    let test_name = "ProdDebugUnlock".to_string();
+
+    if verbose {
+        println!("\n=== Validating Production Debug Unlock (SPDM VDM) ===");
+    }
+
+    match client.prod_debug_unlock_req(unlock_level) {
+        Ok(response) => {
+            if verbose {
+                println!("  Got challenge response:");
+                println!(
+                    "    UDI: {:02X?}...",
+                    &response.unique_device_identifier[..8]
+                );
+                println!("    Challenge: {:02X?}...", &response.challenge[..8]);
+            }
+
+            if let Some(signer) = signer {
+                // Full end-to-end: sign a real token
+                if verbose {
+                    println!("  Signing token with provided signer...");
+                }
+
+                let challenge = ProdDebugUnlockChallenge {
+                    unique_device_identifier: response.unique_device_identifier,
+                    challenge: response.challenge,
+                };
+
+                let token = match signer.sign_debug_unlock_token(&challenge, unlock_level) {
+                    Ok(t) => ProdDebugUnlockTokenRequest {
+                        length: t.length,
+                        unique_device_identifier: t.unique_device_identifier,
+                        unlock_level: t.unlock_level,
+                        reserved: t.reserved,
+                        challenge: t.challenge,
+                        ecc_public_key: t.ecc_public_key,
+                        mldsa_public_key: t.mldsa_public_key,
+                        ecc_signature: t.ecc_signature,
+                        mldsa_signature: t.mldsa_signature,
+                    },
+                    Err(e) => {
+                        return ValidationResult::fail(
+                            test_name,
+                            format!("Failed to sign token: {}", e),
+                        );
+                    }
+                };
+
+                match client.prod_debug_unlock_token(&token) {
+                    Ok(_) => ValidationResult::pass(test_name, "token accepted"),
+                    Err(e) => {
+                        ValidationResult::fail(test_name, format!("Signed token rejected: {}", e))
+                    }
+                }
+            } else {
+                // No signer — send zeroed token (expected to be rejected)
+                let token_req = ProdDebugUnlockTokenRequest::default();
+                match client.prod_debug_unlock_token(&token_req) {
+                    Ok(_) => {
+                        if verbose {
+                            println!("  Token accepted (unexpected in test mode)");
+                        }
+                    }
+                    Err(_) => {
+                        if verbose {
+                            println!("  Token correctly rejected (no valid signature) ✓");
+                        }
+                    }
+                }
+                ValidationResult::pass(test_name, "challenge received, command dispatch works")
+            }
+        }
+        Err(e) => {
+            let msg = format!("{}", e);
+            if verbose {
+                println!(
+                    "  Debug unlock request returned error: {} (may be expected due to lifecycle)",
+                    msg
+                );
+            }
+            // The command was dispatched — the device rejected it, which is OK
+            // (e.g., wrong lifecycle state).
+            ValidationResult::pass(
+                test_name,
+                format!("command dispatched, rejected by device: {}", msg),
+            )
+        }
+    }
 }

--- a/caliptra-util-host/transport/src/transports/spdm_vdm/commands.rs
+++ b/caliptra-util-host/transport/src/transports/spdm_vdm/commands.rs
@@ -16,6 +16,8 @@
 //! - DeviceId (0x03)
 //! - DeviceInfo (0x04)
 //! - ExportIdevidCsr (0x0C)
+//! - RequestDebugUnlock (0x0A)
+//! - AuthorizeDebugUnlockToken (0x0B)
 //! - ExportAttestedCsr (0x0F)
 
 use super::protocol::{
@@ -24,8 +26,15 @@ use super::protocol::{
 };
 use super::transport::{SpdmVdmDriver, SpdmVdmError};
 use crate::TransportError;
+use caliptra_mcu_core_util_host_command_types::debug_unlock::{
+    ProdDebugUnlockReqRequest, ProdDebugUnlockReqResponse, ProdDebugUnlockTokenRequest,
+    ProdDebugUnlockTokenResponse, DEBUG_UNLOCK_CHALLENGE_SIZE, UNIQUE_DEVICE_ID_SIZE,
+};
 use caliptra_mcu_core_util_host_command_types::*;
 use zerocopy::IntoBytes;
+
+/// Caliptra RT mailbox command ID for PRODUCTION_AUTH_DEBUG_UNLOCK_TOKEN.
+const CALIPTRA_RT_CMD_PROD_DEBUG_UNLOCK_TOKEN: u32 = 0x5044_5554; // "PDUT"
 
 // ---------------------------------------------------------------------------
 // Helper: build VDM request, send via driver, validate response header
@@ -391,6 +400,103 @@ pub fn handle_export_idevid_csr(
         common: CommonResponse { fips_status: 0 },
         data_len: csr_len as u32,
         csr_data,
+    };
+
+    let resp_bytes = internal_resp.as_bytes();
+    let copy_len = resp_bytes.len().min(response_buffer.len());
+    response_buffer[..copy_len].copy_from_slice(&resp_bytes[..copy_len]);
+    Ok(copy_len)
+}
+
+// ---------------------------------------------------------------------------
+// RequestDebugUnlock (CaliptraCommandId::ProdDebugUnlockReq)
+// ---------------------------------------------------------------------------
+
+pub fn handle_prod_debug_unlock_req(
+    payload: &[u8],
+    driver: &mut dyn SpdmVdmDriver,
+    response_buffer: &mut [u8],
+) -> Result<usize, TransportError> {
+    let req = ProdDebugUnlockReqRequest::from_bytes(payload)
+        .map_err(|_| TransportError::InvalidMessage)?;
+
+    // VDM payload: [unlock_level(1)]
+    let vdm_payload = [req.unlock_level];
+    let mut resp_buf = [0u8; MAX_VDM_RESPONSE_SIZE];
+    let resp_len = send_vdm_request(
+        CaliptraVdmCommand::RequestDebugUnlock,
+        &vdm_payload,
+        driver,
+        &mut resp_buf,
+    )?;
+
+    let data = &resp_buf[VDM_RESPONSE_HEADER_SIZE..resp_len];
+
+    // Response data: [unique_device_identifier(32), challenge(48)]
+    if data.len() < UNIQUE_DEVICE_ID_SIZE + DEBUG_UNLOCK_CHALLENGE_SIZE {
+        return Err(TransportError::InvalidMessage);
+    }
+
+    let mut unique_device_identifier = [0u8; UNIQUE_DEVICE_ID_SIZE];
+    unique_device_identifier.copy_from_slice(&data[..UNIQUE_DEVICE_ID_SIZE]);
+
+    let mut challenge = [0u8; DEBUG_UNLOCK_CHALLENGE_SIZE];
+    challenge.copy_from_slice(
+        &data[UNIQUE_DEVICE_ID_SIZE..UNIQUE_DEVICE_ID_SIZE + DEBUG_UNLOCK_CHALLENGE_SIZE],
+    );
+
+    let internal_resp = ProdDebugUnlockReqResponse {
+        common: CommonResponse { fips_status: 0 },
+        length: 0,
+        unique_device_identifier,
+        challenge,
+    };
+
+    let resp_bytes = internal_resp.as_bytes();
+    let copy_len = resp_bytes.len().min(response_buffer.len());
+    response_buffer[..copy_len].copy_from_slice(&resp_bytes[..copy_len]);
+    Ok(copy_len)
+}
+
+// ---------------------------------------------------------------------------
+// AuthorizeDebugUnlockToken (CaliptraCommandId::ProdDebugUnlockToken)
+// ---------------------------------------------------------------------------
+
+pub fn handle_prod_debug_unlock_token(
+    payload: &[u8],
+    driver: &mut dyn SpdmVdmDriver,
+    response_buffer: &mut [u8],
+) -> Result<usize, TransportError> {
+    use crate::transports::mailbox::checksum::calc_checksum;
+    use alloc::vec;
+
+    let req = ProdDebugUnlockTokenRequest::from_bytes(payload)
+        .map_err(|_| TransportError::InvalidMessage)?;
+
+    // Build VDM payload in Caliptra RT mailbox format:
+    // [MailboxReqHeader(chksum: u32) | token_struct_bytes...]
+    // The MCU streams this directly to the Caliptra mailbox FIFO.
+    let token_bytes = req.as_bytes();
+    let hdr_size = core::mem::size_of::<u32>(); // MailboxReqHeader = chksum(u32)
+    let total_len = hdr_size + token_bytes.len();
+
+    // Build the payload with zeroed checksum first, then compute
+    let mut mbox_payload = vec![0u8; total_len];
+    mbox_payload[hdr_size..].copy_from_slice(token_bytes);
+    let chksum = calc_checksum(CALIPTRA_RT_CMD_PROD_DEBUG_UNLOCK_TOKEN, &mbox_payload);
+    mbox_payload[..hdr_size].copy_from_slice(&chksum.to_le_bytes());
+
+    let mut resp_buf = [0u8; MAX_VDM_RESPONSE_SIZE];
+    let _resp_len = send_vdm_request(
+        CaliptraVdmCommand::AuthorizeDebugUnlockToken,
+        &mbox_payload,
+        driver,
+        &mut resp_buf,
+    )?;
+
+    // Response is just completion code (already validated by send_vdm_request)
+    let internal_resp = ProdDebugUnlockTokenResponse {
+        common: CommonResponse { fips_status: 0 },
     };
 
     let resp_bytes = internal_resp.as_bytes();

--- a/caliptra-util-host/transport/src/transports/spdm_vdm/dispatch.rs
+++ b/caliptra-util-host/transport/src/transports/spdm_vdm/dispatch.rs
@@ -34,6 +34,12 @@ pub fn get_command_handler(command_id: u32) -> Option<VdmCommandHandlerFn> {
         x if x == CaliptraCommandId::ExportIdevidCsr as u32 => {
             Some(commands::handle_export_idevid_csr)
         }
+        x if x == CaliptraCommandId::ProdDebugUnlockReq as u32 => {
+            Some(commands::handle_prod_debug_unlock_req)
+        }
+        x if x == CaliptraCommandId::ProdDebugUnlockToken as u32 => {
+            Some(commands::handle_prod_debug_unlock_token)
+        }
         _ => None,
     }
 }

--- a/caliptra-util-host/transport/src/transports/spdm_vdm/protocol.rs
+++ b/caliptra-util-host/transport/src/transports/spdm_vdm/protocol.rs
@@ -158,6 +158,12 @@ pub fn command_id_to_vdm(command_id: u32) -> Option<CaliptraVdmCommand> {
         x if x == CaliptraCommandId::ExportIdevidCsr as u32 => {
             Some(CaliptraVdmCommand::ExportIdevidCsr)
         }
+        x if x == CaliptraCommandId::ProdDebugUnlockReq as u32 => {
+            Some(CaliptraVdmCommand::RequestDebugUnlock)
+        }
+        x if x == CaliptraCommandId::ProdDebugUnlockToken as u32 => {
+            Some(CaliptraVdmCommand::AuthorizeDebugUnlockToken)
+        }
         _ => None,
     }
 }

--- a/common/debug-unlock-signer/src/local.rs
+++ b/common/debug-unlock-signer/src/local.rs
@@ -59,6 +59,15 @@ impl DebugUnlockKeys {
         let mut len_buf = [0u8; 4];
         file.read_exact(&mut len_buf)?;
         let mldsa_priv_len = u32::from_le_bytes(len_buf) as usize;
+        // ML-DSA-87 private keys are always exactly 4896 bytes.
+        const MLDSA_PRIVATE_KEY_SIZE: usize = 4896;
+        if mldsa_priv_len != MLDSA_PRIVATE_KEY_SIZE {
+            return Err(anyhow::anyhow!(
+                "Invalid MLDSA private key size: expected {}, got {}",
+                MLDSA_PRIVATE_KEY_SIZE,
+                mldsa_priv_len
+            ));
+        }
         let mut mldsa_private_key_bytes = vec![0u8; mldsa_priv_len];
         file.read_exact(&mut mldsa_private_key_bytes)?;
 

--- a/common/debug-unlock-signer/src/local.rs
+++ b/common/debug-unlock-signer/src/local.rs
@@ -5,6 +5,8 @@ use crate::{
     MLDSA_PUBLIC_KEY_WORD_SIZE, MLDSA_SIGNATURE_WORD_SIZE,
 };
 use anyhow::Result;
+use std::io::{Read, Write};
+use std::path::Path;
 
 use crate::DebugUnlockSigner;
 
@@ -19,6 +21,61 @@ pub struct DebugUnlockKeys {
     pub mldsa_private_key_bytes: Vec<u8>,
     /// ML-DSA-87 public key as little-endian u32 words.
     pub mldsa_public_key: [u32; MLDSA_PUBLIC_KEY_WORD_SIZE],
+}
+
+impl DebugUnlockKeys {
+    /// Serialize keys to a binary file.
+    ///
+    /// Format: `[ecc_priv: 48][ecc_pub: 96][mldsa_priv_len: 4][mldsa_priv: N][mldsa_pub: 2592]`
+    pub fn save_to_file(&self, path: &Path) -> Result<()> {
+        let mut file = std::fs::File::create(path)?;
+        file.write_all(&self.ecc_private_key_bytes)?;
+        for word in &self.ecc_public_key {
+            file.write_all(&word.to_le_bytes())?;
+        }
+        let mldsa_priv_len = self.mldsa_private_key_bytes.len() as u32;
+        file.write_all(&mldsa_priv_len.to_le_bytes())?;
+        file.write_all(&self.mldsa_private_key_bytes)?;
+        for word in &self.mldsa_public_key {
+            file.write_all(&word.to_le_bytes())?;
+        }
+        Ok(())
+    }
+
+    /// Deserialize keys from a binary file written by [`save_to_file`].
+    pub fn load_from_file(path: &Path) -> Result<Self> {
+        let mut file = std::fs::File::open(path)?;
+
+        let mut ecc_private_key_bytes = [0u8; 48];
+        file.read_exact(&mut ecc_private_key_bytes)?;
+
+        let mut ecc_public_key = [0u32; ECC_PUBLIC_KEY_WORD_SIZE];
+        for word in &mut ecc_public_key {
+            let mut buf = [0u8; 4];
+            file.read_exact(&mut buf)?;
+            *word = u32::from_le_bytes(buf);
+        }
+
+        let mut len_buf = [0u8; 4];
+        file.read_exact(&mut len_buf)?;
+        let mldsa_priv_len = u32::from_le_bytes(len_buf) as usize;
+        let mut mldsa_private_key_bytes = vec![0u8; mldsa_priv_len];
+        file.read_exact(&mut mldsa_private_key_bytes)?;
+
+        let mut mldsa_public_key = [0u32; MLDSA_PUBLIC_KEY_WORD_SIZE];
+        for word in &mut mldsa_public_key {
+            let mut buf = [0u8; 4];
+            file.read_exact(&mut buf)?;
+            *word = u32::from_le_bytes(buf);
+        }
+
+        Ok(Self {
+            ecc_private_key_bytes,
+            ecc_public_key,
+            mldsa_private_key_bytes,
+            mldsa_public_key,
+        })
+    }
 }
 
 /// A [`DebugUnlockSigner`] that signs tokens locally using in-memory keys.

--- a/emulator/periph/src/mci.rs
+++ b/emulator/periph/src/mci.rs
@@ -193,6 +193,29 @@ impl MciPeripheral for Mci {
         self.ext_mci_regs.regs.borrow().generic_input_wires[index]
     }
 
+    // Bridge prod_debug_unlock_pk_hash_reg reads/writes to the Caliptra-side MCI
+    // so that ROM writes are visible to Caliptra RT's DMA reads.
+    fn read_mci_reg_prod_debug_unlock_pk_hash_reg(
+        &mut self,
+        index: usize,
+    ) -> caliptra_emu_types::RvData {
+        self.ext_mci_regs
+            .regs
+            .borrow()
+            .prod_debug_unlock_pk_hash_reg[index]
+    }
+
+    fn write_mci_reg_prod_debug_unlock_pk_hash_reg(
+        &mut self,
+        val: caliptra_emu_types::RvData,
+        index: usize,
+    ) {
+        self.ext_mci_regs
+            .regs
+            .borrow_mut()
+            .prod_debug_unlock_pk_hash_reg[index] = val;
+    }
+
     fn read_mci_reg_fw_flow_status(&mut self) -> caliptra_emu_types::RvData {
         self.ext_mci_regs.regs.borrow().flow_status
     }

--- a/platforms/emulator/runtime/src/board.rs
+++ b/platforms/emulator/runtime/src/board.rs
@@ -473,7 +473,10 @@ pub unsafe fn main() {
         board_kernel,
         caliptra_mcu_capsules_runtime::mailbox::DRIVER_NUM,
         mux_alarm,
+        #[cfg(feature = "test-caliptra-mailbox")]
         Some(100_000),
+        #[cfg(not(feature = "test-caliptra-mailbox"))]
+        Some(5_000_000),
     )
     .finalize(mailbox_component_static!(
         InternalTimers<'static>,

--- a/platforms/emulator/runtime/userspace/apps/example/src/test_caliptra_mailbox.rs
+++ b/platforms/emulator/runtime/userspace/apps/example/src/test_caliptra_mailbox.rs
@@ -227,12 +227,8 @@ pub(crate) async fn test_caliptra_mailbox_chunked_timeout() {
     }
 
     // Step 2: Delay long enough for the kernel timeout to fire and reset to idle.
-    // Use a busy loop to burn time without yielding to the kernel scheduler,
-    // then yield so the kernel can process the alarm callback.
-    for _ in 0..1_000_000u32 {
-        core::hint::black_box(0u32);
-    }
-    // Yield to let the kernel fire the alarm callback.
+    // The mailbox chunked-request timeout is 100_000 ticks (100 ms at 1 MHz).
+    // Sleep for 500 ms to ensure the timeout fires.
     crate::sleep::<caliptra_mcu_libsyscall_caliptra::DefaultSyscalls>(
         caliptra_mcu_libtock::alarm::Milliseconds(500),
     )

--- a/platforms/emulator/runtime/userspace/apps/user/src/caliptra_cmd_handler/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/caliptra_cmd_handler/mod.rs
@@ -7,8 +7,8 @@ mod debug_log;
 use alloc::boxed::Box;
 use async_trait::async_trait;
 use caliptra_mcu_common_commands::{
-    CaliptraCmdHandler, CaliptraCmdResult, CaliptraCompletionCode, DeviceCapabilities, DeviceId,
-    DeviceInfo, FirmwareVersion, GetLogResult, LogType,
+    CaliptraCmdHandler, CaliptraCmdResult, CaliptraCompletionCode, DebugUnlockChallenge,
+    DeviceCapabilities, DeviceId, DeviceInfo, FirmwareVersion, GetLogResult, LogType,
 };
 use caliptra_mcu_libapi_caliptra::certificate::{CertContext, IDEV_ECC_CSR_MAX_SIZE};
 use caliptra_mcu_libapi_caliptra::crypto::asym::AsymAlgo;
@@ -134,5 +134,265 @@ impl CaliptraCmdHandler for CaliptraCmdBackend {
             LogType::Debug => debug_log::clear().await,
             LogType::Attestation => Err(CaliptraCompletionCode::UnsupportedOperation),
         }
+    }
+
+    async fn request_debug_unlock(
+        &self,
+        unlock_level: u8,
+        challenge: &mut DebugUnlockChallenge,
+    ) -> CaliptraCmdResult<()> {
+        use caliptra_api::mailbox::{
+            CommandId, MailboxReqHeader, ProductionAuthDebugUnlockChallenge,
+            ProductionAuthDebugUnlockReq,
+        };
+        use caliptra_mcu_libapi_caliptra::mailbox_api::execute_mailbox_cmd;
+        use caliptra_mcu_libsyscall_caliptra::mailbox::Mailbox;
+        use zerocopy::{FromBytes, IntoBytes};
+
+        let mailbox = Mailbox::new();
+        let mut req = ProductionAuthDebugUnlockReq {
+            hdr: MailboxReqHeader::default(),
+            length: 2,
+            unlock_level,
+            reserved: [0; 3],
+        };
+
+        let mut resp_buf = [0u8; core::mem::size_of::<ProductionAuthDebugUnlockChallenge>()];
+
+        execute_mailbox_cmd(
+            &mailbox,
+            CommandId::PRODUCTION_AUTH_DEBUG_UNLOCK_REQ.0,
+            req.as_mut_bytes(),
+            &mut resp_buf,
+        )
+        .await
+        .map_err(|_| CaliptraCompletionCode::OperationFailed)?;
+
+        let resp = ProductionAuthDebugUnlockChallenge::ref_from_bytes(&resp_buf)
+            .map_err(|_| CaliptraCompletionCode::GeneralError)?;
+
+        challenge
+            .unique_device_identifier
+            .copy_from_slice(&resp.unique_device_identifier);
+        challenge.challenge.copy_from_slice(&resp.challenge);
+
+        Ok(())
+    }
+
+    async fn authorize_debug_unlock_token(&self, token_data: &[u8]) -> CaliptraCmdResult<()> {
+        use alloc::vec;
+        use caliptra_api::mailbox::{CommandId, MailboxReqHeader, MailboxRespHeader};
+        use caliptra_mcu_libapi_caliptra::mailbox_api::execute_mailbox_cmd;
+        use caliptra_mcu_libsyscall_caliptra::mailbox::Mailbox;
+
+        let mailbox = Mailbox::new();
+
+        // Build full request: MailboxReqHeader (zeroed, checksum computed by execute_mailbox_cmd) + token_data
+        let hdr_len = core::mem::size_of::<MailboxReqHeader>();
+        let mut req = vec![0u8; hdr_len + token_data.len()];
+        req[hdr_len..].copy_from_slice(token_data);
+
+        let mut resp_buf = [0u8; core::mem::size_of::<MailboxRespHeader>()];
+
+        execute_mailbox_cmd(
+            &mailbox,
+            CommandId::PRODUCTION_AUTH_DEBUG_UNLOCK_TOKEN.0,
+            &mut req,
+            &mut resp_buf,
+        )
+        .await
+        .map_err(|_| CaliptraCompletionCode::OperationFailed)?;
+
+        Ok(())
+    }
+}
+
+/// Small remainder buffer for streaming — holds up to 3 bytes that couldn't be
+/// sent because the mailbox FIFO requires 4-byte-aligned writes.
+static STREAM_REMAINDER: embassy_sync::mutex::Mutex<
+    embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex,
+    StreamRemainder,
+> = embassy_sync::mutex::Mutex::new(StreamRemainder {
+    buf: [0; 3],
+    len: 0,
+});
+
+struct StreamRemainder {
+    buf: [u8; 3],
+    len: usize,
+}
+
+/// Send data to the mailbox in 4-byte-aligned sub-chunks, holding any
+/// remainder (< 4 bytes) in STREAM_REMAINDER for the next call.
+async fn send_aligned(
+    mailbox: &caliptra_mcu_libsyscall_caliptra::mailbox::Mailbox<
+        caliptra_mcu_libsyscall_caliptra::DefaultSyscalls,
+    >,
+    data: &[u8],
+) -> Result<(), caliptra_mcu_spdm_lib::vdm_handler::VdmError> {
+    use caliptra_mcu_spdm_lib::vdm_handler::VdmError;
+
+    let mut remainder = STREAM_REMAINDER.lock().await;
+    // Build a working buffer: remainder from last call + new data
+    // We process in 256-byte sub-chunks max
+    const SUB_CHUNK: usize = 256;
+    let mut buf = [0u8; SUB_CHUNK + 4]; // extra room for remainder prefix
+    let mut offset = 0usize;
+
+    // Prepend any leftover bytes from previous call
+    let rem_len = remainder.len;
+    if rem_len > 0 {
+        buf[..rem_len].copy_from_slice(&remainder.buf[..rem_len]);
+        remainder.len = 0;
+    }
+
+    let total = rem_len + data.len();
+    let mut src_offset = 0usize;
+
+    while offset < total {
+        // Fill buf starting after any remainder already placed
+        let buf_start = if offset == 0 { rem_len } else { 0 };
+        let remaining_data = data.len() - src_offset;
+        let can_fill = SUB_CHUNK.min(buf_start + remaining_data) - buf_start;
+        buf[buf_start..buf_start + can_fill]
+            .copy_from_slice(&data[src_offset..src_offset + can_fill]);
+        src_offset += can_fill;
+        let available = buf_start + can_fill;
+
+        // Round down to 4-byte boundary
+        let send_len = available & !3;
+        let leftover = available - send_len;
+
+        if send_len > 0 {
+            mailbox
+                .send_chunk(&buf[..send_len])
+                .await
+                .map_err(|_| VdmError::StreamError)?;
+        }
+
+        // Save leftover for next iteration or next call
+        if leftover > 0 {
+            let mut new_buf = [0u8; 3];
+            new_buf[..leftover].copy_from_slice(&buf[send_len..send_len + leftover]);
+            if src_offset >= data.len() {
+                // No more data — save remainder for next call
+                remainder.buf[..leftover].copy_from_slice(&new_buf[..leftover]);
+                remainder.len = leftover;
+                break;
+            } else {
+                // More data to process — move leftover to start of buf
+                buf[..leftover].copy_from_slice(&new_buf[..leftover]);
+                // Continue filling from buf[leftover..]
+                offset += send_len;
+                // Set buf_start for next iteration — handled by the else branch above
+                continue;
+            }
+        }
+
+        offset += send_len;
+    }
+
+    Ok(())
+}
+
+/// Flush any remaining bytes in the stream remainder buffer (padded to 4 bytes).
+async fn flush_remainder(
+    mailbox: &caliptra_mcu_libsyscall_caliptra::mailbox::Mailbox<
+        caliptra_mcu_libsyscall_caliptra::DefaultSyscalls,
+    >,
+) -> Result<(), caliptra_mcu_spdm_lib::vdm_handler::VdmError> {
+    use caliptra_mcu_spdm_lib::vdm_handler::VdmError;
+
+    let mut remainder = STREAM_REMAINDER.lock().await;
+    if remainder.len > 0 {
+        let actual_len = remainder.len;
+        let mut buf = [0u8; 4];
+        buf[..actual_len].copy_from_slice(&remainder.buf[..actual_len]);
+        remainder.len = 0;
+        mailbox
+            .send_chunk(&buf)
+            .await
+            .map_err(|_| VdmError::StreamError)?;
+    }
+    Ok(())
+}
+
+#[async_trait]
+impl caliptra_mcu_spdm_lib::vdm_handler::VdmStreamHandler for CaliptraCmdBackend {
+    fn stream_supported(&self, vdm_command_code: u8) -> Option<u32> {
+        use caliptra_api::mailbox::CommandId;
+        match vdm_command_code {
+            // AuthorizeDebugUnlockToken (0x0B)
+            0x0B => Some(CommandId::PRODUCTION_AUTH_DEBUG_UNLOCK_TOKEN.0),
+            // RequestDebugUnlock (0x0A) — small enough for normal buffered path
+            _ => None,
+        }
+    }
+
+    async fn stream_init(
+        &self,
+        mailbox_cmd: u32,
+        total_payload_len: usize,
+        first_chunk_payload: &[u8],
+    ) -> caliptra_mcu_spdm_lib::vdm_handler::VdmResult<()> {
+        use caliptra_mcu_spdm_lib::vdm_handler::VdmError;
+
+        let mailbox = caliptra_mcu_libsyscall_caliptra::mailbox::Mailbox::<
+            caliptra_mcu_libsyscall_caliptra::DefaultSyscalls,
+        >::new();
+
+        // Clear any stale remainder
+        {
+            let mut remainder = STREAM_REMAINDER.lock().await;
+            remainder.len = 0;
+        }
+
+        mailbox
+            .start_chunked_request(mailbox_cmd, total_payload_len)
+            .await
+            .map_err(|_| VdmError::StreamError)?;
+
+        // Send first chunk payload through aligned sender
+        send_aligned(&mailbox, first_chunk_payload).await?;
+
+        Ok(())
+    }
+
+    async fn stream_chunk(
+        &self,
+        chunk_data: &[u8],
+    ) -> caliptra_mcu_spdm_lib::vdm_handler::VdmResult<()> {
+        let mailbox = caliptra_mcu_libsyscall_caliptra::mailbox::Mailbox::<
+            caliptra_mcu_libsyscall_caliptra::DefaultSyscalls,
+        >::new();
+        send_aligned(&mailbox, chunk_data).await
+    }
+
+    async fn stream_finish(
+        &self,
+        mailbox_cmd: u32,
+        rsp_buf: &mut [u8],
+    ) -> caliptra_mcu_spdm_lib::vdm_handler::VdmResult<usize> {
+        use caliptra_mcu_spdm_lib::vdm_handler::VdmError;
+
+        let mailbox = caliptra_mcu_libsyscall_caliptra::mailbox::Mailbox::<
+            caliptra_mcu_libsyscall_caliptra::DefaultSyscalls,
+        >::new();
+
+        // Flush any remaining bytes (padded to 4-byte boundary)
+        flush_remainder(&mailbox).await?;
+
+        let resp_len = mailbox
+            .execute_chunked_request(mailbox_cmd, rsp_buf)
+            .await
+            .map_err(|_| VdmError::StreamError)?;
+
+        Ok(resp_len)
+    }
+
+    async fn stream_abort(&self) {
+        // Clear remainder state
+        let mut remainder = STREAM_REMAINDER.lock().await;
+        remainder.len = 0;
     }
 }

--- a/platforms/emulator/runtime/userspace/apps/user/src/mcu_mbox/cmd_handler_mock.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/mcu_mbox/cmd_handler_mock.rs
@@ -5,8 +5,9 @@ extern crate alloc;
 use alloc::boxed::Box;
 use async_trait::async_trait;
 use caliptra_mcu_common_commands::{
-    CaliptraCmdHandler, CaliptraCmdResult, CaliptraCompletionCode, DeviceCapabilities, DeviceId,
-    DeviceInfo, FirmwareVersion, GetLogResult, Uid, MAX_FW_VERSION_LEN, MAX_UID_LEN,
+    CaliptraCmdHandler, CaliptraCmdResult, CaliptraCompletionCode, DebugUnlockChallenge,
+    DeviceCapabilities, DeviceId, DeviceInfo, FirmwareVersion, GetLogResult, Uid,
+    MAX_FW_VERSION_LEN, MAX_UID_LEN,
 };
 use caliptra_mcu_mbox_common::config;
 
@@ -110,6 +111,20 @@ impl CaliptraCmdHandler for NonCryptoCmdHandlerMock {
         // Delegate to real CaliptraCmdBackend for actual Caliptra mailbox interaction
         let handler = CaliptraCmdBackend;
         handler.export_idevid_csr(algorithm, csr_buf).await
+    }
+
+    async fn request_debug_unlock(
+        &self,
+        unlock_level: u8,
+        challenge: &mut DebugUnlockChallenge,
+    ) -> CaliptraCmdResult<()> {
+        let handler = CaliptraCmdBackend;
+        handler.request_debug_unlock(unlock_level, challenge).await
+    }
+
+    async fn authorize_debug_unlock_token(&self, token_data: &[u8]) -> CaliptraCmdResult<()> {
+        let handler = CaliptraCmdBackend;
+        handler.authorize_debug_unlock_token(token_data).await
     }
 
     async fn get_log(&self, log_type: u32, data: &mut [u8]) -> CaliptraCmdResult<GetLogResult> {

--- a/platforms/emulator/runtime/userspace/apps/user/src/spdm/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/spdm/mod.rs
@@ -35,6 +35,12 @@ const SECURE_SPDM_VERSIONS: &[SpdmVersion] = &[SpdmVersion::V12];
 // Caliptra Crypto timeout exponent (2^20 us)
 const CALIPTRA_SPDM_CT_EXPONENT: u8 = 20;
 
+/// Maximum SPDM message size advertised in capabilities.
+/// Must be large enough for the largest supported large message (including
+/// streaming-eligible ones like debug unlock tokens with MLDSA signatures).
+/// Layout: VDM headers (15 bytes) + MailboxReqHeader (4 bytes) + ProductionAuthDebugUnlockToken (~7500 bytes)
+const ADVERTISED_MAX_SPDM_MSG_SIZE: usize = 8192;
+
 /// Logs an SPDM error in compact, `Debug`-free form. Always prints
 /// `<prefix>: <msg>: <category> 0x<error_code>`; appends ` ext=0x<ext>` only
 /// when the chain transitively wraps an external error (CaliptraApiError /
@@ -111,7 +117,7 @@ async fn spdm_mctp_responder() {
         ct_exponent: CALIPTRA_SPDM_CT_EXPONENT,
         flags: CapabilityFlags::default(),
         data_transfer_size: max_mctp_spdm_msg_size,
-        max_spdm_msg_size: shared_large_msg_buf::LARGE_MSG_BUF_SIZE as u32,
+        max_spdm_msg_size: ADVERTISED_MAX_SPDM_MSG_SIZE as u32,
     };
 
     let local_algorithms = LocalDeviceAlgorithms::default();
@@ -141,6 +147,10 @@ async fn spdm_mctp_responder() {
     let vdm_handlers: Option<&mut [&mut dyn caliptra_mcu_spdm_lib::vdm_handler::VdmHandler]> =
         Some(&mut handlers_array);
 
+    // VDM stream handler for streaming large VDM payloads directly to the
+    // Caliptra mailbox without buffering (e.g., debug unlock tokens ~7.5KB).
+    let vdm_stream_handler = crate::caliptra_cmd_handler::CaliptraCmdBackend;
+
     // Large message buffer provider — shared across MCTP and DOE transports.
     let large_msg_buf_provider = shared_large_msg_buf::SharedLargeMsgBuf::new();
 
@@ -166,6 +176,9 @@ async fn spdm_mctp_responder() {
             return;
         }
     };
+
+    // Register the VDM stream handler for large payload streaming
+    ctx.set_vdm_stream_handler(&vdm_stream_handler);
 
     let mut msg_buffer = MessageBuf::new(&mut raw_buffer);
     loop {

--- a/platforms/emulator/runtime/userspace/apps/user/src/vdm/cmd_handler_mock.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/vdm/cmd_handler_mock.rs
@@ -2,15 +2,15 @@
 
 extern crate alloc;
 
+use crate::caliptra_cmd_handler::CaliptraCmdBackend;
 use alloc::boxed::Box;
 use async_trait::async_trait;
 use caliptra_mcu_common_commands::{
-    CaliptraCmdHandler, CaliptraCmdResult, CaliptraCompletionCode, DeviceCapabilities, DeviceId,
-    DeviceInfo, FirmwareVersion, GetLogResult, Uid, MAX_FW_VERSION_LEN, MAX_UID_LEN,
+    CaliptraCmdHandler, CaliptraCmdResult, CaliptraCompletionCode, DebugUnlockChallenge,
+    DeviceCapabilities, DeviceId, DeviceInfo, FirmwareVersion, GetLogResult, Uid,
+    MAX_FW_VERSION_LEN, MAX_UID_LEN,
 };
 use caliptra_mcu_mbox_common::config;
-
-use crate::caliptra_cmd_handler::CaliptraCmdBackend;
 
 #[derive(Default)]
 pub struct NonCryptoCmdHandlerMock;
@@ -89,12 +89,29 @@ impl CaliptraCmdHandler for NonCryptoCmdHandlerMock {
 
     async fn export_attested_csr(
         &self,
-        _device_key_id: u32,
-        _algorithm: u32,
-        _nonce: &[u8; 32],
-        _csr_buf: &mut [u8],
+        device_key_id: u32,
+        algorithm: u32,
+        nonce: &[u8; 32],
+        csr_buf: &mut [u8],
     ) -> CaliptraCmdResult<usize> {
-        Err(CaliptraCompletionCode::UnsupportedOperation)
+        let handler = CaliptraCmdBackend;
+        handler
+            .export_attested_csr(device_key_id, algorithm, nonce, csr_buf)
+            .await
+    }
+
+    async fn request_debug_unlock(
+        &self,
+        unlock_level: u8,
+        challenge: &mut DebugUnlockChallenge,
+    ) -> CaliptraCmdResult<()> {
+        let handler = CaliptraCmdBackend;
+        handler.request_debug_unlock(unlock_level, challenge).await
+    }
+
+    async fn authorize_debug_unlock_token(&self, token_data: &[u8]) -> CaliptraCmdResult<()> {
+        let handler = CaliptraCmdBackend;
+        handler.authorize_debug_unlock_token(token_data).await
     }
 
     async fn export_idevid_csr(

--- a/runtime/userspace/api/caliptra-common-commands/src/lib.rs
+++ b/runtime/userspace/api/caliptra-common-commands/src/lib.rs
@@ -13,6 +13,11 @@ pub use caliptra_api::mailbox::MAX_ATTESTED_CSR_RESP_DATA_SIZE as MAX_ATTESTED_C
 pub const MAX_FW_VERSION_LEN: usize = 32;
 pub const MAX_UID_LEN: usize = 32;
 
+/// Size of the unique device identifier in bytes.
+pub const DEBUG_UNLOCK_UNIQUE_DEVICE_ID_SIZE: usize = 32;
+/// Size of the debug unlock challenge in bytes.
+pub const DEBUG_UNLOCK_CHALLENGE_SIZE: usize = 48;
+
 /// Caliptra command completion codes.
 /// Standard codes (0x00-0x0F) follow the OCP command registry:
 /// https://github.com/opencomputeproject/ocp-registry/blob/main/command-registry.md
@@ -136,6 +141,22 @@ pub struct DeviceCapabilities {
     pub reserved: [u8; 4],     // Bytes [28:31]
 }
 
+/// Debug unlock challenge response returned by `request_debug_unlock`.
+#[derive(Debug, Clone)]
+pub struct DebugUnlockChallenge {
+    pub unique_device_identifier: [u8; DEBUG_UNLOCK_UNIQUE_DEVICE_ID_SIZE],
+    pub challenge: [u8; DEBUG_UNLOCK_CHALLENGE_SIZE],
+}
+
+impl Default for DebugUnlockChallenge {
+    fn default() -> Self {
+        Self {
+            unique_device_identifier: [0u8; DEBUG_UNLOCK_UNIQUE_DEVICE_ID_SIZE],
+            challenge: [0u8; DEBUG_UNLOCK_CHALLENGE_SIZE],
+        }
+    }
+}
+
 /// Asynchronous trait for handling Caliptra common commands across all transport protocols.
 ///
 /// Each function represents a transport-agnostic command handler. Implementors should provide
@@ -218,6 +239,32 @@ pub trait CaliptraCmdHandler: Send + Sync {
         algorithm: u32,
         csr_buf: &mut [u8],
     ) -> CaliptraCmdResult<usize>;
+
+    /// Requests a production debug unlock challenge.
+    ///
+    /// # Arguments
+    /// * `unlock_level` - The debug unlock level requested (1-8).
+    /// * `challenge` - Mutable reference to store the challenge response.
+    ///
+    /// # Returns
+    /// * `CaliptraCmdResult<()>` - Ok on success, or an error.
+    async fn request_debug_unlock(
+        &self,
+        unlock_level: u8,
+        challenge: &mut DebugUnlockChallenge,
+    ) -> CaliptraCmdResult<()>;
+
+    /// Submits a signed debug unlock token.
+    ///
+    /// The token payload is streamed in chunks via the chunked mailbox API
+    /// because it can be very large (~7.5KB due to MLDSA keys/signatures).
+    ///
+    /// # Arguments
+    /// * `token_data` - The complete token payload bytes (excluding checksum header).
+    ///
+    /// # Returns
+    /// * `CaliptraCmdResult<()>` - Ok on success, or an error.
+    async fn authorize_debug_unlock_token(&self, token_data: &[u8]) -> CaliptraCmdResult<()>;
 
     /// Drain log entries of `log_type` into `data`.
     ///

--- a/runtime/userspace/api/spdm-lib/src/chunk_ctx.rs
+++ b/runtime/userspace/api/spdm-lib/src/chunk_ctx.rs
@@ -86,6 +86,9 @@ enum LargeMessageMode {
     Request,
     /// Buffer is being used to send a large response (CHUNK_GET).
     Response(LargeResponse),
+    /// Request is being streamed directly to a backend (e.g., mailbox FIFO)
+    /// without buffering in `buf`. The u32 is the mailbox command ID.
+    Streaming(u32),
 }
 
 /// Manages the shared buffer for both large SPDM request reassembly (CHUNK_SEND)
@@ -112,6 +115,13 @@ pub(crate) struct LargeMessageCtx<'a> {
     pub(crate) buf: &'static mut [u8],
     /// Provider for acquiring/releasing the shared buffer
     buf_provider: &'a dyn LargeMsgBufProvider,
+    /// For streaming mode: byte offset within the reassembled message where the
+    /// VDM mailbox payload starts (dynamically parsed from the first chunk header).
+    streaming_payload_offset: usize,
+    /// For streaming mode: total mailbox payload size derived from the VDM req_len field.
+    /// This is more accurate than `large_msg_size - payload_offset` because
+    /// `large_msg_size` may not account for all framing overhead.
+    streaming_mbox_payload_len: usize,
 }
 
 impl<'a> LargeMessageCtx<'a> {
@@ -125,6 +135,8 @@ impl<'a> LargeMessageCtx<'a> {
             data_len: 0,
             buf: &mut [],
             buf_provider,
+            streaming_payload_offset: 0,
+            streaming_mbox_payload_len: 0,
         }
     }
 
@@ -273,6 +285,79 @@ impl<'a> LargeMessageCtx<'a> {
             return None;
         }
         Some(self.buf[1])
+    }
+
+    // ── Streaming methods ──
+
+    /// Initialize a streaming request. The first chunk data is stored in `buf`
+    /// (only enough to parse the VDM command code), but subsequent chunks will
+    /// be forwarded directly to the backend without buffering.
+    pub fn init_streaming(
+        &mut self,
+        handle: u8,
+        large_msg_size: usize,
+        mailbox_cmd: u32,
+        payload_offset: usize,
+        mbox_payload_len: usize,
+        first_chunk: &[u8],
+    ) -> ChunkResult<()> {
+        // Store first chunk in buf (truncated to buf capacity) for header parsing
+        let store_len = first_chunk.len().min(self.buf.len());
+        self.buf[..store_len].copy_from_slice(&first_chunk[..store_len]);
+
+        self.mode = LargeMessageMode::Streaming(mailbox_cmd);
+        self.streaming_payload_offset = payload_offset;
+        self.streaming_mbox_payload_len = mbox_payload_len;
+        self.chunk_state.init(large_msg_size, handle);
+        self.chunk_state.bytes_transferred = first_chunk.len();
+        Ok(())
+    }
+
+    /// Returns `true` if a streaming request is in progress.
+    pub fn streaming_in_progress(&self) -> bool {
+        matches!(self.mode, LargeMessageMode::Streaming(_)) && self.chunk_state.in_use
+    }
+
+    /// Returns the mailbox command ID if streaming is in progress.
+    pub fn streaming_mailbox_cmd(&self) -> Option<u32> {
+        match self.mode {
+            LargeMessageMode::Streaming(cmd) => Some(cmd),
+            _ => None,
+        }
+    }
+
+    /// Returns the VDM payload offset for the streaming request.
+    pub fn streaming_payload_offset(&self) -> usize {
+        self.streaming_payload_offset
+    }
+
+    /// Returns the total mailbox payload size for the streaming request.
+    pub fn streaming_mbox_payload_len(&self) -> usize {
+        self.streaming_mbox_payload_len
+    }
+
+    /// Track a streaming chunk (update bytes_transferred and seq_num)
+    /// without copying data into the buffer.
+    pub fn track_streaming_chunk(
+        &mut self,
+        handle: u8,
+        chunk_seq_num: u16,
+        chunk_len: usize,
+    ) -> ChunkResult<()> {
+        self.validate_request_chunk(handle, chunk_seq_num)?;
+
+        let end = self
+            .chunk_state
+            .bytes_transferred
+            .checked_add(chunk_len)
+            .ok_or(ChunkError::InvalidMessageOffset)?;
+        if end > self.chunk_state.large_msg_size {
+            return Err(ChunkError::InvalidMessageOffset);
+        }
+
+        self.chunk_state.bytes_transferred = end;
+        self.chunk_state.seq_num = self.chunk_state.seq_num.wrapping_add(1);
+        Ok(())
     }
 
     // ── Response methods (CHUNK_GET chunking) ──

--- a/runtime/userspace/api/spdm-lib/src/commands/chunk_send_ack_rsp.rs
+++ b/runtime/userspace/api/spdm-lib/src/commands/chunk_send_ack_rsp.rs
@@ -2,10 +2,12 @@
 
 use crate::codec::{Codec, CommonCodec, DataKind, MessageBuf};
 use crate::commands::error_rsp::{encode_error_response, ErrorCode};
+use crate::commands::vendor_defined_rsp::VendorDefRespHdr;
 use crate::context::SpdmContext;
 use crate::error::{CommandError, CommandResult};
 use crate::protocol::*;
 use crate::state::ConnectionState;
+use crate::vdm_handler::iana::ocp::caliptra_vdm::protocol::CALIPTRA_VDM_COMMAND_VERSION;
 use bitfield::bitfield;
 use core::mem::size_of;
 use zerocopy::{FromBytes, Immutable, IntoBytes};
@@ -58,6 +60,17 @@ struct ChunkSendInfo {
     handle: u8,
     chunk_seq_num: u16,
     complete: bool,
+    /// For streaming mode: the byte range within the chunk that contains
+    /// VDM payload (mailbox data) to be streamed. None for buffered mode.
+    streaming_payload: Option<StreamingPayload>,
+}
+
+struct StreamingPayload {
+    /// Offset within the chunk where the VDM payload starts
+    /// (dynamically-parsed payload offset for first chunk, 0 for subsequent chunks)
+    offset: usize,
+    /// Length of the chunk data
+    len: usize,
 }
 
 enum ChunkSendProcessResult {
@@ -149,6 +162,50 @@ fn validate_common(
     Ok(connection_version)
 }
 
+/// Minimum byte offset needed in the first chunk to identify a VDM command code.
+/// SpdmMsgHdr(2) + VendorDefReqHdr(5) + vendor_id(max 4) + vdm_req_len(2) + CaliptraVdmMsgHeader(2)
+/// We need at least up to the cmd_code byte.
+const MIN_VDM_HEADER_BYTES: usize = 16;
+
+/// Parsed VDM header offsets from a reassembled VendorDefinedRequest.
+struct VdmHeaderInfo {
+    /// Byte offset of the CaliptraVdmMsgHeader.command_code field.
+    cmd_code_offset: usize,
+    /// Byte offset where the VDM mailbox payload begins (after CaliptraVdmMsgHeader).
+    payload_offset: usize,
+    /// The VDM request payload size (from the `req_len` field in the VendorDefinedRequest).
+    /// This includes CaliptraVdmMsgHeader(2) + mailbox_payload.
+    vdm_req_len: usize,
+}
+
+/// Parse VDM header fields from the first chunk of a reassembled VendorDefinedRequest.
+/// Returns None if the header can't be parsed.
+fn parse_vdm_header(chunk_data: &[u8]) -> Option<VdmHeaderInfo> {
+    // Layout: SpdmMsgHdr(2) + param1(1) + param2(1) + standard_id(2) + vendor_id_len(1) + vendor_id(N) + req_len(2) + CaliptraVdmMsgHeader(2) + payload...
+    if chunk_data.len() < 7 {
+        return None;
+    }
+    let vendor_id_len = chunk_data[6] as usize;
+    let req_len_offset = 7 + vendor_id_len;
+    if chunk_data.len() < req_len_offset + 2 {
+        return None;
+    }
+    let vdm_req_len =
+        u16::from_le_bytes([chunk_data[req_len_offset], chunk_data[req_len_offset + 1]]) as usize;
+    let caliptra_hdr_offset = req_len_offset + 2; // After req_len(u16)
+    let cmd_code_offset = caliptra_hdr_offset + 1; // After cmd_version(1)
+    let payload_offset = caliptra_hdr_offset + 2; // After CaliptraVdmMsgHeader(2)
+    if chunk_data.len() > cmd_code_offset {
+        Some(VdmHeaderInfo {
+            cmd_code_offset,
+            payload_offset,
+            vdm_req_len,
+        })
+    } else {
+        None
+    }
+}
+
 fn process_chunk_send(
     ctx: &mut SpdmContext<'_>,
     spdm_hdr: SpdmMsgHdr,
@@ -171,7 +228,8 @@ fn process_chunk_send(
 
     let invalid = if has_reserved_bits {
         true
-    } else if !ctx.large_msg_ctx.request_in_progress() {
+    } else if !ctx.large_msg_ctx.request_in_progress() && !ctx.large_msg_ctx.streaming_in_progress()
+    {
         if available_chunk_len < size_of::<u32>() {
             true
         } else {
@@ -184,13 +242,42 @@ fn process_chunk_send(
                 - size_of::<ChunkSendReq>()
                 - size_of::<u32>();
 
+            // Check if this is a streaming-eligible VDM command.
+            // Parse the VDM header dynamically to determine offsets.
+            let (stream_cmd, vdm_payload_offset, mbox_payload_len) =
+                if available_chunk_len >= MIN_VDM_HEADER_BYTES {
+                    // Peek at the chunk data without consuming it to check the VDM command code
+                    let peek_data = req
+                        .data(available_chunk_len)
+                        .map_err(|e| (false, CommandError::Codec(e)))?;
+
+                    if let Some(info) = parse_vdm_header(peek_data) {
+                        let vdm_cmd_code = peek_data[info.cmd_code_offset];
+                        let cmd = ctx
+                            .vdm_stream_handler
+                            .as_ref()
+                            .and_then(|h| h.stream_supported(vdm_cmd_code));
+                        // vdm_req_len includes CaliptraVdmMsgHeader(2) + mailbox payload.
+                        // Subtract 2 to get the actual mailbox payload size.
+                        let mbox_payload_len = info.vdm_req_len.saturating_sub(2);
+                        (cmd, info.payload_offset, mbox_payload_len)
+                    } else {
+                        (None, 0, 0)
+                    }
+                } else {
+                    (None, 0, 0)
+                };
+
+            let is_streaming = stream_cmd.is_some();
+
             let invalid = chunk_seq_num != 0
                 || last_chunk
                 || chunk_size < min_first_chunk_size
                 || chunk_size != available_chunk_len
                 || chunk_send_msg_len > ctx.local_capabilities.data_transfer_size as usize
                 || large_message_size > ctx.local_capabilities.max_spdm_msg_size as usize
-                || large_message_size > ctx.large_msg_ctx.request_capacity()
+                // Skip buffer capacity check for streaming commands
+                || (!is_streaming && large_message_size > ctx.large_msg_ctx.request_capacity())
                 || large_message_size <= MIN_DATA_TRANSFER_SIZE_V12 as usize
                 || chunk_size > large_message_size;
 
@@ -198,14 +285,67 @@ fn process_chunk_send(
                 let chunk = req
                     .data(chunk_size)
                     .map_err(|e| (false, CommandError::Codec(e)))?;
-                ctx.large_msg_ctx
-                    .init_request(handle, large_message_size, chunk)
-                    .is_err()
+
+                if let Some(mailbox_cmd) = stream_cmd {
+                    if ctx
+                        .large_msg_ctx
+                        .init_streaming(
+                            handle,
+                            large_message_size,
+                            mailbox_cmd,
+                            vdm_payload_offset,
+                            mbox_payload_len,
+                            chunk,
+                        )
+                        .is_err()
+                    {
+                        true
+                    } else {
+                        // Mark that we need to call stream_init with the first chunk's
+                        // VDM payload (bytes after the dynamically-parsed payload offset)
+                        false
+                    }
+                } else {
+                    ctx.large_msg_ctx
+                        .init_request(handle, large_message_size, chunk)
+                        .is_err()
+                }
             } else {
                 true
             }
         }
+    } else if ctx.large_msg_ctx.streaming_in_progress() {
+        // Streaming mode: subsequent chunks
+        let min_chunk_size = MIN_DATA_TRANSFER_SIZE_V12 as usize
+            - size_of::<SpdmMsgHdr>()
+            - size_of::<ChunkSendReq>();
+        let transferred = ctx.large_msg_ctx.request_bytes_transferred();
+        let large_message_size = ctx.large_msg_ctx.request_size();
+        let end = transferred.saturating_add(chunk_size);
+
+        let invalid = chunk_seq_num == 0
+            || chunk_size != available_chunk_len
+            || chunk_send_msg_len > ctx.local_capabilities.data_transfer_size as usize
+            || ctx
+                .large_msg_ctx
+                .validate_request_chunk(handle, chunk_seq_num)
+                .is_err()
+            || end > large_message_size
+            || (last_chunk && end != large_message_size)
+            || (!last_chunk && (end >= large_message_size || chunk_size < min_chunk_size));
+
+        if !invalid {
+            let chunk = req
+                .data(chunk_size)
+                .map_err(|e| (false, CommandError::Codec(e)))?;
+            ctx.large_msg_ctx
+                .track_streaming_chunk(handle, chunk_seq_num, chunk.len())
+                .is_err()
+        } else {
+            true
+        }
     } else {
+        // Normal buffered mode: subsequent chunks
         let min_chunk_size = MIN_DATA_TRANSFER_SIZE_V12 as usize
             - size_of::<SpdmMsgHdr>()
             - size_of::<ChunkSendReq>();
@@ -244,10 +384,37 @@ fn process_chunk_send(
         });
     }
 
+    let streaming = ctx.large_msg_ctx.streaming_in_progress();
+    let complete = ctx.large_msg_ctx.request_is_complete()
+        || (streaming
+            && ctx.large_msg_ctx.request_bytes_transferred() == ctx.large_msg_ctx.request_size());
+
+    // For streaming mode, record the payload info so handle_chunk_send can
+    // call the stream handler with the chunk data before it gets overwritten.
+    let streaming_payload = if streaming {
+        if chunk_seq_num == 0 {
+            // First chunk: VDM payload starts at the dynamically-parsed offset
+            let payload_offset = ctx.large_msg_ctx.streaming_payload_offset();
+            Some(StreamingPayload {
+                offset: payload_offset,
+                len: chunk_size,
+            })
+        } else {
+            // Subsequent chunks: entire chunk is VDM payload continuation
+            Some(StreamingPayload {
+                offset: 0,
+                len: chunk_size,
+            })
+        }
+    } else {
+        None
+    };
+
     Ok(ChunkSendProcessResult::Ack(ChunkSendInfo {
         handle,
         chunk_seq_num,
-        complete: ctx.large_msg_ctx.request_is_complete(),
+        complete,
+        streaming_payload,
     }))
 }
 
@@ -259,6 +426,104 @@ async fn generate_chunk_send_ack<'a>(
     let version = ctx.state.connection_info.version_number();
 
     if info.complete {
+        if ctx.large_msg_ctx.streaming_in_progress() {
+            // Streaming mode completion: call stream_finish
+            let mailbox_cmd = ctx
+                .large_msg_ctx
+                .streaming_mailbox_cmd()
+                .ok_or((false, CommandError::BufferTooSmall))?;
+
+            // Extract vendor_id from stored first chunk header before reset
+            let payload_offset = ctx.large_msg_ctx.streaming_payload_offset();
+            let stored_buf =
+                &ctx.large_msg_ctx.buf[..payload_offset.min(ctx.large_msg_ctx.buf.len())];
+            // Parse standard_id and vendor_id from stored header
+            // Layout: SpdmMsgHdr(2) + param1(1) + param2(1) + standard_id(2) + vendor_id_len(1) + vendor_id(N)
+            let standard_id = if stored_buf.len() >= 6 {
+                u16::from_le_bytes([stored_buf[4], stored_buf[5]])
+            } else {
+                0x0004 // IANA default
+            };
+            let vendor_id_len = if stored_buf.len() >= 7 {
+                stored_buf[6] as usize
+            } else {
+                4
+            };
+            let mut vendor_id = [0u8; 8];
+            let vid_end = (7 + vendor_id_len).min(stored_buf.len());
+            if stored_buf.len() >= 7 + vendor_id_len {
+                vendor_id[..vendor_id_len].copy_from_slice(&stored_buf[7..vid_end]);
+            }
+            // Get the command code from the CaliptraVdmMsgHeader
+            let cmd_code_offset = 7 + vendor_id_len + 2 + 1; // after req_len(2) + cmd_version(1)
+            let cmd_code = if stored_buf.len() > cmd_code_offset {
+                stored_buf[cmd_code_offset]
+            } else {
+                0
+            };
+
+            ctx.large_msg_ctx.reset_request();
+
+            ctx.prepare_response_buffer(rsp)?;
+            let header_size = size_of::<ChunkSendAckHdr>();
+            rsp.reserve(header_size)
+                .map_err(|e| (false, CommandError::Codec(e)))?;
+
+            if let Some(stream_handler) = ctx.vdm_stream_handler.as_ref() {
+                // Get response from stream_finish into a temp buffer
+                let mut stream_resp = [0u8; 256];
+                match stream_handler
+                    .stream_finish(mailbox_cmd, &mut stream_resp)
+                    .await
+                {
+                    Ok(resp_len) => {
+                        // Build a VendorDefinedResponse with VDM response payload:
+                        // VDM payload = [cmd_version(1), cmd_code(1), completion_code(1), data...]
+                        let completion_code = 0x00u8; // Success
+                        let vdm_payload_len = 3 + resp_len; // cmd_version + cmd_code + completion + data
+
+                        // Reserve space for VendorDefRespHdr
+                        let mut resp_hdr = VendorDefRespHdr::new(
+                            version,
+                            standard_id,
+                            &vendor_id[..vendor_id_len],
+                        );
+                        let resp_hdr_len = resp_hdr.len();
+                        rsp.reserve(resp_hdr_len)
+                            .map_err(|e| (false, CommandError::Codec(e)))?;
+
+                        // Write VDM payload
+                        rsp.put_data(vdm_payload_len)
+                            .map_err(|e| (false, CommandError::Codec(e)))?;
+                        let rsp_data = rsp
+                            .data_mut(vdm_payload_len)
+                            .map_err(|e| (false, CommandError::Codec(e)))?;
+                        rsp_data[0] = CALIPTRA_VDM_COMMAND_VERSION;
+                        rsp_data[1] = cmd_code;
+                        rsp_data[2] = completion_code;
+                        if resp_len > 0 {
+                            rsp_data[3..3 + resp_len].copy_from_slice(&stream_resp[..resp_len]);
+                        }
+
+                        // Encode VendorDefRespHdr (sets resp_len field)
+                        resp_hdr.set_resp_len(vdm_payload_len as u16);
+                        resp_hdr
+                            .encode(rsp)
+                            .map_err(|e| (false, CommandError::Codec(e)))?;
+                    }
+                    Err(_) => {
+                        append_error_response(version, ErrorCode::Unspecified, rsp)?;
+                    }
+                }
+            } else {
+                append_error_response(version, ErrorCode::Unspecified, rsp)?;
+            }
+
+            encode_chunk_send_ack_hdr(version, false, info.handle, info.chunk_seq_num, rsp)?;
+            return Ok(());
+        }
+
+        // Normal buffered mode completion
         // Validate request code before dispatch
         let request_code = ctx.large_msg_ctx.request_code();
         if matches!(
@@ -325,13 +590,60 @@ pub(crate) async fn handle_chunk_send<'a>(
 
     let result = process_chunk_send(ctx, spdm_hdr, req)?;
 
-    ctx.prepare_response_buffer(req)?;
     match result {
-        ChunkSendProcessResult::Ack(info) => generate_chunk_send_ack(ctx, info, req).await,
+        ChunkSendProcessResult::Ack(info) => {
+            // For streaming mode: call stream handler with chunk data BEFORE
+            // prepare_response_buffer overwrites `req`.
+            if let Some(ref sp) = info.streaming_payload {
+                if let Some(stream_handler) = ctx.vdm_stream_handler.as_ref() {
+                    // The chunk data is still in `req` since data() doesn't consume.
+                    // After process_chunk_send, the cursor is past the CHUNK_SEND header
+                    // fields but the chunk payload data is still accessible.
+                    let chunk_data = req
+                        .data(sp.len)
+                        .map_err(|e| (false, CommandError::Codec(e)))?;
+
+                    if info.chunk_seq_num == 0 {
+                        // First chunk: initialize streaming
+                        let mailbox_cmd = ctx
+                            .large_msg_ctx
+                            .streaming_mailbox_cmd()
+                            .ok_or((false, CommandError::BufferTooSmall))?;
+                        let total_vdm_payload_len = ctx.large_msg_ctx.streaming_mbox_payload_len();
+                        let payload = &chunk_data[sp.offset..];
+
+                        stream_handler
+                            .stream_init(mailbox_cmd, total_vdm_payload_len, payload)
+                            .await
+                            .map_err(|_| {
+                                ctx.large_msg_ctx.reset_request();
+                                (
+                                    false,
+                                    CommandError::Vdm(crate::vdm_handler::VdmError::StreamError),
+                                )
+                            })?;
+                    } else {
+                        // Subsequent chunk: stream the data
+                        stream_handler.stream_chunk(chunk_data).await.map_err(|_| {
+                            ctx.large_msg_ctx.reset_request();
+                            (
+                                false,
+                                CommandError::Vdm(crate::vdm_handler::VdmError::StreamError),
+                            )
+                        })?;
+                    }
+                }
+            }
+
+            generate_chunk_send_ack(ctx, info, req).await
+        }
         ChunkSendProcessResult::EarlyError {
             handle,
             chunk_seq_num,
-        } => generate_chunk_send_early_error_ack(ctx, handle, chunk_seq_num, req),
+        } => {
+            ctx.prepare_response_buffer(req)?;
+            generate_chunk_send_early_error_ack(ctx, handle, chunk_seq_num, req)
+        }
     }
 }
 

--- a/runtime/userspace/api/spdm-lib/src/commands/vendor_defined_rsp.rs
+++ b/runtime/userspace/api/spdm-lib/src/commands/vendor_defined_rsp.rs
@@ -1,7 +1,7 @@
 // Licensed under the Apache-2.0 license
 
 use crate::codec::*;
-use crate::commands::error_rsp::ErrorCode;
+use crate::commands::error_rsp::{encode_error_response, ErrorCode};
 use crate::context::SpdmContext;
 use crate::error::{CommandError, CommandResult};
 use crate::protocol::*;
@@ -26,7 +26,7 @@ impl CommonCodec for VendorDefReqHdr {}
 
 #[derive(FromBytes, IntoBytes, Immutable)]
 #[repr(C, packed)]
-struct VendorDefRespHdr {
+pub(crate) struct VendorDefRespHdr {
     spdm_version: u8,
     resp_code: u8,
     param1: u8,
@@ -53,7 +53,7 @@ impl Default for VendorDefRespHdr {
 }
 
 impl VendorDefRespHdr {
-    fn new(spdm_version: SpdmVersion, standard_id: u16, vendor_id: &[u8]) -> Self {
+    pub(crate) fn new(spdm_version: SpdmVersion, standard_id: u16, vendor_id: &[u8]) -> Self {
         let mut vid = [0u8; MAX_SPDM_VENDOR_ID_LEN as usize];
         assert!(vendor_id.len() <= MAX_SPDM_VENDOR_ID_LEN as usize);
         vid[..vendor_id.len()].copy_from_slice(vendor_id);
@@ -69,11 +69,11 @@ impl VendorDefRespHdr {
         }
     }
 
-    fn set_resp_len(&mut self, resp_len: u16) {
+    pub(crate) fn set_resp_len(&mut self, resp_len: u16) {
         self.resp_len = resp_len;
     }
 
-    fn len(&self) -> usize {
+    pub(crate) fn len(&self) -> usize {
         size_of::<VendorDefRespHdr>() - MAX_SPDM_VENDOR_ID_LEN as usize
             + self.vendor_id_len as usize
     }
@@ -336,4 +336,125 @@ pub(crate) async fn handle_vendor_defined_request<'a>(
     // Generate VENDOR_DEFINED_RESPONSE
     generate_vendor_defined_response(ctx, standard_id, vendor_id, &mut vdm_req_buf, req_payload)
         .await
+}
+
+/// Handle a VendorDefined request that was reassembled from CHUNK_SEND.
+///
+/// Unlike `handle_vendor_defined_request`, this reads the VDM payload directly from the
+/// large-message buffer (`req`) without copying to a stack buffer, so there is no 256-byte
+/// payload limit.
+///
+/// Because the shared large-message buffer is in use for the request, large VDM
+/// responses (LargeResp) are not supported and will be rejected.
+pub(crate) async fn handle_large_vendor_defined_request<'a>(
+    ctx: &mut SpdmContext<'a>,
+    req: &mut MessageBuf<'_>,
+    rsp: &mut MessageBuf<'a>,
+) -> CommandResult<()> {
+    let version = ctx.state.connection_info.version_number();
+
+    // Parse VendorDefined request header
+    let req_hdr = match VendorDefReqHdr::decode(req) {
+        Ok(hdr) => hdr,
+        Err(_) => {
+            encode_error_response(rsp, version, ErrorCode::InvalidRequest, 0, None);
+            return Ok(());
+        }
+    };
+
+    let standard_id: StandardsBodyId = match req_hdr.standard_id.try_into() {
+        Ok(id) => id,
+        Err(_) => {
+            encode_error_response(rsp, version, ErrorCode::InvalidRequest, 0, None);
+            return Ok(());
+        }
+    };
+
+    let vendor_id_len = match standard_id.vendor_id_len() {
+        Ok(len) => {
+            if len != req_hdr.vendor_id_len {
+                encode_error_response(rsp, version, ErrorCode::InvalidRequest, 0, None);
+                return Ok(());
+            }
+            len as usize
+        }
+        Err(_) => {
+            encode_error_response(rsp, version, ErrorCode::UnsupportedRequest, 0, None);
+            return Ok(());
+        }
+    };
+
+    let mut vendor_id = [0u8; MAX_SPDM_VENDOR_ID_LEN as usize];
+    if decode_u8_slice(req, &mut vendor_id[..vendor_id_len]).is_err() {
+        encode_error_response(rsp, version, ErrorCode::InvalidRequest, 0, None);
+        return Ok(());
+    }
+
+    // Decode VDM request payload length
+    let vdm_req_len = match u16::decode(req) {
+        Ok(len) => len as usize,
+        Err(_) => {
+            encode_error_response(rsp, version, ErrorCode::InvalidRequest, 0, None);
+            return Ok(());
+        }
+    };
+
+    if req.data_len() < vdm_req_len {
+        encode_error_response(rsp, version, ErrorCode::InvalidRequest, 0, None);
+        return Ok(());
+    }
+
+    let in_secure_session = ctx.session_mgr.active_session_id().is_some();
+
+    // Prepare response header
+    let mut resp_hdr =
+        VendorDefRespHdr::new(version, standard_id as u16, &vendor_id[..vendor_id_len]);
+    let resp_hdr_len = resp_hdr.len();
+
+    rsp.reserve(resp_hdr_len)
+        .map_err(|e| (false, CommandError::Codec(e)))?;
+
+    // Find matching VDM handler
+    let vdm_handler = ctx.vdm_handlers.as_mut().and_then(|handlers| {
+        handlers.iter_mut().find(|handler| {
+            handler.match_id(standard_id, &vendor_id[..vendor_id_len], in_secure_session)
+        })
+    });
+    let vdm_handler = match vdm_handler {
+        Some(handler) => handler,
+        None => {
+            encode_error_response(
+                rsp,
+                version,
+                ErrorCode::UnsupportedRequest,
+                ReqRespCode::VendorDefinedRequest as u8,
+                None,
+            );
+            return Ok(());
+        }
+    };
+
+    // Pass req directly — remaining data is the VDM payload.
+    // No large_rsp_buf available since the shared buffer holds the request data.
+    let mut empty_large_rsp = [];
+    match vdm_handler
+        .handle_request(req, rsp, &mut empty_large_rsp)
+        .await
+    {
+        Ok(len) => {
+            resp_hdr.set_resp_len(len as u16);
+            resp_hdr
+                .encode(rsp)
+                .map_err(|e| (false, CommandError::Codec(e)))?;
+            Ok(())
+        }
+        Err(VdmError::LargeResp(_)) => {
+            // Large responses cannot be produced when processing a large request
+            // because the shared buffer is occupied by the request data.
+            rsp.reset_payload();
+            encode_error_response(rsp, version, ErrorCode::ResponseTooLarge, 0, None);
+            Ok(())
+        }
+        Err(e) => Err((false, CommandError::Vdm(e))),
+    }
 }

--- a/runtime/userspace/api/spdm-lib/src/context.rs
+++ b/runtime/userspace/api/spdm-lib/src/context.rs
@@ -19,7 +19,7 @@ use crate::session::{SessionManager, SessionState};
 use crate::state::{ConnectionState, State};
 use crate::transcript::{Transcript, TranscriptContext};
 use crate::transport::common::SpdmTransport;
-use crate::vdm_handler::VdmHandler;
+use crate::vdm_handler::{VdmHandler, VdmStreamHandler};
 use caliptra_mcu_libapi_caliptra::crypto::aes_gcm::Aes256GcmTag;
 use caliptra_mcu_libapi_caliptra::crypto::asym::*;
 use caliptra_mcu_libapi_caliptra::crypto::hash::SHA384_HASH_SIZE;
@@ -41,6 +41,7 @@ pub struct SpdmContext<'a> {
     pub(crate) large_msg_ctx: LargeMessageCtx<'a>,
     pub(crate) session_mgr: SessionManager,
     pub(crate) vdm_handlers: Option<&'a mut [&'a mut dyn VdmHandler]>,
+    pub(crate) vdm_stream_handler: Option<&'a dyn VdmStreamHandler>,
 }
 
 impl<'a> SpdmContext<'a> {
@@ -73,7 +74,13 @@ impl<'a> SpdmContext<'a> {
             large_msg_ctx: LargeMessageCtx::new(large_msg_buf_provider),
             session_mgr: SessionManager::new(),
             vdm_handlers,
+            vdm_stream_handler: None,
         })
+    }
+
+    /// Set the VDM stream handler for streaming large VDM requests.
+    pub fn set_vdm_stream_handler(&mut self, handler: &'a dyn VdmStreamHandler) {
+        self.vdm_stream_handler = Some(handler);
     }
 
     pub async fn process_message(&mut self, msg_buf: &mut MessageBuf<'a>) -> SpdmResult<()> {
@@ -160,7 +167,7 @@ impl<'a> SpdmContext<'a> {
             return Err((false, CommandError::BufferTooSmall));
         }
 
-        let (req_msg_header, req_code) = match self.decode_and_validate_request(&mut req) {
+        let (_req_msg_header, req_code) = match self.decode_and_validate_request(&mut req) {
             Ok(v) => v,
             Err((_send, _e)) => {
                 let buf = req.into_inner();
@@ -179,9 +186,7 @@ impl<'a> SpdmContext<'a> {
             return Ok(());
         }
 
-        let result = self
-            .dispatch_large_request(req_msg_header, req_code, &mut req, rsp)
-            .await;
+        let result = self.dispatch_large_request(req_code, &mut req, rsp).await;
 
         let buf = req.into_inner();
         self.large_msg_ctx.replace_buf(buf);
@@ -196,16 +201,20 @@ impl<'a> SpdmContext<'a> {
     /// support (e.g. SET_CERTIFICATE, VDM), add it as a match arm here.
     async fn dispatch_large_request(
         &mut self,
-        _req_msg_header: SpdmMsgHdr,
-        _req_code: ReqRespCode,
-        _req: &mut MessageBuf<'_>,
+        req_code: ReqRespCode,
+        req: &mut MessageBuf<'_>,
         rsp: &mut MessageBuf<'a>,
     ) -> CommandResult<()> {
-        // No commands currently support large-request handling.
-        // As handlers are implemented, add match arms here.
-        let version = self.state.connection_info.version_number();
-        encode_error_response(rsp, version, ErrorCode::UnsupportedRequest, 0, None);
-        Ok(())
+        match req_code {
+            ReqRespCode::VendorDefinedRequest => {
+                vendor_defined_rsp::handle_large_vendor_defined_request(self, req, rsp).await
+            }
+            _ => {
+                let version = self.state.connection_info.version_number();
+                encode_error_response(rsp, version, ErrorCode::UnsupportedRequest, 0, None);
+                Ok(())
+            }
+        }
     }
 
     fn decode_and_validate_request(

--- a/runtime/userspace/api/spdm-lib/src/vdm_handler/iana/ocp/caliptra_vdm/commands/debug_unlock.rs
+++ b/runtime/userspace/api/spdm-lib/src/vdm_handler/iana/ocp/caliptra_vdm/commands/debug_unlock.rs
@@ -1,0 +1,53 @@
+// Licensed under the Apache-2.0 license
+
+use crate::codec::{encode_u8_slice, Codec, MessageBuf};
+use crate::vdm_handler::iana::ocp::caliptra_vdm::protocol::{
+    CaliptraCompletionCode, CaliptraVdmCmdResult,
+};
+use crate::vdm_handler::{VdmError, VdmResult};
+use caliptra_mcu_common_commands::{CaliptraCmdHandler, DebugUnlockChallenge};
+
+pub(crate) async fn handle_request_debug_unlock(
+    handler: &dyn CaliptraCmdHandler,
+    req_buf: &mut MessageBuf<'_>,
+    rsp_buf: &mut MessageBuf<'_>,
+) -> VdmResult<CaliptraVdmCmdResult> {
+    let unlock_level = u8::decode(req_buf).map_err(VdmError::Codec)?;
+
+    let mut challenge = DebugUnlockChallenge::default();
+    match handler
+        .request_debug_unlock(unlock_level, &mut challenge)
+        .await
+    {
+        Ok(()) => {
+            let mut len = (CaliptraCompletionCode::Success as u8)
+                .encode(rsp_buf)
+                .map_err(VdmError::Codec)?;
+            len += encode_u8_slice(&challenge.unique_device_identifier, rsp_buf)
+                .map_err(VdmError::Codec)?;
+            len += encode_u8_slice(&challenge.challenge, rsp_buf).map_err(VdmError::Codec)?;
+            Ok(CaliptraVdmCmdResult::Response(len))
+        }
+        Err(e) => Ok(CaliptraVdmCmdResult::ErrorResponse(e)),
+    }
+}
+
+pub(crate) async fn handle_authorize_debug_unlock_token(
+    handler: &dyn CaliptraCmdHandler,
+    req_buf: &mut MessageBuf<'_>,
+    rsp_buf: &mut MessageBuf<'_>,
+) -> VdmResult<CaliptraVdmCmdResult> {
+    // Read the remaining request bytes as token data
+    let token_len = req_buf.data_len();
+    let token_data = req_buf.data(token_len).map_err(VdmError::Codec)?;
+
+    match handler.authorize_debug_unlock_token(token_data).await {
+        Ok(()) => {
+            let len = (CaliptraCompletionCode::Success as u8)
+                .encode(rsp_buf)
+                .map_err(VdmError::Codec)?;
+            Ok(CaliptraVdmCmdResult::Response(len))
+        }
+        Err(e) => Ok(CaliptraVdmCmdResult::ErrorResponse(e)),
+    }
+}

--- a/runtime/userspace/api/spdm-lib/src/vdm_handler/iana/ocp/caliptra_vdm/commands/mod.rs
+++ b/runtime/userspace/api/spdm-lib/src/vdm_handler/iana/ocp/caliptra_vdm/commands/mod.rs
@@ -2,6 +2,7 @@
 
 pub(crate) mod clear_attestation_log;
 pub(crate) mod clear_debug_log;
+pub(crate) mod debug_unlock;
 pub(crate) mod device_capabilities;
 pub(crate) mod device_id;
 pub(crate) mod device_info;

--- a/runtime/userspace/api/spdm-lib/src/vdm_handler/iana/ocp/caliptra_vdm/mod.rs
+++ b/runtime/userspace/api/spdm-lib/src/vdm_handler/iana/ocp/caliptra_vdm/mod.rs
@@ -5,8 +5,9 @@ extern crate alloc;
 use crate::codec::{Codec, MessageBuf};
 use crate::protocol::StandardsBodyId;
 use crate::vdm_handler::iana::ocp::caliptra_vdm::commands::{
-    clear_attestation_log, clear_debug_log, device_capabilities, device_id, device_info,
-    export_attested_csr, export_idevid_csr, firmware_version, get_attestation_log, get_debug_log,
+    clear_attestation_log, clear_debug_log, debug_unlock, device_capabilities, device_id,
+    device_info, export_attested_csr, export_idevid_csr, firmware_version, get_attestation_log,
+    get_debug_log,
 };
 use crate::vdm_handler::iana::ocp::caliptra_vdm::protocol::*;
 use crate::vdm_handler::{VdmError, VdmHandler, VdmRegistryMatcher, VdmResponder, VdmResult};
@@ -105,6 +106,13 @@ impl VdmResponder for CaliptraVdmHandler<'_> {
             }
             CaliptraVdmCommand::ClearAttestationLog => {
                 clear_attestation_log::handle_clear_attestation_log(self.handler, req_buf, rsp_buf)
+                    .await?
+            }
+            CaliptraVdmCommand::RequestDebugUnlock => {
+                debug_unlock::handle_request_debug_unlock(self.handler, req_buf, rsp_buf).await?
+            }
+            CaliptraVdmCommand::AuthorizeDebugUnlockToken => {
+                debug_unlock::handle_authorize_debug_unlock_token(self.handler, req_buf, rsp_buf)
                     .await?
             }
             _ => CaliptraVdmCmdResult::ErrorResponse(CaliptraCompletionCode::UnsupportedOperation),

--- a/runtime/userspace/api/spdm-lib/src/vdm_handler/mod.rs
+++ b/runtime/userspace/api/spdm-lib/src/vdm_handler/mod.rs
@@ -28,6 +28,8 @@ pub enum VdmError {
     LargeResp(usize),
     Ide(IdeDriverError),
     Tdisp(TdispDriverError),
+    /// Streaming error (e.g., mailbox failure during chunk streaming).
+    StreamError,
 }
 
 impl VdmError {
@@ -50,6 +52,7 @@ impl VdmError {
             VdmError::Tdisp(e) => {
                 ((crate::error::error_type_id::TDISP_DRIVER as u32) << 8) | ((*e as u8) as u32)
             }
+            VdmError::StreamError => 0x09_00,
         }
     }
 }
@@ -93,3 +96,44 @@ pub trait VdmProtocolMatcher {
 pub trait VdmProtocolHandler: VdmResponder + VdmProtocolMatcher + Send + Sync {}
 
 pub trait VdmHandler: VdmResponder + VdmRegistryMatcher + Send + Sync {}
+
+/// Trait for streaming large VDM request payloads directly to a backend
+/// (e.g., Caliptra mailbox) without buffering the entire message.
+///
+/// When the SPDM CHUNK_SEND handler detects a streaming-eligible VDM command
+/// in the first chunk, it calls these methods per-chunk instead of buffering
+/// in `LargeMessageCtx`.
+///
+/// The VDM payload is expected to be in Caliptra RT mailbox format
+/// (MailboxReqHeader + command-specific data), pre-built by the host with
+/// checksum already computed.
+#[async_trait]
+pub trait VdmStreamHandler: Send + Sync {
+    /// Check if a VDM command code supports streaming.
+    /// Returns the mailbox command ID if streaming is supported, None otherwise.
+    fn stream_supported(&self, vdm_command_code: u8) -> Option<u32>;
+
+    /// Initialize a streaming session.
+    /// Called with the first chunk's VDM payload data (mailbox command bytes).
+    ///
+    /// # Arguments
+    /// * `mailbox_cmd` - The Caliptra RT mailbox command ID
+    /// * `total_payload_len` - Total VDM payload length (excluding VDM headers)
+    /// * `first_chunk_payload` - The VDM payload bytes from the first chunk
+    async fn stream_init(
+        &self,
+        mailbox_cmd: u32,
+        total_payload_len: usize,
+        first_chunk_payload: &[u8],
+    ) -> VdmResult<()>;
+
+    /// Stream a subsequent chunk of VDM payload data.
+    async fn stream_chunk(&self, chunk_data: &[u8]) -> VdmResult<()>;
+
+    /// Finalize the streaming session and execute the mailbox command.
+    /// Returns the response data length written to `rsp_buf`.
+    async fn stream_finish(&self, mailbox_cmd: u32, rsp_buf: &mut [u8]) -> VdmResult<usize>;
+
+    /// Abort a streaming session (called on error).
+    async fn stream_abort(&self);
+}

--- a/tests/integration/src/lib.rs
+++ b/tests/integration/src/lib.rs
@@ -464,15 +464,60 @@ mod test {
         let vendor_pk_hash: [u32; 12] = vendor_pk_hash.as_slice().try_into().unwrap();
 
         // Set up OTP memory: use custom otp_memory if provided, otherwise auto-generate from dot_enabled
+        // and prod_dbg_unlock_keypairs
         let otp_memory = if let Some(custom_otp) = params.otp_memory {
             Some(custom_otp)
-        } else if params.dot_enabled {
-            // TODO: move this when we add the fuse-burning scripts
+        } else if params.dot_enabled || !params.prod_dbg_unlock_keypairs.is_empty() {
             use caliptra_mcu_registers_generated::fuses::VENDOR_NON_SECRET_PROD_PARTITION_BYTE_OFFSET;
             // Create OTP memory large enough to include the vendor non-secret prod partition
             let mut otp = vec![0u8; VENDOR_NON_SECRET_PROD_PARTITION_BYTE_OFFSET + 256];
-            // Set dot_initialized to 1 at the start of the vendor non-secret prod partition
-            otp[VENDOR_NON_SECRET_PROD_PARTITION_BYTE_OFFSET] = 0x7; // backed by 3 bits
+
+            if params.dot_enabled {
+                // Set dot_initialized to 1 at the start of the vendor non-secret prod partition
+                otp[VENDOR_NON_SECRET_PROD_PARTITION_BYTE_OFFSET] = 0x7; // backed by 3 bits
+            }
+
+            // Program PK hashes into OTP for prod debug unlock
+            if !params.prod_dbg_unlock_keypairs.is_empty() {
+                use caliptra_mcu_registers_generated::fuses::{
+                    OTP_CPTRA_SS_PROD_DEBUG_UNLOCK_PKS_0, OTP_CPTRA_SS_PROD_DEBUG_UNLOCK_PKS_1,
+                    OTP_CPTRA_SS_PROD_DEBUG_UNLOCK_PKS_2, OTP_CPTRA_SS_PROD_DEBUG_UNLOCK_PKS_3,
+                    OTP_CPTRA_SS_PROD_DEBUG_UNLOCK_PKS_4, OTP_CPTRA_SS_PROD_DEBUG_UNLOCK_PKS_5,
+                    OTP_CPTRA_SS_PROD_DEBUG_UNLOCK_PKS_6, OTP_CPTRA_SS_PROD_DEBUG_UNLOCK_PKS_7,
+                };
+                use sha2::{Digest, Sha384};
+
+                let pk_entries = [
+                    OTP_CPTRA_SS_PROD_DEBUG_UNLOCK_PKS_0,
+                    OTP_CPTRA_SS_PROD_DEBUG_UNLOCK_PKS_1,
+                    OTP_CPTRA_SS_PROD_DEBUG_UNLOCK_PKS_2,
+                    OTP_CPTRA_SS_PROD_DEBUG_UNLOCK_PKS_3,
+                    OTP_CPTRA_SS_PROD_DEBUG_UNLOCK_PKS_4,
+                    OTP_CPTRA_SS_PROD_DEBUG_UNLOCK_PKS_5,
+                    OTP_CPTRA_SS_PROD_DEBUG_UNLOCK_PKS_6,
+                    OTP_CPTRA_SS_PROD_DEBUG_UNLOCK_PKS_7,
+                ];
+
+                for (i, (ecc, mldsa)) in params.prod_dbg_unlock_keypairs.iter().enumerate() {
+                    if i >= pk_entries.len() {
+                        break;
+                    }
+                    let mut hasher = Sha384::new();
+                    hasher.update(ecc);
+                    hasher.update(mldsa);
+                    let hash = hasher.finalize();
+
+                    let offset = pk_entries[i].byte_offset;
+                    // Write hash to OTP: convert each 4-byte chunk from big-endian (SHA output)
+                    // to little-endian (OTP storage format, matching emulator's from_le_bytes read)
+                    for (j, chunk) in hash.chunks(4).enumerate() {
+                        let word = u32::from_be_bytes(chunk.try_into().unwrap());
+                        let byte_pos = offset + j * 4;
+                        otp[byte_pos..byte_pos + 4].copy_from_slice(&word.to_le_bytes());
+                    }
+                }
+            }
+
             Some(otp)
         } else {
             None

--- a/tests/integration/src/test_caliptra_util_host_spdm_vdm_validator.rs
+++ b/tests/integration/src/test_caliptra_util_host_spdm_vdm_validator.rs
@@ -8,6 +8,8 @@
 #[cfg(test)]
 mod test {
     use crate::test::{finish_runtime_hw_model, start_runtime_hw_model, TestParams, TEST_LOCK};
+    use caliptra_api::SocManager;
+    use caliptra_mcu_debug_unlock_signer::DebugUnlockKeys;
     use caliptra_mcu_hw_model::McuHwModel;
     use caliptra_mcu_testing_common::i3c::DynamicI3cAddress;
     use caliptra_mcu_testing_common::i3c_socket::BufferedStream;
@@ -22,6 +24,7 @@ mod test {
     use std::sync::atomic::Ordering;
     use std::thread;
     use std::time::Duration;
+    use zerocopy::IntoBytes;
 
     const TEST_NAME: &str = "SPDM-VDM";
 
@@ -191,23 +194,95 @@ mod test {
     #[ignore]
     #[test]
     fn test_caliptra_util_host_spdm_vdm_validator() {
+        use caliptra_image_fake_keys::{
+            VENDOR_ECC_KEY_0_PRIVATE, VENDOR_ECC_KEY_0_PUBLIC, VENDOR_MLDSA_KEY_0_PRIVATE,
+            VENDOR_MLDSA_KEY_0_PUBLIC,
+        };
+        use caliptra_image_types::{ECC384_SCALAR_BYTE_SIZE, ECC384_SCALAR_WORD_SIZE};
+
         let lock = TEST_LOCK.lock().unwrap();
         lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 
+        let unlock_level = 1u8;
+
+        // --- Prepare ECC public key in hardware format (big-endian u32 words) ---
+        let mut ecc_pub_key_u32 = [0u32; ECC384_SCALAR_WORD_SIZE * 2];
+        ecc_pub_key_u32[..12].copy_from_slice(&VENDOR_ECC_KEY_0_PUBLIC.x);
+        ecc_pub_key_u32[12..].copy_from_slice(&VENDOR_ECC_KEY_0_PUBLIC.y);
+        let ecc_pub_key_bytes: [u8; 96] = ecc_pub_key_u32.as_bytes().try_into().unwrap();
+
+        // --- Prepare MLDSA public key in hardware format (little-endian u32 words) ---
+        let mldsa_pub_key_raw = VENDOR_MLDSA_KEY_0_PUBLIC.0.as_bytes();
+        let mldsa_pub_key_u32: Vec<u32> = mldsa_pub_key_raw
+            .chunks(4)
+            .map(|chunk| {
+                let mut arr = [0u8; 4];
+                arr.copy_from_slice(chunk);
+                u32::from_le_bytes(arr)
+            })
+            .collect();
+        let mldsa_pub_key_bytes: [u8; 2592] = mldsa_pub_key_u32.as_bytes().try_into().unwrap();
+
+        // --- Set up keypairs for fuse provisioning ---
+        let mut prod_dbg_keypairs: Vec<([u8; 96], [u8; 2592])> = vec![([0u8; 96], [0u8; 2592]); 8];
+        prod_dbg_keypairs[(unlock_level - 1) as usize] = (ecc_pub_key_bytes, mldsa_pub_key_bytes);
+
+        // --- Prepare ECC private key bytes for signing ---
+        let mut be_ecc_priv_key_bytes = [0u8; ECC384_SCALAR_BYTE_SIZE];
+        for (i, word) in VENDOR_ECC_KEY_0_PRIVATE.iter().enumerate() {
+            be_ecc_priv_key_bytes[i * 4..i * 4 + 4].copy_from_slice(&word.to_be_bytes());
+        }
+
+        // --- Prepare MLDSA private key bytes for signing ---
+        let mldsa_priv_key_bytes: Vec<u8> = VENDOR_MLDSA_KEY_0_PRIVATE.0.as_bytes().to_vec();
+
+        // --- Build DebugUnlockKeys and write to temp file for the validator binary ---
+        let debug_unlock_keys = DebugUnlockKeys {
+            ecc_private_key_bytes: be_ecc_priv_key_bytes,
+            ecc_public_key: ecc_pub_key_u32,
+            mldsa_private_key_bytes: mldsa_priv_key_bytes,
+            mldsa_public_key: <[u32; 648]>::try_from(mldsa_pub_key_u32.as_slice()).unwrap(),
+        };
+        let keys_file = tempfile::NamedTempFile::new().expect("Failed to create temp file");
+        debug_unlock_keys
+            .save_to_file(keys_file.path())
+            .expect("Failed to write debug unlock keys");
+        let keys_path = keys_file.path().to_str().unwrap().to_string();
+
+        // --- Start hw_model with keys provisioned in fuses ---
         let mut hw = start_runtime_hw_model(TestParams {
             i3c_port: Some(PortPicker::new().pick().unwrap()),
             use_strap_secrets: true,
+            debug_intent: true,
+            lifecycle_controller_state: Some(caliptra_mcu_hw_model::LifecycleControllerState::Prod),
+            prod_dbg_unlock_keypairs: prod_dbg_keypairs,
             ..Default::default()
         });
 
         hw.start_i3c_controller();
+
+        // Set the prod_dbg_unlock_req bit before the SPDM VDM test runs.
+        // This is required for Caliptra RT to accept debug unlock commands.
+        hw.caliptra_soc_manager()
+            .soc_ifc()
+            .ss_dbg_manuf_service_reg_req()
+            .write(|w| w.prod_dbg_unlock_req(true));
 
         let config_path = test_config_path();
         run_spdm_vdm_test(
             hw.i3c_port().unwrap(),
             hw.i3c_address().unwrap().into(),
             Duration::from_secs(120),
-            &["--config", &config_path],
+            &[
+                "--key-ids",
+                "1,2,3",
+                "--algorithm",
+                "1",
+                "--debug-unlock-keys-file",
+                &keys_path,
+                "--unlock-level",
+                &unlock_level.to_string(),
+            ],
         );
 
         let test = finish_runtime_hw_model(&mut hw);


### PR DESCRIPTION
Implement VdmStreamHandler trait to stream large SPDM VDM payloads directly to the Caliptra mailbox FIFO without buffering the entire message in RAM. This enables the 7500-byte ProdDebugUnlockToken to be delivered via SPDM CHUNK_SEND protocol.

Key changes:
- VdmStreamHandler trait with stream_init/stream_chunk/stream_finish/ stream_abort for chunked mailbox delivery
- Dynamic VDM header parsing in CHUNK_SEND handler to extract mailbox command and payload length from the first chunk
- VendorDefRespHdr framing in streaming completion response
- CaliptraCmdBackend implementation with 4-byte aligned sub-chunking
- Debug unlock VDM command handlers (RequestDebugUnlock, AuthorizeDebugUnlockToken)
- Integration test covering ExportAttestedCsr and ProdDebugUnlock flows