### PR TITLE
ocp: Add tests validating image load

### DIFF
--- a/emulator/periph/src/root_bus.rs
+++ b/emulator/periph/src/root_bus.rs
@@ -49,6 +49,8 @@ pub struct McuRootBusOffsets {
     pub direct_read_flash_size: u32,
     pub dot_flash_offset: u32,
     pub dot_flash_size: u32,
+    pub staging_sram_offset: u32,
+    pub staging_sram_size: u32,
 }
 
 impl Default for McuRootBusOffsets {
@@ -71,6 +73,8 @@ impl Default for McuRootBusOffsets {
             direct_read_flash_size: DIRECT_READ_FLASH_SIZE,
             dot_flash_offset: 0x8100_0000,
             dot_flash_size: DOT_FLASH_SIZE,
+            staging_sram_offset: 0xb00c_0000,
+            staging_sram_size: 1024 * 1024,
         }
     }
 }
@@ -101,6 +105,7 @@ pub struct McuRootBus {
     pub mcu_mailbox1: McuMailbox0Internal,
     pub direct_read_flash: Rc<RefCell<Ram>>,
     pub dot_flash: Rc<RefCell<Ram>>,
+    pub staging_sram: Rc<RefCell<Ram>>,
     pub mci_irq: Rc<RefCell<Irq>>,
     event_sender: Option<mpsc::Sender<Event>>,
     offsets: McuRootBusOffsets,
@@ -132,6 +137,7 @@ impl McuRootBus {
         let external_test_sram = Ram::new(vec![0; EXTERNAL_TEST_SRAM_SIZE as usize]);
         let direct_read_flash = Ram::new(vec![0; DIRECT_READ_FLASH_SIZE as usize]);
         let dot_flash = Ram::new(vec![0; DOT_FLASH_SIZE as usize]);
+        let staging_sram = Ram::new(vec![0; args.offsets.staging_sram_size as usize]);
         let mci_irq = pic.register_irq(McuRootBus::MCI_IRQ);
         let mcu_mailbox0 = McuMailbox0Internal::new(&clock.clone());
         let mcu_mailbox1 = McuMailbox0Internal::new(&clock.clone());
@@ -147,6 +153,7 @@ impl McuRootBus {
             external_test_sram: Rc::new(RefCell::new(external_test_sram)),
             direct_read_flash: Rc::new(RefCell::new(direct_read_flash)),
             dot_flash: Rc::new(RefCell::new(dot_flash)),
+            staging_sram: Rc::new(RefCell::new(staging_sram)),
             offsets: args.offsets,
             mci_irq: Rc::new(RefCell::new(mci_irq)),
             mcu_mailbox0,
@@ -227,6 +234,14 @@ impl Bus for McuRootBus {
                 .borrow_mut()
                 .read(size, addr - self.offsets.dot_flash_offset);
         }
+        if addr >= self.offsets.staging_sram_offset
+            && addr < self.offsets.staging_sram_offset + self.offsets.staging_sram_size
+        {
+            return self
+                .staging_sram
+                .borrow_mut()
+                .read(size, addr - self.offsets.staging_sram_offset);
+        }
         Err(BusError::LoadAccessFault)
     }
 
@@ -284,6 +299,15 @@ impl Bus for McuRootBus {
                 val,
             );
         }
+        if addr >= self.offsets.staging_sram_offset
+            && addr < self.offsets.staging_sram_offset + self.offsets.staging_sram_size
+        {
+            return self.staging_sram.borrow_mut().write(
+                size,
+                addr - self.offsets.staging_sram_offset,
+                val,
+            );
+        }
         Err(BusError::StoreAccessFault)
     }
 
