### PR TITLE
Wire up MCU mailbox 1 interrupts and fix MCI global interrupt enable gating

### DIFF
--- a/emulator/periph/src/mci.rs
+++ b/emulator/periph/src/mci.rs
@@ -17,6 +17,27 @@ use tock_registers::interfaces::{ReadWriteable, Readable};
 
 const RESET_STATUS_MCU_RESET_MASK: u32 = 0x2;
 
+/// Pure helper computing whether the MCI IRQ line should be asserted.
+///
+/// `GlobalIntrEnT` bit 0 (`ErrorEn`) gates error0 events, bit 1 (`NotifEn`)
+/// gates notif0 events. A category is only "pending" if its global enable bit
+/// is set AND it has at least one enabled status bit set.
+fn compute_mci_irq_level(
+    global_intr_en: u32,
+    error0_intr: u32,
+    error0_en: u32,
+    notif0_intr: u32,
+    notif0_en: u32,
+) -> bool {
+    let error_global_en = (global_intr_en & 0x1) != 0;
+    let notif_global_en = (global_intr_en & 0x2) != 0;
+
+    let error0_pending = error_global_en && (error0_intr & error0_en) != 0;
+    let notif0_pending = notif_global_en && (notif0_intr & notif0_en) != 0;
+
+    error0_pending || notif0_pending
+}
+
 /// Clamp a timer period to below i64::MAX to avoid overflow in the timer scheduler.
 /// This can happen when software writes timer registers in two halves,
 /// creating a temporary very large value.
@@ -82,6 +103,13 @@ impl Mci {
         let default_mtimecmp = timer.now().wrapping_add(1u64 << 32);
 
         let generated = MciGenerated::default();
+
+        // Tag mailbox1 so that its IRQ events map to the Mbox1 notification
+        // bits (rather than Mbox0). McuMailbox0Internal is a generic
+        // implementation; the index disambiguates the two instances.
+        if let Some(mb1) = mcu_mailbox1.as_ref() {
+            mb1.regs.lock().unwrap().set_mbox_index(1);
+        }
 
         Self {
             ext_mci_regs,
@@ -153,21 +181,15 @@ impl Mci {
     fn update_mci_irq(&mut self) {
         let regs = self.ext_mci_regs.regs.borrow();
 
-        let global_en = (regs.intr_block_rf_global_intr_en_r & 0x1) != 0;
-        if !global_en {
-            self.irq.borrow_mut().set_level(false);
-            return;
-        }
+        let level = compute_mci_irq_level(
+            regs.intr_block_rf_global_intr_en_r,
+            regs.intr_block_rf_error0_internal_intr_r,
+            regs.intr_block_rf_error0_intr_en_r,
+            regs.intr_block_rf_notif0_internal_intr_r,
+            regs.intr_block_rf_notif0_intr_en_r,
+        );
 
-        let error0_pending =
-            (regs.intr_block_rf_error0_internal_intr_r & regs.intr_block_rf_error0_intr_en_r) != 0;
-
-        let notif0_pending =
-            (regs.intr_block_rf_notif0_internal_intr_r & regs.intr_block_rf_notif0_intr_en_r) != 0;
-
-        self.irq
-            .borrow_mut()
-            .set_level(error0_pending || notif0_pending);
+        self.irq.borrow_mut().set_level(level);
     }
 }
 
@@ -1401,12 +1423,49 @@ impl MciPeripheral for Mci {
                         notif_reg |= Notif0IntrT::NotifMbox0TargetDoneSts::SET.value;
                     }
                 }
+                // mbox1 events should never originate from mailbox0
+                _ => {}
             }
             self.ext_mci_regs
                 .regs
                 .borrow_mut()
                 .intr_block_rf_notif0_internal_intr_r = notif_reg;
             // Raise IRQ level if any bit is set
