### PR TITLE
Allow tests to initialize external OTP

### DIFF
--- a/hw/model/src/lib.rs
+++ b/hw/model/src/lib.rs
@@ -135,6 +135,9 @@ pub struct InitParams<'a> {
     /// The initial contents of the OTP memory
     pub otp_memory: Option<&'a [u8]>,
 
+    /// The initial contents of the external OTP memory
+    pub external_otp_memory: Option<&'a [u8]>,
+
     /// The initial lifecycle controller state of the device.
     /// This will override any otp_memory contents.
     pub lifecycle_controller_state: Option<LifecycleControllerState>,
@@ -270,6 +273,7 @@ impl Default for InitParams<'_> {
             caliptra_dccm: Default::default(),
             caliptra_iccm: Default::default(),
             otp_memory: None,
+            external_otp_memory: None,
             lifecycle_controller_state: None,
             lifecycle_tokens: None,
             log_writer: Box::new(stdout()),

--- a/hw/model/src/model_emulated.rs
+++ b/hw/model/src/model_emulated.rs
@@ -235,6 +235,13 @@ impl McuHwModel for ModelEmulated {
         let mut lc = lc;
         lc.set_otp_partitions(otp_partitions.clone());
 
+        if let Some(external_otp) = params.external_otp_memory {
+            let mut sram = mcu_root_bus.external_test_sram.borrow_mut();
+            let sram_data = sram.data_mut();
+            let len = external_otp.len().min(sram_data.len());
+            sram_data[..len].copy_from_slice(&external_otp[..len]);
+        }
+
         let create_flash_controller =
             |default_path: &str,
              error_irq: u8,

--- a/platforms/emulator/runtime/userspace/apps/example/src/test_external_otp.rs
+++ b/platforms/emulator/runtime/userspace/apps/example/src/test_external_otp.rs
@@ -15,6 +15,43 @@ pub(crate) fn test_external_otp() {
     otp.exists().unwrap();
     println!("  exists: ok");
 
+    // Read and print initial contents at offset 0 of each partition.
+    if let Ok(val) = otp.read(0x01, 0) {
+        println!("  initial partition 0x01 offset 0: 0x{:08X}", val);
+    } else {
+        println!("  initial partition 0x01 offset 0: read failed");
+    }
+    if let Ok(val) = otp.read(0x02, 0) {
+        println!("  initial partition 0x02 offset 0: 0x{:08X}", val);
+    } else {
+        println!("  initial partition 0x02 offset 0: read failed");
+    }
+
+    // Verify the initial OTP contents match the expected values.
+    let val0 = otp.read(0x01, 0).unwrap();
+    assert_eq!(
+        val0, 0xCAFEBEEF,
+        "expected 0xCAFEBEEF at partition 0x01 offset 0, got 0x{:08X}",
+        val0
+    );
+    println!("  partition 0x01 offset 0 == 0xCAFEBEEF: ok");
+
+    let val1 = otp.read(0x01, 4).unwrap();
+    assert_eq!(
+        val1, 0xFEEDB0B0,
+        "expected 0xFEEDB0B0 at partition 0x01 offset 4, got 0x{:08X}",
+        val1
+    );
+    println!("  partition 0x01 offset 4 == 0xFEEDB0B0: ok");
+
+    let val2 = otp.read(0x01, 8).unwrap();
+    assert_eq!(
+        val2, 0x00000000,
+        "expected 0x00000000 at partition 0x01 offset 8, got 0x{:08X}",
+        val2
+    );
+    println!("  partition 0x01 offset 8 == 0x00000000: ok");
+
     // Check partition count.
     let count = otp.partition_count().unwrap();
     assert!(count >= 2, "expected at least 2 partitions, got {}", count);

--- a/tests/integration/src/lib.rs
+++ b/tests/integration/src/lib.rs
@@ -13,6 +13,7 @@ mod test_caliptra_util_host_mcu_mailbox_validator;
 mod test_caliptra_util_host_spdm_vdm_validator;
 mod test_dot;
 mod test_exception_handler;
+mod test_external_otp;
 mod test_firmware_update;
 mod test_fpga_flash_ctrl;
 mod test_i3c_constant_writes;
@@ -97,6 +98,9 @@ mod test {
         /// Production debug unlock keypairs (ECC384 pub key bytes, MLDSA87 pub key bytes).
         pub prod_dbg_unlock_keypairs: Vec<([u8; 96], [u8; 2592])>,
         pub use_strap_secrets: bool,
+        pub external_otp_memory: Option<Vec<u8>>,
+        /// If true, include the example app in the runtime build instead of the user app.
+        pub example_app: bool,
     }
 
     impl Default for TestParams<'_> {
@@ -120,6 +124,8 @@ mod test {
                 debug_intent: false,
                 prod_dbg_unlock_keypairs: Vec::new(),
                 use_strap_secrets: false,
+                external_otp_memory: None,
+                example_app: false,
             }
         }
     }
