### PR TITLE
Fix UpdateComponentResponse::decode() to handle failure responses per…

### DIFF
--- a/common/pldm/src/message/firmware_update/update_component.rs
+++ b/common/pldm/src/message/firmware_update/update_component.rs
@@ -2,7 +2,8 @@
 
 use crate::codec::{PldmCodec, PldmCodecError};
 use crate::protocol::base::{
-    InstanceId, PldmMsgHeader, PldmMsgType, PldmSupportedType, PLDM_MSG_HEADER_LEN,
+    InstanceId, PldmBaseCompletionCode, PldmMsgHeader, PldmMsgType, PldmSupportedType,
+    PLDM_MSG_HEADER_LEN,
 };
 use crate::protocol::firmware_update::{
     ComponentClassification, ComponentCompatibilityResponse, ComponentCompatibilityResponseCode,
@@ -233,6 +234,19 @@ impl PldmCodec for UpdateComponentResponse {
         )
         .unwrap();
         offset += core::mem::size_of::<u8>();
+
+        // Per PLDM FW Update spec, failure responses only contain header + completion_code.
+        if completion_code != PldmBaseCompletionCode::Success as u8 {
+            return Ok(UpdateComponentResponse {
+                hdr,
+                completion_code,
+                comp_compatibility_resp: 0,
+                comp_compatibility_resp_code: 0,
+                update_option_flags_enabled: 0,
+                time_before_req_fw_data: 0,
+                get_comp_opaque_data_max_transfer_size: None,
+            });
+        }
 
         let comp_compatibility_resp = u8::read_from_bytes(
             buffer


### PR DESCRIPTION
… PLDM spec

The PLDM Firmware Update specification (DSP0267) states that when a response has a non-success completion code, only the message header and completion_code fields are present in the payload (4 bytes total).

Root cause: When the FD (Firmware Device) receives an UpdateComponent request while not in the ReadyXfer state (e.g. due to a timing/race condition in the MCTP transport), it returns an InvalidStateForCommand (0x84) completion code. Per the PLDM spec, failure responses only contain 4 bytes (header + completion_code). The decoder expected 12+ bytes for ALL responses, failing to parse valid failure responses.

This caused the UA to drop the packet as "Unhandled", never transition out of the ReadyXfer state, and ultimately hang the firmware update protocol.

The fix checks the completion_code immediately after reading it. If it is not PldmBaseCompletionCode::Success, the decoder returns early with the header and completion_code populated and remaining fields set to their default values. This allows the UA to properly process failure responses and handle error recovery.