### PR TITLE
rom: align DOT recovery PK hash with caliptra-sw fuse layout

### DIFF
--- a/rom/src/device_ownership_transfer.rs
+++ b/rom/src/device_ownership_transfer.rs
@@ -35,6 +35,29 @@ pub trait OwnerPolicy {}
 #[derive(Clone, FromBytes, IntoBytes, Immutable, KnownLayout)]
 pub struct RecoveryPkHash(pub [u32; 12]);
 
+/// Convert a 48-byte recovery PK hash payload read from OTP into a
+/// [`RecoveryPkHash`] by reversing the bytes within each 4-byte word.
+///
+/// The vendor recovery PK hash fuse uses the same on-OTP layout as
+/// caliptra-sw's `cptra_ss_owner_pk_hash` and debug-unlock vendor PK hash
+/// fuses: each 4-byte word is stored byte-reversed relative to the natural
+/// (FIPS-standard) SHA-384 byte order. After reversing within each word,
+/// `transmute!(recovery_pk_hash.0)` yields the SHA-384 digest bytes in
+/// natural order, so it can be compared directly against the output of
+/// Caliptra's CM_SHA / SHA-384 mailbox command.
+///
+/// Aligning these three fuses on a single layout means an integrator can
+/// burn the same 48-byte value into any of them (e.g., for testing or for
+/// a shared trust anchor) without having to track per-fuse byte-order
+/// quirks.
+fn recovery_pk_hash_from_otp_bytes(mut bytes: [u8; 48]) -> RecoveryPkHash {
+    for chunk in bytes.chunks_exact_mut(4) {
+        chunk.reverse();
+    }
+    let hash: [u32; 12] = zerocopy::transmute!(bytes);
+    RecoveryPkHash(hash)
+}
+
 #[derive(Clone, Default)]
 pub struct DotFuses {
     pub enabled: bool,
@@ -76,8 +99,7 @@ impl DotFuses {
         let recovery_pk_hash = if pk_buf.iter().all(|&b| b == 0) {
             None
         } else {
-            let hash: [u32; 12] = zerocopy::transmute!(pk_buf);
-            Some(RecoveryPkHash(hash))
+            Some(recovery_pk_hash_from_otp_bytes(pk_buf))
         };
 
         Ok(DotFuses {
@@ -603,11 +625,42 @@ pub trait RecoveryTransport {
 // Shared DOT override helpers (used by both MCI and I3C flows)
 // ---------------------------------------------------------------------------
 
-/// Interpret an `EccP384PublicKey` as a `&[u32]` slice for hashing.
-pub(crate) fn ecc_key_as_u32_slice(key: &EccP384PublicKey) -> &[u32] {
-    let bytes = zerocopy::IntoBytes::as_bytes(key);
-    // EccP384PublicKey is #[repr(C)] with [u32;12]+[u32;12], always aligned.
-    unsafe { core::slice::from_raw_parts(bytes.as_ptr() as *const u32, bytes.len() / 4) }
+/// Compute the SHA-384 of a vendor public key pair using the caliptra-sw
+/// owner-PK-hash convention (the same convention used by
+/// `cptra_ss_owner_pk_hash` and the debug-unlock vendor PK hash).
+///
+/// Inputs are the public keys in **natural FIPS byte order**, as the host
+/// sends them over the mailbox / I3C wire — `ecc_pub_key.x[i]` /
+/// `.y[i]` is `u32::from_le_bytes` of the four natural ECC bytes at offset
+/// `i*4`, and `mldsa_pub_key[i]` is `u32::from_le_bytes` of the four
+/// natural MLDSA bytes at offset `i*4`.
+///
+/// The bytes that go through SHA-384 must match caliptra-sw's image
+/// generator. From `image/gen/src/lib.rs::to_hw_format` and
+/// `image/crypto/src/rustcrypto.rs`, caliptra-sw stores the ECC public key
+/// as `[u32::from_be_bytes(natural_chunk), ...]` but the MLDSA public key
+/// as `[u32::from_le_bytes(natural_chunk), ...]`. On a little-endian
+/// target, this means the SHA input bytes are:
+///
+///   per_dword_reversed(natural ECC bytes) || natural MLDSA bytes
+///
+/// This helper reproduces that exactly by `u32::swap_bytes`-ing each ECC
+/// word before feeding it to `cm_sha384` (which hashes the raw memory
+/// bytes of the u32 words on the caliptra side). The MLDSA words are
+/// passed through unchanged.
+pub(crate) fn cm_owner_pk_hash_sha384(
+    soc_manager: &mut caliptra_mcu_romtime::CaliptraSoC,
+    ecc_pub_key: &EccP384PublicKey,
+    mldsa_pub_key: &[u32],
+) -> McuResult<[u8; SHA384_DIGEST_SIZE]> {
+    let mut ecc_swapped = [0u32; 24];
+    let mut i = 0;
+    while i < 12 {
+        ecc_swapped[i] = ecc_pub_key.x[i].swap_bytes();
+        ecc_swapped[12 + i] = ecc_pub_key.y[i].swap_bytes();
+        i += 1;
+    }
+    cm_sha384(soc_manager, &[&ecc_swapped, mldsa_pub_key])
 }
 
 /// Verify that the vendor public keys match `recovery_pk_hash` and that
@@ -620,9 +673,9 @@ pub(crate) fn verify_override_response(
     recovery_pk_hash: &RecoveryPkHash,
     auth: &OverrideAuth<'_>,
 ) -> McuResult<()> {
-    // Verify PK hash matches OTP fuses
-    let ecc_key_u32 = ecc_key_as_u32_slice(auth.ecc_key);
-    let computed_hash = cm_sha384(soc_manager, &[ecc_key_u32, auth.mldsa_pub_key])?;
+    // Verify PK hash matches OTP fuses, using the caliptra-sw owner-PK-hash
+    // convention (per-dword-reversed ECC || natural MLDSA).
+    let computed_hash = cm_owner_pk_hash_sha384(soc_manager, auth.ecc_key, auth.mldsa_pub_key)?;
 
     let fuse_hash_bytes: [u8; 48] = transmute!(recovery_pk_hash.0);
     if !constant_time_eq::constant_time_eq(&computed_hash, &fuse_hash_bytes) {
@@ -1033,13 +1086,18 @@ pub fn dot_override_challenge_flow(
             .set_flow_checkpoint(McuRomBootStatus::DotOverrideFailed.into());
     })?;
 
-    // Verify vendor public key hash matches recovery PK hash in OTP fuses (ECC + MLDSA)
-    let ecc_key_u32 = ecc_key_as_u32_slice(&request.ecc_pub_key);
-    let computed_hash = cm_sha384(&mut env.soc_manager, &[ecc_key_u32, request.mldsa_pub_key])
-        .inspect_err(|_e| {
-            env.mci
-                .set_flow_checkpoint(McuRomBootStatus::DotOverrideFailed.into());
-        })?;
+    // Verify vendor public key hash matches recovery PK hash in OTP fuses
+    // using the caliptra-sw owner-PK-hash convention (per-dword-reversed
+    // ECC || natural MLDSA).
+    let computed_hash = cm_owner_pk_hash_sha384(
+        &mut env.soc_manager,
+        &request.ecc_pub_key,
+        request.mldsa_pub_key,
+    )
+    .inspect_err(|_e| {
+        env.mci
+            .set_flow_checkpoint(McuRomBootStatus::DotOverrideFailed.into());
+    })?;
 
     let fuse_hash_bytes: [u8; 48] = transmute!(recovery_pk_hash.0);
     if !constant_time_eq::constant_time_eq(&computed_hash, &fuse_hash_bytes) {
@@ -1555,5 +1613,175 @@ impl DotLockedRecoveryHandler for OverrideChallengeRecoveryHandler<'_> {
             ctx.dot_flash,
             ctx.key_type,
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// All-zero OTP bytes must yield an all-zero `RecoveryPkHash`. (The
+    /// `load_from_otp` caller uses this to distinguish "fuse not burned"
+    /// from "fuse burned with some hash value", so the byte-reversal must
+    /// not change the zero detection contract.)
+    #[test]
+    fn recovery_pk_hash_zero_input_round_trips() {
+        let hash = recovery_pk_hash_from_otp_bytes([0u8; 48]);
+        assert_eq!(hash.0, [0u32; 12]);
+    }
+
+    /// A known pattern in OTP must come back as the same logical hash bytes
+    /// in natural (FIPS) SHA-384 order when viewed through
+    /// `transmute!(recovery_pk_hash.0)`.
+    ///
+    /// The OTP bytes are stored byte-reversed within each 4-byte word
+    /// (caliptra-sw fuse layout), so reading bytes `[0x03, 0x02, 0x01, 0x00, ...]`
+    /// from OTP must yield natural bytes `[0x00, 0x01, 0x02, 0x03, ...]`.
+    #[test]
+    fn recovery_pk_hash_reverses_each_word() {
+        let mut otp_bytes = [0u8; 48];
+        for (i, b) in otp_bytes.iter_mut().enumerate() {
+            // In each 4-byte word, the OTP bytes are reversed: word i contains
+            // bytes [i*4+3, i*4+2, i*4+1, i*4+0] of the natural-order hash.
+            let word = i / 4;
+            let pos_in_word = i % 4;
+            *b = (word * 4 + (3 - pos_in_word)) as u8;
+        }
+
+        let hash = recovery_pk_hash_from_otp_bytes(otp_bytes);
+        let natural_bytes: [u8; 48] = zerocopy::transmute!(hash.0);
+
+        let mut expected = [0u8; 48];
+        for (i, b) in expected.iter_mut().enumerate() {
+            *b = i as u8;
+        }
+        assert_eq!(natural_bytes, expected);
+    }
+
+    /// Applying the byte-reversal twice must reproduce the original input.
+    /// This guards against accidentally introducing an asymmetric transform.
+    #[test]
+    fn recovery_pk_hash_reverses_are_involutive() {
+        let mut input = [0u8; 48];
+        for (i, b) in input.iter_mut().enumerate() {
+            *b = (i.wrapping_mul(37) ^ 0xa5) as u8;
+        }
+
+        let first = recovery_pk_hash_from_otp_bytes(input);
+        let first_bytes: [u8; 48] = zerocopy::transmute!(first.0);
+        let second = recovery_pk_hash_from_otp_bytes(first_bytes);
+        let second_bytes: [u8; 48] = zerocopy::transmute!(second.0);
+
+        assert_eq!(second_bytes, input);
+    }
+
+    /// Verify that the recovery PK hash uses the same fuse layout as the
+    /// caliptra-sw `cptra_ss_owner_pk_hash` convention: storing the hash
+    /// as `[u32; 12]` of big-endian-decoded 4-byte chunks.
+    ///
+    /// This is the property that lets an integrator burn the same 48-byte
+    /// value into `cptra_ss_owner_pk_hash`, the debug-unlock vendor PK hash,
+    /// or `vendor_recovery_pk_hash` and have them all be interpreted as the
+    /// same logical hash.
+    #[test]
+    fn recovery_pk_hash_matches_owner_pk_hash_fuse_layout() {
+        // Take an arbitrary 48-byte hash in natural SHA-384 byte order.
+        let mut natural = [0u8; 48];
+        for (i, b) in natural.iter_mut().enumerate() {
+            *b = ((i * 7) ^ 0x5c) as u8;
+        }
+
+        // Compute the [u32; 12] representation using the caliptra-sw fuse
+        // convention (big-endian decode of each 4-byte chunk).
+        let mut caliptra_sw_words = [0u32; 12];
+        for (i, chunk) in natural.chunks_exact(4).enumerate() {
+            caliptra_sw_words[i] = u32::from_be_bytes(chunk.try_into().unwrap());
+        }
+
+        // The OTP byte layout for both fuses: take the [u32; 12] words and
+        // store them little-endian (the natural byte storage on RV32 LE).
+        let mut otp_bytes = [0u8; 48];
+        for (i, word) in caliptra_sw_words.iter().enumerate() {
+            otp_bytes[i * 4..(i + 1) * 4].copy_from_slice(&word.to_le_bytes());
+        }
+
+        // Loading via `recovery_pk_hash_from_otp_bytes` must round-trip to
+        // the FIPS-natural bytes so it can be compared against the SHA-384
+        // digest produced by Caliptra.
+        let hash = recovery_pk_hash_from_otp_bytes(otp_bytes);
+        let recovered_natural: [u8; 48] = zerocopy::transmute!(hash.0);
+        assert_eq!(recovered_natural, natural);
+    }
+
+    /// Documented example: the natural FIPS-order owner PK hash value
+    /// `48afdb073c5e0d4ee46490468ef81f2cf57249b6e76a28f5fca4de696a7d3e2ed3efc4e6774318543e95307a54988bd7`
+    /// must be burned into the fuse as the per-dword-reversed bytes
+    /// `07dbaf484e0d5e3c469064e42c1ff88eb64972f5f5286ae769dea4fc2e3e7d6ae6c4efd35418437777a30953ed78b9854`.
+    ///
+    /// When the MCU reads those fuse bytes from OTP and converts them
+    /// through `recovery_pk_hash_from_otp_bytes`, the resulting
+    /// `transmute!(recovery_pk_hash.0)` must equal the documented natural
+    /// hash. This is the value that `cm_owner_pk_hash_sha384` produces and
+    /// that the comparison in `verify_override_response` checks against.
+    #[test]
+    fn recovery_pk_hash_documented_example() {
+        const NATURAL_HASH: [u8; 48] = [
+            0x48, 0xaf, 0xdb, 0x07, 0x3c, 0x5e, 0x0d, 0x4e, 0xe4, 0x64, 0x90, 0x46, 0x8e, 0xf8,
+            0x1f, 0x2c, 0xf5, 0x72, 0x49, 0xb6, 0xe7, 0x6a, 0x28, 0xf5, 0xfc, 0xa4, 0xde, 0x69,
+            0x6a, 0x7d, 0x3e, 0x2e, 0xd3, 0xef, 0xc4, 0xe6, 0x77, 0x43, 0x18, 0x54, 0x3e, 0x95,
+            0x30, 0x7a, 0x54, 0x98, 0x8b, 0xd7,
+        ];
+        const FUSE_BYTES: [u8; 48] = [
+            0x07, 0xdb, 0xaf, 0x48, 0x4e, 0x0d, 0x5e, 0x3c, 0x46, 0x90, 0x64, 0xe4, 0x2c, 0x1f,
+            0xf8, 0x8e, 0xb6, 0x49, 0x72, 0xf5, 0xf5, 0x28, 0x6a, 0xe7, 0x69, 0xde, 0xa4, 0xfc,
+            0x2e, 0x3e, 0x7d, 0x6a, 0xe6, 0xc4, 0xef, 0xd3, 0x54, 0x18, 0x43, 0x77, 0x7a, 0x30,
+            0x95, 0x3e, 0xd7, 0x8b, 0x98, 0x54,
+        ];
+
+        // Sanity check the constants: FUSE_BYTES is per-dword reverse of NATURAL_HASH.
+        for i in 0..12 {
+            for j in 0..4 {
+                assert_eq!(FUSE_BYTES[i * 4 + j], NATURAL_HASH[i * 4 + (3 - j)]);
+            }
+        }
+
+        let hash = recovery_pk_hash_from_otp_bytes(FUSE_BYTES);
+        let recovered: [u8; 48] = zerocopy::transmute!(hash.0);
+        assert_eq!(recovered, NATURAL_HASH);
+    }
+
+    /// `cm_owner_pk_hash_sha384` operates on a stack-resident `[u32; 24]`
+    /// built by `swap_bytes`-ing each ECC u32 word. This unit test pins
+    /// down that swap_bytes is what's needed.
+    ///
+    /// On a little-endian target, the host-supplied ECC pubkey x-coordinate
+    /// bytes `[X0, X1, X2, X3, ...]` are read into `EccP384PublicKey.x[i]`
+    /// as `u32::from_le_bytes([X0, X1, X2, X3])`. After `swap_bytes()` we
+    /// get `u32::from_be_bytes([X0, X1, X2, X3])`. When that u32 is sent
+    /// over the mailbox and stored in caliptra's memory on a LE target,
+    /// the bytes that go through SHA are `[X3, X2, X1, X0]` — i.e., the
+    /// per-dword-reversed natural ECC bytes that caliptra-sw's
+    /// `to_hw_format` (using `u32::from_be_bytes`) produces in the image
+    /// generator.
+    #[test]
+    fn owner_pk_hash_ecc_swap_bytes_matches_to_hw_format() {
+        let natural_bytes: [u8; 8] = [0xA0, 0xA1, 0xA2, 0xA3, 0xB0, 0xB1, 0xB2, 0xB3];
+
+        // The way the host packs ECC bytes into u32 over the mailbox.
+        let host_word_0 = u32::from_le_bytes([0xA0, 0xA1, 0xA2, 0xA3]);
+
+        // After swap_bytes (what cm_owner_pk_hash_sha384 does to ECC u32s).
+        let swapped = host_word_0.swap_bytes();
+        assert_eq!(swapped, u32::from_be_bytes([0xA0, 0xA1, 0xA2, 0xA3]));
+
+        // The bytes that end up flowing through SHA on caliptra's LE side.
+        let bytes_through_sha = swapped.to_le_bytes();
+        assert_eq!(bytes_through_sha, [0xA3, 0xA2, 0xA1, 0xA0]);
+
+        // This is exactly the per-dword reversal of the natural bytes.
+        let mut expected = [0u8; 4];
+        expected.copy_from_slice(&natural_bytes[..4]);
+        expected.reverse();
+        assert_eq!(bytes_through_sha, expected);
     }
 }

--- a/rom/src/i3c_mailbox.rs
+++ b/rom/src/i3c_mailbox.rs
@@ -321,11 +321,11 @@ impl<'a> I3cMailboxHandler<'a> {
         };
 
         let ecc_key = crate::EccP384PublicKey { x: ecc_x, y: ecc_y };
-        let ecc_key_u32 = crate::device_ownership_transfer::ecc_key_as_u32_slice(&ecc_key);
 
-        let computed_hash = match crate::device_ownership_transfer::cm_sha384(
+        let computed_hash = match crate::device_ownership_transfer::cm_owner_pk_hash_sha384(
             ctx.soc_manager,
-            &[ecc_key_u32, &mldsa_pub_key],
+            &ecc_key,
+            &mldsa_pub_key,
         ) {
             Ok(h) => h,
             Err(err) => {

--- a/tests/integration/src/rom/test_i3c_services.rs
+++ b/tests/integration/src/rom/test_i3c_services.rs
@@ -546,15 +546,30 @@ mod test {
         (pk.into_bytes().to_vec(), sk)
     }
 
+    /// Computes SHA-384 of the combined vendor public keys using the
+    /// caliptra-sw owner-PK-hash convention: the ECC public key is
+    /// per-dword byte-reversed before hashing, the MLDSA public key is
+    /// hashed in its natural byte order. Inputs are in natural FIPS byte
+    /// order.
     fn compute_recovery_pk_hash(
         ecc_pub_x: &[u8; 48],
         ecc_pub_y: &[u8; 48],
         mldsa_pub: &[u8],
     ) -> [u8; 48] {
         use sha2::{Digest, Sha384};
+        let mut ecc_x_rev = [0u8; 48];
+        let mut ecc_y_rev = [0u8; 48];
+        for (i, (xc, yc)) in ecc_pub_x
+            .chunks_exact(4)
+            .zip(ecc_pub_y.chunks_exact(4))
+            .enumerate()
+        {
+            ecc_x_rev[i * 4..(i + 1) * 4].copy_from_slice(&[xc[3], xc[2], xc[1], xc[0]]);
+            ecc_y_rev[i * 4..(i + 1) * 4].copy_from_slice(&[yc[3], yc[2], yc[1], yc[0]]);
+        }
         let mut hasher = Sha384::new();
-        hasher.update(ecc_pub_x);
-        hasher.update(ecc_pub_y);
+        hasher.update(ecc_x_rev);
+        hasher.update(ecc_y_rev);
         hasher.update(mldsa_pub);
         let result = hasher.finalize();
         let mut hash = [0u8; 48];
@@ -562,6 +577,15 @@ mod test {
         hash
     }
 
+    /// Build an OTP image for the DOT override / I3C recovery flow with the
+    /// given SHA-384 vendor recovery PK hash burned in.
+    ///
+    /// `pk_hash` is the digest in natural (FIPS) byte order. The
+    /// `VENDOR_RECOVERY_PK_HASH` fuse uses the caliptra-sw fuse layout —
+    /// each 4-byte word is byte-reversed relative to the natural SHA-384
+    /// byte order, matching `cptra_ss_owner_pk_hash` and the debug-unlock
+    /// vendor PK hash. The bytes are reversed within each 4-byte word
+    /// here before being scrambled into OTP.
     fn create_challenge_recovery_otp_memory(pk_hash: &[u8; 48]) -> Vec<u8> {
         use caliptra_mcu_otp_digest::{otp_scramble, OTP_SCRAMBLE_KEYS};
         use caliptra_mcu_registers_generated::fuses;
@@ -581,7 +605,11 @@ mod test {
         let scramble_key = OTP_SCRAMBLE_KEYS[5];
         let hash_offset = fuses::VENDOR_RECOVERY_PK_HASH.byte_offset;
         let mut hash_buf = [0u8; 48];
-        hash_buf.copy_from_slice(pk_hash);
+        for (i, chunk) in pk_hash.chunks_exact(4).enumerate() {
+            // Reverse each 4-byte word to convert FIPS-natural bytes into
+            // the caliptra-sw fuse layout stored in OTP.
+            hash_buf[i * 4..(i + 1) * 4].copy_from_slice(&[chunk[3], chunk[2], chunk[1], chunk[0]]);
+        }
         // Scramble in 8-byte chunks
         for chunk in hash_buf.chunks_exact_mut(8) {
             let plaintext = u64::from_le_bytes(chunk.try_into().unwrap());

--- a/tests/integration/src/test_dot.rs
+++ b/tests/integration/src/test_dot.rs
@@ -1221,7 +1221,12 @@ mod test {
         (pk_bytes.to_vec(), sk)
     }
 
-    /// Computes SHA-384 hash of the combined vendor public keys (ECC + MLDSA).
+    /// Computes SHA-384 of the combined vendor public keys using the
+    /// caliptra-sw owner-PK-hash convention: the ECC public key is
+    /// per-dword byte-reversed before hashing, the MLDSA public key is
+    /// hashed in its natural byte order. Inputs to this function are in
+    /// natural FIPS byte order (as the host sends them over the mailbox /
+    /// I3C wire).
     fn compute_recovery_pk_hash(
         ecc_pub_x: &[u8; 48],
         ecc_pub_y: &[u8; 48],
@@ -1229,9 +1234,21 @@ mod test {
     ) -> [u8; 48] {
         use sha2::{Digest, Sha384};
 
+        // Per-dword reverse the ECC x and y coordinates.
+        let mut ecc_x_rev = [0u8; 48];
+        let mut ecc_y_rev = [0u8; 48];
+        for (i, (xc, yc)) in ecc_pub_x
+            .chunks_exact(4)
+            .zip(ecc_pub_y.chunks_exact(4))
+            .enumerate()
+        {
+            ecc_x_rev[i * 4..(i + 1) * 4].copy_from_slice(&[xc[3], xc[2], xc[1], xc[0]]);
+            ecc_y_rev[i * 4..(i + 1) * 4].copy_from_slice(&[yc[3], yc[2], yc[1], yc[0]]);
+        }
+
         let mut hasher = Sha384::new();
-        hasher.update(ecc_pub_x);
-        hasher.update(ecc_pub_y);
+        hasher.update(ecc_x_rev);
+        hasher.update(ecc_y_rev);
         hasher.update(mldsa_pub);
         let result = hasher.finalize();
         let mut hash = [0u8; 48];
@@ -1241,6 +1258,13 @@ mod test {
 
     /// Creates OTP memory for override testing.
     /// Includes locked state fuses AND the vendor recovery PK hash.
+    ///
+    /// `pk_hash` is the SHA-384 digest in natural (FIPS) byte order. The
+    /// `VENDOR_RECOVERY_PK_HASH` fuse uses the same on-OTP layout as
+    /// `cptra_ss_owner_pk_hash` and the debug-unlock vendor PK hash:
+    /// each 4-byte word is stored byte-reversed relative to the natural
+    /// SHA-384 byte order. This helper performs that reversal before
+    /// scrambling and writing the bytes into the OTP image.
     fn create_challenge_recovery_otp_memory(pk_hash: &[u8; 48]) -> Vec<u8> {
         use caliptra_mcu_otp_digest::{otp_scramble, OTP_SCRAMBLE_KEYS};
         use caliptra_mcu_registers_generated::fuses;
@@ -1256,12 +1280,20 @@ mod test {
         otp[fuses::DOT_INITIALIZED.byte_offset] = 0x07;
         otp[fuses::DOT_FUSE_ARRAY.byte_offset] = 0x01;
 
+        // Convert the FIPS-natural hash bytes to the caliptra-sw fuse layout
+        // (byte-reversed within each 4-byte word).
+        let mut fuse_layout = [0u8; 48];
+        for (i, chunk) in pk_hash.chunks_exact(4).enumerate() {
+            fuse_layout[i * 4..(i + 1) * 4]
+                .copy_from_slice(&[chunk[3], chunk[2], chunk[1], chunk[0]]);
+        }
+
         // Write recovery PK hash into partition 13 (VendorSecretProdPartition),
         // which is scrambled. Pre-scramble each 8-byte block so the DAI read
         // path unscrambles back to the original plaintext.
         let key = OTP_SCRAMBLE_KEYS[5]; // VendorSecretProdPartition
         let hash_offset = fuses::VENDOR_RECOVERY_PK_HASH.byte_offset;
-        for (i, chunk) in pk_hash.chunks(8).enumerate() {
+        for (i, chunk) in fuse_layout.chunks(8).enumerate() {
             let off = hash_offset + i * 8;
             let mut block = [0u8; 8];
             block[..chunk.len()].copy_from_slice(chunk);
@@ -1479,6 +1511,191 @@ mod test {
         );
 
         println!("[TEST] DOT override succeeded: new unlocked blob written and fuse burned");
+
+        lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// Build OTP memory for an override test using the explicit
+    /// `cptra_ss_owner_pk_hash` storage convention from `get_owner_pk_hash`:
+    /// the 48 FIPS-natural hash bytes are first converted to `[u32; 12]` via
+    /// big-endian decode of each 4-byte chunk, and those u32 words are then
+    /// stored back to OTP as little-endian bytes.
+    ///
+    /// This is the same layout that integrators use today when burning
+    /// `cptra_ss_owner_pk_hash` or debug-unlock vendor PK hash into fuses.
+    /// The point of this helper is to prove — completely independently of
+    /// `create_challenge_recovery_otp_memory` — that the DOT recovery PK
+    /// hash fuse now accepts the same on-OTP byte layout.
+    fn create_recovery_otp_memory_via_owner_pk_hash_convention(pk_hash: &[u8; 48]) -> Vec<u8> {
+        use caliptra_mcu_otp_digest::{otp_scramble, OTP_SCRAMBLE_KEYS};
+        use caliptra_mcu_registers_generated::fuses;
+
+        let required_size = fuses::VENDOR_RECOVERY_PK_HASH.byte_offset
+            + fuses::VENDOR_RECOVERY_PK_HASH.byte_size
+            + 16;
+        let otp_size =
+            required_size.max(fuses::DOT_FUSE_ARRAY.byte_offset + fuses::DOT_FUSE_ARRAY.byte_size);
+        let mut otp = vec![0u8; otp_size];
+
+        otp[fuses::DOT_INITIALIZED.byte_offset] = 0x07;
+        otp[fuses::DOT_FUSE_ARRAY.byte_offset] = 0x01;
+
+        // Step 1: Same conversion an integrator does for cptra_ss_owner_pk_hash.
+        let mut words = [0u32; 12];
+        for (i, chunk) in pk_hash.chunks_exact(4).enumerate() {
+            words[i] = u32::from_be_bytes(chunk.try_into().unwrap());
+        }
+
+        // Step 2: Pack the [u32; 12] back to bytes the way OTP stores them
+        // on a little-endian target (one LE-encoded u32 per word).
+        let mut fuse_bytes = [0u8; 48];
+        for (i, word) in words.iter().enumerate() {
+            fuse_bytes[i * 4..(i + 1) * 4].copy_from_slice(&word.to_le_bytes());
+        }
+
+        // Step 3: Pre-scramble (VENDOR_RECOVERY_PK_HASH lives in the
+        // VendorSecretProdPartition, scramble key index 5).
+        let key = OTP_SCRAMBLE_KEYS[5];
+        let hash_offset = fuses::VENDOR_RECOVERY_PK_HASH.byte_offset;
+        for (i, chunk) in fuse_bytes.chunks(8).enumerate() {
+            let off = hash_offset + i * 8;
+            let mut block = [0u8; 8];
+            block[..chunk.len()].copy_from_slice(chunk);
+            let plaintext = u64::from_le_bytes(block);
+            let scrambled = otp_scramble(plaintext, key);
+            otp[off..off + 8].copy_from_slice(&scrambled.to_le_bytes());
+        }
+
+        otp
+    }
+
+    /// Regression test for the recovery-PK-hash / owner-PK-hash fuse layout
+    /// alignment.
+    ///
+    /// Burns a vendor recovery PK hash into OTP using the *exact same*
+    /// storage convention an integrator would use for
+    /// `cptra_ss_owner_pk_hash` (big-endian decode into `[u32; 12]`, stored
+    /// little-endian). The DOT override flow must accept that layout and
+    /// successfully verify the vendor public keys against the recovery PK
+    /// hash. This proves the three fuses (owner PK hash, debug-unlock
+    /// vendor PK hash, DOT recovery PK hash) use a single consistent
+    /// caliptra-sw fuse layout so an integrator can reuse the same value.
+    #[test]
+    fn test_dot_override_uses_owner_pk_hash_fuse_layout() {
+        use ecdsa::signature::hazmat::PrehashSigner;
+        use fips204::traits::Signer;
+        use p384::ecdsa::SigningKey;
+        use sha2::{Digest, Sha384};
+
+        let lock = TEST_LOCK.lock().unwrap();
+        lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
+        // Identical setup to test_dot_override_challenge_success, but the
+        // OTP image is constructed via the owner-PK-hash storage convention
+        // rather than the DOT-specific helper.
+        let (vendor_pub_x, vendor_pub_y, vendor_priv_bytes) = generate_random_ecc_keys();
+        let (mldsa_pub, mldsa_priv) = generate_random_mldsa_keys();
+        let vendor_pk_hash = compute_recovery_pk_hash(&vendor_pub_x, &vendor_pub_y, &mldsa_pub);
+
+        // Sanity check: the two storage paths must produce byte-identical
+        // OTP images. If this ever diverges, the alignment is broken.
+        let otp_via_owner_convention =
+            create_recovery_otp_memory_via_owner_pk_hash_convention(&vendor_pk_hash);
+        let otp_via_dot_helper = create_challenge_recovery_otp_memory(&vendor_pk_hash);
+        assert_eq!(
+            otp_via_owner_convention, otp_via_dot_helper,
+            "Owner-PK-hash storage convention must produce the same OTP \
+             bytes as the DOT recovery PK hash helper; if this fails, the \
+             three fuse layouts are out of sync."
+        );
+
+        let flash_contents = vec![0u8; DOT_BLOB_SIZE];
+
+        let mut hw = start_runtime_hw_model(TestParams {
+            dot_flash_initial_contents: Some(flash_contents),
+            rom_only: true,
+            otp_memory: Some(otp_via_owner_convention),
+            rom_feature: Some("test-dot-recovery"),
+            ..Default::default()
+        });
+
+        // Run the override challenge / response handshake.
+        let override_payload =
+            build_override_challenge_payload(&vendor_pub_x, &vendor_pub_y, &mldsa_pub);
+        hw.start_mailbox_execute(CMD_DOT_UNLOCK_CHALLENGE, &override_payload)
+            .expect("Failed to send DOT_UNLOCK_CHALLENGE");
+
+        let challenge = hw
+            .finish_mailbox_execute()
+            .expect("Failed to get override challenge response")
+            .expect("Expected challenge data from ROM");
+        assert_eq!(challenge.len(), 48, "Challenge should be 48 bytes");
+
+        // Sign the challenge with VendorKey.priv (ECDSA + MLDSA).
+        let challenge_hash: [u8; 48] = {
+            let mut hasher = Sha384::new();
+            hasher.update(&challenge);
+            hasher.finalize().into()
+        };
+        let vendor_secret_key =
+            p384::SecretKey::from_slice(&vendor_priv_bytes).expect("Invalid vendor private key");
+        let vendor_signing_key = SigningKey::from(&vendor_secret_key);
+        let ecc_sig: p384::ecdsa::Signature = vendor_signing_key
+            .sign_prehash(&challenge_hash)
+            .expect("ECDSA signing failed");
+        let ecc_r_bytes: [u8; 48] = ecc_sig.r().to_bytes().into();
+        let ecc_s_bytes: [u8; 48] = ecc_sig.s().to_bytes().into();
+
+        let mldsa_sig_bytes = mldsa_priv
+            .try_sign_with_seed(&[0u8; 32], &challenge, &[])
+            .expect("MLDSA signing failed");
+
+        let response_payload = build_override_response_payload(
+            &vendor_pub_x,
+            &vendor_pub_y,
+            &ecc_r_bytes,
+            &ecc_s_bytes,
+            &mldsa_pub,
+            &mldsa_sig_bytes,
+        );
+        hw.start_mailbox_execute(CMD_DOT_OVERRIDE, &response_payload)
+            .expect("Failed to send DOT_OVERRIDE");
+
+        // Let the ROM verify signatures, burn the fuse, write the new blob.
+        let start = hw.cycle_count();
+        hw.step_until(|m| m.mci_fw_fatal_error().is_some() || m.cycle_count() - start > 20_000_000);
+
+        // The override must succeed: a new non-empty DOT blob with version 1
+        // and a non-zero HMAC must be written to flash, and the DOT fuse
+        // bit must be burned (from 1 → 2 bits set).
+        let dot_flash = hw.read_dot_flash();
+        let written_blob = &dot_flash[..DOT_BLOB_SIZE];
+        assert!(
+            !written_blob.iter().all(|&b| b == 0) && !written_blob.iter().all(|&b| b == 0xFF),
+            "DOT blob should have been written (not erased) after override; \
+             owner-PK-hash fuse layout was rejected by recovery PK hash check"
+        );
+        let blob_bytes: [u8; DOT_BLOB_SIZE] = written_blob.try_into().unwrap();
+        let blob: TestDotBlob = zerocopy::transmute!(blob_bytes);
+        assert_eq!(blob.cak, [0u32; 12]);
+        assert_eq!(blob.lak_pub, [0u32; 12]);
+        assert_eq!(blob.version, 1);
+        assert!(!blob.hmac.iter().all(|&w| w == 0));
+
+        let otp_memory = hw.read_otp_memory();
+        let fuse_array_offset = caliptra_mcu_registers_generated::fuses::DOT_FUSE_ARRAY.byte_offset;
+        let lock_fuse_byte = otp_memory[fuse_array_offset];
+        assert_eq!(
+            lock_fuse_byte & 0x03,
+            0x03,
+            "DOT fuse should have 2 bits burned (1 → 2) after override"
+        );
+
+        println!(
+            "[TEST] DOT override accepted owner-PK-hash fuse layout: the same \
+             on-OTP byte layout used for cptra_ss_owner_pk_hash works for the \
+             vendor_recovery_pk_hash fuse."
+        );
 
         lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     }


### PR DESCRIPTION
So that a single 48-byte hash can be burned into cptra_ss_owner_pk_hash, debug-unlock vendor PK hash, and vendor_recovery_pk_hash, match the caliptra-sw conventions in the DOT path:

* OTP storage: each 4-byte word of the digest is stored byte-reversed (caliptra-sw `to_hw_format` decodes ECC via `u32::from_be_bytes`). `recovery_pk_hash_from_otp_bytes` undoes that on load.

* SHA input: the ECC public key is per-dword-reversed before hashing (`to_hw_format`), the MLDSA public key is hashed in natural order (the crypto layer uses `u32::from_le_bytes` for MLDSA). `cm_owner_pk_hash_sha384` swap_bytes-es each ECC u32 word before calling `cm_sha384`. Used at all three PK-hash check sites.

Tests cover the documented example 48afdb07...54988bd7 -> fuse bytes 07dbaf48...d7988b54, the SHA input swap convention, and a new integration test that builds OTP via the owner-PK-hash storage path and runs the full DOT_OVERRIDE challenge/response.