@@ -296,6 +320,7 @@ impl Bus for McuRootBus {
         self.pic_regs.poll();
         self.external_test_sram.borrow_mut().poll();
         self.direct_read_flash.borrow_mut().poll();
+        self.staging_sram.borrow_mut().poll();
     }
 
     fn warm_reset(&mut self) {
@@ -307,6 +332,7 @@ impl Bus for McuRootBus {
         self.pic_regs.warm_reset();
         self.external_test_sram.borrow_mut().warm_reset();
         self.direct_read_flash.borrow_mut().warm_reset();
+        self.staging_sram.borrow_mut().warm_reset();
     }
 
     fn update_reset(&mut self) {
@@ -318,6 +344,7 @@ impl Bus for McuRootBus {
         self.pic_regs.update_reset();
         self.external_test_sram.borrow_mut().update_reset();
         self.direct_read_flash.borrow_mut().update_reset();
+        self.staging_sram.borrow_mut().update_reset();
     }
 
     fn register_outgoing_events(&mut self, sender: mpsc::Sender<Event>) {

--- a/hw/model/src/usb_ctrl.rs
+++ b/hw/model/src/usb_ctrl.rs
@@ -144,6 +144,142 @@ pub fn ocp_write(command: ocp::protocol::RecoveryCommand, w_length: u16) -> Setu
     }
 }
 
+/// Perform a complete OCP Recovery read command: SETUP + IN data + OUT ZLP status.
+///
+/// Returns the response data payload.
+pub fn ocp_read_data(
+    model: &mut impl McuHwModel,
+    host: &UsbHostController,
+    command: ocp::protocol::RecoveryCommand,
+    len: u16,
+    iterations: usize,
+) -> Vec<u8> {
+    let setup = ocp_read(command, len);
+    poll_setup(model, host, &setup, iterations);
+    let data = poll_in(model, host, iterations);
+    poll_out(model, host, &[], iterations);
+    data
+}
+
+/// Perform a complete OCP Recovery write command: SETUP + OUT data + IN ZLP status.
+pub fn ocp_write_data(
+    model: &mut impl McuHwModel,
+    host: &UsbHostController,
+    command: ocp::protocol::RecoveryCommand,
+    data: &[u8],
+    iterations: usize,
+) {
+    let setup = ocp_write(command, data.len() as u16);
+    poll_setup(model, host, &setup, iterations);
+    poll_out(model, host, data, iterations);
+    let _zlp = poll_in(model, host, iterations);
+}
+
+/// Write INDIRECT_CTRL to select an indirect CMS region and set the IMO.
+pub fn ocp_select_indirect_cms(
+    model: &mut impl McuHwModel,
+    host: &UsbHostController,
+    cms: u8,
+    imo: u32,
+    iterations: usize,
+) {
+    let imo_bytes = imo.to_le_bytes();
+    let data = [
+        cms,
+        0x00,
+        imo_bytes[0],
+        imo_bytes[1],
+        imo_bytes[2],
+        imo_bytes[3],
+    ];
+    ocp_write_data(
+        model,
+        host,
+        ocp::protocol::RecoveryCommand::IndirectCtrl,
+        &data,
+        iterations,
+    );
+}
+
+/// Write INDIRECT_DATA payload at the current IMO (auto-increments).
+pub fn ocp_write_indirect_data(
+    model: &mut impl McuHwModel,
+    host: &UsbHostController,
+    data: &[u8],
+    iterations: usize,
+) {
+    ocp_write_data(
+        model,
+        host,
+        ocp::protocol::RecoveryCommand::IndirectData,
+        data,
+        iterations,
+    );
+}
+
+/// Write INDIRECT_FIFO_CTRL to select a FIFO CMS region and set the image size.
+///
+/// `image_size_4b` is the image size in 4-byte units.
+pub fn ocp_select_fifo_cms(
+    model: &mut impl McuHwModel,
+    host: &UsbHostController,
+    cms: u8,
+    image_size_4b: u32,
+    iterations: usize,
+) {
+    let size_bytes = image_size_4b.to_le_bytes();
+    let data = [
+        cms,
+        0x00,
+        size_bytes[0],
+        size_bytes[1],
+        size_bytes[2],
+        size_bytes[3],
+    ];
+    ocp_write_data(
+        model,
+        host,
+        ocp::protocol::RecoveryCommand::IndirectFifoCtrl,
+        &data,
+        iterations,
+    );
+}
+
+/// Write INDIRECT_FIFO_DATA payload (streamed into FIFO).
+pub fn ocp_write_fifo_data(
+    model: &mut impl McuHwModel,
+    host: &UsbHostController,
+    data: &[u8],
+    iterations: usize,
+) {
+    ocp_write_data(
+        model,
+        host,
+        ocp::protocol::RecoveryCommand::IndirectFifoData,
+        data,
+        iterations,
+    );
+}
+
+/// Write RECOVERY_CTRL to activate a recovery image from a memory-window CMS.
+///
+/// Sends CMS index, ImageSelection::MemoryWindow (0x01), and Activate (0x0F).
+pub fn ocp_activate_recovery(
+    model: &mut impl McuHwModel,
+    host: &UsbHostController,
+    cms: u8,
+    iterations: usize,
+) {
+    let data = [cms, 0x01, 0x0F];
+    ocp_write_data(
+        model,
+        host,
+        ocp::protocol::RecoveryCommand::RecoveryCtrl,
+        &data,
+        iterations,
+    );
+}
+
 fn desc_value(dt: ocp::usb::descriptors::DescriptorType, idx: u8) -> u16 {
     ((dt as u16) << 8) | idx as u16
 }

--- a/platforms/emulator/rom/usb/src/lib.rs
+++ b/platforms/emulator/rom/usb/src/lib.rs
@@ -154,8 +154,15 @@ impl ExamplarUsbDriver {
         Ok(())
     }
 
+    /// Wait until the host has consumed the current IN packet.
+    ///
+    /// Spins until Rdy0 is cleared by hardware, which happens when the
+    /// host ACKs the IN data. This is preferred over polling Sent0
+    /// because Rdy0 is a per-transfer indicator (set by firmware, cleared
+    /// by hardware on ACK) with no stale-state risk, whereas Sent0 is a
+    /// separate W1C flag that can carry stale state between transfers.
     fn wait_in_sent(&self) {
-        while !self.regs.in_sent.is_set(InSent::Sent0) {}
+        while self.regs.configin_0[0].is_set(Configin0::Rdy0) {}
         self.regs.in_sent.set(InSent::Sent0::SET.value);
     }
 

--- a/rom/src/recovery.rs
+++ b/rom/src/recovery.rs
@@ -362,6 +362,7 @@ fn load_image_to_recovery(
                     RecoveryStatus(i3c_periph.sec_fw_recovery_if_recovery_status.get());
                 let res = state_machine.process_event(Events::RecoveryStatus(recovery_status));
                 if res.is_ok() {
+                    next_print_checkpoint = 0;
                     let recovery_image_index = recovery_status.rec_img_index();
                     romtime::println!(
                         "[mcu-rom] Starting recovery with image index {}",

--- a/tests/integration/src/lib.rs
+++ b/tests/integration/src/lib.rs
@@ -235,14 +235,14 @@ mod test {
         }
     }
 
-    struct TestBinaries {
-        vendor_pk_hash_u8: Vec<u8>,
-        caliptra_rom: Vec<u8>,
-        caliptra_fw: Vec<u8>,
-        mcu_rom: Vec<u8>,
-        soc_manifest: Vec<u8>,
-        mcu_runtime: Vec<u8>,
-        network_rom: Vec<u8>,
+    pub struct TestBinaries {
+        pub vendor_pk_hash_u8: Vec<u8>,
+        pub caliptra_rom: Vec<u8>,
+        pub caliptra_fw: Vec<u8>,
+        pub mcu_rom: Vec<u8>,
+        pub soc_manifest: Vec<u8>,
+        pub mcu_runtime: Vec<u8>,
+        pub network_rom: Vec<u8>,
     }
 
     fn prebuilt_binaries(params: &TestParams, binaries: &'static FirmwareBinaries) -> TestBinaries {
@@ -281,7 +281,7 @@ mod test {
         test_binaries
     }
 
-    fn build_test_binaries(params: &TestParams) -> TestBinaries {
+    pub fn build_test_binaries(params: &TestParams) -> TestBinaries {
         // Get MCU runtime: prefer prebuilt for the requested feature, fall back to compilation
         let mcu_runtime_path = if let Ok(binaries) = FirmwareBinaries::from_env() {
             let runtime_bytes = if let Some(feature) = params.feature {

--- a/tests/integration/src/test_usb_ocp_recovery.rs
+++ b/tests/integration/src/test_usb_ocp_recovery.rs
@@ -8,29 +8,66 @@
 
 #[cfg(test)]
 mod test {
-    use crate::test::{start_runtime_hw_model, TestParams, TEST_LOCK};
+    use crate::test::{build_test_binaries, start_runtime_hw_model, TestParams, TEST_LOCK};
+    use emulator_periph::UsbHostController;
     use mcu_hw_model::usb_ctrl::*;
-    use mcu_hw_model::McuHwModel;
+    use mcu_hw_model::{DefaultHwModel, McuHwModel};
     use ocp::protocol::device_status::{DeviceStatusValue, ProtocolError};
     use ocp::protocol::prot_cap::{self, RecoveryProtocolCapabilities};
     use ocp::protocol::recovery_status::DeviceRecoveryStatus;
     use ocp::protocol::RecoveryCommand;
     use random_port::PortPicker;
+    use romtime::McuBootMilestones;
     use std::sync::atomic::Ordering;
 
+    /// Timeout for quick USB transactions (enumeration, reads).
     const TIMEOUT: usize = 1_000_000;
 
-    /// Start the emulator with the USB OCP recovery feature and enumerate USB.
-    /// Returns the hw model with USB already enumerated.
-    fn start_usb_ocp_recovery() -> mcu_hw_model::DefaultHwModel {
+    /// Timeout for image load operations.  Between recovery stages Caliptra
+    /// must process the previous image, which can take many emulator cycles.
+    /// The poll_* retry loops step the emulator while waiting, giving both
+    /// the MCU ROM and Caliptra core time to progress.
+    const IMAGE_LOAD_TIMEOUT: usize = 6_000_000;
+
+    /// Build all binaries needed for the load-image tests in a single
+    /// compilation pass and return both the hw model and the recovery
+    /// images (caliptra_fw, soc_manifest, mcu_runtime).
+    fn build_and_start_usb_ocp_recovery() -> (DefaultHwModel, Vec<u8>, Vec<u8>, Vec<u8>) {
+        let bins = build_test_binaries(&TestParams {
+            rom_feature: Some("test-usb-ocp-recovery"),
+            ..Default::default()
+        });
+
         let mut hw = start_runtime_hw_model(TestParams {
             rom_feature: Some("test-usb-ocp-recovery"),
-            i3c_port: PortPicker::new().pick().ok(),
+            custom_mcu_rom: Some(bins.mcu_rom),
+            i3c_port: Some(PortPicker::new().pick().unwrap()),
             flash_boot: true,
             rom_only: true,
             ..Default::default()
         });
 
+        let images = (bins.caliptra_fw, bins.soc_manifest, bins.mcu_runtime);
+        start_usb_ocp_recovery_enumerate(&mut hw);
+        (hw, images.0, images.1, images.2)
+    }
+
+    /// Start the emulator with the USB OCP recovery feature and enumerate USB.
+    /// Returns the hw model with USB already enumerated.
+    fn start_usb_ocp_recovery() -> DefaultHwModel {
+        let mut hw = start_runtime_hw_model(TestParams {
+            rom_feature: Some("test-usb-ocp-recovery"),
+            i3c_port: Some(PortPicker::new().pick().unwrap()),
+            flash_boot: true,
+            rom_only: true,
+            ..Default::default()
+        });
+        start_usb_ocp_recovery_enumerate(&mut hw);
+        hw
+    }
+
+    /// Wait for the firmware to enable USB and complete enumeration.
+    fn start_usb_ocp_recovery_enumerate(hw: &mut DefaultHwModel) {
         let host = hw.usb_host_controller.clone();
 
         // Wait for firmware to enable USB.
@@ -51,9 +88,7 @@ mod test {
         host.bus_reset();
 
         // Complete USB enumeration.
-        enumerate(&mut hw, &host, TIMEOUT);
-
-        hw
+        enumerate(hw, &host, TIMEOUT);
     }
 
     /// Happy path: Read PROT_CAP and DEVICE_STATUS to verify the OCP state
@@ -156,6 +191,137 @@ mod test {
             ProtocolError::UnsupportedCommand as u8,
             "protocol error should be UnsupportedCommand"
         );
+
+        lock.fetch_add(1, Ordering::Relaxed);
+    }
+
+    // ---- Image load helpers ------------------------------------------------
+
+    /// Push a complete image via the indirect (memory-window) interface and
+    /// activate.
+    ///
+    /// Selects CMS 0 with IMO 0, writes image data in 64-byte chunks via
+    /// INDIRECT_DATA, then sends RECOVERY_CTRL to activate.
+    fn send_image_indirect(hw: &mut DefaultHwModel, host: &UsbHostController, image: &[u8]) {
+        ocp_select_indirect_cms(hw, host, 0, 0, IMAGE_LOAD_TIMEOUT);
+        for chunk in image.chunks(64) {
+            ocp_write_indirect_data(hw, host, chunk, IMAGE_LOAD_TIMEOUT);
+        }
+        ocp_activate_recovery(hw, host, 0, IMAGE_LOAD_TIMEOUT);
+    }
+
+    /// Stream a complete image via the FIFO interface and activate.
+    ///
+    /// Selects CMS 1 and declares the image size in 4-byte units via
+    /// INDIRECT_FIFO_CTRL, writes image data in 64-byte chunks via
+    /// INDIRECT_FIFO_DATA, then sends RECOVERY_CTRL to activate.
+    fn send_image_fifo(hw: &mut DefaultHwModel, host: &UsbHostController, image: &[u8]) {
+        assert!(image.len() % 4 == 0, "image must be 4-byte aligned");
+        let image_size_4b = (image.len() / 4) as u32;
+
+        ocp_select_fifo_cms(hw, host, 1, image_size_4b, IMAGE_LOAD_TIMEOUT);
+        for chunk in image.chunks(64) {
+            ocp_write_fifo_data(hw, host, chunk, IMAGE_LOAD_TIMEOUT);
+        }
+        ocp_activate_recovery(hw, host, 1, IMAGE_LOAD_TIMEOUT);
+    }
+
+    /// Assert the device is in RecoveryMode and AwaitingImage.
+    fn assert_awaiting_image(hw: &mut DefaultHwModel, host: &UsbHostController) {
+        let status = ocp_read_data(hw, host, RecoveryCommand::DeviceStatus, 7, TIMEOUT);
+        assert_eq!(
+            status[0],
+            DeviceStatusValue::RecoveryMode as u8,
+            "device should be in RecoveryMode"
+        );
+
+        let rec_status = ocp_read_data(hw, host, RecoveryCommand::RecoveryStatus, 2, TIMEOUT);
+        assert_eq!(
+            rec_status[0] & 0x0F,
+            DeviceRecoveryStatus::AwaitingImage as u8,
+            "recovery status should be AwaitingImage"
+        );
+    }
+
+    // ---- Image load tests --------------------------------------------------
+
+    /// Pad a byte vector to 4-byte alignment.
+    fn pad_to_4b(data: &mut Vec<u8>) {
+        while data.len() % 4 != 0 {
+            data.push(0);
+        }
+    }
+
+    /// Load recovery images via the indirect (memory-window) interface and
+    /// verify the ROM completes the recovery boot flow.
+    ///
+    /// Sends the three recovery images (caliptra_fw, soc_manifest,
+    /// mcu_runtime) as separate stages, matching the streaming boot path.
+    #[test]
+    fn test_usb_ocp_recovery_load_image_indirect() {
+        let lock = TEST_LOCK.lock().unwrap();
+
+        let (mut hw, caliptra_fw, soc_manifest, mcu_runtime) = build_and_start_usb_ocp_recovery();
+        let host = hw.usb_host_controller.clone();
+
+        assert_awaiting_image(&mut hw, &host);
+
+        // Send each image as a separate recovery stage.  Between stages the
+        // ROM's I3C state machine activates the image and loops back to
+        // AwaitingImage.  The poll_* retry loops step the emulator so the
+        // ROM progresses through the I3C side while the host waits to send
+        // the next image.
+        for image in [&caliptra_fw, &soc_manifest, &mcu_runtime] {
+            send_image_indirect(&mut hw, &host, image);
+            println!("Got to image");
+        }
+
+        // Wait for the firmware boot flow to complete by polling the MCI
+        // milestone register. We cannot use finish_runtime_hw_model() /
+        // step_until_exit_success() here because the emulator's EmuCtrl
+        // exit handler calls std::process::exit(), which would kill the
+        // entire test runner process instead of just this test.
+        hw.step_until(|m| {
+            m.mci_boot_milestones()
+                .contains(McuBootMilestones::FIRMWARE_BOOT_FLOW_COMPLETE)
+        });
+
+        lock.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Load recovery images via the FIFO interface and verify the ROM
+    /// completes the recovery boot flow.
+    ///
+    /// Sends the three recovery images (caliptra_fw, soc_manifest,
+    /// mcu_runtime) as separate stages via FIFO streaming.
+    #[test]
+    fn test_usb_ocp_recovery_load_image_fifo() {
+        let lock = TEST_LOCK.lock().unwrap();
+
+        let (mut hw, mut caliptra_fw, mut soc_manifest, mut mcu_runtime) =
+            build_and_start_usb_ocp_recovery();
+
+        pad_to_4b(&mut caliptra_fw);
+        pad_to_4b(&mut soc_manifest);
+        pad_to_4b(&mut mcu_runtime);
+
+        let host = hw.usb_host_controller.clone();
+
+        assert_awaiting_image(&mut hw, &host);
+
+        for image in [&caliptra_fw, &soc_manifest, &mcu_runtime] {
+            send_image_fifo(&mut hw, &host, image);
+        }
+
+        // Wait for the firmware boot flow to complete by polling the MCI
+        // milestone register. We cannot use finish_runtime_hw_model() /
+        // step_until_exit_success() here because the emulator's EmuCtrl
+        // exit handler calls std::process::exit(), which would kill the
+        // entire test runner process instead of just this test.
+        hw.step_until(|m| {
+            m.mci_boot_milestones()
+                .contains(McuBootMilestones::FIRMWARE_BOOT_FLOW_COMPLETE)
+        });
 
         lock.fetch_add(1, Ordering::Relaxed);
     }


### PR DESCRIPTION
Add integration tests validating a complete image load can occur and boot the system into a good image state.  This included a couple small bug patches in regard to debug output.  It also enabled Staging RAM within the emulator to allow the INDIRECT CMS concept to be validated.

Finally a number of utilities were added to simplify test writing.