### PR TITLE
Implement populate_idev_mldsa87_cert

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2872,6 +2872,7 @@ dependencies = [
 name = "example-app"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "caliptra-api",
  "caliptra-auth-man-types",
  "caliptra-error",

--- a/platforms/emulator/runtime/userspace/apps/example/Cargo.toml
+++ b/platforms/emulator/runtime/userspace/apps/example/Cargo.toml
@@ -7,6 +7,7 @@ authors.workspace = true
 edition.workspace = true
 
 [dependencies]
+async-trait.workspace = true
 caliptra-api.workspace = true
 caliptra-error.workspace = true
 caliptra-auth-man-types.workspace = true

--- a/platforms/emulator/runtime/userspace/apps/example/src/test_caliptra_certs.rs
+++ b/platforms/emulator/runtime/userspace/apps/example/src/test_caliptra_certs.rs
@@ -1,9 +1,17 @@
 // Licensed under the Apache-2.0 license
 
+extern crate alloc;
+
+use alloc::boxed::Box;
+use async_trait::async_trait;
 use caliptra_mcu_libapi_caliptra::certificate::{
     AsymAlgo, CertContext, IDEV_ECC_CSR_MAX_SIZE, KEY_LABEL_SIZE, MAX_ATTESTED_CSR_SIZE,
     MAX_ECC_CERT_SIZE,
 };
+use caliptra_mcu_libsyscall_caliptra::external_otp::ExternalOtp;
+use caliptra_mcu_libsyscall_caliptra::mailbox::PayloadStream;
+use caliptra_mcu_libsyscall_caliptra::DefaultSyscalls;
+use caliptra_mcu_libtock_platform::ErrorCode;
 use caliptra_mcu_romtime::println;
 use caliptra_mcu_romtime::test_exit;
 
@@ -101,6 +109,128 @@ pub async fn test_populate_idev_ecc384_cert() {
         }
     }
     println!("Populate idev cert test completed successfully");