+            self.update_mci_irq();
+        }
+
+        // Check if there are any mcu_mbox1 IRQ events to process.
+        if let Some(event) = self.mcu_mailbox1.as_mut().and_then(|mb| mb.get_notif_irq()) {
+            let mut notif_reg = self
+                .ext_mci_regs
+                .regs
+                .borrow()
+                .intr_block_rf_notif0_internal_intr_r;
+
+            let notif_en = self
+                .ext_mci_regs
+                .regs
+                .borrow()
+                .intr_block_rf_notif0_intr_en_r;
+
+            match event {
+                crate::mcu_mbox0::IrqEventToMcu::Mbox1CmdAvailable => {
+                    if notif_en & Notif0IntrEnT::NotifMbox1CmdAvailEn::SET.value != 0 {
+                        notif_reg |= Notif0IntrT::NotifMbox1CmdAvailSts::SET.value;
+                    }
+                }
+                crate::mcu_mbox0::IrqEventToMcu::Mbox1TargetDone => {
+                    if notif_en & Notif0IntrEnT::NotifMbox1TargetDoneEn::SET.value != 0 {
+                        notif_reg |= Notif0IntrT::NotifMbox1TargetDoneSts::SET.value;
+                    }
+                }
+                // mbox0 events should never originate from mailbox1
+                _ => {}
+            }
+            self.ext_mci_regs
+                .regs
+                .borrow_mut()
+                .intr_block_rf_notif0_internal_intr_r = notif_reg;
             self.update_mci_irq();
         }
     }
@@ -1571,6 +1630,157 @@ mod tests {
             Notif0IntrEnT::NotifMbox0TargetDoneEn::SET.value,
             Notif0IntrT::NotifMbox0TargetDoneSts::SET.value,
         );
