### PR TITLE
[rom] default unprovisioned max_svn to 128

### DIFF
--- a/rom/src/rom.rs
+++ b/rom/src/rom.rs
@@ -301,7 +301,9 @@ impl Soc {
         let word = otp
             .read_u32_at(fuses::OTP_CPTRA_CORE_SOC_MANIFEST_MAX_SVN.byte_offset)
             .unwrap_or_else(|_| fatal_error(McuError::ROM_OTP_READ_ERROR));
-        self.registers.fuse_soc_manifest_max_svn.set(word);
+        self.registers
+            .fuse_soc_manifest_max_svn
+            .set(if word == 0 { 128 } else { word });
 
         // Manuf Debug Unlock Token.
         for i in 0..self.registers.fuse_manuf_dbg_unlock_token.len() {

--- a/tests/integration/src/lib.rs
+++ b/tests/integration/src/lib.rs
@@ -559,6 +559,7 @@ mod test {
         caliptra_mcu_hw_model::new(InitParams {
             fuses: Fuses {
                 fuse_pqc_key_type: params.vendor_pqc_type.map(|t| t as u32).unwrap_or(0),
+                soc_manifest_max_svn: 0,
                 vendor_pk_hash,
                 ..Default::default()
             },

--- a/tests/integration/src/rom/mod.rs
+++ b/tests/integration/src/rom/mod.rs
@@ -7,6 +7,7 @@ mod test_lc_ctrl;
 mod test_otp_blank_check;
 mod test_otp_scramble_check;
 mod test_rom_hooks;
+mod test_svn;
 mod test_sw_digest_lock;
 mod test_vendor_key_policy;
 mod test_warm_reset;

--- a/tests/integration/src/rom/test_svn.rs
+++ b/tests/integration/src/rom/test_svn.rs
@@ -1,0 +1,27 @@
+// Licensed under the Apache-2.0 license
+
+#[cfg(test)]
+mod test {
+    use caliptra_api::SocManager;
+    use caliptra_mcu_hw_model::McuHwModel;
+
+    use crate::test::{start_runtime_hw_model, TestParams};
+
+    #[test]
+    fn test_unprovisioned_max_svn() {
+        let mut model = start_runtime_hw_model(TestParams {
+            rom_only: true,
+            ..Default::default()
+        });
+
+        assert_eq!(
+            model
+                .caliptra_soc_manager()
+                .soc_ifc()
+                .fuse_soc_manifest_max_svn()
+                .read()
+                .svn(),
+            128
+        );
+    }
+}


### PR DESCRIPTION
So that an unprovisioned MAX_SVN isn't unbootable with an SVN > 0 and allows for the max_svn to be limited later in product life cycle