### PR TITLE
build: add devel and release build profiles

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -38,4 +38,11 @@ rustflags = [
     # the same address in the binary. However, it can save a fair bit of code  size.
     "-C",
     "link-arg=-icf=all",
+    # Strip absolute build paths from panic / debug strings to shrink .rodata.
+    # Repository sources become relative to repo root; cargo registry sources
+    # become "registry/...".  Both reduce the size of file-path strings baked
+    # into `core::panicking::panic_fmt` call sites (unwrap/expect/assert/etc.).
+    "--remap-path-prefix=/root/caliptra-mcu-sw=.",
+    "--remap-path-prefix=/root/.cargo/registry=registry",
+    "--remap-path-prefix=/root/.cargo/git=git",
 ]

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -61,6 +61,12 @@ default-filter = """
 # disabled for now due to flakiness of firmware update
 # (package(caliptra-mcu-tests-integration) and test(test_firmware_update_streaming_fpga)) |
 
+[profile.nightly-release]
+inherits = "nightly-emulator"
+default-filter = """
+(package(caliptra-mcu-tests-integration) and test(test_flash_soc_boot_successful))
+"""
+
 [profile.nightly-ci-spdm]
 inherits = "nightly"
 default-filter = """

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -328,20 +328,20 @@ jobs:
         run: |
           sudo mv /tmp/junit.xml /tmp/junit-${{ matrix.shard }}.xml
 
-      - name: Run release tests (shard ${{ matrix.shard }}/4)
+      - name: Run release tests
+        if: matrix.shard == 1
         run: |
           cargo --config "$EXTRA_CARGO_CONFIG" xtask test \
             --archive /tmp/nextest-archive.tar.zst \
-            --shard hash:${{ matrix.shard }}/4 \
             --firmware-bundle "${PWD}/target/all-fw-release.zip" \
             --emulator-bundle "${PWD}/target/emulators.zip" \
             --workspace-remap . \
             --nextest-profile nightly-release
 
       - name: Move release junit xml
-        if: success() || failure()
+        if: (success() || failure()) && matrix.shard == 1
         run: |
-          sudo mv /tmp/junit.xml /tmp/junit-release-${{ matrix.shard }}.xml
+          sudo mv /tmp/junit.xml /tmp/junit-release.xml
 
       - name: 'Upload test results'
         uses: actions/upload-artifact@v4
@@ -350,7 +350,7 @@ jobs:
           name: caliptra-test-results-${{ matrix.shard }}
           path: |
             /tmp/junit-${{ matrix.shard }}.xml
-            /tmp/junit-release-${{ matrix.shard }}.xml
+            /tmp/junit-release.xml
           retention-days: 1
 
   print_test_results:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -97,11 +97,25 @@ jobs:
           cargo run -p xtask --features parallel-build -- all-build --platform emulator --separate-runtimes
           sccache --show-stats
 
+      - name: Build release ROM and runtime binaries
+        run: |
+          cargo run -p xtask --features parallel-build -- all-build \
+            --platform emulator --separate-runtimes \
+            --profile release
+          sccache --show-stats
+
       - name: Upload firmware bundle
         uses: actions/upload-artifact@v4
         with:
           name: firmware-bundle
           path: target/all-fw.zip
+          retention-days: 1
+
+      - name: Upload release firmware bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-firmware-bundle
+          path: target/all-fw-release.zip
           retention-days: 1
 
   build-emulator:
@@ -277,6 +291,12 @@ jobs:
           name: firmware-bundle
           path: target/
 
+      - name: Download release firmware bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: release-firmware-bundle
+          path: target/
+
       - name: Download emulator bundle
         uses: actions/download-artifact@v4
         with:
@@ -303,17 +323,34 @@ jobs:
             --emulator-bundle "${PWD}/target/emulators.zip" \
             --workspace-remap .
 
-      - name: Move junit xml
+      - name: Move devel junit xml
         if: success() || failure()
         run: |
           sudo mv /tmp/junit.xml /tmp/junit-${{ matrix.shard }}.xml
+
+      - name: Run release tests (shard ${{ matrix.shard }}/4)
+        run: |
+          cargo --config "$EXTRA_CARGO_CONFIG" xtask test \
+            --archive /tmp/nextest-archive.tar.zst \
+            --shard hash:${{ matrix.shard }}/4 \
+            --firmware-bundle "${PWD}/target/all-fw-release.zip" \
+            --emulator-bundle "${PWD}/target/emulators.zip" \
+            --workspace-remap . \
+            --nextest-profile nightly-release
+
+      - name: Move release junit xml
+        if: success() || failure()
+        run: |
+          sudo mv /tmp/junit.xml /tmp/junit-release-${{ matrix.shard }}.xml
 
       - name: 'Upload test results'
         uses: actions/upload-artifact@v4
         if: success() || failure()
         with:
           name: caliptra-test-results-${{ matrix.shard }}
-          path: /tmp/junit-${{ matrix.shard }}.xml
+          path: |
+            /tmp/junit-${{ matrix.shard }}.xml
+            /tmp/junit-release-${{ matrix.shard }}.xml
           retention-days: 1
 
   print_test_results:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -376,10 +376,28 @@ opt-level = 3
 lto = "thin"
 
 [profile.release]
+# Shipping / minimal-size build profile.  `xtask runtime-build --profile
+# release` (or `xtask precheckin`'s release pass) auto-enables the `release`
+# cargo feature, which strips the kernel `debug!()` macro, romtime
+# `println!()`, DebugWriter, Console, LowLevelDebug, and ProcessConsole.  The
+# bundler also uses the constrained 512 KB SRAM platform manifest that
+# mirrors the real device.  Artifacts land in `target/<tuple>/release/`.
 debug = true      # Keep debug symbols in the release ELF so that we can debug more easily.
 lto = true
 opt-level = "z"
 codegen-units = 1
+
+# Default development-time runtime profile.  Same size-optimization settings
+# as `release` (lto, opt-level=z, codegen-units=1) so the binary still
+# actually runs, but builds with the `*-devel.toml` bundler manifest (1 MB
+# SRAM layout vs `release`'s 512 KB) and does NOT enable the `release` cargo
+# feature.  The kernel keeps DebugWriter / Console / LowLevelDebug /
+# ProcessConsole / `debug!()` / romtime `println!()` for live debugging.
+# Default for `xtask runtime-build` and `xtask runtime`.  Artifacts land in
+# `target/<tuple>/devel/` so they don't clobber the shipping
+# `target/<tuple>/release/` build.
+[profile.devel]
+inherits = "release"
 
 [patch.crates-io]
 openssl = { git = "https://github.com/clundin25/rust-openssl.git", rev = "4ada1c1d7c264e052e7bb71ecddbd196a5c2a0c7" } # MLDSA

--- a/builder/src/all.rs
+++ b/builder/src/all.rs
@@ -540,6 +540,7 @@ pub struct AllBuildArgs<'a> {
     pub pldm_manifest: Option<&'a str>,
     pub vendor: Option<&'a str>,
     pub model: Option<&'a str>,
+    pub profile: Option<&'a str>,
 }
 
 /// Build Caliptra ROM and firmware bundle, MCU ROM and runtime, and SoC manifest, and package them all together in a ZIP file.
@@ -555,6 +556,7 @@ pub fn all_build(args: AllBuildArgs) -> Result<()> {
         pldm_manifest,
         vendor,
         model,
+        profile,
     } = args;
 
     // TODO: use temp files
