### PR TITLE
rom: add DOT commands to I3C services with packetized transport (#1221)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -54,6 +54,15 @@ default-filter = """
 (package(tests-integration) and test(test_mcu_mbox_fips_periodic)) |
 (package(tests-integration) and test(test_i3c_constant_writes)) |
 (package(tests-integration) and test(test_i3c_simple)) |
+(package(tests-integration) and test(test_i3c_services_ping)) |
+(package(tests-integration) and test(test_i3c_services_unknown_cmd)) |
+(package(tests-integration) and test(test_i3c_services_dot_status)) |
+(package(tests-integration) and test(test_i3c_services_dot_recovery_invalid_payload)) |
+(package(tests-integration) and test(test_i3c_services_dot_unlock_challenge)) |
+(package(tests-integration) and test(test_i3c_services_dot_override_without_challenge)) |
+(package(tests-integration) and test(test_i3c_services_error_mid_packet_then_recover)) |
+(package(tests-integration) and test(test_i3c_services_dot_error_then_continue)) |
+(package(tests-integration) and test(test_i3c_services_dot_override_full_flow)) |
 (package(tests-integration) and test(test_mctp_vdm_cmds)) |
 (package(tests-integration) and test(test_sw_digest_lock)) |
 (package(tests-integration) and test(test_otp_blank_check))

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -113,7 +113,7 @@ jobs:
           # Build all test runtime features used by integration tests
           # Note: nightly tests (test-*-spdm-*, test-caliptra-util-host-validator) are excluded
           cargo xtask all-build --platform emulator \
-            --rom-features "hw-2-1,ocp-lock" \
+            --rom-features "hw-2-1" \
             --test-rom-features "ocp-lock,stable-owner-key" \
             --runtime-features "${RUNTIME_FEATURES// /}" \
             --separate-runtimes

--- a/common/testing/src/i3c_socket.rs
+++ b/common/testing/src/i3c_socket.rs
@@ -241,6 +241,61 @@ impl BufferedStream {
         true
     }
 
+    /// Send a command with payload using the packetized protocol.
+    ///
+    /// Each packet has a 4-byte header `[cmd, payload_len, seq_num, total_seqs]`
+    /// followed by up to 252 bytes of payload, fitting within the 256-byte
+    /// I3C TTI FIFO. Large payloads are split across multiple private writes.
+    /// A delay is inserted between packets to allow the target to drain its
+    /// FIFO before the next packet arrives.
+    pub fn send_packetized_write(&mut self, target_addr: u8, cmd: u8, payload: &[u8]) {
+        // Each packet must fit in the 256-byte TTI RX FIFO including the
+        // 4-byte header and 1-byte PEC appended by send_private_write.
+        // The chunk size must also be 4-byte aligned so the ROM's u32-word
+        // reassembly buffer doesn't lose partial-word boundaries between
+        // packets.  256 - 4 - 1 = 251, rounded down to 248.
+        const MAX_CHUNK: usize = 248;
+        let total_seqs = if payload.is_empty() {
+            1u8
+        } else {
+            payload.len().div_ceil(MAX_CHUNK) as u8
+        };
+
+        let mut offset = 0usize;
+        for seq in 0..total_seqs {
+            let end = (offset + MAX_CHUNK).min(payload.len());
+            let chunk = &payload[offset..end];
+            let chunk_len = chunk.len() as u8;
+
+            let mut pkt = Vec::with_capacity(4 + chunk.len());
+            pkt.push(cmd);
+            pkt.push(chunk_len);
+            pkt.push(seq);
+            pkt.push(total_seqs);
+            pkt.extend_from_slice(chunk);
+
+            self.send_private_write(target_addr, pkt);
+
+            offset = end;
+
+            // Give the target time to drain its 256-byte RX data FIFO
+            // before the next packet. The FPGA controller adds ~5ms of its
+            // own delay, so total inter-packet gap is ~30ms.
+            if seq + 1 < total_seqs {
+                std::thread::sleep(std::time::Duration::from_millis(25));
+            }
+        }
+    }
+
+    /// Issue a private read request to the target. The response can then be
+    /// retrieved with [`receive_private_read`].
+    pub fn request_private_read(&mut self, target_addr: u8) {
+        let pvt_read_cmd = prepare_private_read_cmd(target_addr);
+        self.stream.set_nonblocking(false).unwrap();
+        self.stream.write_all(&pvt_read_cmd).unwrap();
+        self.stream.set_nonblocking(true).unwrap();
+    }
+
     pub fn receive_ibi(&mut self, target_addr: u8) -> bool {
         self.fill_buffer();
         let mut i = 0;

--- a/hw/model/src/model_fpga_realtime.rs
+++ b/hw/model/src/model_fpga_realtime.rs
@@ -411,6 +411,10 @@ impl McuHwModel for ModelFpgaRealtime {
             m.set_fips_zeroization_ppd(true);
         }
 
+        if let Some(dot_flash_data) = params.dot_flash_initial_contents.as_deref() {
+            m.write_dot_flash(dot_flash_data)?;
+        }
+
         Ok(m)
     }
 
@@ -616,11 +620,18 @@ impl McuHwModel for ModelFpgaRealtime {
     }
 
     fn read_dot_flash(&self) -> Vec<u8> {
-        todo!()
+        // DOT flash is backed by the secondary flash controller.
+        self.base.secondary_flash.clone()
     }
 
-    fn write_dot_flash(&mut self, _data: &[u8]) -> Result<()> {
-        todo!()
+    fn write_dot_flash(&mut self, data: &[u8]) -> Result<()> {
+        // DOT flash is backed by the secondary flash controller.
+        let flash = &mut self.base.secondary_flash;
+        if data.len() > flash.len() {
+            flash.resize(data.len(), 0xFF);
+        }
+        flash[..data.len()].copy_from_slice(data);
+        Ok(())
     }
 }
 

--- a/platforms/emulator/rom/src/riscv.rs
+++ b/platforms/emulator/rom/src/riscv.rs
@@ -197,12 +197,10 @@ pub extern "C" fn rom_entry() -> ! {
 
     #[cfg(feature = "ocp-lock")]
     impl romtime::ocp_lock::Platform for EmulatorOcpPlatform {
-        // This sample implementation hard codes 8 slots.
         fn get_total_slots(&self) -> usize {
             8
         }
 
-        // Sample only supports a subset of `HekSeedState`
         fn get_slot_state(
             &mut self,
             otp: &romtime::otp::Otp,
@@ -246,8 +244,6 @@ pub extern "C" fn rom_entry() -> ! {
             Ok(romtime::ocp_lock::HekSeedState::Programmed)
         }
 
-        // Simple algorithm to determine the active slot.
-        // Returns the first programmed.
         fn get_active_slot(
             &mut self,
             otp: &romtime::otp::Otp,
@@ -255,8 +251,6 @@ pub extern "C" fn rom_entry() -> ! {
             seeds: &romtime::ocp_lock::HekSeeds,
         ) -> Result<usize, romtime::ocp_lock::Error> {
             if *perma_bit == romtime::ocp_lock::PermaBitStatus::Set {
-                // If the permanent bit is set, OCP LOCK spec says the active HEK is fixed.
-                // For this emulator, we'll return the last slot.
                 return Ok(self.get_total_slots() - 1);
             }
 
@@ -282,8 +276,6 @@ pub extern "C" fn rom_entry() -> ! {
         platform: Some(&mut ocp_platform),
         ..Default::default()
     };
-
-    let hooks = LoggingRomHooks;
 
     if cfg!(feature = "test-flash-based-boot") {
         // Initialize the flash controller for testing purposes
@@ -351,6 +343,8 @@ pub extern "C" fn rom_entry() -> ! {
             cptra_dma_axi_user: axi_user0,
             mci_mbox0_axi_users: mbox_axi_users,
             mci_mbox1_axi_users: mbox_axi_users,
+            #[cfg(feature = "ocp-lock")]
+            ocp_lock_config,
             ..Default::default()
         });
     } else if cfg!(any(
@@ -371,6 +365,8 @@ pub extern "C" fn rom_entry() -> ! {
             cptra_dma_axi_user: axi_user0,
             mci_mbox0_axi_users: mbox_axi_users,
             mci_mbox1_axi_users: mbox_axi_users,
+            #[cfg(feature = "ocp-lock")]
+            ocp_lock_config,
             ..Default::default()
         };
         mcu_rom_common::rom_start(rom_parameters);
@@ -389,97 +385,109 @@ pub extern "C" fn rom_entry() -> ! {
             cptra_dma_axi_user: axi_user0,
             mci_mbox0_axi_users: mbox_axi_users,
             mci_mbox1_axi_users: mbox_axi_users,
-            ..Default::default()
-        });
-    } else if cfg!(feature = "test-usb-ocp-recovery") {
-        use mcu_usb_emulator::ExamplarUsbDriver;
-        use ocp::cms::slice_fifo::SliceFifoRegion;
-        use ocp::cms::slice_indirect::SliceIndirectRegion;
-        use ocp::cms::{FifoCmsRegion, IndirectCmsRegion};
-        use ocp::interface::{RecoveryDeviceConfig, RecoveryStateMachine};
-        use ocp::protocol::device_id::{DeviceDescriptor, DeviceId, PciVendorDescriptor};
-        use ocp::protocol::indirect_fifo_status::FifoCmsRegionType;
-        use ocp::protocol::indirect_status::CmsRegionType;
-        use ocp::vendor::NoopVendorHandler;
-        use registers_generated::usbdev;
-
-        romtime::println!("[mcu-rom] USB OCP Recovery boot path");
-
-        let usb_regs =
-            unsafe { romtime::StaticRef::new(usbdev::USBDEV_ADDR as *const usbdev::regs::Usbdev) };
-        let mut usb_driver = ExamplarUsbDriver::new(usb_regs);
-
-        // CMS 0: Indirect CodeSpace backed by MCI staging SRAM (required by spec).
-        // Safety: This boot path is mutually exclusive with other features via
-        // cfg, so no other component uses the staging SRAM concurrently.
-        let indirect_buf = unsafe {
-            core::slice::from_raw_parts_mut(
-                MCU_MEMORY_MAP.staging_sram_offset as *mut u8,
-                MCU_MEMORY_MAP.staging_sram_size as usize,
-            )
-        };
-
-        fn ocp_setup_failed() -> ! {
-            fatal_error(mcu_error::McuError::ROM_COLD_BOOT_RECOVERY_NOT_CONFIGURED_ERROR);
-        }
-        let mut indirect = SliceIndirectRegion::new(indirect_buf, CmsRegionType::CodeSpace)
-            .ok()
-            .unwrap_or_else(|| ocp_setup_failed());
-        let mut indirect_regions: [(u8, &mut dyn IndirectCmsRegion); 1] = [(0, &mut indirect)];
-
-        // CMS 1: FIFO CodeSpace for streaming recovery data.
-        let mut fifo_buf = [0u8; 4096];
-        let mut fifo = SliceFifoRegion::new(&mut fifo_buf, FifoCmsRegionType::CodeSpace, 256)
-            .ok()
-            .unwrap_or_else(|| ocp_setup_failed());
-        let mut fifo_regions: [(u8, &mut dyn FifoCmsRegion); 1] = [(1, &mut fifo)];
-
-        let desc = DeviceDescriptor::PciVendor(PciVendorDescriptor::new(0x1209, 0x0001, 0, 0, 0));
-        let config = RecoveryDeviceConfig {
-            device_id: DeviceId::new(desc, &[])
-                .ok()
-                .unwrap_or_else(|| ocp_setup_failed()),
-            major_version: 1,
-            minor_version: 1,
-            max_response_time: 17,
-            heartbeat_period: 0,
-            local_c_image_support: false,
-        };
-
-        let sm = RecoveryStateMachine::new(
-            config,
-            &mut usb_driver,
-            &mut indirect_regions,
-            &mut fifo_regions,
-            NoopVendorHandler,
-        )
-        .ok()
-        .unwrap_or_else(|| ocp_setup_failed());
-
-        use mcu_rom_common::recovery::ocp::OcpImageProvider;
-        use mcu_rom_common::recovery::{ErrorPolicy, ImageProviderEntry, ImageProviderManager};
-
-        let mut ocp_provider = OcpImageProvider::new(sm);
-        let mut entries = [ImageProviderEntry {
-            provider: &mut ocp_provider,
-            policy: ErrorPolicy::RetryForever,
-        }];
-        let manager = ImageProviderManager::new(&mut entries);
-
-        mcu_rom_common::rom_start(RomParameters {
-            image_provider_manager: Some(manager),
-            dot_flash: Some(dot_flash),
-            cptra_mbox_axi_users: mbox_axi_users,
-            cptra_fuse_axi_user: axi_user0,
-            cptra_trng_axi_user: axi_user0,
-            cptra_dma_axi_user: axi_user0,
-            mci_mbox0_axi_users: mbox_axi_users,
-            mci_mbox1_axi_users: mbox_axi_users,
             #[cfg(feature = "ocp-lock")]
             ocp_lock_config,
             ..Default::default()
         });
-    } else if cfg!(feature = "hw-2-1") {
+    } else if cfg!(feature = "test-usb-ocp-recovery") {
+        #[cfg(feature = "test-usb-ocp-recovery")]
+        {
+            use mcu_usb_emulator::ExamplarUsbDriver;
+            use ocp::cms::slice_fifo::SliceFifoRegion;
+            use ocp::cms::slice_indirect::SliceIndirectRegion;
+            use ocp::cms::{FifoCmsRegion, IndirectCmsRegion};
+            use ocp::interface::{RecoveryDeviceConfig, RecoveryStateMachine};
+            use ocp::protocol::device_id::{DeviceDescriptor, DeviceId, PciVendorDescriptor};
+            use ocp::protocol::indirect_fifo_status::FifoCmsRegionType;
+            use ocp::protocol::indirect_status::CmsRegionType;
+            use ocp::vendor::NoopVendorHandler;
+            use registers_generated::usbdev;
+
+            romtime::println!("[mcu-rom] USB OCP Recovery boot path");
+
+            let usb_regs = unsafe {
+                romtime::StaticRef::new(usbdev::USBDEV_ADDR as *const usbdev::regs::Usbdev)
+            };
+            let mut usb_driver = ExamplarUsbDriver::new(usb_regs);
+
+            // CMS 0: Indirect CodeSpace backed by MCI staging SRAM (required by spec).
+            let indirect_buf = unsafe {
+                core::slice::from_raw_parts_mut(
+                    MCU_MEMORY_MAP.staging_sram_offset as *mut u8,
+                    MCU_MEMORY_MAP.staging_sram_size as usize,
+                )
+            };
+
+            fn ocp_setup_failed() -> ! {
+                fatal_error(mcu_error::McuError::ROM_COLD_BOOT_RECOVERY_NOT_CONFIGURED_ERROR);
+            }
+            let mut indirect = SliceIndirectRegion::new(indirect_buf, CmsRegionType::CodeSpace)
+                .ok()
+                .unwrap_or_else(|| ocp_setup_failed());
+            let mut indirect_regions: [(u8, &mut dyn IndirectCmsRegion); 1] = [(0, &mut indirect)];
+
+            // CMS 1: FIFO CodeSpace for streaming recovery data.
+            let mut fifo_buf = [0u8; 4096];
+            let mut fifo = SliceFifoRegion::new(&mut fifo_buf, FifoCmsRegionType::CodeSpace, 256)
+                .ok()
+                .unwrap_or_else(|| ocp_setup_failed());
+            let mut fifo_regions: [(u8, &mut dyn FifoCmsRegion); 1] = [(1, &mut fifo)];
+
+            let desc =
+                DeviceDescriptor::PciVendor(PciVendorDescriptor::new(0x1209, 0x0001, 0, 0, 0));
+            let config = RecoveryDeviceConfig {
+                device_id: DeviceId::new(desc, &[])
+                    .ok()
+                    .unwrap_or_else(|| ocp_setup_failed()),
+                major_version: 1,
+                minor_version: 1,
+                max_response_time: 17,
+                heartbeat_period: 0,
+                local_c_image_support: false,
+            };
+
+            let sm = RecoveryStateMachine::new(
+                config,
+                &mut usb_driver,
+                &mut indirect_regions,
+                &mut fifo_regions,
+                NoopVendorHandler,
+            )
+            .ok()
+            .unwrap_or_else(|| ocp_setup_failed());
+
+            use mcu_rom_common::recovery::ocp::OcpImageProvider;
+            use mcu_rom_common::recovery::{ErrorPolicy, ImageProviderEntry, ImageProviderManager};
+
+            let mut ocp_provider = OcpImageProvider::new(sm);
+            let mut entries = [ImageProviderEntry {
+                provider: &mut ocp_provider,
+                policy: ErrorPolicy::RetryForever,
+            }];
+            let manager = ImageProviderManager::new(&mut entries);
+
+            mcu_rom_common::rom_start(RomParameters {
+                image_provider_manager: Some(manager),
+                dot_flash: Some(dot_flash),
+                cptra_mbox_axi_users: mbox_axi_users,
+                cptra_fuse_axi_user: axi_user0,
+                cptra_trng_axi_user: axi_user0,
+                cptra_dma_axi_user: axi_user0,
+                mci_mbox0_axi_users: mbox_axi_users,
+                mci_mbox1_axi_users: mbox_axi_users,
+                #[cfg(feature = "ocp-lock")]
+                ocp_lock_config,
+                ..Default::default()
+            });
+        }
+    } else if cfg!(feature = "hw-2-1")
+        && !cfg!(any(
+            feature = "test-dot-recovery",
+            feature = "test-i3c-services",
+            feature = "test-rom-hooks",
+            feature = "test-usb-ocp-recovery",
+        ))
+    {
         // Simple flash-based boot for hw-2-1 without partition tables.
         // Uses flash image starting at offset 0.
         let primary_flash_ctrl = EmulatedFlashCtrl::initialize_flash_ctrl(PRIMARY_FLASH_CTRL_BASE);
@@ -494,31 +502,6 @@ pub extern "C" fn rom_entry() -> ! {
         .unwrap_or_else(|_| fatal_error(EmulatorError::InitFlashPartitionDriver.into()));
 
         romtime::println!("[mcu-rom] Booting from flash");
-
-        // Read backup blob from DOT flash region for test-dot-recovery feature
-        let recovery_backup_blob = {
-            const RECOVERY_BLOB_OFFSET: usize = 2048;
-            let mut blob = [0u8; DOT_BLOB_SIZE];
-            let mut i = 0;
-            while i < blob.len() {
-                blob[i] = unsafe { *EMULATOR_DOT_FLASH_ADDR.add(RECOVERY_BLOB_OFFSET + i) };
-                i += 1;
-            }
-            blob
-        };
-        let recovery_handler = TestDotRecoveryHandler {
-            blob: recovery_backup_blob,
-        };
-
-        // Create MCI mbox0 challenge/response transport for DOT recovery.
-        let challenge_transport = {
-            let mci_base: romtime::StaticRef<registers_generated::mci::regs::Mci> = unsafe {
-                romtime::StaticRef::new(
-                    MCU_MEMORY_MAP.mci_offset as *const registers_generated::mci::regs::Mci,
-                )
-            };
-            mcu_rom_common::Mbox0RecoveryTransport::new(mci_base)
-        };
 
         use mcu_rom_common::recovery::flash::FlashImageProvider;
         use mcu_rom_common::recovery::{ErrorPolicy, ImageProviderEntry, ImageProviderManager};
@@ -543,27 +526,6 @@ pub extern "C" fn rom_entry() -> ! {
             mci_mbox1_axi_users: mbox_axi_users,
             #[cfg(feature = "ocp-lock")]
             ocp_lock_config,
-            dot_recovery_handler: if cfg!(feature = "test-dot-recovery") {
-                Some(&recovery_handler)
-            } else {
-                None
-            },
-            dot_recovery_transport: if cfg!(feature = "test-dot-recovery") {
-                Some(&challenge_transport)
-            } else {
-                None
-            },
-            i3c_services: if cfg!(feature = "test-i3c-services") {
-                Some(mcu_rom_common::I3cServicesModes::DOT_RECOVERY)
-            } else {
-                None
-            },
-            force_i3c_services: cfg!(feature = "test-i3c-services"),
-            hooks: if cfg!(feature = "test-rom-hooks") {
-                Some(&hooks)
-            } else {
-                None
-            },
             ..Default::default()
         });
     } else {
@@ -578,18 +540,28 @@ pub extern "C" fn rom_entry() -> ! {
             }
             blob
         };
-        let recovery_handler = TestDotRecoveryHandler {
-            blob: recovery_backup_blob,
+
+        // Store recovery handler and transport in statics so the
+        // DotLockedRecoveryHandler wrappers can reference them with
+        // 'static lifetime.
+        static mut RECOVERY_HANDLER: core::mem::MaybeUninit<TestDotRecoveryHandler> =
+            core::mem::MaybeUninit::uninit();
+        let recovery_handler = unsafe {
+            RECOVERY_HANDLER.write(TestDotRecoveryHandler {
+                blob: recovery_backup_blob,
+            })
         };
 
-        // Create MCI mbox0 transport for DOT recovery/override.
-        let recovery_transport = {
-            let mci_base: romtime::StaticRef<registers_generated::mci::regs::Mci> = unsafe {
-                romtime::StaticRef::new(
-                    MCU_MEMORY_MAP.mci_offset as *const registers_generated::mci::regs::Mci,
-                )
-            };
-            mcu_rom_common::Mbox0RecoveryTransport::new(mci_base)
+        let mci_base: romtime::StaticRef<registers_generated::mci::regs::Mci> = unsafe {
+            romtime::StaticRef::new(
+                MCU_MEMORY_MAP.mci_offset as *const registers_generated::mci::regs::Mci,
+            )
+        };
+        static mut RECOVERY_TRANSPORT: core::mem::MaybeUninit<
+            mcu_rom_common::Mbox0RecoveryTransport,
+        > = core::mem::MaybeUninit::uninit();
+        let recovery_transport = unsafe {
+            RECOVERY_TRANSPORT.write(mcu_rom_common::Mbox0RecoveryTransport::new(mci_base))
         };
 
         let hooks = LoggingRomHooks;
@@ -602,15 +574,13 @@ pub extern "C" fn rom_entry() -> ! {
             cptra_dma_axi_user: axi_user0,
             mci_mbox0_axi_users: mbox_axi_users,
             mci_mbox1_axi_users: mbox_axi_users,
-            #[cfg(feature = "ocp-lock")]
-            ocp_lock_config,
             dot_recovery_handler: if cfg!(feature = "test-dot-recovery") {
-                Some(&recovery_handler)
+                Some(&*recovery_handler)
             } else {
                 None
             },
             dot_recovery_transport: if cfg!(feature = "test-dot-recovery") {
-                Some(&recovery_transport)
+                Some(&*recovery_transport)
             } else {
                 None
             },
@@ -625,6 +595,73 @@ pub extern "C" fn rom_entry() -> ! {
             } else {
                 None
             },
+            dot_locked_recovery_handlers: if cfg!(feature = "test-dot-recovery") {
+                static mut BLOB_HANDLER: core::mem::MaybeUninit<
+                    mcu_rom_common::BackupBlobRecoveryHandler<'static>,
+                > = core::mem::MaybeUninit::uninit();
+                let blob_h = unsafe {
+                    BLOB_HANDLER.write(mcu_rom_common::BackupBlobRecoveryHandler {
+                        recovery_handler: &*recovery_handler,
+                    })
+                };
+                static mut OVERRIDE_HANDLER: core::mem::MaybeUninit<
+                    mcu_rom_common::OverrideChallengeRecoveryHandler<'static>,
+                > = core::mem::MaybeUninit::uninit();
+                let override_h = unsafe {
+                    OVERRIDE_HANDLER.write(mcu_rom_common::OverrideChallengeRecoveryHandler {
+                        transport: &*recovery_transport,
+                        wdt_timeout: 0,
+                    })
+                };
+                static mut HANDLER_ENTRIES: core::mem::MaybeUninit<
+                    [mcu_rom_common::DotLockedRecoveryEntry<'static>; 2],
+                > = core::mem::MaybeUninit::uninit();
+                unsafe {
+                    HANDLER_ENTRIES
+                        .write([
+                            mcu_rom_common::DotLockedRecoveryEntry {
+                                handler: blob_h,
+                                policy: mcu_rom_common::DotLockedRecoveryErrorPolicy::Continue,
+                            },
+                            mcu_rom_common::DotLockedRecoveryEntry {
+                                handler: override_h,
+                                policy: mcu_rom_common::DotLockedRecoveryErrorPolicy::Continue,
+                            },
+                        ])
+                        .as_slice()
+                }
+            } else if cfg!(feature = "test-i3c-services") {
+                let i3c_base = unsafe {
+                    romtime::StaticRef::new(
+                        MCU_MEMORY_MAP.i3c_offset as *const registers_generated::i3c::regs::I3c,
+                    )
+                };
+                static mut I3C_HANDLER: core::mem::MaybeUninit<
+                    mcu_rom_common::I3cDotLockedRecoveryHandler,
+                > = core::mem::MaybeUninit::uninit();
+                let handler = unsafe {
+                    I3C_HANDLER.write(mcu_rom_common::I3cDotLockedRecoveryHandler {
+                        i3c_base,
+                        services: mcu_rom_common::I3cServicesModes::DOT_RECOVERY,
+                        i3c_target_addr: 0x5a,
+                    })
+                };
+                static mut HANDLER_ENTRIES: core::mem::MaybeUninit<
+                    [mcu_rom_common::DotLockedRecoveryEntry<'static>; 1],
+                > = core::mem::MaybeUninit::uninit();
+                unsafe {
+                    HANDLER_ENTRIES
+                        .write([mcu_rom_common::DotLockedRecoveryEntry {
+                            handler,
+                            policy: mcu_rom_common::DotLockedRecoveryErrorPolicy::Continue,
+                        }])
+                        .as_slice()
+                }
+            } else {
+                &[]
+            },
+            #[cfg(feature = "ocp-lock")]
+            ocp_lock_config,
             ..Default::default()
         });
     }

--- a/platforms/fpga/rom/src/riscv.rs
+++ b/platforms/fpga/rom/src/riscv.rs
@@ -12,7 +12,7 @@ Abstract:
 
 --*/
 
-use crate::flash::flash_drv::{FpgaFlashCtrl, PRIMARY_FLASH_CTRL_BASE};
+use crate::flash::flash_drv::{FpgaFlashCtrl, PRIMARY_FLASH_CTRL_BASE, SECONDARY_FLASH_CTRL_BASE};
 use crate::io::{print_to_console, EXITER, FATAL_ERROR_HANDLER, FPGA_WRITER};
 use core::fmt::Write;
 
@@ -21,10 +21,10 @@ core::arch::global_asm!(include_str!("start.s"));
 
 use mcu_config::{McuMemoryMap, McuStraps};
 use mcu_rom_common::flash::flash_partition::FlashPartition;
-use mcu_rom_common::recovery::flash::FlashImageProvider;
-use mcu_rom_common::recovery::{ErrorPolicy, ImageProviderEntry, ImageProviderManager};
 use mcu_rom_common::{RomHooks, RomParameters};
-use romtime::{LifecycleControllerState, LifecycleHashedToken, LifecycleToken};
+use romtime::{
+    LifecycleControllerState, LifecycleHashedToken, LifecycleHashedTokens, LifecycleToken,
+};
 
 /// Example `RomHooks` implementation for the FPGA platform. Emits a
 /// distinctive tagged log line for each milestone and records which
@@ -179,7 +179,7 @@ pub extern "C" fn rom_entry() -> ! {
 
     // For now, we use the same tokens for all lifecycle transitions.
     let burn_lifecycle_tokens = if burn_tokens {
-        Some(romtime::LifecycleHashedTokens {
+        Some(LifecycleHashedTokens {
             test_unlock: [burn_hashed_token; 7],
             manuf: burn_hashed_token,
             manuf_to_prod: burn_hashed_token,
@@ -211,6 +211,13 @@ pub extern "C" fn rom_entry() -> ! {
     let mbox_axi_users = [axi_user0, axi_user1, 0, 0, 0];
 
     let hooks = LoggingRomHooks;
+
+    // DOT flash is backed by the secondary flash controller.
+    let secondary_flash_ctrl = FpgaFlashCtrl::initialize_flash_ctrl(SECONDARY_FLASH_CTRL_BASE);
+    let dot_flash: &dyn mcu_rom_common::hil::FlashStorage = &secondary_flash_ctrl;
+
+    use mcu_rom_common::recovery::flash::FlashImageProvider;
+    use mcu_rom_common::recovery::{ErrorPolicy, ImageProviderEntry, ImageProviderManager};
 
     let mut flash_provider = FlashImageProvider::new(&mut flash_partition);
     let mut entries = [ImageProviderEntry {
@@ -334,6 +341,7 @@ pub extern "C" fn rom_entry() -> ! {
         otp_enable_integrity_check: true,
         otp_enable_consistency_check: true,
         image_provider_manager: Some(manager),
+        dot_flash: Some(dot_flash),
         cptra_mbox_axi_users: mbox_axi_users,
         cptra_fuse_axi_user: axi_user0,
         cptra_trng_axi_user: axi_user0,

--- a/rom/src/cold_boot.rs
+++ b/rom/src/cold_boot.rs
@@ -36,6 +36,7 @@ use core::ops::Deref;
 use mcu_error::McuError;
 use registers_generated::fuses;
 use registers_generated::i3c::bits::RecIntfCfg;
+use registers_generated::mci::bits::{MboxExecute, MboxLock};
 #[cfg(feature = "ocp-lock")]
 use romtime::ocp_lock::HekState;
 use romtime::{
@@ -702,78 +703,74 @@ impl ColdBoot {
     }
 }
 
-/// Attempts DOT recovery using available recovery mechanisms.
-/// The order is determined by `params.dot_recovery_policy`.
-/// If recovery succeeds, triggers a warm reset (never returns).
-/// If recovery fails or no handler is available, returns the last error (if any).
-fn attempt_dot_recovery(
+/// Run integrator-configured DOT locked-state recovery handlers in sequence.
+///
+/// Each handler that succeeds triggers a warm reset and never returns.
+/// The integrator controls the order and retry policy via
+/// `RomParameters::dot_locked_recovery_handlers`.
+#[inline(never)]
+fn attempt_dot_locked_recovery(
     env: &mut RomEnv,
     dot_fuses: &crate::DotFuses,
     params: &RomParameters,
     dot_flash: &dyn crate::hil::FlashStorage,
     key_type: CmStableKeyType,
-) -> Option<McuError> {
-    use crate::DotRecoveryPolicy;
+) -> McuError {
+    use crate::device_ownership_transfer::{DotLockedRecoveryContext, DotLockedRecoveryManager};
 
-    if params.dot_recovery_policy == DotRecoveryPolicy::None {
-        return None;
+    if params.dot_locked_recovery_handlers.is_empty() {
+        return McuError::ROM_COLD_BOOT_DOT_ERROR;
     }
 
-    let recovery_handler = params.dot_recovery_handler?;
-    romtime::println!("[mcu-rom] Attempting DOT recovery via backup blob");
-    match device_ownership_transfer::dot_recovery_flow(
-        env,
+    let ctx = DotLockedRecoveryContext {
         dot_fuses,
-        recovery_handler,
         dot_flash,
         key_type,
-    ) {
+    };
+    let mut manager = DotLockedRecoveryManager::new(params.dot_locked_recovery_handlers);
+    match manager.run(env, &ctx) {
         Ok(()) => {
-            romtime::println!("[mcu-rom] DOT backup recovery succeeded, resetting");
+            romtime::println!("[mcu-rom] DOT locked-state recovery succeeded, resetting");
             env.mci.trigger_warm_reset();
             fatal_error(McuError::ROM_COLD_BOOT_RESET_ERROR);
         }
-        Err(err) => {
-            romtime::println!(
-                "[mcu-rom] DOT backup recovery failed: {}",
-                HexWord(err.into())
-            );
-            Some(err)
-        }
+        Err(err) => err,
     }
 }
 
-/// Attempts DOT override using the recovery transport if available.
-/// DOT_OVERRIDE happens in recovery mode when the blob is corrupted/invalid.
-/// If override succeeds, triggers a warm reset (never returns).
-/// If override fails or no transport is available, returns to caller.
-fn attempt_dot_override(
-    env: &mut RomEnv,
-    dot_fuses: &crate::DotFuses,
-    params: &RomParameters,
-    dot_flash: &dyn crate::hil::FlashStorage,
-    key_type: CmStableKeyType,
-) {
-    if let Some(transport) = params.dot_recovery_transport {
-        if params.dot_recovery_wdt_timeout > 0 {
-            env.mci.configure_wdt(params.dot_recovery_wdt_timeout, 1);
-        }
-        romtime::println!("[mcu-rom] Attempting DOT override via challenge/response");
-        match device_ownership_transfer::dot_override_challenge_flow(
-            env, dot_fuses, transport, dot_flash, key_type,
-        ) {
-            Ok(()) => {
-                romtime::println!("[mcu-rom] DOT override succeeded, resetting");
-                env.mci.trigger_warm_reset();
-                fatal_error(McuError::ROM_COLD_BOOT_RESET_ERROR);
-            }
-            Err(err) => {
-                romtime::println!(
-                    "[mcu-rom] DOT override failed: {}, continuing boot",
-                    HexWord(err.into())
-                );
-            }
-        }
+/// [`DotLockedRecoveryHandler`] that enters the I3C services mailbox loop.
+///
+/// The handler runs the interactive I3C command loop (DOT_RECOVERY,
+/// DOT_OVERRIDE, etc.) and returns success if the loop completes
+/// without error.
+pub struct I3cDotLockedRecoveryHandler {
+    pub i3c_base: romtime::StaticRef<registers_generated::i3c::regs::I3c>,
+    pub services: crate::I3cServicesModes,
+    pub i3c_target_addr: u8,
+}
+
+impl crate::device_ownership_transfer::DotLockedRecoveryHandler for I3cDotLockedRecoveryHandler {
+    fn attempt(
+        &self,
+        env: &mut RomEnv,
+        ctx: &crate::device_ownership_transfer::DotLockedRecoveryContext<'_>,
+    ) -> mcu_error::McuResult<()> {
+        let dot_ctx = crate::DotContext {
+            soc_manager: &mut env.soc_manager,
+            mci: &env.mci,
+            otp: &env.otp,
+            dot_fuses: ctx.dot_fuses,
+            dot_flash: ctx.dot_flash,
+            key_type: ctx.key_type,
+        };
+        enter_i3c_services(
+            &env.mci,
+            self.i3c_base,
+            self.services,
+            self.i3c_target_addr,
+            Some(dot_ctx),
+        );
+        Ok(())
     }
 }
 
@@ -781,10 +778,13 @@ fn attempt_dot_override(
 ///
 /// Runs the I3C mailbox handler loop, processing commands until completion
 /// or timeout. Sets boot status checkpoints on entry and exit.
+#[inline(never)]
 fn enter_i3c_services(
     mci: &romtime::Mci,
     i3c_base: romtime::StaticRef<registers_generated::i3c::regs::I3c>,
     services: I3cServicesModes,
+    target_addr: u8,
+    dot_ctx: Option<crate::DotContext<'_>>,
 ) {
     // Extend the watchdog timeout for I3C services since the loop may run
     // for an extended period waiting for commands from the BMC.
@@ -805,14 +805,61 @@ fn enter_i3c_services(
     romtime::println!("[mcu-rom-i3c-svc] Recovery disabled");
 
     mci.set_flow_checkpoint(McuRomBootStatus::I3cServicesStarted.into());
-    let mut handler = I3cMailboxHandler::new(i3c_base, services);
-    match handler.run() {
+
+    // Acquire the MCI mailbox lock so we can use its SRAM as a word-aligned
+    // reassembly buffer for multi-packet I3C commands.
+    //
+    // On HW the lock is forced to 1 on reset, so reading it will return
+    // 1 (locked). We release any stale lock by writing execute=0, then retry.
+    // See issue #1220.
+
+    // Reading the lock register atomically acquires it when it returns 0.
+    // Loop until acquired or give up after a bounded number of attempts.
+    // On the first failure we release a potentially stale lock.
+    let mut lock_acquired = false;
+    let mut released_stale = false;
+    for _ in 0..100 {
+        if mci.registers.mcu_mbox0_csr_mbox_lock.read(MboxLock::Lock) == 0 {
+            lock_acquired = true;
+            break;
+        }
+        // First failed attempt: release a possibly stale lock from a prior run
+        if !released_stale {
+            released_stale = true;
+            mci.registers
+                .mcu_mbox0_csr_mbox_execute
+                .write(MboxExecute::Execute::CLEAR);
+        }
+    }
+    if !lock_acquired {
+        romtime::println!("[mcu-rom-i3c-svc] Warning: could not acquire mailbox lock");
+    }
+
+    let reassembly_buf = unsafe {
+        core::slice::from_raw_parts_mut(
+            mci.registers.mcu_mbox0_csr_mbox_sram.as_ptr() as *mut u32,
+            crate::i3c_mailbox::MAX_REASSEMBLY_WORDS,
+        )
+    };
+
+    let mut handler =
+        I3cMailboxHandler::new(i3c_base, services, target_addr, dot_ctx, reassembly_buf);
+    match handler.run(|| {
+        mci.set_flow_checkpoint(McuRomBootStatus::I3cServicesReady.into());
+    }) {
         Ok(()) => {
             mci.set_flow_checkpoint(McuRomBootStatus::I3cServicesComplete.into());
         }
         Err(err) => {
             romtime::println!("[mcu-rom] I3C services error: {}", HexWord(err.into()));
         }
+    }
+
+    // Release mailbox lock if we acquired it
+    if lock_acquired {
+        mci.registers
+            .mcu_mbox0_csr_mbox_execute
+            .write(MboxExecute::Execute::CLEAR);
     }
 }
 
@@ -849,6 +896,11 @@ impl BootFlow for ColdBoot {
             env.i3c1_base
         } else {
             env.i3c_base
+        };
+        let i3c_target_addr = if straps.active_i3c == 1 {
+            straps.i3c1_static_addr
+        } else {
+            straps.i3c_static_addr
         };
         romtime::println!(
             "[mcu-rom] Active I3C core for recovery: {}",
@@ -1172,26 +1224,15 @@ impl BootFlow for ColdBoot {
 
             if dot_blob.iter().all(|&b| b == 0) || dot_blob.iter().all(|&b| b == 0xFF) {
                 if dot_fuses.enabled && dot_fuses.is_locked() {
-                    // DOT is in ODD state but blob is empty/corrupt.
-                    // Try backup-blob recovery first, then override.
                     let key_type = params
                         .dot_stable_key_type
                         .unwrap_or(CmStableKeyType::IDevId);
-                    let recovery_err =
-                        attempt_dot_recovery(env, &dot_fuses, &params, dot_flash, key_type);
-                    // Recovery success triggers a warm reset and never returns.
-                    // If recovery failed or was not configured, try override.
-                    attempt_dot_override(env, &dot_fuses, &params, dot_flash, key_type);
-                    // Try I3C services if DOT_RECOVERY enabled
-                    if let Some(services) = params.i3c_services {
-                        if services.contains(I3cServicesModes::DOT_RECOVERY) {
-                            enter_i3c_services(&env.mci, i3c_base, services);
-                        }
-                    }
                     romtime::println!(
                         "[mcu-rom] DOT fuses are initialized but DOT blob is empty/corrupt"
                     );
-                    fatal_error(recovery_err.unwrap_or(McuError::ROM_COLD_BOOT_DOT_ERROR));
+                    let err =
+                        attempt_dot_locked_recovery(env, &dot_fuses, &params, dot_flash, key_type);
+                    fatal_error(err);
                 }
                 romtime::println!("[mcu-rom] DOT blob is empty; skipping DOT flow");
                 device_ownership_transfer::load_owner_pkhash(&env.otp)
@@ -1207,28 +1248,15 @@ impl BootFlow for ColdBoot {
                 ) {
                     Ok(owner) => owner,
                     Err(err) => {
-                        // DOT flow failed (e.g., HMAC verification) - attempt recovery/override if in ODD state
                         if dot_fuses.is_locked() {
                             let key_type = params
                                 .dot_stable_key_type
                                 .unwrap_or(CmStableKeyType::IDevId);
-                            let recovery_err =
-                                attempt_dot_recovery(env, &dot_fuses, &params, dot_flash, key_type);
-                            // Recovery success triggers a warm reset and never returns.
-                            // If recovery failed or was not configured, try override.
-                            attempt_dot_override(env, &dot_fuses, &params, dot_flash, key_type);
-                            if let Some(e) = recovery_err {
-                                romtime::println!(
-                                    "[mcu-rom] DOT recovery failed: {}",
-                                    HexWord(e.into())
-                                );
-                            }
-                            // Try I3C services if DOT_RECOVERY enabled
-                            if let Some(services) = params.i3c_services {
-                                if services.contains(I3cServicesModes::DOT_RECOVERY) {
-                                    enter_i3c_services(&env.mci, i3c_base, services);
-                                }
-                            }
+                            // Try locked-state recovery; if it succeeds it
+                            // resets and never returns.
+                            let _recovery_err = attempt_dot_locked_recovery(
+                                env, &dot_fuses, &params, dot_flash, key_type,
+                            );
                         }
                         romtime::println!(
                             "[mcu-rom] Fatal error performing Device Ownership Transfer: {}",
@@ -1265,7 +1293,20 @@ impl BootFlow for ColdBoot {
         // Enter I3C services unconditionally if force_i3c_services is set
         if params.force_i3c_services {
             if let Some(services) = params.i3c_services {
-                enter_i3c_services(&env.mci, i3c_base, services);
+                let dot_ctx = params.dot_flash.map(|dot_flash| {
+                    let key_type = params
+                        .dot_stable_key_type
+                        .unwrap_or(CmStableKeyType::IDevId);
+                    crate::DotContext {
+                        soc_manager: &mut env.soc_manager,
+                        mci: &env.mci,
+                        otp: &env.otp,
+                        dot_fuses: &dot_fuses,
+                        dot_flash,
+                        key_type,
+                    }
+                });
+                enter_i3c_services(&env.mci, i3c_base, services, i3c_target_addr, dot_ctx);
             }
         }
 

--- a/rom/src/device_ownership_transfer.rs
+++ b/rom/src/device_ownership_transfer.rs
@@ -12,8 +12,8 @@ Abstract:
 
 --*/
 
-use crate::flash::hil::FlashStorage;
 use crate::fuses::OwnerPkHash;
+use crate::hil::FlashStorage;
 use crate::RomEnv;
 use caliptra_api::mailbox::{
     CmDeriveStableKeyReq, CmDeriveStableKeyResp, CmHashAlgorithm, CmHmacResp, CmShaReqHdr,
@@ -21,27 +21,11 @@ use caliptra_api::mailbox::{
 };
 use mcu_error::{McuError, McuResult};
 use romtime::otp::Otp;
-use romtime::HexWord;
-use romtime::McuRomBootStatus;
+use romtime::{HexWord, McuRomBootStatus};
 use zerocopy::{transmute, FromBytes, Immutable, IntoBytes, KnownLayout};
 
 const DOT_LABEL: &[u8; 23] = b"Caliptra DOT stable key";
 pub const DOT_BLOB_SIZE: usize = core::mem::size_of::<DotBlob>();
-
-/// Copy `src` into `dst` without pulling in a panic path.
-///
-/// `[u8]::copy_from_slice` contains a length-mismatch panic that the
-/// compiler sometimes cannot optimise away.  This helper returns an
-/// error instead, keeping the ROM binary provably panic-free.
-fn copy_slice(dst: &mut [u8], src: &[u8]) -> McuResult<()> {
-    if dst.len() != src.len() {
-        return Err(McuError::ROM_COLD_BOOT_DOT_ERROR);
-    }
-    for (d, s) in dst.iter_mut().zip(src.iter()) {
-        *d = *s;
-    }
-    Ok(())
-}
 
 #[derive(Clone, Debug, FromBytes, IntoBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct LakPkHash(pub [u32; 12]);
@@ -71,7 +55,7 @@ impl DotFuses {
     pub fn load_from_otp(otp: &Otp) -> McuResult<Self> {
         use registers_generated::fuses;
 
-        // dot_initialized: LinearMajorityVote(1 bit, 3x) → logical 0 or 1
+        // dot_initialized: LinearOr(1 bit, 3x) → logical 0 or 1
         let enabled = otp.read_entry(fuses::DOT_INITIALIZED)? != 0;
 
         // dot_fuse_array: OneHot(256 bits) → count of burned bits
@@ -224,6 +208,7 @@ impl DotBlob {
 /// # Returns
 /// * `Ok(OwnerPkHash)` - The determined owner's public key hash on success.
 /// * `Err(McuError)` - If any step of the DOT flow fails.
+#[inline(never)]
 pub fn dot_flow(
     env: &mut RomEnv,
     dot_fuses: &DotFuses,
@@ -231,16 +216,12 @@ pub fn dot_flow(
     stable_key_type: CmStableKeyType,
 ) -> McuResult<Option<OwnerPkHash>> {
     romtime::println!("[mcu-rom-dot] Performing Device Ownership Transfer flow");
-    romtime::println!(
-        "[mcu-rom-dot] DOT raw blob: {}",
-        romtime::HexBytes(blob.as_bytes())
-    );
     env.mci
         .set_flow_checkpoint(McuRomBootStatus::DeviceOwnershipTransferStarted.into());
 
     let dot_effective_key = derive_stable_key_flow(env, dot_fuses, stable_key_type)?;
 
-    verify_dot_blob(env, blob, &dot_effective_key)?;
+    verify_dot_blob(&mut env.soc_manager, blob, &dot_effective_key)?;
 
     burn_dot_fuses(env, dot_fuses, blob)?;
 
@@ -282,14 +263,19 @@ pub fn derive_stable_key_flow(
 }
 
 /// Calls Caliptra to derive the DOT Effective Key using the stable key derivation command.
-/// Uses `start_mailbox_req_bytes` + `finish_mailbox_resp_bytes` to stream.
 fn cm_derive_stable_key(
     env: &mut RomEnv,
     dot_fuses: &DotFuses,
     key_type: CmStableKeyType,
 ) -> McuResult<DotEffectiveKey> {
-    use caliptra_api::mailbox::CMK_SIZE_BYTES;
+    cm_derive_stable_key_impl(&mut env.soc_manager, dot_fuses, key_type)
+}
 
+pub(crate) fn cm_derive_stable_key_impl(
+    soc_manager: &mut romtime::CaliptraSoC,
+    dot_fuses: &DotFuses,
+    key_type: CmStableKeyType,
+) -> McuResult<DotEffectiveKey> {
     // Construct the label as fixed label + 16-bit fuse value.
     // Per spec, EVEN state (unlocked) derives with (n+1) for next DOT_BLOB sealing,
     // while ODD state (locked) derives with (n) for current DOT_BLOB authentication.
@@ -298,144 +284,79 @@ fn cm_derive_stable_key(
     } else {
         dot_fuses.burned
     };
-    let mut req = CmDeriveStableKeyReq {
-        info: [0u8; 32],
+    let mut info = [0u8; 32];
+    const LABEL_LEN: usize = DOT_LABEL.len();
+    let mut i = 0;
+    while i < LABEL_LEN {
+        info[i] = DOT_LABEL[i];
+        i += 1;
+    }
+    let fuse_slice: [u8; 2] = derivation_value.to_le_bytes();
+    info[LABEL_LEN] = fuse_slice[0];
+    info[LABEL_LEN + 1] = fuse_slice[1];
+
+    let mut resp = [0u32; core::mem::size_of::<CmDeriveStableKeyResp>() / 4];
+    let req = CmDeriveStableKeyReq {
+        info,
         key_type: key_type.into(),
         ..Default::default()
     };
-    const LABEL_LEN: usize = DOT_LABEL.len();
-    copy_slice(&mut req.info[..LABEL_LEN], DOT_LABEL)?;
-    let fuse_slice: [u8; 2] = derivation_value.to_le_bytes();
-    req.info[LABEL_LEN] = fuse_slice[0];
-    req.info[LABEL_LEN + 1] = fuse_slice[1];
+    let mut req32: [u32; core::mem::size_of::<CmDeriveStableKeyReq>() / 4] = transmute!(req);
 
-    let cmd: u32 = CommandId::CM_DERIVE_STABLE_KEY.into();
-    let chksum = caliptra_api::calc_checksum(cmd, &req.as_bytes()[4..]);
-    req.hdr.chksum = chksum;
-
-    if let Err(err) = env.soc_manager.start_mailbox_req_bytes(cmd, req.as_bytes()) {
+    if let Err(err) = soc_manager.exec_mailbox_req_u32(
+        CommandId::CM_DERIVE_STABLE_KEY.into(),
+        &mut req32,
+        &mut resp,
+    ) {
         romtime::println!(
             "[mcu-rom] Error deriving DOT stable key: {}",
             HexWord(crate::err_code(&err))
         );
         return Err(McuError::ROM_COLD_BOOT_DOT_ERROR);
     }
-
-    // CmDeriveStableKeyResp = hdr(8) + cmk(128) = 136 bytes
-    let mut resp_buf = [0u8; core::mem::size_of::<CmDeriveStableKeyResp>()];
-    if let Err(err) = env.soc_manager.finish_mailbox_resp_bytes(&mut resp_buf) {
-        romtime::println!(
-            "[mcu-rom] Error deriving DOT stable key: {}",
-            HexWord(crate::err_code(&err))
-        );
-        return Err(McuError::ROM_COLD_BOOT_DOT_ERROR);
-    }
-
-    // Extract CMK (128 bytes = 32 u32 words) from response after the 8-byte header.
-    let cmk_bytes: [u8; CMK_SIZE_BYTES] = match resp_buf.get(8..8 + CMK_SIZE_BYTES) {
-        Some(src) => match src.try_into() {
-            Ok(arr) => arr,
-            Err(_) => return Err(McuError::ROM_COLD_BOOT_DOT_ERROR),
-        },
-        None => return Err(McuError::ROM_COLD_BOOT_DOT_ERROR),
-    };
-    Ok(DotEffectiveKey(Cmk(zerocopy::transmute!(cmk_bytes))))
+    let resp: CmDeriveStableKeyResp = transmute!(resp);
+    let dot_effective_key = DotEffectiveKey(Cmk(transmute!(resp.cmk)));
+    Ok(dot_effective_key)
 }
 
-/// Calls Caliptra to compute an HMAC.  Builds the request in a flat byte
-/// buffer and sends it via `start_mailbox_req_bytes`, matching the proven
-/// pattern used by `cm_derive_stable_key` and `cm_import_aes_key`.
-///
-/// The data length must not exceed [`CM_HMAC_MAX_DATA`] bytes.
-fn cm_hmac(env: &mut RomEnv, key: &Cmk, data: &[u8]) -> McuResult<[u32; 16]> {
-    use caliptra_api::mailbox::CMK_SIZE_BYTES;
+// CM_HMAC copy with smaller data to save stack space
+#[repr(C)]
+#[derive(Debug, Default, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct CmHmacDotBlobReq {
+    pub hdr: MailboxReqHeader,
+    pub cmk: Cmk,
+    pub hash_algorithm: u32,
+    pub data_size: u32,
+    pub data: DotBlobFields,
+}
 
-    // Maximum data payload supported by this helper.  Sized to fit DOT blob
-    // contents (104 bytes) with generous headroom.
-    const CM_HMAC_MAX_DATA: usize = 256;
-
-    if data.len() > CM_HMAC_MAX_DATA {
-        return Err(McuError::ROM_COLD_BOOT_DOT_ERROR);
-    }
-
-    let cmd: u32 = CommandId::CM_HMAC.into();
-    let hash_algorithm: u32 = CmHashAlgorithm::Sha512.into();
-    let data_size: u32 = data.len() as u32;
-
-    // Build the flat request buffer:
-    //   [chksum:4] [cmk:128] [hash_algorithm:4] [data_size:4] [data:N]
-    const HDR: usize = 4; // MailboxReqHeader (chksum only)
-    let req_len = HDR + CMK_SIZE_BYTES + 4 + 4 + data.len();
-    // Fixed buffer large enough for the maximum request size.
-    let mut buf = [0u8; HDR + CMK_SIZE_BYTES + 4 + 4 + CM_HMAC_MAX_DATA];
-
-    let mut off = HDR; // skip chksum; will fill it after payload
-                       // cmk – serialise each u32 word in native byte order (matches write_data)
-    for &w in key.0.iter() {
-        if let Some(dst) = buf.get_mut(off..off + 4) {
-            copy_slice(dst, &w.to_ne_bytes())?;
-        }
-        off += 4;
-    }
-    // hash_algorithm (LE)
-    if let Some(dst) = buf.get_mut(off..off + 4) {
-        copy_slice(dst, &hash_algorithm.to_le_bytes())?;
-    }
-    off += 4;
-    // data_size (LE)
-    if let Some(dst) = buf.get_mut(off..off + 4) {
-        copy_slice(dst, &data_size.to_le_bytes())?;
-    }
-    off += 4;
-    // data
-    if let Some(dst) = buf.get_mut(off..off + data.len()) {
-        copy_slice(dst, data)?;
-    }
-
-    // Compute and store checksum over payload bytes (everything after chksum).
-    let chksum = caliptra_api::calc_checksum(
-        cmd,
-        match buf.get(HDR..req_len) {
-            Some(b) => b,
-            None => return Err(McuError::ROM_COLD_BOOT_DOT_ERROR),
-        },
-    );
-    if let Some(dst) = buf.get_mut(0..4) {
-        copy_slice(dst, &chksum.to_le_bytes())?;
-    }
-
-    // Send the request using the same API as cm_derive_stable_key.
-    let req_bytes = match buf.get(..req_len) {
-        Some(b) => b,
-        None => return Err(McuError::ROM_COLD_BOOT_DOT_ERROR),
+/// Calls Caliptra to compute an HMAC over DotBlobFields.
+pub(crate) fn cm_hmac(
+    soc_manager: &mut romtime::CaliptraSoC,
+    key: &Cmk,
+    fields: &DotBlobFields,
+) -> McuResult<[u32; 16]> {
+    let mut resp = [0u32; core::mem::size_of::<CmHmacResp>() / 4];
+    let req = CmHmacDotBlobReq {
+        cmk: transmute!(key.0),
+        hash_algorithm: CmHashAlgorithm::Sha512.into(),
+        data_size: core::mem::size_of::<DotBlobFields>() as u32,
+        data: fields.clone(),
+        ..Default::default()
     };
-    if let Err(err) = env.soc_manager.start_mailbox_req_bytes(cmd, req_bytes) {
+    let mut req: [u32; core::mem::size_of::<CmHmacDotBlobReq>() / 4] = transmute!(req);
+
+    if let Err(err) =
+        soc_manager.exec_mailbox_req_u32(CommandId::CM_HMAC.into(), &mut req, &mut resp)
+    {
         romtime::println!(
             "[mcu-rom] Error computing HMAC: {}",
             HexWord(crate::err_code(&err))
         );
         return Err(McuError::ROM_COLD_BOOT_DOT_ERROR);
     }
-
-    // Read response – CmHmacResp is MailboxRespHeaderVarSize(12) + mac(64) = 76 bytes.
-    let mut resp_buf = [0u8; core::mem::size_of::<CmHmacResp>()];
-    if let Err(err) = env.soc_manager.finish_mailbox_resp_bytes(&mut resp_buf) {
-        romtime::println!(
-            "[mcu-rom] Error computing HMAC: {}",
-            HexWord(crate::err_code(&err))
-        );
-        return Err(McuError::ROM_COLD_BOOT_DOT_ERROR);
-    }
-
-    // Extract the 64-byte MAC starting after the var-size header (12 bytes).
-    let mac_bytes: [u8; 64] = match resp_buf.get(12..76) {
-        Some(b) => match b.try_into() {
-            Ok(arr) => arr,
-            Err(_) => return Err(McuError::ROM_COLD_BOOT_DOT_ERROR),
-        },
-        None => return Err(McuError::ROM_COLD_BOOT_DOT_ERROR),
-    };
-    Ok(zerocopy::transmute!(mac_bytes))
+    let resp: CmHmacResp = transmute!(resp);
+    Ok(transmute!(resp.mac))
 }
 
 /// Verifies the authenticity of a DOT blob using HMAC.
@@ -453,9 +374,12 @@ fn cm_hmac(env: &mut RomEnv, key: &Cmk, data: &[u8]) -> McuResult<[u32; 16]> {
 /// # Returns
 /// * `Ok(())` - If the DOT blob is authentic.
 /// * `Err(McuError)` - If HMAC verification fails (blob is corrupted or invalid).
-pub fn verify_dot_blob(env: &mut RomEnv, blob: &DotBlob, key: &DotEffectiveKey) -> McuResult<()> {
-    // compute the HMAC over everything except the HMAC itself
-    let verify = cm_hmac(env, &key.0, blob.fields.as_bytes())?;
+pub fn verify_dot_blob(
+    soc_manager: &mut romtime::CaliptraSoC,
+    blob: &DotBlob,
+    key: &DotEffectiveKey,
+) -> McuResult<()> {
+    let verify = cm_hmac(soc_manager, &key.0, &blob.fields)?;
     if !constant_time_eq::constant_time_eq(verify.as_bytes(), blob.hmac.as_bytes()) {
         romtime::println!("[mcu-rom] DOT blob HMAC did not match");
         return Err(McuError::ROM_COLD_BOOT_DOT_BLOB_CORRUPT_ERROR);
@@ -587,7 +511,7 @@ fn burn_dot_fuses(env: &mut RomEnv, dot_fuses: &DotFuses, blob: &DotBlob) -> Mcu
 /// # Returns
 /// * `Ok(())` - If the fuse was successfully burned.
 /// * `Err(McuError)` - If the OTP write operation fails.
-fn burn_dot_lock_fuse(otp: &Otp, dot_fuses: &DotFuses) -> McuResult<()> {
+pub(crate) fn burn_dot_lock_fuse(otp: &Otp, dot_fuses: &DotFuses) -> McuResult<()> {
     use registers_generated::fuses;
     // Each state transition burns the next sequential bit in the dot_fuse_array.
     let next_bit = dot_fuses.burned as u32;
@@ -615,6 +539,573 @@ fn burn_dot_lock_fuse(otp: &Otp, dot_fuses: &DotFuses) -> McuResult<()> {
     );
 
     otp.write_word(fuse_array_word_addr, new_value)?;
+
+    Ok(())
+}
+
+#[repr(C)]
+#[derive(Clone, Debug, FromBytes, IntoBytes, Immutable, KnownLayout)]
+pub struct EccP384PublicKey {
+    pub x: [u32; 12],
+    pub y: [u32; 12],
+}
+
+pub const MLDSA87_PUB_KEY_SIZE_DWORDS: usize = 2592 / 4;
+pub const MLDSA87_SIGNATURE_SIZE_DWORDS: usize = 4628 / 4;
+
+/// Override request containing vendor public keys for verification.
+pub struct OverrideRequest<'a> {
+    pub ecc_pub_key: EccP384PublicKey,
+    pub mldsa_pub_key: &'a [u32; MLDSA87_PUB_KEY_SIZE_DWORDS],
+}
+
+/// Override challenge response containing vendor public keys and dual signatures over the challenge.
+pub struct OverrideChallengeResponse<'a> {
+    pub ecc_pub_key: EccP384PublicKey,
+    pub ecc_signature_r: [u8; 48],
+    pub ecc_signature_s: [u8; 48],
+    pub mldsa_signature: &'a [u32; MLDSA87_SIGNATURE_SIZE_DWORDS],
+    pub mldsa_pub_key: &'a [u32; MLDSA87_PUB_KEY_SIZE_DWORDS],
+}
+
+/// Authentication parameters for a DOT override challenge/response.
+///
+/// Bundles the parsed cryptographic material needed to verify an override
+/// response, shared by both the MCI mailbox and I3C services flows.
+pub(crate) struct OverrideAuth<'a> {
+    pub ecc_key: &'a EccP384PublicKey,
+    pub ecc_sig_r: &'a [u8; 48],
+    pub ecc_sig_s: &'a [u8; 48],
+    pub mldsa_pub_key: &'a [u32; MLDSA87_PUB_KEY_SIZE_DWORDS],
+    pub mldsa_signature: &'a [u32; MLDSA87_SIGNATURE_SIZE_DWORDS],
+    pub challenge: &'a [u8; 48],
+}
+
+/// Transport trait for DOT recovery and override communication.
+///
+/// Abstracts the communication channel between ROM and the BMC for
+/// DOT_OVERRIDE operations. Implementations may use MCI mailbox 0,
+/// a SoC-specific mailbox, or I3C.
+pub trait RecoveryTransport {
+    /// Wait for a DOT_UNLOCK_CHALLENGE request from the BMC.
+    ///
+    /// Returns the VendorKey public keys that will be used for signature verification.
+    fn wait_for_override_request(&self) -> McuResult<OverrideRequest<'_>>;
+
+    /// Send a challenge nonce to the BMC.
+    fn send_challenge(&self, challenge: &[u8; 48]) -> McuResult<()>;
+
+    /// Receive the signed challenge response from the BMC.
+    fn receive_override_response(&self) -> McuResult<OverrideChallengeResponse<'_>>;
+}
+
+// ---------------------------------------------------------------------------
+// Shared DOT override helpers (used by both MCI and I3C flows)
+// ---------------------------------------------------------------------------
+
+/// Interpret an `EccP384PublicKey` as a `&[u32]` slice for hashing.
+pub(crate) fn ecc_key_as_u32_slice(key: &EccP384PublicKey) -> &[u32] {
+    let bytes = zerocopy::IntoBytes::as_bytes(key);
+    // EccP384PublicKey is #[repr(C)] with [u32;12]+[u32;12], always aligned.
+    unsafe { core::slice::from_raw_parts(bytes.as_ptr() as *const u32, bytes.len() / 4) }
+}
+
+/// Verify that the vendor public keys match `recovery_pk_hash` and that
+/// both signatures (ECDSA P-384 + MLDSA-87) are valid over the challenge.
+///
+/// This is the core cryptographic verification shared between the MCI
+/// mailbox override flow and the I3C services override flow.
+pub(crate) fn verify_override_response(
+    soc_manager: &mut romtime::CaliptraSoC,
+    recovery_pk_hash: &RecoveryPkHash,
+    auth: &OverrideAuth<'_>,
+) -> McuResult<()> {
+    // Verify PK hash matches OTP fuses
+    let ecc_key_u32 = ecc_key_as_u32_slice(auth.ecc_key);
+    let computed_hash = cm_sha384(soc_manager, &[ecc_key_u32, auth.mldsa_pub_key])?;
+
+    let fuse_hash_bytes: [u8; 48] = transmute!(recovery_pk_hash.0);
+    if !constant_time_eq::constant_time_eq(&computed_hash, &fuse_hash_bytes) {
+        romtime::println!("[mcu-rom-dot] Override response PK hash mismatch");
+        return Err(McuError::ROM_DOT_OVERRIDE_PK_HASH_MISMATCH);
+    }
+
+    // Verify ECDSA signature over SHA-384(challenge)
+    let challenge_u32: [u32; 12] = transmute!(*auth.challenge);
+    let challenge_hash = cm_sha384(soc_manager, &[&challenge_u32])?;
+
+    cm_ecdsa384_verify(
+        soc_manager,
+        auth.ecc_key,
+        auth.ecc_sig_r,
+        auth.ecc_sig_s,
+        &challenge_hash,
+    )
+    .inspect_err(|_e| {
+        romtime::println!("[mcu-rom-dot] Override ECDSA signature verification failed");
+    })?;
+
+    // Verify MLDSA-87 signature over raw challenge
+    cm_mldsa87_verify(
+        soc_manager,
+        auth.mldsa_pub_key,
+        auth.mldsa_signature,
+        &challenge_u32,
+    )
+    .inspect_err(|_e| {
+        romtime::println!("[mcu-rom-dot] Override MLDSA signature verification failed");
+    })?;
+
+    Ok(())
+}
+
+/// After a successful override verification, burn the DOT lock fuse and
+/// write an empty DOT blob sealed with the new EVEN-state key.
+pub(crate) fn apply_override(
+    soc_manager: &mut romtime::CaliptraSoC,
+    otp: &Otp,
+    dot_fuses: &DotFuses,
+    dot_flash: &dyn FlashStorage,
+    stable_key_type: CmStableKeyType,
+) -> McuResult<()> {
+    burn_dot_lock_fuse(otp, dot_fuses)?;
+
+    // Derive the EVEN-state key (fuse count + 1) for the new blob
+    let even_fuses = DotFuses {
+        enabled: dot_fuses.enabled,
+        burned: dot_fuses.burned + 1,
+        total: dot_fuses.total,
+        recovery_pk_hash: dot_fuses.recovery_pk_hash.clone(),
+    };
+    let even_key = cm_derive_stable_key_impl(soc_manager, &even_fuses, stable_key_type)?;
+
+    let mut new_blob = DotBlob {
+        fields: DotBlobFields::default(),
+        hmac: [0u32; 16],
+    };
+    new_blob.fields.version = 1;
+    let hmac = cm_hmac(soc_manager, &even_key.0, &new_blob.fields)?;
+    new_blob.hmac = hmac;
+
+    dot_flash
+        .write(new_blob.as_bytes(), 0)
+        .map_err(|_| McuError::ROM_DOT_RECOVERY_FLASH_WRITE_ERROR)?;
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Caliptra crypto helper: SHA-384 (one-shot CM_SHA command)
+// ---------------------------------------------------------------------------
+
+/// SHA-384 hash output size.
+const SHA384_DIGEST_SIZE: usize = 48;
+
+/// Computes SHA-384 hash by streaming `&[u32]` data parts to Caliptra's
+/// CM_SHA command via `exec_mailbox_req_u32_parts`.  This avoids copying
+/// large buffers (e.g. MLDSA public keys) onto the stack.
+pub(crate) fn cm_sha384(
+    soc_manager: &mut romtime::CaliptraSoC,
+    data_parts: &[&[u32]],
+) -> McuResult<[u8; SHA384_DIGEST_SIZE]> {
+    let total_data_bytes: usize = data_parts.iter().map(|p| p.len() * 4).sum();
+
+    let mut hdr: [u32; core::mem::size_of::<CmShaReqHdr>() / 4] = transmute!(CmShaReqHdr {
+        hdr: MailboxReqHeader::default(),
+        hash_algorithm: CmHashAlgorithm::Sha384.into(),
+        input_size: total_data_bytes as u32,
+    });
+
+    let mut resp32: [u32; core::mem::size_of::<CmShaResp>() / 4] = transmute!(CmShaResp::default());
+
+    if let Err(err) = soc_manager.exec_mailbox_req_u32_parts(
+        CommandId::CM_SHA.into(),
+        &mut hdr,
+        data_parts,
+        &mut resp32,
+    ) {
+        romtime::println!(
+            "[mcu-rom-dot] CM_SHA failed: {}",
+            HexWord(crate::err_code(&err))
+        );
+        return Err(McuError::ROM_DOT_OVERRIDE_CHALLENGE_FAILED);
+    }
+
+    let resp: CmShaResp = transmute!(resp32);
+    let src = resp
+        .hash
+        .get(..SHA384_DIGEST_SIZE)
+        .ok_or(McuError::ROM_DOT_OVERRIDE_CHALLENGE_FAILED)?;
+    let mut hash = [0u8; SHA384_DIGEST_SIZE];
+    for (d, s) in hash.iter_mut().zip(src.iter()) {
+        *d = *s;
+    }
+    Ok(hash)
+}
+
+/// Generates random bytes using Caliptra's CM_RANDOM_GENERATE command.
+pub(crate) fn cm_random_generate(soc_manager: &mut romtime::CaliptraSoC) -> McuResult<[u8; 48]> {
+    #[repr(C)]
+    #[derive(Default, IntoBytes, FromBytes, KnownLayout, Immutable)]
+    struct CmRandomReq {
+        hdr: MailboxReqHeader,
+        size: u32,
+    }
+
+    // Response: varsize header (chksum + fips_status + data_len) + 48 bytes data
+    #[repr(C)]
+    #[derive(IntoBytes, FromBytes, KnownLayout, Immutable)]
+    struct CmRandomResp {
+        chksum: u32,
+        fips_status: u32,
+        data_len: u32,
+        data: [u8; 48],
+    }
+
+    impl Default for CmRandomResp {
+        fn default() -> Self {
+            Self {
+                chksum: 0,
+                fips_status: 0,
+                data_len: 0,
+                data: [0u8; 48],
+            }
+        }
+    }
+
+    let req = CmRandomReq {
+        size: 48,
+        ..Default::default()
+    };
+    let mut req32: [u32; core::mem::size_of::<CmRandomReq>() / 4] = transmute!(req);
+    let mut resp32: [u32; core::mem::size_of::<CmRandomResp>() / 4] =
+        transmute!(CmRandomResp::default());
+
+    if let Err(err) = soc_manager.exec_mailbox_req_u32(
+        CommandId::CM_RANDOM_GENERATE.into(),
+        &mut req32,
+        &mut resp32,
+    ) {
+        romtime::println!(
+            "[mcu-rom-dot] CM_RANDOM_GENERATE failed: {}",
+            HexWord(crate::err_code(&err))
+        );
+        return Err(McuError::ROM_DOT_OVERRIDE_CHALLENGE_FAILED);
+    }
+    let resp: CmRandomResp = transmute!(resp32);
+    Ok(resp.data)
+}
+
+/// Verifies an ECDSA P-384 signature using Caliptra's ECDSA384_SIGNATURE_VERIFY command.
+///
+/// This ROM command takes raw public key coordinates (not a CMK handle).
+pub(crate) fn cm_ecdsa384_verify(
+    soc_manager: &mut romtime::CaliptraSoC,
+    pub_key: &EccP384PublicKey,
+    signature_r: &[u8; 48],
+    signature_s: &[u8; 48],
+    hash: &[u8; 48],
+) -> McuResult<()> {
+    let mut pub_key_x = [0u8; 48];
+    let mut pub_key_y = [0u8; 48];
+    let mut i = 0;
+    while i < 12 {
+        let xb = pub_key.x[i].to_le_bytes();
+        let yb = pub_key.y[i].to_le_bytes();
+        let mut j = 0;
+        while j < 4 {
+            pub_key_x[i * 4 + j] = xb[j];
+            pub_key_y[i * 4 + j] = yb[j];
+            j += 1;
+        }
+        i += 1;
+    }
+    let req = EcdsaVerifyReq {
+        hdr: Default::default(),
+        pub_key_x,
+        pub_key_y,
+        signature_r: *signature_r,
+        signature_s: *signature_s,
+        hash: *hash,
+    };
+    let mut req32: [u32; core::mem::size_of::<EcdsaVerifyReq>() / 4] = transmute!(req);
+    let mut resp32: [u32; core::mem::size_of::<MailboxRespHeader>() / 4] =
+        transmute!(MailboxRespHeader::default());
+
+    if let Err(err) = soc_manager.exec_mailbox_req_u32(
+        CommandId::ECDSA384_SIGNATURE_VERIFY.into(),
+        &mut req32,
+        &mut resp32,
+    ) {
+        romtime::println!(
+            "[mcu-rom-dot] ECDSA384_SIGNATURE_VERIFY failed: {}",
+            HexWord(crate::err_code(&err))
+        );
+        return Err(McuError::ROM_DOT_OVERRIDE_SIG_VERIFY_FAILED);
+    }
+    Ok(())
+}
+
+/// Verifies an MLDSA87 signature using Caliptra's MLDSA87_SIGNATURE_VERIFY command.
+///
+/// The public key and signature are passed as `&[u32]` slices and streamed
+/// directly to the mailbox to avoid an ~11 KB stack allocation.
+pub(crate) fn cm_mldsa87_verify(
+    soc_manager: &mut romtime::CaliptraSoC,
+    pub_key: &[u32],
+    signature: &[u32],
+    message: &[u32],
+) -> McuResult<()> {
+    if pub_key.len() != MLDSA87_PUB_KEY_SIZE_DWORDS
+        || signature.len() != MLDSA87_SIGNATURE_SIZE_DWORDS
+    {
+        return Err(McuError::ROM_DOT_OVERRIDE_SIG_VERIFY_FAILED);
+    }
+
+    // Build the small parts that live on the stack:
+    //   part 0: pub_key  (borrowed)
+    //   part 1: signature (borrowed)
+    //   part 2: message_size (u32) + message data (u32 words)
+    let mut hdr = [0u32; core::mem::size_of::<MailboxReqHeader>() / 4];
+    let message_bytes = (message.len() * 4) as u32;
+    // message_size word + message data; 64 u32s supports messages up to 252 bytes
+    const MAX_MSG_WORDS: usize = 64;
+    if message.len() > MAX_MSG_WORDS - 1 {
+        return Err(McuError::ROM_DOT_OVERRIDE_SIG_VERIFY_FAILED);
+    }
+    let mut msg_part = [0u32; MAX_MSG_WORDS];
+    msg_part[0] = message_bytes;
+    let mut i = 0;
+    while i < message.len() {
+        msg_part[i + 1] = message[i];
+        i += 1;
+    }
+    let msg_slice: &[u32] = &msg_part[..1 + message.len()];
+
+    let data_parts: &[&[u32]] = &[pub_key, signature, msg_slice];
+    let mut resp32: [u32; core::mem::size_of::<MailboxRespHeader>() / 4] =
+        transmute!(MailboxRespHeader::default());
+
+    if let Err(err) = soc_manager.exec_mailbox_req_u32_parts(
+        CommandId::MLDSA87_SIGNATURE_VERIFY.into(),
+        &mut hdr,
+        data_parts,
+        &mut resp32,
+    ) {
+        romtime::println!(
+            "[mcu-rom-dot] MLDSA87_SIGNATURE_VERIFY failed: {}",
+            HexWord(crate::err_code(&err))
+        );
+        return Err(McuError::ROM_DOT_OVERRIDE_SIG_VERIFY_FAILED);
+    }
+    Ok(())
+}
+
+/// Trait for providing a backup DOT blob during recovery.
+///
+/// When a device is in ODD state (locked) but the DOT blob is corrupted,
+/// a recovery agent (e.g., BMC) can provide a backup DOT blob to restore
+/// the device to a working locked state.
+///
+/// Implementors should retrieve the backup DOT blob from the recovery agent
+/// and return it as raw bytes matching the `DotBlob` layout.
+pub trait DotRecoveryHandler {
+    /// Read a backup DOT blob from the recovery agent.
+    ///
+    /// Returns the raw bytes of a backup DOT blob that will be authenticated
+    /// against the current DOT_EFFECTIVE_KEY before being written to flash.
+    fn read_recovery_blob(&self) -> McuResult<[u8; DOT_BLOB_SIZE]>;
+}
+
+/// A `DotRecoveryHandler` that returns a blob already held in memory.
+/// Used by the I3C services handler where the blob has been fully received
+/// and reassembled before recovery begins.
+pub struct BufferedRecoveryHandler {
+    pub blob: [u8; DOT_BLOB_SIZE],
+}
+
+impl DotRecoveryHandler for BufferedRecoveryHandler {
+    fn read_recovery_blob(&self) -> McuResult<[u8; DOT_BLOB_SIZE]> {
+        Ok(self.blob)
+    }
+}
+
+/// Authenticate a recovery blob and write it to flash.
+///
+/// This is the shared core of DOT_RECOVERY used by both
+/// `dot_recovery_flow` (MCI path) and the I3C services handler.
+pub(crate) fn verify_and_write_recovery_blob(
+    soc_manager: &mut romtime::CaliptraSoC,
+    dot_fuses: &DotFuses,
+    blob_bytes: &[u8; DOT_BLOB_SIZE],
+    dot_flash: &dyn FlashStorage,
+    stable_key_type: CmStableKeyType,
+) -> McuResult<()> {
+    let backup_blob: DotBlob = transmute!(*blob_bytes);
+    let dot_effective_key = cm_derive_stable_key_impl(soc_manager, dot_fuses, stable_key_type)?;
+    verify_dot_blob(soc_manager, &backup_blob, &dot_effective_key)?;
+    dot_flash
+        .write(blob_bytes, 0)
+        .map_err(|_| McuError::ROM_DOT_RECOVERY_FLASH_WRITE_ERROR)?;
+    Ok(())
+}
+
+/// Performs DOT recovery by authenticating a backup blob and writing it to flash.
+///
+/// This implements the DOT_RECOVERY flow from the spec:
+/// 1. Get backup DOT blob from recovery handler
+/// 2. Derive DOT_EFFECTIVE_KEY
+/// 3. Authenticate backup blob via HMAC
+/// 4. Write authenticated blob to flash
+///
+/// After this function returns successfully, the caller should request a
+/// subsystem reset so the next boot will find a valid DOT blob.
+pub fn dot_recovery_flow(
+    env: &mut RomEnv,
+    dot_fuses: &DotFuses,
+    recovery_handler: &dyn DotRecoveryHandler,
+    dot_flash: &dyn FlashStorage,
+    stable_key_type: CmStableKeyType,
+) -> McuResult<()> {
+    romtime::println!("[mcu-rom-dot] Starting DOT recovery flow");
+    env.mci
+        .set_flow_checkpoint(McuRomBootStatus::DotRecoveryStarted.into());
+
+    let backup_blob_bytes = recovery_handler.read_recovery_blob()?;
+
+    verify_and_write_recovery_blob(
+        &mut env.soc_manager,
+        dot_fuses,
+        &backup_blob_bytes,
+        dot_flash,
+        stable_key_type,
+    )
+    .inspect_err(|_e| {
+        env.mci
+            .set_flow_checkpoint(McuRomBootStatus::DotRecoveryFailed.into());
+    })?;
+
+    romtime::println!("[mcu-rom-dot] DOT recovery complete, reset required");
+    env.mci
+        .set_flow_checkpoint(McuRomBootStatus::DotRecoveryComplete.into());
+
+    Ok(())
+}
+
+/// Performs DOT override with challenge/response authentication.
+///
+/// This implements the DOT_OVERRIDE flow:
+/// 1. Wait for override request from BMC (includes VendorKey public keys: ECC + MLDSA)
+/// 2. Verify device is in ODD (locked) state
+/// 3. Verify vendor public key hash matches vendor recovery PK hash in OTP fuses
+/// 4. Generate random challenge and send to BMC
+/// 5. Receive and verify ECDSA P-384 and MLDSA-87 signatures over challenge
+/// 6. Burn DOT fuse (n→n+1) to transition to EVEN state
+/// 7. Write a new empty DOT blob (no CAK/LAK) HMAC'd with the new EVEN-state key
+///
+/// After success, the caller should trigger a warm reset.
+pub fn dot_override_challenge_flow(
+    env: &mut RomEnv,
+    dot_fuses: &DotFuses,
+    transport: &dyn RecoveryTransport,
+    dot_flash: &dyn FlashStorage,
+    stable_key_type: CmStableKeyType,
+) -> McuResult<()> {
+    romtime::println!("[mcu-rom-dot] Starting DOT override flow");
+    env.mci
+        .set_flow_checkpoint(McuRomBootStatus::DotOverrideStarted.into());
+
+    if !dot_fuses.is_locked() {
+        env.mci
+            .set_flow_checkpoint(McuRomBootStatus::DotOverrideFailed.into());
+        return Err(McuError::ROM_DOT_OVERRIDE_NOT_LOCKED);
+    }
+
+    let recovery_pk_hash = match dot_fuses.recovery_pk_hash.as_ref() {
+        Some(hash) => hash,
+        None => {
+            env.mci
+                .set_flow_checkpoint(McuRomBootStatus::DotOverrideFailed.into());
+            return Err(McuError::ROM_DOT_OVERRIDE_NO_RECOVERY_PK_HASH);
+        }
+    };
+
+    let request = transport.wait_for_override_request().inspect_err(|_e| {
+        env.mci
+            .set_flow_checkpoint(McuRomBootStatus::DotOverrideFailed.into());
+    })?;
+
+    // Verify vendor public key hash matches recovery PK hash in OTP fuses (ECC + MLDSA)
+    let ecc_key_u32 = ecc_key_as_u32_slice(&request.ecc_pub_key);
+    let computed_hash = cm_sha384(&mut env.soc_manager, &[ecc_key_u32, request.mldsa_pub_key])
+        .inspect_err(|_e| {
+            env.mci
+                .set_flow_checkpoint(McuRomBootStatus::DotOverrideFailed.into());
+        })?;
+
+    let fuse_hash_bytes: [u8; 48] = transmute!(recovery_pk_hash.0);
+    if !constant_time_eq::constant_time_eq(&computed_hash, &fuse_hash_bytes) {
+        romtime::println!("[mcu-rom-dot] Vendor recovery PK hash mismatch");
+        env.mci
+            .set_flow_checkpoint(McuRomBootStatus::DotOverrideFailed.into());
+        return Err(McuError::ROM_DOT_OVERRIDE_PK_HASH_MISMATCH);
+    }
+
+    // Generate and send challenge
+    let challenge = cm_random_generate(&mut env.soc_manager).inspect_err(|_e| {
+        env.mci
+            .set_flow_checkpoint(McuRomBootStatus::DotOverrideFailed.into());
+    })?;
+
+    transport.send_challenge(&challenge).inspect_err(|_e| {
+        env.mci
+            .set_flow_checkpoint(McuRomBootStatus::DotOverrideFailed.into());
+    })?;
+    env.mci
+        .set_flow_checkpoint(McuRomBootStatus::DotOverrideChallengeSent.into());
+
+    // Receive and verify signed response
+    let response = transport.receive_override_response().inspect_err(|_e| {
+        env.mci
+            .set_flow_checkpoint(McuRomBootStatus::DotOverrideFailed.into());
+    })?;
+
+    let auth = OverrideAuth {
+        ecc_key: &response.ecc_pub_key,
+        ecc_sig_r: &response.ecc_signature_r,
+        ecc_sig_s: &response.ecc_signature_s,
+        mldsa_pub_key: response.mldsa_pub_key,
+        mldsa_signature: response.mldsa_signature,
+        challenge: &challenge,
+    };
+
+    verify_override_response(&mut env.soc_manager, recovery_pk_hash, &auth).inspect_err(|_e| {
+        env.mci
+            .set_flow_checkpoint(McuRomBootStatus::DotOverrideFailed.into());
+    })?;
+
+    env.mci
+        .set_flow_checkpoint(McuRomBootStatus::DotOverrideSigVerified.into());
+
+    // Burn DOT fuse and write empty blob
+    apply_override(
+        &mut env.soc_manager,
+        &env.otp,
+        dot_fuses,
+        dot_flash,
+        stable_key_type,
+    )
+    .inspect_err(|_e| {
+        env.mci
+            .set_flow_checkpoint(McuRomBootStatus::DotOverrideFailed.into());
+    })?;
+
+    env.mci
+        .set_flow_checkpoint(McuRomBootStatus::DotOverrideBlobWritten.into());
+
+    romtime::println!("[mcu-rom-dot] DOT override complete");
+    env.mci
+        .set_flow_checkpoint(McuRomBootStatus::DotOverrideComplete.into());
 
     Ok(())
 }
@@ -667,8 +1158,8 @@ fn create_and_seal_dot_blob(
         hmac: [0u32; 16],
     };
 
-    // Compute HMAC over the blob fields (excluding the hmac tag).
-    let hmac_tag = cm_hmac(env, &dot_effective_key.0, blob.fields.as_bytes())?;
+    // Compute HMAC over the blob fields (everything except the HMAC tag).
+    let hmac_tag = cm_hmac(&mut env.soc_manager, &dot_effective_key.0, &blob.fields)?;
     blob.hmac = hmac_tag;
 
     // Write the sealed DOT blob to flash.
@@ -938,510 +1429,129 @@ pub fn process_fw_manifest_dot_commands(
     Ok(())
 }
 
-#[repr(C)]
-#[derive(Clone, Debug, FromBytes, IntoBytes, Immutable, KnownLayout)]
-pub struct EccP384PublicKey {
-    pub x: [u32; 12],
-    pub y: [u32; 12],
+/// Policy for handling errors from a [`DotLockedRecoveryHandler`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DotLockedRecoveryErrorPolicy {
+    /// On error, skip this handler and try the next one.
+    Continue,
+    /// Retry up to N times, then fall through to the next handler.
+    Retry(core::num::NonZeroU8),
 }
 
-pub const MLDSA87_PUB_KEY_SIZE_DWORDS: usize = 2592 / 4;
-pub const MLDSA87_SIGNATURE_SIZE_DWORDS: usize = 4628 / 4;
-
-/// Override request containing vendor public keys for verification.
-pub struct OverrideRequest<'a> {
-    pub ecc_pub_key: EccP384PublicKey,
-    pub mldsa_pub_key: &'a [u32; MLDSA87_PUB_KEY_SIZE_DWORDS],
-}
-
-/// Override challenge response containing vendor public keys and dual signatures over the challenge.
-pub struct OverrideChallengeResponse<'a> {
-    pub ecc_pub_key: EccP384PublicKey,
-    pub ecc_signature_r: [u8; 48],
-    pub ecc_signature_s: [u8; 48],
-    pub mldsa_signature: &'a [u32; MLDSA87_SIGNATURE_SIZE_DWORDS],
-    pub mldsa_pub_key: &'a [u32; MLDSA87_PUB_KEY_SIZE_DWORDS],
-}
-
-/// Transport trait for DOT recovery and override communication.
+/// A handler that attempts to recover from DOT locked state.
 ///
-/// Abstracts the communication channel between ROM and the BMC for
-/// DOT_OVERRIDE operations. Implementations may use MCI mailbox 0,
-/// a SoC-specific mailbox, or I3C.
-pub trait RecoveryTransport {
-    /// Wait for a DOT_UNLOCK_CHALLENGE request from the BMC.
-    ///
-    /// Returns the VendorKey public keys that will be used for signature verification.
-    fn wait_for_override_request(&self) -> McuResult<OverrideRequest<'_>>;
-
-    /// Send a challenge nonce to the BMC.
-    fn send_challenge(&self, challenge: &[u8; 48]) -> McuResult<()>;
-
-    /// Receive the signed challenge response from the BMC.
-    fn receive_override_response(&self) -> McuResult<OverrideChallengeResponse<'_>>;
+/// Integrators provide an ordered list of these handlers so the ROM tries
+/// each recovery mechanism in the integrator-chosen order.  If a handler
+/// succeeds it should write the DOT blob to flash and return `Ok(())`;
+/// the caller will then trigger a warm reset.
+pub trait DotLockedRecoveryHandler {
+    /// Attempt to recover from DOT locked state.
+    fn attempt(&self, env: &mut RomEnv, ctx: &DotLockedRecoveryContext<'_>) -> McuResult<()>;
 }
 
-// ---------------------------------------------------------------------------
-// Caliptra crypto helper: SHA-384 (one-shot CM_SHA command)
-// ---------------------------------------------------------------------------
-
-/// SHA-384 hash output size.
-const SHA384_DIGEST_SIZE: usize = 48;
-
-/// Computes SHA-384 hash by streaming `&[u32]` data parts to Caliptra's
-/// CM_SHA command via `exec_mailbox_req_u32_parts`.  This avoids copying
-/// large buffers (e.g. MLDSA public keys) onto the stack.
-fn cm_sha384(env: &mut RomEnv, data_parts: &[&[u32]]) -> McuResult<[u8; SHA384_DIGEST_SIZE]> {
-    let total_data_bytes: usize = data_parts.iter().map(|p| p.len() * 4).sum();
-
-    let mut hdr: [u32; core::mem::size_of::<CmShaReqHdr>() / 4] = transmute!(CmShaReqHdr {
-        hdr: MailboxReqHeader::default(),
-        hash_algorithm: CmHashAlgorithm::Sha384.into(),
-        input_size: total_data_bytes as u32,
-    });
-
-    let mut resp32: [u32; core::mem::size_of::<CmShaResp>() / 4] = transmute!(CmShaResp::default());
-
-    if let Err(err) = env.soc_manager.exec_mailbox_req_u32_parts(
-        CommandId::CM_SHA.into(),
-        &mut hdr,
-        data_parts,
-        &mut resp32,
-    ) {
-        romtime::println!(
-            "[mcu-rom-dot] CM_SHA failed: {}",
-            HexWord(crate::err_code(&err))
-        );
-        return Err(McuError::ROM_DOT_OVERRIDE_CHALLENGE_FAILED);
-    }
-
-    let resp: CmShaResp = transmute!(resp32);
-    let src = resp
-        .hash
-        .get(..SHA384_DIGEST_SIZE)
-        .ok_or(McuError::ROM_DOT_OVERRIDE_CHALLENGE_FAILED)?;
-    let mut hash = [0u8; SHA384_DIGEST_SIZE];
-    for (d, s) in hash.iter_mut().zip(src.iter()) {
-        *d = *s;
-    }
-    Ok(hash)
+/// Shared context passed to every [`DotLockedRecoveryHandler`].
+pub struct DotLockedRecoveryContext<'a> {
+    pub dot_fuses: &'a DotFuses,
+    pub dot_flash: &'a dyn FlashStorage,
+    pub key_type: CmStableKeyType,
 }
 
-/// Generates random bytes using Caliptra's CM_RANDOM_GENERATE command.
-fn cm_random_generate(env: &mut RomEnv) -> McuResult<[u8; 48]> {
-    #[repr(C)]
-    #[derive(Default, IntoBytes, FromBytes, KnownLayout, Immutable)]
-    struct CmRandomReq {
-        hdr: MailboxReqHeader,
-        size: u32,
+/// A [`DotLockedRecoveryHandler`] paired with its error-handling policy.
+pub struct DotLockedRecoveryEntry<'a> {
+    pub handler: &'a dyn DotLockedRecoveryHandler,
+    pub policy: DotLockedRecoveryErrorPolicy,
+}
+
+/// Manages a sequence of [`DotLockedRecoveryEntry`]s, iterating through them
+/// according to each entry's error policy.
+pub struct DotLockedRecoveryManager<'a> {
+    entries: &'a [DotLockedRecoveryEntry<'a>],
+    current: usize,
+    retries: u8,
+}
+
+impl<'a> DotLockedRecoveryManager<'a> {
+    pub fn new(entries: &'a [DotLockedRecoveryEntry<'a>]) -> Self {
+        Self {
+            entries,
+            current: 0,
+            retries: 0,
+        }
     }
 
-    // Response: varsize header (chksum + fips_status + data_len) + 48 bytes data
-    #[repr(C)]
-    #[derive(IntoBytes, FromBytes, KnownLayout, Immutable)]
-    struct CmRandomResp {
-        chksum: u32,
-        fips_status: u32,
-        data_len: u32,
-        data: [u8; 48],
-    }
-
-    impl Default for CmRandomResp {
-        fn default() -> Self {
-            Self {
-                chksum: 0,
-                fips_status: 0,
-                data_len: 0,
-                data: [0u8; 48],
+    /// Run through the handler chain.  Stops and returns `Ok(())` on the
+    /// first successful handler.  Returns the last error if all are
+    /// exhausted.
+    pub fn run(&mut self, env: &mut RomEnv, ctx: &DotLockedRecoveryContext<'_>) -> McuResult<()> {
+        let mut last_err = McuError::ROM_COLD_BOOT_DOT_ERROR;
+        while self.current < self.entries.len() {
+            let entry = &self.entries[self.current];
+            match entry.handler.attempt(env, ctx) {
+                Ok(()) => return Ok(()),
+                Err(err) => {
+                    last_err = err;
+                    romtime::println!(
+                        "[mcu-rom-dot] locked-state handler failed: {}",
+                        HexWord(err.into())
+                    );
+                    self.retries += 1;
+                    match entry.policy {
+                        DotLockedRecoveryErrorPolicy::Continue => {
+                            self.current += 1;
+                            self.retries = 0;
+                        }
+                        DotLockedRecoveryErrorPolicy::Retry(n) => {
+                            if self.retries >= n.get() {
+                                self.current += 1;
+                                self.retries = 0;
+                            }
+                        }
+                    }
+                }
             }
         }
+        Err(last_err)
     }
-
-    let req = CmRandomReq {
-        size: 48,
-        ..Default::default()
-    };
-    let mut req32: [u32; core::mem::size_of::<CmRandomReq>() / 4] = transmute!(req);
-    let mut resp32: [u32; core::mem::size_of::<CmRandomResp>() / 4] =
-        transmute!(CmRandomResp::default());
-
-    if let Err(err) = env.soc_manager.exec_mailbox_req_u32(
-        CommandId::CM_RANDOM_GENERATE.into(),
-        &mut req32,
-        &mut resp32,
-    ) {
-        romtime::println!(
-            "[mcu-rom-dot] CM_RANDOM_GENERATE failed: {}",
-            HexWord(crate::err_code(&err))
-        );
-        return Err(McuError::ROM_DOT_OVERRIDE_CHALLENGE_FAILED);
-    }
-    let resp: CmRandomResp = transmute!(resp32);
-    Ok(resp.data)
 }
 
-/// Verifies an ECDSA P-384 signature using Caliptra's ECDSA384_SIGNATURE_VERIFY command.
-///
-/// This ROM command takes raw public key coordinates (not a CMK handle).
-fn cm_ecdsa384_verify(
-    env: &mut RomEnv,
-    pub_key: &EccP384PublicKey,
-    signature_r: &[u8; 48],
-    signature_s: &[u8; 48],
-    hash: &[u8; 48],
-) -> McuResult<()> {
-    let mut pub_key_x = [0u8; 48];
-    let mut pub_key_y = [0u8; 48];
-    let mut i = 0;
-    while i < 12 {
-        let xb = pub_key.x[i].to_le_bytes();
-        let yb = pub_key.y[i].to_le_bytes();
-        let mut j = 0;
-        while j < 4 {
-            pub_key_x[i * 4 + j] = xb[j];
-            pub_key_y[i * 4 + j] = yb[j];
-            j += 1;
+/// A [`DotLockedRecoveryHandler`] that recovers via a backup DOT blob
+/// obtained from a [`DotRecoveryHandler`].
+pub struct BackupBlobRecoveryHandler<'a> {
+    pub recovery_handler: &'a dyn DotRecoveryHandler,
+}
+
+impl DotLockedRecoveryHandler for BackupBlobRecoveryHandler<'_> {
+    fn attempt(&self, env: &mut RomEnv, ctx: &DotLockedRecoveryContext<'_>) -> McuResult<()> {
+        romtime::println!("[mcu-rom-dot] Attempting backup-blob recovery");
+        dot_recovery_flow(
+            env,
+            ctx.dot_fuses,
+            self.recovery_handler,
+            ctx.dot_flash,
+            ctx.key_type,
+        )
+    }
+}
+
+/// A [`DotLockedRecoveryHandler`] that recovers via the DOT override
+/// challenge/response protocol using a [`RecoveryTransport`].
+pub struct OverrideChallengeRecoveryHandler<'a> {
+    pub transport: &'a dyn crate::RecoveryTransport,
+    pub wdt_timeout: u64,
+}
+
+impl DotLockedRecoveryHandler for OverrideChallengeRecoveryHandler<'_> {
+    fn attempt(&self, env: &mut RomEnv, ctx: &DotLockedRecoveryContext<'_>) -> McuResult<()> {
+        if self.wdt_timeout > 0 {
+            env.mci.configure_wdt(self.wdt_timeout, 1);
         }
-        i += 1;
+        romtime::println!("[mcu-rom-dot] Attempting override challenge/response");
+        dot_override_challenge_flow(
+            env,
+            ctx.dot_fuses,
+            self.transport,
+            ctx.dot_flash,
+            ctx.key_type,
+        )
     }
-    let req = EcdsaVerifyReq {
-        hdr: Default::default(),
-        pub_key_x,
-        pub_key_y,
-        signature_r: *signature_r,
-        signature_s: *signature_s,
-        hash: *hash,
-    };
-    let mut req32: [u32; core::mem::size_of::<EcdsaVerifyReq>() / 4] = transmute!(req);
-    let mut resp32: [u32; core::mem::size_of::<MailboxRespHeader>() / 4] =
-        transmute!(MailboxRespHeader::default());
-
-    if let Err(err) = env.soc_manager.exec_mailbox_req_u32(
-        CommandId::ECDSA384_SIGNATURE_VERIFY.into(),
-        &mut req32,
-        &mut resp32,
-    ) {
-        romtime::println!(
-            "[mcu-rom-dot] ECDSA384_SIGNATURE_VERIFY failed: {}",
-            HexWord(crate::err_code(&err))
-        );
-        return Err(McuError::ROM_DOT_OVERRIDE_SIG_VERIFY_FAILED);
-    }
-    Ok(())
-}
-
-/// Verifies an MLDSA87 signature using Caliptra's MLDSA87_SIGNATURE_VERIFY command.
-///
-/// The public key and signature are passed as `&[u32]` slices and streamed
-/// directly to the mailbox to avoid an ~11 KB stack allocation.
-fn cm_mldsa87_verify(
-    env: &mut RomEnv,
-    pub_key: &[u32],
-    signature: &[u32],
-    message: &[u32],
-) -> McuResult<()> {
-    if pub_key.len() != MLDSA87_PUB_KEY_SIZE_DWORDS
-        || signature.len() != MLDSA87_SIGNATURE_SIZE_DWORDS
-    {
-        return Err(McuError::ROM_DOT_OVERRIDE_SIG_VERIFY_FAILED);
-    }
-
-    // Build the small parts that live on the stack:
-    //   part 0: pub_key  (borrowed)
-    //   part 1: signature (borrowed)
-    //   part 2: message_size (u32) + message data (u32 words)
-    let mut hdr = [0u32; core::mem::size_of::<MailboxReqHeader>() / 4];
-    let message_bytes = (message.len() * 4) as u32;
-    // message_size word + message data; 64 u32s supports messages up to 252 bytes
-    const MAX_MSG_WORDS: usize = 64;
-    if message.len() > MAX_MSG_WORDS - 1 {
-        return Err(McuError::ROM_DOT_OVERRIDE_SIG_VERIFY_FAILED);
-    }
-    let mut msg_part = [0u32; MAX_MSG_WORDS];
-    msg_part[0] = message_bytes;
-    let mut i = 0;
-    while i < message.len() {
-        msg_part[i + 1] = message[i];
-        i += 1;
-    }
-    let msg_slice: &[u32] = &msg_part[..1 + message.len()];
-
-    let data_parts: &[&[u32]] = &[pub_key, signature, msg_slice];
-    let mut resp32: [u32; core::mem::size_of::<MailboxRespHeader>() / 4] =
-        transmute!(MailboxRespHeader::default());
-
-    if let Err(err) = env.soc_manager.exec_mailbox_req_u32_parts(
-        CommandId::MLDSA87_SIGNATURE_VERIFY.into(),
-        &mut hdr,
-        data_parts,
-        &mut resp32,
-    ) {
-        romtime::println!(
-            "[mcu-rom-dot] MLDSA87_SIGNATURE_VERIFY failed: {}",
-            HexWord(crate::err_code(&err))
-        );
-        return Err(McuError::ROM_DOT_OVERRIDE_SIG_VERIFY_FAILED);
-    }
-    Ok(())
-}
-
-/// Trait for providing a backup DOT blob during recovery.
-///
-/// When a device is in ODD state (locked) but the DOT blob is corrupted,
-/// a recovery agent (e.g., BMC) can provide a backup DOT blob to restore
-/// the device to a working locked state.
-///
-/// Implementors should retrieve the backup DOT blob from the recovery agent
-/// and return it as raw bytes matching the `DotBlob` layout.
-pub trait DotRecoveryHandler {
-    /// Read a backup DOT blob from the recovery agent.
-    ///
-    /// Returns the raw bytes of a backup DOT blob that will be authenticated
-    /// against the current DOT_EFFECTIVE_KEY before being written to flash.
-    fn read_recovery_blob(&self) -> McuResult<[u8; DOT_BLOB_SIZE]>;
-}
-
-/// Performs DOT recovery by authenticating a backup blob and writing it to flash.
-///
-/// This implements the DOT_RECOVERY flow from the spec:
-/// 1. Get backup DOT blob from recovery handler
-/// 2. Derive DOT_EFFECTIVE_KEY
-/// 3. Authenticate backup blob via HMAC
-/// 4. Write authenticated blob to flash
-///
-/// After this function returns successfully, the caller should request a
-/// subsystem reset so the next boot will find a valid DOT blob.
-pub fn dot_recovery_flow(
-    env: &mut RomEnv,
-    dot_fuses: &DotFuses,
-    recovery_handler: &dyn DotRecoveryHandler,
-    dot_flash: &dyn FlashStorage,
-    stable_key_type: CmStableKeyType,
-) -> McuResult<()> {
-    romtime::println!("[mcu-rom-dot] Starting DOT recovery flow");
-    env.mci
-        .set_flow_checkpoint(McuRomBootStatus::DotRecoveryStarted.into());
-
-    // Get backup DOT blob from recovery agent
-    let backup_blob_bytes = recovery_handler.read_recovery_blob()?;
-    let backup_blob: DotBlob = transmute!(backup_blob_bytes);
-
-    // Derive DOT_EFFECTIVE_KEY for the current fuse state
-    let dot_effective_key = derive_stable_key_flow(env, dot_fuses, stable_key_type)?;
-
-    // Authenticate the backup blob with HMAC
-    if let Err(err) = verify_dot_blob(env, &backup_blob, &dot_effective_key) {
-        romtime::println!("[mcu-rom-dot] Recovery blob authentication failed");
-        env.mci
-            .set_flow_checkpoint(McuRomBootStatus::DotRecoveryFailed.into());
-        return Err(err);
-    }
-    romtime::println!("[mcu-rom-dot] Recovery blob authenticated successfully");
-    env.mci
-        .set_flow_checkpoint(McuRomBootStatus::DotRecoveryBlobAuthenticated.into());
-
-    // Write authenticated blob to flash
-    if let Err(err) = dot_flash.write(&backup_blob_bytes, 0) {
-        romtime::println!(
-            "[mcu-rom-dot] Failed to write recovery blob to flash: {}",
-            HexWord(usize::from(err) as u32)
-        );
-        env.mci
-            .set_flow_checkpoint(McuRomBootStatus::DotRecoveryFailed.into());
-        return Err(McuError::ROM_DOT_RECOVERY_FLASH_WRITE_ERROR);
-    }
-    romtime::println!("[mcu-rom-dot] Recovery blob written to flash");
-    env.mci
-        .set_flow_checkpoint(McuRomBootStatus::DotRecoveryBlobWritten.into());
-
-    romtime::println!("[mcu-rom-dot] DOT recovery complete, reset required");
-    env.mci
-        .set_flow_checkpoint(McuRomBootStatus::DotRecoveryComplete.into());
-
-    Ok(())
-}
-
-/// Performs DOT override with challenge/response authentication.
-///
-/// This implements the DOT_OVERRIDE flow:
-/// 1. Wait for override request from BMC (includes VendorKey public keys: ECC + MLDSA)
-/// 2. Verify device is in ODD (locked) state
-/// 3. Verify vendor public key hash matches vendor recovery PK hash in OTP fuses
-/// 4. Generate random challenge and send to BMC
-/// 5. Receive and verify ECDSA P-384 and MLDSA-87 signatures over challenge
-/// 6. Burn DOT fuse (n→n+1) to transition to EVEN state
-/// 7. Write a new empty DOT blob (no CAK/LAK) HMAC'd with the new EVEN-state key
-///
-/// After success, the caller should trigger a warm reset.
-pub fn dot_override_challenge_flow(
-    env: &mut RomEnv,
-    dot_fuses: &DotFuses,
-    transport: &dyn RecoveryTransport,
-    dot_flash: &dyn FlashStorage,
-    stable_key_type: CmStableKeyType,
-) -> McuResult<()> {
-    romtime::println!("[mcu-rom-dot] Starting DOT override flow");
-    env.mci
-        .set_flow_checkpoint(McuRomBootStatus::DotOverrideStarted.into());
-
-    if !dot_fuses.is_locked() {
-        env.mci
-            .set_flow_checkpoint(McuRomBootStatus::DotOverrideFailed.into());
-        return Err(McuError::ROM_DOT_OVERRIDE_NOT_LOCKED);
-    }
-
-    let recovery_pk_hash = match dot_fuses.recovery_pk_hash.as_ref() {
-        Some(hash) => hash,
-        None => {
-            env.mci
-                .set_flow_checkpoint(McuRomBootStatus::DotOverrideFailed.into());
-            return Err(McuError::ROM_DOT_OVERRIDE_NO_RECOVERY_PK_HASH);
-        }
-    };
-
-    let request = transport.wait_for_override_request().inspect_err(|_e| {
-        env.mci
-            .set_flow_checkpoint(McuRomBootStatus::DotOverrideFailed.into());
-    })?;
-
-    // Verify vendor public key hash matches recovery PK hash in OTP fuses (ECC + MLDSA)
-    let ecc_key_u32: &[u32] = {
-        let ecc_bytes = request.ecc_pub_key.as_bytes();
-        unsafe {
-            core::slice::from_raw_parts(ecc_bytes.as_ptr() as *const u32, ecc_bytes.len() / 4)
-        }
-    };
-    let computed_hash =
-        cm_sha384(env, &[ecc_key_u32, request.mldsa_pub_key]).inspect_err(|_e| {
-            env.mci
-                .set_flow_checkpoint(McuRomBootStatus::DotOverrideFailed.into());
-        })?;
-
-    let fuse_hash_bytes: [u8; 48] = transmute!(recovery_pk_hash.0);
-    if !constant_time_eq::constant_time_eq(&computed_hash, &fuse_hash_bytes) {
-        romtime::println!("[mcu-rom-dot] Vendor recovery PK hash mismatch");
-        env.mci
-            .set_flow_checkpoint(McuRomBootStatus::DotOverrideFailed.into());
-        return Err(McuError::ROM_DOT_OVERRIDE_PK_HASH_MISMATCH);
-    }
-
-    // Generate and send challenge
-    let challenge = cm_random_generate(env).inspect_err(|_e| {
-        env.mci
-            .set_flow_checkpoint(McuRomBootStatus::DotOverrideFailed.into());
-    })?;
-
-    transport.send_challenge(&challenge).inspect_err(|_e| {
-        env.mci
-            .set_flow_checkpoint(McuRomBootStatus::DotOverrideFailed.into());
-    })?;
-    env.mci
-        .set_flow_checkpoint(McuRomBootStatus::DotOverrideChallengeSent.into());
-
-    // Receive and verify signed response
-    let response = transport.receive_override_response().inspect_err(|_e| {
-        env.mci
-            .set_flow_checkpoint(McuRomBootStatus::DotOverrideFailed.into());
-    })?;
-
-    // Re-verify that the public keys in the response match the OTP hash.
-    // The override response carries fresh copies of both keys; without this
-    // check an attacker could substitute their own keys + matching signatures.
-    let response_ecc_u32: &[u32] = {
-        let ecc_bytes = response.ecc_pub_key.as_bytes();
-        unsafe {
-            core::slice::from_raw_parts(ecc_bytes.as_ptr() as *const u32, ecc_bytes.len() / 4)
-        }
-    };
-    let response_pk_hash = cm_sha384(env, &[response_ecc_u32, response.mldsa_pub_key])
-        .inspect_err(|_e| {
-            env.mci
-                .set_flow_checkpoint(McuRomBootStatus::DotOverrideFailed.into());
-        })?;
-    if !constant_time_eq::constant_time_eq(&response_pk_hash, &fuse_hash_bytes) {
-        romtime::println!("[mcu-rom-dot] Override response PK hash mismatch");
-        env.mci
-            .set_flow_checkpoint(McuRomBootStatus::DotOverrideFailed.into());
-        return Err(McuError::ROM_DOT_OVERRIDE_PK_HASH_MISMATCH);
-    }
-
-    let challenge_u32: [u32; 12] = transmute!(challenge);
-    let challenge_hash = cm_sha384(env, &[&challenge_u32]).inspect_err(|_e| {
-        env.mci
-            .set_flow_checkpoint(McuRomBootStatus::DotOverrideFailed.into());
-    })?;
-
-    if let Err(_e) = cm_ecdsa384_verify(
-        env,
-        &response.ecc_pub_key,
-        &response.ecc_signature_r,
-        &response.ecc_signature_s,
-        &challenge_hash,
-    ) {
-        romtime::println!("[mcu-rom-dot] Override ECDSA signature verification failed");
-        env.mci
-            .set_flow_checkpoint(McuRomBootStatus::DotOverrideFailed.into());
-        return Err(McuError::ROM_DOT_OVERRIDE_SIG_VERIFY_FAILED);
-    }
-
-    romtime::println!("[mcu-rom-dot] ECDSA verified, verifying MLDSA signature...");
-    if let Err(_e) = cm_mldsa87_verify(
-        env,
-        response.mldsa_pub_key,
-        response.mldsa_signature,
-        &challenge_u32,
-    ) {
-        romtime::println!("[mcu-rom-dot] Override MLDSA signature verification failed");
-        env.mci
-            .set_flow_checkpoint(McuRomBootStatus::DotOverrideFailed.into());
-        return Err(McuError::ROM_DOT_OVERRIDE_SIG_VERIFY_FAILED);
-    }
-
-    env.mci
-        .set_flow_checkpoint(McuRomBootStatus::DotOverrideSigVerified.into());
-
-    // Burn DOT fuse (n→n+1) to transition ODD→EVEN
-    if let Err(e) = burn_dot_lock_fuse(&env.otp, dot_fuses) {
-        env.mci
-            .set_flow_checkpoint(McuRomBootStatus::DotOverrideFailed.into());
-        return Err(e);
-    }
-    env.mci
-        .set_flow_checkpoint(McuRomBootStatus::DotOverrideFuseBurned.into());
-
-    // Write a new empty DOT blob HMAC'd with the EVEN-state key.
-    // The fuse has been burned so the device is now EVEN (unlocked). Derive
-    // the key that the next boot will use to verify this blob.
-    let even_fuses = DotFuses {
-        enabled: dot_fuses.enabled,
-        burned: dot_fuses.burned + 1,
-        total: dot_fuses.total,
-        recovery_pk_hash: dot_fuses.recovery_pk_hash.clone(),
-    };
-    let even_key = derive_stable_key_flow(env, &even_fuses, stable_key_type)?;
-
-    let mut new_blob = DotBlob {
-        fields: DotBlobFields::default(),
-        hmac: [0u32; 16],
-    };
-    new_blob.fields.version = 1;
-
-    // Step 7: Compute HMAC over blob data (everything except the HMAC field)
-    romtime::println!("[mcu-rom-dot] Computing HMAC...");
-    let hmac = cm_hmac(env, &even_key.0, new_blob.fields.as_bytes())?;
-    new_blob.hmac = hmac;
-
-    if let Err(_err) = dot_flash.write(new_blob.as_bytes(), 0) {
-        env.mci
-            .set_flow_checkpoint(McuRomBootStatus::DotOverrideFailed.into());
-        return Err(McuError::ROM_DOT_RECOVERY_FLASH_WRITE_ERROR);
-    }
-    env.mci
-        .set_flow_checkpoint(McuRomBootStatus::DotOverrideBlobWritten.into());
-
-    romtime::println!("[mcu-rom-dot] DOT override complete");
-    env.mci
-        .set_flow_checkpoint(McuRomBootStatus::DotOverrideComplete.into());
-
-    Ok(())
 }

--- a/rom/src/fw_hitless_update.rs
+++ b/rom/src/fw_hitless_update.rs
@@ -14,33 +14,17 @@ Abstract:
 
 #![allow(clippy::empty_loop)]
 
-#[cfg(any(
-    not(feature = "test-force-hitless-update"),
-    all(target_arch = "riscv32", feature = "fw-manifest-dot")
-))]
-use crate::fatal_error;
-#[cfg(target_arch = "riscv32")]
-use crate::MCU_MEMORY_MAP;
-use crate::{BootFlow, RomEnv, RomParameters};
-#[cfg(not(feature = "test-force-hitless-update"))]
-use caliptra_api::{mailbox::MailboxRespHeader, CaliptraApiError};
-use core::fmt::Write;
-#[cfg(not(feature = "test-force-hitless-update"))]
-use mcu_error::McuError;
-#[cfg(any(
-    all(target_arch = "riscv32", feature = "fw-manifest-dot"),
-    not(feature = "test-force-hitless-update")
-))]
-use romtime::HexWord;
-#[cfg(target_arch = "riscv32")]
-use romtime::McuBootMilestones;
-#[cfg(all(target_arch = "riscv32", feature = "fw-manifest-dot"))]
-use romtime::McuRomBootStatus;
-#[cfg(all(target_arch = "riscv32", feature = "fw-manifest-dot"))]
-use zerocopy::FromBytes;
-
 #[cfg(all(target_arch = "riscv32", feature = "fw-manifest-dot"))]
 use crate::device_ownership_transfer;
+#[cfg(target_arch = "riscv32")]
+use crate::MCU_MEMORY_MAP;
+use crate::{fatal_error, BootFlow, RomEnv, RomParameters};
+use caliptra_api::{mailbox::MailboxRespHeader, CaliptraApiError};
+use core::fmt::Write;
+use mcu_error::McuError;
+use romtime::HexWord;
+#[cfg(all(target_arch = "riscv32", feature = "fw-manifest-dot"))]
+use zerocopy::FromBytes;
 
 pub struct FwHitlessUpdate {}
 
@@ -53,7 +37,10 @@ impl BootFlow for FwHitlessUpdate {
         let soc_manager = &mut env.soc_manager;
         let soc = &env.soc;
 
-        // Release mailbox from activate command before device reboot
+        // Release mailbox from activate command before device reboot.
+        // Skipped under the test-force-hitless-update integration test, which
+        // synthesizes the hitless reset without going through the usual
+        // PLDM activate flow, so the mailbox is not in the expected state.
         #[cfg(not(feature = "test-force-hitless-update"))]
         if let Err(err) = soc_manager.finish_mailbox_resp(
             core::mem::size_of::<MailboxRespHeader>(),
@@ -112,7 +99,7 @@ impl BootFlow for FwHitlessUpdate {
                         firmware_offset += manifest_size as u32;
 
                         env.mci.set_flow_checkpoint(
-                            McuRomBootStatus::FwManifestDotProcessingStarted.into(),
+                            romtime::McuRomBootStatus::FwManifestDotProcessingStarted.into(),
                         );
                         if let Err(err) =
                             device_ownership_transfer::process_fw_manifest_dot_commands(
@@ -128,14 +115,14 @@ impl BootFlow for FwHitlessUpdate {
                             fatal_error(err);
                         }
                         env.mci.set_flow_checkpoint(
-                            McuRomBootStatus::FwManifestDotProcessingComplete.into(),
+                            romtime::McuRomBootStatus::FwManifestDotProcessingComplete.into(),
                         );
                     }
                 }
             }
 
             env.mci
-                .set_flow_milestone(McuBootMilestones::FIRMWARE_BOOT_FLOW_COMPLETE.into());
+                .set_flow_milestone(romtime::McuBootMilestones::FIRMWARE_BOOT_FLOW_COMPLETE.into());
 
             let firmware_entry = MCU_MEMORY_MAP.sram_offset + firmware_offset;
             core::arch::asm!(

--- a/rom/src/i3c_mailbox.rs
+++ b/rom/src/i3c_mailbox.rs
@@ -11,60 +11,142 @@ const MDB_SERVICES: u8 = 0x1F;
 
 /// Built-in command IDs.
 const CMD_PING: u8 = 0x00;
+const CMD_DOT_STATUS: u8 = 0x01;
+const CMD_DOT_RECOVERY: u8 = 0x02;
+const CMD_DOT_UNLOCK_CHALLENGE: u8 = 0x03;
+const CMD_DOT_OVERRIDE: u8 = 0x04;
 
 /// Status codes.
 const STATUS_SUCCESS: u8 = 0x00;
 const STATUS_INVALID_CMD: u8 = 0x01;
+const STATUS_INVALID_PAYLOAD: u8 = 0x02;
+const STATUS_ERROR: u8 = 0x03;
 const STATUS_AWAITING: u8 = 0x80;
 
 /// Maximum number of poll iterations before giving up.
 /// At ~200 MHz AXI clock this gives roughly 5 seconds of polling.
 const MAX_POLL_ITERATIONS: u32 = 200_000_000;
 
-/// Maximum number of poll iterations waiting for an IBI to complete.
-const MAX_IBI_POLL_ITERATIONS: u32 = 100_000_000;
-
 /// Maximum number of poll iterations for the initial STATUS_AWAITING IBI.
 /// Shorter than the normal IBI timeout since the controller may not be
 /// ready yet. At ~200 MHz this gives roughly 50ms.
 const AWAITING_IBI_POLL_ITERATIONS: u32 = 10_000_000;
 
-/// Maximum RX data words (each word is 4 bytes).
+/// Maximum RX data words for a single I3C private write (limited by TTI FIFO).
 const MAX_RX_WORDS: usize = 64;
+
+/// Packet header size: [cmd, payload_len, seq_num, total_seqs].
+const PACKET_HEADER_SIZE: usize = 4;
+
+// Maximum payload bytes per packet: 248. The TTI RX FIFO is 256 bytes
+// (64 DWORDs). The on-wire size includes a 4-byte header, payload, and
+// 1-byte PEC (CRC-8/SMBus). The chunk must be 4-byte aligned for u32
+// word reassembly. 256 - 4 - 1 = 251, aligned → 248.
+
+/// Maximum reassembled command payload (covers DOT_OVERRIDE at 7412 bytes).
+pub const MAX_REASSEMBLY_BYTES: usize = 8192;
+
+/// Maximum reassembly buffer size in u32 words.
+pub const MAX_REASSEMBLY_WORDS: usize = MAX_REASSEMBLY_BYTES / 4;
 
 /// "PONG" response payload (ASCII, little-endian u32).
 const PONG_PAYLOAD: [u8; 4] = *b"PONG";
 
+/// ECC P-384 public key size: two 48-byte coordinates.
+const ECC_P384_PUB_KEY_SIZE: usize = 96;
+/// ECC P-384 signature size: r (48 bytes) + s (48 bytes).
+const ECC_P384_SIGNATURE_SIZE: usize = 96;
+
 /// Result from dispatching a single command.
-#[allow(dead_code)]
 enum DispatchResult {
     /// Command handled; continue processing.
     Continue,
-    /// Handler requests the mailbox loop to exit normally.
+    /// Handler requests the mailbox loop to exit normally (e.g., after reset).
     Done,
+}
+
+/// DOT context passed to the I3C handler for DOT command processing.
+///
+/// Holds split borrows of individual ROM environment fields rather than
+/// `&mut RomEnv`, so that `enter_i3c_services` can independently borrow
+/// `&Mci` for boot-status checkpoints without creating a duplicate handle.
+pub struct DotContext<'a> {
+    pub soc_manager: &'a mut romtime::CaliptraSoC,
+    pub mci: &'a romtime::Mci,
+    pub otp: &'a romtime::otp::Otp,
+    pub dot_fuses: &'a crate::DotFuses,
+    pub dot_flash: &'a dyn crate::hil::FlashStorage,
+    pub key_type: caliptra_api::mailbox::CmStableKeyType,
+}
+
+/// Tracks state for the multi-message DOT_OVERRIDE challenge/response flow.
+enum OverrideState {
+    /// No override in progress.
+    Idle,
+    /// Challenge has been sent; waiting for DOT_OVERRIDE response.
+    /// Stores the 48-byte challenge so we can verify the signed response.
+    ChallengeSent { challenge: [u8; 48] },
 }
 
 /// Generic I3C mailbox handler.
 ///
 /// The I3C peripheral must already be configured (via `I3c::configure()`)
 /// before constructing this handler.
-pub struct I3cMailboxHandler {
+pub struct I3cMailboxHandler<'a> {
     registers: StaticRef<i3c::regs::I3c>,
     services: crate::I3cServicesModes,
+    /// I3C target address for PEC computation. Uses the dynamic address
+    /// assigned by the controller (via ENTDAA/SETDASA), falling back to
+    /// the static address if no dynamic address has been assigned.
+    pec_addr: u8,
+    dot_ctx: Option<DotContext<'a>>,
+    override_state: OverrideState,
+    /// Word-aligned reassembly buffer (backed by MCI mailbox SRAM).
+    reassembly_buf: &'a mut [u32],
+    /// Number of payload bytes accumulated so far.
+    reassembly_len: usize,
+    reassembly_cmd: u8,
+    reassembly_total: u8,
+    reassembly_next_seq: u8,
 }
 
-impl I3cMailboxHandler {
-    pub fn new(registers: StaticRef<i3c::regs::I3c>, services: crate::I3cServicesModes) -> Self {
+impl<'a> I3cMailboxHandler<'a> {
+    pub fn new(
+        registers: StaticRef<i3c::regs::I3c>,
+        services: crate::I3cServicesModes,
+        target_addr: u8,
+        dot_ctx: Option<DotContext<'a>>,
+        reassembly_buf: &'a mut [u32],
+    ) -> Self {
+        use registers_generated::i3c::bits::StbyCrDeviceAddr;
+        // Prefer the dynamic address assigned by the controller; fall back
+        // to the caller-provided static address.
+        let dev_addr = registers.stdby_ctrl_mode_stby_cr_device_addr.extract();
+        let pec_addr = if dev_addr.is_set(StbyCrDeviceAddr::DynamicAddrValid) {
+            dev_addr.read(StbyCrDeviceAddr::DynamicAddr) as u8
+        } else {
+            target_addr
+        };
         Self {
             registers,
             services,
+            pec_addr,
+            dot_ctx,
+            override_state: OverrideState::Idle,
+            reassembly_buf,
+            reassembly_len: 0,
+            reassembly_cmd: 0,
+            reassembly_total: 0,
+            reassembly_next_seq: 0,
         }
     }
 
     /// Run the mailbox processing loop until completion or timeout.
-    pub fn run(&mut self) -> Result<(), McuError> {
-        romtime::println!("[mcu-rom-i3c-svc] Entering I3C services mode");
-
+    ///
+    /// `on_ready` is invoked after the IBI announcement completes and the
+    /// handler is ready to accept commands. Callers typically use it to set
+    /// an MCI boot status checkpoint.
+    pub fn run(&mut self, on_ready: impl FnOnce()) -> Result<(), McuError> {
         // Announce readiness via IBI. Use a short timeout since the I3C
         // controller may not be ready to acknowledge IBIs yet (e.g. on FPGA
         // it re-enumerates the bus after recovery). If the IBI doesn't
@@ -73,9 +155,13 @@ impl I3cMailboxHandler {
         // incoming private writes (i3c-core: i3c_target_fsm.sv line 565).
         self.send_ibi_with_abort(&[STATUS_AWAITING]);
 
+        on_ready();
+
+        romtime::println!("[mcu-rom-i3c-svc] Ready for commands");
+
         for _ in 0..MAX_POLL_ITERATIONS {
-            if let Some((cmd, rx_buf, data_len)) = self.try_receive_command() {
-                match self.dispatch(cmd, &rx_buf, data_len) {
+            if let Some((cmd, payload_len)) = self.try_receive_reassembled_command() {
+                match self.dispatch(cmd, payload_len) {
                     DispatchResult::Continue => {}
                     DispatchResult::Done => return Ok(()),
                 }
@@ -86,14 +172,28 @@ impl I3cMailboxHandler {
         Err(McuError::ROM_COLD_BOOT_DOT_ERROR)
     }
 
-    /// Dispatch a received command to the appropriate handler.
-    fn dispatch(&self, cmd: u8, _rx_buf: &[u32; MAX_RX_WORDS], _data_len: usize) -> DispatchResult {
+    /// Check whether DOT commands are available.
+    fn dot_enabled(&self) -> bool {
+        self.services
+            .contains(crate::I3cServicesModes::DOT_RECOVERY)
+            && self.dot_ctx.is_some()
+    }
+
+    /// Dispatch a reassembled command. `payload_len` is the number of valid
+    /// bytes in the static reassembly buffer.
+    fn dispatch(&mut self, cmd: u8, payload_len: usize) -> DispatchResult {
         match cmd {
             CMD_PING => {
                 romtime::println!("[mcu-rom-i3c-svc] PING received");
                 self.send_response(STATUS_SUCCESS, &PONG_PAYLOAD);
                 DispatchResult::Continue
             }
+            CMD_DOT_STATUS if self.dot_enabled() => self.handle_dot_status(),
+            CMD_DOT_RECOVERY if self.dot_enabled() => self.handle_dot_recovery(payload_len),
+            CMD_DOT_UNLOCK_CHALLENGE if self.dot_enabled() => {
+                self.handle_dot_unlock_challenge(payload_len)
+            }
+            CMD_DOT_OVERRIDE if self.dot_enabled() => self.handle_dot_override(payload_len),
             _ => {
                 romtime::println!("[mcu-rom-i3c-svc] Unknown command: {:#x}", cmd);
                 self.send_status(STATUS_INVALID_CMD);
@@ -102,14 +202,298 @@ impl I3cMailboxHandler {
         }
     }
 
-    // ── I3C TTI low-level helpers ──────────────────────────────────────
+    // ── DOT command handlers ──────────────────────────────────────────
 
-    /// Send a status-only response (1 byte) via IBI.
-    fn send_status(&self, status: u8) {
-        self.send_ibi_with_payload(&[status]);
+    /// Handle DOT_STATUS: return current DOT fuse state.
+    fn handle_dot_status(&mut self) -> DispatchResult {
+        romtime::println!("[mcu-rom-i3c-svc] DOT_STATUS received");
+        let ctx = self.dot_ctx.as_ref().unwrap();
+        // Response: [status, enabled, locked, burned_lo, burned_hi]
+        let enabled = ctx.dot_fuses.enabled as u8;
+        let locked = ctx.dot_fuses.is_locked() as u8;
+        let burned_le = ctx.dot_fuses.burned.to_le_bytes();
+        self.send_response(
+            STATUS_SUCCESS,
+            &[enabled, locked, burned_le[0], burned_le[1]],
+        );
+        DispatchResult::Continue
     }
 
-    /// Send a response with status byte followed by data via IBI.
+    /// Handle DOT_RECOVERY: receive backup blob and run recovery flow.
+    fn handle_dot_recovery(&mut self, payload_len: usize) -> DispatchResult {
+        romtime::println!("[mcu-rom-i3c-svc] DOT_RECOVERY received");
+
+        let blob_size = crate::DOT_BLOB_SIZE;
+        if payload_len < blob_size {
+            romtime::println!(
+                "[mcu-rom-i3c-svc] DOT_RECOVERY payload too small: {} < {}",
+                payload_len,
+                blob_size
+            );
+            self.send_status(STATUS_INVALID_PAYLOAD);
+            return DispatchResult::Continue;
+        }
+
+        let mut blob_bytes = [0u8; crate::DOT_BLOB_SIZE];
+        read_bytes_from_words(self.reassembly_buf, 0, &mut blob_bytes);
+
+        let result = {
+            let ctx = self.dot_ctx.as_mut().unwrap();
+            let key_type = ctx.key_type;
+            crate::device_ownership_transfer::verify_and_write_recovery_blob(
+                ctx.soc_manager,
+                ctx.dot_fuses,
+                &blob_bytes,
+                ctx.dot_flash,
+                key_type,
+            )
+        };
+
+        match result {
+            Ok(()) => {
+                romtime::println!("[mcu-rom-i3c-svc] DOT_RECOVERY succeeded, triggering reset");
+                self.send_status(STATUS_SUCCESS);
+                let ctx = self.dot_ctx.as_ref().unwrap();
+                ctx.mci.trigger_warm_reset();
+                return DispatchResult::Done;
+            }
+            Err(err) => {
+                romtime::println!(
+                    "[mcu-rom-i3c-svc] DOT_RECOVERY failed: {}",
+                    romtime::HexWord(err.into())
+                );
+                self.send_status(STATUS_ERROR);
+            }
+        }
+        DispatchResult::Continue
+    }
+
+    /// Handle DOT_UNLOCK_CHALLENGE: start override by receiving vendor PK and
+    /// generating a challenge.
+    ///
+    /// Payload: ECC P-384 PK (96 bytes) + MLDSA-87 PK (2592 bytes) = 2688 bytes
+    fn handle_dot_unlock_challenge(&mut self, payload_len: usize) -> DispatchResult {
+        romtime::println!("[mcu-rom-i3c-svc] DOT_UNLOCK_CHALLENGE received");
+
+        let expected_payload = 96 + crate::MLDSA87_PUB_KEY_SIZE_DWORDS * 4;
+        if payload_len < expected_payload {
+            romtime::println!(
+                "[mcu-rom-i3c-svc] DOT_UNLOCK_CHALLENGE payload too small: {} < {}",
+                payload_len,
+                expected_payload
+            );
+            self.send_status(STATUS_INVALID_PAYLOAD);
+            return DispatchResult::Continue;
+        }
+
+        // ECC public key (all offsets are word-aligned)
+        let mut ecc_x = [0u32; 12];
+        let mut ecc_y = [0u32; 12];
+        read_words(self.reassembly_buf, 0, &mut ecc_x);
+        read_words(self.reassembly_buf, 12, &mut ecc_y);
+
+        // MLDSA public key
+        let mut mldsa_pub_key = [0u32; crate::MLDSA87_PUB_KEY_SIZE_DWORDS];
+        read_words(self.reassembly_buf, 24, &mut mldsa_pub_key);
+
+        let ctx = self.dot_ctx.as_mut().unwrap();
+
+        // Verify device is in locked state
+        if !ctx.dot_fuses.is_locked() {
+            romtime::println!("[mcu-rom-i3c-svc] DOT_UNLOCK_CHALLENGE: device not locked");
+            self.send_status(STATUS_ERROR);
+            return DispatchResult::Continue;
+        }
+
+        let recovery_pk_hash = match ctx.dot_fuses.recovery_pk_hash.as_ref() {
+            Some(hash) => hash,
+            None => {
+                romtime::println!("[mcu-rom-i3c-svc] No vendor recovery PK hash in OTP");
+                self.send_status(STATUS_ERROR);
+                return DispatchResult::Continue;
+            }
+        };
+
+        let ecc_key = crate::EccP384PublicKey { x: ecc_x, y: ecc_y };
+        let ecc_key_u32 = crate::device_ownership_transfer::ecc_key_as_u32_slice(&ecc_key);
+
+        let computed_hash = match crate::device_ownership_transfer::cm_sha384(
+            ctx.soc_manager,
+            &[ecc_key_u32, &mldsa_pub_key],
+        ) {
+            Ok(h) => h,
+            Err(err) => {
+                romtime::println!(
+                    "[mcu-rom-i3c-svc] PK hash computation failed: {}",
+                    romtime::HexWord(err.into())
+                );
+                self.send_status(STATUS_ERROR);
+                return DispatchResult::Continue;
+            }
+        };
+
+        let fuse_hash_bytes: [u8; 48] = zerocopy::transmute!(recovery_pk_hash.0);
+        if !constant_time_eq::constant_time_eq(&computed_hash, &fuse_hash_bytes) {
+            romtime::println!("[mcu-rom-i3c-svc] Vendor recovery PK hash mismatch");
+            self.send_status(STATUS_ERROR);
+            return DispatchResult::Continue;
+        }
+        romtime::println!("[mcu-rom-i3c-svc] Vendor PK hash verified");
+
+        // Generate random challenge
+        let challenge = match crate::device_ownership_transfer::cm_random_generate(ctx.soc_manager)
+        {
+            Ok(c) => c,
+            Err(err) => {
+                romtime::println!(
+                    "[mcu-rom-i3c-svc] Challenge generation failed: {}",
+                    romtime::HexWord(err.into())
+                );
+                self.send_status(STATUS_ERROR);
+                return DispatchResult::Continue;
+            }
+        };
+
+        // Release mutable borrow before calling self.send_response
+
+        // Send challenge as response
+        self.send_response(STATUS_SUCCESS, &challenge);
+        self.override_state = OverrideState::ChallengeSent { challenge };
+        romtime::println!(
+            "[mcu-rom-i3c-svc] Challenge sent, waiting for DOT_OVERRIDE: {}",
+            romtime::HexBytes(&challenge),
+        );
+        DispatchResult::Continue
+    }
+
+    /// Handle DOT_OVERRIDE: receive signed challenge response and complete override.
+    ///
+    /// Payload:
+    ///   bytes 0..95:    ECC P-384 public key (x: 48, y: 48)
+    ///   bytes 96..191:  ECC signature (r: 48, s: 48)
+    ///   bytes 192..2783: MLDSA-87 public key (2592 bytes)
+    ///   bytes 2784..7411: MLDSA-87 signature (4628 bytes)
+    fn handle_dot_override(&mut self, payload_len: usize) -> DispatchResult {
+        romtime::println!("[mcu-rom-i3c-svc] DOT_OVERRIDE received");
+
+        // Verify we're in the correct state
+        let challenge = match &self.override_state {
+            OverrideState::ChallengeSent { challenge } => *challenge,
+            OverrideState::Idle => {
+                romtime::println!("[mcu-rom-i3c-svc] DOT_OVERRIDE without prior challenge");
+                self.send_status(STATUS_ERROR);
+                return DispatchResult::Continue;
+            }
+        };
+
+        // Reset override state
+        self.override_state = OverrideState::Idle;
+
+        let expected_payload = ECC_P384_PUB_KEY_SIZE
+            + ECC_P384_SIGNATURE_SIZE
+            + crate::MLDSA87_PUB_KEY_SIZE_DWORDS * 4
+            + crate::MLDSA87_SIGNATURE_SIZE_DWORDS * 4;
+        if payload_len < expected_payload {
+            romtime::println!(
+                "[mcu-rom-i3c-svc] DOT_OVERRIDE payload too small: {} < {}",
+                payload_len,
+                expected_payload
+            );
+            self.send_status(STATUS_INVALID_PAYLOAD);
+            return DispatchResult::Continue;
+        }
+
+        let payload = &self.reassembly_buf;
+        let mut woff = 0usize; // word offset
+
+        // ECC PK
+        let mut ecc_x = [0u32; 12];
+        let mut ecc_y = [0u32; 12];
+        read_words(payload, woff, &mut ecc_x);
+        woff += 12;
+        read_words(payload, woff, &mut ecc_y);
+        woff += 12;
+
+        // ECC signature (read as bytes from word-aligned data)
+        let mut ecc_sig_r = [0u8; 48];
+        let mut ecc_sig_s = [0u8; 48];
+        read_bytes_from_words(payload, woff * 4, &mut ecc_sig_r);
+        woff += 12;
+        read_bytes_from_words(payload, woff * 4, &mut ecc_sig_s);
+        woff += 12;
+
+        // MLDSA PK
+        let mut mldsa_pub_key = [0u32; crate::MLDSA87_PUB_KEY_SIZE_DWORDS];
+        read_words(payload, woff, &mut mldsa_pub_key);
+        woff += crate::MLDSA87_PUB_KEY_SIZE_DWORDS;
+
+        // MLDSA signature
+        let mut mldsa_signature = [0u32; crate::MLDSA87_SIGNATURE_SIZE_DWORDS];
+        read_words(payload, woff, &mut mldsa_signature);
+
+        let ctx = self.dot_ctx.as_mut().unwrap();
+
+        let recovery_pk_hash = match ctx.dot_fuses.recovery_pk_hash.as_ref() {
+            Some(hash) => hash,
+            None => {
+                self.send_status(STATUS_ERROR);
+                return DispatchResult::Continue;
+            }
+        };
+
+        let ecc_key = crate::EccP384PublicKey { x: ecc_x, y: ecc_y };
+        let auth = crate::device_ownership_transfer::OverrideAuth {
+            ecc_key: &ecc_key,
+            ecc_sig_r: &ecc_sig_r,
+            ecc_sig_s: &ecc_sig_s,
+            mldsa_pub_key: &mldsa_pub_key,
+            mldsa_signature: &mldsa_signature,
+            challenge: &challenge,
+        };
+
+        if crate::device_ownership_transfer::verify_override_response(
+            ctx.soc_manager,
+            recovery_pk_hash,
+            &auth,
+        )
+        .is_err()
+        {
+            self.send_status(STATUS_ERROR);
+            return DispatchResult::Continue;
+        }
+
+        romtime::println!("[mcu-rom-i3c-svc] Both signatures verified");
+
+        let key_type = ctx.key_type;
+        if crate::device_ownership_transfer::apply_override(
+            ctx.soc_manager,
+            ctx.otp,
+            ctx.dot_fuses,
+            ctx.dot_flash,
+            key_type,
+        )
+        .is_err()
+        {
+            romtime::println!("[mcu-rom-i3c-svc] Failed to apply DOT override");
+            self.send_status(STATUS_ERROR);
+            return DispatchResult::Continue;
+        }
+
+        romtime::println!("[mcu-rom-i3c-svc] DOT override complete, triggering reset");
+        self.send_status(STATUS_SUCCESS);
+        let ctx = self.dot_ctx.as_ref().unwrap();
+        ctx.mci.trigger_warm_reset();
+        DispatchResult::Done
+    }
+
+    // ── I3C TTI low-level helpers ──────────────────────────────────────
+
+    /// Send a status-only response (1 byte) via TX (private read).
+    fn send_status(&self, status: u8) {
+        self.send_tx_response(&[status]);
+    }
+
+    /// Send a response with status byte followed by data via TX (private read).
     fn send_response(&self, status: u8, data: &[u8]) {
         let mut buf = [0u8; 64];
         buf[0] = status;
@@ -119,49 +503,62 @@ impl I3cMailboxHandler {
             buf[i + 1] = data[i];
             i += 1;
         }
-        self.send_ibi_with_payload(&buf[..1 + copy_len]);
+        self.send_tx_response(&buf[..1 + copy_len]);
     }
 
-    /// Send an IBI with MDB and inline payload data.
-    fn send_ibi_with_payload(&self, data: &[u8]) {
+    /// Queue a response for the BMC to read via a private read transaction.
+    /// Writes a TX descriptor (creating the buffer), then fills it with data
+    /// words followed by a PEC (CRC-8/SMBus) byte. The I3C controller holds
+    /// this data until the BMC issues a private read.
+    fn send_tx_response(&self, data: &[u8]) {
         let regs = self.registers;
 
-        let ibi_desc = ((MDB_SERVICES as u32) << 24) | (data.len() as u32);
-        regs.tti_tti_ibi_port.set(ibi_desc);
+        // Compute PEC over the read address byte and payload, matching the
+        // MCTP-over-I3C transport binding (transport_binding.rs).
+        let addr_byte = (self.pec_addr << 1) | 1; // R/W bit = 1 for read
+        let mut crc = 0u8;
+        crc = romtime::crc8(crc, addr_byte);
+        let mut k = 0;
+        while k < data.len() {
+            crc = romtime::crc8(crc, data[k]);
+            k += 1;
+        }
 
-        // Write payload 4 bytes at a time
-        let words = data.len().div_ceil(4);
+        let total_len = data.len() + 1; // data + PEC byte
+
+        // Write TX descriptor first (creates the data buffer in the controller)
+        regs.tti_tx_desc_queue_port.set(total_len as u32);
+
+        // Write data + PEC as words
+        let words = total_len.div_ceil(4);
         let mut i = 0;
         while i < words {
             let base = i * 4;
             let mut word = 0u32;
             let mut j = 0;
+            // if-chain avoids match/cmp which prevents LLVM from eliding the bounds check
+            #[allow(clippy::comparison_chain)]
             while j < 4 {
-                if base + j < data.len() {
-                    word |= (data[base + j] as u32) << (j * 8);
-                }
+                let pos = base + j;
+                let byte = if pos < data.len() {
+                    data.get(pos).copied().unwrap_or(0)
+                } else if pos == data.len() {
+                    crc
+                } else {
+                    0
+                };
+                word |= (byte as u32) << (j * 8);
                 j += 1;
             }
-            regs.tti_tti_ibi_port.set(word);
+            regs.tti_tx_data_port.set(word);
             i += 1;
-        }
-
-        for _ in 0..MAX_IBI_POLL_ITERATIONS {
-            if regs
-                .tti_interrupt_status
-                .extract()
-                .is_set(InterruptStatus::IbiDone)
-            {
-                // Read LastIbiStatus to clear the IbiDone interrupt.
-                let _ = regs.tti_status.read(Status::LastIbiStatus);
-                break;
-            }
         }
     }
 
     /// Send an IBI with a short timeout; if the controller does not
-    /// acknowledge it, reset the IBI queue to prevent the pending IBI
-    /// from blocking the target FSM (which would prevent TTI RX).
+    /// acknowledge it, reset the target core to force the FSM out of the
+    /// DoIBI state (the RTL ties `ibi_abort_i` to 0, so only a soft
+    /// reset can recover the FSM once an IBI gets stuck).
     fn send_ibi_with_abort(&self, data: &[u8]) {
         let regs = self.registers;
 
@@ -195,41 +592,169 @@ impl I3cMailboxHandler {
             }
         }
 
-        // IBI was not acknowledged — flush the IBI queue so the pending
-        // entry does not keep the target FSM in DoIBI state.
+        // IBI was not acknowledged — hold the IBI queue in reset so
+        // the pending entry is cleared and no retries are attempted.
+        // These TTI reset bits are persistent ("hold-in-reset"), not
+        // self-clearing, so the IBI queue stays disabled for the
+        // remainder of the services loop.
+        romtime::println!("[mcu-rom-i3c-svc] IBI not acknowledged, flushing IBI queue");
         regs.tti_tti_reset_control
-            .write(TtiResetControl::IbiQueueRst::SET);
+            .write(TtiResetControl::IbiQueueRst::SET + TtiResetControl::IbiRetryCtrRst::SET);
     }
 
-    /// Try to read a command from the I3C RX queue.
-    /// Returns `Some((cmd_byte, word_buffer, data_len))` if a command arrived.
-    fn try_receive_command(&self) -> Option<(u8, [u32; MAX_RX_WORDS], usize)> {
+    /// Try to receive and reassemble a complete command from packetized
+    /// I3C private writes. Returns `Some((cmd, payload_len))` when all
+    /// packets have arrived. The payload data is in the static `REASSEMBLY_BUF`.
+    ///
+    /// Packet format: `[cmd, payload_len, seq_num, total_seqs, payload...]`
+    fn try_receive_reassembled_command(&mut self) -> Option<(u8, usize)> {
         let regs = self.registers;
 
-        // Read RX descriptor to get data length. If the queue is empty the
-        // descriptor reads as 0.
+        // Reading the descriptor queue port when empty returns 0 on real
+        // hardware (I3C core read_queue.sv). We rely on the data_len check
+        // below to discard empty reads rather than checking RxDescStat,
+        // because RxDescStat is edge-triggered (set on write, cleared on
+        // read) and would miss batched descriptors.
         let rx_desc = regs.tti_rx_desc_queue_port.get();
         let data_len = (rx_desc & 0xFFFF) as usize;
-
-        if data_len == 0 {
+        if data_len < PACKET_HEADER_SIZE {
             return None;
         }
 
+        // Read all words from the RX FIFO
+        let total_words = data_len.div_ceil(4);
+        let read_words = total_words.min(MAX_RX_WORDS);
         let mut buf = [0u32; MAX_RX_WORDS];
-        let words = data_len.div_ceil(4);
         let mut i = 0;
-        while i < words && i < MAX_RX_WORDS {
+        while i < read_words {
             buf[i] = regs.tti_rx_data_port.get();
             i += 1;
         }
 
-        let cmd = (buf[0] & 0xFF) as u8;
-        Some((cmd, buf, data_len))
+        // Parse the 4-byte packet header
+        let first_word = buf[0].to_le_bytes();
+        let cmd = first_word[0];
+        let pkt_payload_len = first_word[1] as usize;
+        let seq_num = first_word[2];
+        let total_seqs = first_word[3];
+
+        if total_seqs == 0 {
+            return None;
+        }
+
+        romtime::println!(
+            "[mcu-rom-i3c-svc] Packet: cmd=0x{:02x} len={} seq={}/{} data_len={}",
+            cmd,
+            pkt_payload_len,
+            seq_num,
+            total_seqs,
+            data_len,
+        );
+        // Validate the packet payload length against what arrived
+        let actual_payload = data_len.saturating_sub(PACKET_HEADER_SIZE);
+        let copy_bytes = actual_payload.min(pkt_payload_len);
+        // Number of whole payload words to copy from buf[1..]
+        let copy_words = copy_bytes.div_ceil(4);
+        let buf_capacity = self.reassembly_buf.len() * 4; // in bytes
+
+        if total_seqs == 1 {
+            self.reassembly_len = copy_bytes.min(buf_capacity);
+            copy_payload_words(&buf, 1, self.reassembly_buf, 0, copy_words);
+            return Some((cmd, self.reassembly_len));
+        }
+
+        // Multi-packet: validate sequence
+        if seq_num == 0 {
+            self.reassembly_cmd = cmd;
+            self.reassembly_total = total_seqs;
+            self.reassembly_next_seq = 1;
+            self.reassembly_len = copy_bytes.min(buf_capacity);
+            copy_payload_words(&buf, 1, self.reassembly_buf, 0, copy_words);
+        } else if seq_num == self.reassembly_next_seq
+            && cmd == self.reassembly_cmd
+            && total_seqs == self.reassembly_total
+        {
+            let space = buf_capacity.saturating_sub(self.reassembly_len);
+            let n_bytes = copy_bytes.min(space);
+            let n_words = n_bytes.div_ceil(4);
+            let dst_word = self.reassembly_len / 4;
+            copy_payload_words(&buf, 1, self.reassembly_buf, dst_word, n_words);
+            self.reassembly_len += n_bytes;
+            self.reassembly_next_seq += 1;
+        } else {
+            romtime::println!(
+                "[mcu-rom-i3c-svc] Packet seq mismatch: got {}/{}, expected {}/{}",
+                seq_num,
+                total_seqs,
+                self.reassembly_next_seq,
+                self.reassembly_total,
+            );
+            self.reassembly_len = 0;
+            self.reassembly_next_seq = 0;
+            self.reassembly_total = 0;
+            return None;
+        }
+
+        if self.reassembly_next_seq == self.reassembly_total {
+            let len = self.reassembly_len;
+            let cmd = self.reassembly_cmd;
+            self.reassembly_next_seq = 0;
+            self.reassembly_total = 0;
+            Some((cmd, len))
+        } else {
+            None
+        }
     }
 
     /// Returns the enabled service modes.
     #[allow(dead_code)]
     pub fn services(&self) -> crate::I3cServicesModes {
         self.services
+    }
+}
+
+/// Copy u32 words from the RX FIFO buffer into the reassembly buffer.
+fn copy_payload_words(
+    src: &[u32; MAX_RX_WORDS],
+    src_word_start: usize,
+    dst: &mut [u32],
+    dst_word_start: usize,
+    word_count: usize,
+) {
+    let mut i = 0;
+    while i < word_count {
+        let si = src_word_start + i;
+        let di = dst_word_start + i;
+        if si < MAX_RX_WORDS && di < dst.len() {
+            dst[di] = src[si];
+        }
+        i += 1;
+    }
+}
+
+/// Copy u32 words from the reassembly buffer into a destination u32 slice.
+fn read_words(src: &[u32], src_word_offset: usize, dst: &mut [u32]) {
+    let mut i = 0;
+    while i < dst.len() {
+        let si = src_word_offset + i;
+        dst[i] = if si < src.len() { src[si] } else { 0 };
+        i += 1;
+    }
+}
+
+/// Read bytes from a u32-word buffer at a given byte offset.
+fn read_bytes_from_words(src: &[u32], byte_offset: usize, dst: &mut [u8]) {
+    let mut i = 0;
+    while i < dst.len() {
+        let pos = byte_offset + i;
+        let word_idx = pos / 4;
+        let byte_idx = pos % 4;
+        let w = if word_idx < src.len() {
+            src[word_idx]
+        } else {
+            0
+        };
+        dst[i] = ((w >> (byte_idx * 8)) & 0xFF) as u8;
+        i += 1;
     }
 }

--- a/rom/src/lib.rs
+++ b/rom/src/lib.rs
@@ -37,7 +37,7 @@ mod rom_env;
 pub use rom_env::*;
 mod i3c;
 mod i3c_mailbox;
-pub use i3c_mailbox::I3cMailboxHandler;
+pub use i3c_mailbox::{DotContext, I3cMailboxHandler};
 mod mailbox;
 pub mod recovery;
 #[cfg(feature = "stable-owner-key")]
@@ -48,6 +48,7 @@ mod cold_boot;
 mod fw_boot;
 mod warm_boot;
 pub use cold_boot::ColdBoot;
+pub use cold_boot::I3cDotLockedRecoveryHandler;
 pub use fw_boot::FwBoot;
 pub use warm_boot::WarmBoot;
 

--- a/rom/src/rom.rs
+++ b/rom/src/rom.rs
@@ -900,6 +900,12 @@ pub struct RomParameters<'a> {
     /// the MCU watchdog is configured with this value before waiting for
     /// mbox0 commands during recovery or override. 0 = no watchdog.
     pub dot_recovery_wdt_timeout: u64,
+    /// Integrator-ordered list of DOT locked-state recovery handlers.
+    /// When DOT is in ODD state, the ROM iterates through these in order,
+    /// respecting each entry's error policy. The first handler that succeeds
+    /// triggers a warm reset. If empty, no locked-state recovery is attempted.
+    pub dot_locked_recovery_handlers:
+        &'a [crate::device_ownership_transfer::DotLockedRecoveryEntry<'a>],
     pub otp_enable_integrity_check: bool,
     pub otp_enable_consistency_check: bool,
     pub otp_check_timeout_override: Option<u32>,

--- a/romtime/src/boot_status.rs
+++ b/romtime/src/boot_status.rs
@@ -86,7 +86,8 @@ pub enum McuRomBootStatus {
     StableOwnerKeyDerivationStarted = CALIPTRA_SETUP_BASE + 18,
     StableOwnerKeyDerivationComplete = CALIPTRA_SETUP_BASE + 19,
     I3cServicesStarted = CALIPTRA_SETUP_BASE + 20,
-    I3cServicesComplete = CALIPTRA_SETUP_BASE + 21,
+    I3cServicesReady = CALIPTRA_SETUP_BASE + 21,
+    I3cServicesComplete = CALIPTRA_SETUP_BASE + 22,
 
     // Firmware Loading Statuses
     RiDownloadFirmwareCommandSent = FIRMWARE_LOADING_BASE,

--- a/tests/integration/src/lib.rs
+++ b/tests/integration/src/lib.rs
@@ -252,6 +252,15 @@ mod test {
         output
     }
 
+    /// Check if a prebuilt feature-specific MCU ROM is available.
+    pub fn has_prebuilt_rom(feature: &str) -> bool {
+        if let Ok(binaries) = FirmwareBinaries::from_env() {
+            binaries.test_feature_rom(feature).is_ok()
+        } else {
+            false
+        }
+    }
+
     /// Check if prebuilt binaries are available for the given feature.
     pub fn has_prebuilt_binaries(feature: &str) -> bool {
         if let Ok(binaries) = FirmwareBinaries::from_env() {
@@ -465,7 +474,8 @@ mod test {
         } = match FirmwareBinaries::from_env() {
             Ok(binaries)
                 if params.firmware_prefix.is_none()
-                    && params.rom_feature.is_none()
+                    && (params.rom_feature.is_none()
+                        || has_prebuilt_rom(params.rom_feature.unwrap()))
                     && (params.feature.is_none()
                         || has_prebuilt_binaries(params.feature.unwrap())) =>
             {

--- a/tests/integration/src/rom/test_i3c_services.rs
+++ b/tests/integration/src/rom/test_i3c_services.rs
@@ -14,9 +14,31 @@ mod test {
     use std::net::{SocketAddr, TcpStream};
     use std::sync::atomic::Ordering;
 
-    /// Boot into I3C services, connect, and send a command. Returns the
-    /// hw model output after sending.
-    fn boot_and_send_i3c_cmd(cmd: Vec<u8>, expected_output: &str) -> String {
+    use romtime::McuRomBootStatus;
+
+    const I3C_SERVICES_READY_CHECKPOINT: u16 = McuRomBootStatus::I3cServicesReady as u16;
+
+    /// Step the model until the ROM sets the I3cServicesReady boot checkpoint.
+    /// This ensures the ROM has completed IBI announcement and is actively
+    /// polling for packets before we send any.
+    fn wait_for_i3c_ready(hw: &mut impl McuHwModel) {
+        let start = std::time::Instant::now();
+        hw.step_until(|m| {
+            m.mci_boot_checkpoint() >= I3C_SERVICES_READY_CHECKPOINT
+                || m.mci_fw_fatal_error().is_some()
+                || start.elapsed().as_secs() > 60
+        });
+        assert!(
+            hw.mci_boot_checkpoint() >= I3C_SERVICES_READY_CHECKPOINT,
+            "ROM did not enter I3C services mode within timeout (checkpoint: {})",
+            hw.mci_boot_checkpoint()
+        );
+    }
+
+    /// Boot into I3C services, connect, and send a packetized command. Returns
+    /// the hw model output after sending. `cmd` is the command byte and
+    /// `payload` is the payload (without the command byte).
+    fn boot_and_send_i3c_cmd(cmd: u8, payload: &[u8], expected_output: &str) -> String {
         let i3c_port = PortPicker::new().random(true).pick().unwrap();
 
         let mut hw = start_runtime_hw_model(TestParams {
@@ -31,15 +53,64 @@ mod test {
         let port = hw.i3c_port().unwrap();
         let target_addr = hw.i3c_address().unwrap();
 
-        // By the time boot() returns the ROM is already in the I3C services
-        // loop (the FPGA runs autonomously; the emulator stepped through it).
-        // Connect to the I3C socket and send the command directly.
         let addr = SocketAddr::from(([127, 0, 0, 1], port));
         let stream = TcpStream::connect(addr).expect("Failed to connect to I3C socket");
         let mut stream = BufferedStream::new(stream);
-        stream.send_private_write(target_addr, cmd);
 
-        // Step until the expected output appears.
+        // Wait for ROM to enter I3C services mode before sending packets.
+        // On FPGA the initial IBI can block for tens of ms; packets arriving
+        // during that window overflow the 256-byte RX data FIFO.
+        wait_for_i3c_ready(&mut hw);
+
+        stream.send_packetized_write(target_addr, cmd, payload);
+
+        hw.output().set_search_term(expected_output);
+        let start = std::time::Instant::now();
+        hw.step_until(|m| {
+            m.output().search_matched()
+                || m.mci_fw_fatal_error().is_some()
+                || start.elapsed().as_secs() > 120
+        });
+
+        let output_text = hw.output().take(usize::MAX);
+        println!("Test output:\n{output_text}");
+        assert!(start.elapsed().as_secs() <= 120, "Test timed out");
+        assert_eq!(hw.mci_fw_fatal_error(), None, "ROM hit fatal error");
+
+        drop(stream);
+        output_text
+    }
+
+    /// Boot into I3C services with DOT flash configured so DOT commands
+    /// are available. Uses force_i3c_services + test-i3c-services feature.
+    fn boot_and_send_i3c_cmd_with_dot(cmd: u8, payload: &[u8], expected_output: &str) -> String {
+        use mcu_rom_common::DOT_BLOB_SIZE;
+
+        let i3c_port = PortPicker::new().random(true).pick().unwrap();
+
+        let dot_flash = vec![0u8; DOT_BLOB_SIZE];
+
+        let mut hw = start_runtime_hw_model(TestParams {
+            rom_feature: Some("test-i3c-services"),
+            rom_only: true,
+            i3c_port: Some(i3c_port),
+            dot_flash_initial_contents: Some(dot_flash),
+            ..Default::default()
+        });
+
+        hw.start_i3c_controller();
+
+        let port = hw.i3c_port().unwrap();
+        let target_addr = hw.i3c_address().unwrap();
+
+        let addr = SocketAddr::from(([127, 0, 0, 1], port));
+        let stream = TcpStream::connect(addr).expect("Failed to connect to I3C socket");
+        let mut stream = BufferedStream::new(stream);
+
+        wait_for_i3c_ready(&mut hw);
+
+        stream.send_packetized_write(target_addr, cmd, payload);
+
         hw.output().set_search_term(expected_output);
         let start = std::time::Instant::now();
         hw.step_until(|m| {
@@ -63,7 +134,7 @@ mod test {
         let lock = TEST_LOCK.lock().unwrap();
         lock.fetch_add(1, Ordering::Relaxed);
 
-        let output = boot_and_send_i3c_cmd(vec![0x00], "[mcu-rom-i3c-svc] PING received");
+        let output = boot_and_send_i3c_cmd(0x00, &[], "[mcu-rom-i3c-svc] PING received");
         assert!(
             output.contains("[mcu-rom-i3c-svc] PING received"),
             "PING was not received by I3C services handler"
@@ -78,12 +149,441 @@ mod test {
         let lock = TEST_LOCK.lock().unwrap();
         lock.fetch_add(1, Ordering::Relaxed);
 
-        let output = boot_and_send_i3c_cmd(vec![0xFF], "[mcu-rom-i3c-svc] Unknown command: 0xff");
+        let output = boot_and_send_i3c_cmd(0xFF, &[], "[mcu-rom-i3c-svc] Unknown command: 0xff");
         assert!(
             output.contains("[mcu-rom-i3c-svc] Unknown command: 0xff"),
             "Unknown command was not logged"
         );
 
         lock.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Test that DOT_STATUS returns DOT fuse state when DOT context is available.
+    #[test]
+    fn test_i3c_services_dot_status() {
+        let lock = TEST_LOCK.lock().unwrap();
+        lock.fetch_add(1, Ordering::Relaxed);
+
+        let output =
+            boot_and_send_i3c_cmd_with_dot(0x01, &[], "[mcu-rom-i3c-svc] DOT_STATUS received");
+        assert!(
+            output.contains("[mcu-rom-i3c-svc] DOT_STATUS received"),
+            "DOT_STATUS was not handled by I3C services handler"
+        );
+
+        lock.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Test that DOT_RECOVERY with a too-small payload returns INVALID_PAYLOAD.
+    #[test]
+    fn test_i3c_services_dot_recovery_invalid_payload() {
+        let lock = TEST_LOCK.lock().unwrap();
+        lock.fetch_add(1, Ordering::Relaxed);
+
+        // Send DOT_RECOVERY (0x02) with only a few bytes of payload
+        let output = boot_and_send_i3c_cmd_with_dot(
+            0x02,
+            &[0x00, 0x01],
+            "[mcu-rom-i3c-svc] DOT_RECOVERY payload too small",
+        );
+        assert!(
+            output.contains("[mcu-rom-i3c-svc] DOT_RECOVERY payload too small"),
+            "DOT_RECOVERY should reject small payloads"
+        );
+
+        lock.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Test that DOT_OVERRIDE without a prior DOT_UNLOCK_CHALLENGE returns error.
+    #[test]
+    fn test_i3c_services_dot_override_without_challenge() {
+        let lock = TEST_LOCK.lock().unwrap();
+        lock.fetch_add(1, Ordering::Relaxed);
+
+        // Construct a minimal DOT_OVERRIDE payload (won't be processed
+        // because no challenge was issued first).
+        let payload = vec![0u8; 96 + 96 + 2592 + 4628];
+
+        let output = boot_and_send_i3c_cmd_with_dot(
+            0x04,
+            &payload,
+            "[mcu-rom-i3c-svc] DOT_OVERRIDE without prior challenge",
+        );
+        assert!(
+            output.contains("[mcu-rom-i3c-svc] DOT_OVERRIDE without prior challenge"),
+            "DOT_OVERRIDE should fail without prior challenge"
+        );
+
+        lock.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Full DOT_OVERRIDE flow over I3C: challenge/response with ECDSA + MLDSA.
+    ///
+    /// 1. Boot with locked DOT fuses and vendor PK hash in OTP
+    /// 2. Send DOT_UNLOCK_CHALLENGE with vendor public keys
+    /// 3. Receive challenge from ROM via IBI
+    /// 4. Sign challenge with both ECDSA P-384 and MLDSA-87
+    /// 5. Send DOT_OVERRIDE with public keys and signatures
+    /// 6. Verify ROM logs success
+    #[test]
+    #[cfg_attr(
+        feature = "fpga_realtime",
+        ignore = "FPGA does not support otp_memory provisioning for DOT fuses"
+    )]
+    fn test_i3c_services_dot_override_full_flow() {
+        use ecdsa::signature::hazmat::PrehashSigner;
+        use fips204::traits::Signer;
+        use mcu_rom_common::DOT_BLOB_SIZE;
+        use p384::ecdsa::SigningKey;
+        use sha2::{Digest, Sha384};
+
+        let lock = TEST_LOCK.lock().unwrap();
+        lock.fetch_add(1, Ordering::Relaxed);
+
+        // Generate random vendor ECC P-384 and MLDSA-87 key pairs
+        let (vendor_pub_x, vendor_pub_y, vendor_priv_bytes) = generate_random_ecc_keys();
+        let (mldsa_pub, mldsa_priv) = generate_random_mldsa_keys();
+
+        // Compute vendor PK hash for OTP fuses
+        let vendor_pk_hash = compute_recovery_pk_hash(&vendor_pub_x, &vendor_pub_y, &mldsa_pub);
+
+        let i3c_port = PortPicker::new().random(true).pick().unwrap();
+        let dot_flash = vec![0u8; DOT_BLOB_SIZE];
+
+        let mut hw = start_runtime_hw_model(TestParams {
+            rom_feature: Some("test-i3c-services"),
+            rom_only: true,
+            i3c_port: Some(i3c_port),
+            dot_flash_initial_contents: Some(dot_flash),
+            otp_memory: Some(create_challenge_recovery_otp_memory(&vendor_pk_hash)),
+            ..Default::default()
+        });
+
+        hw.start_i3c_controller();
+        let port = hw.i3c_port().unwrap();
+        let target_addr = hw.i3c_address().unwrap();
+
+        let addr = SocketAddr::from(([127, 0, 0, 1], port));
+        let tcp = TcpStream::connect(addr).expect("Failed to connect to I3C socket");
+        let mut stream = BufferedStream::new(tcp);
+
+        wait_for_i3c_ready(&mut hw);
+
+        // Step 1: Build and send DOT_UNLOCK_CHALLENGE (cmd 0x03)
+        // Payload: ECC PK X (48) + ECC PK Y (48) + MLDSA PK (2592)
+        let mut challenge_payload = Vec::new();
+        challenge_payload.extend_from_slice(&vendor_pub_x);
+        challenge_payload.extend_from_slice(&vendor_pub_y);
+        challenge_payload.extend_from_slice(&mldsa_pub);
+        let mldsa_expected = 2592;
+        if mldsa_pub.len() < mldsa_expected {
+            challenge_payload.resize(
+                challenge_payload.len() + mldsa_expected - mldsa_pub.len(),
+                0,
+            );
+        }
+
+        stream.send_packetized_write(target_addr, 0x03, &challenge_payload);
+
+        // Step 2: Read the challenge via private read. The ROM queues the
+        // response (status + 48-byte challenge) via the TX descriptor path.
+        // The I3C controller thread pushes it to the socket automatically.
+        let start = std::time::Instant::now();
+
+        // First wait for the ROM to process the command and log the challenge.
+        hw.output()
+            .set_search_term("[mcu-rom-i3c-svc] Challenge sent, waiting for DOT_OVERRIDE");
+        hw.step_until(|m| {
+            m.output().search_matched()
+                || m.mci_fw_fatal_error().is_some()
+                || start.elapsed().as_secs() > 120
+        });
+        // Step a bit more to let the I3C controller thread forward the TX response
+        let flush = hw.cycle_count() + 100_000;
+        hw.step_until(|m| m.cycle_count() >= flush);
+
+        assert_eq!(
+            hw.mci_fw_fatal_error(),
+            None,
+            "ROM hit fatal error during challenge"
+        );
+
+        // Read the challenge response via private read from the I3C socket.
+        std::thread::sleep(std::time::Duration::from_millis(500));
+        let challenge_data = stream
+            .receive_private_read(target_addr)
+            .expect("Could not obtain challenge response via private read");
+        assert!(challenge_data.len() >= 49, "Response too short");
+        assert_eq!(challenge_data[0], 0x00, "Expected SUCCESS status");
+
+        let challenge: [u8; 48] = challenge_data[1..49].try_into().unwrap();
+
+        // Step 3: Sign the challenge with vendor keys
+        let challenge_hash: [u8; 48] = {
+            let mut hasher = Sha384::new();
+            hasher.update(&challenge);
+            hasher.finalize().into()
+        };
+        let vendor_secret =
+            p384::SecretKey::from_slice(&vendor_priv_bytes).expect("Invalid vendor private key");
+        let signing_key = SigningKey::from(&vendor_secret);
+        let ecc_sig: p384::ecdsa::Signature = signing_key
+            .sign_prehash(&challenge_hash)
+            .expect("ECDSA signing failed");
+        let ecc_r: [u8; 48] = ecc_sig.r().to_bytes().into();
+        let ecc_s: [u8; 48] = ecc_sig.s().to_bytes().into();
+
+        let mldsa_sig = mldsa_priv
+            .try_sign_with_seed(&[0u8; 32], &challenge, &[])
+            .expect("MLDSA signing failed");
+        let mldsa_sig_bytes = mldsa_sig.to_vec();
+
+        // Step 4: Build and send DOT_OVERRIDE (cmd 0x04)
+        // Payload: ECC PK (96) + ECC sig (96) + MLDSA PK (2592) + MLDSA sig (4628)
+        let mut override_payload = Vec::new();
+        override_payload.extend_from_slice(&vendor_pub_x);
+        override_payload.extend_from_slice(&vendor_pub_y);
+        override_payload.extend_from_slice(&ecc_r);
+        override_payload.extend_from_slice(&ecc_s);
+        override_payload.extend_from_slice(&mldsa_pub);
+        if mldsa_pub.len() < mldsa_expected {
+            override_payload.resize(override_payload.len() + mldsa_expected - mldsa_pub.len(), 0);
+        }
+        let mldsa_sig_expected = 4628;
+        override_payload.extend_from_slice(&mldsa_sig_bytes);
+        if mldsa_sig_bytes.len() < mldsa_sig_expected {
+            override_payload.resize(
+                override_payload.len() + mldsa_sig_expected - mldsa_sig_bytes.len(),
+                0,
+            );
+        }
+
+        stream.send_packetized_write(target_addr, 0x04, &override_payload);
+
+        // Step 5: Wait for ROM to verify and complete override
+        hw.output()
+            .set_search_term("[mcu-rom-i3c-svc] DOT override complete");
+        let start = std::time::Instant::now();
+        hw.step_until(|m| {
+            m.output().search_matched()
+                || m.mci_fw_fatal_error().is_some()
+                || start.elapsed().as_secs() > 120
+        });
+
+        let output_text = hw.output().take(usize::MAX);
+        println!("Test output:\n{output_text}");
+        assert!(
+            output_text.contains("[mcu-rom-i3c-svc] DOT override complete"),
+            "DOT override did not complete successfully"
+        );
+        assert!(
+            output_text.contains("[mcu-rom-i3c-svc] Both signatures verified"),
+            "Signature verification not logged"
+        );
+
+        lock.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Test that the handler recovers from a corrupted multi-packet sequence
+    /// and can still process a subsequent valid command.
+    ///
+    /// Sends a multi-packet DOT_RECOVERY with a bad sequence number in the
+    /// middle, then sends a valid PING. The handler should discard the broken
+    /// reassembly and respond to the PING.
+    #[test]
+    fn test_i3c_services_error_mid_packet_then_recover() {
+        let lock = TEST_LOCK.lock().unwrap();
+        lock.fetch_add(1, Ordering::Relaxed);
+
+        let i3c_port = PortPicker::new().random(true).pick().unwrap();
+
+        let mut hw = start_runtime_hw_model(TestParams {
+            rom_feature: Some("test-i3c-services"),
+            rom_only: true,
+            i3c_port: Some(i3c_port),
+            ..Default::default()
+        });
+
+        hw.start_i3c_controller();
+
+        let port = hw.i3c_port().unwrap();
+        let target_addr = hw.i3c_address().unwrap();
+
+        let addr = SocketAddr::from(([127, 0, 0, 1], port));
+        let stream = TcpStream::connect(addr).expect("Failed to connect to I3C socket");
+        let mut stream = BufferedStream::new(stream);
+
+        wait_for_i3c_ready(&mut hw);
+
+        // Send first packet of a multi-packet DOT_RECOVERY (cmd=0x02)
+        // with total_seqs=3 but only send seq=0, then inject seq=2
+        // (skipping seq=1) to trigger reassembly reset.
+        let mut pkt0 = vec![0x02u8, 100, 0, 3];
+        pkt0.extend_from_slice(&[0u8; 100]);
+        stream.send_private_write(target_addr, pkt0);
+        std::thread::sleep(std::time::Duration::from_millis(50));
+
+        // Send seq=2 (skipping seq=1) — triggers sequence mismatch
+        let mut pkt2 = vec![0x02u8, 100, 2, 3];
+        pkt2.extend_from_slice(&[0u8; 100]);
+        stream.send_private_write(target_addr, pkt2);
+        std::thread::sleep(std::time::Duration::from_millis(50));
+
+        // Now send a valid PING command — handler should recover
+        stream.send_packetized_write(target_addr, 0x00, &[]);
+
+        hw.output()
+            .set_search_term("[mcu-rom-i3c-svc] PING received");
+        let start = std::time::Instant::now();
+        hw.step_until(|m| {
+            m.output().search_matched()
+                || m.mci_fw_fatal_error().is_some()
+                || start.elapsed().as_secs() > 120
+        });
+
+        let output_text = hw.output().take(usize::MAX);
+        println!("Test output:\n{output_text}");
+        assert!(
+            output_text.contains("[mcu-rom-i3c-svc] Packet seq mismatch"),
+            "Sequence mismatch should be logged"
+        );
+        assert!(
+            output_text.contains("[mcu-rom-i3c-svc] PING received"),
+            "Handler should recover and process PING after error"
+        );
+
+        lock.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Test that after a failed DOT command (invalid payload), the handler
+    /// continues to accept subsequent commands.
+    #[test]
+    fn test_i3c_services_dot_error_then_continue() {
+        use mcu_rom_common::DOT_BLOB_SIZE;
+
+        let lock = TEST_LOCK.lock().unwrap();
+        lock.fetch_add(1, Ordering::Relaxed);
+
+        let i3c_port = PortPicker::new().random(true).pick().unwrap();
+        let dot_flash = vec![0u8; DOT_BLOB_SIZE];
+
+        let mut hw = start_runtime_hw_model(TestParams {
+            rom_feature: Some("test-i3c-services"),
+            rom_only: true,
+            i3c_port: Some(i3c_port),
+            dot_flash_initial_contents: Some(dot_flash),
+            ..Default::default()
+        });
+
+        hw.start_i3c_controller();
+
+        let port = hw.i3c_port().unwrap();
+        let target_addr = hw.i3c_address().unwrap();
+
+        let addr = SocketAddr::from(([127, 0, 0, 1], port));
+        let stream = TcpStream::connect(addr).expect("Failed to connect to I3C socket");
+        let mut stream = BufferedStream::new(stream);
+
+        wait_for_i3c_ready(&mut hw);
+
+        // Send DOT_RECOVERY with invalid (too small) payload
+        stream.send_packetized_write(target_addr, 0x02, &[0x00, 0x01]);
+
+        hw.output()
+            .set_search_term("[mcu-rom-i3c-svc] DOT_RECOVERY payload too small");
+        let start = std::time::Instant::now();
+        hw.step_until(|m| {
+            m.output().search_matched()
+                || m.mci_fw_fatal_error().is_some()
+                || start.elapsed().as_secs() > 60
+        });
+        assert!(
+            hw.output()
+                .take(usize::MAX)
+                .contains("DOT_RECOVERY payload too small"),
+            "Invalid payload should be rejected"
+        );
+
+        // Now send a valid DOT_STATUS — handler should still work
+        stream.send_packetized_write(target_addr, 0x01, &[]);
+
+        hw.output()
+            .set_search_term("[mcu-rom-i3c-svc] DOT_STATUS received");
+        let start = std::time::Instant::now();
+        hw.step_until(|m| {
+            m.output().search_matched()
+                || m.mci_fw_fatal_error().is_some()
+                || start.elapsed().as_secs() > 60
+        });
+
+        let output_text = hw.output().take(usize::MAX);
+        println!("Test output:\n{output_text}");
+        assert!(
+            output_text.contains("[mcu-rom-i3c-svc] DOT_STATUS received"),
+            "Handler should continue processing after a failed DOT command"
+        );
+
+        lock.fetch_add(1, Ordering::Relaxed);
+    }
+
+    // ── Test helpers ──────────────────────────────────────────────────
+
+    fn generate_random_ecc_keys() -> ([u8; 48], [u8; 48], [u8; 48]) {
+        use p384::elliptic_curve::sec1::ToEncodedPoint;
+        let secret_key = p384::SecretKey::random(&mut rand::thread_rng());
+        let pub_point = secret_key.public_key().to_encoded_point(false);
+        let x_bytes: [u8; 48] = pub_point.x().unwrap().as_slice().try_into().unwrap();
+        let y_bytes: [u8; 48] = pub_point.y().unwrap().as_slice().try_into().unwrap();
+        let priv_bytes: [u8; 48] = secret_key.to_bytes().into();
+        (x_bytes, y_bytes, priv_bytes)
+    }
+
+    fn generate_random_mldsa_keys() -> (Vec<u8>, fips204::ml_dsa_87::PrivateKey) {
+        use fips204::ml_dsa_87;
+        use fips204::traits::SerDes;
+        let (pk, sk) =
+            ml_dsa_87::try_keygen_with_rng(&mut rand::thread_rng()).expect("MLDSA keygen failed");
+        (pk.into_bytes().to_vec(), sk)
+    }
+
+    fn compute_recovery_pk_hash(
+        ecc_pub_x: &[u8; 48],
+        ecc_pub_y: &[u8; 48],
+        mldsa_pub: &[u8],
+    ) -> [u8; 48] {
+        use sha2::{Digest, Sha384};
+        let mut hasher = Sha384::new();
+        hasher.update(ecc_pub_x);
+        hasher.update(ecc_pub_y);
+        hasher.update(mldsa_pub);
+        let result = hasher.finalize();
+        let mut hash = [0u8; 48];
+        hash.copy_from_slice(&result);
+        hash
+    }
+
+    fn create_challenge_recovery_otp_memory(pk_hash: &[u8; 48]) -> Vec<u8> {
+        use registers_generated::fuses;
+
+        let required_size = fuses::VENDOR_RECOVERY_PK_HASH.byte_offset
+            + fuses::VENDOR_RECOVERY_PK_HASH.byte_size
+            + 16;
+        let otp_size =
+            required_size.max(fuses::DOT_FUSE_ARRAY.byte_offset + fuses::DOT_FUSE_ARRAY.byte_size);
+        let mut otp = vec![0u8; otp_size];
+        otp[fuses::DOT_INITIALIZED.byte_offset] = 0x07;
+        otp[fuses::DOT_FUSE_ARRAY.byte_offset] = 0x01;
+
+        // VENDOR_RECOVERY_PK_HASH lives in the vendor_secret_prod_partition,
+        // which on real hardware is scrambled. The emulator's OTP model does
+        // not descramble on DAI reads, so we write the plaintext bytes
+        // directly here. (On FPGA, this test path is `#[ignore]`d because the
+        // FPGA stack does not currently support provisioning DOT fuses via
+        // `otp_memory`.)
+        let hash_offset = fuses::VENDOR_RECOVERY_PK_HASH.byte_offset;
+        otp[hash_offset..hash_offset + 32].copy_from_slice(&pk_hash[..32]);
+        let next_offset = hash_offset + fuses::VENDOR_RECOVERY_PK_HASH.byte_size;
+        otp[next_offset..next_offset + 16].copy_from_slice(&pk_hash[32..48]);
+        otp
     }
 }

--- a/tests/integration/src/test_dot.rs
+++ b/tests/integration/src/test_dot.rs
@@ -869,20 +869,12 @@ mod test {
         // Run until error or timeout
         hw.step_until(|m| m.mci_fw_fatal_error().is_some() || m.cycle_count() > 50_000_000);
 
-        // Should have a fatal error - backup blob HMAC doesn't match
+        // Should have a fatal error — recovery handlers all failed.
+        // The exact error depends on the last handler in the chain.
         let fatal_error = hw.mci_fw_fatal_error();
         assert!(
             fatal_error.is_some(),
             "Recovery with invalid HMAC should cause fatal error"
-        );
-
-        // The error should be the blob corrupt error (HMAC mismatch)
-        let error_code = fatal_error.unwrap();
-        let expected_error: u32 = McuError::ROM_COLD_BOOT_DOT_BLOB_CORRUPT_ERROR.into();
-        assert_eq!(
-            error_code, expected_error,
-            "Expected ROM_COLD_BOOT_DOT_BLOB_CORRUPT_ERROR (0x{:x}), got 0x{:x}",
-            expected_error, error_code
         );
 
         // Verify the blob was NOT written to flash (offset 0 should still be zeros)


### PR DESCRIPTION
Implement DOT_STATUS, DOT_RECOVERY, DOT_UNLOCK_CHALLENGE, and DOT_OVERRIDE as ROM I3C service commands. Adds a packetization protocol to handle payloads exceeding the 256-byte I3C TTI FIFO, using MCI mailbox SRAM for reassembly.

There is an inconsistency with how the MCI mbox lock and SRAM clearing works on emulator and FPGA. I went down the rabbit hole on making them consistent, but it ended up spiraling into a bunch of unrelated changes, so I am saving that for a follow-up PR. (Filed as issue #1220.)

Fixes #1078

rom: address PR #1221 review comments

- Use DotRecoveryHandler trait
- Fix mailbox lock handling: try to acquire first, release stale lock only on first failed attempt, retry in a bounded loop (mlvisaya)
- Deduplicate DOT override logic: extract verify_override_response() and apply_override() shared by both MCI and I3C flows, with OverrideAuth struct to bundle auth parameters (ternst-nv)
- Centralize ECC key to u32 slice conversion in ecc_key_as_u32_slice()
- Add PEC (CRC-8/SMBus) to TX responses
- Fix test OTP provisioning: scramble VENDOR_RECOVERY_PK_HASH data since it lives in the scrambled vendor_secret_prod_partition
- Remove UART fallback hack from dot_override_full_flow test; private reads now work correctly on the emulator
- Add error recovery tests: sequence mismatch mid-packet and failed DOT command followed by successful command

Fix clippy warning about unused mut

rom: add DotLockedRecoveryManager and cleanup constants

Add DotLockedRecoveryHandler trait and DotLockedRecoveryManager so integrators can configure the order and retry policy of DOT locked-state recovery mechanisms (backup-blob, override, I3C).

Also replace magic numbers with named constants and remove dead code.

(cherry picked from commit 0b4613343ba523af535187ce66668c9cc7190e8d)