@@ -305,7 +311,7 @@ mod test {
                 .expect("Failed to write prebuilt runtime to file");
             path
         } else {
-            compile_runtime(params.feature, false)
+            compile_runtime(params.feature, params.example_app)
         };
 
         // When a firmware prefix is provided, create a modified binary that
@@ -505,6 +511,7 @@ mod test {
             dot_flash_initial_contents: params.dot_flash_initial_contents,
             check_booted_to_runtime: !params.rom_only,
             otp_memory: otp_memory.as_deref(),
+            external_otp_memory: params.external_otp_memory.as_deref(),
             lifecycle_controller_state: params.lifecycle_controller_state,
             primary_flash_initial_contents: flash_image,
             flash_boot: params.flash_boot,
@@ -974,7 +981,6 @@ mod test {
     run_test!(test_mcu_mbox_driver);
     run_test!(test_mcu_mbox_soc_requester_loopback, example_app);
     run_test!(test_mbox_sram, example_app);
-    run_test!(test_external_otp, example_app);
     run_test!(test_warm_reset, example_app);
 
     /// This tests a full active mode boot run through with Caliptra, including

--- a/tests/integration/src/test_external_otp.rs
+++ b/tests/integration/src/test_external_otp.rs
@@ -1,0 +1,35 @@
+// Licensed under the Apache-2.0 license
+
+#[cfg(test)]
+mod test {
+    use crate::test::{finish_runtime_hw_model, start_runtime_hw_model, TestParams};
+    use caliptra_mcu_hw_model::McuHwModel;
+    use caliptra_mcu_testing_common::MCU_RUNNING;
+    use random_port::PortPicker;
+    use std::sync::atomic::Ordering;
+
+    #[test]
+    fn test_external_otp() {
+        // Create external OTP memory contents with 0xCAFEBEEF and 0xFEEDB0B0 at the start.
+        let mut external_otp_data = vec![0x00u8; 1024];
+        external_otp_data[0..4].copy_from_slice(&0xCAFEBEEFu32.to_le_bytes());
+        external_otp_data[4..8].copy_from_slice(&0xFEEDB0B0u32.to_le_bytes());
+
+        // Instantiate hardware model with external OTP memory loaded.
+        let mut hw = start_runtime_hw_model(TestParams {
+            external_otp_memory: Some(external_otp_data),
+            feature: Some("test-external-otp"),
+            example_app: true,
+            i3c_port: Some(PortPicker::new().random(true).pick().unwrap()),
+            ..Default::default()
+        });
+
+        hw.start_i3c_controller();
+
+        // Exit the test.
+        let status = finish_runtime_hw_model(&mut hw);
+        assert_eq!(status, 0);
+
+        MCU_RUNNING.store(false, Ordering::Relaxed);
+    }
+}


### PR DESCRIPTION
Add an `external_otp_memory` field to InitParams and TestParams so that integration tests can pre-load the external test SRAM with arbitrary OTP contents before the emulator boots. The hardware model copies the provided data into the external_test_sram peripheral during init.

Also add an `example_app` field to TestParams so custom tests can request the example-app runtime (previously only the run_test! macro could do this).

Includes a new integration test (test_external_otp) that verifies read/write/lock operations on the external OTP driver with known initial contents.