### PR TITLE
[cherry-pick] [bugfix] fix default FW_SRAM_EXEC_REGION_SIZE calculation in ROM

### DIFF
--- a/rom/src/cold_boot.rs
+++ b/rom/src/cold_boot.rs
@@ -1029,8 +1029,8 @@ impl BootFlow for ColdBoot {
         mci.set_flow_checkpoint(McuRomBootStatus::McuMboxAxiUsersConfigured.into());
 
         let size_value = params.mcu_fw_sram_exec_region_size.unwrap_or(
-            unsafe { MCU_MEMORY_MAP.sram_size }
-                - crate::MCU_SRAM_DEFAULT_PROTECTED_REGION_BLOCKS * 4096
+            (unsafe { MCU_MEMORY_MAP.sram_size } / 4096)
+                - crate::MCU_SRAM_DEFAULT_PROTECTED_REGION_BLOCKS
                 - 1,
         );
         mci.set_fw_sram_exec_region_size(size_value);

--- a/rom/src/warm_boot.rs
+++ b/rom/src/warm_boot.rs
@@ -95,8 +95,8 @@ impl BootFlow for WarmBoot {
         mci.set_flow_checkpoint(McuRomBootStatus::McuMboxAxiUsersConfigured.into());
 
         let size_value = params.mcu_fw_sram_exec_region_size.unwrap_or(
-            unsafe { MCU_MEMORY_MAP.sram_size }
-                - crate::MCU_SRAM_DEFAULT_PROTECTED_REGION_BLOCKS * 4096
+            (unsafe { MCU_MEMORY_MAP.sram_size } / 4096)
+                - crate::MCU_SRAM_DEFAULT_PROTECTED_REGION_BLOCKS
                 - 1,
         );
         mci.set_fw_sram_exec_region_size(size_value);


### PR DESCRIPTION
The calculation for `FW_SRAM_EXEC_REGION_SIZE` was using byte sizes instead of 4KB block counts.

(cherry picked from commit b66c5940b3099f5f84798e5a8bfcfed554e1d09a)