### PR TITLE
kernel: Add capsule logging and optimize mctp to reduce .text

### DIFF
--- a/runtime/kernel/capsules/Cargo.toml
+++ b/runtime/kernel/capsules/Cargo.toml
@@ -21,3 +21,7 @@ caliptra-mcu-registers-generated.workspace = true
 caliptra-mcu-romtime.workspace = true
 tock-registers.workspace = true
 zerocopy.workspace = true
+
+[features]
+default = []
+debug-capsule-prints = []

--- a/runtime/kernel/capsules/src/doe/driver.rs
+++ b/runtime/kernel/capsules/src/doe/driver.rs
@@ -105,9 +105,10 @@ impl<'a, T: DoeTransport<'a>> DoeDriver<'a, T> {
         let _result = kernel_data
             .get_readonly_processbuffer(ro_allow::MESSAGE_WRITE)
             .map_err(|e| {
-                println!(
-                    "DOE_CAPSULE: Error getting ReadOnlyProcessBuffer buffer: {:?}",
-                    e
+                capsule_error!(
+                    "DOE",
+                    "Error getting ReadOnlyProcessBuffer buffer: 0x{:08x}",
+                    e as u32
                 );
                 ErrorCode::INVAL
             })
@@ -115,7 +116,11 @@ impl<'a, T: DoeTransport<'a>> DoeDriver<'a, T> {
                 tx_buf
                     .enter(|app_buf| self.start_transmit(app_buf))
                     .map_err(|e| {
-                        println!("DOE_CAPSULE: Error getting application tx buffer: {:?}", e);
+                        capsule_error!(
+                            "DOE",
+                            "Error getting application tx buffer: 0x{:08x}",
+                            e as u32
+                        );
                         ErrorCode::FAIL
                     })
             })?;
@@ -127,7 +132,7 @@ impl<'a, T: DoeTransport<'a>> DoeDriver<'a, T> {
     fn handle_doe_discovery(&self, doe_req: DoeDiscoveryRequest) {
         let data_object_protocol = DataObjectType::from(doe_req.index());
         if data_object_protocol == DataObjectType::Unsupported {
-            println!("DOE_CAPSULE: Unsupported DOE Discovery Request");
+            capsule_debug!("DOE", "Unsupported DOE Discovery Request");
             return;
         }
 
@@ -144,14 +149,14 @@ impl<'a, T: DoeTransport<'a>> DoeDriver<'a, T> {
             .encode(&mut doe_resp[..DOE_DATA_OBJECT_HEADER_LEN_DW])
             .is_err()
         {
-            println!("DOE_CAPSULE: Error encoding DOE header");
+            capsule_error!("DOE", "Error encoding DOE header");
             return;
         }
         if discovery_response
             .encode(&mut doe_resp[DOE_DATA_OBJECT_HEADER_LEN_DW..])
             .is_err()
         {
-            println!("DOE_CAPSULE: Error encoding DOE discovery response");
+            capsule_error!("DOE", "Error encoding DOE discovery response");
             return;
         }
 
@@ -160,9 +165,10 @@ impl<'a, T: DoeTransport<'a>> DoeDriver<'a, T> {
             .doe_transport
             .transmit(doe_resp.iter().copied(), doe_resp.len())
         {
-            println!(
-                "DOE_CAPSULE: Error transmitting DOE Discovery Response: {:?}",
-                err
+            capsule_error!(
+                "DOE",
+                "Error transmitting DOE Discovery Response: 0x{:08x}",
+                err as u32
             );
         }
     }
@@ -173,7 +179,7 @@ impl<'a, T: DoeTransport<'a>> DoeDriver<'a, T> {
             if app.waiting_rx.get() {
                 app.waiting_rx.set(false);
             } else {
-                println!("DOE_CAPSULE: Application not waiting for Data Object");
+                capsule_debug!("DOE", "Application not waiting for Data Object");
                 return;
             }
 
@@ -193,14 +199,15 @@ impl<'a, T: DoeTransport<'a>> DoeDriver<'a, T> {
                             Ok(copy_len_dw * 4)
                         })
                         .map_err(|e| {
-                            println!("DOE_CAPSULE: Error entering ReadWriteProcessBuffer buffer");
+                            capsule_error!("DOE", "Error entering ReadWriteProcessBuffer buffer");
                             e.into()
                         })
                 }
                 Err(err) => {
-                    println!(
-                        "DOE_CAPSULE: Error getting ReadWriteProcessBuffer buffer: {:?}",
-                        err
+                    capsule_error!(
+                        "DOE",
+                        "Error getting ReadWriteProcessBuffer buffer: 0x{:08x}",
+                        err as u32
                     );
                     Err(ErrorCode::INVAL)
                 }
@@ -213,10 +220,18 @@ impl<'a, T: DoeTransport<'a>> DoeDriver<'a, T> {
                         .ok();
                 }
                 Ok(Err(err)) => {
-                    println!("DOE_CAPSULE: Error copying data to app buffer: {:?}", err);
+                    capsule_error!(
+                        "DOE",
+                        "Error copying data to app buffer: 0x{:08x}",
+                        err as u32
+                    );
                 }
                 Err(err) => {
-                    println!("DOE_CAPSULE: Error while accessing app buffer: {:?}", err);
+                    capsule_error!(
+                        "DOE",
+                        "Error while accessing app buffer: 0x{:08x}",
+                        err as u32
+                    );
                 }
             }
         });
@@ -269,13 +284,21 @@ impl<'a, T: DoeTransport<'a>> SyscallDriver for DoeDriver<'a, T> {
                         self.send_app_data(process_id, app, kernel_data)
                     })
                     .map_err(|err| {
-                        println!("DOE_CAPSULE: Error sending DOE Data object: {:?}", err);
+                        capsule_error!(
+                            "DOE",
+                            "Error sending DOE Data object: 0x{:08x}",
+                            err as u32
+                        );
                         err.into()
                     });
                 match result {
                     Ok(_) => CommandReturn::success(),
                     Err(err) => {
-                        println!("DOE_CAPSULE: Error sending DOE Data object: {:?}", err);
+                        capsule_error!(
+                            "DOE",
+                            "Error sending DOE Data object: 0x{:08x}",
+                            err as u32
+                        );
                         CommandReturn::failure(err)
                     }
                 }
