### PR TITLE
[cherry-pick] [rom] migrate pk hash strapping to input wires

### DIFF
--- a/rom/src/cold_boot.rs
+++ b/rom/src/cold_boot.rs
@@ -1467,7 +1467,7 @@ impl BootFlow for ColdBoot {
             mci.set_flow_checkpoint(McuRomBootStatus::CaliptraRuntimeReady.into());
         }
 
-        soc.pk_hash_volatile_lock(&env.otp, _fuse_state.pk_hash_idx);
+        soc.pk_hash_volatile_lock(&env.otp, &env.mci, _fuse_state.pk_hash_idx);
         if env.otp.check_error().is_some() {
             romtime::println!("[mcu-rom] OTP error: {}", HexWord(env.otp.status()));
             env.otp.print_errors();

--- a/rom/src/rom.rs
+++ b/rom/src/rom.rs
@@ -37,7 +37,7 @@ use romtime::LifecycleControllerState;
 use romtime::LifecycleHashedTokens;
 use romtime::LifecycleToken;
 use romtime::PqcKeyType;
-use romtime::{HexWord, McuBootMilestones, StaticRef};
+use romtime::{HexWord, Mci, McuBootMilestones, StaticRef};
 use tock_registers::interfaces::ReadWriteable;
 use tock_registers::interfaces::{Readable, Writeable};
 
@@ -226,7 +226,9 @@ impl Soc {
 
         // Select the vendor public key slot to use.
         let default_policy = DefaultVendorKeyPolicy::new(
-            self.registers.ss_strap_generic[3].get() & Self::PK_HASH_ROTATION_STRAPPING_MASK != 0,
+            mci.registers.mci_reg_generic_input_wires[1].get()
+                & Self::PK_HASH_ROTATION_STRAPPING_MASK
+                != 0,
         );
         let policy = params.vendor_key_policy.unwrap_or(&default_policy);
         let pk_hash_idx = policy
@@ -540,10 +542,10 @@ impl Soc {
         })
     }
 
-    pub fn pk_hash_volatile_lock(&self, otp: &Otp, selected_index: usize) {
-        // Read strap register to check for provisioning mode.
-        let strap_reg = self.registers.ss_strap_generic[3].get();
-        if (strap_reg & Self::PK_HASH_SKIP_LOCK_STRAPPING_MASK) != 0 {
+    pub fn pk_hash_volatile_lock(&self, otp: &Otp, mci: &Mci, selected_index: usize) {
+        // Read generic input wires to check for provisioning mode.
+        let input_wires = mci.registers.mci_reg_generic_input_wires[1].get();
+        if (input_wires & Self::PK_HASH_SKIP_LOCK_STRAPPING_MASK) != 0 {
             romtime::println!(
               "[mcu-fuse-write] PK Hash provisioning mode detected, skipping vendor PK hash lock."
           );

--- a/tests/integration/src/rom/test_vendor_key_policy.rs
+++ b/tests/integration/src/rom/test_vendor_key_policy.rs
@@ -246,13 +246,8 @@ mod test {
     fn test_vendor_pk_lock_not_applied() -> Result<()> {
         let mut hw = setup_hw_model(0x0000, &[(0, SlotConfig::default())]);
 
-        // Set strapping bit to not lock the pk hashes
-        hw.caliptra_soc_manager()
-            .soc_ifc()
-            .ss_strap_generic()
-            .get(3)
-            .expect("failed to get strapping register")
-            .write(|_| 0x1);
+        // Set input wire bit to not lock the pk hashes
+        hw.set_mcu_generic_input_wires(&[0, 0x1]);
 
         hw.step_until_output_contains("[mcu-fuse-write] Selected vendor PK slot 0")?;
 
@@ -274,13 +269,8 @@ mod test {
             0x0002,
             &[(0, SlotConfig::default()), (2, SlotConfig::default())],
         );
-        // Set strapping bit to jump 1 PK hash slot
-        hw.caliptra_soc_manager()
-            .soc_ifc()
-            .ss_strap_generic()
-            .get(3)
-            .expect("failed to get strapping register")
-            .write(|_| 0x2);
+        // Set input wire bit to jump 1 PK hash slot
+        hw.set_mcu_generic_input_wires(&[0, 0x2]);
 
         // Slot 0 is the first functional slot which we skip
         // Slot 1 is marked invalid


### PR DESCRIPTION
instead of ss_strap_generic, which we'd like to use for owner soc manifest

(cherry picked from commit c0c3914c4895e20fd458f15addc88d194eda266a)

stripped doc updates in cherry-pick