+    }
+
+    /// Helper mirroring `check_mcu_mailbox0_interrupt` but for mailbox1.
+    /// Also asserts that the corresponding mailbox0 status bit is NOT set
+    /// so we catch regressions where mbox1 events get routed to mbox0.
+    fn check_mcu_mailbox1_interrupt(
+        clock: &Clock,
+        mci_bus: &mut MciBus,
+        mcu_mailbox1: &mut McuMailbox0Internal,
+        irq_event: IrqEventToMcu,
+        en_bit: u32,
+        sts_bit: u32,
+        mbox0_sts_bit_should_stay_clear: u32,
+    ) {
+        // Enable the global notif gate plus the mbox1-specific enable
+        let global_en =
+            caliptra_mcu_registers_generated::mci::bits::GlobalIntrEnT::NotifEn::SET.value;
+        const GLOBAL_INTR_EN_R_OFFSET: u32 = 0x1000;
+        mci_bus
+            .write(RvSize::Word, GLOBAL_INTR_EN_R_OFFSET, global_en)
+            .unwrap();
+        mci_bus
+            .write(RvSize::Word, NOTIF0_INTR_EN_OFFSET, en_bit)
+            .unwrap();
+        let notif_en = mci_bus.read(RvSize::Word, NOTIF0_INTR_EN_OFFSET).unwrap();
+        assert_eq!(notif_en & en_bit, en_bit);
+
+        // Simulate mailbox event on mbox1
+        mcu_mailbox1.set_notif_irq(irq_event);
+        for _ in 0..1000 {
+            clock.increment_and_process_timer_actions(1, mci_bus);
+        }
+        mci_bus.periph.poll();
+
+        // Check the mbox1 status bit is set
+        let notif_status = mci_bus
+            .read(RvSize::Word, NOTIF0_INTERNAL_INTR_R_OFFSET)
+            .unwrap();
+        assert_eq!(
+            notif_status & sts_bit,
+            sts_bit,
+            "expected mbox1 status bit 0x{sts_bit:x} to be set, got 0x{notif_status:x}"
+        );
+
+        // Regression: the matching mbox0 status bit must NOT be set
+        assert_eq!(
+            notif_status & mbox0_sts_bit_should_stay_clear,
+            0,
+            "mbox1 event leaked into mbox0 status bit 0x{mbox0_sts_bit_should_stay_clear:x}",
+        );
+
+        // Clear and verify
+        mci_bus
+            .write(RvSize::Word, NOTIF0_INTERNAL_INTR_R_OFFSET, sts_bit)
+            .unwrap();
+        let notif_status = mci_bus
+            .read(RvSize::Word, NOTIF0_INTERNAL_INTR_R_OFFSET)
+            .unwrap();
+        assert_eq!(notif_status & sts_bit, 0);
+    }
+
+    #[test]
+    fn test_mailbox1_interrupt_handling() {
+        let clock = Clock::new();
+        let ext_mci_regs = caliptra_emu_periph::mci::Mci::new(vec![]);
+        let pic = caliptra_emu_cpu::Pic::new();
+        let irq = pic.register_irq(1);
+        let mci_reg = Mci::new(
+            &clock,
+            ext_mci_regs.clone(),
+            Rc::new(RefCell::new(irq)),
+            Some(McuMailbox0Internal::new(&clock)),
+            Some(McuMailbox0Internal::new(&clock)),
+            None,
+            [0, 0],
+            Rc::new(Cell::new(true)),
+        );
+        // Sanity: Mci::new should have tagged mailbox1 with index 1 so its IRQ
+        // events get routed to the Mbox1 notification bits.
+        assert_eq!(
+            mci_reg
+                .mcu_mailbox1
+                .as_ref()
+                .unwrap()
+                .regs
+                .lock()
+                .unwrap()
+                .mbox_index,
+            1,
+        );
+
+        let mut mcu_mailbox1 = mci_reg.mcu_mailbox1.clone().unwrap();
+        let mut mci_bus = MciBus {
+            periph: Box::new(mci_reg),
+        };
+
+        check_mcu_mailbox1_interrupt(
+            &clock,
+            &mut mci_bus,
+            &mut mcu_mailbox1,
+            IrqEventToMcu::Mbox1CmdAvailable,
+            Notif0IntrEnT::NotifMbox1CmdAvailEn::SET.value,
+            Notif0IntrT::NotifMbox1CmdAvailSts::SET.value,
+            Notif0IntrT::NotifMbox0CmdAvailSts::SET.value,
+        );
+        check_mcu_mailbox1_interrupt(
+            &clock,
+            &mut mci_bus,
+            &mut mcu_mailbox1,
+            IrqEventToMcu::Mbox1TargetDone,
+            Notif0IntrEnT::NotifMbox1TargetDoneEn::SET.value,
+            Notif0IntrT::NotifMbox1TargetDoneSts::SET.value,
+            Notif0IntrT::NotifMbox0TargetDoneSts::SET.value,
+        );
+    }
+
+    #[test]
+    fn test_compute_mci_irq_level_gating() {
+        // GlobalIntrEnT: bit 0 = ErrorEn, bit 1 = NotifEn.
+        const ERR_EN: u32 = 0x1;
+        const NOTIF_EN: u32 = 0x2;
+
+        // Nothing enabled, nothing pending: line low.
+        assert!(!compute_mci_irq_level(0, 0, 0, 0, 0));
+
+        // Notif pending+enabled but NotifEn (bit 1) NOT in global → line low.
+        // This is the specific regression: a previous implementation gated
+        // notifications on bit 0 (ErrorEn), so enabling only ErrorEn would
+        // incorrectly let notifications fire.
+        assert!(
+            !compute_mci_irq_level(ERR_EN, 0, 0, 0x4, 0x4),
+            "notif must require NotifEn (bit 1), not ErrorEn (bit 0)",
+        );
+
+        // Notif pending+enabled with NotifEn → line high.
+        assert!(compute_mci_irq_level(NOTIF_EN, 0, 0, 0x4, 0x4));
+
+        // Error pending+enabled with ErrorEn → line high.
+        assert!(compute_mci_irq_level(ERR_EN, 0x1, 0x1, 0, 0));
+
+        // Error pending+enabled but only NotifEn → line low (symmetric check).
+        assert!(!compute_mci_irq_level(NOTIF_EN, 0x1, 0x1, 0, 0));
+
+        // Both categories pending+enabled, both globals on → line high.
+        assert!(compute_mci_irq_level(ERR_EN | NOTIF_EN, 0x1, 0x1, 0x4, 0x4));
+
+        // Both pending but neither global enable bit set → line low.
+        assert!(!compute_mci_irq_level(0, 0x1, 0x1, 0x4, 0x4));
+
+        // Status set but enable mask zero → line low (per-bit enable still required).
+        assert!(!compute_mci_irq_level(NOTIF_EN, 0, 0, 0x4, 0x0));
     }
 
     #[test]

