### PR TITLE
[cherry-pick] remaining PK hash selection commits

### DIFF
--- a/rom/src/cold_boot.rs
+++ b/rom/src/cold_boot.rs
@@ -1362,6 +1362,12 @@ impl BootFlow for ColdBoot {
             mci.set_flow_checkpoint(McuRomBootStatus::CaliptraRuntimeReady.into());
         }
 
+        soc.pk_hash_volatile_lock(&env.otp, _fuse_state.pk_hash_idx);
+        if env.otp.check_error().is_some() {
+            romtime::println!("[mcu-rom] OTP error: {}", HexWord(env.otp.status()));
+            env.otp.print_errors();
+        }
+
         let stash_rom_digest = params.stash_rom_digest.unwrap_or(false);
         Self::rom_digest_integrity(&mut env.soc_manager, stash_rom_digest);
 

--- a/rom/src/fuses.rs
+++ b/rom/src/fuses.rs
@@ -149,23 +149,28 @@ pub trait VendorKeyPolicy {
 ///
 /// This policy selects the first key slot that is both marked valid
 /// in the VENDOR_PK_HASH_VALID mask and is functional (not fully revoked).
-pub struct DefaultVendorKeyPolicy;
+pub struct DefaultVendorKeyPolicy {
+    rotate_pk_hash: bool,
+}
 
 impl DefaultVendorKeyPolicy {
-    pub const fn new() -> Self {
-        Self
+    pub const fn new(rotate_pk_hash: bool) -> Self {
+        Self { rotate_pk_hash }
     }
 }
 
 impl Default for DefaultVendorKeyPolicy {
     fn default() -> Self {
-        Self::new()
+        Self::new(false)
     }
 }
 
 impl VendorKeyPolicy for DefaultVendorKeyPolicy {
     fn select_key(&self, otp: &Otp) -> McuResult<usize> {
         let valid_mask = otp.read_entry_multi::<1>(generated_fuses::VENDOR_PK_HASH_VALID)?[0];
+        let target_slot_count = if self.rotate_pk_hash { 2 } else { 1 };
+        let mut slots_found = 0;
+        let mut first_functional: Option<usize> = None;
 
         for i in 0..16 {
             if (valid_mask >> i) & 1 == 1 {
@@ -189,10 +194,19 @@ impl VendorKeyPolicy for DefaultVendorKeyPolicy {
             };
 
             if ecc_functional && pqc_functional {
-                return Ok(i);
+                slots_found += 1;
+                first_functional = Some(i);
+                if slots_found == target_slot_count {
+                    return Ok(i);
+                }
             }
         }
 
-        Err(McuError::ROM_PK_HASH_SELECTION_FAILED)
+        match first_functional {
+            // if the rotation strap is asserted, but we only found one valid PK hash
+            // fall back to that one.
+            Some(i) => Ok(i),
+            None => Err(McuError::ROM_PK_HASH_SELECTION_FAILED),
+        }
     }
 }

--- a/rom/src/rom.rs
+++ b/rom/src/rom.rs
@@ -83,7 +83,9 @@ pub struct FuseState {
 
 impl Soc {
     pub const BOOT_FSM_DONE: u32 = 4;
-    pub const PK_HASH_STRAPPING_MASK: u32 = 0x1;
+    pub const PK_HASH_SKIP_LOCK_STRAPPING_MASK: u32 = 0x1;
+    pub const PK_HASH_ROTATION_STRAPPING_MASK: u32 = 0x1 << 1;
+
     pub const fn new(registers: StaticRef<soc::regs::Soc>) -> Self {
         Soc { registers }
     }
@@ -223,7 +225,9 @@ impl Soc {
         self.registers.ss_strap_generic[1].set(OTP_DIRECT_ACCESS_CMD_REG_OFFSET);
 
         // Select the vendor public key slot to use.
-        let default_policy = DefaultVendorKeyPolicy::new();
+        let default_policy = DefaultVendorKeyPolicy::new(
+            self.registers.ss_strap_generic[3].get() & Self::PK_HASH_ROTATION_STRAPPING_MASK != 0,
+        );
         let policy = params.vendor_key_policy.unwrap_or(&default_policy);
         let pk_hash_idx = policy
             .select_key(otp)
@@ -531,8 +535,8 @@ impl Soc {
 
     pub fn pk_hash_volatile_lock(&self, otp: &Otp, selected_index: usize) {
         // Read strap register to check for provisioning mode.
-        let strap_reg = self.registers.ss_strap_generic[2].get();
-        if (strap_reg & Self::PK_HASH_STRAPPING_MASK) != 0 {
+        let strap_reg = self.registers.ss_strap_generic[3].get();
+        if (strap_reg & Self::PK_HASH_SKIP_LOCK_STRAPPING_MASK) != 0 {
             romtime::println!(
               "[mcu-fuse-write] PK Hash provisioning mode detected, skipping vendor PK hash lock."
           );

--- a/rom/src/rom.rs
+++ b/rom/src/rom.rs
@@ -78,11 +78,12 @@ pub struct FuseParams<'a, 'b> {
 pub struct FuseState {
     #[cfg(feature = "ocp-lock")]
     pub hek_state: Option<romtime::ocp_lock::HekState>,
+    pub pk_hash_idx: usize,
 }
 
 impl Soc {
     pub const BOOT_FSM_DONE: u32 = 4;
-
+    pub const PK_HASH_STRAPPING_MASK: u32 = 0x1;
     pub const fn new(registers: StaticRef<soc::regs::Soc>) -> Self {
         Soc { registers }
     }
@@ -224,17 +225,14 @@ impl Soc {
         // Select the vendor public key slot to use.
         let default_policy = DefaultVendorKeyPolicy::new();
         let policy = params.vendor_key_policy.unwrap_or(&default_policy);
-        let selected_index = policy
+        let pk_hash_idx = policy
             .select_key(otp)
             .unwrap_or_else(|_| fatal_error(McuError::ROM_PK_HASH_SELECTION_FAILED));
-        romtime::println!(
-            "[mcu-fuse-write] Selected vendor PK slot {}",
-            selected_index
-        );
+        romtime::println!("[mcu-fuse-write] Selected vendor PK slot {}", pk_hash_idx);
 
         // PQC Key Type.
         let pqc_type = otp
-            .read_pqc_key_type(selected_index)
+            .read_pqc_key_type(pk_hash_idx)
             .unwrap_or_else(|_| fatal_error(McuError::ROM_OTP_READ_ERROR));
         let pqc_caliptra_val = match pqc_type {
             PqcKeyType::MLDSA => MLDSA_CALIPTRA_VALUE,
@@ -257,7 +255,7 @@ impl Soc {
         // Vendor PK Hash.
         romtime::print!("[mcu-fuse-write] Writing fuse key vendor PK hash: ");
         let mut hash_buf = [0u8; 48];
-        otp.read_vendor_pk_hash(selected_index, &mut hash_buf)
+        otp.read_vendor_pk_hash(pk_hash_idx, &mut hash_buf)
             .unwrap_or_else(|_| fatal_error(McuError::ROM_OTP_READ_ERROR));
         for (i, word_bytes) in hash_buf.chunks_exact(4).enumerate() {
             let word = u32::from_le_bytes(word_bytes.try_into().unwrap());
@@ -300,19 +298,19 @@ impl Soc {
         // Load Owner ECC/LMS/MLDSA revocation CSRs.
         // ECC Revocation.
         let word = otp
-            .read_vendor_ecc_revocation(selected_index)
+            .read_vendor_ecc_revocation(pk_hash_idx)
             .unwrap_or_else(|_| fatal_error(McuError::ROM_OTP_READ_ERROR));
         self.registers.fuse_ecc_revocation.set(word);
 
         // LMS Revocation.
         let word = otp
-            .read_vendor_lms_revocation(selected_index)
+            .read_vendor_lms_revocation(pk_hash_idx)
             .unwrap_or_else(|_| fatal_error(McuError::ROM_OTP_READ_ERROR));
         self.registers.fuse_lms_revocation.set(word);
 
         // MLDSA Revocation.
         let word = otp
-            .read_vendor_mldsa_revocation(selected_index)
+            .read_vendor_mldsa_revocation(pk_hash_idx)
             .unwrap_or_else(|_| fatal_error(McuError::ROM_OTP_READ_ERROR));
         self.registers.fuse_mldsa_revocation.set(word);
 
@@ -430,6 +428,7 @@ impl Soc {
         FuseState {
             #[cfg(feature = "ocp-lock")]
             hek_state,
+            pk_hash_idx,
         }
     }
 
@@ -528,6 +527,22 @@ impl Soc {
             total_slots: total_slots as u32,
             active_state,
         })
+    }
+
+    pub fn pk_hash_volatile_lock(&self, otp: &Otp, selected_index: usize) {
+        // Read strap register to check for provisioning mode.
+        let strap_reg = self.registers.ss_strap_generic[2].get();
+        if (strap_reg & Self::PK_HASH_STRAPPING_MASK) != 0 {
+            romtime::println!(
+              "[mcu-fuse-write] PK Hash provisioning mode detected, skipping vendor PK hash lock."
+          );
+        } else {
+            romtime::println!(
+                "[mcu-fuse-write] Locking vendor PK hash slots from index {}",
+                selected_index
+            );
+            otp.volatile_lock(selected_index as u32);
+        }
     }
 
     pub fn set_axi_users(&self, users: AxiUsers) {

--- a/romtime/src/otp.rs
+++ b/romtime/src/otp.rs
@@ -74,8 +74,9 @@ impl Otp {
         Otp { registers }
     }
 
-    pub fn volatile_lock(&self) {
-        self.registers.vendor_pk_hash_volatile_lock.set(1);
+    pub fn volatile_lock(&self, index: u32) {
+        // the register is 1-indexed in hardware
+        self.registers.vendor_pk_hash_volatile_lock.set(index + 1);
     }
 
     pub fn wait_for_not_pending(&self) -> McuResult<()> {

--- a/tests/integration/src/lib.rs
+++ b/tests/integration/src/lib.rs
@@ -64,7 +64,6 @@ mod test {
         pub soc_manifest: Vec<u8>,
     }
 
-    #[derive(Default)]
     pub struct TestParams<'a> {
         pub feature: Option<&'a str>,
         pub rom_feature: Option<&'a str>,
@@ -88,11 +87,37 @@ mod test {
         pub custom_mcu_rom: Option<Vec<u8>>,
         /// Optional bytes to prepend to the MCU firmware image (e.g., a manifest header).
         pub firmware_prefix: Option<Vec<u8>>,
-        /// If true (with `firmware_prefix` set), use the DOT hitless-update
-        /// test ROM which forces the cold-boot warm reset to come back as
-        /// `FirmwareHitlessUpdate` so `FwHitlessUpdate::run` processes the
-        /// manifest instead of `FwBoot::run`.
         pub fw_manifest_dot_hitless: bool,
+        pub active_i3c1: bool,
+        pub lifecycle_controller_state: Option<romtime::LifecycleControllerState>,
+        pub vendor_pqc_type: Option<caliptra_image_types::FwVerificationPqcKeyType>,
+    }
+
+    impl Default for TestParams<'_> {
+        fn default() -> Self {
+            Self {
+                feature: None,
+                rom_feature: None,
+                network_rom_feature: None,
+                i3c_port: None,
+                dot_flash_initial_contents: None,
+                rom_only: false,
+                include_network_rom: false,
+                flash_boot: false,
+                network_tap_device: None,
+                dot_enabled: false,
+                custom_caliptra_fw: None,
+                otp_memory: None,
+                fips_zeroization: false,
+                ocp_lock_en: false,
+                custom_mcu_rom: None,
+                firmware_prefix: None,
+                fw_manifest_dot_hitless: false,
+                active_i3c1: false,
+                lifecycle_controller_state: None,
+                vendor_pqc_type: Some(caliptra_image_types::FwVerificationPqcKeyType::LMS),
+            }
+        }
     }
 
     static PROJECT_ROOT: LazyLock<PathBuf> = LazyLock::new(|| {
@@ -511,10 +536,9 @@ mod test {
                 (None, caliptra_fw, soc_manifest, mcu_runtime)
             };
 
-        // TODO: read the PQC type
         mcu_hw_model::new(InitParams {
             fuses: Fuses {
-                fuse_pqc_key_type: FwVerificationPqcKeyType::LMS as u32,
+                fuse_pqc_key_type: params.vendor_pqc_type.map(|t| t as u32).unwrap_or(0),
                 vendor_pk_hash,
                 ..Default::default()
             },
@@ -527,7 +551,7 @@ mod test {
             network_tap_device: params.network_tap_device,
             vendor_pk_hash: Some(vendor_pk_hash_u8.try_into().unwrap()),
             active_mode: true,
-            vendor_pqc_type: Some(FwVerificationPqcKeyType::LMS),
+            vendor_pqc_type: params.vendor_pqc_type,
             i3c_port: params.i3c_port,
             enable_mcu_uart_log: true,
             dot_flash_initial_contents: params.dot_flash_initial_contents,

--- a/tests/integration/src/rom/test_vendor_key_policy.rs
+++ b/tests/integration/src/rom/test_vendor_key_policy.rs
@@ -3,6 +3,7 @@
 #[cfg(test)]
 mod test {
     use anyhow::Result;
+    use caliptra_api::SocManager;
     use mcu_error::McuError;
     use mcu_hw_model::{new, DefaultHwModel, InitParams, McuHwModel, McuManager};
     use registers_generated::fuses;
@@ -14,12 +15,23 @@ mod test {
 
     use crate::test::{start_runtime_hw_model, TestParams};
 
-    #[derive(Default, Clone, Copy)]
+    #[derive(Clone, Copy)]
     struct SlotConfig {
         pqc_type: Option<PqcKeyType>,
         ecc_revocation: u32,
         lms_revocation: u32,
         mldsa_revocation: u32,
+    }
+
+    impl Default for SlotConfig {
+        fn default() -> Self {
+            SlotConfig {
+                pqc_type: Some(PqcKeyType::MLDSA),
+                ecc_revocation: 0,
+                lms_revocation: 0,
+                mldsa_revocation: 0,
+            }
+        }
     }
 
     fn build_otp_memory(valid_mask: u16, slot_configs: &[(usize, SlotConfig)]) -> Vec<u8> {
@@ -45,7 +57,7 @@ mod test {
                     .copy_from_slice(&raw_pqc.to_le_bytes());
             }
 
-            // 3. Populate Revocations (OneHotLinearMajorityVote)
+            // 3. Populate Revocations (LinearMajorityVote)
             let ecc_entry =
                 vendor_ecc_revocation_entry(slot).expect("Invalid ECC Revocation entry");
             let ecc_layout = FuseLayout::from_generated(&ecc_entry.layout).unwrap();
@@ -84,16 +96,7 @@ mod test {
 
     #[test]
     fn test_select_first_functional() -> Result<()> {
-        let mut hw = setup_hw_model(
-            0x0000,
-            &[(
-                0,
-                SlotConfig {
-                    pqc_type: Some(PqcKeyType::MLDSA),
-                    ..SlotConfig::default()
-                },
-            )],
-        );
+        let mut hw = setup_hw_model(0x0000, &[(0, SlotConfig::default())]);
         hw.step_until_output_contains("[mcu-fuse-write] Selected vendor PK slot 0")?;
         Ok(())
     }
@@ -106,18 +109,11 @@ mod test {
                 (
                     0,
                     SlotConfig {
-                        pqc_type: Some(PqcKeyType::MLDSA),
                         ecc_revocation: 0b1111,
                         ..SlotConfig::default()
                     },
                 ),
-                (
-                    1,
-                    SlotConfig {
-                        pqc_type: Some(PqcKeyType::MLDSA),
-                        ..SlotConfig::default()
-                    },
-                ),
+                (1, SlotConfig::default()),
             ],
         );
         hw.step_until_output_contains("[mcu-fuse-write] Selected vendor PK slot 1")?;
@@ -132,18 +128,11 @@ mod test {
                 (
                     0,
                     SlotConfig {
-                        pqc_type: Some(PqcKeyType::MLDSA),
                         mldsa_revocation: 0b1111,
                         ..SlotConfig::default()
                     },
                 ),
-                (
-                    1,
-                    SlotConfig {
-                        pqc_type: Some(PqcKeyType::MLDSA),
-                        ..SlotConfig::default()
-                    },
-                ),
+                (1, SlotConfig::default()),
             ],
         );
         hw.step_until_output_contains("[mcu-fuse-write] Selected vendor PK slot 1")?;
@@ -169,32 +158,14 @@ mod test {
 
     #[test]
     fn test_middle_slot_selection() -> Result<()> {
-        let mut hw = setup_hw_model(
-            0x00FF,
-            &[(
-                8,
-                SlotConfig {
-                    pqc_type: Some(PqcKeyType::MLDSA),
-                    ..SlotConfig::default()
-                },
-            )],
-        );
+        let mut hw = setup_hw_model(0x00FF, &[(8, SlotConfig::default())]);
         hw.step_until_output_contains("[mcu-fuse-write] Selected vendor PK slot 8")?;
         Ok(())
     }
 
     #[test]
     fn test_last_slot_selection() -> Result<()> {
-        let mut hw = setup_hw_model(
-            0x7FFF,
-            &[(
-                15,
-                SlotConfig {
-                    pqc_type: Some(PqcKeyType::MLDSA),
-                    ..SlotConfig::default()
-                },
-            )],
-        );
+        let mut hw = setup_hw_model(0x7FFF, &[(15, SlotConfig::default())]);
         hw.step_until_output_contains("[mcu-fuse-write] Selected vendor PK slot 15")?;
         Ok(())
     }
@@ -219,7 +190,6 @@ mod test {
                 (
                     0,
                     SlotConfig {
-                        pqc_type: Some(PqcKeyType::MLDSA),
                         ecc_revocation: 0b1111,
                         ..SlotConfig::default()
                     },
@@ -269,6 +239,53 @@ mod test {
             .mcu_manager()
             .with_otp(|otp| otp.vendor_pk_hash_volatile_lock().read());
         assert_eq!(lock_val, 1);
+        Ok(())
+    }
+
+    #[test]
+    fn test_vendor_pk_lock_not_applied() -> Result<()> {
+        let mut hw = setup_hw_model(0x0000, &[(0, SlotConfig::default())]);
+
+        // Set strapping bit to not lock the pk hashes
+        hw.caliptra_soc_manager()
+            .soc_ifc()
+            .ss_strap_generic()
+            .get(3)
+            .expect("failed to get strapping register")
+            .write(|_| 0x1);
+
+        hw.step_until_output_contains("[mcu-fuse-write] Selected vendor PK slot 0")?;
+
+        // Step a few cycles
+        for _ in 0..100 {
+            hw.step();
+        }
+
+        let lock_val = hw
+            .mcu_manager()
+            .with_otp(|otp| otp.vendor_pk_hash_volatile_lock().read());
+        assert_eq!(lock_val, 0);
+        Ok(())
+    }
+
+    #[test]
+    fn test_key_rotation_strap() -> Result<()> {
+        let mut hw = setup_hw_model(
+            0x0002,
+            &[(0, SlotConfig::default()), (2, SlotConfig::default())],
+        );
+        // Set strapping bit to jump 1 PK hash slot
+        hw.caliptra_soc_manager()
+            .soc_ifc()
+            .ss_strap_generic()
+            .get(3)
+            .expect("failed to get strapping register")
+            .write(|_| 0x2);
+
+        // Slot 0 is the first functional slot which we skip
+        // Slot 1 is marked invalid
+        // Slot 2 should be selected
+        hw.step_until_output_contains("[mcu-fuse-write] Selected vendor PK slot 2")?;
         Ok(())
     }
 }

--- a/tests/integration/src/rom/test_vendor_key_policy.rs
+++ b/tests/integration/src/rom/test_vendor_key_policy.rs
@@ -4,13 +4,15 @@
 mod test {
     use anyhow::Result;
     use mcu_error::McuError;
-    use mcu_hw_model::{new, DefaultHwModel, InitParams, McuHwModel};
+    use mcu_hw_model::{new, DefaultHwModel, InitParams, McuHwModel, McuManager};
     use registers_generated::fuses;
     use romtime::{
         pqc_key_type_entry, vendor_ecc_revocation_entry, vendor_lms_revocation_entry,
         vendor_mldsa_revocation_entry, write_fuse_value, write_single_fuse_value, FuseLayout,
         PqcKeyType,
     };
+
+    use crate::test::{start_runtime_hw_model, TestParams};
 
     #[derive(Default, Clone, Copy)]
     struct SlotConfig {
@@ -69,19 +71,13 @@ mod test {
         otp
     }
 
-    fn setup_hw_model(
-        valid_mask: u16,
-        slot_configs: &[(usize, SlotConfig)],
-    ) -> Result<DefaultHwModel> {
-        let binaries = mcu_builder::FirmwareBinaries::from_env()?;
+    fn setup_hw_model(valid_mask: u16, slot_configs: &[(usize, SlotConfig)]) -> DefaultHwModel {
         let otp_memory = build_otp_memory(valid_mask, slot_configs);
 
-        new(InitParams {
-            caliptra_rom: &binaries.caliptra_rom,
-            mcu_rom: &binaries.mcu_rom,
-            otp_memory: Some(&otp_memory),
-            check_booted_to_runtime: false,
-            enable_mcu_uart_log: true,
+        start_runtime_hw_model(TestParams {
+            otp_memory: Some(otp_memory),
+            rom_only: true,
+            vendor_pqc_type: None,
             ..Default::default()
         })
     }
@@ -97,7 +93,7 @@ mod test {
                     ..SlotConfig::default()
                 },
             )],
-        )?;
+        );
         hw.step_until_output_contains("[mcu-fuse-write] Selected vendor PK slot 0")?;
         Ok(())
     }
@@ -123,7 +119,7 @@ mod test {
                     },
                 ),
             ],
-        )?;
+        );
         hw.step_until_output_contains("[mcu-fuse-write] Selected vendor PK slot 1")?;
         Ok(())
     }
@@ -137,7 +133,7 @@ mod test {
                     0,
                     SlotConfig {
                         pqc_type: Some(PqcKeyType::MLDSA),
-                        mldsa_revocation: 0b1_1111,
+                        mldsa_revocation: 0b1111,
                         ..SlotConfig::default()
                     },
                 ),
@@ -149,7 +145,7 @@ mod test {
                     },
                 ),
             ],
-        )?;
+        );
         hw.step_until_output_contains("[mcu-fuse-write] Selected vendor PK slot 1")?;
         Ok(())
     }
@@ -166,7 +162,7 @@ mod test {
                     ..SlotConfig::default()
                 },
             )],
-        )?;
+        );
         hw.step_until_output_contains("[mcu-fuse-write] Selected vendor PK slot 0")?;
         Ok(())
     }
@@ -182,7 +178,7 @@ mod test {
                     ..SlotConfig::default()
                 },
             )],
-        )?;
+        );
         hw.step_until_output_contains("[mcu-fuse-write] Selected vendor PK slot 8")?;
         Ok(())
     }
@@ -198,14 +194,14 @@ mod test {
                     ..SlotConfig::default()
                 },
             )],
-        )?;
+        );
         hw.step_until_output_contains("[mcu-fuse-write] Selected vendor PK slot 15")?;
         Ok(())
     }
 
     #[test]
     fn test_all_invalid_fails() -> Result<()> {
-        let mut hw = setup_hw_model(0xFFFF, &[])?;
+        let mut hw = setup_hw_model(0xFFFF, &[]);
         hw.step_until(|hw| hw.mci_fw_fatal_error().is_some());
         let fatal_error = hw.mci_fw_fatal_error().unwrap();
         assert_eq!(
@@ -237,13 +233,42 @@ mod test {
                     },
                 ),
             ],
-        )?;
+        );
         hw.step_until(|hw| hw.mci_fw_fatal_error().is_some());
         let fatal_error = hw.mci_fw_fatal_error().unwrap();
         assert_eq!(
             fatal_error,
             u32::from(McuError::ROM_PK_HASH_SELECTION_FAILED)
         );
+        Ok(())
+    }
+
+    #[test]
+    fn test_vendor_pk_lock_applied() -> Result<()> {
+        let mut hw = setup_hw_model(
+            0x0000,
+            &[(
+                0,
+                SlotConfig {
+                    pqc_type: Some(PqcKeyType::LMS),
+                    ..SlotConfig::default()
+                },
+            )],
+        );
+        hw.step_until_output_contains("[mcu-fuse-write] Selected vendor PK slot 0")?;
+        hw.step_until_output_contains(
+            "[mcu-fuse-write] Locking vendor PK hash slots from index 0",
+        )?;
+
+        // Step a few cycles to ensure the write is executed
+        for _ in 0..100 {
+            hw.step();
+        }
+
+        let lock_val = hw
+            .mcu_manager()
+            .with_otp(|otp| otp.vendor_pk_hash_volatile_lock().read());
+        assert_eq!(lock_val, 1);
         Ok(())
     }
 }


### PR DESCRIPTION
* Lock PK Hash slots after selection
* Enable use of a strap to skip one PK Hash slot for rotation