### PR TITLE
rom: send ACTIVATE_FIRMWARE INITIAL_ACTIVATE after encrypted decrypt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,7 +330,7 @@ checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 [[package]]
 name = "caliptra-api"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fcc64aeceef3552bdb152e38d5c933d48b6634e3#fcc64aeceef3552bdb152e38d5c933d48b6634e3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a6e877530a7f123bd76f44a2c30c01805b62a357#a6e877530a7f123bd76f44a2c30c01805b62a357"
 dependencies = [
  "bitflags 2.10.0",
  "caliptra-api-types",
@@ -345,7 +345,7 @@ dependencies = [
 [[package]]
 name = "caliptra-api-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fcc64aeceef3552bdb152e38d5c933d48b6634e3#fcc64aeceef3552bdb152e38d5c933d48b6634e3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a6e877530a7f123bd76f44a2c30c01805b62a357#a6e877530a7f123bd76f44a2c30c01805b62a357"
 dependencies = [
  "caliptra-image-types",
 ]
@@ -353,7 +353,7 @@ dependencies = [
 [[package]]
 name = "caliptra-auth-man-gen"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fcc64aeceef3552bdb152e38d5c933d48b6634e3#fcc64aeceef3552bdb152e38d5c933d48b6634e3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a6e877530a7f123bd76f44a2c30c01805b62a357#a6e877530a7f123bd76f44a2c30c01805b62a357"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",
@@ -369,7 +369,7 @@ dependencies = [
 [[package]]
 name = "caliptra-auth-man-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fcc64aeceef3552bdb152e38d5c933d48b6634e3#fcc64aeceef3552bdb152e38d5c933d48b6634e3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a6e877530a7f123bd76f44a2c30c01805b62a357#a6e877530a7f123bd76f44a2c30c01805b62a357"
 dependencies = [
  "bitfield",
  "bitflags 2.10.0",
@@ -398,7 +398,7 @@ dependencies = [
 [[package]]
 name = "caliptra-builder"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fcc64aeceef3552bdb152e38d5c933d48b6634e3#fcc64aeceef3552bdb152e38d5c933d48b6634e3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a6e877530a7f123bd76f44a2c30c01805b62a357#a6e877530a7f123bd76f44a2c30c01805b62a357"
 dependencies = [
  "anyhow",
  "caliptra-image-crypto",
@@ -455,7 +455,7 @@ source = "git+https://github.com/chipsalliance/caliptra-cfi.git?rev=aa96c53073ce
 [[package]]
 name = "caliptra-common"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fcc64aeceef3552bdb152e38d5c933d48b6634e3#fcc64aeceef3552bdb152e38d5c933d48b6634e3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a6e877530a7f123bd76f44a2c30c01805b62a357#a6e877530a7f123bd76f44a2c30c01805b62a357"
 dependencies = [
  "bitfield",
  "bitflags 2.10.0",
@@ -479,7 +479,7 @@ dependencies = [
 [[package]]
 name = "caliptra-coverage"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fcc64aeceef3552bdb152e38d5c933d48b6634e3#fcc64aeceef3552bdb152e38d5c933d48b6634e3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a6e877530a7f123bd76f44a2c30c01805b62a357#a6e877530a7f123bd76f44a2c30c01805b62a357"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -497,7 +497,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cpu"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fcc64aeceef3552bdb152e38d5c933d48b6634e3#fcc64aeceef3552bdb152e38d5c933d48b6634e3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a6e877530a7f123bd76f44a2c30c01805b62a357#a6e877530a7f123bd76f44a2c30c01805b62a357"
 dependencies = [
  "caliptra-drivers",
  "caliptra-registers",
@@ -548,7 +548,7 @@ dependencies = [
 [[package]]
 name = "caliptra-drivers"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fcc64aeceef3552bdb152e38d5c933d48b6634e3#fcc64aeceef3552bdb152e38d5c933d48b6634e3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a6e877530a7f123bd76f44a2c30c01805b62a357#a6e877530a7f123bd76f44a2c30c01805b62a357"
 dependencies = [
  "arrayvec",
  "bitfield",
@@ -574,7 +574,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-bus"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fcc64aeceef3552bdb152e38d5c933d48b6634e3#fcc64aeceef3552bdb152e38d5c933d48b6634e3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a6e877530a7f123bd76f44a2c30c01805b62a357#a6e877530a7f123bd76f44a2c30c01805b62a357"
 dependencies = [
  "caliptra-emu-types",
  "caliptra-ureg",
@@ -584,7 +584,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-cpu"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fcc64aeceef3552bdb152e38d5c933d48b6634e3#fcc64aeceef3552bdb152e38d5c933d48b6634e3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a6e877530a7f123bd76f44a2c30c01805b62a357#a6e877530a7f123bd76f44a2c30c01805b62a357"
 dependencies = [
  "bit-vec",
  "bitfield",
@@ -598,7 +598,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fcc64aeceef3552bdb152e38d5c933d48b6634e3#fcc64aeceef3552bdb152e38d5c933d48b6634e3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a6e877530a7f123bd76f44a2c30c01805b62a357#a6e877530a7f123bd76f44a2c30c01805b62a357"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -614,7 +614,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-derive"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fcc64aeceef3552bdb152e38d5c933d48b6634e3#fcc64aeceef3552bdb152e38d5c933d48b6634e3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a6e877530a7f123bd76f44a2c30c01805b62a357#a6e877530a7f123bd76f44a2c30c01805b62a357"
 dependencies = [
  "caliptra-emu-bus",
  "caliptra-emu-types",
@@ -625,7 +625,7 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-periph"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fcc64aeceef3552bdb152e38d5c933d48b6634e3#fcc64aeceef3552bdb152e38d5c933d48b6634e3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a6e877530a7f123bd76f44a2c30c01805b62a357#a6e877530a7f123bd76f44a2c30c01805b62a357"
 dependencies = [
  "aes",
  "arrayref",
@@ -654,17 +654,17 @@ dependencies = [
 [[package]]
 name = "caliptra-emu-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fcc64aeceef3552bdb152e38d5c933d48b6634e3#fcc64aeceef3552bdb152e38d5c933d48b6634e3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a6e877530a7f123bd76f44a2c30c01805b62a357#a6e877530a7f123bd76f44a2c30c01805b62a357"
 
 [[package]]
 name = "caliptra-error"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fcc64aeceef3552bdb152e38d5c933d48b6634e3#fcc64aeceef3552bdb152e38d5c933d48b6634e3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a6e877530a7f123bd76f44a2c30c01805b62a357#a6e877530a7f123bd76f44a2c30c01805b62a357"
 
 [[package]]
 name = "caliptra-gen-linker-scripts"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fcc64aeceef3552bdb152e38d5c933d48b6634e3#fcc64aeceef3552bdb152e38d5c933d48b6634e3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a6e877530a7f123bd76f44a2c30c01805b62a357#a6e877530a7f123bd76f44a2c30c01805b62a357"
 dependencies = [
  "caliptra-common",
 ]
@@ -672,7 +672,7 @@ dependencies = [
 [[package]]
 name = "caliptra-hw-model"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fcc64aeceef3552bdb152e38d5c933d48b6634e3#fcc64aeceef3552bdb152e38d5c933d48b6634e3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a6e877530a7f123bd76f44a2c30c01805b62a357#a6e877530a7f123bd76f44a2c30c01805b62a357"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -710,7 +710,7 @@ dependencies = [
 [[package]]
 name = "caliptra-hw-model-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fcc64aeceef3552bdb152e38d5c933d48b6634e3#fcc64aeceef3552bdb152e38d5c933d48b6634e3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a6e877530a7f123bd76f44a2c30c01805b62a357#a6e877530a7f123bd76f44a2c30c01805b62a357"
 dependencies = [
  "caliptra-api-types",
  "rand 0.8.5",
@@ -719,7 +719,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fcc64aeceef3552bdb152e38d5c933d48b6634e3#fcc64aeceef3552bdb152e38d5c933d48b6634e3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a6e877530a7f123bd76f44a2c30c01805b62a357#a6e877530a7f123bd76f44a2c30c01805b62a357"
 dependencies = [
  "anyhow",
  "caliptra-image-gen",
@@ -739,7 +739,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-elf"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fcc64aeceef3552bdb152e38d5c933d48b6634e3#fcc64aeceef3552bdb152e38d5c933d48b6634e3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a6e877530a7f123bd76f44a2c30c01805b62a357#a6e877530a7f123bd76f44a2c30c01805b62a357"
 dependencies = [
  "anyhow",
  "caliptra-image-gen",
@@ -750,7 +750,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-fake-keys"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fcc64aeceef3552bdb152e38d5c933d48b6634e3#fcc64aeceef3552bdb152e38d5c933d48b6634e3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a6e877530a7f123bd76f44a2c30c01805b62a357#a6e877530a7f123bd76f44a2c30c01805b62a357"
 dependencies = [
  "caliptra-image-gen",
  "caliptra-image-types",
@@ -761,7 +761,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-gen"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fcc64aeceef3552bdb152e38d5c933d48b6634e3#fcc64aeceef3552bdb152e38d5c933d48b6634e3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a6e877530a7f123bd76f44a2c30c01805b62a357#a6e877530a7f123bd76f44a2c30c01805b62a357"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",
@@ -778,7 +778,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fcc64aeceef3552bdb152e38d5c933d48b6634e3#fcc64aeceef3552bdb152e38d5c933d48b6634e3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a6e877530a7f123bd76f44a2c30c01805b62a357#a6e877530a7f123bd76f44a2c30c01805b62a357"
 dependencies = [
  "caliptra-cfi-derive 0.1.0 (git+https://github.com/chipsalliance/caliptra-cfi.git?rev=aa96c53073ce7f298f7482c1ac57f5f65ffc115e)",
  "caliptra-cfi-lib 0.1.0 (git+https://github.com/chipsalliance/caliptra-cfi.git?rev=aa96c53073ce7f298f7482c1ac57f5f65ffc115e)",
@@ -794,7 +794,7 @@ dependencies = [
 [[package]]
 name = "caliptra-image-verify"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fcc64aeceef3552bdb152e38d5c933d48b6634e3#fcc64aeceef3552bdb152e38d5c933d48b6634e3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a6e877530a7f123bd76f44a2c30c01805b62a357#a6e877530a7f123bd76f44a2c30c01805b62a357"
 dependencies = [
  "bitflags 2.10.0",
  "caliptra-cfi-derive 0.1.0 (git+https://github.com/chipsalliance/caliptra-cfi.git?rev=aa96c53073ce7f298f7482c1ac57f5f65ffc115e)",
@@ -809,7 +809,7 @@ dependencies = [
 [[package]]
 name = "caliptra-kat"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fcc64aeceef3552bdb152e38d5c933d48b6634e3#fcc64aeceef3552bdb152e38d5c933d48b6634e3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a6e877530a7f123bd76f44a2c30c01805b62a357#a6e877530a7f123bd76f44a2c30c01805b62a357"
 dependencies = [
  "caliptra-drivers",
  "caliptra-lms-types",
@@ -821,7 +821,7 @@ dependencies = [
 [[package]]
 name = "caliptra-lms-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fcc64aeceef3552bdb152e38d5c933d48b6634e3#fcc64aeceef3552bdb152e38d5c933d48b6634e3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a6e877530a7f123bd76f44a2c30c01805b62a357#a6e877530a7f123bd76f44a2c30c01805b62a357"
 dependencies = [
  "caliptra-cfi-derive 0.1.0 (git+https://github.com/chipsalliance/caliptra-cfi.git?rev=aa96c53073ce7f298f7482c1ac57f5f65ffc115e)",
  "caliptra-cfi-lib 0.1.0 (git+https://github.com/chipsalliance/caliptra-cfi.git?rev=aa96c53073ce7f298f7482c1ac57f5f65ffc115e)",
@@ -844,7 +844,7 @@ dependencies = [
 [[package]]
 name = "caliptra-ocp-eat"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fcc64aeceef3552bdb152e38d5c933d48b6634e3#fcc64aeceef3552bdb152e38d5c933d48b6634e3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a6e877530a7f123bd76f44a2c30c01805b62a357#a6e877530a7f123bd76f44a2c30c01805b62a357"
 dependencies = [
  "arrayvec",
 ]
@@ -852,12 +852,12 @@ dependencies = [
 [[package]]
 name = "caliptra-okref"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fcc64aeceef3552bdb152e38d5c933d48b6634e3#fcc64aeceef3552bdb152e38d5c933d48b6634e3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a6e877530a7f123bd76f44a2c30c01805b62a357#a6e877530a7f123bd76f44a2c30c01805b62a357"
 
 [[package]]
 name = "caliptra-registers"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fcc64aeceef3552bdb152e38d5c933d48b6634e3#fcc64aeceef3552bdb152e38d5c933d48b6634e3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a6e877530a7f123bd76f44a2c30c01805b62a357#a6e877530a7f123bd76f44a2c30c01805b62a357"
 dependencies = [
  "caliptra-registers-latest",
 ]
@@ -865,7 +865,7 @@ dependencies = [
 [[package]]
 name = "caliptra-registers-latest"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fcc64aeceef3552bdb152e38d5c933d48b6634e3#fcc64aeceef3552bdb152e38d5c933d48b6634e3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a6e877530a7f123bd76f44a2c30c01805b62a357#a6e877530a7f123bd76f44a2c30c01805b62a357"
 dependencies = [
  "caliptra-ureg",
 ]
@@ -873,7 +873,7 @@ dependencies = [
 [[package]]
 name = "caliptra-runtime"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fcc64aeceef3552bdb152e38d5c933d48b6634e3#fcc64aeceef3552bdb152e38d5c933d48b6634e3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a6e877530a7f123bd76f44a2c30c01805b62a357#a6e877530a7f123bd76f44a2c30c01805b62a357"
 dependencies = [
  "arrayvec",
  "bitfield",
@@ -909,7 +909,7 @@ dependencies = [
 [[package]]
 name = "caliptra-test"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fcc64aeceef3552bdb152e38d5c933d48b6634e3#fcc64aeceef3552bdb152e38d5c933d48b6634e3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a6e877530a7f123bd76f44a2c30c01805b62a357#a6e877530a7f123bd76f44a2c30c01805b62a357"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -953,12 +953,12 @@ dependencies = [
 [[package]]
 name = "caliptra-test-harness-types"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fcc64aeceef3552bdb152e38d5c933d48b6634e3#fcc64aeceef3552bdb152e38d5c933d48b6634e3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a6e877530a7f123bd76f44a2c30c01805b62a357#a6e877530a7f123bd76f44a2c30c01805b62a357"
 
 [[package]]
 name = "caliptra-ureg"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fcc64aeceef3552bdb152e38d5c933d48b6634e3#fcc64aeceef3552bdb152e38d5c933d48b6634e3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a6e877530a7f123bd76f44a2c30c01805b62a357#a6e877530a7f123bd76f44a2c30c01805b62a357"
 
 [[package]]
 name = "caliptra-util-host-mailbox-test-config"
@@ -972,7 +972,7 @@ dependencies = [
 [[package]]
 name = "caliptra-x509"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fcc64aeceef3552bdb152e38d5c933d48b6634e3#fcc64aeceef3552bdb152e38d5c933d48b6634e3"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=a6e877530a7f123bd76f44a2c30c01805b62a357#a6e877530a7f123bd76f44a2c30c01805b62a357"
 dependencies = [
  "zeroize",
 ]
@@ -2043,7 +2043,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4373,7 +4373,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4704,7 +4704,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5253,7 +5253,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6057,7 +6057,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -278,30 +278,30 @@ libtock_unittest = { path = "runtime/userspace/libtock/unittest" }
 tbf-header = { path = "runtime/userspace/libtock/tbf-header" }
 
 # caliptra-sw dependencies; keep git revs in sync
-caliptra-api = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fcc64aeceef3552bdb152e38d5c933d48b6634e3" }
-caliptra-api-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fcc64aeceef3552bdb152e38d5c933d48b6634e3" }
-caliptra-auth-man-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fcc64aeceef3552bdb152e38d5c933d48b6634e3" }
-caliptra-auth-man-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fcc64aeceef3552bdb152e38d5c933d48b6634e3" }
-caliptra-builder = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fcc64aeceef3552bdb152e38d5c933d48b6634e3" }
-caliptra-drivers = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fcc64aeceef3552bdb152e38d5c933d48b6634e3" }
-caliptra-emu-bus = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fcc64aeceef3552bdb152e38d5c933d48b6634e3" }
-caliptra-emu-cpu = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fcc64aeceef3552bdb152e38d5c933d48b6634e3" }
-caliptra-emu-derive = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fcc64aeceef3552bdb152e38d5c933d48b6634e3" }
-caliptra-emu-periph = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fcc64aeceef3552bdb152e38d5c933d48b6634e3" }
-caliptra-emu-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fcc64aeceef3552bdb152e38d5c933d48b6634e3" }
-caliptra-error = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fcc64aeceef3552bdb152e38d5c933d48b6634e3", default-features = false }
-caliptra-hw-model = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fcc64aeceef3552bdb152e38d5c933d48b6634e3", features = ["ocp-lock"] }
-caliptra-hw-model-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fcc64aeceef3552bdb152e38d5c933d48b6634e3" }
-caliptra-image-crypto = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fcc64aeceef3552bdb152e38d5c933d48b6634e3", default-features = false, features = ["rustcrypto"] }
-caliptra-image-fake-keys = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fcc64aeceef3552bdb152e38d5c933d48b6634e3" }
-caliptra-image-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fcc64aeceef3552bdb152e38d5c933d48b6634e3" }
-caliptra-image-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fcc64aeceef3552bdb152e38d5c933d48b6634e3" }
-caliptra-registers = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fcc64aeceef3552bdb152e38d5c933d48b6634e3" }
-caliptra-test = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fcc64aeceef3552bdb152e38d5c933d48b6634e3", features = ["cfi"] }
-caliptra-test-harness = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fcc64aeceef3552bdb152e38d5c933d48b6634e3" }
-caliptra-test-harness-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fcc64aeceef3552bdb152e38d5c933d48b6634e3" }
-caliptra-ocp-eat = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fcc64aeceef3552bdb152e38d5c933d48b6634e3", default-features = false }
-caliptra-ureg = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fcc64aeceef3552bdb152e38d5c933d48b6634e3" }
+caliptra-api = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a6e877530a7f123bd76f44a2c30c01805b62a357" }
+caliptra-api-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a6e877530a7f123bd76f44a2c30c01805b62a357" }
+caliptra-auth-man-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a6e877530a7f123bd76f44a2c30c01805b62a357" }
+caliptra-auth-man-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a6e877530a7f123bd76f44a2c30c01805b62a357" }
+caliptra-builder = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a6e877530a7f123bd76f44a2c30c01805b62a357" }
+caliptra-drivers = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a6e877530a7f123bd76f44a2c30c01805b62a357" }
+caliptra-emu-bus = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a6e877530a7f123bd76f44a2c30c01805b62a357" }
+caliptra-emu-cpu = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a6e877530a7f123bd76f44a2c30c01805b62a357" }
+caliptra-emu-derive = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a6e877530a7f123bd76f44a2c30c01805b62a357" }
+caliptra-emu-periph = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a6e877530a7f123bd76f44a2c30c01805b62a357" }
+caliptra-emu-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a6e877530a7f123bd76f44a2c30c01805b62a357" }
+caliptra-error = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a6e877530a7f123bd76f44a2c30c01805b62a357", default-features = false }
+caliptra-hw-model = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a6e877530a7f123bd76f44a2c30c01805b62a357", features = ["ocp-lock"] }
+caliptra-hw-model-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a6e877530a7f123bd76f44a2c30c01805b62a357" }
+caliptra-image-crypto = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a6e877530a7f123bd76f44a2c30c01805b62a357", default-features = false, features = ["rustcrypto"] }
+caliptra-image-fake-keys = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a6e877530a7f123bd76f44a2c30c01805b62a357" }
+caliptra-image-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a6e877530a7f123bd76f44a2c30c01805b62a357" }
+caliptra-image-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a6e877530a7f123bd76f44a2c30c01805b62a357" }
+caliptra-registers = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a6e877530a7f123bd76f44a2c30c01805b62a357" }
+caliptra-test = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a6e877530a7f123bd76f44a2c30c01805b62a357", features = ["cfi"] }
+caliptra-test-harness = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a6e877530a7f123bd76f44a2c30c01805b62a357" }
+caliptra-test-harness-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a6e877530a7f123bd76f44a2c30c01805b62a357" }
+caliptra-ocp-eat = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a6e877530a7f123bd76f44a2c30c01805b62a357", default-features = false }
+caliptra-ureg = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "a6e877530a7f123bd76f44a2c30c01805b62a357" }
 
 # caliptra-dpe dependencies; keep git revs in sync with version pulled into caliptra-sw
 dpe = { git = "https://github.com/chipsalliance/caliptra-dpe", rev = "337f7e4151f60add8e97445f71fc1393afc661a8", default-features = false, features = ["p384"] }

--- a/docs/src/rom.md
+++ b/docs/src/rom.md
@@ -67,7 +67,7 @@ These are selected based on the MCI `RESET_REASON` register that is set by hardw
       1. Caliptra runtime returns to mailbox processing mode.
       1. MCU derives or imports the decryption key to the Caliptra cryptographic mailbox.
       1. MCU issues a CM_AES_GCM_DECRYPT_DMA command to decrypt the firmware in MCU SRAM.
-      1. MCU issues the ACTIVATE_FIRMWARE command to Caliptra to activate the MCU firmware.
+      1. MCU issues the `ACTIVATE_FIRMWARE` command to Caliptra (with the `INITIAL_ACTIVATE` flag) to publish `FW_EXEC_CTRL[2]` without triggering the hitless update reset sequence.
    1. Caliptra sets the MCI [`FW_EXEC_CTRL[2]`](https://chipsalliance.github.io/caliptra-rtl/main/internal-regs/?p=clp.soc_ifc_reg.SS_GENERIC_FW_EXEC_CTRL%5B0%5D) bit to indicate that MCU firmware is ready
 1. Wait for Caliptra to indicate MCU firmware is ready by polling the firmware ready status.
 1. Stash the MCU ROM and other security-sensitive measurements to Caliptra. (In 2.1 subsystem mode, this should happen after Caliptra runtime is available using CM_SHA_{INIT,UPDATE,FINAL}. In 2.0 or 2.1 core mode, this could potentially happen earlier using the CM_SHA ROM command.)
@@ -139,7 +139,7 @@ sequenceDiagram
 
 ### Hitless Firmware Update Flow
 
-Hitless Update Flow is triggered when MCU runtime FW requests an update of the MCU FW by sending the `ACTIVATE_FIRMWARE` mailbox command to Caliptra. Upon receiving the mailbox command, Caliptra will initialize the MCU reset sequence causing the MCU to boot to ROM and run the Hitless Firmware Update Flow.
+Hitless Update Flow is triggered when MCU runtime FW requests an update of the MCU FW by sending the `ACTIVATE_FIRMWARE` mailbox command to Caliptra (without the `INITIAL_ACTIVATE` flag). Upon receiving the mailbox command, Caliptra will initialize the MCU reset sequence causing the MCU to boot to ROM and run the Hitless Firmware Update Flow.
 
 1. Check the MCI `RESET_REASON` register for reset status (it should be in hitless firmware update mode `FirmwareHitlessUpdate`).
 1. Enable the `notif_cptra_mcu_reset_req_sts` interrupt.

--- a/platforms/emulator/runtime/userspace/apps/user/src/image_loader/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/image_loader/mod.rs
@@ -245,6 +245,7 @@ async fn activate_soc_images(fw_id_list: &[u32]) -> Result<(), ErrorCode> {
         fw_id_count: fw_id_list.len() as u32,
         fw_ids,
         mcu_fw_image_size: 0, // MCU image is not activated here
+        flags: 0,
     };
 
     let req = req.as_mut_bytes();

--- a/rom/src/cold_boot.rs
+++ b/rom/src/cold_boot.rs
@@ -21,9 +21,9 @@ use crate::{
     FuseParams, I3cMailboxHandler, I3cServicesModes, RomEnv, RomParameters, MCU_MEMORY_MAP,
 };
 use caliptra_api::mailbox::{
-    CmImportReq, CmImportResp, CmKeyUsage, CmStableKeyType, Cmk, CommandId, FeProgReq,
-    MailboxReqHeader, MailboxRespHeader, StashMeasurementReq, StashMeasurementResp, CMK_SIZE_BYTES,
-    MAX_CMB_DATA_SIZE,
+    ActivateFirmwareFlags, ActivateFirmwareReq, ActivateFirmwareResp, CmImportReq, CmImportResp,
+    CmKeyUsage, CmStableKeyType, Cmk, CommandId, FeProgReq, MailboxReqHeader, MailboxRespHeader,
+    StashMeasurementReq, StashMeasurementResp, CMK_SIZE_BYTES, MAX_CMB_DATA_SIZE,
 };
 #[cfg(feature = "ocp-lock")]
 use caliptra_api::mailbox::{
@@ -457,6 +457,48 @@ impl ColdBoot {
                 tag_verified
             );
             fatal_error(McuError::ROM_COLD_BOOT_ENCRYPTED_FW_DECRYPT_TAG_MISMATCH);
+        }
+    }
+
+    /// Send `ACTIVATE_FIRMWARE` with the `INITIAL_ACTIVATE` flag so Caliptra
+    /// runtime publishes `FW_EXEC_CTRL[MCU]` without performing the
+    /// hitless-update reset/reload/verify dance. Must be called only after a
+    /// successful `decrypt_firmware()` on the encrypted-boot path — the MCU
+    /// firmware that Caliptra will now mark ready is the plaintext that we
+    /// just wrote into MCU SRAM via `CM_AES_GCM_DECRYPT_DMA`.
+    ///
+    /// Without this step MCI's `BOOT_RST_MCU` state holds MCU in reset
+    /// forever after the upcoming `trigger_warm_reset()`, because
+    /// `mcu_sram_fw_exec_region_lock` (= Caliptra's `FW_EXEC_CTRL[MCU]`)
+    /// is what gates reset release.
+    fn activate_firmware_initial(soc_manager: &mut CaliptraSoC, ciphertext_size: u32) {
+        let mut req = ActivateFirmwareReq {
+            fw_id_count: 1,
+            mcu_fw_image_size: ciphertext_size,
+            flags: ActivateFirmwareFlags::INITIAL_ACTIVATE.bits(),
+            ..Default::default()
+        };
+        req.fw_ids[0] = ActivateFirmwareReq::MCU_IMAGE_ID;
+
+        let cmd: u32 = CommandId::ACTIVATE_FIRMWARE.into();
+        let chksum = calc_checksum(cmd, &req.as_bytes()[4..]);
+        req.hdr.chksum = chksum;
+
+        if let Err(err) = soc_manager.start_mailbox_req_bytes(cmd, req.as_bytes()) {
+            romtime::println!(
+                "[mcu-rom] ACTIVATE_FIRMWARE start error: {}",
+                HexWord(Self::err_code(&err))
+            );
+            fatal_error(McuError::ROM_COLD_BOOT_ENCRYPTED_FW_ACTIVATE_START_ERROR);
+        }
+
+        let mut resp_buf = [0u8; core::mem::size_of::<ActivateFirmwareResp>()];
+        if let Err(err) = soc_manager.finish_mailbox_resp_bytes(&mut resp_buf) {
+            romtime::println!(
+                "[mcu-rom] ACTIVATE_FIRMWARE finish error: {}",
+                HexWord(Self::err_code(&err))
+            );
+            fatal_error(McuError::ROM_COLD_BOOT_ENCRYPTED_FW_ACTIVATE_FINISH_ERROR);
         }
     }
 
@@ -1329,6 +1371,15 @@ impl BootFlow for ColdBoot {
 
             // Decrypt firmware in MCU SRAM via CM_IMPORT + CM_AES_GCM_DECRYPT_DMA
             Self::decrypt_firmware(&mut env.soc_manager, ciphertext_size, &sha384);
+
+            // Ask Caliptra RT to publish FW_EXEC_CTRL[MCU] so MCI will
+            // release MCU from BOOT_RST_MCU after the upcoming warm reset.
+            // Uses the INITIAL_ACTIVATE flag to skip the hitless-update
+            // dance — the firmware in SRAM was already integrity-checked
+            // end-to-end (ciphertext digest by recovery, GCM tag by
+            // CM_AES_GCM_DECRYPT_DMA).
+            romtime::println!("[mcu-rom] Encrypted boot: activating firmware");
+            Self::activate_firmware_initial(&mut env.soc_manager, ciphertext_size);
             crate::call_hook(params.hooks, |h| h.post_load_firmware());
         } else {
             // --- Normal (unencrypted) firmware boot flow ---

--- a/runtime/userspace/api/caliptra-api/src/firmware_update/mod.rs
+++ b/runtime/userspace/api/caliptra-api/src/firmware_update/mod.rs
@@ -600,6 +600,7 @@ impl<'a, D: DMAMapping> FirmwareUpdater<'a, D> {
                 fw_ids
             },
             mcu_fw_image_size: mcu_image_len as u32,
+            flags: 0,
         };
 
         let req = req.as_mut_bytes();


### PR DESCRIPTION
On the encrypted-boot path, after MCU ROM decrypts firmware in MCU SRAM via CM_AES_GCM_DECRYPT_DMA, send ACTIVATE_FIRMWARE with the new INITIAL_ACTIVATE flag so Caliptra runtime publishes FW_EXEC_CTRL[MCU]. Without this, MCI's BOOT_RST_MCU state would hold MCU in reset forever after the warm reset, since mcu_sram_fw_exec_region_lock gates reset release.

Bumps the caliptra-sw git pin to a6e87753 (current main) to pick up the new `flags` field on `ActivateFirmwareReq` and the `ActivateFirmwareFlags::INITIAL_ACTIVATE` constant added in chipsalliance/caliptra-sw#3720, and sets `flags: 0` on the existing `ActivateFirmwareReq` initializers in image_loader and firmware_update.

This will enable us to re-enable the encrypted FW test in caliptra-sw.