+}
+
+struct OtpPayloadStream {
+    otp: ExternalOtp<DefaultSyscalls>,
+    partition_id: u32,
+    total_size: usize,
+    cursor: usize,
+}
+
+impl OtpPayloadStream {
+    fn new(partition_id: u32, total_size: usize) -> Self {
+        Self {
+            otp: ExternalOtp::new(),
+            partition_id,
+            total_size,
+            cursor: 0,
+        }
+    }
+
+    fn reset(&mut self) {
+        self.cursor = 0;
+    }
+
+    async fn get_bytesum(&mut self) -> Result<u32, ErrorCode> {
+        self.reset();
+        let mut sum = 0u32;
+        let mut buf = [0u8; 256];
+        loop {
+            let n = self.read(&mut buf).await?;
+            if n == 0 {
+                break;
+            }
+            for b in &buf[..n] {
+                sum = sum.wrapping_add(u32::from(*b));
+            }
+        }
+        self.reset();
+        Ok(sum)
+    }
+}
+
+#[async_trait(?Send)]
+impl PayloadStream for OtpPayloadStream {
+    fn size(&self) -> usize {
+        self.total_size
+    }
+
+    async fn read(&mut self, buffer: &mut [u8]) -> Result<usize, ErrorCode> {
+        if self.cursor >= self.total_size || buffer.is_empty() {
+            return Ok(0);
+        }
+
+        let mut written = 0;
+
+        // Read full words while there's room in the buffer and data in the partition
+        while self.cursor + 4 <= self.total_size && written + 4 <= buffer.len() {
+            let word = self
+                .otp
+                .read(self.partition_id, self.cursor as u32)
+                .await
+                .map_err(|_| ErrorCode::Fail)?;
+            buffer[written..written + 4].copy_from_slice(&word.to_le_bytes());
+            written += 4;
+            self.cursor += 4;
+        }
+
+        // Handle tail bytes (remaining bytes < 4)
+        if self.cursor < self.total_size && written < buffer.len() {
+            let tail_len = self.total_size - self.cursor;
+            let word = self
+                .otp
+                .read(self.partition_id, self.cursor as u32)
+                .await
+                .map_err(|_| ErrorCode::Fail)?;
+            let word_bytes = word.to_le_bytes();
+            let n = tail_len.min(buffer.len() - written);
+            buffer[written..written + n].copy_from_slice(&word_bytes[..n]);
+            written += n;
+            self.cursor += n;
+        }
+
+        Ok(written)
+    }
+}
+
+pub async fn test_populate_idev_mldsa87_cert() {
+    println!("Starting Caliptra mailbox populate idev MLDSA cert test");
+
+    const MLDSA_CERT_SIZE: usize = 4627;
+    let mut stream = OtpPayloadStream::new(0x02, MLDSA_CERT_SIZE);
+
+    let bytesum = match stream.get_bytesum().await {
+        Ok(sum) => sum,
+        Err(e) => {
+            println!("Failed to compute MLDSA cert bytesum: {:?}", e);
+            test_exit(1);
+            return;
+        }
+    };
+
+    println!(
+        "Populating idev MLDSA certificate with size: {}, bytesum: 0x{:08x}",
+        MLDSA_CERT_SIZE, bytesum
+    );
+
+    let mut cert_mgr = CertContext::new();
+    let result = cert_mgr
+        .populate_idev_mldsa87_cert(MLDSA_CERT_SIZE, bytesum, &mut stream)
+        .await;
+    match result {
+        Ok(_) => {
+            println!("Successfully populated idev MLDSA certificate");
+        }
+        Err(e) => {
+            println!(
+                "Failed to populate idev MLDSA certificate with error: {:?}",
+                e
+            );
+            test_exit(1);
+        }
+    }
+    println!("Populate idev MLDSA cert test completed successfully");
 }
 
 pub async fn test_get_ldev_ecc384_cert() {

--- a/platforms/emulator/runtime/userspace/apps/user/src/spdm/endorsement_certs/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/spdm/endorsement_certs/mod.rs
@@ -12,7 +12,9 @@ use caliptra_mcu_libapi_caliptra::crypto::asym::AsymAlgo;
 use caliptra_mcu_libapi_caliptra::crypto::hash::{HashAlgoType, HashContext, SHA384_HASH_SIZE};
 use caliptra_mcu_libapi_caliptra::error::CaliptraApiError;
 use caliptra_mcu_libsyscall_caliptra::external_otp::ExternalOtp;
+use caliptra_mcu_libsyscall_caliptra::mailbox::PayloadStream;
 use caliptra_mcu_libsyscall_caliptra::DefaultSyscalls;
+use caliptra_mcu_libtock_platform::ErrorCode;
 use caliptra_mcu_spdm_lib::cert_store::{CertStoreError, CertStoreResult};
 
 // Example implementation of Endorsement cert chain
@@ -69,10 +71,122 @@ async fn populate_idev_cert() -> CertStoreResult<()> {
     Ok(())
 }
 
+#[allow(unused)]
+struct OtpPayloadStream {
+    otp: ExternalOtp<DefaultSyscalls>,
+    partition_id: u32,
+    total_size: usize,
+    cursor: usize,
+}
+
+impl OtpPayloadStream {
+    fn new(partition_id: u32, total_size: usize) -> Self {
+        Self {
+            otp: ExternalOtp::new(),
+            partition_id,
+            total_size,
+            cursor: 0,
+        }
+    }
+
+    fn reset(&mut self) {
+        self.cursor = 0;
+    }
+
+    async fn get_bytesum(&mut self) -> Result<u32, ErrorCode> {
+        self.reset();
+        let mut sum = 0u32;
+        let mut buf = [0u8; 256];
+        loop {
+            let n = self.read(&mut buf).await?;
+            if n == 0 {
+                break;
+            }
+            for b in &buf[..n] {
+                sum = sum.wrapping_add(u32::from(*b));
+            }
+        }
+        self.reset();
+        Ok(sum)
+    }
+}
+
+#[async_trait(?Send)]
+impl PayloadStream for OtpPayloadStream {
+    fn size(&self) -> usize {
+        self.total_size
+    }
+
+    async fn read(&mut self, buffer: &mut [u8]) -> Result<usize, ErrorCode> {
+        if self.cursor >= self.total_size || buffer.is_empty() {
+            return Ok(0);
+        }
+
+        let mut written = 0;
+
+        // Read full words while there's room in the buffer and data in the partition
+        while self.cursor + 4 <= self.total_size && written + 4 <= buffer.len() {
+            let word = self
+                .otp
+                .read(self.partition_id, self.cursor as u32)
+                .await
+                .map_err(|_| ErrorCode::Fail)?;
+            buffer[written..written + 4].copy_from_slice(&word.to_le_bytes());
+            written += 4;
+            self.cursor += 4;
+        }
+
+        // Handle tail bytes (remaining bytes < 4)
+        if self.cursor < self.total_size && written < buffer.len() {
+            let tail_len = self.total_size - self.cursor;
+            let word = self
+                .otp
+                .read(self.partition_id, self.cursor as u32)
+                .await
+                .map_err(|_| ErrorCode::Fail)?;
+            let word_bytes = word.to_le_bytes();
+            let n = tail_len.min(buffer.len() - written);
+            buffer[written..written + n].copy_from_slice(&word_bytes[..n]);
+            written += n;
+            self.cursor += n;
+        }
+
+        Ok(written)
+    }
+}
+
+#[allow(unused)]
+async fn populate_idev_mldsa_cert() -> CertStoreResult<()> {
+    const MLDSA_CERT_SIZE: usize = 4627;
+    let mut stream = OtpPayloadStream::new(0x02, MLDSA_CERT_SIZE);
+
+    let bytesum = stream
+        .get_bytesum()
+        .await
+        .map_err(|_| CertStoreError::CertReadError)?;
+
+    let mut cert_ctx = CertContext::new();
+
+    while let Err(e) = cert_ctx
+        .populate_idev_mldsa87_cert(MLDSA_CERT_SIZE, bytesum, &mut stream)
+        .await
+    {
+        match e {
+            CaliptraApiError::MailboxBusy => {
+                stream.reset();
+                continue;
+            }
+            _ => Err(CertStoreError::CaliptraApi(e))?,
+        }
+    }
+
+    Ok(())
+}
+
 impl EndorsementCertChain<'_> {
     pub async fn new(slot_id: u8) -> CertStoreResult<Self> {
         if slot_id == 0 {
-            // populate signed idev cert into the device.
+            // populate signed idev certs into the device.
             populate_idev_cert().await?;
         }
 

--- a/runtime/userspace/api/caliptra-api/src/certificate.rs
+++ b/runtime/userspace/api/caliptra-api/src/certificate.rs
@@ -11,7 +11,8 @@ use caliptra_api::mailbox::{
     GetRtAliasEcc384CertReq, InvokeDpeReq, InvokeDpeResp, MailboxRespHeader,
     PopulateIdevEcc384CertReq, Request, VarSizeDataResp,
 };
-use caliptra_mcu_libsyscall_caliptra::mailbox::Mailbox;
+use caliptra_mcu_libsyscall_caliptra::mailbox::{Mailbox, MailboxError, PayloadStream};
+use caliptra_mcu_libtock_platform::ErrorCode;
 use dpe::commands::{
     CertifyKeyCommand, CertifyKeyFlags, CertifyKeyP384Cmd, Command, CommandHdr,
     GetCertificateChainCmd, SignCommand, SignFlags, SignP384Cmd,
@@ -94,6 +95,46 @@ impl CertContext {
         let resp_bytes = resp.as_mut_bytes();
 
         execute_mailbox_cmd(&self.mbox, cmd, req_bytes, resp_bytes).await?;
+        Ok(())
+    }
+
+    pub async fn populate_idev_mldsa87_cert(
+        &mut self,
+        cert_size: usize,
+        cert_bytesum: u32,
+        payload: &mut dyn PayloadStream,
+    ) -> CaliptraApiResult<()> {
+        let cmd: u32 = CommandId::POPULATE_IDEV_MLDSA87_CERT.into();
+
+        // Build header: chksum (u32) + cert_size (u32)
+        let cert_size_bytes = (cert_size as u32).to_le_bytes();
+
+        // checksum = 0 - (sum(cmd LE bytes) + sum(header bytes with chksum=0) + sum(cert bytes))
+        let mut sum = cert_bytesum;
+        for b in cmd.to_le_bytes().iter() {
+            sum = sum.wrapping_add(u32::from(*b));
+        }
+        // chksum field is 0 so contributes nothing
+        for b in cert_size_bytes.iter() {
+            sum = sum.wrapping_add(u32::from(*b));
+        }
+        let chksum = 0u32.wrapping_sub(sum);
+
+        let mut header = [0u8; 8];
+        header[..4].copy_from_slice(&chksum.to_le_bytes());
+        header[4..8].copy_from_slice(&cert_size_bytes);
+
+        let mut resp = MailboxRespHeader::default();
+        let resp_bytes = resp.as_mut_bytes();
+
+        self.mbox
+            .execute_with_payload_stream(cmd, Some(&header), payload, resp_bytes)
+            .await
+            .map_err(|e| match e {
+                MailboxError::ErrorCode(ErrorCode::Busy) => CaliptraApiError::MailboxBusy,
+                _ => CaliptraApiError::Mailbox(e),
+            })?;
+
         Ok(())
     }
 


### PR DESCRIPTION

Add support for populating the IDevID MLDSA87 certificate via the
Caliptra mailbox using a streaming payload API. The MLDSA cert (up to
8KB) is too large for the fixed-size mailbox request buffer, so it is
streamed from external OTP using a PayloadStream implementation.

Changes:
- certificate.rs: Add populate_idev_mldsa87_cert() method that builds
  an 8-byte header (checksum + cert_size), computes the checksum from
  the pre-calculated bytesum, and calls execute_with_payload_stream.
- endorsement_certs/mod.rs: Add OtpPayloadStream struct that implements
  PayloadStream by reading word-by-word from ExternalOtp partitions.
  Add populate_idev_mldsa_cert() that reads the MLDSA cert from OTP
  partition 0x02, computes the bytesum, and streams it to the mailbox.
  Integrate into EndorsementCertChain::new() for slot 0.
- test_caliptra_certs.rs: Add test_populate_idev_mldsa87_cert() that
  exercises the streaming cert population path via OTP partition 0x02.