### PR TITLE
spdm: flatten error codes into 2 u32 values

### DIFF
--- a/platforms/emulator/runtime/userspace/apps/user/src/caliptra_cmd_handler/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/caliptra_cmd_handler/mod.rs
@@ -66,11 +66,13 @@ impl CaliptraCmdHandler for CaliptraCmdBackend {
             .await
             .map_err(|e| match e {
                 CaliptraApiError::MailboxBusy => CaliptraCompletionCode::CaliptraMailboxBusy,
-                CaliptraApiError::InvalidArgument(_) => CaliptraCompletionCode::InvalidParameter,
-                CaliptraApiError::AsymAlgoUnsupported => {
-                    CaliptraCompletionCode::UnsupportedOperation
-                }
                 CaliptraApiError::BufferTooSmall => CaliptraCompletionCode::CaliptraBufferTooSmall,
+                CaliptraApiError::InvalidResponse
+                | CaliptraApiError::Mailbox(_)
+                | CaliptraApiError::Syscall(_) => CaliptraCompletionCode::OperationFailed,
+                // Any other variant is not produced by get_attested_csr's call
+                // chain today. Reaching here means a deeper call started
+                // returning an unanticipated variant — surface it loudly.
                 _ => CaliptraCompletionCode::GeneralError,
             })?;
 
@@ -98,9 +100,11 @@ impl CaliptraCmdHandler for CaliptraCmdBackend {
                             CaliptraCompletionCode::CaliptraMailboxBusy
                         }
                         CaliptraApiError::UnprovisionedCsr => CaliptraCompletionCode::InvalidState,
-                        CaliptraApiError::BufferTooSmall => {
-                            CaliptraCompletionCode::CaliptraBufferTooSmall
-                        }
+                        CaliptraApiError::InvalidResponse
+                        | CaliptraApiError::Mailbox(_)
+                        | CaliptraApiError::Syscall(_) => CaliptraCompletionCode::OperationFailed,
+                        // Any other variant is not produced by get_idev_csr's
+                        // call chain today; surface it as GeneralError.
                         _ => CaliptraCompletionCode::GeneralError,
                     })?;
                 if len > csr_buf.len() {

--- a/platforms/emulator/runtime/userspace/apps/user/src/spdm/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/spdm/mod.rs
@@ -35,6 +35,29 @@ const SECURE_SPDM_VERSIONS: &[SpdmVersion] = &[SpdmVersion::V12];
 // Caliptra Crypto timeout exponent (2^20 us)
 const CALIPTRA_SPDM_CT_EXPONENT: u8 = 20;
 
+/// Logs an SPDM error in compact, `Debug`-free form. Always prints
+/// `<prefix>: <msg>: <category> 0x<error_code>`; appends ` ext=0x<ext>` only
+/// when the chain transitively wraps an external error (CaliptraApiError /
+/// EatError).
+fn log_spdm_err<W: Write>(w: &mut W, prefix: &str, msg: &str, e: &SpdmError) {
+    let path = e.error_code();
+    let ext = e.ext_code();
+    if ext != 0 {
+        writeln!(
+            w,
+            "{}: {}: {} 0x{:08x} ext=0x{:08x}",
+            prefix,
+            msg,
+            e.category(),
+            path,
+            ext
+        )
+        .unwrap();
+    } else {
+        writeln!(w, "{}: {}: {} 0x{:08x}", prefix, msg, e.category(), path).unwrap();
+    }
+}
+
 #[embassy_executor::task]
 pub(crate) async fn spdm_task(spawner: Spawner) {
     let mut console_writer = Console::<DefaultSyscalls>::writer();
@@ -47,8 +70,8 @@ pub(crate) async fn spdm_task(spawner: Spawner) {
     if let Err(e) = initialize_cert_store().await {
         writeln!(
             console_writer,
-            "SPDM_TASK: Failed to initialize certificate store: {:?}",
-            e
+            "SPDM_TASK: Failed to initialize certificate store: 0x{:08x}",
+            e.error_code()
         )
         .unwrap();
         return;
@@ -58,21 +81,19 @@ pub(crate) async fn spdm_task(spawner: Spawner) {
     #[cfg(not(feature = "pcr-quote-measurements"))]
     init_target_env_claims();
 
-    if let Err(e) = spawner.spawn(spdm_mctp_responder()) {
+    if spawner.spawn(spdm_mctp_responder()).is_err() {
         writeln!(
             console_writer,
-            "SPDM_TASK: Failed to spawn spdm_mctp_responder: {:?}",
-            e
+            "SPDM_TASK: Failed to spawn spdm_mctp_responder"
         )
         .unwrap();
     }
 
     #[cfg(feature = "doe")]
-    if let Err(e) = spawner.spawn(spdm_doe_responder()) {
+    if spawner.spawn(spdm_doe_responder()).is_err() {
         writeln!(
             console_writer,
-            "SPDM_TASK: Failed to spawn spdm_doe_responder: {:?}",
-            e
+            "SPDM_TASK: Failed to spawn spdm_doe_responder"
         )
         .unwrap();
     }
@@ -137,12 +158,12 @@ async fn spdm_mctp_responder() {
     ) {
         Ok(ctx) => ctx,
         Err(e) => {
-            writeln!(
-                cw,
-                "SPDM_MCTP_RESPONDER: Failed to create SPDM context: {:?}",
-                e
-            )
-            .unwrap();
+            log_spdm_err(
+                &mut cw,
+                "SPDM_MCTP_RESPONDER",
+                "Failed to create SPDM context",
+                &e,
+            );
             return;
         }
     };
@@ -150,13 +171,8 @@ async fn spdm_mctp_responder() {
     let mut msg_buffer = MessageBuf::new(&mut raw_buffer);
     loop {
         let result = ctx.process_message(&mut msg_buffer).await;
-        match result {
-            Ok(_) => {
-                writeln!(cw, "SPDM_MCTP_RESPONDER: Process message successfully").unwrap();
-            }
-            Err(e) => {
-                writeln!(cw, "SPDM_MCTP_RESPONDER: Process message failed: {:?}", e).unwrap();
-            }
+        if let Err(e) = result {
+            log_spdm_err(&mut cw, "SPDM_MCTP_RESPONDER", "Process message failed", &e);
         }
     }
 }
@@ -268,12 +284,12 @@ async fn spdm_doe_responder() {
     ) {
         Ok(ctx) => ctx,
         Err(e) => {
-            writeln!(
-                cw,
-                "SPDM_DOE_RESPONDER: Failed to create SPDM context: {:?}",
-                e
-            )
-            .unwrap();
+            log_spdm_err(
+                &mut cw,
+                "SPDM_DOE_RESPONDER",
+                "Failed to create SPDM context",
+                &e,
+            );
             return;
         }
     };
@@ -282,15 +298,13 @@ async fn spdm_doe_responder() {
     loop {
         let result = ctx.process_message(&mut msg_buffer).await;
         match result {
-            Ok(_) => {
-                writeln!(cw, "SPDM_DOE_RESPONDER: Process message successfully").unwrap();
-            }
+            Ok(_) => {}
             Err(SpdmError::Transport(TransportError::DriverError(ErrorCode::NoDevice))) => {
                 writeln!(cw, "SPDM_DOE_RESPONDER: No DOE device, exiting task").unwrap();
                 break;
             }
             Err(e) => {
-                writeln!(cw, "SPDM_DOE_RESPONDER: Process message failed: {:?}", e).unwrap();
+                log_spdm_err(&mut cw, "SPDM_DOE_RESPONDER", "Process message failed", &e);
             }
         }
     }

--- a/runtime/userspace/api/caliptra-api/src/certificate.rs
+++ b/runtime/userspace/api/caliptra-api/src/certificate.rs
@@ -80,7 +80,7 @@ impl CertContext {
 
     pub async fn populate_idev_ecc384_cert(&mut self, cert: &[u8]) -> CaliptraApiResult<()> {
         if cert.len() > PopulateIdevEcc384CertReq::MAX_CERT_SIZE {
-            return Err(CaliptraApiError::InvalidArgument("Invalid cert size"));
+            return Err(CaliptraApiError::InvalidArgCertSize);
         }
         let cmd = CommandId::POPULATE_IDEV_ECC384_CERT.into();
         let mut req = PopulateIdevEcc384CertReq {
@@ -154,12 +154,12 @@ impl CertContext {
     ) -> CaliptraApiResult<usize> {
         if let Some(ref x) = derived_pubkey_x {
             if x.len() != DPE_PROFILE.tci_size() {
-                Err(CaliptraApiError::InvalidArgument("Invalid pubkey size"))?;
+                Err(CaliptraApiError::InvalidArgPubkeySize)?;
             }
         }
         if let Some(ref y) = derived_pubkey_y {
             if y.len() != DPE_PROFILE.tci_size() {
-                Err(CaliptraApiError::InvalidArgument("Invalid pubkey size"))?;
+                Err(CaliptraApiError::InvalidArgPubkeySize)?;
             }
         }
 
@@ -220,11 +220,11 @@ impl CertContext {
         signature: &mut [u8],
     ) -> CaliptraApiResult<usize> {
         if digest.len() != DPE_PROFILE.hash_size() {
-            return Err(CaliptraApiError::InvalidArgument("Invalid digest size"));
+            return Err(CaliptraApiError::InvalidArgDigestSize);
         }
 
         if signature.len() < DPE_PROFILE.tci_size() {
-            return Err(CaliptraApiError::InvalidArgument("Invalid signature size"));
+            return Err(CaliptraApiError::InvalidArgSignatureSize);
         }
 
         let mut dpe_cmd = SignP384Cmd {
@@ -272,7 +272,7 @@ impl CertContext {
     ) -> CaliptraApiResult<usize> {
         let size = cert_chunk.len();
         if size > MAX_CERT_CHUNK_SIZE {
-            Err(CaliptraApiError::InvalidArgument("Chunk size is too large"))?;
+            Err(CaliptraApiError::InvalidArgChunkSizeTooLarge)?;
         }
 
         let dpe_cmd = GetCertificateChainCmd {

--- a/runtime/userspace/api/caliptra-api/src/crypto/hash.rs
+++ b/runtime/userspace/api/caliptra-api/src/crypto/hash.rs
@@ -76,7 +76,7 @@ impl HashContext {
     ) -> CaliptraApiResult<()> {
         let mut ctx = HashContext::new();
         if hash.len() < hash_algo.hash_size() {
-            Err(CaliptraApiError::InvalidArgument("Hash buffer too small"))?;
+            Err(CaliptraApiError::InvalidArgHashBufferTooSmall)?;
         }
         ctx.init(hash_algo, Some(data)).await?;
         ctx.finalize(hash).await
@@ -102,9 +102,7 @@ impl HashContext {
 
         if let Some(data) = data {
             if data.len() > MAX_CRYPTO_MBOX_DATA_SIZE {
-                return Err(CaliptraApiError::InvalidArgument(
-                    "Data size exceeds maximum limit",
-                ));
+                return Err(CaliptraApiError::InvalidArgDataSizeExceedsLimit);
             }
             let data_size = data.len();
             init_req.input_size = data_size as u32;
@@ -128,9 +126,9 @@ impl HashContext {
         let mut data_offset = 0;
 
         while data_offset < data.len() {
-            let ctx = self.ctx.ok_or(CaliptraApiError::InvalidOperation(
-                "Context not initialized",
-            ))?;
+            let ctx = self
+                .ctx
+                .ok_or(CaliptraApiError::InvalidOpContextNotInitialized)?;
 
             let mut update_req = ShaUpdateReq {
                 hdr: MailboxReqHeader::default(),
@@ -166,20 +164,18 @@ impl HashContext {
     }
 
     pub async fn finalize(&mut self, hash: &mut [u8]) -> CaliptraApiResult<()> {
-        let ctx = self.ctx.ok_or(CaliptraApiError::InvalidOperation(
-            "Context not initialized",
-        ))?;
+        let ctx = self
+            .ctx
+            .ok_or(CaliptraApiError::InvalidOpContextNotInitialized)?;
 
         let hash_size = self
             .algo
             .as_ref()
-            .ok_or(CaliptraApiError::InvalidOperation(
-                "Hash algorithm not initialized",
-            ))?
+            .ok_or(CaliptraApiError::InvalidOpHashAlgoNotInitialized)?
             .hash_size();
 
         if hash.len() < hash_size {
-            return Err(CaliptraApiError::InvalidArgument("Hash buffer too small"));
+            return Err(CaliptraApiError::InvalidArgHashBufferTooSmall);
         }
 
         let mut final_req = ShaFinalReq {

--- a/runtime/userspace/api/caliptra-api/src/crypto/hmac.rs
+++ b/runtime/userspace/api/caliptra-api/src/crypto/hmac.rs
@@ -28,9 +28,7 @@ impl Hmac {
         };
         req.cmk.0.copy_from_slice(&cmk.0);
         if data.len() > req.data.len() {
-            return Err(CaliptraApiError::InvalidArgument(
-                "Data size exceeds maximum allowed",
-            ));
+            return Err(CaliptraApiError::InvalidArgDataSizeExceedsMax);
         }
         req.data[..data.len()].copy_from_slice(data);
 
@@ -57,9 +55,7 @@ impl Hmac {
             }
             HkdfSalt::Data(data) => {
                 if data.len() > MAX_CMB_DATA_SIZE {
-                    return Err(CaliptraApiError::InvalidArgument(
-                        "Salt size exceeds maximum allowed",
-                    ));
+                    return Err(CaliptraApiError::InvalidArgSaltSizeExceedsMax);
                 }
                 let salt_cmk = Import::import(CmKeyUsage::Hmac, data).await?;
                 req.salt.0.copy_from_slice(&salt_cmk.cmk.0);
@@ -93,9 +89,7 @@ impl Hmac {
             ..Default::default()
         };
         if info.len() > req.info.len() {
-            return Err(CaliptraApiError::InvalidArgument(
-                "Info size exceeds maximum allowed",
-            ));
+            return Err(CaliptraApiError::InvalidArgInfoSizeExceedsMax);
         }
         req.prk.0.copy_from_slice(&prk.0);
         req.info[..info.len()].copy_from_slice(info);

--- a/runtime/userspace/api/caliptra-api/src/crypto/import.rs
+++ b/runtime/userspace/api/caliptra-api/src/crypto/import.rs
@@ -21,9 +21,7 @@ impl Import {
             ..Default::default()
         };
         if data.len() > req.input.len() {
-            return Err(CaliptraApiError::InvalidArgument(
-                "Info size exceeds maximum allowed",
-            ));
+            return Err(CaliptraApiError::InvalidArgInfoSizeExceedsMax);
         }
         req.input[..data.len()].copy_from_slice(data);
 

--- a/runtime/userspace/api/caliptra-api/src/crypto/rng.rs
+++ b/runtime/userspace/api/caliptra-api/src/crypto/rng.rs
@@ -18,7 +18,7 @@ pub struct Rng;
 impl Rng {
     pub async fn generate_random_number(random_number: &mut [u8]) -> CaliptraApiResult<()> {
         if random_number.len() > MAX_RANDOM_NUM_SIZE {
-            return Err(CaliptraApiError::InvalidArgument("Invalid size"));
+            return Err(CaliptraApiError::InvalidArgSize);
         }
 
         let mailbox = Mailbox::new();
@@ -51,7 +51,7 @@ impl Rng {
 
     pub async fn add_random_stir(random_stir: &[u8]) -> CaliptraApiResult<()> {
         if random_stir.len() > MAX_RANDOM_STIR_SIZE {
-            return Err(CaliptraApiError::InvalidArgument("Invalid size"));
+            return Err(CaliptraApiError::InvalidArgSize);
         }
         let mailbox = Mailbox::new();
 

--- a/runtime/userspace/api/caliptra-api/src/error.rs
+++ b/runtime/userspace/api/caliptra-api/src/error.rs
@@ -6,21 +6,140 @@ use caliptra_ocp_eat::EatError;
 
 pub type CaliptraApiResult<T> = Result<T, CaliptraApiError>;
 
+/// Errors returned by the Caliptra mailbox API (the MCU userspace interface
+/// to Caliptra mailbox commands).
+///
+/// `Mailbox(_)`, `Syscall(_)`, and `Eat(_)` wrap inner errors from the
+/// libsyscall, tock, and EAT crates respectively; all other variants are
+/// field-less. `error_code()` returns a stable u8 per variant (table below)
+/// used by consumers for compact numeric logging.
+///
+/// ```text
+///   Caliptra mailbox / firmware state
+///   0x01 MailboxBusy
+///   0x02 InvalidResponse
+///   0x03 UnprovisionedCsr
+///   0x04 AsymAlgoUnsupported
+///
+///   Generic
+///   0x05 BufferTooSmall
+///
+///   AES-GCM
+///   0x06 AesGcmInvalidDataLength
+///   0x07 AesGcmInvalidAadLength
+///   0x08 AesGcmInvalidOperation
+///   0x09 AesGcmInvalidContext
+///   0x0A AesGcmTagVerifyFailed
+///
+///   Caller bad argument (flattened from InvalidArgument)
+///   0x0B InvalidArgBufferTooSmall
+///   0x0C InvalidArgChunkSizeTooLarge
+///   0x0D InvalidArgDataSizeExceedsLimit
+///   0x0E InvalidArgDataSizeExceedsMax
+///   0x0F InvalidArgHashBufferTooSmall
+///   0x10 InvalidArgInfoSizeExceedsMax
+///   0x11 InvalidArgSaltSizeExceedsMax
+///   0x12 InvalidArgCertSize
+///   0x13 InvalidArgDigestSize
+///   0x14 InvalidArgPubkeySize
+///   0x15 InvalidArgSignatureSize
+///   0x16 InvalidArgSize
+///
+///   Caller in wrong state (flattened from InvalidOperation)
+///   0x17 InvalidOpContextNotInitialized
+///   0x18 InvalidOpHashAlgoNotInitialized
+///
+///   External-error wrappers
+///   0x19 Mailbox(MailboxError)
+///   0x1A Syscall(ErrorCode)
+///   0x1B Eat(EatError)
+/// ```
 #[derive(Debug, PartialEq)]
 pub enum CaliptraApiError {
+    // Caliptra mailbox / firmware state
     MailboxBusy,
-    Mailbox(MailboxError),
-    Syscall(ErrorCode),
-    InvalidArgument(&'static str),
-    InvalidOperation(&'static str),
+    InvalidResponse,
+    UnprovisionedCsr,
+    AsymAlgoUnsupported,
+    // Generic
+    BufferTooSmall,
+    // AES-GCM
     AesGcmInvalidDataLength,
     AesGcmInvalidAadLength,
     AesGcmInvalidOperation,
     AesGcmInvalidContext,
     AesGcmTagVerifyFailed,
-    AsymAlgoUnsupported,
-    InvalidResponse,
-    BufferTooSmall,
-    UnprovisionedCsr,
+    // Caller bad argument (flattened from InvalidArgument)
+    InvalidArgBufferTooSmall,
+    InvalidArgChunkSizeTooLarge,
+    InvalidArgDataSizeExceedsLimit,
+    InvalidArgDataSizeExceedsMax,
+    InvalidArgHashBufferTooSmall,
+    InvalidArgInfoSizeExceedsMax,
+    InvalidArgSaltSizeExceedsMax,
+    InvalidArgCertSize,
+    InvalidArgDigestSize,
+    InvalidArgPubkeySize,
+    InvalidArgSignatureSize,
+    InvalidArgSize,
+    // Caller in wrong state (flattened from InvalidOperation)
+    InvalidOpContextNotInitialized,
+    InvalidOpHashAlgoNotInitialized,
+    // External-error wrappers
+    Mailbox(MailboxError),
+    Syscall(ErrorCode),
     Eat(EatError),
+}
+
+impl CaliptraApiError {
+    /// Returns a stable numeric ID for this variant.
+    pub fn error_code(&self) -> u8 {
+        match self {
+            CaliptraApiError::MailboxBusy => 0x01,
+            CaliptraApiError::InvalidResponse => 0x02,
+            CaliptraApiError::UnprovisionedCsr => 0x03,
+            CaliptraApiError::AsymAlgoUnsupported => 0x04,
+            CaliptraApiError::BufferTooSmall => 0x05,
+            CaliptraApiError::AesGcmInvalidDataLength => 0x06,
+            CaliptraApiError::AesGcmInvalidAadLength => 0x07,
+            CaliptraApiError::AesGcmInvalidOperation => 0x08,
+            CaliptraApiError::AesGcmInvalidContext => 0x09,
+            CaliptraApiError::AesGcmTagVerifyFailed => 0x0A,
+            CaliptraApiError::InvalidArgBufferTooSmall => 0x0B,
+            CaliptraApiError::InvalidArgChunkSizeTooLarge => 0x0C,
+            CaliptraApiError::InvalidArgDataSizeExceedsLimit => 0x0D,
+            CaliptraApiError::InvalidArgDataSizeExceedsMax => 0x0E,
+            CaliptraApiError::InvalidArgHashBufferTooSmall => 0x0F,
+            CaliptraApiError::InvalidArgInfoSizeExceedsMax => 0x10,
+            CaliptraApiError::InvalidArgSaltSizeExceedsMax => 0x11,
+            CaliptraApiError::InvalidArgCertSize => 0x12,
+            CaliptraApiError::InvalidArgDigestSize => 0x13,
+            CaliptraApiError::InvalidArgPubkeySize => 0x14,
+            CaliptraApiError::InvalidArgSignatureSize => 0x15,
+            CaliptraApiError::InvalidArgSize => 0x16,
+            CaliptraApiError::InvalidOpContextNotInitialized => 0x17,
+            CaliptraApiError::InvalidOpHashAlgoNotInitialized => 0x18,
+            CaliptraApiError::Mailbox(_) => 0x19,
+            CaliptraApiError::Syscall(_) => 0x1A,
+            CaliptraApiError::Eat(_) => 0x1B,
+        }
+    }
+
+    /// If this is the `Eat(_)` variant, returns the inner `EatError` mapped to
+    /// a stable u8 ID; otherwise `None`. Lets callers (e.g. SPDM error
+    /// logging) treat EAT failures as their own external error kind without
+    /// taking a direct dependency on `caliptra-ocp-eat`.
+    pub fn eat_id(&self) -> Option<u8> {
+        match self {
+            CaliptraApiError::Eat(e) => Some(match e {
+                EatError::BufferTooSmall => 0x01,
+                EatError::InvalidData => 0x02,
+                EatError::MissingMandatoryClaim => 0x03,
+                EatError::InvalidClaimSize => 0x04,
+                EatError::EncodingError => 0x05,
+                EatError::InvalidUtf8 => 0x06,
+            }),
+            _ => None,
+        }
+    }
 }

--- a/runtime/userspace/api/caliptra-api/src/evidence/pcr_quote.rs
+++ b/runtime/userspace/api/caliptra-api/src/evidence/pcr_quote.rs
@@ -36,7 +36,7 @@ impl PcrQuote {
         let mailbox = Mailbox::new();
 
         if buffer.len() < MLDSA87_QUOTE_RSP_LEN {
-            return Err(CaliptraApiError::InvalidArgument("Buffer too small"));
+            return Err(CaliptraApiError::InvalidArgBufferTooSmall);
         }
 
         let mut req = QuotePcrsMldsa87Req {
@@ -78,7 +78,7 @@ impl PcrQuote {
 
     async fn pcr_quote_ecc384(nonce: Option<&[u8]>, buffer: &mut [u8]) -> CaliptraApiResult<usize> {
         if buffer.len() < ECC384_QUOTE_RSP_LEN {
-            return Err(CaliptraApiError::InvalidArgument("Buffer too small"));
+            return Err(CaliptraApiError::InvalidArgBufferTooSmall);
         }
 
         let resp = Self::get_quote_ecc384_resp(nonce).await?;

--- a/runtime/userspace/api/spdm-lib/src/cert_store.rs
+++ b/runtime/userspace/api/spdm-lib/src/cert_store.rs
@@ -2,7 +2,7 @@
 
 extern crate alloc;
 
-use crate::error::{SpdmError, SpdmResult};
+use crate::error::{ProtocolError, SpdmError, SpdmResult};
 use crate::protocol::*;
 use alloc::boxed::Box;
 use async_trait::async_trait;
@@ -29,6 +29,36 @@ pub enum CertStoreError {
     OperationFailed,
     ResetRequired,
     CaliptraApi(CaliptraApiError),
+}
+
+impl CertStoreError {
+    pub fn error_code(&self) -> u32 {
+        match self {
+            CertStoreError::InitFailed => 0x01_00,
+            CertStoreError::NotInitialized => 0x02_00,
+            CertStoreError::InvalidSlotId => 0x03_00,
+            CertStoreError::UnprovisionedSlot => 0x04_00,
+            CertStoreError::UnsupportedAsymAlgo => 0x05_00,
+            CertStoreError::UnsupportedHashAlgo => 0x06_00,
+            CertStoreError::BufferTooSmall => 0x07_00,
+            CertStoreError::InvalidOffset => 0x08_00,
+            CertStoreError::CertReadError => 0x09_00,
+            CertStoreError::CertWriteError => 0x0A_00,
+            CertStoreError::SlotBusy => 0x0B_00,
+            CertStoreError::OperationFailed => 0x0C_00,
+            CertStoreError::ResetRequired => 0x0D_00,
+            CertStoreError::CaliptraApi(_) => {
+                (crate::error::error_type_id::CALIPTRA_API as u32) << 8
+            }
+        }
+    }
+
+    pub fn caliptra_api(&self) -> Option<&CaliptraApiError> {
+        match self {
+            CertStoreError::CaliptraApi(e) => Some(e),
+            _ => None,
+        }
+    }
 }
 pub type CertStoreResult<T> = Result<T, CertStoreError>;
 
@@ -189,7 +219,7 @@ pub trait SpdmCertStore {
 pub(crate) fn validate_cert_store(cert_store: &dyn SpdmCertStore) -> SpdmResult<()> {
     let slot_count = cert_store.slot_count();
     if slot_count > MAX_CERT_SLOTS_SUPPORTED {
-        Err(SpdmError::InvalidParam)?;
+        Err(SpdmError::Protocol(ProtocolError::InvalidParam))?;
     }
     Ok(())
 }

--- a/runtime/userspace/api/spdm-lib/src/chunk_ctx.rs
+++ b/runtime/userspace/api/spdm-lib/src/chunk_ctx.rs
@@ -2,22 +2,23 @@
 
 use crate::commands::certificate_rsp::CertificateResponse;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
 pub enum ChunkError {
     /// Error initializing a large message context
-    LargeMessageInitError,
+    LargeMessageInitError = 0x01,
     /// No large response is currently in progress
-    NoLargeResponseInProgress,
+    NoLargeResponseInProgress = 0x02,
     /// Invalid chunk handle provided
-    InvalidChunkHandle,
+    InvalidChunkHandle = 0x03,
     /// Invalid chunk sequence number provided
-    InvalidChunkSeqNum,
+    InvalidChunkSeqNum = 0x04,
     /// Invalid message offset provided
-    InvalidMessageOffset,
+    InvalidMessageOffset = 0x05,
     /// Response data exceeds the shared buffer capacity
-    BufferCapacityExceeded,
+    BufferCapacityExceeded = 0x06,
     /// Shared large message buffer is not available (in use by another transport)
-    BufUnavailable,
+    BufUnavailable = 0x07,
 }
 
 /// Provider for the shared large message buffer.

--- a/runtime/userspace/api/spdm-lib/src/codec.rs
+++ b/runtime/userspace/api/spdm-lib/src/codec.rs
@@ -4,13 +4,14 @@ use zerocopy::{FromBytes, Immutable, IntoBytes};
 
 pub type CodecResult<T> = Result<T, CodecError>;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
 pub enum CodecError {
-    BufferTooSmall,
-    ReadError,
-    WriteError,
-    BufferOverflow,
-    BufferUnderflow,
+    BufferTooSmall = 0x01,
+    ReadError = 0x02,
+    WriteError = 0x03,
+    BufferOverflow = 0x04,
+    BufferUnderflow = 0x05,
 }
 
 pub trait Codec {

--- a/runtime/userspace/api/spdm-lib/src/commands/algorithms_rsp.rs
+++ b/runtime/userspace/api/spdm-lib/src/commands/algorithms_rsp.rs
@@ -3,7 +3,7 @@
 use crate::codec::{Codec, CommonCodec, MessageBuf};
 use crate::commands::error_rsp::ErrorCode;
 use crate::context::SpdmContext;
-use crate::error::{CommandResult, SpdmError};
+use crate::error::{CommandResult, ProtocolError, SpdmError};
 use crate::protocol::*;
 use crate::state::ConnectionState;
 use bitfield::bitfield;
@@ -59,7 +59,7 @@ impl NegotiateAlgorithmsReq {
         };
 
         if total_ext_alg_count > max_count {
-            Err(SpdmError::InvalidParam)
+            Err(SpdmError::Protocol(ProtocolError::InvalidParam))
         } else {
             Ok(())
         }
@@ -115,7 +115,7 @@ impl TryFrom<u8> for AlgType {
             3 => Ok(AlgType::AeadCipherSuite),
             4 => Ok(AlgType::ReqBaseAsymAlg),
             5 => Ok(AlgType::KeySchedule),
-            _ => Err(SpdmError::InvalidParam),
+            _ => Err(SpdmError::Protocol(ProtocolError::InvalidParam)),
         }
     }
 }

--- a/runtime/userspace/api/spdm-lib/src/context.rs
+++ b/runtime/userspace/api/spdm-lib/src/context.rs
@@ -306,7 +306,7 @@ impl<'a> SpdmContext<'a> {
             let app_data = resp.data(app_data_len).map_err(SpdmError::Codec)?;
 
             self.prepare_response_buffer(&mut secure_message_buf)
-                .map_err(|_| SpdmError::BufferTooSmall)?;
+                .map_err(|e| SpdmError::Command(e.1))?;
             self.session_mgr
                 .encode_secure_message(self.transport, app_data, &mut secure_message_buf)
                 .await

--- a/runtime/userspace/api/spdm-lib/src/error.rs
+++ b/runtime/userspace/api/spdm-lib/src/error.rs
@@ -12,22 +12,109 @@ use crate::transcript::TranscriptError;
 use crate::transport::common::TransportError;
 use crate::vdm_handler::VdmError;
 use caliptra_mcu_libapi_caliptra::error::CaliptraApiError;
+use caliptra_mcu_libsyscall_caliptra::mailbox::MailboxError;
 
+/// Stable byte IDs for each spdm-lib error type.
+///
+/// A given inner error type uses the same byte value regardless of which
+/// parent wraps it, so a packed `error_code()` u32 decodes without
+/// per-parent tables. Parents' leaf variants take `0x01..0xDF`; these IDs
+/// occupy `0xE0..0xFF`.
+pub(crate) mod error_type_id {
+    pub const CODEC: u8 = 0xE1;
+    pub const TRANSPORT: u8 = 0xE2;
+    pub const COMMAND: u8 = 0xE3;
+    pub const CERT_STORE: u8 = 0xE4;
+    pub const CALIPTRA_API: u8 = 0xE5;
+    pub const SESSION: u8 = 0xE6;
+    pub const OPAQUE_DATA: u8 = 0xE7;
+    pub const VDM: u8 = 0xE8;
+    pub const SIGN_CTX: u8 = 0xE9;
+    pub const CHUNK: u8 = 0xEA;
+    pub const TRANSCRIPT: u8 = 0xEB;
+    pub const MEASUREMENT: u8 = 0xEC;
+    pub const KEY_SCHEDULE: u8 = 0xED;
+    pub const IDE_DRIVER: u8 = 0xEE;
+    pub const TDISP_DRIVER: u8 = 0xEF;
+    pub const PROTOCOL: u8 = 0xF0;
+}
+
+/// SPDM-protocol validation errors raised by the responder before/around
+/// command dispatch (version negotiation, vendor ID parsing, request-type
+/// rejection, parameter validation).
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum ProtocolError {
+    UnsupportedVersion = 0x01,
+    InvalidStandardsBodyId = 0x02,
+    InvalidParam = 0x03,
+    UnsupportedRequest = 0x04,
+}
+
+/// SPDM error type, used as the SPDM responder/library's top-level error.
+///
+/// For no_std use, errors are logged as two compact u32s rather than via
+/// formatted printing:
+///
+/// ```text
+///   error_code() = (top << 24) | (inner << 16) | (sub << 8) | leaf
+/// ```
+///
+/// Each byte is the variant ID at one level of the SPDM error hierarchy:
+///   * `top`   — SpdmError variant
+///   * `inner` — inner-enum variant (e.g. CommandError under Command(_))
+///   * `sub`   — next-level variant
+///   * `leaf`  — deepest variant ID
+///
+/// **Stable type IDs**: a variant that wraps another error type uses the
+/// same byte from [`error_type_id`] regardless of nesting position (e.g.
+/// `CALIPTRA_API = 0xE5` everywhere). Leaf variants use `0x01..0xDF`.
+/// A 0 in any lower byte means the path bottoms out earlier.
+///
+/// All external-error detail (CaliptraApi and the sub-level errors it wraps)
+/// is reached via the `CaliptraApi(_)` wrapper. Where the SPDM-side path
+/// reaches that wrapper the lower bytes are 0 — the external detail is
+/// carried by `ext_code()` instead:
+///
+/// ```text
+///   ext_code() = (kind << 24) | (variant << 16) | (sub << 8) | leaf
+/// ```
+///
+/// Layout:
+///   * `kind`    — external-error kind tag
+///                   0x00  no external error (error is purely SPDM-internal,
+///                         all detail is in `error_code()`)
+///                   0x01  CaliptraApiError (mailbox / syscall / crypto / etc.)
+///                   0x02  EatError (hoisted from CaliptraApiError::Eat)
+///   * `variant` — variant ID within `kind` (`CaliptraApiError::error_code()`
+///                 for kind=0x01, or the EatError variant for kind=0x02)
+///   * `sub`     — sub-variant tag (kind=0x01 only):
+///                   0x00  CaliptraApi variant has no sub-classification
+///                   0x01  CaliptraApi::Mailbox(MailboxError::ErrorCode(_))
+///                   0x02  CaliptraApi::Mailbox(MailboxError::MailboxError(_))
+///                   0x03  CaliptraApi::Syscall(_)
+///   * `leaf`    — low byte of the numeric tail (kind=0x01 only):
+///                   sub=0x01 or 0x03  tock ErrorCode value
+///                   sub=0x02          MailboxError u32 value
+///                   sub=0x00          0
+///
+/// Example log lines (decode wrappers via [`error_type_id`], leaves via the
+/// owning enum's `error_code()`):
+///
+/// ```text
+///   SPDM err: protocol 0xF0010000                        # ProtocolError::UnsupportedVersion
+///   SPDM err: cmd 0xE3020001                             # cmd → ErrorCode 0x01
+///   SPDM err: cmd 0xE3ECE500 ext=0x01130000              # cmd → measurement
+///                                                        # → CaliptraApi (InvalidArgDigestSize)
+///   SPDM err: session 0xE6080000                         # session → DecodeAeadError
+/// ```
 #[derive(Debug)]
 pub enum SpdmError {
-    UnsupportedVersion,
-    InvalidStandardsBodyId,
-    InvalidParam,
-    BufferTooSmall,
-    UnsupportedRequest,
+    Protocol(ProtocolError),
     Codec(CodecError),
     Transport(TransportError),
     Command(CommandError),
-    CertStore(CertStoreError),
-    CaliptraApi(CaliptraApiError),
     Session(SessionError),
-    OpaqueData(OpaqueDataError),
-    Vdm(VdmError),
 }
 
 pub type SpdmResult<T> = Result<T, SpdmError>;
@@ -53,4 +140,108 @@ pub enum CommandError {
     Session(SessionError),
     OpaqueData(OpaqueDataError),
     Vdm(VdmError),
+}
+
+impl SpdmError {
+    pub fn error_code(&self) -> u32 {
+        match self {
+            SpdmError::Protocol(e) => {
+                ((error_type_id::PROTOCOL as u32) << 24) | ((*e as u8) as u32)
+            }
+            SpdmError::Codec(e) => ((error_type_id::CODEC as u32) << 24) | ((*e as u8) as u32),
+            SpdmError::Transport(e) => ((error_type_id::TRANSPORT as u32) << 24) | e.error_code(),
+            SpdmError::Command(e) => ((error_type_id::COMMAND as u32) << 24) | e.error_code(),
+            SpdmError::Session(e) => ((error_type_id::SESSION as u32) << 24) | e.error_code(),
+        }
+    }
+
+    pub fn category(&self) -> &'static str {
+        match self {
+            SpdmError::Protocol(_) => "protocol",
+            SpdmError::Codec(_) => "codec",
+            SpdmError::Transport(_) => "transport",
+            SpdmError::Command(_) => "cmd",
+            SpdmError::Session(_) => "session",
+        }
+    }
+
+    /// Encoded external error detail (see type-level docs). Returns 0 if the
+    /// SPDM error doesn't transitively wrap a `CaliptraApiError`.
+    pub fn ext_code(&self) -> u32 {
+        match self.caliptra_api() {
+            Some(e) => encode_ext(e),
+            None => 0,
+        }
+    }
+
+    fn caliptra_api(&self) -> Option<&CaliptraApiError> {
+        match self {
+            SpdmError::Command(e) => e.caliptra_api(),
+            SpdmError::Session(e) => e.caliptra_api(),
+            _ => None,
+        }
+    }
+}
+
+impl CommandError {
+    pub fn error_code(&self) -> u32 {
+        match self {
+            CommandError::BufferTooSmall => 0x01_00_00,
+            CommandError::ErrorCode(e) => 0x02_00_00 | u32::from(u8::from(*e)),
+            CommandError::UnsupportedAsymAlgo => 0x03_00_00,
+            CommandError::UnsupportedRequest => 0x04_00_00,
+            CommandError::UnsupportedLargeResponse => 0x05_00_00,
+            CommandError::InvalidChunkContext => 0x06_00_00,
+            CommandError::MissingVdmHandler => 0x07_00_00,
+            CommandError::Codec(e) => ((error_type_id::CODEC as u32) << 16) | ((*e as u8) as u32),
+            CommandError::SignCtx(e) => ((error_type_id::SIGN_CTX as u32) << 16) | e.error_code(),
+            CommandError::Chunk(e) => ((error_type_id::CHUNK as u32) << 16) | ((*e as u8) as u32),
+            CommandError::CertStore(e) => {
+                ((error_type_id::CERT_STORE as u32) << 16) | e.error_code()
+            }
+            CommandError::CaliptraApi(_) => (error_type_id::CALIPTRA_API as u32) << 16,
+            CommandError::Transcript(e) => {
+                ((error_type_id::TRANSCRIPT as u32) << 16) | e.error_code()
+            }
+            CommandError::Measurement(e) => {
+                ((error_type_id::MEASUREMENT as u32) << 16) | e.error_code()
+            }
+            CommandError::Session(e) => ((error_type_id::SESSION as u32) << 16) | e.error_code(),
+            CommandError::OpaqueData(e) => {
+                ((error_type_id::OPAQUE_DATA as u32) << 16) | e.error_code()
+            }
+            CommandError::Vdm(e) => ((error_type_id::VDM as u32) << 16) | e.error_code(),
+        }
+    }
+
+    pub fn caliptra_api(&self) -> Option<&CaliptraApiError> {
+        match self {
+            CommandError::CaliptraApi(e) => Some(e),
+            CommandError::SignCtx(e) => e.caliptra_api(),
+            CommandError::CertStore(e) => e.caliptra_api(),
+            CommandError::Transcript(e) => e.caliptra_api(),
+            CommandError::Measurement(e) => e.caliptra_api(),
+            CommandError::Session(e) => e.caliptra_api(),
+            _ => None,
+        }
+    }
+}
+
+/// Encodes the external (non-SPDM) portion of an error chain into the u32
+/// layout documented on `SpdmError`. EAT is hoisted to its own kind tag so
+/// log lines clearly distinguish CBOR encoding failures from Caliptra
+/// mailbox failures.
+fn encode_ext(e: &CaliptraApiError) -> u32 {
+    if let Some(id) = e.eat_id() {
+        return 0x02_00_00_00 | ((id as u32) << 16);
+    }
+    let kind = 0x01_u32 << 24;
+    let variant = (e.error_code() as u32) << 16;
+    let (sub, leaf) = match e {
+        CaliptraApiError::Mailbox(MailboxError::ErrorCode(ec)) => (0x01u32, (*ec as u32) & 0xFF),
+        CaliptraApiError::Mailbox(MailboxError::MailboxError(v)) => (0x02u32, v & 0xFF),
+        CaliptraApiError::Syscall(ec) => (0x03u32, (*ec as u32) & 0xFF),
+        _ => (0u32, 0u32),
+    };
+    kind | variant | (sub << 8) | leaf
 }

--- a/runtime/userspace/api/spdm-lib/src/measurements.rs
+++ b/runtime/userspace/api/spdm-lib/src/measurements.rs
@@ -33,9 +33,39 @@ pub enum MeasurementsError {
     InvalidSlotId,
     InvalidParam,
     InvalidInput,
-    MissingParam(&'static str),
+    MissingParamAsymAlgo,
+    MissingParamSpdmVersion,
     MeasurementSizeMismatch,
     CaliptraApi(CaliptraApiError),
+}
+
+impl MeasurementsError {
+    pub fn error_code(&self) -> u32 {
+        match self {
+            MeasurementsError::InvalidIndex => 0x01_00,
+            MeasurementsError::InvalidOffset => 0x02_00,
+            MeasurementsError::InvalidSize => 0x03_00,
+            MeasurementsError::InvalidBuffer => 0x04_00,
+            MeasurementsError::BufferTooSmall => 0x05_00,
+            MeasurementsError::InvalidOperation => 0x06_00,
+            MeasurementsError::InvalidSlotId => 0x07_00,
+            MeasurementsError::InvalidParam => 0x08_00,
+            MeasurementsError::InvalidInput => 0x09_00,
+            MeasurementsError::MissingParamAsymAlgo => 0x0A_00,
+            MeasurementsError::MissingParamSpdmVersion => 0x0B_00,
+            MeasurementsError::MeasurementSizeMismatch => 0x0C_00,
+            MeasurementsError::CaliptraApi(_) => {
+                (crate::error::error_type_id::CALIPTRA_API as u32) << 8
+            }
+        }
+    }
+
+    pub fn caliptra_api(&self) -> Option<&CaliptraApiError> {
+        match self {
+            MeasurementsError::CaliptraApi(e) => Some(e),
+            _ => None,
+        }
+    }
 }
 pub type MeasurementsResult<T> = Result<T, MeasurementsError>;
 
@@ -368,7 +398,7 @@ impl<'a> SpdmMeasurements<'a> {
     ) -> MeasurementsResult<()> {
         let asym_algo = self
             .asym_algo
-            .ok_or(MeasurementsError::MissingParam("AsymAlgo"))?;
+            .ok_or(MeasurementsError::MissingParamAsymAlgo)?;
 
         let nonce = self.nonce.unwrap_or_default();
 
@@ -377,7 +407,7 @@ impl<'a> SpdmMeasurements<'a> {
         let meas_value_type = if meas_info.value_type == MeasurementValueType::StructuredManifest {
             let spdm_version = self
                 .spdm_version
-                .ok_or(MeasurementsError::MissingParam("SpdmVersion"))?;
+                .ok_or(MeasurementsError::MissingParamSpdmVersion)?;
             if spdm_version < SpdmVersion::V13 {
                 MeasurementValueType::FreeformManifest
             } else {

--- a/runtime/userspace/api/spdm-lib/src/protocol/algorithms.rs
+++ b/runtime/userspace/api/spdm-lib/src/protocol/algorithms.rs
@@ -1,6 +1,6 @@
 // Licensed under the Apache-2.0 license
 
-use crate::error::SpdmError;
+use crate::error::{ProtocolError, SpdmError};
 use bitfield::bitfield;
 use caliptra_mcu_libapi_caliptra::crypto::hash::HashAlgoType;
 use zerocopy::{FromBytes, Immutable, IntoBytes};
@@ -301,7 +301,7 @@ impl TryFrom<u8> for BaseHashAlgoType {
             4 => Ok(BaseHashAlgoType::TpmAlgSha3_384),
             5 => Ok(BaseHashAlgoType::TpmAlgSha3_512),
             6 => Ok(BaseHashAlgoType::TpmAlgSm3_256),
-            _ => Err(SpdmError::InvalidParam),
+            _ => Err(SpdmError::Protocol(ProtocolError::InvalidParam)),
         }
     }
 }
@@ -312,7 +312,7 @@ impl TryFrom<BaseHashAlgoType> for HashAlgoType {
         match value {
             BaseHashAlgoType::TpmAlgSha384 => Ok(HashAlgoType::SHA384),
             BaseHashAlgoType::TpmAlgSha512 => Ok(HashAlgoType::SHA512),
-            _ => Err(SpdmError::InvalidParam),
+            _ => Err(SpdmError::Protocol(ProtocolError::InvalidParam)),
         }
     }
 }

--- a/runtime/userspace/api/spdm-lib/src/protocol/common.rs
+++ b/runtime/userspace/api/spdm-lib/src/protocol/common.rs
@@ -1,7 +1,7 @@
 // Licensed under the Apache-2.0 license
 
 use crate::codec::CommonCodec;
-use crate::error::{SpdmError, SpdmResult};
+use crate::error::{ProtocolError, SpdmError, SpdmResult};
 use crate::protocol::{version::SpdmVersion, REQUESTER_CONTEXT_LEN, SPDM_CONTEXT_LEN};
 use zerocopy::{FromBytes, Immutable, IntoBytes};
 
@@ -68,7 +68,7 @@ impl TryFrom<u8> for ReqRespCode {
             0x6C => Ok(ReqRespCode::EndSessionAck),
             0xFE => Ok(ReqRespCode::VendorDefinedRequest),
             0x7E => Ok(ReqRespCode::VendorDefinedResponse),
-            _ => Err(SpdmError::UnsupportedRequest),
+            _ => Err(SpdmError::Protocol(ProtocolError::UnsupportedRequest)),
         }
     }
 }
@@ -80,22 +80,19 @@ impl From<ReqRespCode> for u8 {
 }
 
 impl ReqRespCode {
-    pub(crate) fn spdm_context_string(&self) -> SpdmResult<[u8; SPDM_CONTEXT_LEN]> {
-        let mut context = [0u8; SPDM_CONTEXT_LEN];
-        let ctx_str = match self {
+    pub(crate) fn spdm_context_string(&self) -> Option<[u8; SPDM_CONTEXT_LEN]> {
+        let ctx_str: &str = match self {
             ReqRespCode::ChallengeAuth => "responder-challenge_auth signing",
             ReqRespCode::Measurements => "responder-measurements signing",
             ReqRespCode::KeyExchangeRsp => "responder-key_exchange_rsp signing",
-            _ => return Err(SpdmError::UnsupportedRequest),
+            _ => return None,
         };
 
-        if ctx_str.len() > SPDM_CONTEXT_LEN {
-            return Err(SpdmError::InvalidParam);
-        }
+        let mut context = [0u8; SPDM_CONTEXT_LEN];
         let zero_pad_size = SPDM_CONTEXT_LEN - ctx_str.len();
         context[zero_pad_size..].copy_from_slice(ctx_str.as_bytes());
 
-        Ok(context)
+        Some(context)
     }
 }
 

--- a/runtime/userspace/api/spdm-lib/src/protocol/opaque_data.rs
+++ b/runtime/userspace/api/spdm-lib/src/protocol/opaque_data.rs
@@ -19,6 +19,20 @@ pub enum OpaqueDataError {
     Codec(CodecError),
 }
 
+impl OpaqueDataError {
+    pub fn error_code(&self) -> u32 {
+        match self {
+            OpaqueDataError::InvalidStandardsBodyId => 0x01_00,
+            OpaqueDataError::InvalidVendorIdLength => 0x02_00,
+            OpaqueDataError::UnalignedOpaqueData => 0x03_00,
+            OpaqueDataError::InvalidFormat => 0x04_00,
+            OpaqueDataError::Codec(e) => {
+                ((crate::error::error_type_id::CODEC as u32) << 8) | ((*e as u8) as u32)
+            }
+        }
+    }
+}
+
 pub type OpaqueDataResult<T> = Result<T, OpaqueDataError>;
 
 pub(crate) struct OpaqueData {

--- a/runtime/userspace/api/spdm-lib/src/protocol/signature.rs
+++ b/runtime/userspace/api/spdm-lib/src/protocol/signature.rs
@@ -20,6 +20,24 @@ pub enum SignCtxError {
     CaliptraApi(CaliptraApiError),
 }
 
+impl SignCtxError {
+    pub fn error_code(&self) -> u32 {
+        match self {
+            SignCtxError::UnsupportedVersion => 0x01_00,
+            SignCtxError::BufferTooSmall => 0x02_00,
+            SignCtxError::InvalidSignCtxString => 0x03_00,
+            SignCtxError::CaliptraApi(_) => (crate::error::error_type_id::CALIPTRA_API as u32) << 8,
+        }
+    }
+
+    pub fn caliptra_api(&self) -> Option<&CaliptraApiError> {
+        match self {
+            SignCtxError::CaliptraApi(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
 pub type SignatureCtxResult<T> = Result<T, SignCtxError>;
 
 pub(crate) fn create_responder_signing_context(
@@ -49,7 +67,7 @@ pub(crate) fn create_responder_signing_context(
 
     let spdm_context = opcode
         .spdm_context_string()
-        .map_err(|_| SignCtxError::InvalidSignCtxString)?;
+        .ok_or(SignCtxError::InvalidSignCtxString)?;
     combined_spdm_prefix[..SPDM_PREFIX_LEN].copy_from_slice(&spdm_prefix);
     combined_spdm_prefix[SPDM_PREFIX_LEN..].copy_from_slice(&spdm_context);
 

--- a/runtime/userspace/api/spdm-lib/src/protocol/vendor.rs
+++ b/runtime/userspace/api/spdm-lib/src/protocol/vendor.rs
@@ -1,6 +1,6 @@
 // Licensed under the Apache-2.0 license
 
-use crate::error::{SpdmError, SpdmResult};
+use crate::error::{ProtocolError, SpdmError, SpdmResult};
 
 // Maximum length can be up to 255. Update MAX_SPDM_VENDOR_ID_LEN as needed.
 pub const MAX_SPDM_VENDOR_ID_LEN: u8 = 4;
@@ -33,7 +33,9 @@ impl StandardsBodyId {
             | StandardsBodyId::Jedec
             | StandardsBodyId::DmtfDsp => Ok(2),
             StandardsBodyId::Iana | StandardsBodyId::HdBaseT => Ok(4),
-            StandardsBodyId::IanaCbor => Err(SpdmError::UnsupportedRequest), // This is a variable field
+            StandardsBodyId::IanaCbor => {
+                Err(SpdmError::Protocol(ProtocolError::UnsupportedRequest))
+            } // This is a variable field
         }
     }
 }
@@ -54,7 +56,7 @@ impl TryFrom<u16> for StandardsBodyId {
             0x9 => Ok(StandardsBodyId::Vesa),
             0xA => Ok(StandardsBodyId::IanaCbor),
             0xB => Ok(StandardsBodyId::DmtfDsp),
-            _ => Err(SpdmError::InvalidStandardsBodyId),
+            _ => Err(SpdmError::Protocol(ProtocolError::InvalidStandardsBodyId)),
         }
     }
 }

--- a/runtime/userspace/api/spdm-lib/src/protocol/version.rs
+++ b/runtime/userspace/api/spdm-lib/src/protocol/version.rs
@@ -1,6 +1,6 @@
 // Licensed under the Apache-2.0 license
 
-use crate::error::{SpdmError, SpdmResult};
+use crate::error::{ProtocolError, SpdmError, SpdmResult};
 
 const MAX_NUM_SUPPORTED_SPDM_VERSIONS: usize = 4;
 const MAX_SUPPORTED_VERSION: SpdmVersion = SpdmVersion::V13;
@@ -33,7 +33,7 @@ impl TryFrom<u8> for SpdmVersion {
             0x11 => Ok(SpdmVersion::V11),
             0x12 => Ok(SpdmVersion::V12),
             0x13 => Ok(SpdmVersion::V13),
-            _ => Err(SpdmError::UnsupportedVersion),
+            _ => Err(SpdmError::Protocol(ProtocolError::UnsupportedVersion)),
         }
     }
 }
@@ -75,7 +75,7 @@ pub(crate) fn validate_supported_versions(supported_versions: &[SpdmVersion]) ->
             .iter()
             .any(|v| *v > MAX_SUPPORTED_VERSION)
     {
-        Err(SpdmError::InvalidParam)?;
+        Err(SpdmError::Protocol(ProtocolError::InvalidParam))?;
     }
     Ok(())
 }

--- a/runtime/userspace/api/spdm-lib/src/session/key_schedule.rs
+++ b/runtime/userspace/api/spdm-lib/src/session/key_schedule.rs
@@ -27,6 +27,27 @@ pub enum KeyScheduleError {
     CaliptraApi(CaliptraApiError),
 }
 
+impl KeyScheduleError {
+    pub fn error_code(&self) -> u32 {
+        match self {
+            KeyScheduleError::BufferTooSmall => 0x01,
+            KeyScheduleError::InvalidSessionKeyType => 0x02,
+            KeyScheduleError::DheSecretNotFound => 0x03,
+            KeyScheduleError::HandshakeSecretNotFound => 0x04,
+            KeyScheduleError::MasterSecretNotFound => 0x05,
+            KeyScheduleError::DataSecretNotFound => 0x06,
+            KeyScheduleError::CaliptraApi(_) => crate::error::error_type_id::CALIPTRA_API as u32,
+        }
+    }
+
+    pub fn caliptra_api(&self) -> Option<&CaliptraApiError> {
+        match self {
+            KeyScheduleError::CaliptraApi(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
 pub type KeyScheduleResult<T> = Result<T, KeyScheduleError>;
 
 #[derive(Debug, PartialEq, Clone, Copy)]

--- a/runtime/userspace/api/spdm-lib/src/session/mod.rs
+++ b/runtime/userspace/api/spdm-lib/src/session/mod.rs
@@ -34,6 +34,36 @@ pub enum SessionError {
     Codec(CodecError),
 }
 
+impl SessionError {
+    pub fn error_code(&self) -> u32 {
+        match self {
+            SessionError::SessionsLimitReached => 0x01_00,
+            SessionError::InvalidSessionId => 0x02_00,
+            SessionError::InvalidState => 0x03_00,
+            SessionError::DheSecretNotFound => 0x04_00,
+            SessionError::HandshakeSecretNotFound => 0x05_00,
+            SessionError::BufferTooSmall => 0x06_00,
+            SessionError::EncodeAeadError => 0x07_00,
+            SessionError::DecodeAeadError => 0x08_00,
+            SessionError::KeySchedule(e) => {
+                ((crate::error::error_type_id::KEY_SCHEDULE as u32) << 8) | e.error_code()
+            }
+            SessionError::CaliptraApi(_) => (crate::error::error_type_id::CALIPTRA_API as u32) << 8,
+            SessionError::Codec(e) => {
+                ((crate::error::error_type_id::CODEC as u32) << 8) | ((*e as u8) as u32)
+            }
+        }
+    }
+
+    pub fn caliptra_api(&self) -> Option<&CaliptraApiError> {
+        match self {
+            SessionError::CaliptraApi(e) => Some(e),
+            SessionError::KeySchedule(e) => e.caliptra_api(),
+            _ => None,
+        }
+    }
+}
+
 pub type SessionResult<T> = Result<T, SessionError>;
 
 #[derive(Default)]

--- a/runtime/userspace/api/spdm-lib/src/transcript.rs
+++ b/runtime/userspace/api/spdm-lib/src/transcript.rs
@@ -15,6 +15,26 @@ pub enum TranscriptError {
     CaliptraApi(CaliptraApiError),
 }
 
+impl TranscriptError {
+    pub fn error_code(&self) -> u32 {
+        match self {
+            TranscriptError::BufferOverflow => 0x01_00,
+            TranscriptError::InvalidState => 0x02_00,
+            TranscriptError::MissingSessionInfo => 0x03_00,
+            TranscriptError::CaliptraApi(_) => {
+                (crate::error::error_type_id::CALIPTRA_API as u32) << 8
+            }
+        }
+    }
+
+    pub fn caliptra_api(&self) -> Option<&CaliptraApiError> {
+        match self {
+            TranscriptError::CaliptraApi(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
 pub type TranscriptResult<T> = Result<T, TranscriptError>;
 
 // Buffer size constants

--- a/runtime/userspace/api/spdm-lib/src/transport/common.rs
+++ b/runtime/userspace/api/spdm-lib/src/transport/common.rs
@@ -45,3 +45,20 @@ pub enum TransportError {
     InvalidMessage,
     OperationNotSupported,
 }
+
+impl TransportError {
+    pub fn error_code(&self) -> u32 {
+        match self {
+            TransportError::DriverError(e) => 0x01_00 | ((*e as u32) & 0xFF),
+            TransportError::UnexpectedMessageType => 0x02_00,
+            TransportError::UnsupportedMessageType => 0x03_00,
+            TransportError::ResponseNotExpected => 0x04_00,
+            TransportError::NoRequestInFlight => 0x05_00,
+            TransportError::InvalidMessage => 0x06_00,
+            TransportError::OperationNotSupported => 0x07_00,
+            TransportError::Codec(e) => {
+                ((crate::error::error_type_id::CODEC as u32) << 8) | ((*e as u8) as u32)
+            }
+        }
+    }
+}

--- a/runtime/userspace/api/spdm-lib/src/vdm_handler/mod.rs
+++ b/runtime/userspace/api/spdm-lib/src/vdm_handler/mod.rs
@@ -30,6 +30,30 @@ pub enum VdmError {
     Tdisp(TdispDriverError),
 }
 
+impl VdmError {
+    pub fn error_code(&self) -> u32 {
+        match self {
+            VdmError::InvalidVendorId => 0x01_00,
+            VdmError::InvalidRequestPayload => 0x02_00,
+            VdmError::UnsupportedProtocol => 0x03_00,
+            VdmError::InvalidVdmCommand => 0x04_00,
+            VdmError::SessionRequired => 0x05_00,
+            VdmError::UnsupportedRequest => 0x06_00,
+            VdmError::UnsupportedTdispVersion => 0x07_00,
+            VdmError::LargeResp(_) => 0x08_00,
+            VdmError::Codec(e) => {
+                ((crate::error::error_type_id::CODEC as u32) << 8) | ((*e as u8) as u32)
+            }
+            VdmError::Ide(e) => {
+                ((crate::error::error_type_id::IDE_DRIVER as u32) << 8) | ((*e as u8) as u32)
+            }
+            VdmError::Tdisp(e) => {
+                ((crate::error::error_type_id::TDISP_DRIVER as u32) << 8) | ((*e as u8) as u32)
+            }
+        }
+    }
+}
+
 pub type VdmResult<T> = Result<T, VdmError>;
 
 #[async_trait]

--- a/runtime/userspace/api/spdm-lib/src/vdm_handler/pci_sig/ide_km/driver.rs
+++ b/runtime/userspace/api/spdm-lib/src/vdm_handler/pci_sig/ide_km/driver.rs
@@ -7,16 +7,17 @@ use alloc::boxed::Box;
 use async_trait::async_trait;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
 pub enum IdeDriverError {
-    InvalidPortIndex,
-    UnsupportedPortIndex,
-    InvalidStreamId,
-    InvalidArgument,
-    GetPortConfigFail,
-    KeyProgFail,
-    KeySetGoFail,
-    KeySetStopFail,
-    NoMemory,
+    InvalidPortIndex = 0x01,
+    UnsupportedPortIndex = 0x02,
+    InvalidStreamId = 0x03,
+    InvalidArgument = 0x04,
+    GetPortConfigFail = 0x05,
+    KeyProgFail = 0x06,
+    KeySetGoFail = 0x07,
+    KeySetStopFail = 0x08,
+    NoMemory = 0x09,
 }
 
 pub type IdeDriverResult<T> = Result<T, IdeDriverError>;

--- a/runtime/userspace/api/spdm-lib/src/vdm_handler/pci_sig/tdisp/driver.rs
+++ b/runtime/userspace/api/spdm-lib/src/vdm_handler/pci_sig/tdisp/driver.rs
@@ -7,28 +7,29 @@ use alloc::boxed::Box;
 use async_trait::async_trait;
 
 /// Error codes returned by TDISP driver
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
 pub enum TdispDriverError {
     /// Input parameter is null or invalid.
-    InvalidArgument,
+    InvalidArgument = 0x01,
     /// Memory allocation failed.
-    NoMemory,
+    NoMemory = 0x02,
     /// The driver failed to get TDISP capabilities.
-    GetTdispCapabilitiesFail,
+    GetTdispCapabilitiesFail = 0x03,
     /// The driver failed to get the device interface state.
-    GetDeviceInterfaceStateFail,
+    GetDeviceInterfaceStateFail = 0x04,
     /// The driver failed to lock the device interface.
-    LockInterfaceReqFail,
+    LockInterfaceReqFail = 0x05,
     /// The driver failed to start the device interface.
-    StartInterfaceReqFail,
+    StartInterfaceReqFail = 0x06,
     /// The driver failed to stop the device interface.
-    StopInterfaceReqFail,
+    StopInterfaceReqFail = 0x07,
     /// The driver failed to get the device interface report.
-    GetInterfaceReportFail,
+    GetInterfaceReportFail = 0x08,
     /// The driver failed to get the mmio ranges.
-    GetMmioRangesFail,
+    GetMmioRangesFail = 0x09,
     /// The driver function is not implemented.
-    FunctionNotImplemented,
+    FunctionNotImplemented = 0x0A,
 }
 
 pub type TdispDriverResult<T> = Result<T, TdispDriverError>;


### PR DESCRIPTION
- Add error_code()/ext_code() u32s on SpdmError replacing Debug-based console prints.
- Introduce stable wrapper-type IDs (error_type_id, 0xE0..0xFF) so a given inner error type uses the same byte value at every nesting depth.
- Group related variants into sub-enums so SpdmError stays simple.
- Replace &'static str-carrying variants across the SPDM error types with named variants.

Saves ~22 KB user-app .text.