### PR TITLE
[rom] migrate pk hash strapping to input wires

### DIFF
--- a/docs/src/integrator-guide.md
+++ b/docs/src/integrator-guide.md
@@ -93,22 +93,20 @@ available slots):
     into the ROM parameters.
 
 ### Key Rotation via Strapping
+
 Integrators can force the ROM to rotate to the next available key by using a
 hardware strapping pin:
--   **Strap Register**: `SS_STRAP_GENERIC[3]` (today). **Upcoming:** the PK-hash
-    skip-lock and rotation straps are moving from `SS_STRAP_GENERIC[3]` to MCI
-    generic input wires (`mci_reg_generic_input_wires[*]`) so the low byte of
-    `SS_STRAP_GENERIC[3]` can be repurposed for the new
-    `CPTRA_CORE_OWNER_MANIFEST_MIN_SVN` fuse value (see
-    [ROM Fuses](rom-fuses.md)).
--   **Bit 1 (Rotation)**: If this bit is set to `1`, the ROM will **skip the
-    first functional slot** it finds and select the **second functional slot**.
-This allows a platform to switch to a new key without burning fuses, simply
-by changing a strapping register or GPIO state, provided that a second valid and
-functional key is provisioned in the fuses. This enables rolling back to the
-previous known-good firmware image should the new one have a fatal issue.
+
+- **Generic Input Wires**: `mci_reg_generic_input_wires[1]`
+- **Bit 1 (Rotation)**: If this bit is set to `1`, the ROM will **skip the
+  first functional slot** it finds and select the **second functional slot**.
+  This allows a platform to switch to a new key without burning fuses, simply
+  by changing a strapping register or GPIO state, provided that a second valid and
+  functional key is provisioned in the fuses. This enables rolling back to the
+  previous known-good firmware image should the new one have a fatal issue.
 
 ### Key Revocation
+
 Keys can be revoked permanently by burning fuses:
 -   Setting the corresponding bit in `VENDOR_PK_HASH_VALID` to `1` invalidates
     the entire slot.

--- a/docs/src/rom.md
+++ b/docs/src/rom.md
@@ -308,7 +308,7 @@ The verification process:
 The MCU ROM supports locking the selected vendor public key hash slot (and all higher order slots) to prevent post-ROM manipulation. This is controlled by writing to the `VENDOR_PK_HASH_VOLATILE_LOCK` register.
 
 **Strapping Override**:
-The locking behavior is gated by bit 0 of the hardware strapping register `SS_STRAP_GENERIC[3]`.
+The locking behavior is gated by bit 0 of the MCI generic input wires (`mci_reg_generic_input_wires[1]`).
 *   **Production Mode** (Bit 0 is `0`): The ROM automatically applies the volatile lock to the selected key slot index (locking that slot and all higher slots).
 *   **Provisioning Mode** (Bit 0 is `1`): The ROM skips applying the lock, allowing potential post-ROM code to provision higher order hash slots.
 

--- a/rom/src/cold_boot.rs
+++ b/rom/src/cold_boot.rs
@@ -805,7 +805,7 @@ impl BootFlow for ColdBoot {
         caliptra_mcu_romtime::println!("[mcu-rom] Firmware is ready");
         mci.set_flow_checkpoint(McuRomBootStatus::FirmwareReadyDetected.into());
 
-        soc.pk_hash_volatile_lock(&env.otp, pk_hash_idx);
+        soc.pk_hash_volatile_lock(&env.otp, &env.mci, pk_hash_idx);
         if env.otp.check_error().is_some() {
             caliptra_mcu_romtime::println!("[mcu-rom] OTP error: {}", HexWord(env.otp.status()));
             env.otp.print_errors();

--- a/rom/src/rom.rs
+++ b/rom/src/rom.rs
@@ -35,7 +35,7 @@ use caliptra_mcu_romtime::LifecycleHashedTokens;
 use caliptra_mcu_romtime::LifecycleToken;
 use caliptra_mcu_romtime::PqcKeyType;
 use caliptra_mcu_romtime::{HexWord, McuBootMilestones, StaticRef};
-use caliptra_mcu_romtime::{Otp, PROD_DEBUG_UNLOCK_PK_ENTRIES};
+use caliptra_mcu_romtime::{Mci, Otp, PROD_DEBUG_UNLOCK_PK_ENTRIES};
 use core::fmt::Write;
 use tock_registers::interfaces::ReadWriteable;
 use tock_registers::interfaces::{Readable, Writeable};
@@ -208,7 +208,9 @@ impl Soc {
 
         // Select the vendor public key slot to use.
         let default_policy = DefaultVendorKeyPolicy::new(
-            self.registers.ss_strap_generic[3].get() & Self::PK_HASH_ROTATION_STRAPPING_MASK != 0,
+            mci.registers.mci_reg_generic_input_wires[1].get()
+                & Self::PK_HASH_ROTATION_STRAPPING_MASK
+                != 0,
         );
         let policy = params.vendor_key_policy.unwrap_or(&default_policy);
         let pk_hash_idx = policy
@@ -389,10 +391,10 @@ impl Soc {
         pk_hash_idx
     }
 
-    pub fn pk_hash_volatile_lock(&self, otp: &Otp, selected_index: usize) {
-        // Read strap register to check for provisioning mode.
-        let strap_reg = self.registers.ss_strap_generic[3].get();
-        if (strap_reg & Self::PK_HASH_SKIP_LOCK_STRAPPING_MASK) != 0 {
+    pub fn pk_hash_volatile_lock(&self, otp: &Otp, mci: &Mci, selected_index: usize) {
+        // Read generic input wires to check for provisioning mode.
+        let input_wires = mci.registers.mci_reg_generic_input_wires[1].get();
+        if (input_wires & Self::PK_HASH_SKIP_LOCK_STRAPPING_MASK) != 0 {
             caliptra_mcu_romtime::println!(
               "[mcu-fuse-write] PK Hash provisioning mode detected, skipping vendor PK hash lock."
           );

--- a/tests/integration/src/rom/test_vendor_key_policy.rs
+++ b/tests/integration/src/rom/test_vendor_key_policy.rs
@@ -246,13 +246,8 @@ mod test {
     fn test_vendor_pk_lock_not_applied() -> Result<()> {
         let mut hw = setup_hw_model(0x0000, &[(0, SlotConfig::default())]);
 
-        // Set strapping bit to not lock the pk hashes
-        hw.caliptra_soc_manager()
-            .soc_ifc()
-            .ss_strap_generic()
-            .get(3)
-            .expect("failed to get strapping register")
-            .write(|_| 0x1);
+        // Set input wire bit to not lock the pk hashes
+        hw.set_mcu_generic_input_wires(&[0, 0x1]);
 
         hw.step_until_output_contains("[mcu-fuse-write] Selected vendor PK slot 0")?;
 
@@ -274,13 +269,8 @@ mod test {
             0x0002,
             &[(0, SlotConfig::default()), (2, SlotConfig::default())],
         );
-        // Set strapping bit to jump 1 PK hash slot
-        hw.caliptra_soc_manager()
-            .soc_ifc()
-            .ss_strap_generic()
-            .get(3)
-            .expect("failed to get strapping register")
-            .write(|_| 0x2);
+        // Set input wire bit to jump 1 PK hash slot
+        hw.set_mcu_generic_input_wires(&[0, 0x2]);
 
         // Slot 0 is the first functional slot which we skip
         // Slot 1 is marked invalid


### PR DESCRIPTION
Instead of ss_strap_generic, which we'd like to use for owner soc manifest