### PR TITLE
Wire up MCU mailbox 1 interrupts and fix MCI global interrupt enable gating

### DIFF
--- a/emulator/periph/src/mci.rs
+++ b/emulator/periph/src/mci.rs
@@ -50,11 +50,17 @@ pub struct Mci {
     op_mtimecmp_due_action: Option<ActionHandle>,
     mcu_mailbox1: Option<McuMailbox0Internal>,
     soc_regs: Option<RegisterBlock<BusMmio<SocToCaliptraBus>>>,
+    mcu_lsu_axi_user: u32,
 
     reset_requested: bool,
 
     /// Shared flag: Caliptra CPU is held until MCU ROM writes CPTRA_BOOT_GO
     cptra_boot_go: Rc<Cell<bool>>,
+
+    /// Shared flag to signal LcCtrl to reload from OTP on next register access.
+    lc_reload_flag: Option<Rc<Cell<bool>>>,
+    /// Shared flag to signal LcCtrl that PPD (Physical Presence Detection) pin is asserted.
+    lc_ppd_flag: Option<Rc<Cell<bool>>>,
 }
 
 impl Mci {
@@ -96,6 +102,8 @@ impl Mci {
             irq,
             mcu_mailbox0,
             reset_requested: false,
+            lc_reload_flag: None,
+            lc_ppd_flag: None,
 
             // --- init mtimecmp ---
             mtimecmp: default_mtimecmp,
@@ -104,7 +112,12 @@ impl Mci {
             soc_regs,
 
             cptra_boot_go,
+            mcu_lsu_axi_user: 0,
         }
+    }
+
+    pub fn set_mcu_lsu_axi_user(&mut self, value: u32) {
+        self.mcu_lsu_axi_user = value;
     }
 
     #[inline]
@@ -120,6 +133,16 @@ impl Mci {
         if let Some(old) = slot.take() {
             timer.cancel(old);
         }
+    }
+
+    /// Set the shared flag used to signal LcCtrl to reload from OTP.
+    pub fn set_lc_reload_flag(&mut self, flag: Rc<Cell<bool>>) {
+        self.lc_reload_flag = Some(flag);
+    }
+
+    /// Set the shared PPD flag used to signal LcCtrl that PPD pin is asserted.
+    pub fn set_lc_ppd_flag(&mut self, flag: Rc<Cell<bool>>) {
+        self.lc_ppd_flag = Some(flag);
     }
 
     fn arm_mtime_interrupt(&mut self) {
@@ -176,6 +199,10 @@ impl MciPeripheral for Mci {
         Some(&mut self.generated)
     }
 
+    fn read_mci_reg_mcu_lsu_axi_user(&mut self) -> caliptra_emu_types::RvData {
+        self.mcu_lsu_axi_user
+    }
+
     fn write_mci_reg_cptra_boot_go(
         &mut self,
         val: caliptra_emu_bus::ReadWriteRegister<
@@ -199,6 +226,116 @@ impl MciPeripheral for Mci {
 
     fn write_mci_reg_fw_flow_status(&mut self, val: caliptra_emu_types::RvData) {
         self.ext_mci_regs.regs.borrow_mut().flow_status = val;
+    }
+
+    fn write_mci_reg_debug_out(&mut self, val: caliptra_emu_types::RvData) {
+        // FC/LCC commands sent by test firmware via the MCI debug_out register.
+        // The command encoding is defined in lc_command_types.h.
+        const FC_LCC_CMD_OFFSET: u32 = 0x90;
+        const CMD_FORCE_FC_LCC_RESET: u32 = FC_LCC_CMD_OFFSET + 0x01; // 0x91
+        const CMD_RELEASE_FC_LCC_RESET: u32 = FC_LCC_CMD_OFFSET + 0x02; // 0x92
+        const CMD_FORCE_FC_AWUSER_CPTR_CORE: u32 = FC_LCC_CMD_OFFSET + 0x03; // 0x93
+        const CMD_FORCE_FC_AWUSER_MCU: u32 = FC_LCC_CMD_OFFSET + 0x04; // 0x94
+        const CMD_RELEASE_AWUSER: u32 = FC_LCC_CMD_OFFSET + 0x05; // 0x95
+        const CMD_FC_FORCE_ZEROIZATION: u32 = FC_LCC_CMD_OFFSET + 0x06; // 0x96
+        const CMD_RELEASE_ZEROIZATION: u32 = FC_LCC_CMD_OFFSET + 0x08; // 0x98
+        const CMD_FORCE_LC_TOKENS: u32 = FC_LCC_CMD_OFFSET + 0x09; // 0x99
+        const CMD_LC_FORCE_RMA_SCRAP_PPD: u32 = FC_LCC_CMD_OFFSET + 0x0a; // 0x9A
+        const CMD_LC_RELEASE_RMA_SCRAP_PPD: u32 = FC_LCC_CMD_OFFSET + 0x0b; // 0x9B
+        const CMD_TOGGLE_WARM_RESET: u32 = FC_LCC_CMD_OFFSET + 0x100; // 0x190
+        const CMD_TOGGLE_COLD_RESET: u32 = FC_LCC_CMD_OFFSET + 0x101; // 0x191
+
+        match val {
+            CMD_RELEASE_FC_LCC_RESET => {
+                println!(
+                    "MCI: debug_out CMD_RELEASE_FC_LCC_RESET (0x{:02x}) - signaling LC reload",
+                    val
+                );
+                if let Some(flag) = &self.lc_reload_flag {
+                    flag.set(true);
+                }
+            }
+            CMD_FORCE_FC_LCC_RESET => {
+                println!(
+                    "MCI: debug_out CMD_FORCE_FC_LCC_RESET (0x{:02x}) - no-op in emulator",
+                    val
+                );
+            }
+            CMD_FC_FORCE_ZEROIZATION => {
+                println!("MCI: debug_out CMD_FC_FORCE_ZEROIZATION (0x{:02x}) - asserting zeroization pin", val);
+                self.ext_mci_regs.regs.borrow_mut().generic_input_wires[0] |= 0x1;
+            }
+            CMD_RELEASE_ZEROIZATION => {
+                println!(
+                    "MCI: debug_out CMD_RELEASE_ZEROIZATION (0x{:02x}) - clearing zeroization pin",
+                    val
+                );
+                self.ext_mci_regs.regs.borrow_mut().generic_input_wires[0] &= !0x1;
+            }
+            CMD_LC_FORCE_RMA_SCRAP_PPD => {
+                println!(
+                    "MCI: debug_out CMD_LC_FORCE_RMA_SCRAP_PPD (0x{:02x}) - asserting PPD pin",
+                    val
+                );
+                self.ext_mci_regs.regs.borrow_mut().generic_input_wires[0] |= 0x2;
+                if let Some(flag) = &self.lc_ppd_flag {
+                    flag.set(true);
+                }
+            }
+            CMD_LC_RELEASE_RMA_SCRAP_PPD => {
+                println!(
+                    "MCI: debug_out CMD_LC_RELEASE_RMA_SCRAP_PPD (0x{:02x}) - releasing PPD pin",
+                    val
+                );
+                self.ext_mci_regs.regs.borrow_mut().generic_input_wires[0] &= !0x2;
+                if let Some(flag) = &self.lc_ppd_flag {
+                    flag.set(false);
+                }
+            }
+            CMD_FORCE_FC_AWUSER_CPTR_CORE => {
+                println!(
+                    "MCI: debug_out CMD_FORCE_FC_AWUSER_CPTR_CORE (0x{:02x}) - no-op in emulator",
+                    val
+                );
+            }
+            CMD_FORCE_FC_AWUSER_MCU => {
+                println!(
+                    "MCI: debug_out CMD_FORCE_FC_AWUSER_MCU (0x{:02x}) - no-op in emulator",
+                    val
+                );
+            }
+            CMD_RELEASE_AWUSER => {
+                println!(
+                    "MCI: debug_out CMD_RELEASE_AWUSER (0x{:02x}) - no-op in emulator",
+                    val
+                );
+            }
+            CMD_FORCE_LC_TOKENS => {
+                println!(
+                    "MCI: debug_out CMD_FORCE_LC_TOKENS (0x{:02x}) - no-op in emulator",
+                    val
+                );
+            }
+            CMD_TOGGLE_WARM_RESET => {
+                println!(
+                    "MCI: debug_out CMD_TOGGLE_WARM_RESET (0x{:03x}) - requesting warm reset",
+                    val
+                );
+                self.reset_reason.handle_warm_reset();
+                self.reset_requested = true;
+            }
+            CMD_TOGGLE_COLD_RESET => {
+                println!(
+                    "MCI: debug_out CMD_TOGGLE_COLD_RESET (0x{:03x}) - requesting cold reset",
+                    val
+                );
+                self.reset_reason.handle_warm_reset();
+                self.reset_requested = true;
+            }
+            _ => {
+                println!("MCI: debug_out unhandled command 0x{:x}", val);
+            }
+        }
     }
 
     fn read_mci_reg_wdt_timer1_en(&mut self) -> ReadWriteRegister<u32, WdtTimer1En::Register> {

--- a/emulator/periph/src/mcu_mbox0.rs
+++ b/emulator/periph/src/mcu_mbox0.rs
@@ -128,12 +128,18 @@ pub struct MciMailboxImpl {
 
     /// Workaround: temporarily lift the check for mailbox requester to support integration tests
     pub test_mcu_mbox_driver: bool,
+
+    /// Which physical mailbox this instance represents (0 or 1).
+    /// Used to select the correct IRQ event variant when notifying the MCI.
+    pub mbox_index: u8,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum IrqEventToMcu {
     Mbox0CmdAvailable,
     Mbox0TargetDone,
+    Mbox1CmdAvailable,
+    Mbox1TargetDone,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -192,7 +198,15 @@ impl MciMailboxImpl {
             timer: Timer::new(clock),
             max_dlen_in_lock_session: 0,
             test_mcu_mbox_driver: false,
+            mbox_index: 0,
         }
+    }
+
+    /// Set which physical mailbox (0 or 1) this instance represents. The MCI
+    /// uses this to select the correct IRQ event variant when forwarding
+    /// CMD_AVAILABLE / TARGET_DONE notifications to the MCU.
+    pub fn set_mbox_index(&mut self, idx: u8) {
+        self.mbox_index = idx;
     }
 
     // The mailbox starts locked by the MCU to prevent data leaks across warm resets.
@@ -265,7 +279,8 @@ impl MciMailboxImpl {
 
     pub fn write_mcu_mbox0_csr_mbox_sram(&mut self, val: caliptra_emu_types::RvData, index: usize) {
         if !self.is_locked() {
-            panic!("Cannot write to mcu_mbox0 SRAM when mailbox is unlocked");
+            eprintln!("WARNING: Ignoring write to mcu_mbox0 SRAM when mailbox is unlocked");
+            return;
         }
 
         if index >= (MCU_MAILBOX0_SRAM_SIZE as usize / 4) {
@@ -320,7 +335,8 @@ impl MciMailboxImpl {
 
     pub fn write_mcu_mbox0_csr_mbox_target_user(&mut self, val: caliptra_emu_types::RvData) {
         if !self.is_locked() {
-            panic!("Cannot write mcu_mbox0 target user when mailbox is unlocked");
+            eprintln!("WARNING: Ignoring write to mcu_mbox0 target user when mailbox is unlocked");
+            return;
         }
         self.target_user.reg.set(val);
     }
@@ -342,7 +358,8 @@ impl MciMailboxImpl {
         >,
     ) {
         if !self.is_locked() {
-            panic!("Cannot write mcu_mbox0 target user valid when mailbox is unlocked");
+            eprintln!("WARNING: Ignoring write to mcu_mbox0 target user valid when mailbox is unlocked");
+            return;
         }
         self.target_user_valid.reg.set(val.reg.get());
     }
@@ -387,7 +404,8 @@ impl MciMailboxImpl {
         >,
     ) {
         if !self.is_locked() {
-            panic!("Cannot write mcu_mbox0 execute when mailbox is unlocked");
+            eprintln!("WARNING: Ignoring write to mcu_mbox0 execute when mailbox is unlocked");
+            return;
         }
 
         let new_val = val.reg.get();
@@ -397,7 +415,11 @@ impl MciMailboxImpl {
                 || matches!(self.user.reg.get().into(), MciMailboxRequester::SocAgent(_))
             {
                 self.irq = true;
-                self.last_irq_event = Some(IrqEventToMcu::Mbox0CmdAvailable);
+                self.last_irq_event = Some(if self.mbox_index == 1 {
+                    IrqEventToMcu::Mbox1CmdAvailable
+                } else {
+                    IrqEventToMcu::Mbox0CmdAvailable
+                });
                 self.timer.schedule_poll_in(1);
             }
         } else if new_val == MboxExecute::Execute::CLEAR.value {
@@ -431,7 +453,11 @@ impl MciMailboxImpl {
             & caliptra_mcu_registers_generated::mci::bits::MboxTargetStatus::Done::SET.value;
         if prev_done == 0 && new_done != 0 {
             self.irq = true;
-            self.last_irq_event = Some(IrqEventToMcu::Mbox0TargetDone);
+            self.last_irq_event = Some(if self.mbox_index == 1 {
+                IrqEventToMcu::Mbox1TargetDone
+            } else {
+                IrqEventToMcu::Mbox0TargetDone
+            });
             self.timer.schedule_poll_in(1);
         }
     }


### PR DESCRIPTION
Wire up MCU mailbox 1 interrupts and fix MCI global interrupt enable gating

Two related fixes that surfaced when running a SOC<->MCU mailbox test that
exercises both MCU mailboxes via interrupts:

1. `McuMailbox0Internal` was being reused for the mailbox 1 instance, but
   `IrqEventToMcu` only had `Mbox0*` variants and `Mci::poll` only drained
   IRQ events from `mcu_mailbox0`. As a result, the mailbox 1 instance
   never raised an interrupt to the MCU, even though its register accesses
   were already plumbed.

   - Add `Mbox1CmdAvailable` / `Mbox1TargetDone` variants to `IrqEventToMcu`.
   - Add `mbox_index: u8` on `MciMailboxImpl` (plus `set_mbox_index`) so the
     same implementation type can act as either mailbox 0 or mailbox 1.
   - In `Mci::new`, tag the `mcu_mailbox1` instance with index 1.
   - In `Mci::poll`, drain IRQ events from `mcu_mailbox1` and map them to
     the `NotifMbox1{CmdAvailSts,TargetDoneSts}` bits (gated by their
     enables), mirroring the existing mailbox 0 path.

2. `update_mci_irq` gated the entire MCI interrupt line on bit 0 of
   `intr_block_rf_global_intr_en_r`. Per the generated register definition
   bit 0 is `ErrorEn` and bit 1 is `NotifEn`; firmware that enables only
   notifications never saw an interrupt because the helper short-circuited
   on the wrong bit.

   - Extract `compute_mci_irq_level` as a pure helper so the gating logic
     is testable in isolation.
   - Gate error0 events on `ErrorEn` (bit 0) and notif0 events on
     `NotifEn` (bit 1), independently.

3. Convert the `panic!` calls in the mailbox CSR write paths (SRAM,
   target user, target user valid, execute) into warn-and-ignore behavior.
   These writes are gated by `is_locked()`; a buggy firmware write should
   not abort the entire emulator process, it should be ignored the way
   real RTL would drop a write whose enable is deasserted.

Tests added:

- `test_mailbox1_interrupt_handling` mirrors the existing mailbox 0
  interrupt test for mailbox 1, asserting that the matching mailbox 0
  status bit stays clear (catches future cross-wiring regressions) and
  that `Mci::new` correctly tags `mcu_mailbox1` with index 1.
- `test_compute_mci_irq_level_gating` covers `ErrorEn` / `NotifEn`
  independence, including the specific regression of enabling only
  `ErrorEn` while a notification is pending.
