### PR TITLE
mctp: Reduce MCTP_MAX_MESSAGE_SIZE from 2048 to 1024

### DIFF
--- a/runtime/kernel/capsules/src/mctp/driver.rs
+++ b/runtime/kernel/capsules/src/mctp/driver.rs
@@ -16,7 +16,7 @@ use kernel::utilities::cells::{MapCell, OptionalCell, TakeCell};
 use kernel::utilities::leasable_buffer::SubSliceMut;
 use kernel::{ErrorCode, ProcessId};
 
-pub const MCTP_MAX_MESSAGE_SIZE: usize = 2048;
+pub const MCTP_MAX_MESSAGE_SIZE: usize = 1024;
 pub const MCTP_SPDM_DRIVER_NUM: usize = 0xA0000;
 pub const MCTP_SECURE_SPDM_DRIVER_NUM: usize = 0xA0001;
 pub const MCTP_PLDM_DRIVER_NUM: usize = 0xA0002;


### PR DESCRIPTION
SPDM responder uses MAX_SPDM_RESPONDER_BUF_SIZE = 1024 for message buffers. The kernel MCTP driver allocated 2048 per buffer, double what is needed. Each MCTP driver instance has 3 message buffers (rx, tx, buffered_rx), and there are 3 driver instances (SPDM, PLDM, Caliptra).

Saves ~8 KB kernel .sram (9 buffers × 1024 B reduction).