@@ -610,11 +612,18 @@ pub fn all_build(args: AllBuildArgs) -> Result<()> {
             .collect();
     test_roms.extend(cptra_test_roms?);
 
+    // Auto-enable the `release` cargo feature when building with the `release`
+    // profile, mirroring the same logic in `xtask runtime-build`.  This strips
+    // kernel `debug!()`, romtime `println!()`, Console, DebugWriter, etc.
+    let is_release = matches!(profile, Some("release"));
+
     let runtime_features = match runtime_features {
         Some(r) if !r.is_empty() => r.split(",").collect::<Vec<&str>>(),
         _ => {
             if separate_runtimes {
-                if platform == "fpga" {
+                if is_release {
+                    crate::features::RELEASE_RUNTIME_TEST_FEATURES.to_vec()
+                } else if platform == "fpga" {
                     crate::features::FPGA_RUNTIME_TEST_FEATURES.to_vec()
                 } else {
                     crate::features::EMULATOR_RUNTIME_TEST_FEATURES.to_vec()
@@ -633,6 +642,10 @@ pub fn all_build(args: AllBuildArgs) -> Result<()> {
     } else {
         // build one runtime with all feature flags
         base_runtime_features = runtime_features;
+    }
+
+    if is_release && !base_runtime_features.contains(&"release") {
+        base_runtime_features.push("release");
     }
 
     // Determine effective SoC images for base runtime features.
@@ -684,6 +697,7 @@ pub fn all_build(args: AllBuildArgs) -> Result<()> {
         output_name: Some(base_runtime_path.to_string()),
         example_app: false,
         platform: Some(platform),
+        profile,
         ..Default::default()
     })?;
 
@@ -824,11 +838,17 @@ pub fn all_build(args: AllBuildArgs) -> Result<()> {
             let feature_runtime_path = feature_runtime_file.path().to_str().unwrap().to_string();
             let include_example_app = FEATURES_WITH_EXAMPLE_APP.contains(feature);
 
+            let feature_str = if is_release && !feature.contains("release") {
+                format!("{},release", feature)
+            } else {
+                feature.to_string()
+            };
             crate::runtime_build_with_apps(&CaliptraBuildArgs {
-                features: Some(feature),
+                features: Some(&feature_str),
                 output_name: Some(feature_runtime_path),
                 example_app: include_example_app,
                 platform: Some(platform),
+                profile,
                 target_dir,
                 ..Default::default()
             })?;
@@ -944,7 +964,12 @@ pub fn all_build(args: AllBuildArgs) -> Result<()> {
         .collect();
     let test_runtimes = test_runtimes?;
 
-    let default_path = crate::target_dir().join("all-fw.zip");
+    let default_name = if is_release {
+        "all-fw-release.zip"
+    } else {
+        "all-fw.zip"
+    };
+    let default_path = crate::target_dir().join(default_name);
     let path = output.map(Path::new).unwrap_or(&default_path);
     println!("Creating ZIP file: {}", path.display());
     let file = std::fs::File::create(path)?;

--- a/builder/src/features.rs
+++ b/builder/src/features.rs
@@ -64,6 +64,11 @@ pub const FPGA_RUNTIME_TEST_FEATURES: &[&str] = &[
     "test-mctp-spdm-responder-conformance",
 ];
 
+/// Release-profile runtime test features (emulator).
+/// These are the subset of tests we run against the release (512 KB SRAM,
+/// no debug logs) firmware to verify it boots and works correctly.
+pub const RELEASE_RUNTIME_TEST_FEATURES: &[&str] = &["test-flash-based-boot"];
+
 /// ROM-only test features that need a prebuilt ROM but no custom runtime.
 /// These features exist in both the emulator and FPGA ROM crates; the
 /// standard runtime is used unmodified.

--- a/builder/src/lib.rs
+++ b/builder/src/lib.rs
@@ -26,6 +26,13 @@ pub struct CaliptraBuildArgs<'a> {
     pub output_name: Option<String>,
     pub example_app: bool,
     pub svn: Option<u16>,
+    /// Cargo profile name to build with (e.g. `"release"` or `"devel"`).
+    /// When `None`, builds use `release`.  Drives both the `cargo --profile
+    /// <name>` invocation and the bundler manifest selection (`devel` swaps to
+    /// the `*-devel.toml` platform manifest with the larger 1 MB SRAM
+    /// dev-time layout; everything else falls through to the default 512 KB
+    /// shipping layout).
+    pub profile: Option<&'a str>,
     pub caliptra_rom: Option<PathBuf>,
     pub caliptra_firmware: Option<PathBuf>,
     pub soc_manifest: Option<PathBuf>,

--- a/builder/src/runtime.rs
+++ b/builder/src/runtime.rs
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-use crate::utils::manifest_file;
+use crate::utils::manifest_file_for_profile;
 use crate::{CaliptraBuildArgs, PROJECT_ROOT};
 use anyhow::Result;
 use caliptra_mcu_firmware_bundler::args::{
@@ -21,8 +21,9 @@ pub fn runtime_build_with_apps(args: &CaliptraBuildArgs) -> Result<PathBuf> {
     let platform = args.platform;
     let svn = args.svn;
     let target_dir = args.target_dir.clone();
+    let profile = args.profile.unwrap_or("devel").to_string();
 
-    let manifest = manifest_file(platform, example_app)?;
+    let manifest = manifest_file_for_profile(platform, example_app, args.profile)?;
     let platform_str = platform.unwrap_or("emulator");
     let output_name = output_name.unwrap_or_else(|| format!("runtime-{}.bin", platform_str));
 
@@ -30,6 +31,7 @@ pub fn runtime_build_with_apps(args: &CaliptraBuildArgs) -> Result<PathBuf> {
         manifest,
         svn,
         target_dir,
+        profile,
         ..Default::default()
     };
     let release_dir = common.release_dir()?;

--- a/builder/src/utils.rs
+++ b/builder/src/utils.rs
@@ -8,21 +8,45 @@ use anyhow::{bail, Result};
 
 use caliptra_mcu_firmware_bundler::utils::find_workspace_directory;
 
+// Default emulator manifests use the constrained 512 KB SRAM layout (matches
+// the real device).  Built by the default `release` cargo profile.
 const EMU_USER_APP_MANIFEST: &str = "firmware-bundler/reference/emulator/user-app.toml";
 const EMU_EXAMPLE_APP_MANIFEST: &str = "firmware-bundler/reference/emulator/example-app.toml";
+// `devel` profile mirrors the dev-time layout with 1 MB SRAM so the debug-only
+// Tock components (Console / DebugWriter / LowLevelDebug / ProcessConsole) fit
+// alongside the kernel and apps.  Only emulator gets a `*-devel.toml` for now —
+// FPGA SRAM is fixed by the FPGA fabric and always uses the single layout.
+const EMU_USER_APP_MANIFEST_DEVEL: &str = "firmware-bundler/reference/emulator/user-app-devel.toml";
+const EMU_EXAMPLE_APP_MANIFEST_DEVEL: &str =
+    "firmware-bundler/reference/emulator/example-app-devel.toml";
 const FPGA_USER_APP_MANIFEST: &str = "firmware-bundler/reference/fpga/user-app.toml";
 const FPGA_EXAMPLE_APP_MANIFEST: &str = "firmware-bundler/reference/fpga/example-app.toml";
 
 pub fn manifest_file(platform: Option<&str>, example_app: bool) -> Result<PathBuf> {
+    manifest_file_for_profile(platform, example_app, None)
+}
+
+/// Resolve the bundler platform manifest for `platform`, optionally swapping
+/// to the shipping `*.toml` variant when `profile == Some("release")`.  All
+/// other profile names — including `None`, `"devel"`, and any custom name —
+/// fall through to the dev-time `*-devel.toml` manifest with the 1 MB SRAM
+/// layout.  This matches `xtask`'s default-profile semantics: `runtime-build`
+/// uses `devel` unless the caller explicitly opts into `--profile release`.
+pub fn manifest_file_for_profile(
+    platform: Option<&str>,
+    example_app: bool,
+    profile: Option<&str>,
+) -> Result<PathBuf> {
+    let release = matches!(profile, Some("release"));
     let manifest = match platform {
-        Some("emulator") | None => {
-            if example_app {
-                EMU_EXAMPLE_APP_MANIFEST
-            } else {
-                EMU_USER_APP_MANIFEST
-            }
-        }
+        Some("emulator") | None => match (example_app, release) {
+            (true, true) => EMU_EXAMPLE_APP_MANIFEST,
+            (true, false) => EMU_EXAMPLE_APP_MANIFEST_DEVEL,
+            (false, true) => EMU_USER_APP_MANIFEST,
+            (false, false) => EMU_USER_APP_MANIFEST_DEVEL,
+        },
         Some("fpga") => {
+            // FPGA SRAM is hardware-constrained; no `*-devel.toml` variant.
             if example_app {
                 FPGA_EXAMPLE_APP_MANIFEST
             } else {

--- a/firmware-bundler/reference/emulator/example-app-devel.toml
+++ b/firmware-bundler/reference/emulator/example-app-devel.toml
@@ -1,10 +1,10 @@
 # Licensed under the Apache-2.0 license
 #
-# Default (`release` profile) bundler manifest for the emulator example-app
-# build.  Uses the constrained 512 KB SRAM layout that mirrors the real device,
-# paired with the `release` cargo feature (auto-enabled by `xtask runtime-build
-# --profile release`).  See `example-app-devel.toml` for the larger 1 MB
-# devel-time layout.
+# Devel-time (`devel` profile) bundler manifest for the emulator example-app
+# build.  Uses a larger 1 MB SRAM layout (vs the 512 KB shipping layout in
+# `example-app.toml`) so debug-only Tock components fit alongside the kernel +
+# app, and is paired with the default cargo features (without the `release` cargo feature).  Selected by
+# `xtask runtime-build --profile devel` and `xtask runtime`.
 
 [platform]
 name = "emulator-example-app"
@@ -17,7 +17,7 @@ offset = 0x8000_0000
 size = 0x1_0000
 
 [platform.runtime_memory]
-sram = { offset = 0x4000_0000, size = 0x8_0000 }
+sram = { offset = 0x4000_0000, size = 0x10_0000 }
 
 [platform.dccm]
 offset = 0x5000_0000
@@ -41,3 +41,4 @@ stack = 0x0_7000
 name = "example-app"
 stack = 0x7600
 grant_space = 0x4000
+

--- a/firmware-bundler/reference/emulator/user-app-devel.toml
+++ b/firmware-bundler/reference/emulator/user-app-devel.toml
@@ -1,13 +1,13 @@
 # Licensed under the Apache-2.0 license
 #
-# Default (`release` profile) bundler manifest for the emulator example-app
-# build.  Uses the constrained 512 KB SRAM layout that mirrors the real device,
-# paired with the `release` cargo feature (auto-enabled by `xtask runtime-build
-# --profile release`).  See `example-app-devel.toml` for the larger 1 MB
-# devel-time layout.
+# Devel-time (`devel` profile) bundler manifest for the emulator user-app
+# build.  Uses a larger 1 MB SRAM layout (vs the 512 KB shipping layout in
+# `user-app.toml`) so debug-only Tock components fit alongside the kernel +
+# app, and is paired with the default cargo features (without the `release` cargo feature).  Selected by
+# `xtask runtime-build --profile devel` and `xtask runtime`.
 
 [platform]
-name = "emulator-example-app"
+name = "emulator-user-app"
 tuple = "riscv32imc-unknown-none-elf"
 dynamic_sizing = true
 page_size = 256
@@ -17,7 +17,7 @@ offset = 0x8000_0000
 size = 0x1_0000
 
 [platform.runtime_memory]
-sram = { offset = 0x4000_0000, size = 0x8_0000 }
+sram = { offset = 0x4000_0000, size = 0x10_0000 }
 
 [platform.dccm]
 offset = 0x5000_0000
@@ -38,6 +38,7 @@ name = "mcu-runtime-emulator"
 stack = 0x0_7000
 
 [[app]]
-name = "example-app"
-stack = 0x7600
+name = "user-app"
+stack = 0xae00
 grant_space = 0x4000
+

--- a/firmware-bundler/reference/emulator/user-app.toml
+++ b/firmware-bundler/reference/emulator/user-app.toml
@@ -1,4 +1,9 @@
 # Licensed under the Apache-2.0 license
+#
+# Default (`release` profile) bundler manifest for the emulator user-app build.
+# Uses the constrained 512 KB SRAM layout that mirrors the real device, paired
+# with the `release` cargo feature (auto-enabled by `xtask runtime-build --profile
+# release`).  See `user-app-devel.toml` for the larger 1 MB devel-time layout.
 
 [platform]
 name = "emulator-user-app"
@@ -35,4 +40,3 @@ stack = 0x0_7000
 name = "user-app"
 stack = 0xae00
 grant_space = 0x4000
-

--- a/firmware-bundler/src/args.rs
+++ b/firmware-bundler/src/args.rs
@@ -31,6 +31,11 @@ pub struct Common {
     /// the target directory based on the workspace directory.
     #[arg(long)]
     pub target_dir: Option<PathBuf>,
+
+    /// The cargo profile to build with (passed to `cargo rustc --profile <name>`).  Defaults to
+    /// `release`; built artifacts land in `target/<tuple>/<profile>/`.
+    #[arg(long, default_value = "release")]
+    pub profile: String,
 }
 
 impl Common {
@@ -56,12 +61,23 @@ impl Common {
         }
     }
 
-    /// Retrieve the release directory, using the target tuple for the manifest and an invocation
-    /// of `target_dir`.
+    /// Retrieve the cargo profile name (defaults to `"release"` if unset / empty).
+    pub fn profile(&self) -> &str {
+        if self.profile.is_empty() {
+            "release"
+        } else {
+            &self.profile
+        }
+    }
+
+    /// Retrieve the build-output directory: `<target>/<tuple>/<profile>/`.
+    /// Named `release_dir` for backwards compatibility — historically the bundler always built
+    /// with `--release` and emitted into `target/<tuple>/release/`.
     pub fn release_dir(&self) -> Result<PathBuf> {
         let manifest = self.manifest()?;
+        let profile = self.profile().to_string();
         self.target_dir()
-            .map(|t| t.join(manifest.platform.tuple).join("release"))
+            .map(|t| t.join(manifest.platform.tuple).join(profile))
     }
 
     /// Create a new Common struct for testing purposes.
@@ -72,6 +88,7 @@ impl Common {
             workspace_dir: Some(workspace_dir),
             svn: None,
             target_dir: None,
+            profile: "release".to_string(),
         }
     }
 }

--- a/firmware-bundler/src/build.rs
+++ b/firmware-bundler/src/build.rs
@@ -125,6 +125,7 @@ struct BuildPass<'a> {
     build_args: &'a BuildArgs,
     binary_dir: PathBuf,
     target_dir: PathBuf,
+    profile: String,
     objcopy: PathBuf,
 }
 
@@ -140,6 +141,7 @@ impl<'a> BuildPass<'a> {
         // wish to place binaries.
         let binary_dir = common.release_dir()?;
         let target_dir = common.target_dir()?;
+        let profile = common.profile().to_string();
 
         let objcopy = match &build_args.objcopy {
             Some(o) => o.clone(),
@@ -152,6 +154,7 @@ impl<'a> BuildPass<'a> {
             build_args,
             binary_dir,
             target_dir,
+            profile,
             objcopy,
         })
     }
@@ -239,7 +242,8 @@ impl<'a> BuildPass<'a> {
             .arg(&self.manifest.platform.tuple)
             .arg("--target-dir")
             .arg(&self.target_dir)
-            .arg("--release");
+            .arg("--profile")
+            .arg(&self.profile);
 
         if let Some(f) = features {
             cmd.arg("--features").arg(f);

--- a/platforms/emulator/config/src/lib.rs
+++ b/platforms/emulator/config/src/lib.rs
@@ -17,7 +17,12 @@ pub const EMULATOR_MEMORY_MAP: McuMemoryMap = McuMemoryMap {
     dccm_properties: MemoryRegionType::MEMORY,
 
     sram_offset: 0x4000_0000,
-    sram_size: 512 * 1024, // TEMPORARY: Increased SRAM size to accommodate integration testing
+    // 1 MB SRAM declared.  Default `devel` builds use the full region; `release`
+    // builds (selected by `xtask runtime-build --profile release`) use a linker
+    // layout that fits in the lower 512 KB to mirror the real device.  Setting
+    // the const to the larger value covers both cases at runtime — the release
+    // image just doesn't reference the upper half.
+    sram_size: 1024 * 1024,
     sram_properties: MemoryRegionType::MEMORY,
 
     pic_offset: 0x6000_0000,

--- a/platforms/emulator/runtime/Cargo.toml
+++ b/platforms/emulator/runtime/Cargo.toml
@@ -41,7 +41,12 @@ rv32i.workspace = true
 
 [features]
 default = []
-debug = []
+# Production / minimal-size build.  Strips:
+#   - kernel `debug!()` macro          (via kernel/no_debug_panics)
+#   - romtime `print!`/`println!`      (via caliptra-mcu-romtime/no-print)
+#   - DebugWriter, Console, LowLevelDebug, ProcessConsole, ProcessPrinter
+# Default (off) = full debug / interactive experience.
+release = ["kernel/no_debug_panics", "caliptra-mcu-romtime/no-print"]
 hw-2-1 = []
 test-caliptra-certs = []
 test-caliptra-crypto = []

--- a/platforms/emulator/runtime/src/board.rs
+++ b/platforms/emulator/runtime/src/board.rs
@@ -124,10 +124,12 @@ struct VeeR {
         'static,
         VirtualMuxAlarm<'static, InternalTimers<'static>>,
     >,
-    console: &'static capsules_core::console::Console<'static>,
-    lldb: &'static capsules_core::low_level_debug::LowLevelDebug<
-        'static,
-        capsules_core::virtualizers::virtual_uart::UartDevice<'static>,
+    console: Option<&'static capsules_core::console::Console<'static>>,
+    lldb: Option<
+        &'static capsules_core::low_level_debug::LowLevelDebug<
+            'static,
+            capsules_core::virtualizers::virtual_uart::UartDevice<'static>,
+        >,
     >,
     scheduler: &'static CooperativeSched<'static>,
     scheduler_timer:
@@ -172,8 +174,12 @@ impl SyscallDriverLookup for VeeR {
     {
         match driver_num {
             capsules_core::alarm::DRIVER_NUM => f(Some(self.alarm)),
-            capsules_core::console::DRIVER_NUM => f(Some(self.console)),
-            capsules_core::low_level_debug::DRIVER_NUM => f(Some(self.lldb)),
+            capsules_core::console::DRIVER_NUM => f(self
+                .console
+                .map(|c| c as &dyn kernel::syscall::SyscallDriver)),
+            capsules_core::low_level_debug::DRIVER_NUM => {
+                f(self.lldb.map(|l| l as &dyn kernel::syscall::SyscallDriver))
+            }
             caliptra_mcu_capsules_runtime::mctp::driver::MCTP_SPDM_DRIVER_NUM => {
                 f(Some(self.mctp_spdm))
             }
@@ -566,32 +572,53 @@ pub unsafe fn main() {
     CHIP = Some(chip);
 
     // Create a shared UART channel for the console and for kernel debug.
+    // The DebugWriter must always be initialized because the kernel's `debug!()`
+    // macro and panic/fault handlers unconditionally call `get_debug_writer()`.
     let uart_mux = components::console::UartMuxComponent::new(&emulator_peripherals.uart, 115200)
         .finalize(components::uart_mux_component_static!());
 
     // Create the debugger object that handles calls to `debug!()`.
+    // Must always be present — the kernel's panic handler and fault diagnostics
+    // require it.  The `no_debug_panics` feature only gates process-info
+    // printing, not the writer itself.
     components::debug_writer::DebugWriterComponent::new(uart_mux)
         .finalize(components::debug_writer_component_static!());
 
-    let lldb = components::lldb::LowLevelDebugComponent::new(
-        board_kernel,
-        capsules_core::low_level_debug::DRIVER_NUM,
-        uart_mux,
-    )
-    .finalize(components::low_level_debug_component_static!());
+    // LowLevelDebug capsule (alert-code printer used by user-app panic
+    // handlers).  Stripped in `release` builds.
+    #[cfg(not(feature = "release"))]
+    let lldb = Some(
+        components::lldb::LowLevelDebugComponent::new(
+            board_kernel,
+            capsules_core::low_level_debug::DRIVER_NUM,
+            uart_mux,
+        )
+        .finalize(components::low_level_debug_component_static!()),
+    );
+    #[cfg(feature = "release")]
+    let lldb = None;
 
-    // Setup the console.
-    let console = components::console::ConsoleComponent::new(
-        board_kernel,
-        capsules_core::console::DRIVER_NUM,
-        uart_mux,
-    )
-    .finalize(components::console_component_static!());
+    // Setup the console.  Userspace `Console::<>::writer()` writes to this
+    // syscall driver.  Stripped in `release` builds; user-app `writeln!()` calls use `let _ = ...`
+    // so the syscall returning `NoDevice` does not panic.
+    #[cfg(not(feature = "release"))]
+    let console = Some(
+        components::console::ConsoleComponent::new(
+            board_kernel,
+            capsules_core::console::DRIVER_NUM,
+            uart_mux,
+        )
+        .finalize(components::console_component_static!()),
+    );
+    #[cfg(feature = "release")]
+    let console = None;
 
     // Create a process printer for panic.
-
-    // disabled by default as this takes almost 20 KB of code space
-    if cfg!(feature = "debug") {
+    // Disabled by default as this takes almost 20 KB of code space.  Use the
+    // attribute form (not `if cfg!(...)`) so the body — which references
+    // `uart_mux` — is excluded from compilation when the feature is off.
+    #[cfg(not(feature = "release"))]
+    {
         let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
             .finalize(components::process_printer_text_component_static!());
         PROCESS_PRINTER = Some(process_printer);
@@ -914,7 +941,13 @@ pub fn run_kernel_op(loops: usize) {
 /// - The watchdog timer should be disabled so tests are not killed by it.
 ///
 /// Exits the emulator if a test returns an exit code.
-#[allow(unused_variables)]
+///
+/// Each test arm is gated with `#[cfg(feature = "...")]` (attribute form, not
+/// `if cfg!(...)`) so test bodies — including their `crate::tests::*` module
+/// references and `storage_volume!()` allocations — are excluded from
+/// compilation entirely when their feature is off.  This keeps the test code
+/// out of production builds.
+#[allow(unused_variables, unused_mut, unused_assignments)]
 fn run_kernel_tests(
     mux_alarm: &'static MuxAlarm<'static, InternalTimers<'static>>,
     emulator_peripherals: &'static EmulatorPeripherals<'static>,
@@ -924,59 +957,88 @@ fn run_kernel_tests(
         caliptra_mcu_capsules_runtime::mctp::transport_binding::MCTPI3CBinding<'static>,
     >,
 ) {
-    let exit = if cfg!(feature = "test-exit-immediately") {
+    let mut exit: Option<u32> = None;
+
+    #[cfg(feature = "test-exit-immediately")]
+    {
         debug!("Executing test-exit-immediately");
-        Some(0)
-    } else if cfg!(feature = "test-i3c-simple") {
+        exit = Some(0);
+    }
+    #[cfg(feature = "test-i3c-simple")]
+    {
         debug!("Executing test-i3c-simple");
-        crate::tests::i3c_target_test::run_test_i3c_simple()
-    } else if cfg!(feature = "test-i3c-constant-writes") {
+        exit = crate::tests::i3c_target_test::run_test_i3c_simple();
+    }
+    #[cfg(feature = "test-i3c-constant-writes")]
+    {
         debug!("Executing test-i3c-constant-writes");
-        crate::tests::i3c_target_test::run_test_i3c_constant_writes()
-    } else if cfg!(feature = "test-flash-ctrl-init") {
+        exit = crate::tests::i3c_target_test::run_test_i3c_constant_writes();
+    }
+    #[cfg(feature = "test-flash-ctrl-init")]
+    {
         debug!("Executing test-flash-ctrl-init");
-        crate::tests::flash_ctrl_test::test_flash_ctrl_init()
-    } else if cfg!(feature = "test-flash-ctrl-read-write-page") {
+        exit = crate::tests::flash_ctrl_test::test_flash_ctrl_init();
+    }
+    #[cfg(feature = "test-flash-ctrl-read-write-page")]
+    {
         debug!("Executing test-flash-ctrl-read-write-page");
-        crate::tests::flash_ctrl_test::test_flash_ctrl_read_write_page()
-    } else if cfg!(feature = "test-flash-ctrl-erase-page") {
+        exit = crate::tests::flash_ctrl_test::test_flash_ctrl_read_write_page();
+    }
+    #[cfg(feature = "test-flash-ctrl-erase-page")]
+    {
         debug!("Executing test-flash-ctrl-erase-page");
-        crate::tests::flash_ctrl_test::test_flash_ctrl_erase_page()
-    } else if cfg!(feature = "test-flash-storage-read-write") {
+        exit = crate::tests::flash_ctrl_test::test_flash_ctrl_erase_page();
+    }
+    #[cfg(feature = "test-flash-storage-read-write")]
+    {
         debug!("Executing test-flash-storage-read-write");
-        crate::tests::flash_storage_test::test_flash_storage_read_write()
-    } else if cfg!(feature = "test-flash-storage-erase") {
+        exit = crate::tests::flash_storage_test::test_flash_storage_read_write();
+    }
+    #[cfg(feature = "test-flash-storage-erase")]
+    {
         debug!("Executing test-flash-storage-erase");
-        crate::tests::flash_storage_test::test_flash_storage_erase()
-    } else if cfg!(feature = "test-mcu-rom-flash-access") {
+        exit = crate::tests::flash_storage_test::test_flash_storage_erase();
+    }
+    #[cfg(feature = "test-mcu-rom-flash-access")]
+    {
         debug!("Executing test-mcu-rom-flash-access");
-        Some(0)
-    } else if cfg!(feature = "test-doe-transport-loopback") {
+        exit = Some(0);
+    }
+    #[cfg(feature = "test-doe-transport-loopback")]
+    {
         debug!("Executing test-doe-transport-loopback");
-        crate::tests::doe_transport_test::test_doe_transport_loopback()
-    } else if cfg!(feature = "test-log-flash-circular") {
+        exit = crate::tests::doe_transport_test::test_doe_transport_loopback();
+    }
+    #[cfg(feature = "test-log-flash-circular")]
+    {
         debug!("Executing test-log-flash-circular");
         unsafe {
-            crate::tests::circular_log_test::run(
+            exit = crate::tests::circular_log_test::run(
                 mux_alarm,
                 &emulator_peripherals.primary_flash_ctrl,
-            )
+            );
         }
-    } else if cfg!(feature = "test-log-flash-linear") {
+    }
+    #[cfg(feature = "test-log-flash-linear")]
+    {
         debug!("Executing test-log-flash-linear");
         unsafe {
-            crate::tests::linear_log_test::run(mux_alarm, &emulator_peripherals.primary_flash_ctrl)
+            exit = crate::tests::linear_log_test::run(
+                mux_alarm,
+                &emulator_peripherals.primary_flash_ctrl,
+            );
         }
-    } else if cfg!(feature = "test-mcu-mbox-driver") {
+    }
+    #[cfg(feature = "test-mcu-mbox-driver")]
+    {
         debug!("Executing test-mcu-mbox-driver");
-        crate::tests::mcu_mbox_test::test_mcu_mbox()
-    } else if cfg!(feature = "test-mcu-mbox-soc-requester-loopback") {
+        exit = crate::tests::mcu_mbox_test::test_mcu_mbox();
+    }
+    #[cfg(feature = "test-mcu-mbox-soc-requester-loopback")]
+    {
         debug!("Executing test-mcu-mbox-soc-requester-loopback");
         crate::tests::mcu_mbox_driver_loopback_test::test_mcu_mbox_soc_requester_loopback();
-        None
-    } else {
-        None
-    };
+    }
 
     #[cfg(feature = "test-mctp-capsule-loopback")]
     {

--- a/platforms/emulator/runtime/src/tests/mod.rs
+++ b/platforms/emulator/runtime/src/tests/mod.rs
@@ -1,12 +1,27 @@
 // Licensed under the Apache-2.0 license
 
+#[cfg(any(feature = "test-log-flash-circular", feature = "test-log-flash-linear",))]
 pub(crate) mod circular_log_test;
+#[cfg(feature = "test-doe-transport-loopback")]
 pub(crate) mod doe_transport_test;
+#[cfg(any(
+    feature = "test-flash-ctrl-init",
+    feature = "test-flash-ctrl-read-write-page",
+    feature = "test-flash-ctrl-erase-page",
+))]
 pub(crate) mod flash_ctrl_test;
+#[cfg(any(
+    feature = "test-flash-storage-read-write",
+    feature = "test-flash-storage-erase",
+))]
 pub(crate) mod flash_storage_test;
+#[cfg(any(feature = "test-i3c-simple", feature = "test-i3c-constant-writes",))]
 pub(crate) mod i3c_target_test;
+#[cfg(any(feature = "test-log-flash-circular", feature = "test-log-flash-linear",))]
 pub(crate) mod linear_log_test;
 #[cfg(feature = "test-mctp-capsule-loopback")]
 pub(crate) mod mctp_test;
+#[cfg(feature = "test-mcu-mbox-soc-requester-loopback")]
 pub(crate) mod mcu_mbox_driver_loopback_test;
+#[cfg(feature = "test-mcu-mbox-driver")]
 pub(crate) mod mcu_mbox_test;

--- a/platforms/emulator/runtime/src/tests/mod.rs
+++ b/platforms/emulator/runtime/src/tests/mod.rs
@@ -23,5 +23,8 @@ pub(crate) mod linear_log_test;
 pub(crate) mod mctp_test;
 #[cfg(feature = "test-mcu-mbox-soc-requester-loopback")]
 pub(crate) mod mcu_mbox_driver_loopback_test;
-#[cfg(feature = "test-mcu-mbox-driver")]
+#[cfg(any(
+    feature = "test-mcu-mbox-driver",
+    feature = "test-mcu-mbox-soc-requester-loopback",
+))]
 pub(crate) mod mcu_mbox_test;

--- a/platforms/emulator/runtime/userspace/apps/example/Cargo.toml
+++ b/platforms/emulator/runtime/userspace/apps/example/Cargo.toml
@@ -40,6 +40,9 @@ default = []
 debug = []
 doe = []
 hw-2-1 = []
+# No-op stub forwarded through `runtime_build_with_apps`; size optimization
+# lives in `mcu-runtime-emulator`/`mcu-runtime-fpga`.
+release = []
 test-caliptra-certs = []
 test-caliptra-crypto = []
 test-caliptra-mailbox = []

--- a/platforms/emulator/runtime/userspace/apps/user/Cargo.toml
+++ b/platforms/emulator/runtime/userspace/apps/user/Cargo.toml
@@ -50,10 +50,17 @@ portable-atomic = { workspace = true, features = ["critical-section"] }
 
 [features]
 default = []
-debug = []
 hw-2-1 = []
 doe = []
 pcr-quote-measurements = []
+# Production / minimal-size build for user-app.  Activated automatically by
+# `xtask runtime-build --profile release` (via `--features release` forwarded
+# through the bundler).  Gates `console_writeln!` to a no-op so all of
+# user-app's informational and diagnostic output (including the `{:?}` Debug
+# format paths) is stripped, and forwards to `caliptra-mcu-romtime/no-print`
+# so the romtime `print!`/`println!` macros become no-ops inside user-app's
+# private dependency build of `caliptra-mcu-romtime`.
+release = ["caliptra-mcu-romtime/no-print"]
 test-caliptra-certs = []
 test-caliptra-crypto = []
 test-caliptra-mailbox = []

--- a/platforms/emulator/runtime/userspace/apps/user/src/firmware_update/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/firmware_update/mod.rs
@@ -34,7 +34,7 @@ pub async fn firmware_update<D: DMAMapping>(dma_mapping: &D) -> Result<(), Error
         // Device rebooted due to firmware update, skip firmware update
         return Ok(());
     }
-    writeln!(console_writer, "[FW Upd] Start").unwrap();
+    crate::console_writeln!(console_writer, "[FW Upd] Start");
     #[cfg(feature = "test-firmware-update-streaming")]
     {
         let fw_params = PldmFirmwareDeviceParams {
@@ -72,7 +72,7 @@ pub async fn firmware_update<D: DMAMapping>(dma_mapping: &D) -> Result<(), Error
     }
 
     // Trigger MCU warm reset to boot into new firmware
-    writeln!(console_writer, "[FW Upd] Triggering MCU reset").unwrap();
+    crate::console_writeln!(console_writer, "[FW Upd] Triggering MCU reset");
     let mci = MciSyscall::<DefaultSyscalls>::new();
     mci.trigger_warm_reset()?;
 
@@ -271,13 +271,12 @@ mod flash_memory {
                 .get_partition_from_id(inactive_partition_id)
                 .map_err(|_| ErrorCode::Fail)?;
 
-            writeln!(
+            crate::console_writeln!(
                 Console::<DefaultSyscalls>::writer(),
                 "[FW Upd] Copying image from staging to inactive partition {:?} length {}",
                 inactive_partition_id,
                 img_sz
-            )
-            .unwrap();
+            );
             // Mark inactive partittion as invalid
             boot_config
                 .set_partition_status(inactive_partition_id, PartitionStatus::Invalid)

--- a/platforms/emulator/runtime/userspace/apps/user/src/image_loader/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/image_loader/mod.rs
@@ -120,7 +120,7 @@ pub async fn image_loading_task() {
 #[allow(unused_variables)]
 async fn image_loading<D: DMAMapping>(dma_mapping: &'static D) -> Result<(), ErrorCode> {
     let mut console_writer = Console::<DefaultSyscalls>::writer();
-    writeln!(console_writer, "IMAGE_LOADER_APP: Hello async world!").unwrap();
+    crate::console_writeln!(console_writer, "IMAGE_LOADER_APP: Hello async world!");
     #[cfg(feature = "test-pldm-streaming-boot")]
     {
         let fw_params = PldmFirmwareDeviceParams {
@@ -220,18 +220,16 @@ async fn image_loading<D: DMAMapping>(dma_mapping: &'static D) -> Result<(), Err
     {
         let fdops = pldm_fdops_mock::FdOpsObject::new();
         let mut pldm_service = PldmService::init(&fdops, EXECUTOR.get().spawner());
-        writeln!(
+        crate::console_writeln!(
             console_writer,
             "PLDM_APP: Starting PLDM service for testing..."
-        )
-        .unwrap();
+        );
         if let Err(e) = pldm_service.start().await {
-            writeln!(
+            crate::console_writeln!(
                 console_writer,
                 "PLDM_APP: Error starting PLDM service: {:?}",
                 e
-            )
-            .unwrap();
+            );
         }
         pldm_fdops_mock::FdOpsObject::wait_for_pldm_done().await;
     }

--- a/platforms/emulator/runtime/userspace/apps/user/src/main.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/main.rs
@@ -11,6 +11,31 @@ use caliptra_mcu_libtockasync::TockExecutor;
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 #[allow(unused)]
 use embassy_sync::{lazy_lock::LazyLock, signal::Signal};
+
+/// Console `writeln!` that compiles to a no-op in `release` cargo-feature
+/// builds (i.e. the shipping `--profile release` build that auto-enables
+/// `--features release`).  In `devel` builds the macro is a real `writeln!`,
+/// preserving every diagnostic and informational message.
+///
+/// The `release` arm expands to a never-called closure so its arguments are
+/// type-checked (no unused-var warnings, formatting traits satisfied) but the
+/// closure body is unreachable.  LTO + lld `--gc-sections` strip the format
+/// strings, any `Debug` impls reached via `{:?}`, and the entire console
+/// syscall path from the binary.
+#[macro_export]
+macro_rules! console_writeln {
+    ($($arg:tt)*) => {{
+        #[cfg(not(feature = "release"))]
+        {
+            let _ = ::core::writeln!($($arg)*);
+        }
+        #[cfg(feature = "release")]
+        {
+            let _ = || -> ::core::fmt::Result { ::core::writeln!($($arg)*) };
+        }
+    }};
+}
+
 mod caliptra_cmd_handler;
 #[cfg(any(
     feature = "test-firmware-update-streaming",

--- a/platforms/emulator/runtime/userspace/apps/user/src/mcu_mbox/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/mcu_mbox/mod.rs
@@ -37,7 +37,7 @@ pub async fn mcu_mbox_task() {
 #[allow(unused_variables)]
 async fn start_mcu_mbox_service() -> Result<(), ErrorCode> {
     let mut console_writer = Console::<DefaultSyscalls>::writer();
-    writeln!(console_writer, "Starting MCU_MBOX task...").unwrap();
+    crate::console_writeln!(console_writer, "Starting MCU_MBOX task...");
 
     #[cfg(any(
         feature = "test-mcu-mbox-cmds",
@@ -57,19 +57,17 @@ async fn start_mcu_mbox_service() -> Result<(), ErrorCode> {
             &mut transport,
             crate::EXECUTOR.get().spawner(),
         );
-        writeln!(
+        crate::console_writeln!(
             console_writer,
             "Starting MCU_MBOX service for integration tests..."
-        )
-        .unwrap();
+        );
 
         if let Err(e) = mcu_mbox_service.start().await {
-            writeln!(
+            crate::console_writeln!(
                 console_writer,
                 "USER_APP: Error starting MCU_MBOX service: {:?}",
                 e
-            )
-            .unwrap();
+            );
         }
         let suspend_signal: Signal<CriticalSectionRawMutex, ()> = Signal::new();
         suspend_signal.wait().await;

--- a/platforms/emulator/runtime/userspace/apps/user/src/riscv.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/riscv.rs
@@ -24,7 +24,7 @@ fn main() {
     unsafe { HEAP.init(HEAP_MEM.as_ptr() as usize, HEAP_SIZE) }
 
     let mut console_writer = Console::writer();
-    writeln!(console_writer, "Hello world! from SPDM main").unwrap();
+    crate::console_writeln!(console_writer, "Hello world! from SPDM main");
 
     caliptra_mcu_libtockasync::start_async(crate::start());
 }

--- a/platforms/emulator/runtime/userspace/apps/user/src/spdm/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/spdm/mod.rs
@@ -61,14 +61,14 @@ fn log_spdm_err<W: Write>(w: &mut W, prefix: &str, msg: &str, e: &SpdmError) {
 #[embassy_executor::task]
 pub(crate) async fn spdm_task(spawner: Spawner) {
     let mut console_writer = Console::<DefaultSyscalls>::writer();
-    writeln!(console_writer, "SPDM_TASK: Running SPDM-TASK...").unwrap();
+    crate::console_writeln!(console_writer, "SPDM_TASK: Running SPDM-TASK...");
 
     // Initialize the shared large message buffer (once, before spawning responders)
     shared_large_msg_buf::init();
 
     // Initialize the shared certificate store
     if let Err(e) = initialize_cert_store().await {
-        writeln!(
+        crate::console_writeln!(
             console_writer,
             "SPDM_TASK: Failed to initialize certificate store: 0x{:08x}",
             e.error_code()
@@ -300,7 +300,7 @@ async fn spdm_doe_responder() {
         match result {
             Ok(_) => {}
             Err(SpdmError::Transport(TransportError::DriverError(ErrorCode::NoDevice))) => {
-                writeln!(cw, "SPDM_DOE_RESPONDER: No DOE device, exiting task").unwrap();
+                crate::console_writeln!(cw, "SPDM_DOE_RESPONDER: No DOE device, exiting task");
                 break;
             }
             Err(e) => {

--- a/platforms/emulator/runtime/userspace/apps/user/src/spdm/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/spdm/mod.rs
@@ -72,8 +72,7 @@ pub(crate) async fn spdm_task(spawner: Spawner) {
             console_writer,
             "SPDM_TASK: Failed to initialize certificate store: 0x{:08x}",
             e.error_code()
-        )
-        .unwrap();
+        );
         return;
     }
 

--- a/platforms/emulator/runtime/userspace/apps/user/src/vdm/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/vdm/mod.rs
@@ -33,7 +33,7 @@ pub async fn vdm_task() {
 #[allow(unused_variables)]
 async fn start_vdm_service() -> Result<(), ErrorCode> {
     let mut console_writer = Console::<DefaultSyscalls>::writer();
-    writeln!(console_writer, "Starting MCTP VDM task...").unwrap();
+    crate::console_writeln!(console_writer, "Starting MCTP VDM task...");
 
     #[cfg(any(
         feature = "test-mctp-vdm-cmds",
@@ -55,11 +55,10 @@ async fn start_vdm_service() -> Result<(), ErrorCode> {
 
         // Check if the transport driver exists
         if !transport.exists() {
-            writeln!(
+            crate::console_writeln!(
                 console_writer,
                 "USER_APP: MCTP VDM driver not found, skipping VDM service"
-            )
-            .unwrap();
+            );
             return Ok(());
         }
 
@@ -70,22 +69,20 @@ async fn start_vdm_service() -> Result<(), ErrorCode> {
             transport, handler,
         ));
 
-        writeln!(
+        crate::console_writeln!(
             console_writer,
             "Starting MCTP VDM service for integration tests..."
-        )
-        .unwrap();
+        );
 
         if let Err(e) = caliptra_mcu_mctp_vdm_lib::daemon::spawn_vdm_responder(
             crate::EXECUTOR.get().spawner(),
             cmd_interface,
         ) {
-            writeln!(
+            crate::console_writeln!(
                 console_writer,
                 "USER_APP: Error starting MCTP VDM service: {:?}",
                 e
-            )
-            .unwrap();
+            );
         }
         let suspend_signal: Signal<CriticalSectionRawMutex, ()> = Signal::new();
         suspend_signal.wait().await;

--- a/platforms/fpga/runtime/Cargo.toml
+++ b/platforms/fpga/runtime/Cargo.toml
@@ -37,7 +37,8 @@ rv32i.workspace = true
 
 [features]
 default = []
-debug = []
+# See `mcu-runtime-emulator`'s `release` feature for rationale.
+release = ["kernel/no_debug_panics", "caliptra-mcu-romtime/no-print"]
 test-caliptra-certs = []
 test-caliptra-crypto = []
 test-caliptra-mailbox = []

--- a/platforms/fpga/runtime/src/board.rs
+++ b/platforms/fpga/runtime/src/board.rs
@@ -129,10 +129,12 @@ struct VeeR {
         'static,
         VirtualMuxAlarm<'static, InternalTimers<'static>>,
     >,
-    console: &'static capsules_core::console::Console<'static>,
-    lldb: &'static capsules_core::low_level_debug::LowLevelDebug<
-        'static,
-        capsules_core::virtualizers::virtual_uart::UartDevice<'static>,
+    console: Option<&'static capsules_core::console::Console<'static>>,
+    lldb: Option<
+        &'static capsules_core::low_level_debug::LowLevelDebug<
+            'static,
+            capsules_core::virtualizers::virtual_uart::UartDevice<'static>,
+        >,
     >,
     scheduler: &'static CooperativeSched<'static>,
     scheduler_timer:
@@ -170,8 +172,12 @@ impl SyscallDriverLookup for VeeR {
     {
         match driver_num {
             capsules_core::alarm::DRIVER_NUM => f(Some(self.alarm)),
-            capsules_core::console::DRIVER_NUM => f(Some(self.console)),
-            capsules_core::low_level_debug::DRIVER_NUM => f(Some(self.lldb)),
+            capsules_core::console::DRIVER_NUM => f(self
+                .console
+                .map(|c| c as &dyn kernel::syscall::SyscallDriver)),
+            capsules_core::low_level_debug::DRIVER_NUM => {
+                f(self.lldb.map(|l| l as &dyn kernel::syscall::SyscallDriver))
+            }
             caliptra_mcu_capsules_runtime::mctp::driver::MCTP_SPDM_DRIVER_NUM => {
                 f(Some(self.mctp_spdm))
             }
@@ -507,35 +513,59 @@ pub unsafe fn main() {
     caliptra_mcu_romtime::println!("[mcu-runtime] Chip initialized");
 
     // Create a shared UART channel for the console and for kernel debug.
+    // The DebugWriter must always be initialized because the kernel's `debug!()`
+    // macro and panic/fault handlers unconditionally call `get_debug_writer()`.
     // TODO: add a new UART for the FPGA
     let uart_mux = components::console::UartMuxComponent::new(&fpga_peripherals.uart, 115200)
         .finalize(components::uart_mux_component_static!());
     caliptra_mcu_romtime::println!("[mcu-runtime] UART initialized");
 
     // Create the debugger object that handles calls to `debug!()`.
+    // Must always be present — the kernel's panic handler and fault diagnostics
+    // require it.
     components::debug_writer::DebugWriterComponent::new(uart_mux)
         .finalize(components::debug_writer_component_static!());
     caliptra_mcu_romtime::println!("[mcu-runtime] DebugWriter initialized");
 
-    let lldb = components::lldb::LowLevelDebugComponent::new(
-        board_kernel,
-        capsules_core::low_level_debug::DRIVER_NUM,
-        uart_mux,
-    )
-    .finalize(components::low_level_debug_component_static!());
-    caliptra_mcu_romtime::println!("[mcu-runtime] LowLevelDebugComponent initialized");
+    // LowLevelDebug capsule (alert-code printer used by user-app panic
+    // handlers).  Stripped in `release` builds.
+    #[cfg(not(feature = "release"))]
+    let lldb = Some({
+        let lldb = components::lldb::LowLevelDebugComponent::new(
+            board_kernel,
+            capsules_core::low_level_debug::DRIVER_NUM,
+            uart_mux,
+        )
+        .finalize(components::low_level_debug_component_static!());
+        caliptra_mcu_romtime::println!("[mcu-runtime] LowLevelDebugComponent initialized");
+        lldb
+    });
+    #[cfg(feature = "release")]
+    let lldb = None;
 
-    // Setup the console.
-    let console = components::console::ConsoleComponent::new(
-        board_kernel,
-        capsules_core::console::DRIVER_NUM,
-        uart_mux,
-    )
-    .finalize(components::console_component_static!());
-    caliptra_mcu_romtime::println!("[mcu-runtime] Console initialized");
+    // Setup the console.  Userspace `Console::<>::writer()` writes to this
+    // syscall driver.  Stripped in `release` builds; user-app `writeln!()` calls use `let _ = ...`
+    // so the syscall returning `NoDevice` does not panic.
+    #[cfg(not(feature = "release"))]
+    let console = Some({
+        let console = components::console::ConsoleComponent::new(
+            board_kernel,
+            capsules_core::console::DRIVER_NUM,
+            uart_mux,
+        )
+        .finalize(components::console_component_static!());
+        caliptra_mcu_romtime::println!("[mcu-runtime] Console initialized");
+        console
+    });
+    #[cfg(feature = "release")]
+    let console = None;
 
     // Create a process printer for panic.
-    if cfg!(feature = "debug") {
+    // Use the attribute form (not `if cfg!(...)`) so the body is excluded from
+    // compilation when the feature is off (it references items that may also
+    // be cfg'd out, e.g. `uart_mux`).
+    #[cfg(not(feature = "release"))]
+    {
         let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
             .finalize(components::process_printer_text_component_static!());
         PROCESS_PRINTER = Some(process_printer);
@@ -756,19 +786,26 @@ pub unsafe fn main() {
         BOARD = Some(board_kernel);
     }
 
-    // Run any requested test
-    let exit = if cfg!(feature = "test-exit-immediately") {
+    // Run any requested test.  Each arm is gated with `#[cfg(feature = ...)]`
+    // (attribute form, not `if cfg!(...)`) so test bodies are excluded from
+    // compilation entirely when their feature is off.
+    #[allow(unused_mut, unused_assignments)]
+    let mut exit: Option<u32> = None;
+    #[cfg(feature = "test-exit-immediately")]
+    {
         debug!("Executing test-exit-immediately");
-        Some(0)
-    } else if cfg!(feature = "test-i3c-simple") {
+        exit = Some(0);
+    }
+    #[cfg(feature = "test-i3c-simple")]
+    {
         debug!("Executing test-i3c-simple");
-        crate::tests::i3c_target_test::run_test_i3c_simple()
-    } else if cfg!(feature = "test-i3c-constant-writes") {
+        exit = crate::tests::i3c_target_test::run_test_i3c_simple();
+    }
+    #[cfg(feature = "test-i3c-constant-writes")]
+    {
         debug!("Executing test-i3c-constant-writes");
-        crate::tests::i3c_target_test::run_test_i3c_constant_writes()
-    } else {
-        None
-    };
+        exit = crate::tests::i3c_target_test::run_test_i3c_constant_writes();
+    }
 
     #[cfg(feature = "test-mctp-capsule-loopback")]
     {

--- a/platforms/fpga/runtime/src/tests/mod.rs
+++ b/platforms/fpga/runtime/src/tests/mod.rs
@@ -1,5 +1,6 @@
 // Licensed under the Apache-2.0 license
 
+#[cfg(any(feature = "test-i3c-simple", feature = "test-i3c-constant-writes",))]
 pub(crate) mod i3c_target_test;
 #[cfg(feature = "test-mctp-capsule-loopback")]
 pub(crate) mod mctp_test;

--- a/romtime/Cargo.toml
+++ b/romtime/Cargo.toml
@@ -26,3 +26,9 @@ rv32i.workspace = true
 [features]
 default = []
 core_test = []
+# Strip the `print!` / `println!` macros to no-ops that still type-check
+# `format_args!` so all call sites compile cleanly.  Used to drop a few KB of
+# `.rodata` (format strings) and `.text` (`core::fmt` machinery) in production
+# builds.  Disabled by default; enabled by `mcu-runtime-emulator`/
+# `mcu-runtime-fpga` via their `no-debug-print` feature.
+no-print = []

--- a/romtime/src/lib.rs
+++ b/romtime/src/lib.rs
@@ -36,6 +36,7 @@ pub fn set_printer(writer: &'static mut dyn Write) {
     }
 }
 
+#[cfg(not(feature = "no-print"))]
 #[macro_export]
 macro_rules! print {
     ($($arg:tt)*) => {
@@ -47,6 +48,19 @@ macro_rules! print {
     };
 }
 
+#[cfg(feature = "no-print")]
+#[macro_export]
+macro_rules! print {
+    ($($arg:tt)*) => {{
+        // Type-check `format_args!` (so all call sites stay valid) but discard
+        // the resulting `Arguments` so LTO/lld can drop it along with any
+        // `Display`/`Debug` impls reached through it.  Same pattern as Tock's
+        // `no_debug_panics` feature on the `debug!` macro.
+        let _ = ::core::format_args!($($arg)*);
+    }};
+}
+
+#[cfg(not(feature = "no-print"))]
 #[macro_export]
 macro_rules! println {
     ($($arg:tt)*) => {
@@ -54,6 +68,14 @@ macro_rules! println {
             let _ = writeln!(writer, $($arg)*);
         }
     };
+}
+
+#[cfg(feature = "no-print")]
+#[macro_export]
+macro_rules! println {
+    ($($arg:tt)*) => {{
+        let _ = ::core::format_args!($($arg)*);
+    }};
 }
 
 pub struct HexBytes<'a>(pub &'a [u8]);

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -112,6 +112,16 @@ enum Commands {
         /// Platform to build for. Default: emulator
         #[arg(long)]
         platform: Option<String>,
+
+        /// Cargo profile to build with.  Default: `devel` (1 MB SRAM, all
+        /// debug components present, `release` cargo feature OFF — suitable for
+        /// live debugging and dev-time iteration).  Use `--profile release`
+        /// for the constrained 512 KB SRAM layout that mirrors the real
+        /// device, with the `release` cargo feature auto-enabled (strips kernel
+        /// `debug!()`, romtime `println!()`, DebugWriter, Console,
+        /// LowLevelDebug, ProcessConsole).
+        #[arg(long, default_value = "devel")]
+        profile: String,
     },
     /// Build ROM
     RomBuild {
@@ -179,6 +189,10 @@ enum Commands {
         /// Device model string for firmware components (e.g. "DeviceX")
         #[arg(long, value_name = "MODEL")]
         model: Option<String>,
+
+        /// Cargo profile to build with.  Default: `devel`.
+        #[arg(long, default_value = "devel")]
+        profile: String,
     },
     /// Generate CoRIM (Concise Reference Integrity Manifest) from build artifacts
     Corim {
@@ -235,6 +249,10 @@ enum Commands {
         /// A specific test filter to apply (e.g., "test(my_test)")
         #[arg(long)]
         test_filter: Option<String>,
+
+        /// Nextest profile to use (default: nightly-emulator)
+        #[arg(long)]
+        nextest_profile: Option<String>,
     },
     /// Archive tests to a file
     TestArchive {
@@ -494,6 +512,7 @@ fn main() {
             pldm_manifest,
             vendor,
             model,
+            profile,
         } => caliptra_mcu_builder::all_build(caliptra_mcu_builder::AllBuildArgs {
             output: output.as_deref(),
             platform: platform.as_deref(),
@@ -505,6 +524,7 @@ fn main() {
             pldm_manifest: pldm_manifest.as_deref(),
             vendor: vendor.as_deref(),
             model: model.as_deref(),
+            profile: Some(profile.as_str()),
         }),
         Commands::EmulatorBuild { output } => {
             caliptra_mcu_builder::emulator_build(caliptra_mcu_builder::EmulatorBuildArgs {
@@ -516,13 +536,26 @@ fn main() {
             features,
             output,
             platform,
+            profile,
         } => {
+            // The opt-in `release` cargo profile auto-enables the `release` cargo
+            // feature, which strips the kernel `debug!()` macro, romtime
+            // `println!`, DebugWriter, Console, LowLevelDebug, and
+            // ProcessConsole.  The bundler also uses the default 512 KB SRAM
+            // platform manifest.  The default `devel` profile keeps all of
+            // those for live-debugging-friendly builds with the 1 MB SRAM
+            // layout.
+            let mut features: Vec<&str> = features.iter().map(|x| x.as_str()).collect();
+            if profile == "release" && !features.contains(&"release") {
+                features.push("release");
+            }
             let features_str = features.join(",");
             caliptra_mcu_builder::runtime_build_with_apps(
                 &caliptra_mcu_builder::CaliptraBuildArgs {
                     features: Some(&features_str),
                     output_name: output.clone(),
                     platform: platform.as_deref(),
+                    profile: Some(profile.as_str()),
                     ..Default::default()
                 },
             )
@@ -574,6 +607,7 @@ fn main() {
             firmware_bundle,
             emulator_bundle,
             test_filter,
+            nextest_profile,
         } => test::test(test::TestArgs {
             archive: archive.as_deref().and_then(|p| p.to_str()),
             shard: shard.as_deref(),
@@ -581,6 +615,7 @@ fn main() {
             firmware_bundle: firmware_bundle.as_deref().and_then(|p| p.to_str()),
             emulator_bundle: emulator_bundle.as_deref().and_then(|p| p.to_str()),
             test_filter: test_filter.as_deref(),
+            nextest_profile: nextest_profile.as_deref(),
         }),
         Commands::TestArchive { archive } => test::test_archive(archive.clone()),
         Commands::RegistersAutogen {

--- a/xtask/src/precheckin.rs
+++ b/xtask/src/precheckin.rs
@@ -10,6 +10,10 @@ pub(crate) fn precheckin() -> Result<()> {
     crate::deps::check()?;
     crate::docs::check_docs()?;
     crate::registers::autogen(true, &[], &[], None, None)?;
+
+    // Default `devel` profile: 1 MB SRAM, no `release` feature, all debug
+    // components present.  Catches code that the dev-time build would actually
+    // exercise.  Artifacts land in `target/<tuple>/devel/`.
     caliptra_mcu_builder::runtime_build_with_apps(
         &caliptra_mcu_builder::CaliptraBuildArgs::default(),
     )?;
@@ -17,6 +21,28 @@ pub(crate) fn precheckin() -> Result<()> {
         platform: Some("fpga"),
         ..Default::default()
     })?;
+
+    // `release` profile: strips kernel `debug!()`, romtime `println!`,
+    // DebugWriter, Console, LowLevelDebug, ProcessConsole; uses the
+    // constrained 512 KB SRAM layout that mirrors the real device.  Catches
+    // size regressions before they reach a shipping build.  Artifacts land in
+    // `target/<tuple>/release/`.
+    caliptra_mcu_builder::runtime_build_with_apps(&caliptra_mcu_builder::CaliptraBuildArgs {
+        features: Some("release"),
+        profile: Some("release"),
+        ..Default::default()
+    })?;
+    // FPGA does not have a `*-devel.toml` manifest variant (HW-fixed SRAM);
+    // still exercise the `release` cargo feature / `release` cargo profile
+    // against its single 512 KB layout so size regressions and
+    // release-only `cfg`s are caught.
+    caliptra_mcu_builder::runtime_build_with_apps(&caliptra_mcu_builder::CaliptraBuildArgs {
+        platform: Some("fpga"),
+        features: Some("release"),
+        profile: Some("release"),
+        ..Default::default()
+    })?;
+
     crate::test::test_panic_missing()?;
     crate::test::e2e_tests()?;
     crate::test::test_hello_c_emulator()?;

--- a/xtask/src/runtime.rs
+++ b/xtask/src/runtime.rs
@@ -33,8 +33,9 @@ pub(crate) fn runtime_run(args: Commands) -> Result<()> {
     if hw_revision >= semver::Version::new(2, 1, 0) && !features.contains(&"hw-2-1") {
         features.push("hw-2-1");
     }
-    // include debug features since this is interactive
-    features.push("debug");
+    // NOTE: interactive `xtask runtime` runs default-feature builds (without the `release` cargo feature),
+    // so DebugWriter / Console / LowLevelDebug / ProcessConsole / kernel
+    // `debug!()` / romtime `println!` are all available for live debugging.
     let features_str = features.join(",");
     let rom_binary =
         caliptra_mcu_builder::rom_build(&caliptra_mcu_builder::CaliptraBuildArgs::default())?;

--- a/xtask/src/test.rs
+++ b/xtask/src/test.rs
@@ -13,6 +13,7 @@ pub(crate) struct TestArgs<'a> {
     pub firmware_bundle: Option<&'a str>,
     pub emulator_bundle: Option<&'a str>,
     pub test_filter: Option<&'a str>,
+    pub nextest_profile: Option<&'a str>,
 }
 
 const EXCLUDED_PACKAGES: &[&str] = &[
@@ -50,6 +51,7 @@ pub(crate) fn test(args: TestArgs) -> Result<()> {
         args.workspace_remap,
         args.archive,
         args.test_filter,
+        args.nextest_profile,
     )
 }
 
@@ -62,15 +64,13 @@ fn cargo_test(
     workspace_remap: Option<&str>,
     archive: Option<&str>,
     test_filter: Option<&str>,
+    nextest_profile: Option<&str>,
 ) -> Result<()> {
     // Run all tests with nextest for proper sequencing, excluding ROM packages that don't have tests
-    println!("Running: cargo nextest run");
-    let mut args = vec![
-        "nextest",
-        "run",
-        "--test-threads=1",
-        "--profile=nightly-emulator",
-    ];
+    let profile = nextest_profile.unwrap_or("nightly-emulator");
+    let profile_arg = format!("--profile={}", profile);
+    println!("Running: cargo nextest run (profile={})", profile);
+    let mut args = vec!["nextest", "run", "--test-threads=1", &profile_arg];
 
     if let Some(archive_path) = archive {
         args.push("--archive-file");


### PR DESCRIPTION
Introduce two build profiles for the MCU firmware:

- devel (default): 1MB SRAM, debug logging enabled via Console, LowLevelDebug, ProcessConsole, and romtime println!(). Used for integration testing in CI.
- release: 512KB SRAM, strips Console/LowLevelDebug/ProcessConsole capsules and silences romtime print macros via the 'release' cargo feature and 'no-print'/'no_debug_panics' flags. DebugWriter and uart_mux remain initialized to avoid kernel debug!() panics.

Build system changes:
- Add [profile.devel] (inherits release) and [profile.release] to workspace Cargo.toml.
- Add 'release' feature to emulator/fpga runtime and romtime crates that gates debug output.
- firmware-bundler: select devel vs release manifest (1MB vs 512KB SRAM) based on --profile flag.
- builder: auto-enable 'release' feature when --profile release is used; output release bundles as all-fw-release.zip.
- Add RELEASE_RUNTIME_TEST_FEATURES list for release-specific tests.
- xtask: add --profile to all-build/runtime-build, --nextest-profile to test command; add release build+test to precheckin.

CI changes:
- build-firmware job builds both devel and release bundles.
- test_emulator job runs release tests (nightly-release nextest profile) after devel tests in each shard.
- Add nightly-release nextest profile filtering to test_flash_soc_boot_successful.

User app changes:
- Add console_writeln!() macro that compiles to no-op in release while preserving type-checking.
- Replace Debug format specifiers ({:?}) with static strings in spdm and caliptra_cmd_handler to reduce code size.