@@ -297,7 +320,7 @@ impl<'a, T: DoeTransport<'a>> SyscallDriver for DoeDriver<'a, T> {
 impl<'a, T: DoeTransport<'a>> DoeTransportRxClient for DoeDriver<'a, T> {
     fn receive(&self, rx_buf: &'static mut [u32], len: usize) {
         if len < 3 || len > rx_buf.len() {
-            println!("DOE_CAPSULE: Invalid length received: {}", len);
+            capsule_debug!("DOE", "Invalid length received: {}", len);
             self.doe_transport.set_rx_buffer(rx_buf);
             return;
         }
@@ -306,20 +329,21 @@ impl<'a, T: DoeTransport<'a>> DoeTransportRxClient for DoeDriver<'a, T> {
         let doe_hdr = match DoeDataObjectHeader::decode(rx_buf) {
             Ok(header) => header,
             Err(_) => {
-                println!("DOE_CAPSULE: Failed to decode DOE header");
+                capsule_error!("DOE", "Failed to decode DOE header");
                 self.doe_transport.set_rx_buffer(rx_buf);
                 return;
             }
         };
 
         if !doe_hdr.validate(len as u32) {
-            println!("DOE_CAPSULE: Invalid DOE Data Object");
+            capsule_debug!("DOE", "Invalid DOE Data Object");
             self.doe_transport.set_rx_buffer(rx_buf);
             return;
         }
 
-        println!(
-            "DOE_CAPSULE: Received DOE Data Object: vendor_id: {}, type: {:?}, length: {}",
+        capsule_debug!(
+            "DOE",
+            "Received DOE Data Object: vendor_id: {}, type: {:?}, length: {}",
             doe_hdr.vendor_id,
             doe_hdr.data_object_type(),
             doe_hdr.length
@@ -337,7 +361,7 @@ impl<'a, T: DoeTransport<'a>> DoeTransportRxClient for DoeDriver<'a, T> {
                 // Note: rx_buf is consumed by handle_spdm_upcall, so we don't call set_rx_buffer here
             }
             DataObjectType::Unsupported => {
-                println!("DOE_CAPSULE: Unsupported DOE Data Object");
+                capsule_debug!("DOE", "Unsupported DOE Data Object");
                 self.doe_transport.set_rx_buffer(rx_buf);
             }
         }

--- a/runtime/kernel/capsules/src/lib.rs
+++ b/runtime/kernel/capsules/src/lib.rs
@@ -3,6 +3,23 @@
 #![cfg_attr(target_arch = "riscv32", no_std)]
 #![forbid(unsafe_code)]
 
+/// Error log — always compiled in. Use for failures that affect correctness.
+#[macro_export]
+macro_rules! capsule_error {
+    ($prefix:literal, $fmt:literal $(, $arg:expr)* $(,)?) => {{
+        println!(concat!("[", $prefix, "] ERR: ", $fmt) $(, $arg)*)
+    }};
+}
+
+/// Debug log — compiled out unless `debug-capsule-prints` feature is enabled.
+#[macro_export]
+macro_rules! capsule_debug {
+    ($prefix:literal, $fmt:literal $(, $arg:expr)* $(,)?) => {{
+        #[cfg(feature = "debug-capsule-prints")]
+        println!(concat!("[", $prefix, "] DBG: ", $fmt) $(, $arg)*)
+    }};
+}
+
 pub mod test;
 
 pub mod caliptra;

--- a/runtime/kernel/capsules/src/mailbox.rs
+++ b/runtime/kernel/capsules/src/mailbox.rs
@@ -4,6 +4,7 @@
 //! communicate with Caliptra.
 
 use caliptra_api::CaliptraApiError;
+use caliptra_mcu_romtime::println;
 use caliptra_mcu_romtime::CaliptraSoC;
 use core::cell::Cell;
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
@@ -13,7 +14,57 @@ use kernel::processbuffer::{
 };
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::{OptionalCell, TakeCell};
-use kernel::{debug, ErrorCode, ProcessId};
+use kernel::{ErrorCode, ProcessId};
+
+fn log_caliptra_error(err: &CaliptraApiError) {
+    match err {
+        CaliptraApiError::MailboxCmdFailed(code) => {
+            capsule_error!("MBOX", "Mailbox cmd failed: 0x{:08x}", code)
+        }
+        CaliptraApiError::UnknownCommandStatus(code) => {
+            capsule_error!("MBOX", "Unknown command status: 0x{:08x}", code)
+        }
+        CaliptraApiError::MailboxRespInvalidChecksum { expected, actual } => capsule_error!(
+            "MBOX",
+            "Invalid checksum: exp=0x{:08x} act=0x{:08x}",
+            expected,
+            actual
+        ),
+        CaliptraApiError::MailboxRespInvalidFipsStatus(status) => {
+            capsule_error!("MBOX", "Invalid FIPS status: 0x{:08x}", status)
+        }
+        CaliptraApiError::MailboxUnexpectedResponseLen {
+            expected_min,
+            expected_max,
+            actual,
+        } => capsule_error!(
+            "MBOX",
+            "Unexpected resp len: min={} max={} actual={}",
+            expected_min,
+            expected_max,
+            actual
+        ),
+        CaliptraApiError::UnexpectedMailboxFsmStatus { expected, actual } => capsule_error!(
+            "MBOX",
+            "Unexpected FSM status: exp=0x{:08x} act=0x{:08x}",
+            expected,
+            actual
+        ),
+        CaliptraApiError::BufferTooLargeForMailbox => {
+            capsule_error!("MBOX", "Buffer too large for mailbox")
+        }
+        CaliptraApiError::UnableToLockMailbox => capsule_error!("MBOX", "Unable to lock mailbox"),
+        CaliptraApiError::MailboxTimeout => capsule_error!("MBOX", "Mailbox timeout"),
+        CaliptraApiError::MailboxRespTypeTooSmall => {
+            capsule_error!("MBOX", "Response type too small")
+        }
+        CaliptraApiError::MailboxReqTypeTooSmall => {
+            capsule_error!("MBOX", "Request type too small")
+        }
+        CaliptraApiError::MailboxNoResponseData => capsule_error!("MBOX", "No response data"),
+        _ => capsule_error!("MBOX", "Mailbox error"),
+    }
+}
 
 /// The driver number for Caliptra mailbox commands.
 pub const DRIVER_NUM: usize = 0x8000_0009;
@@ -95,7 +146,7 @@ impl<'a, A: Alarm<'a>> Mailbox<'a, A> {
             kernel_data
                 .get_readonly_processbuffer(ro_allow::REQUEST)
                 .map_err(|err| {
-                    debug!("Error getting process buffer: {:?}", err);
+                    capsule_error!("MBOX", "Error getting process buffer: 0x{:x}", err as u32);
                     ErrorCode::FAIL
                 })
                 .and_then(|ro_buffer| {
@@ -108,7 +159,11 @@ impl<'a, A: Alarm<'a>> Mailbox<'a, A> {
                                 .ok_or(ErrorCode::RESERVE)?
                         })
                         .map_err(|err| {
-                            debug!("Error getting application buffer: {:?}", err);
+                            capsule_error!(
+                                "MBOX",
+                                "Error getting application buffer: 0x{:08x}",
+                                err as u32
+                            );
                             ErrorCode::FAIL
                         })?
                 })
