### PR TITLE
rom: SVN anti-rollback - MCU-side fuses and Component SVN Manifest

### DIFF
--- a/hw/fuses.hjson
+++ b/hw/fuses.hjson
@@ -21,6 +21,14 @@
     {"trng_health_test_window_size": 2},
     {"cptra_itrng_entropy_config_0": 4},
     {"cptra_itrng_entropy_config_1": 4},
+    // SVN anti-rollback fuses (see docs/src/svn.md).
+    // Sizes here are informational and refer to the raw OTP storage actually
+    // used by the OneHotLinearOr encoding (bits * duplication / 8). The
+    // underlying OTP slots (VENDOR_SPECIFIC_NON_SECRET_FUSE_5..7) are 32 bytes
+    // each; the remaining bits in each slot stay 0.
+    {"mcu_component_svn_manifest_min_svn": 4},
+    {"soc_image_min_svn_0": 4},
+    {"soc_image_min_svn_1": 4},
   ],
 
   // Field definitions specify bit-level details within fuse bytes
@@ -73,6 +81,36 @@
       partition: "VENDOR_SECRET_PROD_PARTITION",
       otp_item: "CPTRA_SS_VENDOR_SPECIFIC_SECRET_FUSE_0",
       layout: {type: "Single"},
+    },
+    // SVN anti-rollback fuses (see docs/src/svn.md).
+    //
+    // OneHotLinearOr with 3x duplication: each effective bit is stored as
+    // three OR-tied raw bits, so the maximum representable min_svn equals
+    // `bits`. The MCU runtime SVN floor lives in CPTRA_CORE_SOC_MANIFEST_SVN
+    // (Caliptra-owned) and is not duplicated here.
+    {
+      name: "mcu_component_svn_manifest_min_svn",
+      bits: 10,
+      description: "MCU Component SVN Manifest min SVN (one-hot, used by MCU ROM for manifest-format anti-rollback).",
+      partition: "VENDOR_NON_SECRET_PROD_PARTITION",
+      otp_item: "CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_5",
+      layout: {type: "OneHotLinearOr", duplication: 3},
+    },
+    {
+      name: "soc_image_min_svn_0",
+      bits: 10,
+      description: "SoC component min SVN for fuse slot 0 (one-hot, optional per-component rollback floor mapped via SVN_FUSE_MAP).",
+      partition: "VENDOR_NON_SECRET_PROD_PARTITION",
+      otp_item: "CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_6",
+      layout: {type: "OneHotLinearOr", duplication: 3},
+    },
+    {
+      name: "soc_image_min_svn_1",
+      bits: 10,
+      description: "SoC component min SVN for fuse slot 1 (one-hot, optional per-component rollback floor mapped via SVN_FUSE_MAP).",
+      partition: "VENDOR_NON_SECRET_PROD_PARTITION",
+      otp_item: "CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_7",
+      layout: {type: "OneHotLinearOr", duplication: 3},
     },
     {
         name: "vendor_pk_hash_valid",

--- a/registers/generated-firmware/src/fuse_map.md
+++ b/registers/generated-firmware/src/fuse_map.md
@@ -242,9 +242,9 @@
 | 2 | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_2 | 0x0ab8 | 32 | Single |
 | 3 | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_3 | 0x0ad8 | 32 | Single |
 | 4 | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_4 | 0x0af8 | 32 | Single |
-| 5 | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_5 | 0x0b18 | 32 | Single |
-| 6 | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_6 | 0x0b38 | 32 | Single |
-| 7 | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_7 | 0x0b58 | 32 | Single |
+| 5 | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_5 | 0x0b18 | 32 | OneHotLinearOr(3x) |
+| 6 | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_6 | 0x0b38 | 32 | OneHotLinearOr(3x) |
+| 7 | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_7 | 0x0b58 | 32 | OneHotLinearOr(3x) |
 | 8 | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_8 | 0x0b78 | 32 | Single |
 | 9 | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_9 | 0x0b98 | 32 | Single |
 | 10 | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_10 | 0x0bb8 | 32 | Single |
@@ -271,6 +271,9 @@
 | cptra_itrng_entropy_config_0 | 32 | VENDOR_NON_SECRET_PROD_PARTITION | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_3 | Single | Entropy config 0: Low threshold (bits 15:0), High threshold (bits 31:16) |
 | cptra_itrng_entropy_config_1 | 32 | VENDOR_NON_SECRET_PROD_PARTITION | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_4 | Single | Entropy config 1: Repetition count (bits 15:0), Alert threshold (bits 31:16). See [spec](https://chipsalliance.github.io/caliptra-web/docs/2.1/firmware/rom_spec.html#entropy-source-configuration-registers) for details. |
 | vendor_recovery_pk_hash | 384 | VENDOR_SECRET_PROD_PARTITION | CPTRA_SS_VENDOR_SPECIFIC_SECRET_FUSE_0 | Single | Vendor recovery key for DOT_OVERRIDE catastrophic recovery operations |
+| mcu_component_svn_manifest_min_svn | 10 | VENDOR_NON_SECRET_PROD_PARTITION | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_5 | OneHotLinearOr(3x) | MCU Component SVN Manifest min SVN (one-hot, used by MCU ROM for manifest-format anti-rollback). |
+| soc_image_min_svn_0 | 10 | VENDOR_NON_SECRET_PROD_PARTITION | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_6 | OneHotLinearOr(3x) | SoC component min SVN for fuse slot 0 (one-hot, optional per-component rollback floor mapped via SVN_FUSE_MAP). |
+| soc_image_min_svn_1 | 10 | VENDOR_NON_SECRET_PROD_PARTITION | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_7 | OneHotLinearOr(3x) | SoC component min SVN for fuse slot 1 (one-hot, optional per-component rollback floor mapped via SVN_FUSE_MAP). |
 | vendor_pk_hash_valid | 16 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_VENDOR_PK_HASH_VALID | LinearOr(3x) | Bitmask indicating vendor PK hash validity. Unburnt bits (0) are valid; burnt bits (1) are revoked/invalid. |
 | vendor_ecc_revocation_0 | 4 | VENDOR_REVOCATIONS_PROD_PARTITION | CPTRA_CORE_ECC_REVOCATION_0 | LinearOr(3x) | Revocation bits for ECC keys in slot 0. |
 | vendor_mldsa_revocation_0 | 4 | VENDOR_REVOCATIONS_PROD_PARTITION | CPTRA_CORE_MLDSA_REVOCATION_0 | LinearOr(3x) | Revocation bits for MLDSA keys in slot 0. |

--- a/registers/generated-firmware/src/fuses.rs
+++ b/registers/generated-firmware/src/fuses.rs
@@ -355,6 +355,18 @@ pub const NON_SECRET_VENDOR_FUSES: &[Fuse] = &[
         name: "cptra_itrng_entropy_config_1",
         size: Bytes(4),
     },
+    Fuse {
+        name: "mcu_component_svn_manifest_min_svn",
+        size: Bytes(4),
+    },
+    Fuse {
+        name: "soc_image_min_svn_0",
+        size: Bytes(4),
+    },
+    Fuse {
+        name: "soc_image_min_svn_1",
+        size: Bytes(4),
+    },
 ];
 pub const FUSE_FIELDS: &[FuseField] = &[
     FuseField {
@@ -380,6 +392,18 @@ pub const FUSE_FIELDS: &[FuseField] = &[
     FuseField {
         name: "vendor_recovery_pk_hash",
         bits: Bits(384),
+    },
+    FuseField {
+        name: "mcu_component_svn_manifest_min_svn",
+        bits: Bits(10),
+    },
+    FuseField {
+        name: "soc_image_min_svn_0",
+        bits: Bits(10),
+    },
+    FuseField {
+        name: "soc_image_min_svn_1",
+        bits: Bits(10),
     },
     FuseField {
         name: "vendor_pk_hash_valid",
@@ -695,6 +719,39 @@ pub const FUSE_ENTRY_TABLE: &[FuseEntryInfo] = &[
         byte_size: 32,
         name: "vendor_recovery_pk_hash",
         layout: FuseLayoutType::Single { bits: 384 },
+    },
+    FuseEntryInfo {
+        partition_num: 14,
+        entry_num: 5,
+        byte_offset: 0xb18,
+        byte_size: 32,
+        name: "mcu_component_svn_manifest_min_svn",
+        layout: FuseLayoutType::OneHotLinearOr {
+            bits: 10,
+            duplication: 3,
+        },
+    },
+    FuseEntryInfo {
+        partition_num: 14,
+        entry_num: 6,
+        byte_offset: 0xb38,
+        byte_size: 32,
+        name: "soc_image_min_svn_0",
+        layout: FuseLayoutType::OneHotLinearOr {
+            bits: 10,
+            duplication: 3,
+        },
+    },
+    FuseEntryInfo {
+        partition_num: 14,
+        entry_num: 7,
+        byte_offset: 0xb58,
+        byte_size: 32,
+        name: "soc_image_min_svn_1",
+        layout: FuseLayoutType::OneHotLinearOr {
+            bits: 10,
+            duplication: 3,
+        },
     },
     FuseEntryInfo {
         partition_num: 11,
@@ -1424,136 +1481,142 @@ pub const CPTRA_ITRNG_ENTROPY_CONFIG_0: &FuseEntryInfo = &FUSE_ENTRY_TABLE[3];
 pub const CPTRA_ITRNG_ENTROPY_CONFIG_1: &FuseEntryInfo = &FUSE_ENTRY_TABLE[4];
 /// Fuse entry for `vendor_recovery_pk_hash`.
 pub const VENDOR_RECOVERY_PK_HASH: &FuseEntryInfo = &FUSE_ENTRY_TABLE[5];
+/// Fuse entry for `mcu_component_svn_manifest_min_svn`.
+pub const MCU_COMPONENT_SVN_MANIFEST_MIN_SVN: &FuseEntryInfo = &FUSE_ENTRY_TABLE[6];
+/// Fuse entry for `soc_image_min_svn_0`.
+pub const SOC_IMAGE_MIN_SVN_0: &FuseEntryInfo = &FUSE_ENTRY_TABLE[7];
+/// Fuse entry for `soc_image_min_svn_1`.
+pub const SOC_IMAGE_MIN_SVN_1: &FuseEntryInfo = &FUSE_ENTRY_TABLE[8];
 /// Fuse entry for `vendor_pk_hash_valid`.
-pub const VENDOR_PK_HASH_VALID: &FuseEntryInfo = &FUSE_ENTRY_TABLE[6];
+pub const VENDOR_PK_HASH_VALID: &FuseEntryInfo = &FUSE_ENTRY_TABLE[9];
 /// Fuse entry for `vendor_ecc_revocation_0`.
-pub const VENDOR_ECC_REVOCATION_0: &FuseEntryInfo = &FUSE_ENTRY_TABLE[7];
+pub const VENDOR_ECC_REVOCATION_0: &FuseEntryInfo = &FUSE_ENTRY_TABLE[10];
 /// Fuse entry for `vendor_mldsa_revocation_0`.
-pub const VENDOR_MLDSA_REVOCATION_0: &FuseEntryInfo = &FUSE_ENTRY_TABLE[8];
+pub const VENDOR_MLDSA_REVOCATION_0: &FuseEntryInfo = &FUSE_ENTRY_TABLE[11];
 /// Fuse entry for `vendor_lms_revocation_0`.
-pub const VENDOR_LMS_REVOCATION_0: &FuseEntryInfo = &FUSE_ENTRY_TABLE[9];
+pub const VENDOR_LMS_REVOCATION_0: &FuseEntryInfo = &FUSE_ENTRY_TABLE[12];
 /// Fuse entry for `vendor_ecc_revocation_1`.
-pub const VENDOR_ECC_REVOCATION_1: &FuseEntryInfo = &FUSE_ENTRY_TABLE[10];
+pub const VENDOR_ECC_REVOCATION_1: &FuseEntryInfo = &FUSE_ENTRY_TABLE[13];
 /// Fuse entry for `vendor_mldsa_revocation_1`.
-pub const VENDOR_MLDSA_REVOCATION_1: &FuseEntryInfo = &FUSE_ENTRY_TABLE[11];
+pub const VENDOR_MLDSA_REVOCATION_1: &FuseEntryInfo = &FUSE_ENTRY_TABLE[14];
 /// Fuse entry for `vendor_lms_revocation_1`.
-pub const VENDOR_LMS_REVOCATION_1: &FuseEntryInfo = &FUSE_ENTRY_TABLE[12];
+pub const VENDOR_LMS_REVOCATION_1: &FuseEntryInfo = &FUSE_ENTRY_TABLE[15];
 /// Fuse entry for `vendor_ecc_revocation_2`.
-pub const VENDOR_ECC_REVOCATION_2: &FuseEntryInfo = &FUSE_ENTRY_TABLE[13];
+pub const VENDOR_ECC_REVOCATION_2: &FuseEntryInfo = &FUSE_ENTRY_TABLE[16];
 /// Fuse entry for `vendor_mldsa_revocation_2`.
-pub const VENDOR_MLDSA_REVOCATION_2: &FuseEntryInfo = &FUSE_ENTRY_TABLE[14];
+pub const VENDOR_MLDSA_REVOCATION_2: &FuseEntryInfo = &FUSE_ENTRY_TABLE[17];
 /// Fuse entry for `vendor_lms_revocation_2`.
-pub const VENDOR_LMS_REVOCATION_2: &FuseEntryInfo = &FUSE_ENTRY_TABLE[15];
+pub const VENDOR_LMS_REVOCATION_2: &FuseEntryInfo = &FUSE_ENTRY_TABLE[18];
 /// Fuse entry for `vendor_ecc_revocation_3`.
-pub const VENDOR_ECC_REVOCATION_3: &FuseEntryInfo = &FUSE_ENTRY_TABLE[16];
+pub const VENDOR_ECC_REVOCATION_3: &FuseEntryInfo = &FUSE_ENTRY_TABLE[19];
 /// Fuse entry for `vendor_mldsa_revocation_3`.
-pub const VENDOR_MLDSA_REVOCATION_3: &FuseEntryInfo = &FUSE_ENTRY_TABLE[17];
+pub const VENDOR_MLDSA_REVOCATION_3: &FuseEntryInfo = &FUSE_ENTRY_TABLE[20];
 /// Fuse entry for `vendor_lms_revocation_3`.
-pub const VENDOR_LMS_REVOCATION_3: &FuseEntryInfo = &FUSE_ENTRY_TABLE[18];
+pub const VENDOR_LMS_REVOCATION_3: &FuseEntryInfo = &FUSE_ENTRY_TABLE[21];
 /// Fuse entry for `vendor_ecc_revocation_4`.
-pub const VENDOR_ECC_REVOCATION_4: &FuseEntryInfo = &FUSE_ENTRY_TABLE[19];
+pub const VENDOR_ECC_REVOCATION_4: &FuseEntryInfo = &FUSE_ENTRY_TABLE[22];
 /// Fuse entry for `vendor_mldsa_revocation_4`.
-pub const VENDOR_MLDSA_REVOCATION_4: &FuseEntryInfo = &FUSE_ENTRY_TABLE[20];
+pub const VENDOR_MLDSA_REVOCATION_4: &FuseEntryInfo = &FUSE_ENTRY_TABLE[23];
 /// Fuse entry for `vendor_lms_revocation_4`.
-pub const VENDOR_LMS_REVOCATION_4: &FuseEntryInfo = &FUSE_ENTRY_TABLE[21];
+pub const VENDOR_LMS_REVOCATION_4: &FuseEntryInfo = &FUSE_ENTRY_TABLE[24];
 /// Fuse entry for `vendor_ecc_revocation_5`.
-pub const VENDOR_ECC_REVOCATION_5: &FuseEntryInfo = &FUSE_ENTRY_TABLE[22];
+pub const VENDOR_ECC_REVOCATION_5: &FuseEntryInfo = &FUSE_ENTRY_TABLE[25];
 /// Fuse entry for `vendor_mldsa_revocation_5`.
-pub const VENDOR_MLDSA_REVOCATION_5: &FuseEntryInfo = &FUSE_ENTRY_TABLE[23];
+pub const VENDOR_MLDSA_REVOCATION_5: &FuseEntryInfo = &FUSE_ENTRY_TABLE[26];
 /// Fuse entry for `vendor_lms_revocation_5`.
-pub const VENDOR_LMS_REVOCATION_5: &FuseEntryInfo = &FUSE_ENTRY_TABLE[24];
+pub const VENDOR_LMS_REVOCATION_5: &FuseEntryInfo = &FUSE_ENTRY_TABLE[27];
 /// Fuse entry for `vendor_ecc_revocation_6`.
-pub const VENDOR_ECC_REVOCATION_6: &FuseEntryInfo = &FUSE_ENTRY_TABLE[25];
+pub const VENDOR_ECC_REVOCATION_6: &FuseEntryInfo = &FUSE_ENTRY_TABLE[28];
 /// Fuse entry for `vendor_mldsa_revocation_6`.
-pub const VENDOR_MLDSA_REVOCATION_6: &FuseEntryInfo = &FUSE_ENTRY_TABLE[26];
+pub const VENDOR_MLDSA_REVOCATION_6: &FuseEntryInfo = &FUSE_ENTRY_TABLE[29];
 /// Fuse entry for `vendor_lms_revocation_6`.
-pub const VENDOR_LMS_REVOCATION_6: &FuseEntryInfo = &FUSE_ENTRY_TABLE[27];
+pub const VENDOR_LMS_REVOCATION_6: &FuseEntryInfo = &FUSE_ENTRY_TABLE[30];
 /// Fuse entry for `vendor_ecc_revocation_7`.
-pub const VENDOR_ECC_REVOCATION_7: &FuseEntryInfo = &FUSE_ENTRY_TABLE[28];
+pub const VENDOR_ECC_REVOCATION_7: &FuseEntryInfo = &FUSE_ENTRY_TABLE[31];
 /// Fuse entry for `vendor_mldsa_revocation_7`.
-pub const VENDOR_MLDSA_REVOCATION_7: &FuseEntryInfo = &FUSE_ENTRY_TABLE[29];
+pub const VENDOR_MLDSA_REVOCATION_7: &FuseEntryInfo = &FUSE_ENTRY_TABLE[32];
 /// Fuse entry for `vendor_lms_revocation_7`.
-pub const VENDOR_LMS_REVOCATION_7: &FuseEntryInfo = &FUSE_ENTRY_TABLE[30];
+pub const VENDOR_LMS_REVOCATION_7: &FuseEntryInfo = &FUSE_ENTRY_TABLE[33];
 /// Fuse entry for `vendor_ecc_revocation_8`.
-pub const VENDOR_ECC_REVOCATION_8: &FuseEntryInfo = &FUSE_ENTRY_TABLE[31];
+pub const VENDOR_ECC_REVOCATION_8: &FuseEntryInfo = &FUSE_ENTRY_TABLE[34];
 /// Fuse entry for `vendor_mldsa_revocation_8`.
-pub const VENDOR_MLDSA_REVOCATION_8: &FuseEntryInfo = &FUSE_ENTRY_TABLE[32];
+pub const VENDOR_MLDSA_REVOCATION_8: &FuseEntryInfo = &FUSE_ENTRY_TABLE[35];
 /// Fuse entry for `vendor_lms_revocation_8`.
-pub const VENDOR_LMS_REVOCATION_8: &FuseEntryInfo = &FUSE_ENTRY_TABLE[33];
+pub const VENDOR_LMS_REVOCATION_8: &FuseEntryInfo = &FUSE_ENTRY_TABLE[36];
 /// Fuse entry for `vendor_ecc_revocation_9`.
-pub const VENDOR_ECC_REVOCATION_9: &FuseEntryInfo = &FUSE_ENTRY_TABLE[34];
+pub const VENDOR_ECC_REVOCATION_9: &FuseEntryInfo = &FUSE_ENTRY_TABLE[37];
 /// Fuse entry for `vendor_mldsa_revocation_9`.
-pub const VENDOR_MLDSA_REVOCATION_9: &FuseEntryInfo = &FUSE_ENTRY_TABLE[35];
+pub const VENDOR_MLDSA_REVOCATION_9: &FuseEntryInfo = &FUSE_ENTRY_TABLE[38];
 /// Fuse entry for `vendor_lms_revocation_9`.
-pub const VENDOR_LMS_REVOCATION_9: &FuseEntryInfo = &FUSE_ENTRY_TABLE[36];
+pub const VENDOR_LMS_REVOCATION_9: &FuseEntryInfo = &FUSE_ENTRY_TABLE[39];
 /// Fuse entry for `vendor_ecc_revocation_10`.
-pub const VENDOR_ECC_REVOCATION_10: &FuseEntryInfo = &FUSE_ENTRY_TABLE[37];
+pub const VENDOR_ECC_REVOCATION_10: &FuseEntryInfo = &FUSE_ENTRY_TABLE[40];
 /// Fuse entry for `vendor_mldsa_revocation_10`.
-pub const VENDOR_MLDSA_REVOCATION_10: &FuseEntryInfo = &FUSE_ENTRY_TABLE[38];
+pub const VENDOR_MLDSA_REVOCATION_10: &FuseEntryInfo = &FUSE_ENTRY_TABLE[41];
 /// Fuse entry for `vendor_lms_revocation_10`.
-pub const VENDOR_LMS_REVOCATION_10: &FuseEntryInfo = &FUSE_ENTRY_TABLE[39];
+pub const VENDOR_LMS_REVOCATION_10: &FuseEntryInfo = &FUSE_ENTRY_TABLE[42];
 /// Fuse entry for `vendor_ecc_revocation_11`.
-pub const VENDOR_ECC_REVOCATION_11: &FuseEntryInfo = &FUSE_ENTRY_TABLE[40];
+pub const VENDOR_ECC_REVOCATION_11: &FuseEntryInfo = &FUSE_ENTRY_TABLE[43];
 /// Fuse entry for `vendor_mldsa_revocation_11`.
-pub const VENDOR_MLDSA_REVOCATION_11: &FuseEntryInfo = &FUSE_ENTRY_TABLE[41];
+pub const VENDOR_MLDSA_REVOCATION_11: &FuseEntryInfo = &FUSE_ENTRY_TABLE[44];
 /// Fuse entry for `vendor_lms_revocation_11`.
-pub const VENDOR_LMS_REVOCATION_11: &FuseEntryInfo = &FUSE_ENTRY_TABLE[42];
+pub const VENDOR_LMS_REVOCATION_11: &FuseEntryInfo = &FUSE_ENTRY_TABLE[45];
 /// Fuse entry for `vendor_ecc_revocation_12`.
-pub const VENDOR_ECC_REVOCATION_12: &FuseEntryInfo = &FUSE_ENTRY_TABLE[43];
+pub const VENDOR_ECC_REVOCATION_12: &FuseEntryInfo = &FUSE_ENTRY_TABLE[46];
 /// Fuse entry for `vendor_mldsa_revocation_12`.
-pub const VENDOR_MLDSA_REVOCATION_12: &FuseEntryInfo = &FUSE_ENTRY_TABLE[44];
+pub const VENDOR_MLDSA_REVOCATION_12: &FuseEntryInfo = &FUSE_ENTRY_TABLE[47];
 /// Fuse entry for `vendor_lms_revocation_12`.
-pub const VENDOR_LMS_REVOCATION_12: &FuseEntryInfo = &FUSE_ENTRY_TABLE[45];
+pub const VENDOR_LMS_REVOCATION_12: &FuseEntryInfo = &FUSE_ENTRY_TABLE[48];
 /// Fuse entry for `vendor_ecc_revocation_13`.
-pub const VENDOR_ECC_REVOCATION_13: &FuseEntryInfo = &FUSE_ENTRY_TABLE[46];
+pub const VENDOR_ECC_REVOCATION_13: &FuseEntryInfo = &FUSE_ENTRY_TABLE[49];
 /// Fuse entry for `vendor_mldsa_revocation_13`.
-pub const VENDOR_MLDSA_REVOCATION_13: &FuseEntryInfo = &FUSE_ENTRY_TABLE[47];
+pub const VENDOR_MLDSA_REVOCATION_13: &FuseEntryInfo = &FUSE_ENTRY_TABLE[50];
 /// Fuse entry for `vendor_lms_revocation_13`.
-pub const VENDOR_LMS_REVOCATION_13: &FuseEntryInfo = &FUSE_ENTRY_TABLE[48];
+pub const VENDOR_LMS_REVOCATION_13: &FuseEntryInfo = &FUSE_ENTRY_TABLE[51];
 /// Fuse entry for `vendor_ecc_revocation_14`.
-pub const VENDOR_ECC_REVOCATION_14: &FuseEntryInfo = &FUSE_ENTRY_TABLE[49];
+pub const VENDOR_ECC_REVOCATION_14: &FuseEntryInfo = &FUSE_ENTRY_TABLE[52];
 /// Fuse entry for `vendor_mldsa_revocation_14`.
-pub const VENDOR_MLDSA_REVOCATION_14: &FuseEntryInfo = &FUSE_ENTRY_TABLE[50];
+pub const VENDOR_MLDSA_REVOCATION_14: &FuseEntryInfo = &FUSE_ENTRY_TABLE[53];
 /// Fuse entry for `vendor_lms_revocation_14`.
-pub const VENDOR_LMS_REVOCATION_14: &FuseEntryInfo = &FUSE_ENTRY_TABLE[51];
+pub const VENDOR_LMS_REVOCATION_14: &FuseEntryInfo = &FUSE_ENTRY_TABLE[54];
 /// Fuse entry for `vendor_ecc_revocation_15`.
-pub const VENDOR_ECC_REVOCATION_15: &FuseEntryInfo = &FUSE_ENTRY_TABLE[52];
+pub const VENDOR_ECC_REVOCATION_15: &FuseEntryInfo = &FUSE_ENTRY_TABLE[55];
 /// Fuse entry for `vendor_mldsa_revocation_15`.
-pub const VENDOR_MLDSA_REVOCATION_15: &FuseEntryInfo = &FUSE_ENTRY_TABLE[53];
+pub const VENDOR_MLDSA_REVOCATION_15: &FuseEntryInfo = &FUSE_ENTRY_TABLE[56];
 /// Fuse entry for `vendor_lms_revocation_15`.
-pub const VENDOR_LMS_REVOCATION_15: &FuseEntryInfo = &FUSE_ENTRY_TABLE[54];
+pub const VENDOR_LMS_REVOCATION_15: &FuseEntryInfo = &FUSE_ENTRY_TABLE[57];
 /// Fuse entry for `vendor_pqc_key_type_0`.
-pub const VENDOR_PQC_KEY_TYPE_0: &FuseEntryInfo = &FUSE_ENTRY_TABLE[55];
+pub const VENDOR_PQC_KEY_TYPE_0: &FuseEntryInfo = &FUSE_ENTRY_TABLE[58];
 /// Fuse entry for `vendor_pqc_key_type_1`.
-pub const VENDOR_PQC_KEY_TYPE_1: &FuseEntryInfo = &FUSE_ENTRY_TABLE[56];
+pub const VENDOR_PQC_KEY_TYPE_1: &FuseEntryInfo = &FUSE_ENTRY_TABLE[59];
 /// Fuse entry for `vendor_pqc_key_type_2`.
-pub const VENDOR_PQC_KEY_TYPE_2: &FuseEntryInfo = &FUSE_ENTRY_TABLE[57];
+pub const VENDOR_PQC_KEY_TYPE_2: &FuseEntryInfo = &FUSE_ENTRY_TABLE[60];
 /// Fuse entry for `vendor_pqc_key_type_3`.
-pub const VENDOR_PQC_KEY_TYPE_3: &FuseEntryInfo = &FUSE_ENTRY_TABLE[58];
+pub const VENDOR_PQC_KEY_TYPE_3: &FuseEntryInfo = &FUSE_ENTRY_TABLE[61];
 /// Fuse entry for `vendor_pqc_key_type_4`.
-pub const VENDOR_PQC_KEY_TYPE_4: &FuseEntryInfo = &FUSE_ENTRY_TABLE[59];
+pub const VENDOR_PQC_KEY_TYPE_4: &FuseEntryInfo = &FUSE_ENTRY_TABLE[62];
 /// Fuse entry for `vendor_pqc_key_type_5`.
-pub const VENDOR_PQC_KEY_TYPE_5: &FuseEntryInfo = &FUSE_ENTRY_TABLE[60];
+pub const VENDOR_PQC_KEY_TYPE_5: &FuseEntryInfo = &FUSE_ENTRY_TABLE[63];
 /// Fuse entry for `vendor_pqc_key_type_6`.
-pub const VENDOR_PQC_KEY_TYPE_6: &FuseEntryInfo = &FUSE_ENTRY_TABLE[61];
+pub const VENDOR_PQC_KEY_TYPE_6: &FuseEntryInfo = &FUSE_ENTRY_TABLE[64];
 /// Fuse entry for `vendor_pqc_key_type_7`.
-pub const VENDOR_PQC_KEY_TYPE_7: &FuseEntryInfo = &FUSE_ENTRY_TABLE[62];
+pub const VENDOR_PQC_KEY_TYPE_7: &FuseEntryInfo = &FUSE_ENTRY_TABLE[65];
 /// Fuse entry for `vendor_pqc_key_type_8`.
-pub const VENDOR_PQC_KEY_TYPE_8: &FuseEntryInfo = &FUSE_ENTRY_TABLE[63];
+pub const VENDOR_PQC_KEY_TYPE_8: &FuseEntryInfo = &FUSE_ENTRY_TABLE[66];
 /// Fuse entry for `vendor_pqc_key_type_9`.
-pub const VENDOR_PQC_KEY_TYPE_9: &FuseEntryInfo = &FUSE_ENTRY_TABLE[64];
+pub const VENDOR_PQC_KEY_TYPE_9: &FuseEntryInfo = &FUSE_ENTRY_TABLE[67];
 /// Fuse entry for `vendor_pqc_key_type_10`.
-pub const VENDOR_PQC_KEY_TYPE_10: &FuseEntryInfo = &FUSE_ENTRY_TABLE[65];
+pub const VENDOR_PQC_KEY_TYPE_10: &FuseEntryInfo = &FUSE_ENTRY_TABLE[68];
 /// Fuse entry for `vendor_pqc_key_type_11`.
-pub const VENDOR_PQC_KEY_TYPE_11: &FuseEntryInfo = &FUSE_ENTRY_TABLE[66];
+pub const VENDOR_PQC_KEY_TYPE_11: &FuseEntryInfo = &FUSE_ENTRY_TABLE[69];
 /// Fuse entry for `vendor_pqc_key_type_12`.
-pub const VENDOR_PQC_KEY_TYPE_12: &FuseEntryInfo = &FUSE_ENTRY_TABLE[67];
+pub const VENDOR_PQC_KEY_TYPE_12: &FuseEntryInfo = &FUSE_ENTRY_TABLE[70];
 /// Fuse entry for `vendor_pqc_key_type_13`.
-pub const VENDOR_PQC_KEY_TYPE_13: &FuseEntryInfo = &FUSE_ENTRY_TABLE[68];
+pub const VENDOR_PQC_KEY_TYPE_13: &FuseEntryInfo = &FUSE_ENTRY_TABLE[71];
 /// Fuse entry for `vendor_pqc_key_type_14`.
-pub const VENDOR_PQC_KEY_TYPE_14: &FuseEntryInfo = &FUSE_ENTRY_TABLE[69];
+pub const VENDOR_PQC_KEY_TYPE_14: &FuseEntryInfo = &FUSE_ENTRY_TABLE[72];
 /// Fuse entry for `vendor_pqc_key_type_15`.
-pub const VENDOR_PQC_KEY_TYPE_15: &FuseEntryInfo = &FUSE_ENTRY_TABLE[70];
+pub const VENDOR_PQC_KEY_TYPE_15: &FuseEntryInfo = &FUSE_ENTRY_TABLE[73];
 /// OTP item entry for `CPTRA_SS_MANUF_DEBUG_UNLOCK_TOKEN`.
 pub const OTP_CPTRA_SS_MANUF_DEBUG_UNLOCK_TOKEN: &FuseEntryInfo = &FuseEntryInfo {
     partition_num: 0,
@@ -2994,32 +3057,41 @@ pub const OTP_CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_4: &FuseEntryInfo = &Fuse
     name: "cptra_itrng_entropy_config_1",
     layout: FuseLayoutType::Single { bits: 32 },
 };
-/// OTP item entry for `CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_5`.
+/// OTP item entry for `mcu_component_svn_manifest_min_svn`.
 pub const OTP_CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_5: &FuseEntryInfo = &FuseEntryInfo {
     partition_num: 14,
     entry_num: 5,
     byte_offset: 0xb18,
     byte_size: 32,
-    name: "CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_5",
-    layout: FuseLayoutType::Single { bits: 256 },
+    name: "mcu_component_svn_manifest_min_svn",
+    layout: FuseLayoutType::OneHotLinearOr {
+        bits: 10,
+        duplication: 3,
+    },
 };
-/// OTP item entry for `CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_6`.
+/// OTP item entry for `soc_image_min_svn_0`.
 pub const OTP_CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_6: &FuseEntryInfo = &FuseEntryInfo {
     partition_num: 14,
     entry_num: 6,
     byte_offset: 0xb38,
     byte_size: 32,
-    name: "CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_6",
-    layout: FuseLayoutType::Single { bits: 256 },
+    name: "soc_image_min_svn_0",
+    layout: FuseLayoutType::OneHotLinearOr {
+        bits: 10,
+        duplication: 3,
+    },
 };
-/// OTP item entry for `CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_7`.
+/// OTP item entry for `soc_image_min_svn_1`.
 pub const OTP_CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_7: &FuseEntryInfo = &FuseEntryInfo {
     partition_num: 14,
     entry_num: 7,
     byte_offset: 0xb58,
     byte_size: 32,
-    name: "CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_7",
-    layout: FuseLayoutType::Single { bits: 256 },
+    name: "soc_image_min_svn_1",
+    layout: FuseLayoutType::OneHotLinearOr {
+        bits: 10,
+        duplication: 3,
+    },
 };
 /// OTP item entry for `CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_8`.
 pub const OTP_CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_8: &FuseEntryInfo = &FuseEntryInfo {

--- a/rom/src/component_svn_manifest.rs
+++ b/rom/src/component_svn_manifest.rs
@@ -1,0 +1,382 @@
+// Licensed under the Apache-2.0 license
+
+//! MCU Component SVN Manifest format and validation. See `docs/src/svn.md`.
+//!
+//! This module defines the on-disk layout, parsing, and structural
+//! validation. Fuse reads and burns happen in the caller.
+
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
+
+/// Magic at the start of the manifest. On disk (little-endian) the bytes
+/// are `"VSCM"`; the constant value reads as `"MCSV"` MSB-first.
+pub const MCU_COMPONENT_SVN_MANIFEST_MAGIC: u32 = 0x4D43_5356;
+
+/// Currently supported manifest format version.
+pub const MCU_COMPONENT_SVN_MANIFEST_VERSION: u16 = 1;
+
+/// Number of `McuComponentSvnEntry` slots. Matches Caliptra's
+/// `AUTH_MANIFEST_IMAGE_METADATA_MAX_COUNT`.
+pub const MCU_COMPONENT_SVN_MANIFEST_ENTRY_COUNT: usize = 127;
+
+/// Total on-disk size of the manifest, in bytes.
+pub const MCU_COMPONENT_SVN_MANIFEST_SIZE: usize = 1024;
+
+#[repr(C)]
+#[derive(
+    Clone, Copy, Debug, Default, PartialEq, Eq, FromBytes, IntoBytes, Immutable, KnownLayout,
+)]
+pub struct McuComponentSvnEntry {
+    /// Same identifier Caliptra uses in `AuthManifestImageMetadata`.
+    pub component_id: u32,
+    pub current_svn: u16,
+    /// Requested new floor for the mapped `SOC_IMAGE_MIN_SVN[i]` slot
+    /// (0 = no update).
+    pub min_svn: u16,
+}
+
+impl McuComponentSvnEntry {
+    /// All-zero entries are treated as empty slots.
+    pub fn is_empty(&self) -> bool {
+        self.component_id == 0 && self.current_svn == 0 && self.min_svn == 0
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, FromBytes, IntoBytes, Immutable, KnownLayout)]
+pub struct McuComponentSvnManifest {
+    /// Must be [`MCU_COMPONENT_SVN_MANIFEST_MAGIC`].
+    pub magic: u32,
+    pub format_version: u16,
+    pub current_svn: u8,
+    /// Requested new floor for `MCU_COMPONENT_SVN_MANIFEST_MIN_SVN`
+    /// (0 = no update).
+    pub min_svn: u8,
+    pub entries: [McuComponentSvnEntry; MCU_COMPONENT_SVN_MANIFEST_ENTRY_COUNT],
+}
+
+// `#[repr(C)]` lays the fields out in declaration order with each field
+// aligned to its type. McuComponentSvnEntry packs to 8 B (u32 + u16 +
+// u16, all 4-byte-aligned at start), and the manifest header packs to
+// 8 B (u32 + u16 + u8 + u8), so the entry array starts immediately
+// after the header with no padding. These asserts make any future
+// field-order change a compile error.
+const _: () = assert!(core::mem::size_of::<McuComponentSvnEntry>() == 8);
+const _: () =
+    assert!(core::mem::size_of::<McuComponentSvnManifest>() == MCU_COMPONENT_SVN_MANIFEST_SIZE);
+
+/// Errors that can result from parsing or validating a manifest.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SvnManifestError {
+    /// Byte slice is too short to contain a manifest.
+    TooShort,
+    MagicMismatch,
+    UnsupportedFormatVersion(u16),
+    HeaderMinSvnExceedsCurrent {
+        min_svn: u8,
+        current_svn: u8,
+    },
+    /// A header SVN does not fit within
+    /// `MCU_COMPONENT_SVN_MANIFEST_MIN_SVN`'s one-hot range.
+    HeaderSvnExceedsFuseRange {
+        value: u8,
+        max: u32,
+    },
+    EntryMinSvnExceedsCurrent {
+        index: usize,
+        min_svn: u16,
+        current_svn: u16,
+    },
+}
+
+/// One-hot range limits the caller must supply to [`validate`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SvnLimits {
+    /// Max representable value for `MCU_COMPONENT_SVN_MANIFEST_MIN_SVN`.
+    pub manifest_min_svn_max: u32,
+}
+
+impl McuComponentSvnManifest {
+    /// Parse a manifest from `bytes` if it begins with the manifest
+    /// magic. Returns `Ok(None)` when the magic is absent (the manifest
+    /// header is optional in the MCU runtime image) and `Err(TooShort)`
+    /// when the magic is present but the buffer can't fit the struct.
+    pub fn parse_if_present(bytes: &[u8]) -> Result<Option<&Self>, SvnManifestError> {
+        let magic = bytes.get(..4).ok_or(SvnManifestError::TooShort)?;
+        let magic = u32::from_le_bytes([magic[0], magic[1], magic[2], magic[3]]);
+        if magic != MCU_COMPONENT_SVN_MANIFEST_MAGIC {
+            return Ok(None);
+        }
+        let (header, _) = Self::ref_from_prefix(bytes).map_err(|_| SvnManifestError::TooShort)?;
+        Ok(Some(header))
+    }
+
+    /// Validate structural constraints from `docs/src/svn.md`. Does not
+    /// consult OTP; the caller separately compares `current_svn`
+    /// against the fuse value.
+    pub fn validate(&self, limits: &SvnLimits) -> Result<(), SvnManifestError> {
+        if self.magic != MCU_COMPONENT_SVN_MANIFEST_MAGIC {
+            return Err(SvnManifestError::MagicMismatch);
+        }
+        if self.format_version != MCU_COMPONENT_SVN_MANIFEST_VERSION {
+            return Err(SvnManifestError::UnsupportedFormatVersion(
+                self.format_version,
+            ));
+        }
+        if self.min_svn > self.current_svn {
+            return Err(SvnManifestError::HeaderMinSvnExceedsCurrent {
+                min_svn: self.min_svn,
+                current_svn: self.current_svn,
+            });
+        }
+        if u32::from(self.current_svn) > limits.manifest_min_svn_max {
+            return Err(SvnManifestError::HeaderSvnExceedsFuseRange {
+                value: self.current_svn,
+                max: limits.manifest_min_svn_max,
+            });
+        }
+        if u32::from(self.min_svn) > limits.manifest_min_svn_max {
+            return Err(SvnManifestError::HeaderSvnExceedsFuseRange {
+                value: self.min_svn,
+                max: limits.manifest_min_svn_max,
+            });
+        }
+        for (i, entry) in self.entries.iter().enumerate() {
+            if entry.is_empty() {
+                continue;
+            }
+            if entry.min_svn > entry.current_svn {
+                return Err(SvnManifestError::EntryMinSvnExceedsCurrent {
+                    index: i,
+                    min_svn: entry.min_svn,
+                    current_svn: entry.current_svn,
+                });
+            }
+            // Per-entry one-hot-range checks against SOC_IMAGE_MIN_SVN[i]
+            // are deferred to the fuse-burn step, where SVN_FUSE_MAP
+            // supplies the per-slot maximum.
+        }
+        Ok(())
+    }
+
+    /// Iterator over non-empty entries paired with their index.
+    pub fn entries_present(&self) -> impl Iterator<Item = (usize, &McuComponentSvnEntry)> {
+        self.entries
+            .iter()
+            .enumerate()
+            .filter(|(_, e)| !e.is_empty())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate alloc;
+    use super::*;
+    use alloc::vec;
+    use core::mem::size_of;
+
+    const LIMITS: SvnLimits = SvnLimits {
+        manifest_min_svn_max: 10,
+    };
+
+    fn empty_manifest() -> McuComponentSvnManifest {
+        McuComponentSvnManifest {
+            magic: MCU_COMPONENT_SVN_MANIFEST_MAGIC,
+            format_version: MCU_COMPONENT_SVN_MANIFEST_VERSION,
+            current_svn: 0,
+            min_svn: 0,
+            entries: [McuComponentSvnEntry::default(); MCU_COMPONENT_SVN_MANIFEST_ENTRY_COUNT],
+        }
+    }
+
+    #[test]
+    fn manifest_size_is_1024_bytes() {
+        assert_eq!(
+            size_of::<McuComponentSvnManifest>(),
+            MCU_COMPONENT_SVN_MANIFEST_SIZE
+        );
+    }
+
+    #[test]
+    fn entry_size_is_8_bytes() {
+        assert_eq!(size_of::<McuComponentSvnEntry>(), 8);
+    }
+
+    #[test]
+    fn header_size_is_8_bytes() {
+        // 4 (magic) + 2 (format_version) + 1 (current_svn) + 1 (min_svn)
+        let header_size = MCU_COMPONENT_SVN_MANIFEST_SIZE
+            - MCU_COMPONENT_SVN_MANIFEST_ENTRY_COUNT * size_of::<McuComponentSvnEntry>();
+        assert_eq!(header_size, 8);
+    }
+
+    #[test]
+    fn magic_on_disk_is_vscm() {
+        let m = empty_manifest();
+        let bytes = m.as_bytes();
+        assert_eq!(&bytes[0..4], b"VSCM");
+    }
+
+    #[test]
+    fn parse_if_present_returns_none_when_magic_absent() {
+        let mut bytes = vec![0u8; MCU_COMPONENT_SVN_MANIFEST_SIZE];
+        bytes[0..4].copy_from_slice(&0xDEAD_BEEFu32.to_le_bytes());
+        assert!(McuComponentSvnManifest::parse_if_present(&bytes)
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn parse_if_present_returns_some_when_magic_present() {
+        let m = empty_manifest();
+        let bytes = m.as_bytes();
+        let parsed = McuComponentSvnManifest::parse_if_present(bytes)
+            .unwrap()
+            .unwrap();
+        assert_eq!(parsed.magic, MCU_COMPONENT_SVN_MANIFEST_MAGIC);
+    }
+
+    #[test]
+    fn parse_if_present_too_short_with_magic_errors() {
+        // Magic present but slice too short to fit the structure
+        let mut bytes = vec![0u8; 16];
+        bytes[0..4].copy_from_slice(&MCU_COMPONENT_SVN_MANIFEST_MAGIC.to_le_bytes());
+        let result = McuComponentSvnManifest::parse_if_present(&bytes);
+        assert_eq!(result.err(), Some(SvnManifestError::TooShort));
+    }
+
+    #[test]
+    fn parse_if_present_too_short_without_magic_errors() {
+        let bytes = [0u8; 3];
+        let result = McuComponentSvnManifest::parse_if_present(&bytes);
+        assert_eq!(result.err(), Some(SvnManifestError::TooShort));
+    }
+
+    #[test]
+    fn validate_accepts_well_formed_empty_manifest() {
+        let m = empty_manifest();
+        assert!(m.validate(&LIMITS).is_ok());
+    }
+
+    #[test]
+    fn validate_accepts_well_formed_populated_manifest() {
+        let mut m = empty_manifest();
+        m.current_svn = 5;
+        m.min_svn = 3;
+        m.entries[0] = McuComponentSvnEntry {
+            component_id: 0x1000,
+            current_svn: 7,
+            min_svn: 2,
+        };
+        m.entries[42] = McuComponentSvnEntry {
+            component_id: 0x2000,
+            current_svn: 4,
+            min_svn: 4,
+        };
+        assert!(m.validate(&LIMITS).is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_bad_magic() {
+        let mut m = empty_manifest();
+        m.magic = 0;
+        assert_eq!(m.validate(&LIMITS), Err(SvnManifestError::MagicMismatch));
+    }
+
+    #[test]
+    fn validate_rejects_unsupported_format_version() {
+        let mut m = empty_manifest();
+        m.format_version = 99;
+        assert_eq!(
+            m.validate(&LIMITS),
+            Err(SvnManifestError::UnsupportedFormatVersion(99))
+        );
+    }
+
+    #[test]
+    fn validate_rejects_header_min_svn_above_current_svn() {
+        let mut m = empty_manifest();
+        m.current_svn = 3;
+        m.min_svn = 4;
+        assert_eq!(
+            m.validate(&LIMITS),
+            Err(SvnManifestError::HeaderMinSvnExceedsCurrent {
+                min_svn: 4,
+                current_svn: 3,
+            })
+        );
+    }
+
+    #[test]
+    fn validate_rejects_header_current_svn_above_fuse_range() {
+        let mut m = empty_manifest();
+        m.current_svn = 11;
+        m.min_svn = 0;
+        assert_eq!(
+            m.validate(&LIMITS),
+            Err(SvnManifestError::HeaderSvnExceedsFuseRange { value: 11, max: 10 })
+        );
+    }
+
+    #[test]
+    fn validate_rejects_header_min_svn_above_fuse_range_when_current_in_range() {
+        // current_svn within range but min_svn > range is structurally
+        // impossible (min_svn <= current_svn). Confirm we don't false-
+        // positive on a manifest where current_svn = max.
+        let mut m = empty_manifest();
+        m.current_svn = 10;
+        m.min_svn = 10;
+        assert!(m.validate(&LIMITS).is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_entry_min_svn_above_current_svn() {
+        let mut m = empty_manifest();
+        m.entries[3] = McuComponentSvnEntry {
+            component_id: 0x42,
+            current_svn: 5,
+            min_svn: 6,
+        };
+        assert_eq!(
+            m.validate(&LIMITS),
+            Err(SvnManifestError::EntryMinSvnExceedsCurrent {
+                index: 3,
+                min_svn: 6,
+                current_svn: 5,
+            })
+        );
+    }
+
+    #[test]
+    fn validate_ignores_zero_entries() {
+        let mut m = empty_manifest();
+        // Leave most entries zero, only populate a sparse subset.
+        m.entries[0] = McuComponentSvnEntry {
+            component_id: 0x1,
+            current_svn: 1,
+            min_svn: 0,
+        };
+        m.entries[126] = McuComponentSvnEntry {
+            component_id: 0x2,
+            current_svn: 1,
+            min_svn: 1,
+        };
+        assert!(m.validate(&LIMITS).is_ok());
+    }
+
+    #[test]
+    fn entries_present_skips_zero_entries() {
+        let mut m = empty_manifest();
+        m.entries[5] = McuComponentSvnEntry {
+            component_id: 1,
+            current_svn: 1,
+            min_svn: 0,
+        };
+        m.entries[100] = McuComponentSvnEntry {
+            component_id: 2,
+            current_svn: 2,
+            min_svn: 1,
+        };
+        let present: alloc::vec::Vec<_> = m.entries_present().map(|(i, _)| i).collect();
+        assert_eq!(present, vec![5, 100]);
+    }
+}

--- a/rom/src/lib.rs
+++ b/rom/src/lib.rs
@@ -14,6 +14,12 @@ Abstract:
 
 #![no_std]
 
+mod component_svn_manifest;
+pub use component_svn_manifest::{
+    McuComponentSvnEntry, McuComponentSvnManifest, SvnLimits, SvnManifestError,
+    MCU_COMPONENT_SVN_MANIFEST_ENTRY_COUNT, MCU_COMPONENT_SVN_MANIFEST_MAGIC,
+    MCU_COMPONENT_SVN_MANIFEST_SIZE, MCU_COMPONENT_SVN_MANIFEST_VERSION,
+};
 mod device_ownership_transfer;
 pub use device_ownership_transfer::*;
 mod dot_override;


### PR DESCRIPTION
Implement the MCU-owned pieces of the SVN anti-rollback spec (docs/src/svn.md):

Fuses (hw/fuses.hjson, regenerated registers/generated-firmware):

  - MCU_COMPONENT_SVN_MANIFEST_MIN_SVN: floor for the manifest's own SVN.
  - SOC_IMAGE_MIN_SVN[0..1]: per-component SoC image rollback floors.

  All use OneHotLinearOr with 3x duplication in the vendor non-secret
  prod partition. The MCU runtime SVN floor lives in
  CPTRA_CORE_SOC_MANIFEST_SVN (Caliptra-owned); MCU ROM only burns it
  on Caliptra Core's request.

McuComponentSvnManifest (rom/src/component_svn_manifest.rs):

  - 1024-byte structure: 8-byte header (magic 'MCSV', format version, manifest current_svn/min_svn) + 127 8-byte entries (component_id, current_svn, min_svn). Matches Caliptra's AUTH_MANIFEST_IMAGE_METADATA_MAX_COUNT. Compile-time asserts pin the layout.
  - parse_if_present locates the manifest by magic, returning None when absent (the header is optional in the runtime image).
  - validate enforces the structural constraints from the spec; zero entries are treated as empty slots.
  - 18 host unit tests cover layout, parsing, and every validation rule.