### PR TITLE
rom: add ROM hooks for OCP LOCK fuses, stable owner key, encrypted FW…

### DIFF
--- a/platforms/emulator/rom/src/riscv.rs
+++ b/platforms/emulator/rom/src/riscv.rs
@@ -136,6 +136,30 @@ impl RomHooks for LoggingRomHooks {
         caliptra_mcu_romtime::println!("[mcu-rom-hook] post_load_firmware");
         record_hook_bit(13);
     }
+    fn pre_set_ocp_lock_fuses(&self) {
+        caliptra_mcu_romtime::println!("[mcu-rom-hook] pre_set_ocp_lock_fuses");
+        record_hook_bit(14);
+    }
+    fn post_set_ocp_lock_fuses(&self) {
+        caliptra_mcu_romtime::println!("[mcu-rom-hook] post_set_ocp_lock_fuses");
+        record_hook_bit(15);
+    }
+    fn pre_stable_owner_key_derivation(&self) {
+        caliptra_mcu_romtime::println!("[mcu-rom-hook] pre_stable_owner_key_derivation");
+        record_hook_bit(16);
+    }
+    fn post_stable_owner_key_derivation(&self) {
+        caliptra_mcu_romtime::println!("[mcu-rom-hook] post_stable_owner_key_derivation");
+        record_hook_bit(17);
+    }
+    fn pre_encrypted_firmware_decrypt(&self) {
+        caliptra_mcu_romtime::println!("[mcu-rom-hook] pre_encrypted_firmware_decrypt");
+        record_hook_bit(18);
+    }
+    fn post_encrypted_firmware_decrypt(&self) {
+        caliptra_mcu_romtime::println!("[mcu-rom-hook] post_encrypted_firmware_decrypt");
+        record_hook_bit(19);
+    }
 }
 
 // re-export these so the common ROM can use it

--- a/platforms/fpga/rom/src/riscv.rs
+++ b/platforms/fpga/rom/src/riscv.rs
@@ -108,6 +108,30 @@ impl RomHooks for LoggingRomHooks {
         caliptra_mcu_romtime::println!("[mcu-rom-hook] post_load_firmware");
         record_hook_bit(13);
     }
+    fn pre_set_ocp_lock_fuses(&self) {
+        caliptra_mcu_romtime::println!("[mcu-rom-hook] pre_set_ocp_lock_fuses");
+        record_hook_bit(14);
+    }
+    fn post_set_ocp_lock_fuses(&self) {
+        caliptra_mcu_romtime::println!("[mcu-rom-hook] post_set_ocp_lock_fuses");
+        record_hook_bit(15);
+    }
+    fn pre_stable_owner_key_derivation(&self) {
+        caliptra_mcu_romtime::println!("[mcu-rom-hook] pre_stable_owner_key_derivation");
+        record_hook_bit(16);
+    }
+    fn post_stable_owner_key_derivation(&self) {
+        caliptra_mcu_romtime::println!("[mcu-rom-hook] post_stable_owner_key_derivation");
+        record_hook_bit(17);
+    }
+    fn pre_encrypted_firmware_decrypt(&self) {
+        caliptra_mcu_romtime::println!("[mcu-rom-hook] pre_encrypted_firmware_decrypt");
+        record_hook_bit(18);
+    }
+    fn post_encrypted_firmware_decrypt(&self) {
+        caliptra_mcu_romtime::println!("[mcu-rom-hook] post_encrypted_firmware_decrypt");
+        record_hook_bit(19);
+    }
 }
 
 // re-export these so the common ROM and runtime can use them