@@ -139,7 +194,7 @@ impl<'a, A: Alarm<'a>> Mailbox<'a, A> {
                 Ok(())
             }
             Err(err) => {
-                debug!("Error starting mailbox command: {:?}", err);
+                log_caliptra_error(&err);
                 Err(ErrorCode::FAIL)
             }
         }
@@ -175,7 +230,7 @@ impl<'a, A: Alarm<'a>> Mailbox<'a, A> {
             kernel_data
                 .get_readonly_processbuffer(ro_allow::REQUEST)
                 .map_err(|err| {
-                    debug!("Error getting process buffer: {:?}", err);
+                    capsule_error!("MBOX", "Error getting process buffer: 0x{:x}", err as u32);
                     ErrorCode::FAIL
                 })
                 .and_then(|ro_buffer| {
@@ -186,14 +241,18 @@ impl<'a, A: Alarm<'a>> Mailbox<'a, A> {
                                 .ok_or(ErrorCode::RESERVE)?
                         })
                         .map_err(|err| {
-                            debug!("Error getting application buffer: {:?}", err);
+                            capsule_error!(
+                                "MBOX",
+                                "Error getting application buffer: 0x{:08x}",
+                                err as u32
+                            );
                             ErrorCode::FAIL
                         })?
                 })?;
             kernel_data
                 .schedule_upcall(upcall::COMMAND_DONE, (0, 0, 0))
                 .map_err(|err| {
-                    debug!("Error scheduling upcall: {:?}", err);
+                    capsule_error!("MBOX", "Error scheduling upcall: 0x{:x}", err as u32);
                     ErrorCode::FAIL
                 })
         })?
@@ -212,7 +271,7 @@ impl<'a, A: Alarm<'a>> Mailbox<'a, A> {
                 driver.write_data(data).map_err(|_| ErrorCode::FAIL)?;
             } else {
                 // If the last chunk is not 4 bytes, we can't write it to the mailbox
-                debug!("Error: Incomplete data chunk in mailbox request");
+                capsule_error!("MBOX", "Error: Incomplete data chunk in mailbox request");
                 return Err(ErrorCode::FAIL);
             }
         }
@@ -230,7 +289,7 @@ impl<'a, A: Alarm<'a>> Mailbox<'a, A> {
                     self.schedule_alarm();
                     Ok(())
                 }
-                Err(_) => Err(ErrorCode::FAIL),
+                Err(_err) => Err(ErrorCode::FAIL),
             })
             .unwrap_or(Err(ErrorCode::FAIL))
     }
@@ -256,7 +315,7 @@ impl<'a, A: Alarm<'a>> Mailbox<'a, A> {
                 }
             }
             Err(err) => {
-                debug!("Error copying from mailbox: {:?}", err);
+                log_caliptra_error(&err);
                 Err(err)
             }
         }
@@ -274,7 +333,11 @@ impl<'a, A: Alarm<'a>> Mailbox<'a, A> {
                         self.copy_from_mailbox(driver, app_buffer)
                     }) {
                         Err(err) => {
-                            debug!("Error accessing writable buffer {:?}", err);
+                            capsule_error!(
+                                "MBOX",
+                                "Error accessing writable buffer: 0x{:08x}",
+                                err as u32
+                            );
                         }
                         Ok(Err(err)) => {
                             // Error from Caliptra
@@ -286,21 +349,29 @@ impl<'a, A: Alarm<'a>> Mailbox<'a, A> {
                             if let Err(err) = kernel_data
                                 .schedule_upcall(upcall::COMMAND_DONE, (0, err as usize, 0))
                             {
-                                debug!("Error scheduling upcall: {:?}", err);
+                                capsule_error!(
+                                    "MBOX",
+                                    "Error scheduling upcall: 0x{:08x}",
+                                    err as u32
+                                );
                             }
                         }
                         Ok(Ok(len)) => {
                             if let Err(err) =
                                 kernel_data.schedule_upcall(upcall::COMMAND_DONE, (len, 0, 0))
                             {
-                                debug!("Error scheduling upcall: {:?}", err);
+                                capsule_error!(
+                                    "MBOX",
+                                    "Error scheduling upcall: 0x{:08x}",
+                                    err as u32
+                                );
                             }
                         }
                     }
                 }
             });
             if let Err(err) = enter_result {
-                debug!("Error entering app: {:?}", err);
+                capsule_error!("MBOX", "Error entering app: 0x{:x}", err as u32);
             }
         }
     }