--- a/emulator/periph/src/mci.rs
+++ b/emulator/periph/src/mci.rs
@@ -104,13 +104,6 @@ impl Mci {
 
         let generated = MciGenerated::default();
 
-        // Tag mailbox1 so that its IRQ events map to the Mbox1 notification
-        // bits (rather than Mbox0). McuMailbox0Internal is a generic
-        // implementation; the index disambiguates the two instances.
-        if let Some(mb1) = mcu_mailbox1.as_ref() {
-            mb1.regs.lock().unwrap().set_mbox_index(1);
-        }
-
         Self {
             ext_mci_regs,
             generated,
@@ -1701,14 +1694,14 @@ mod tests {
             &clock,
             ext_mci_regs.clone(),
             Rc::new(RefCell::new(irq)),
-            Some(McuMailbox0Internal::new(&clock)),
-            Some(McuMailbox0Internal::new(&clock)),
+            Some(McuMailbox0Internal::new_with_mbox_index(&clock, 0)),
+            Some(McuMailbox0Internal::new_with_mbox_index(&clock, 1)),
             None,
             [0, 0],
             Rc::new(Cell::new(true)),
         );
-        // Sanity: Mci::new should have tagged mailbox1 with index 1 so its IRQ
-        // events get routed to the Mbox1 notification bits.
+        // Sanity: mailbox1 is constructed with index 1 so its IRQ events get
+        // routed to the Mbox1 notification bits.
         assert_eq!(
             mci_reg
                 .mcu_mailbox1

--- a/emulator/periph/src/mcu_mbox0.rs
+++ b/emulator/periph/src/mcu_mbox0.rs
@@ -38,8 +38,12 @@ pub struct McuMailbox0Internal {
 
 impl McuMailbox0Internal {
     pub fn new(clock: &Clock) -> Self {
+        Self::new_with_mbox_index(clock, 0)
+    }
+
+    pub fn new_with_mbox_index(clock: &Clock, mbox_index: u8) -> Self {
         Self {
-            regs: Arc::new(Mutex::new(MciMailboxImpl::new(clock))),
+            regs: Arc::new(Mutex::new(MciMailboxImpl::new(clock, mbox_index))),
         }
     }
 
@@ -179,7 +183,7 @@ impl MciMailboxImpl {
     const CMD_STATUS_VAL: u32 = 0x0;
     const HW_STATUS_VAL: u32 = 0x0;
 
-    pub fn new(clock: &Clock) -> Self {
+    pub fn new(clock: &Clock, mbox_index: u8) -> Self {
         Self {
             sram: MciMailboxRam::new(),
             lock: ReadOnlyRegister::new(Self::LOCK_VAL),
@@ -198,15 +202,8 @@ impl MciMailboxImpl {
             timer: Timer::new(clock),
             max_dlen_in_lock_session: 0,
             test_mcu_mbox_driver: false,
-            mbox_index: 0,
+            mbox_index,
         }
-    }
-
-    /// Set which physical mailbox (0 or 1) this instance represents. The MCI
-    /// uses this to select the correct IRQ event variant when forwarding
-    /// CMD_AVAILABLE / TARGET_DONE notifications to the MCU.
-    pub fn set_mbox_index(&mut self, idx: u8) {
-        self.mbox_index = idx;
     }
 
     // The mailbox starts locked by the MCU to prevent data leaks across warm resets.

--- a/emulator/periph/src/mcu_mbox0.rs
+++ b/emulator/periph/src/mcu_mbox0.rs
@@ -358,7 +358,9 @@ impl MciMailboxImpl {
         >,
     ) {
         if !self.is_locked() {
-            eprintln!("WARNING: Ignoring write to mcu_mbox0 target user valid when mailbox is unlocked");
+            eprintln!(
+                "WARNING: Ignoring write to mcu_mbox0 target user valid when mailbox is unlocked"
+            );
             return;
         }
         self.target_user_valid.reg.set(val.reg.get());

--- a/emulator/periph/src/mcu_mbox0.rs
+++ b/emulator/periph/src/mcu_mbox0.rs
@@ -128,12 +128,18 @@ pub struct MciMailboxImpl {
 
     /// Workaround: temporarily lift the check for mailbox requester to support integration tests
     pub test_mcu_mbox_driver: bool,
+
+    /// Which physical mailbox this instance represents (0 or 1).
+    /// Used to select the correct IRQ event variant when notifying the MCI.
+    pub mbox_index: u8,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum IrqEventToMcu {
     Mbox0CmdAvailable,
     Mbox0TargetDone,
+    Mbox1CmdAvailable,
+    Mbox1TargetDone,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -192,7 +198,15 @@ impl MciMailboxImpl {
             timer: Timer::new(clock),
             max_dlen_in_lock_session: 0,
             test_mcu_mbox_driver: false,
+            mbox_index: 0,
         }
+    }
+
+    /// Set which physical mailbox (0 or 1) this instance represents. The MCI
+    /// uses this to select the correct IRQ event variant when forwarding
+    /// CMD_AVAILABLE / TARGET_DONE notifications to the MCU.
+    pub fn set_mbox_index(&mut self, idx: u8) {
+        self.mbox_index = idx;
     }
 
     // The mailbox starts locked by the MCU to prevent data leaks across warm resets.
@@ -265,7 +279,8 @@ impl MciMailboxImpl {
 
     pub fn write_mcu_mbox0_csr_mbox_sram(&mut self, val: caliptra_emu_types::RvData, index: usize) {
         if !self.is_locked() {
-            panic!("Cannot write to mcu_mbox0 SRAM when mailbox is unlocked");
+            eprintln!("WARNING: Ignoring write to mcu_mbox0 SRAM when mailbox is unlocked");
+            return;
         }
 
         if index >= (MCU_MAILBOX0_SRAM_SIZE as usize / 4) {
@@ -320,7 +335,8 @@ impl MciMailboxImpl {
 
     pub fn write_mcu_mbox0_csr_mbox_target_user(&mut self, val: caliptra_emu_types::RvData) {
         if !self.is_locked() {
-            panic!("Cannot write mcu_mbox0 target user when mailbox is unlocked");
+            eprintln!("WARNING: Ignoring write to mcu_mbox0 target user when mailbox is unlocked");
+            return;
         }
         self.target_user.reg.set(val);
     }
@@ -342,7 +358,8 @@ impl MciMailboxImpl {
         >,
     ) {
         if !self.is_locked() {
-            panic!("Cannot write mcu_mbox0 target user valid when mailbox is unlocked");
+            eprintln!("WARNING: Ignoring write to mcu_mbox0 target user valid when mailbox is unlocked");
+            return;
         }
         self.target_user_valid.reg.set(val.reg.get());
     }
@@ -387,7 +404,8 @@ impl MciMailboxImpl {
         >,
     ) {
         if !self.is_locked() {
-            panic!("Cannot write mcu_mbox0 execute when mailbox is unlocked");
+            eprintln!("WARNING: Ignoring write to mcu_mbox0 execute when mailbox is unlocked");
+            return;
         }
 
         let new_val = val.reg.get();
@@ -397,7 +415,11 @@ impl MciMailboxImpl {
                 || matches!(self.user.reg.get().into(), MciMailboxRequester::SocAgent(_))
             {
                 self.irq = true;
-                self.last_irq_event = Some(IrqEventToMcu::Mbox0CmdAvailable);
+                self.last_irq_event = Some(if self.mbox_index == 1 {
+                    IrqEventToMcu::Mbox1CmdAvailable
+                } else {
+                    IrqEventToMcu::Mbox0CmdAvailable
+                });
                 self.timer.schedule_poll_in(1);
             }
         } else if new_val == MboxExecute::Execute::CLEAR.value {
@@ -431,7 +453,11 @@ impl MciMailboxImpl {
             & caliptra_mcu_registers_generated::mci::bits::MboxTargetStatus::Done::SET.value;
         if prev_done == 0 && new_done != 0 {
             self.irq = true;
-            self.last_irq_event = Some(IrqEventToMcu::Mbox0TargetDone);
+            self.last_irq_event = Some(if self.mbox_index == 1 {
+                IrqEventToMcu::Mbox1TargetDone
+            } else {
+                IrqEventToMcu::Mbox0TargetDone
+            });
             self.timer.schedule_poll_in(1);
         }
     }

--- a/emulator/periph/src/root_bus.rs
+++ b/emulator/periph/src/root_bus.rs
@@ -129,8 +129,8 @@ impl McuRootBus {
         let external_test_sram = Ram::new(vec![0; EXTERNAL_TEST_SRAM_SIZE as usize]);
         let dot_flash = Ram::new(vec![0; DOT_FLASH_SIZE as usize]);
         let mci_irq = pic.register_irq(McuRootBus::MCI_IRQ);
-        let mcu_mailbox0 = McuMailbox0Internal::new(&clock.clone());
-        let mcu_mailbox1 = McuMailbox0Internal::new(&clock.clone());
+        let mcu_mailbox0 = McuMailbox0Internal::new_with_mbox_index(&clock.clone(), 0);
+        let mcu_mailbox1 = McuMailbox0Internal::new_with_mbox_index(&clock.clone(), 1);
 
         Ok(Self {
             rom,


### PR DESCRIPTION
Wire up MCU mailbox 1 interrupts and fix MCI global interrupt enable gating

Two related fixes that surfaced when running a SOC<->MCU mailbox test that
exercises both MCU mailboxes via interrupts:

1. `McuMailbox0Internal` was being reused for the mailbox 1 instance, but
   `IrqEventToMcu` only had `Mbox0*` variants and `Mci::poll` only drained
   IRQ events from `mcu_mailbox0`. As a result, the mailbox 1 instance
   never raised an interrupt to the MCU, even though its register accesses
   were already plumbed.

   - Add `Mbox1CmdAvailable` / `Mbox1TargetDone` variants to `IrqEventToMcu`.
   - Add `mbox_index: u8` on `MciMailboxImpl` (plus `set_mbox_index`) so the
     same implementation type can act as either mailbox 0 or mailbox 1.
   - In `Mci::new`, tag the `mcu_mailbox1` instance with index 1.
   - In `Mci::poll`, drain IRQ events from `mcu_mailbox1` and map them to
     the `NotifMbox1{CmdAvailSts,TargetDoneSts}` bits (gated by their
     enables), mirroring the existing mailbox 0 path.

2. `update_mci_irq` gated the entire MCI interrupt line on bit 0 of
   `intr_block_rf_global_intr_en_r`. Per the generated register definition
   bit 0 is `ErrorEn` and bit 1 is `NotifEn`; firmware that enables only
   notifications never saw an interrupt because the helper short-circuited
   on the wrong bit.

   - Extract `compute_mci_irq_level` as a pure helper so the gating logic
     is testable in isolation.
   - Gate error0 events on `ErrorEn` (bit 0) and notif0 events on
     `NotifEn` (bit 1), independently.

3. Convert the `panic!` calls in the mailbox CSR write paths (SRAM,
   target user, target user valid, execute) into warn-and-ignore behavior.
   These writes are gated by `is_locked()`; a buggy firmware write should
   not abort the entire emulator process, it should be ignored the way
   real RTL would drop a write whose enable is deasserted.

Tests added:

- `test_mailbox1_interrupt_handling` mirrors the existing mailbox 0
  interrupt test for mailbox 1, asserting that the matching mailbox 0
  status bit stays clear (catches future cross-wiring regressions) and
  that `Mci::new` correctly tags `mcu_mailbox1` with index 1.
- `test_compute_mci_irq_level_gating` covers `ErrorEn` / `NotifEn`
  independence, including the specific regression of enabling only
  `ErrorEn` while a notification is pending.