--- a/rom/src/cold_boot.rs
+++ b/rom/src/cold_boot.rs
@@ -1110,6 +1110,8 @@ impl BootFlow for ColdBoot {
 
         caliptra_mcu_romtime::println!("[mcu-rom] Populating fuses");
         crate::call_hook(params.hooks, |h| h.pre_populate_fuses_to_caliptra());
+        #[cfg(feature = "ocp-lock")]
+        crate::call_hook(params.hooks, |h| h.pre_set_ocp_lock_fuses());
         let _fuse_state = soc.populate_fuses(
             otp,
             mci,
@@ -1121,6 +1123,8 @@ impl BootFlow for ColdBoot {
                 ..Default::default()
             },
         );
+        #[cfg(feature = "ocp-lock")]
+        crate::call_hook(params.hooks, |h| h.post_set_ocp_lock_fuses());
 
         // Create handoff data
         caliptra_mcu_romtime::handoff::HandoffData::write(
@@ -1302,6 +1306,7 @@ impl BootFlow for ColdBoot {
         #[cfg(feature = "stable-owner-key")]
         {
             // Derive stable owner key using the OTP personalization seed.
+            crate::call_hook(params.hooks, |h| h.pre_stable_owner_key_derivation());
             if let Err(err) = crate::stable_owner_key::derive_stable_owner_key(env) {
                 caliptra_mcu_romtime::println!(
                     "[mcu-rom] Stable owner key derivation failed: {}",
@@ -1309,6 +1314,7 @@ impl BootFlow for ColdBoot {
                 );
                 fatal_error(err);
             }
+            crate::call_hook(params.hooks, |h| h.post_stable_owner_key_derivation());
         }
 
         // Enter I3C services unconditionally if force_i3c_services is set
@@ -1437,7 +1443,9 @@ impl BootFlow for ColdBoot {
             );
 
             // Decrypt firmware in MCU SRAM via CM_IMPORT + CM_AES_GCM_DECRYPT_DMA
+            crate::call_hook(params.hooks, |h| h.pre_encrypted_firmware_decrypt());
             Self::decrypt_firmware(&mut env.soc_manager, ciphertext_size, &sha384);
+            crate::call_hook(params.hooks, |h| h.post_encrypted_firmware_decrypt());
 
             // Ask Caliptra RT to publish FW_EXEC_CTRL[MCU] so MCI will
             // release MCU from BOOT_RST_MCU after the upcoming warm reset.

--- a/rom/src/hooks.rs
+++ b/rom/src/hooks.rs
@@ -49,6 +49,29 @@ pub trait RomHooks {
     /// Immediately after MCU firmware has been detected as loaded into
     /// SRAM (before any header verification).
     fn post_load_firmware(&self) {}
+
+    /// Immediately before programming OCP LOCK HEK fuses into Caliptra
+    /// (`Soc::set_ocp_lock_fuses`). Only fires when the `ocp-lock`
+    /// feature is enabled.
+    fn pre_set_ocp_lock_fuses(&self) {}
+    /// Immediately after the OCP LOCK HEK fuses have been programmed.
+    fn post_set_ocp_lock_fuses(&self) {}
+
+    /// Immediately before deriving the stable owner key from the OTP
+    /// personalization seed. Only fires when the `stable-owner-key`
+    /// feature is enabled. Mutually exclusive with the OCP LOCK hooks.
+    fn pre_stable_owner_key_derivation(&self) {}
+    /// Immediately after stable-owner-key derivation completes
+    /// successfully.
+    fn post_stable_owner_key_derivation(&self) {}
+
+    /// Immediately before decrypting MCU firmware with the
+    /// `CM_AES_GCM_DECRYPT_DMA` Caliptra mailbox command. Only fires on
+    /// the encrypted-firmware boot path (cfg `core_test` + recovery
+    /// wire asserted).
+    fn pre_encrypted_firmware_decrypt(&self) {}
+    /// Immediately after a successful firmware decryption.
+    fn post_encrypted_firmware_decrypt(&self) {}
 }
 
 /// Convenience helper that invokes `f` on the hooks attached to `params`,

--- a/tests/integration/src/rom/test_rom_hooks.rs
+++ b/tests/integration/src/rom/test_rom_hooks.rs
@@ -23,11 +23,14 @@ mod test {
     /// the `record_hook_bit(N)` calls in the platform ROMs'
     /// `LoggingRomHooks` implementations.
     ///
-    /// The `warm_boot` and `fw_hitless_update` hooks are intentionally
-    /// excluded: the WarmBoot flow requires an external warm reset (not
-    /// the internal FirmwareBootReset at the end of cold boot), and
-    /// FwHitlessUpdate requires a runtime update — neither is exercised
-    /// on the default boot-to-runtime path.
+    /// The 2.1-specific hooks (`dot_flow`, `dot_locked_recovery`,
+    /// `set_ocp_lock_fuses`, `stable_owner_key_derivation`,
+    /// `fips_zeroization`, `encrypted_firmware_decrypt`,
+    /// `i3c_services`) and the `warm_boot` / `fw_hitless_update` hooks
+    /// are intentionally excluded: their flows are not exercised on the
+    /// default boot-to-runtime path with an empty DOT blob (they require
+    /// specific feature flags, populated DOT state, external signals,
+    /// or failure paths).
     const EXPECTED_HOOK_BITS: u32 = (1 << 0)  // pre_cold_boot
         | (1 << 1)  // post_cold_boot
         | (1 << 4)  // pre_fw_boot


### PR DESCRIPTION
… decrypt

Extends the RomHooks trait (#1270) with hook pairs for three 2.1-specific cold-boot flows so integrators can observe them without patching the common ROM:

- pre/post_set_ocp_lock_fuses: OCP LOCK HEK fuse programming
                                          (cfg ocp-lock)
- pre/post_stable_owner_key_derivation: stable owner key derivation
                                          (cfg stable-owner-key)
- pre/post_encrypted_firmware_decrypt: CM_AES_GCM_DECRYPT_DMA on the
                                          encrypted-boot path
                                          (cfg core_test + recovery wire)

All three hook pairs live on code paths that are dead-code-eliminated when their corresponding feature is off, so they contribute zero bytes to ROMs that don't enable the feature:

- OCP LOCK and stable-owner-key hooks are inside `#[cfg(feature = "...")]` blocks.
- Encrypted FW hooks are inside the `if encrypted_boot { ... }` block; and a runtime wire check, so when `core_test` is off the whole block (including the hook calls) is DCE'd.

The hooks are wired in:
- `Soc::populate_fuses` call site in `cold_boot.rs` (around the OCP LOCK fuse block, gated by `cfg(feature = "ocp-lock")`).
- Around `derive_stable_owner_key` call in `cold_boot.rs` (gated by `cfg(feature = "stable-owner-key")`).
- Around `decrypt_firmware` call inside the encrypted boot branch in `cold_boot.rs` (only reachable on the encrypted-firmware path).

All hook methods are default no-ops on the RomHooks trait so existing integrators don't need to update their impls. The example LoggingRomHooks in platforms/{emulator,fpga}/rom record bits 14\u201319 in mci_reg_fw_extended_error_info[0] alongside the existing hooks.

Limitation: hooks for the other 2.1 flows (DOT, FIPS zeroization, I3C services) were intentionally dropped because each `call_hook` site costs ~12-40 bytes of .text (Option check + vtable dispatch) on always-compiled code paths and the `test-usb-ocp-recovery` ROM is already near the 64 KiB ROM size budget. Integrators that want fine-grained DOT/FIPS/I3C observability can still use the existing `McuRomBootStatus` flow checkpoints written to MCI registers.