--- a/runtime/kernel/capsules/src/mctp/control_msg.rs
+++ b/runtime/kernel/capsules/src/mctp/control_msg.rs
@@ -148,67 +148,32 @@ impl MCTPCtrlCmd {
 
         match version_type {
             VersionSupportType::BaseSpec | VersionSupportType::ControlProtocolMessage => {
-                // Support MCTP Base and Control specs with 4 versions: 1.0, 1.1, 1.2, 1.3.3
-                let header = GetVersionSupportHeaderResp {
-                    completion_code: 0x00, // Success
-                    entry_counter: 4,      // 4 version entries
-                };
+                // MCTP Base and Control specs: versions 1.0, 1.1, 1.2, 1.3.3
+                const VERSIONS: [[u8; 4]; 4] = [
+                    [0xF1, 0xF0, 0xFF, 0x00], // 1.0
+                    [0xF1, 0xF1, 0xFF, 0x00], // 1.1
+                    [0xF1, 0xF2, 0xFF, 0x00], // 1.2
+                    [0xF1, 0xF3, 0xF3, 0x00], // 1.3.3
+                ];
 
+                let header = GetVersionSupportHeaderResp {
+                    completion_code: 0x00,
+                    entry_counter: VERSIONS.len() as u8,
+                };
                 header
                     .write_to(&mut rsp_buf[..2])
                     .map_err(|_| ErrorCode::FAIL)?;
 
-                // Version 1.0: major=0xF1, minor=0xF0, update=0xFF, alpha=0x00
-                let version_1_0 = GetVersionSupportEntryResp {
-                    major: 0xF1,
-                    minor: 0xF0,
-                    update: 0xFF,
-                    alpha: 0x00,
-                };
-                version_1_0
-                    .write_to(&mut rsp_buf[2..6])
-                    .map_err(|_| ErrorCode::FAIL)?;
-
-                // Version 1.1: major=0xF1, minor=0xF1, update=0xFF, alpha=0x00
-                let version_1_1 = GetVersionSupportEntryResp {
-                    major: 0xF1,
-                    minor: 0xF1,
-                    update: 0xFF,
-                    alpha: 0x00,
-                };
-                version_1_1
-                    .write_to(&mut rsp_buf[6..10])
-                    .map_err(|_| ErrorCode::FAIL)?;
-
-                // Version 1.2: major=0xF1, minor=0xF2, update=0xFF, alpha=0x00
-                let version_1_2 = GetVersionSupportEntryResp {
-                    major: 0xF1,
-                    minor: 0xF2,
-                    update: 0xFF,
-                    alpha: 0x00,
-                };
-                version_1_2
-                    .write_to(&mut rsp_buf[10..14])
-                    .map_err(|_| ErrorCode::FAIL)?;
-
-                // Version 1.3.3: major=0xF1, minor=0xF3, update=0xF3, alpha=0x00
-                let version_1_3_3 = GetVersionSupportEntryResp {
-                    major: 0xF1,
-                    minor: 0xF3,
-                    update: 0xF3,
-                    alpha: 0x00,
-                };
-                version_1_3_3
-                    .write_to(&mut rsp_buf[14..18])
-                    .map_err(|_| ErrorCode::FAIL)?;
+                for (i, ver) in VERSIONS.iter().enumerate() {
+                    let offset = 2 + i * 4;
+                    rsp_buf[offset..offset + 4].copy_from_slice(ver);
+                }
             }
             _ => {
-                // Unsupported version types
                 let header = GetVersionSupportHeaderResp {
                     completion_code: 0x80, // Unsupported
                     entry_counter: 0,
                 };
-
                 header
                     .write_to(&mut rsp_buf[..2])
                     .map_err(|_| ErrorCode::FAIL)?;

--- a/runtime/kernel/capsules/src/mctp/driver.rs
+++ b/runtime/kernel/capsules/src/mctp/driver.rs
@@ -251,7 +251,7 @@ impl<'a> MCTPDriver<'a> {
                             ) {
                                 Ok(_) => Ok(()),
                                 Err(mut buf) => {
-                                    println!("[MCTP-CAPSULE]: send_msg failed");
+                                    capsule_error!("MCTP", "send_msg failed");
                                     // Reset the kernel buffer to original size and restore it
                                     buf.reset();
                                     self.kernel_msg_buf.replace(buf);
@@ -327,9 +327,11 @@ impl<'a> MCTPDriver<'a> {
     ) -> bool {
         // Check if we already have a buffered message and warn about replacement
         if self.buffered_message.is_some() {
-            println!(
-                "[MCTP-CAPSULE]::buffer_message replacing existing buffered message with new one (msg_tag={}, {} bytes)",
-                msg_tag, msg_len
+            capsule_debug!(
+                "MCTP",
+                "buffer_message replacing existing buffered message with new one (msg_tag={}, {} bytes)",
+                msg_tag,
+                msg_len
             );
         }
 
@@ -338,7 +340,10 @@ impl<'a> MCTPDriver<'a> {
             if msg_len > rx_buf.len() {
                 // Message too large, restore buffer and drop message
                 self.kernel_rx_buf.replace(rx_buf);
-                println!("[MCTP-CAPSULE]::buffer_message message too large for buffer. Dropping message.");
+                capsule_debug!(
+                    "MCTP",
+                    "buffer_message message too large for buffer. Dropping message."
+                );
                 return false;
             }
 
@@ -360,13 +365,15 @@ impl<'a> MCTPDriver<'a> {
             self.buffered_message.set(buffered_msg);
             self.kernel_rx_buf.replace(rx_buf);
 
-            println!(
-                "[MCTP-CAPSULE]::buffer_message buffered {} bytes msg tag {}",
-                msg_len, msg_tag
+            capsule_debug!(
+                "MCTP",
+                "buffer_message buffered {} bytes msg tag {}",
+                msg_len,
+                msg_tag
             );
             true
         } else {
-            println!("[MCTP-CAPSULE]::buffer_message no rx buffer available");
+            capsule_debug!("MCTP", "buffer_message no rx buffer available");
             false
         }
     }
@@ -392,12 +399,14 @@ impl<'a> MCTPDriver<'a> {
                     let rw_buffer: usize;
                     let rx_request: bool;
 
-                    let request_match = app.pending_rx_request.as_ref().is_some_and(|req_ctx| {
-                        buffered_msg.matches_pending_operation(req_ctx)
-                    });
-                    let response_match = app.pending_rx_response.as_ref().is_some_and(|rsp_ctx| {
-                        buffered_msg.matches_pending_operation(rsp_ctx)
-                    });
+                    let request_match = app
+                        .pending_rx_request
+                        .as_ref()
+                        .is_some_and(|req_ctx| buffered_msg.matches_pending_operation(req_ctx));
+                    let response_match = app
+                        .pending_rx_response
+                        .as_ref()
+                        .is_some_and(|rsp_ctx| buffered_msg.matches_pending_operation(rsp_ctx));
 
                     if request_match {
                         rw_buffer = rw_allow::READ_REQUEST;
@@ -417,7 +426,8 @@ impl<'a> MCTPDriver<'a> {
                                 if rmsg_payload.len() < buffered_msg.msg_len {
                                     Err(ErrorCode::SIZE)
                                 } else {
-                                    rmsg_payload[..buffered_msg.msg_len].copy_from_slice(&rx_buf[..buffered_msg.msg_len]);
+                                    rmsg_payload[..buffered_msg.msg_len]
+                                        .copy_from_slice(&rx_buf[..buffered_msg.msg_len]);
                                     Ok(())
                                 }
                             })
@@ -434,14 +444,23 @@ impl<'a> MCTPDriver<'a> {
                             upcall::RECEIVED_RESPONSE
                         };
 
-                        let msg_info =
-                            ((buffered_msg.op_context.peer_eid as usize) << 16) | ((buffered_msg.msg_type as usize) << 8) | (buffered_msg.op_context.msg_tag as usize);
+                        let msg_info = ((buffered_msg.op_context.peer_eid as usize) << 16)
+                            | ((buffered_msg.msg_type as usize) << 8)
+                            | (buffered_msg.op_context.msg_tag as usize);
 
                         if let Err(e) = kernel_data.schedule_upcall(
-                                subscribe_num,
-                            (buffered_msg.msg_len, buffered_msg.recv_time as usize, msg_info),
+                            subscribe_num,
+                            (
+                                buffered_msg.msg_len,
+                                buffered_msg.recv_time as usize,
+                                msg_info,
+                            ),
                         ) {
-                            println!("[MCTP-CAPSULE]::deliver_buffered_message upcall schedule failed: {:?}", e);
+                            capsule_error!(
+                                "MCTP",
+                                "deliver_buffered_message upcall schedule failed: 0x{:08x}",
+                                e as u32
+                            );
                         }
                     }
                 });
@@ -492,7 +511,7 @@ impl SyscallDriver for MCTPDriver<'_> {
                 let (peer_eid, msg_tag) = match self.parse_args(command_num, arg1, arg2) {
                     Ok((peer_eid, msg_tag)) => (peer_eid, msg_tag),
                     Err(e) => {
-                        println!("[MCTP-CAPSULE]: parse_args failed");
+                        capsule_error!("MCTP", "parse_args failed");
                         return CommandReturn::failure(e);
                     }
                 };
@@ -539,7 +558,7 @@ impl SyscallDriver for MCTPDriver<'_> {
                 let (peer_eid, msg_tag) = match self.parse_args(command_num, arg1, arg2) {
                     Ok((peer_eid, msg_tag)) => (peer_eid, msg_tag),
                     Err(e) => {
-                        println!("[MCTP-CAPSULE]: parse_args failed");
+                        capsule_error!("MCTP", "parse_args failed");
                         return CommandReturn::failure(e);
                     }
                 };
@@ -591,7 +610,7 @@ impl MCTPTxClient for MCTPDriver<'_> {
         let process_id = match self.current_app.get() {
             Some(process_id) => process_id,
             None => {
-                println!("[MCTP-CAPSULE]::send_done no app waiting for send_done");
+                capsule_debug!("MCTP", "send_done no app waiting for send_done");
                 return;
             }
         };
@@ -599,7 +618,7 @@ impl MCTPTxClient for MCTPDriver<'_> {
         _ = self.apps.enter(process_id, |app, up_calls| {
             // Check if the send operation matches the pending tx operation
             if !self.tx_pending(app, msg_tag, dest_eid) {
-                println!("[MCTP-CAPSULE]::send_done no pending tx operation");
+                capsule_debug!("MCTP", "send_done no pending tx operation");
                 return;
             }
 
@@ -689,7 +708,7 @@ impl MCTPRxClient for MCTPDriver<'_> {
                 if let Err(e) = kernel_data
                     .schedule_upcall(subscribe_num, (msg_len, recv_time as usize, msg_info))
                 {
-                    println!("[MCTP-CAPSULE]::receive upcall schedule failed: {:?}", e);
+                    capsule_error!("MCTP", "receive upcall schedule failed: 0x{:x}", e as u32);
                 } else {
                     rx_upcall_scheduled = true;
                 }
@@ -700,7 +719,10 @@ impl MCTPRxClient for MCTPDriver<'_> {
         if !rx_upcall_scheduled {
             if self.buffer_message(src_eid, msg_type, msg_tag, msg_payload, msg_len, recv_time) {
             } else {
-                println!("[MCTP-CAPSULE]::receive no pending rx operation and buffering failed - dropping message");
+                capsule_error!(
+                    "MCTP",
+                    "receive no pending rx operation and buffering failed - dropping message"
+                );
             }
         }
     }

--- a/runtime/kernel/capsules/src/mctp/mux.rs
+++ b/runtime/kernel/capsules/src/mctp/mux.rs
@@ -202,8 +202,9 @@ impl<'a, A: Alarm<'a>, M: MCTPTransportBinding<'a>> MuxMCTPDriver<'a, A, M> {
         let resp_len = MCTP_CTRL_MSG_HEADER_LEN + MCTP_HDR_SIZE + mctp_ctrl_cmd.resp_data_len();
 
         if req_buf.len() < mctp_ctrl_cmd.req_data_len() {
-            println!(
-                "MuxMCTPDriver: Invalid buffer len Dropping packet. {:?} ctrl_cmd_len {:?}",
+            capsule_debug!(
+                "MCTP",
+                "Invalid buffer len Dropping packet. {} ctrl_cmd_len {}",
                 req_buf.len(),
                 mctp_ctrl_cmd.req_data_len()
             );
@@ -289,13 +290,13 @@ impl<'a, A: Alarm<'a>, M: MCTPTransportBinding<'a>> MuxMCTPDriver<'a, A, M> {
                 {
                     Ok(_) => (),
                     Err((err, buf)) => {
-                        println!("MuxMCTPDriver: Failed to transmit {:?}", err);
+                        capsule_error!("MCTP-MUX", "Failed to transmit: 0x{:x}", err as u32);
                         self.tx_pkt_buffer.replace(buf);
                     }
                 }
             }
             Err(err) => {
-                println!("MuxMCTPDriver: Failed to start transmit {:?}", err);
+                capsule_error!("MCTP-MUX", "Failed to start transmit: 0x{:x}", err as u32);
                 self.tx_pkt_buffer.replace(tx_pkt.take());
             }
         }
@@ -310,8 +311,9 @@ impl<'a, A: Alarm<'a>, M: MCTPTransportBinding<'a>> MuxMCTPDriver<'a, A, M> {
         // Check if the first packet of a multi-packet message has at least length of
         // MCTP_BASELINE_TRANSMISSION_UNIT bytes.
         if mctp_hdr.eom() == 0 && pkt_payload.len() < MCTP_BASELINE_TRANSMISSION_UNIT {
-            println!(
-                "MuxMCTPDriver: Received first packet with less than 64 bytes. Dropping packet."
+            capsule_debug!(
+                "MCTP",
+                "Received first packet with less than 64 bytes. Dropping packet."
             );
             return;
         }
@@ -325,19 +327,25 @@ impl<'a, A: Alarm<'a>, M: MCTPTransportBinding<'a>> MuxMCTPDriver<'a, A, M> {
             let recv_time = self.clock.now().into_u32();
             rx_state.start_receive(mctp_hdr, msg_type, pkt_payload, recv_time);
         } else {
-            println!("MuxMCTPDriver: No matching receive request found. Dropping packet.");
+            capsule_debug!(
+                "MCTP",
+                "No matching receive request found. Dropping packet."
+            );
         }
     }
 
     #[inline(never)]
     fn process_packet(&self, mctp_hdr: MCTPHeader, pkt_payload: &[u8]) {
         if self.local_eid != mctp_hdr.dest_eid().into() {
-            println!("MuxMCTPDriver: Packet not for this Endpoint. Dropping packet.");
+            capsule_debug!("MCTP-MUX", "Packet not for this Endpoint. Dropping packet.");
             return;
         }
 
         if mctp_hdr.eom() != 1 && pkt_payload.len() < MCTP_BASELINE_TRANSMISSION_UNIT {
-            println!("MuxMCTPDriver: Received first or middle packet with less than 64 bytes. Dropping packet.");
+            capsule_debug!(
+                "MCTP",
+                "Received first or middle packet with less than 64 bytes. Dropping packet."
+            );
             return;
         }
 
@@ -346,14 +354,14 @@ impl<'a, A: Alarm<'a>, M: MCTPTransportBinding<'a>> MuxMCTPDriver<'a, A, M> {
             .iter()
             .find(|rx_state| rx_state.is_next_packet(mctp_hdr, pkt_payload.len()));
 
-        match rx_state {
-            Some(rx_state) => {
-                let recv_time = self.clock.now().into_u32();
-                rx_state.receive_next(mctp_hdr, pkt_payload, recv_time);
-            }
-            None => {
-                println!("MuxMCTPDriver: No matching receive request found. Dropping packet.");
-            }
+        if let Some(rx_state) = rx_state {
+            let recv_time = self.clock.now().into_u32();
+            rx_state.receive_next(mctp_hdr, pkt_payload, recv_time);
+        } else {
+            capsule_debug!(
+                "MCTP",
+                "No matching receive request found. Dropping packet."
+            );
         }
     }
 
@@ -384,7 +392,7 @@ impl<'a, A: Alarm<'a>, M: MCTPTransportBinding<'a>> TransportTxClient for MuxMCT
 impl<'a, A: Alarm<'a>, M: MCTPTransportBinding<'a>> TransportRxClient for MuxMCTPDriver<'a, A, M> {
     fn receive(&self, rx_buffer: &'static mut [u8], len: usize) {
         if len == 0 || len > rx_buffer.len() {
-            println!("MuxMCTPDriver: Invalid packet length. Dropping packet.");
+            capsule_debug!("MCTP-MUX", "Invalid packet length. Dropping packet.");
             self.rx_pkt_buffer.replace(rx_buffer);
             return;
         }
@@ -400,7 +408,10 @@ impl<'a, A: Alarm<'a>, M: MCTPTransportBinding<'a>> TransportRxClient for MuxMCT
                         let _ = self
                             .process_mctp_control_msg(mctp_header, &rx_buffer[payload_offset..len]);
                     } else {
-                        println!("MuxMCTPDriver: Invalid MCTP Control message. Dropping packet.");
+                        capsule_debug!(
+                            "MCTP-MUX",
+                            "Invalid MCTP Control message. Dropping packet."
+                        );
                     }
                 }
                 MessageType::Pldm
@@ -415,7 +426,7 @@ impl<'a, A: Alarm<'a>, M: MCTPTransportBinding<'a>> TransportRxClient for MuxMCT
                     );
                 }
                 _ => {
-                    println!("MuxMCTPDriver: Unsupported message type. Dropping packet.");
+                    capsule_debug!("MCTP-MUX", "Unsupported message type. Dropping packet.");
                 }
             }
         } else {

--- a/runtime/kernel/capsules/src/mctp/recv.rs
+++ b/runtime/kernel/capsules/src/mctp/recv.rs
@@ -1,8 +1,6 @@
 // Licensed under the Apache-2.0 license
 
 use crate::mctp::base_protocol::{MCTPHeader, MessageType, MCTP_TAG_MASK, MCTP_TAG_OWNER};
-use caliptra_mcu_romtime::println;
-use core::fmt::Write;
 use kernel::collections::list::{ListLink, ListNode};
 use kernel::utilities::cells::{MapCell, OptionalCell, TakeCell};
 
@@ -40,7 +38,6 @@ impl<'a> ListNode<'a, MCTPRxState<'a>> for MCTPRxState<'a> {
     }
 }
 
-#[derive(Debug)]
 struct MsgTerminus {
     msg_type: u8,
     msg_tag: u8,
@@ -117,7 +114,10 @@ impl<'a> MCTPRxState<'a> {
             let offset = msg_terminus.msg_size;
             let end_offset = offset + pkt_payload.len();
             if end_offset > self.msg_payload.map_or(0, |msg_payload| msg_payload.len()) {
-                println!("MuxMCTPDriver - Received packet with payload length greater than buffer size. Reset assembly.");
+                capsule_debug!(
+                    "MCTP",
+                    "Received packet with payload length greater than buffer size. Reset assembly."
+                );
                 return;
             }
 
@@ -189,7 +189,10 @@ impl<'a> MCTPRxState<'a> {
         recv_time: u32,
     ) {
         if mctp_hdr.som() != 1 {
-            println!("MuxMCTPDriver - Received first packet without SOM. Dropping packet.");
+            capsule_debug!(
+                "MCTP",
+                "Received first packet without SOM. Dropping packet."
+            );
             return;
         }
 
@@ -198,7 +201,7 @@ impl<'a> MCTPRxState<'a> {
         if pkt_payload_len == 0
             || pkt_payload_len > self.msg_payload.map_or(0, |msg_payload| msg_payload.len())
         {
-            println!("MuxMCTPDriver - Received bad packet length. Dropping packet.");
+            capsule_debug!("MCTP-RX", "Received bad packet length. Dropping packet.");
             return;
         }
 

--- a/runtime/kernel/capsules/src/mctp/send.rs
+++ b/runtime/kernel/capsules/src/mctp/send.rs
@@ -137,7 +137,7 @@ impl<'a, A: Alarm<'a>, M: MCTPTransportBinding<'a>> MCTPTxState<'a, A, M> {
         src_eid: u8,
     ) -> Result<usize, ErrorCode> {
         if self.is_eom() {
-            println!("MCTPTxState - Error!! fill_next_packet: EOM reached");
+            capsule_error!("MCTP-TX", "fill_next_packet: EOM reached");
             Err(ErrorCode::FAIL)?;
         }
 
@@ -195,7 +195,7 @@ impl<'a, A: Alarm<'a>, M: MCTPTransportBinding<'a>> MCTPTxState<'a, A, M> {
                     msg_payload,
                 );
             } else {
-                println!("MCTPTxState - Error!! send_done: msg_payload is None");
+                capsule_error!("MCTP-TX", "send_done: msg_payload is None");
             }
         });
     }

--- a/runtime/kernel/capsules/src/mctp/transport_binding.rs
+++ b/runtime/kernel/capsules/src/mctp/transport_binding.rs
@@ -2,7 +2,6 @@
 
 use crate::mctp::base_protocol::{MCTP_BASELINE_TRANSMISSION_UNIT, MCTP_HDR_SIZE};
 use caliptra_mcu_i3c_driver::hil::{I3CTarget, RxClient, TxClient};
-use caliptra_mcu_romtime::println;
 use core::cell::Cell;
 use kernel::utilities::cells::OptionalCell;
 use kernel::utilities::cells::TakeCell;
@@ -131,8 +130,9 @@ impl<'a> MCTPTransportBinding<'a> for MCTPI3CBinding<'a> {
 
         // Make sure there's enough space for the PEC byte
         if len == 0 || len > self.max_write_len.get() - 1 {
-            println!(
-                "MCTPI3CBinding: Invalid length. Expected: {}",
+            capsule_debug!(
+                "MCTP",
+                "Invalid length. Expected: {}",
                 self.max_write_len.get() - 1
             );
             Err((ErrorCode::SIZE, self.tx_buffer.take().unwrap()))?;
@@ -153,7 +153,7 @@ impl<'a> MCTPTransportBinding<'a> for MCTPI3CBinding<'a> {
                         }
                     }
                 } else {
-                    println!("MCTPI3CBinding: Invalid length. Expected: {}", len + 1);
+                    capsule_debug!("MCTP-I3C", "Invalid length. Expected: {}", len + 1);
                     Err((ErrorCode::SIZE, tx_buffer))?;
                 }
             }
@@ -207,8 +207,9 @@ impl RxClient for MCTPI3CBinding<'_> {
                 client.receive(rx_buffer, len - 1);
             });
         } else {
-            println!(
-                "MCTPI3CBinding: Invalid PEC {:02x} (expected {:02x}) for address {:02x}. Dropping packet. len={}",
+            capsule_debug!(
+                "MCTP",
+                "Invalid PEC {:02x} (expected {:02x}) for address {:02x}. Dropping packet. len={}",
                 rx_buffer[len - 1],
                 pec,
                 addr >> 1,

--- a/runtime/kernel/capsules/src/mcu_mbox.rs
+++ b/runtime/kernel/capsules/src/mcu_mbox.rs
@@ -112,20 +112,22 @@ impl<'a, T: hil::Mailbox<'a>> McuMboxDriver<'a, T> {
 
         let _result = kernel_data
             .get_readonly_processbuffer(ro_allow::RESPONSE)
-            .map_err(|e| {
-                println!(
-                    "MCU_MBOX_CAPSULE: Error getting ReadOnlyProcessBuffer buffer: {:?}",
-                    e
+            .map_err(|_e| {
+                capsule_debug!(
+                    "MCU_MBOX",
+                    "Error getting ReadOnlyProcessBuffer buffer: {}",
+                    _e as u32
                 );
                 ErrorCode::INVAL
             })
             .and_then(|tx_buf| {
                 tx_buf
                     .enter(|app_buf| self.start_transmit(app_buf))
-                    .map_err(|e| {
-                        println!(
-                            "MCU_MBOX_CAPSULE: Error getting application tx buffer: {:?}",
-                            e
+                    .map_err(|_e| {
+                        capsule_debug!(
+                            "MCU_MBOX",
+                            "Error getting application tx buffer: {}",
+                            _e as u32
                         );
                         ErrorCode::FAIL
                     })
@@ -139,8 +141,9 @@ impl<'a, T: hil::Mailbox<'a>> McuMboxDriver<'a, T> {
         let dw_len = dlen.div_ceil(4);
         if dw_len > app.buffered_msg.data.len() {
             // Message too large to buffer
-            println!(
-                "MCU_MBOX_CAPSULE: Cannot buffer message, size {} exceeds buffer capacity {}",
+            capsule_debug!(
+                "MCU_MBOX",
+                "Cannot buffer message, size {} exceeds buffer capacity {}",
                 dw_len,
                 app.buffered_msg.data.len()
             );
@@ -148,7 +151,10 @@ impl<'a, T: hil::Mailbox<'a>> McuMboxDriver<'a, T> {
         }
         // Print warning if replacing an old message
         if app.buffered_msg.valid {
-            println!("MCU_MBOX_CAPSULE: Warning - replacing old buffered message with new one");
+            capsule_debug!(
+                "MCU_MBOX",
+                "Warning - replacing old buffered message with new one"
+            );
         }
         // Always replace the old message with the new one
         app.buffered_msg.command = command;
@@ -199,27 +205,30 @@ impl<'a, T: hil::Mailbox<'a>> McuMboxDriver<'a, T> {
 
         match result {
             Ok(Ok(len)) => {
-                if let Err(e) = kernel_data
+                if let Err(_e) = kernel_data
                     .schedule_upcall(upcall::REQUEST_RECEIVED, (command as usize, len, 0))
                 {
-                    println!(
-                        "MCU_MBOX_CAPSULE: deliver_message error scheduling upcall: {:?}",
-                        e
+                    capsule_debug!(
+                        "MCU_MBOX",
+                        "deliver_message error scheduling upcall: {}",
+                        _e as u32
                     );
                     return Err(ErrorCode::FAIL);
                 }
             }
             Ok(Err(err)) => {
-                println!(
-                    "MCU_MBOX_CAPSULE: deliver_message error copying data to app buffer: {:?}",
-                    err
+                capsule_debug!(
+                    "MCU_MBOX",
+                    "deliver_message error copying data to app buffer: {}",
+                    err as u32
                 );
                 return Err(err);
             }
             Err(err) => {
-                println!(
-                    "MCU_MBOX_CAPSULE: deliver_message error while accessing app buffer: {:?}",
-                    err
+                capsule_debug!(
+                    "MCU_MBOX",
+                    "deliver_message error while accessing app buffer: {}",
+                    err as u32
                 );
                 return Err(err);
             }
@@ -236,8 +245,9 @@ impl<'a, T: hil::Mailbox<'a>> hil::MailboxClient for McuMboxDriver<'a, T> {
     fn request_received(&self, command: u32, rx_buf: &'static mut [u32], dlen: usize) {
         let dw_len = dlen.div_ceil(4);
         if dw_len > rx_buf.len() {
-            println!(
-                "MCU_MBOX_CAPSULE: Received request with invalid length {}",
+            capsule_debug!(
+                "MCU_MBOX",
+                "Received request with invalid length {}",
                 dw_len
             );
             self.driver.restore_rx_buffer(rx_buf);
@@ -252,7 +262,7 @@ impl<'a, T: hil::Mailbox<'a>> hil::MailboxClient for McuMboxDriver<'a, T> {
                 return;
             }
 
-            let process_result : Result<Result<usize, ErrorCode>, ErrorCode> =
+            let process_result: Result<Result<usize, ErrorCode>, ErrorCode> =
                 match kernel_data.get_readwrite_processbuffer(rw_allow::REQUEST) {
                     Ok(rw_buf) => {
                         let copy_len_dw = core::cmp::min(rw_buf.len() / 4, dw_len);
@@ -267,30 +277,43 @@ impl<'a, T: hil::Mailbox<'a>> hil::MailboxClient for McuMboxDriver<'a, T> {
                                 Ok(core::cmp::min(copy_len_dw * 4, dlen))
                             })
                             .map_err(|e| {
-                                println!("MCU_MBOX_CAPSULE: Error entering WriteableProcessBuffer buffer: {:?}", e);
+                                capsule_error!(
+                                    "MCU_MBOX",
+                                    "Error entering WriteableProcessBuffer buffer: 0x{:08x}",
+                                    e as u32
+                                );
                                 e.into()
                             })
                     }
-                    Err(err) => {
-                        println!(
-                            "MCU_MBOX_CAPSULE: Error getting WriteableProcessBuffer buffer: {:?}",
-                            err
+                    Err(_err) => {
+                        capsule_debug!(
+                            "MCU_MBOX",
+                            "Error getting WriteableProcessBuffer buffer: {}",
+                            _err as u32
                         );
                         Err(ErrorCode::INVAL)
                     }
                 };
 
-            match process_result  {
+            match process_result {
                 Ok(Ok(len)) => {
                     kernel_data
                         .schedule_upcall(upcall::REQUEST_RECEIVED, (command as usize, len, 0))
                         .ok();
                 }
                 Ok(Err(err)) => {
-                    println!("MCU_MBOX_CAPSULE: Error copying data to app buffer: {:?}", err);
+                    capsule_error!(
+                        "MCU_MBOX",
+                        "Error copying data to app buffer: 0x{:08x}",
+                        err as u32
+                    );
                 }
                 Err(err) => {
-                    println!("MCU_MBOX_CAPSULE: Error while accessing app buffer: {:?}", err);
+                    capsule_error!(
+                        "MCU_MBOX",
+                        "Error while accessing app buffer: 0x{:08x}",
+                        err as u32
+                    );
                 }
             }
         });


### PR DESCRIPTION
- Add capsule_error!/capsule_debug! with feature-gated debug prints
- Replace {:?} with hex error codes across MCTP, DOE, MBOX capsules
- Add CaliptraApiError match with hex codes in mailbox capsule
- Table-driven MCTP version support entries

Saves ~5 KB kernel .text.