### PR TITLE
Use chipsalliance SPDM DMTF mirrors for CI tests

### DIFF
--- a/.github/workflows/attestation.yml
+++ b/.github/workflows/attestation.yml
@@ -81,8 +81,8 @@ jobs:
       - name: Checkout spdm-emu repository
         uses: actions/checkout@v4
         with:
-          repository: parvathib/spdm-emu
-          ref: pbhogaraju/spdm_emu_main_custom
+          repository: chipsalliance/caliptra-spdm-emu
+          ref: caliptra-main
           path: spdm-emu
           submodules: recursive
 
@@ -92,7 +92,7 @@ jobs:
           git submodule update --init --recursive
           mkdir build
           pushd build
-          cmake -DARCH=x64 -DTOOLCHAIN=GCC -DTARGET=Debug -DCRYPTO=openssl ..
+          cmake -DARCH=x64 -DTOOLCHAIN=GCC -DTARGET=Debug -DCRYPTO=openssl -DCMAKE_C_FLAGS="-DLIBSPDM_MAX_CERT_CHAIN_SIZE=0x2000" ..
           make copy_sample_key
           make
           popd

--- a/.github/workflows/fpga-spdm.yml
+++ b/.github/workflows/fpga-spdm.yml
@@ -169,11 +169,11 @@ jobs:
 
       - name: Build spdm-emu for aarch64
         run: |
-          git clone --recursive --branch pbhogaraju/spdm_emu_main_custom https://github.com/parvathib/spdm-emu.git /tmp/spdm-emu
+          git clone --recursive --branch caliptra-main https://github.com/chipsalliance/caliptra-spdm-emu.git /tmp/spdm-emu
           pushd /tmp/spdm-emu
           mkdir build
           pushd build
-          cmake -DARCH=aarch64 -DTOOLCHAIN=AARCH64_GCC -DTARGET=Debug -DCRYPTO=openssl ..
+          cmake -DARCH=aarch64 -DTOOLCHAIN=AARCH64_GCC -DTARGET=Debug -DCRYPTO=openssl -DCMAKE_C_FLAGS="-DLIBSPDM_MAX_CERT_CHAIN_SIZE=0x2000" ..
           make copy_sample_key
           make -j$(nproc)
           popd

--- a/.github/workflows/spdm-validator.yml
+++ b/.github/workflows/spdm-validator.yml
@@ -78,8 +78,8 @@ jobs:
       - name: Checkout spdm-emu repository
         uses: actions/checkout@v4
         with:
-          repository: parvathib/spdm-emu
-          ref: pbhogaraju/spdm_emu_main_custom
+          repository: chipsalliance/caliptra-spdm-emu
+          ref: caliptra-main
           path: spdm-emu
           submodules: recursive
 
@@ -89,7 +89,7 @@ jobs:
           git submodule update --init --recursive
           mkdir build
           pushd build
-          cmake -DARCH=x64 -DTOOLCHAIN=GCC -DTARGET=Debug -DCRYPTO=openssl ..
+          cmake -DARCH=x64 -DTOOLCHAIN=GCC -DTARGET=Debug -DCRYPTO=openssl -DCMAKE_C_FLAGS="-DLIBSPDM_MAX_CERT_CHAIN_SIZE=0x2000" ..
           make copy_sample_key
           make
           popd
@@ -120,8 +120,6 @@ jobs:
             ${{ env.SPDM_VALIDATOR_DIR }}/test.log
             ${{ env.SPDM_VALIDATOR_DIR }}/caliptra_spdm_validator.pcap
             ${{ env.SPDM_VALIDATOR_DIR }}/spdm_device_validator_output.txt
-            ${{ env.SPDM_VALIDATOR_DIR }}/measurement_block_fd.bin
-            ${{ env.SPDM_VALIDATOR_DIR }}/certificate_chain_slot_00.der
 
       - name: Display SPDM Validator test results on MCTP transport
         env:
@@ -137,15 +135,6 @@ jobs:
             echo "Test suite had failures."
             exit 1
           fi
-
-      - name: Verify EAT from measurement block for SPDM-MCTP
-        working-directory: ocp-eat-verifier
-        env:
-          SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-emu/build/bin
-        run: |
-          cargo build --release -p ocptoken
-          ./target/release/ocptoken verify \
-          -e $SPDM_VALIDATOR_DIR/measurement_block_fd.bin
 
       - name: Run SPDM attestation test on MCTP transport (PCR Quote measurements)
         env:
@@ -192,8 +181,8 @@ jobs:
       - name: Checkout CCC spdm-rs repository
         uses: actions/checkout@v4
         with:
-          repository: parvathib/spdm-rs
-          ref: pbhogaraju/custom_v0.5.0
+          repository: chipsalliance/caliptra-spdm-rs
+          ref: caliptra-0.5.2
           path: spdm-rs
           submodules: recursive
 

--- a/ocp-eat-verifier/Cargo.toml
+++ b/ocp-eat-verifier/Cargo.toml
@@ -19,6 +19,6 @@ hex = "0.4"
 thiserror = "2.0"
 openssl = { version = "0.10", features = ["vendored"] }
 clap = { version = "4", features = ["derive"] }
-corim-rs = { git = "https://github.com/parvathib/corim-rs.git", branch = "pbhogaraju/add_coev" }
+corim-rs = { git = "https://github.com/chipsalliance/caliptra-corim-rs.git", branch = "caliptra-main" }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 ciborium = "0.2"

--- a/runtime/userspace/api/spdm-lib/src/commands/measurements_rsp.rs
+++ b/runtime/userspace/api/spdm-lib/src/commands/measurements_rsp.rs
@@ -500,9 +500,15 @@ pub(crate) async fn generate_measurements_response<'a>(
     let rsp_len = match rsp_ctx.response_size(&mut ctx.measurements, meas_buf).await {
         Ok(len) => len,
         Err((_, CommandError::Measurement(MeasurementsError::InvalidIndex))) => {
+            // Reset L1 transcript on error to stay in sync with the requester,
+            // which also resets its transcript (message_m) on error responses.
+            ctx.shared_transcript.reset_context(TranscriptContext::L1);
             Err(ctx.generate_error_response(rsp, ErrorCode::InvalidRequest, 0, None))?
         }
-        Err(e) => Err(e)?,
+        Err(e) => {
+            ctx.shared_transcript.reset_context(TranscriptContext::L1);
+            Err(e)?
+        }
     };
 
     if rsp_len > ctx.min_data_transfer_size() {


### PR DESCRIPTION
- Point CI workflows to chipsalliance mirror repos created for Caliptra to run spdm tests
- Configure LIBSPDM_MAX_CERT_CHAIN_SIZE=0x2000 for Caliptra cert chains
- Reset L1 transcript on measurement error responses