### PR TITLE
ocp: no panic ocp

### DIFF
--- a/common/ocp/src/cms/slice_fifo.rs
+++ b/common/ocp/src/cms/slice_fifo.rs
@@ -51,7 +51,9 @@ impl<'a> SliceFifoRegion<'a> {
     }
 
     fn capacity_4b(&self) -> u32 {
-        (self.buf.len() as u32) / 4
+        // new() ensures buf.len() >= 4 && buf.len() % 4 == 0, so always >= 1.
+        // .max(1) lets the optimizer prove non-zero for downstream % operations.
+        ((self.buf.len() as u32) / 4).max(1)
     }
 
     fn is_read_only(&self) -> bool {
@@ -97,7 +99,9 @@ impl<'a> SliceFifoRegion<'a> {
         let buf_byte_len = cap as usize * 4;
         for (i, &b) in data.iter().enumerate() {
             let pos = (self.write_idx as usize * 4 + i) % buf_byte_len;
-            self.buf[pos] = b;
+            if let Some(slot) = self.buf.get_mut(pos) {
+                *slot = b;
+            }
         }
         self.write_idx = (self.write_idx + data_4b) % cap;
         Ok(())
@@ -120,7 +124,9 @@ impl<'a> SliceFifoRegion<'a> {
         let buf_byte_len = cap as usize * 4;
         for (i, slot) in buf.iter_mut().enumerate().take(read_len) {
             let pos = (self.read_idx as usize * 4 + i) % buf_byte_len;
-            *slot = self.buf[pos];
+            if let Some(&val) = self.buf.get(pos) {
+                *slot = val;
+            }
         }
         self.read_idx = (self.read_idx + consume_4b) % cap;
         Ok(read_len)

--- a/common/ocp/src/cms/slice_indirect.rs
+++ b/common/ocp/src/cms/slice_indirect.rs
@@ -57,11 +57,16 @@ impl<'a> SliceIndirectRegion<'a> {
     ///
     /// Returns the number of bytes actually copied.
     fn read_at(&self, offset: usize, buf: &mut [u8]) -> usize {
-        let size = self.size_bytes() as usize;
-        let available = size.saturating_sub(offset);
-        let copy_len = buf.len().min(available);
-        buf[..copy_len].copy_from_slice(&self.buf[offset..offset + copy_len]);
-        copy_len
+        let src = match self.buf.get(offset..) {
+            Some(s) => s,
+            None => return 0,
+        };
+        let mut n = 0;
+        for (d, s) in buf.iter_mut().zip(src.iter()) {
+            *d = *s;
+            n += 1;
+        }
+        n
     }
 
     fn advance_imo(&mut self, transfer_len: usize) {
@@ -95,10 +100,12 @@ impl IndirectCmsRegion for SliceIndirectRegion<'_> {
             self.flags.set_read_only_error(true);
             return Err(CmsError::ReadOnly);
         }
-        let size = self.size_bytes() as usize;
         let offset = self.imo as usize;
-        let copy_len = data.len().min(size - offset);
-        self.buf[offset..offset + copy_len].copy_from_slice(&data[..copy_len]);
+        if let Some(dst) = self.buf.get_mut(offset..) {
+            for (d, s) in dst.iter_mut().zip(data.iter()) {
+                *d = *s;
+            }
+        }
         self.advance_imo(data.len());
         Ok(())
     }

--- a/common/ocp/src/error.rs
+++ b/common/ocp/src/error.rs
@@ -63,6 +63,8 @@ pub enum OcpError {
     IndirectCms0NotCodeSpace = 26,
     /// Two or more CMS regions share the same index.
     DuplicateCmsIndex = 27,
+    /// Source and destination slices have different lengths.
+    SliceLengthMismatch = 28,
 }
 
 impl From<UsbDriverError> for OcpError {

--- a/common/ocp/src/interface.rs
+++ b/common/ocp/src/interface.rs
@@ -176,7 +176,7 @@ impl<'a, U: UsbDeviceDriver, V: VendorHandler> RecoveryStateMachine<'a, U, V> {
         // Verify no CMS index appears more than once across both slices.
         // Note: CMS regions are likely to be few, so this operation is not prohibetively expensive.
         for (i, (idx_a, _)) in indirect_regions.iter().enumerate() {
-            for (idx_b, _) in indirect_regions[i + 1..].iter() {
+            for (idx_b, _) in indirect_regions.get(i + 1..).unwrap_or_default().iter() {
                 if idx_a == idx_b {
                     return Err(OcpError::DuplicateCmsIndex);
                 }
@@ -188,7 +188,7 @@ impl<'a, U: UsbDeviceDriver, V: VendorHandler> RecoveryStateMachine<'a, U, V> {
             }
         }
         for (i, (idx_a, _)) in fifo_regions.iter().enumerate() {
-            for (idx_b, _) in fifo_regions[i + 1..].iter() {
+            for (idx_b, _) in fifo_regions.get(i + 1..).unwrap_or_default().iter() {
                 if idx_a == idx_b {
                     return Err(OcpError::DuplicateCmsIndex);
                 }
@@ -517,7 +517,10 @@ impl<V: VendorHandler> RecoveryState<'_, V> {
     fn handle_device_status_read(&mut self, buf: &mut [u8]) -> Result<usize, OcpError> {
         let heartbeat = self.vendor.heartbeat();
         let mut vendor_buf = [0u8; device_status::MAX_VENDOR_STATUS_LEN];
-        let vendor_len = self.vendor.vendor_device_status(&mut vendor_buf);
+        let vendor_len = self
+            .vendor
+            .vendor_device_status(&mut vendor_buf)
+            .min(vendor_buf.len());
 
         let status = DeviceStatus::new(
             self.device_status_value,

--- a/common/ocp/src/lib.rs
+++ b/common/ocp/src/lib.rs
@@ -11,4 +11,5 @@ pub mod error;
 pub mod interface;
 pub mod protocol;
 pub mod usb;
+pub mod utils;
 pub mod vendor;

--- a/common/ocp/src/protocol/device_id.rs
+++ b/common/ocp/src/protocol/device_id.rs
@@ -339,7 +339,11 @@ impl<'a> DeviceId<'a> {
         self.inner
             .write_to_prefix(buf)
             .map_err(|_| OcpError::BufferTooSmall)?;
-        buf[MIN_MESSAGE_LEN..len].copy_from_slice(self.vendor_string);
+        crate::utils::try_copy_from_slice(
+            buf.get_mut(MIN_MESSAGE_LEN..len)
+                .ok_or(OcpError::BufferTooSmall)?,
+            self.vendor_string,
+        )?;
 
         Ok(len)
     }

--- a/common/ocp/src/protocol/device_status.rs
+++ b/common/ocp/src/protocol/device_status.rs
@@ -232,7 +232,11 @@ impl<'a> DeviceStatus<'a> {
         self.inner
             .write_to_prefix(buf)
             .map_err(|_| OcpError::BufferTooSmall)?;
-        buf[MIN_MESSAGE_LEN..len].copy_from_slice(self.vendor_status);
+        crate::utils::try_copy_from_slice(
+            buf.get_mut(MIN_MESSAGE_LEN..len)
+                .ok_or(OcpError::BufferTooSmall)?,
+            self.vendor_status,
+        )?;
 
         Ok(len)
     }

--- a/common/ocp/src/protocol/hw_status.rs
+++ b/common/ocp/src/protocol/hw_status.rs
@@ -155,7 +155,11 @@ impl<'a> HwStatus<'a> {
         self.inner
             .write_to_prefix(buf)
             .map_err(|_| OcpError::BufferTooSmall)?;
-        buf[MIN_MESSAGE_LEN..len].copy_from_slice(self.vendor_specific_status);
+        crate::utils::try_copy_from_slice(
+            buf.get_mut(MIN_MESSAGE_LEN..len)
+                .ok_or(OcpError::BufferTooSmall)?,
+            self.vendor_specific_status,
+        )?;
 
         Ok(len)
     }

--- a/common/ocp/src/utils.rs
+++ b/common/ocp/src/utils.rs
@@ -1,0 +1,56 @@
+// Licensed under the Apache-2.0 license
+
+//! Panic-free utilities for the OCP crate.
+
+use crate::error::OcpError;
+
+/// Copy `src` into `dst` without panicking.
+///
+/// Returns [`OcpError::SliceLengthMismatch`] if the two slices differ in
+/// length. This is the non-panicking equivalent of
+/// [`<[u8]>::copy_from_slice`].
+pub fn try_copy_from_slice(dst: &mut [u8], src: &[u8]) -> Result<(), OcpError> {
+    if dst.len() != src.len() {
+        return Err(OcpError::SliceLengthMismatch);
+    }
+    for (d, s) in dst.iter_mut().zip(src.iter()) {
+        *d = *s;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn copy_equal_length() {
+        let src = [1u8, 2, 3, 4];
+        let mut dst = [0u8; 4];
+        try_copy_from_slice(&mut dst, &src).unwrap();
+        assert_eq!(dst, src);
+    }
+
+    #[test]
+    fn copy_empty() {
+        try_copy_from_slice(&mut [], &[]).unwrap();
+    }
+
+    #[test]
+    fn dst_shorter_than_src() {
+        let mut dst = [0u8; 2];
+        assert_eq!(
+            try_copy_from_slice(&mut dst, &[1, 2, 3]),
+            Err(OcpError::SliceLengthMismatch),
+        );
+    }
+
+    #[test]
+    fn src_shorter_than_dst() {
+        let mut dst = [0u8; 4];
+        assert_eq!(
+            try_copy_from_slice(&mut dst, &[1, 2]),
+            Err(OcpError::SliceLengthMismatch),
+        );
+    }
+}

--- a/common/ocp/src/vendor.rs
+++ b/common/ocp/src/vendor.rs
@@ -87,10 +87,9 @@ pub trait VendorHandler {
 
 /// A no-op `VendorHandler` that advertises no optional capabilities.
 ///
-/// `capabilities()` returns all-zero (nothing supported). Methods that are
-/// only reachable when their corresponding capability bit is set are
-/// `unimplemented!()` — the state machine will never call them because
-/// `capabilities()` reports them as unsupported.
+/// `capabilities()` returns all-zero (nothing supported). Methods guarded
+/// by capability bits are unreachable at runtime; they return default/error
+/// values rather than panicking so the ROM binary stays panic-free.
 pub struct NoopVendorHandler;
 
 impl VendorHandler for NoopVendorHandler {
@@ -98,16 +97,14 @@ impl VendorHandler for NoopVendorHandler {
         VendorCapabilities(0)
     }
 
-    fn execute_reset(&mut self, _reset: &DeviceReset) {
-        unimplemented!("NoopVendorHandler: device_reset capability is not advertised")
-    }
+    fn execute_reset(&mut self, _reset: &DeviceReset) {}
 
     fn handle_vendor_write(&mut self, _data: &[u8]) -> Result<(), OcpError> {
-        unimplemented!("NoopVendorHandler: vendor_command capability is not advertised")
+        Err(OcpError::ProtCapIdentificationRequired)
     }
 
     fn handle_vendor_read(&self, _buf: &mut [u8]) -> Result<usize, OcpError> {
-        unimplemented!("NoopVendorHandler: vendor_command capability is not advertised")
+        Err(OcpError::ProtCapIdentificationRequired)
     }
 
     fn vendor_device_status(&self, _buf: &mut [u8]) -> usize {
@@ -119,7 +116,7 @@ impl VendorHandler for NoopVendorHandler {
     }
 
     fn hw_status(&self) -> Result<HwStatus<'_>, OcpError> {
-        unimplemented!("NoopVendorHandler: hardware_status capability is not advertised")
+        Err(OcpError::ProtCapIdentificationRequired)
     }
 }
 

--- a/platforms/emulator/rom/src/riscv.rs
+++ b/platforms/emulator/rom/src/riscv.rs
@@ -681,6 +681,7 @@ enum EmulatorError {
     InitFlashPartitionA,
     InitFlashPartitionB,
     InvalidPartitionId,
+    InitOcpRecovery,
 }
 
 impl From<EmulatorError> for mcu_error::McuError {

--- a/platforms/emulator/rom/usb/src/lib.rs
+++ b/platforms/emulator/rom/usb/src/lib.rs
@@ -14,7 +14,7 @@ use registers_generated::usbdev::bits::*;
 use romtime::StaticRef;
 use tock_registers::interfaces::{Readable, Writeable};
 use tock_registers::LocalRegisterCopy;
-use zerocopy::{FromBytes, IntoBytes};
+use zerocopy::IntoBytes;
 
 type RxEntry = LocalRegisterCopy<u32, Rxfifo::Register>;
 
@@ -51,32 +51,41 @@ impl ExamplarUsbDriver {
     fn get_in_buf(&self) -> u32 {
         let buf = BUF_IN;
 
-        // Zeroize the buffer before sending data out on it.
         let base = buf_word_base(buf);
         for i in 0..16 {
-            self.regs.buffer[base + i].set(0);
+            if let Some(reg) = self.regs.buffer.get(base + i) {
+                reg.set(0);
+            }
         }
         buf
     }
 
     fn read_setup_packet(&self, buf_id: u32) -> SetupPacket {
         let base = buf_word_base(buf_id);
-        let w0 = self.regs.buffer[base].get();
-        let w1 = self.regs.buffer[base + 1].get();
-        let mut raw_bytes = [0u8; SETUP_PACKET_LEN];
-        raw_bytes[..4].copy_from_slice(&w0.to_le_bytes());
-        raw_bytes[4..].copy_from_slice(&w1.to_le_bytes());
-        SetupPacket::read_from_bytes(&raw_bytes).unwrap()
+        let w0 = self.regs.buffer.get(base).map_or(0, |r| r.get());
+        let w1 = self.regs.buffer.get(base + 1).map_or(0, |r| r.get());
+        let w0b = w0.to_le_bytes();
+        let w1b = w1.to_le_bytes();
+        let raw_bytes: [u8; SETUP_PACKET_LEN] = [
+            w0b[0], w0b[1], w0b[2], w0b[3], w1b[0], w1b[1], w1b[2], w1b[3],
+        ];
+        zerocopy::transmute!(raw_bytes)
     }
 
     fn write_buffer(&self, buf_id: u32, data: &[u8]) {
         let base = buf_word_base(buf_id);
         let mut i = 0;
         while i < data.len() {
-            let end = core::cmp::min(i + 4, data.len());
             let mut word_bytes = [0u8; 4];
-            word_bytes[..end - i].copy_from_slice(&data[i..end]);
-            self.regs.buffer[base + i / 4].set(u32::from_le_bytes(word_bytes));
+            for (d, s) in word_bytes
+                .iter_mut()
+                .zip(data.get(i..).unwrap_or_default().iter())
+            {
+                *d = *s;
+            }
+            if let Some(reg) = self.regs.buffer.get(base + i / 4) {
+                reg.set(u32::from_le_bytes(word_bytes));
+            }
             i += 4;
         }
     }
@@ -85,10 +94,13 @@ impl ExamplarUsbDriver {
         let base = buf_word_base(buf_id);
         let mut i = 0;
         while i < size {
-            let word = self.regs.buffer[base + i / 4].get();
+            let word = self.regs.buffer.get(base + i / 4).map_or(0, |r| r.get());
             let bytes = word.to_le_bytes();
+            let dst = self.out_buf.get_mut(offset + i..).unwrap_or_default();
             let chunk = core::cmp::min(4, size - i);
-            self.out_buf[offset + i..offset + i + chunk].copy_from_slice(&bytes[..chunk]);
+            for (d, s) in dst.iter_mut().zip(bytes.iter()).take(chunk) {
+                *d = *s;
+            }
             i += 4;
         }
     }
@@ -370,6 +382,7 @@ impl UsbDeviceDriver for ExamplarUsbDriver {
             // IN status ZLP completes the write transfer
             self.send_zlp_in()?;
 
+            let total = total.min(self.out_buf.len());
             Ok((
                 command,
                 RecoveryRequest::Write {
@@ -393,9 +406,7 @@ impl UsbDeviceDriver for ExamplarUsbDriver {
             .ok_or(UsbDriverError::NoPendingRead)?
             .into();
         let len = populate_buffer(&mut self.out_buf).map_err(UsbDriverError::OcpError)?;
-        if len > MAX_WRITE_TRANSFER {
-            return Err(UsbDriverError::TransferTooLarge);
-        }
+        let len = len.min(self.out_buf.len());
         self.send_in(&self.out_buf[..len], expected)?;
         // self.send_out_buf(len, expected)?;
         self.recv_zlp_out()?;

--- a/rom/src/recovery/ocp.rs
+++ b/rom/src/recovery/ocp.rs
@@ -164,7 +164,8 @@ impl<U: UsbDeviceDriver, V: VendorHandler> ImageProvider for OcpImageProvider<'_
                     // perspective) while the device must always be able to
                     // consume the data.
                     let fifo = self.state_machine.fifo_cms_region().ok_or(())?;
-                    match fifo.device_drain(&mut data[filled..]) {
+                    let filled_clamped = filled.min(data.len());
+                    match fifo.device_drain(&mut data[filled_clamped..]) {
                         Ok(n) if n > 0 => {
                             filled += n;
                             self.bytes_read += n;

--- a/xtask/src/test.rs
+++ b/xtask/src/test.rs
@@ -151,31 +151,27 @@ pub(crate) fn test_hello_c_emulator() -> Result<()> {
 }
 
 pub(crate) fn test_panic_missing() -> Result<()> {
-    let rom_elf_path = PROJECT_ROOT
-        .join("target")
-        .join(TARGET)
-        .join("release")
-        .join("mcu-rom-emulator");
+    let test_features = [
+        None,
+        Some("test-usb-ocp-recovery".to_string()),
+        Some("test-flash-based-boot".to_string()),
+    ];
 
-    // Check default build
-    rom_build(None, None)?;
-    check_no_panic(&rom_elf_path, "default")?;
-
-    // Check test-flash-based-boot build
-    rom_build(None, Some("test-flash-based-boot".to_string()))?;
-    check_no_panic(&rom_elf_path, "test-flash-based-boot")?;
-
-    Ok(())
-}
-
-fn check_no_panic(rom_elf_path: &std::path::Path, label: &str) -> Result<()> {
-    let rom_elf = std::fs::read(rom_elf_path)?;
-    let symbols = elf_symbols(&rom_elf)?;
-    if symbols.iter().any(|s| s.contains("panic_is_possible")) {
-        bail!(
-            "The MCU ROM ({label}) contains the panic_is_possible symbol, which is not allowed. \
+    for test_feature in test_features.into_iter() {
+        rom_build(None, test_feature)?;
+        let rom_elf = PROJECT_ROOT
+            .join("target")
+            .join(TARGET)
+            .join("release")
+            .join("mcu-rom-emulator");
+        let rom_elf = std::fs::read(rom_elf)?;
+        let symbols = elf_symbols(&rom_elf)?;
+        if symbols.iter().any(|s| s.contains("panic_is_possible")) {
+            bail!(
+                "The MCU ROM contains the panic_is_possible symbol, which is not allowed. \
                 Please remove any code that might panic."
-        );
+            );
+        }
     }
     Ok(())
 }


### PR DESCRIPTION
Introduce a number of small changes to remove the possibility of the ROM panicking with the ocp feature enabled.

Then add the ocp feature to the list of features validated as panic free within the precheckin.