### PR TITLE
rom: fix clippy warnings and remove panic paths

### DIFF
--- a/platforms/emulator/rom/src/flash/flash_boot_cfg.rs
+++ b/platforms/emulator/rom/src/flash/flash_boot_cfg.rs
@@ -34,7 +34,7 @@ impl<'a> FlashBootCfg<'a> {
     }
 }
 
-impl<'a> BootConfig for FlashBootCfg<'a> {
+impl BootConfig for FlashBootCfg<'_> {
     fn get_active_partition(&self) -> Result<PartitionId, BootConfigError> {
         let partition_table = self
             .read_partition_table()

--- a/platforms/emulator/rom/src/flash/flash_test.rs
+++ b/platforms/emulator/rom/src/flash/flash_test.rs
@@ -13,8 +13,8 @@ pub fn test_rom_flash_access(partition: &FlashPartition) {
 
     for iter in 0..NUM_ITER {
         let mut test_data = [0u8; TEST_DATA_SIZE];
-        for i in 0..test_data.len() {
-            test_data[i] = (i & 0xFF) as u8;
+        for (i, byte) in test_data.iter_mut().enumerate() {
+            *byte = (i & 0xFF) as u8;
         }
         let start_addr = 0x50 + iter * ADDR_STEP;
         let mut read_buf = [0u8; TEST_DATA_SIZE];
@@ -40,12 +40,11 @@ pub fn test_rom_flash_access(partition: &FlashPartition) {
             test_exit(1);
         }
 
-        // Verify the data
-        for i in 0..test_data.len() {
-            if read_buf[i] != test_data[i] {
+        for (i, (got, want)) in read_buf.iter().zip(test_data.iter()).enumerate() {
+            if got != want {
                 println!(
                     "Flash data mismatch at iter {}, index {}: expected {:02x}, got {:02x}",
-                    iter, i, test_data[i], read_buf[i]
+                    iter, i, want, got
                 );
                 test_exit(1);
             }

--- a/platforms/emulator/rom/src/flash/mod.rs
+++ b/platforms/emulator/rom/src/flash/mod.rs
@@ -2,8 +2,5 @@
 pub mod flash_boot_cfg;
 pub mod flash_drv;
 
-#[cfg(any(
-    feature = "test-mcu-rom-flash-access",
-    feature = "test-flash-based-boot"
-))]
+#[cfg(feature = "test-mcu-rom-flash-access")]
 pub mod flash_test;

--- a/platforms/emulator/rom/src/io.rs
+++ b/platforms/emulator/rom/src/io.rs
@@ -49,5 +49,7 @@ pub fn exit_emulator(exit_code: u32) -> ! {
         // By writing to this address we can exit the emulator.
         core::ptr::write_volatile(0x1000_2000 as *mut u32, exit_code);
     }
-    loop {}
+    loop {
+        core::hint::spin_loop();
+    }
 }

--- a/platforms/emulator/rom/src/riscv.rs
+++ b/platforms/emulator/rom/src/riscv.rs
@@ -38,6 +38,17 @@ use caliptra_mcu_rom_common::memory::SimpleFlash;
 use caliptra_mcu_rom_common::{fatal_error, RomHooks, RomParameters};
 use caliptra_mcu_rom_common::{DotRecoveryHandler, DOT_BLOB_SIZE};
 use caliptra_mcu_romtime::HexWord;
+
+/// Initialize a `MaybeUninit<T>` static via a raw pointer and return a
+/// `&'static mut T` to its contents.
+///
+/// # Safety
+///
+/// `s` must point to a not-yet-initialized `MaybeUninit<T>`, and the
+/// caller must hold exclusive access for the duration of this call.
+unsafe fn init_static<T>(s: *mut core::mem::MaybeUninit<T>, value: T) -> &'static mut T {
+    (*s).write(value)
+}
 use zerocopy::{transmute, FromBytes, IntoBytes};
 
 /// DOT recovery handler using MCI mbox0.
@@ -319,9 +330,12 @@ pub extern "C" fn rom_entry() -> ! {
         static mut RECOVERY_HANDLER: core::mem::MaybeUninit<TestDotRecoveryHandler> =
             core::mem::MaybeUninit::uninit();
         let recovery_handler = unsafe {
-            RECOVERY_HANDLER.write(TestDotRecoveryHandler {
-                blob: recovery_backup_blob,
-            })
+            init_static(
+                &raw mut RECOVERY_HANDLER,
+                TestDotRecoveryHandler {
+                    blob: recovery_backup_blob,
+                },
+            )
         };
 
         let mci_base: caliptra_mcu_romtime::StaticRef<
@@ -336,9 +350,10 @@ pub extern "C" fn rom_entry() -> ! {
             caliptra_mcu_rom_common::Mbox0RecoveryTransport,
         > = core::mem::MaybeUninit::uninit();
         let recovery_transport = unsafe {
-            RECOVERY_TRANSPORT.write(caliptra_mcu_rom_common::Mbox0RecoveryTransport::new(
-                mci_base,
-            ))
+            init_static(
+                &raw mut RECOVERY_TRANSPORT,
+                caliptra_mcu_rom_common::Mbox0RecoveryTransport::new(mci_base),
+            )
         };
 
         let hooks = LoggingRomHooks;
@@ -377,15 +392,19 @@ pub extern "C" fn rom_entry() -> ! {
                     caliptra_mcu_rom_common::BackupBlobRecoveryHandler<'static>,
                 > = core::mem::MaybeUninit::uninit();
                 let blob_h = unsafe {
-                    BLOB_HANDLER.write(caliptra_mcu_rom_common::BackupBlobRecoveryHandler {
-                        recovery_handler: &*recovery_handler,
-                    })
+                    init_static(
+                        &raw mut BLOB_HANDLER,
+                        caliptra_mcu_rom_common::BackupBlobRecoveryHandler {
+                            recovery_handler: &*recovery_handler,
+                        },
+                    )
                 };
                 static mut OVERRIDE_HANDLER: core::mem::MaybeUninit<
                     caliptra_mcu_rom_common::OverrideChallengeRecoveryHandler<'static>,
                 > = core::mem::MaybeUninit::uninit();
                 let override_h = unsafe {
-                    OVERRIDE_HANDLER.write(
+                    init_static(
+                        &raw mut OVERRIDE_HANDLER,
                         caliptra_mcu_rom_common::OverrideChallengeRecoveryHandler {
                             transport: &*recovery_transport,
                             wdt_timeout: 0,
@@ -396,8 +415,9 @@ pub extern "C" fn rom_entry() -> ! {
                     [caliptra_mcu_rom_common::DotLockedRecoveryEntry<'static>; 2],
                 > = core::mem::MaybeUninit::uninit();
                 unsafe {
-                    HANDLER_ENTRIES
-                        .write([
+                    init_static(
+                        &raw mut HANDLER_ENTRIES,
+                        [
                             caliptra_mcu_rom_common::DotLockedRecoveryEntry {
                                 handler: blob_h,
                                 policy:
@@ -408,8 +428,9 @@ pub extern "C" fn rom_entry() -> ! {
                                 policy:
                                     caliptra_mcu_rom_common::DotLockedRecoveryErrorPolicy::Continue,
                             },
-                        ])
-                        .as_slice()
+                        ],
+                    )
+                    .as_slice()
                 }
             } else if cfg!(feature = "test-i3c-services") {
                 let i3c_base = unsafe {
@@ -422,22 +443,27 @@ pub extern "C" fn rom_entry() -> ! {
                     caliptra_mcu_rom_common::I3cDotLockedRecoveryHandler,
                 > = core::mem::MaybeUninit::uninit();
                 let handler = unsafe {
-                    I3C_HANDLER.write(caliptra_mcu_rom_common::I3cDotLockedRecoveryHandler {
-                        i3c_base,
-                        services: caliptra_mcu_rom_common::I3cServicesModes::DOT_RECOVERY,
-                        i3c_target_addr: 0x5a,
-                    })
+                    init_static(
+                        &raw mut I3C_HANDLER,
+                        caliptra_mcu_rom_common::I3cDotLockedRecoveryHandler {
+                            i3c_base,
+                            services: caliptra_mcu_rom_common::I3cServicesModes::DOT_RECOVERY,
+                            i3c_target_addr: 0x5a,
+                        },
+                    )
                 };
                 static mut HANDLER_ENTRIES: core::mem::MaybeUninit<
                     [caliptra_mcu_rom_common::DotLockedRecoveryEntry<'static>; 1],
                 > = core::mem::MaybeUninit::uninit();
                 unsafe {
-                    HANDLER_ENTRIES
-                        .write([caliptra_mcu_rom_common::DotLockedRecoveryEntry {
+                    init_static(
+                        &raw mut HANDLER_ENTRIES,
+                        [caliptra_mcu_rom_common::DotLockedRecoveryEntry {
                             handler,
                             policy: caliptra_mcu_rom_common::DotLockedRecoveryErrorPolicy::Continue,
-                        }])
-                        .as_slice()
+                        }],
+                    )
+                    .as_slice()
                 }
             } else {
                 &[]
@@ -457,7 +483,7 @@ pub extern "C" fn rom_entry() -> ! {
 
     caliptra_mcu_romtime::println!(
         "[mcu-rom] Jumping to firmware at {}",
-        HexWord(MCU_MEMORY_MAP.sram_offset as u32)
+        HexWord(MCU_MEMORY_MAP.sram_offset)
     );
     exit_rom();
 }

--- a/platforms/fpga/rom/src/flash/flash_drv.rs
+++ b/platforms/fpga/rom/src/flash/flash_drv.rs
@@ -105,8 +105,16 @@ impl FlashStorage for FpgaFlashCtrl {
             // Read the page into page_buf
             self.read_page(page_number, &mut page_buf)?;
 
-            buf[buf_offset..buf_offset + to_read]
-                .copy_from_slice(&page_buf.0[page_offset..page_offset + to_read]);
+            let dest = buf
+                .get_mut(buf_offset..buf_offset + to_read)
+                .ok_or(FlashDrvError::INVAL)?;
+            let src = page_buf
+                .0
+                .get(page_offset..page_offset + to_read)
+                .ok_or(FlashDrvError::INVAL)?;
+            for (d, s) in dest.iter_mut().zip(src.iter()) {
+                *d = *s;
+            }
 
             remaining -= to_read;
             buf_offset += to_read;
@@ -137,8 +145,16 @@ impl FlashStorage for FpgaFlashCtrl {
                 FpgaFlashPage::default()
             };
 
-            page_buf.0[page_offset..page_offset + to_write]
-                .copy_from_slice(&buf[buf_offset..buf_offset + to_write]);
+            let dest = page_buf
+                .0
+                .get_mut(page_offset..page_offset + to_write)
+                .ok_or(FlashDrvError::INVAL)?;
+            let src = buf
+                .get(buf_offset..buf_offset + to_write)
+                .ok_or(FlashDrvError::INVAL)?;
+            for (d, s) in dest.iter_mut().zip(src.iter()) {
+                *d = *s;
+            }
 
             self.write_page(page_number, &mut page_buf)?;
 

--- a/platforms/fpga/rom/src/io.rs
+++ b/platforms/fpga/rom/src/io.rs
@@ -44,7 +44,9 @@ pub fn exit_fpga(exit_code: u32) -> ! {
         let b = if exit_code == 0 { 0xff } else { 0x01 };
         core::ptr::write_volatile(FPGA_UART_OUTPUT, b as u32 | 0x100);
     }
-    loop {}
+    loop {
+        core::hint::spin_loop();
+    }
 }
 
 pub struct Exiter {}

--- a/romtime/src/lib.rs
+++ b/romtime/src/lib.rs
@@ -194,5 +194,5 @@ pub fn mcycle() -> u64 {
         value::Register,
         { riscv_csr::csr::MCYCLEH },
     > = riscv_csr::csr::ReadWriteRiscvCsr::new();
-    (mcycleh.get() as u64) << 32 | (mcycle.get() as u64)
+    ((mcycleh.get() as u64) << 32) | (mcycle.get() as u64)
 }

--- a/xtask/src/clippy.rs
+++ b/xtask/src/clippy.rs
@@ -5,11 +5,9 @@ use caliptra_mcu_builder::features::RomVariant;
 use caliptra_mcu_builder::PROJECT_ROOT;
 use std::process::Command;
 
-pub(crate) fn clippy(_rom_variants: &[RomVariant]) -> Result<()> {
+pub(crate) fn clippy(rom_variants: &[RomVariant]) -> Result<()> {
     clippy_all()?;
-    // TODO: extend coverage with `clippy_rom_variants(_rom_variants)`
-    // once each ROM variant is clippy-clean.
-    // Tracked in https://github.com/chipsalliance/caliptra-mcu-sw/issues/1478
+    clippy_rom_variants(rom_variants)?;
     Ok(())
 }
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -141,8 +141,7 @@ enum Commands {
         trace: bool,
     },
     /// Report binary `.text` sizes vs. ROM size budgets across all
-    /// ROM variants (per platform / feature combo). Future expansion:
-    /// runtime kernel and userspace apps.
+    /// ROM variants (per platform / feature combo).
     Sizes {
         /// Output CSV instead of a Unicode table.
         #[arg(long, default_value_t = false)]
@@ -225,10 +224,7 @@ enum Commands {
         variants: Option<String>,
     },
     /// On-demand per-variant clippy pass against
-    /// `mcu-rom-{emulator,fpga}`. Catches lints that the workspace
-    /// clippy pass misses because it only exercises default features.
-    /// Not wired into `precheckin` today — see the TODO in
-    /// `xtask/src/clippy.rs`.
+    /// `mcu-rom-{emulator,fpga}`.
     ClippyRomVariants {
         /// Override the default ROM variant list. See `precheckin
         /// --variants` for the syntax.
@@ -262,6 +258,13 @@ enum Commands {
     HeaderCheck,
     /// Add Apache license header to files where it is missing
     HeaderFix,
+    /// Build each ROM variant and verify it doesn't panic.
+    PanicCheck {
+        /// Override the default ROM variant list. See `precheckin
+        /// --variants` for the syntax.
+        #[arg(long)]
+        variants: Option<String>,
+    },
     /// Run tests (or from an archive)
     Test {
         /// File path to a pre-built test archive
@@ -670,6 +673,9 @@ fn main() {
         Commands::Coverage { analyze_only } => coverage::coverage(*analyze_only),
         Commands::HeaderFix => header::fix(),
         Commands::HeaderCheck => header::check(),
+        Commands::PanicCheck { variants } => {
+            resolve_variants(variants.as_deref()).and_then(|v| test::test_panic_missing(&v))
+        }
         Commands::Test {
             archive,
             shard,

--- a/xtask/src/precheckin.rs
+++ b/xtask/src/precheckin.rs
@@ -44,7 +44,7 @@ pub(crate) fn precheckin(rom_variants: &[RomVariant]) -> Result<()> {
         ..Default::default()
     })?;
 
-    crate::test::test_panic_missing()?;
+    crate::test::test_panic_missing(rom_variants)?;
     crate::test::e2e_tests()?;
     crate::test::test_hello_c_emulator()?;
     crate::rom::build_all_variants(rom_variants)?;

--- a/xtask/src/test.rs
+++ b/xtask/src/test.rs
@@ -1,6 +1,6 @@
 // Licensed under the Apache-2.0 license
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use caliptra_mcu_builder::{rom_build, PROJECT_ROOT, TARGET};
 use std::process::Command;
 
@@ -240,29 +240,26 @@ pub(crate) fn test_hello_c_emulator() -> Result<()> {
     Ok(())
 }
 
-pub(crate) fn test_panic_missing() -> Result<()> {
-    // TODO: switch to iterating `caliptra_mcu_builder::features::ROM_VARIANTS`
-    // once every variant in that list is panic-free. The FPGA ROM and a
-    // few other variants currently pull in slice-index / copy_from_slice
-    // panic paths from their flash drivers, so extending coverage here
-    // would require fixing those panics first.
-    let rom_elf_path = PROJECT_ROOT
-        .join("target")
-        .join(TARGET)
-        .join("release")
-        .join("mcu-rom-emulator");
-
-    // Check default build
-    rom_build(&caliptra_mcu_builder::CaliptraBuildArgs::default())?;
-    check_no_panic(&rom_elf_path, "default")?;
-
-    // Check test-flash-based-boot build
-    rom_build(&caliptra_mcu_builder::CaliptraBuildArgs {
-        features: Some("test-flash-based-boot"),
-        ..Default::default()
-    })?;
-    check_no_panic(&rom_elf_path, "test-flash-based-boot")?;
-
+pub(crate) fn test_panic_missing(
+    variants: &[caliptra_mcu_builder::features::RomVariant],
+) -> Result<()> {
+    for variant in variants {
+        let display = variant.display();
+        println!("Checking ROM panic-freeness for {display}...");
+        let rom_binary = rom_build(&caliptra_mcu_builder::CaliptraBuildArgs {
+            platform: variant.platform,
+            features: variant.features,
+            ..Default::default()
+        })
+        .with_context(|| format!("building ROM variant {display}"))?;
+        // rom_build returns the `.bin`; the bare ELF lives alongside it
+        // under `mcu-rom-<platform>` with no extension.
+        let platform = variant.platform.unwrap_or("emulator");
+        let rom_elf_path = rom_binary
+            .with_file_name(format!("mcu-rom-{platform}"))
+            .with_extension("");
+        check_no_panic(&rom_elf_path, &display)?;
+    }
     Ok(())
 }
 


### PR DESCRIPTION
Fix all per-variant clippy lints and eliminate panic symbols from the FPGA flash driver. Enable per-variant clippy and panic-check for all 11 ROM variants in precheckin.

Add `cargo xtask panic-check` subcommand for ad-hoc use.