### PR TITLE
[builder] simplify test-usb-ocp-recovery build orchestration

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -109,8 +109,6 @@ jobs:
             test-pldm-discovery,test-pldm-fw-update,test-mci,test-mcu-mbox-driver,
             test-mcu-mbox-soc-requester-loopback,test-mbox-sram,test-warm-reset,test-mcu-mbox-cmds,
             test-ocp-lock,test-exit-immediately,test-mcu-rom-flash-access,test-mcu-svn-gt-fuse,test-mcu-svn-lt-fuse
-          ROM_TEST_FEATURES: >-
-            test-usb-ocp-recovery
         run: |
           # Build all test runtime features used by integration tests
           # Note: nightly tests (test-*-spdm-*, test-caliptra-util-host-validator) are excluded
@@ -118,7 +116,6 @@ jobs:
             --rom-features "hw-2-1,ocp-lock" \
             --test-rom-features "ocp-lock,stable-owner-key" \
             --runtime-features "${RUNTIME_FEATURES// /}" \
-            --rom-test-features "${ROM_TEST_FEATURES// /}" \
             --separate-runtimes
           sccache --show-stats
 

--- a/builder/src/all.rs
+++ b/builder/src/all.rs
@@ -462,7 +462,6 @@ pub struct AllBuildArgs<'a> {
     pub soc_images: Option<Vec<ImageCfg>>,
     pub mcu_cfgs: Option<Vec<ImageCfg>>,
     pub pldm_manifest: Option<&'a str>,
-    pub rom_test_features: Option<&'a str>,
 }
 
 /// Build Caliptra ROM and firmware bundle, MCU ROM and runtime, and SoC manifest, and package them all together in a ZIP file.
@@ -478,7 +477,6 @@ pub fn all_build(args: AllBuildArgs) -> Result<()> {
         soc_images,
         mcu_cfgs,
         pldm_manifest,
-        rom_test_features,
     } = args;
 
     // TODO: use temp files
@@ -623,6 +621,7 @@ pub fn all_build(args: AllBuildArgs) -> Result<()> {
         "test-fw-manifest-dot",
         "test-fw-manifest-dot-hitless",
         "test-dot-recovery",
+        "test-usb-ocp-recovery",
     ];
 
     let mut feature_roms_to_build = separate_features.clone();
@@ -648,24 +647,6 @@ pub fn all_build(args: AllBuildArgs) -> Result<()> {
                 println!("Skipping feature ROM for {}: {}", feature, e);
             }
         }
-    }
-
-    // Build ROM-only test features (e.g. test-usb-ocp-recovery) that aren't runtime
-    // features but need their own ROM binary. Each is built with the base rom_features
-    // combined with the test feature so the resulting binary matches what tests expect.
-    let rom_test_feature_list: Vec<&str> = match rom_test_features {
-        Some(f) if !f.is_empty() => f.split(',').collect(),
-        _ => vec![],
-    };
-    for feature in rom_test_feature_list.iter() {
-        let combined = if rom_features.is_empty() {
-            feature.to_string()
-        } else {
-            format!("{},{}", rom_features, feature)
-        };
-        let rom_path = crate::rom_build(Some(platform.to_string()), Some(combined))?;
-        let rom_name = format!("mcu-test-rom-feature-{}.bin", feature);
-        test_roms.push((rom_path, rom_name));
     }
 
     // Build feature-specific Network ROMs

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -183,11 +183,6 @@ enum Commands {
         /// Path to the PLDM manifest TOML file
         #[arg(short, long, value_name = "MANIFEST", required = false)]
         pldm_manifest: Option<String>,
-
-        /// Comma-separated list of ROM-only test features that need separate ROM builds.
-        /// Each feature gets its own ROM binary built with --rom-features plus the test feature.
-        #[arg(long)]
-        rom_test_features: Option<String>,
     },
     /// Generate CoRIM (Concise Reference Integrity Manifest) from build artifacts
     Corim {
@@ -467,7 +462,6 @@ fn main() {
             soc_images,
             mcu_cfgs,
             pldm_manifest,
-            rom_test_features,
         } => mcu_builder::all_build(mcu_builder::AllBuildArgs {
             output: output.as_deref(),
             platform: platform.as_deref(),
@@ -479,7 +473,6 @@ fn main() {
             soc_images: soc_images.clone(),
             mcu_cfgs: mcu_cfgs.clone(),
             pldm_manifest: pldm_manifest.as_deref(),
-            rom_test_features: rom_test_features.as_deref(),
         }),
         Commands::EmulatorBuild { output, features } => {
             mcu_builder::emulator_build(mcu_builder::EmulatorBuildArgs {


### PR DESCRIPTION
Promote the test-usb-ocp-recovery feature flag internally to the ROM_ONLY_TEST_FEATURES array in builder/src/all.rs. This allows the firmware bundler to natively compile the standalone feature test ROM binary without requiring outer command-line orchestration.

This approach is safe because the test-usb-ocp-recovery feature flag already explicitly pulls in base silicon hardware definitions (hw-2-1) via internal Cargo.toml dependencies. Consequently, outer base feature inheritance (such as inheriting ocp-lock from command-line parameters) is unnecessary to generate a fully functional test environment.

Remove the redundant --rom-test-features CLI argument from xtask subcommands and clean up outer CI build workflows accordingly.