### PR TITLE
mcu-runtime: reduce release-profile kernel image size by ~20 KB

### DIFF
--- a/.github/workflows/fpga.yml
+++ b/.github/workflows/fpga.yml
@@ -150,6 +150,10 @@ jobs:
             --separate-runtimes
           sccache --show-stats
 
+          echo "Cross compiling FPGA release-profile runtime"
+          cargo xtask runtime-build --platform fpga --profile release
+          sccache --show-stats
+
           mkdir -p /tmp/caliptra-binaries
           tar -cvz -f /tmp/caliptra-binaries/caliptra-binaries.tar.gz \
             all-fw.zip

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -349,7 +349,7 @@ capsules-core = { git = "https://github.com/tock/tock.git", rev = "release-2.2" 
 capsules-extra = { git = "https://github.com/tock/tock.git", rev = "release-2.2" }
 capsules-system = { git = "https://github.com/tock/tock.git", rev = "release-2.2" }
 components = { git = "https://github.com/tock/tock.git", rev = "release-2.2" }
-kernel = { git = "https://github.com/tock/tock.git", rev = "release-2.2" , features = ["debug_load_processes"] }
+kernel = { git = "https://github.com/tock/tock.git", rev = "release-2.2" }
 riscv = { git = "https://github.com/tock/tock.git", rev = "release-2.2" }
 riscv-csr = { git = "https://github.com/tock/tock.git", rev = "release-2.2" }
 rv32i = { git = "https://github.com/tock/tock.git", rev = "release-2.2" }

--- a/platforms/emulator/runtime/src/board.rs
+++ b/platforms/emulator/runtime/src/board.rs
@@ -43,7 +43,7 @@ use kernel::process;
 use kernel::scheduler::cooperative::CooperativeSched;
 use kernel::syscall;
 use kernel::utilities::registers::interfaces::ReadWriteable;
-use kernel::{create_capability, debug, static_init};
+use kernel::{create_capability, static_init};
 use rv32i::csr;
 
 // These symbols are defined in the linker script.
@@ -843,11 +843,11 @@ pub unsafe fn main() {
         .modify(csr::mie::mie::mext::SET + csr::mie::mie::msoft::SET + csr::mie::mie::BIT29::SET);
     csr::CSR.mstatus.modify(csr::mstatus::mstatus::mie::SET);
 
-    debug!("MUX MCTP enable");
+    caliptra_mcu_romtime::println!("[mcu-runtime] MUX MCTP enable");
     mux_mctp.enable();
 
-    debug!("MCU initialization complete.");
-    debug!("Entering main loop.");
+    caliptra_mcu_romtime::println!("[mcu-runtime] MCU initialization complete.");
+    caliptra_mcu_romtime::println!("[mcu-runtime] Entering main loop.");
 
     let scheduler =
         components::sched::cooperative::CooperativeComponent::new(&*addr_of!(PROCESSES))
@@ -901,8 +901,8 @@ pub unsafe fn main() {
         &process_mgmt_cap,
     )
     .unwrap_or_else(|err| {
-        debug!("Error loading processes!");
-        debug!("{:?}", err);
+        caliptra_mcu_romtime::println!("[mcu-runtime] Error loading processes!");
+        caliptra_mcu_romtime::println!("{:?}", err);
     });
 
     // Used by flash driver integration tests.
@@ -982,57 +982,57 @@ fn run_kernel_tests(
 
     #[cfg(feature = "test-exit-immediately")]
     {
-        debug!("Executing test-exit-immediately");
+        caliptra_mcu_romtime::println!("Executing test-exit-immediately");
         exit = Some(0);
     }
     #[cfg(feature = "test-i3c-simple")]
     {
-        debug!("Executing test-i3c-simple");
+        caliptra_mcu_romtime::println!("Executing test-i3c-simple");
         exit = crate::tests::i3c_target_test::run_test_i3c_simple();
     }
     #[cfg(feature = "test-i3c-constant-writes")]
     {
-        debug!("Executing test-i3c-constant-writes");
+        caliptra_mcu_romtime::println!("Executing test-i3c-constant-writes");
         exit = crate::tests::i3c_target_test::run_test_i3c_constant_writes();
     }
     #[cfg(feature = "test-flash-ctrl-init")]
     {
-        debug!("Executing test-flash-ctrl-init");
+        caliptra_mcu_romtime::println!("Executing test-flash-ctrl-init");
         exit = crate::tests::flash_ctrl_test::test_flash_ctrl_init();
     }
     #[cfg(feature = "test-flash-ctrl-read-write-page")]
     {
-        debug!("Executing test-flash-ctrl-read-write-page");
+        caliptra_mcu_romtime::println!("Executing test-flash-ctrl-read-write-page");
         exit = crate::tests::flash_ctrl_test::test_flash_ctrl_read_write_page();
     }
     #[cfg(feature = "test-flash-ctrl-erase-page")]
     {
-        debug!("Executing test-flash-ctrl-erase-page");
+        caliptra_mcu_romtime::println!("Executing test-flash-ctrl-erase-page");
         exit = crate::tests::flash_ctrl_test::test_flash_ctrl_erase_page();
     }
     #[cfg(feature = "test-flash-storage-read-write")]
     {
-        debug!("Executing test-flash-storage-read-write");
+        caliptra_mcu_romtime::println!("Executing test-flash-storage-read-write");
         exit = crate::tests::flash_storage_test::test_flash_storage_read_write();
     }
     #[cfg(feature = "test-flash-storage-erase")]
     {
-        debug!("Executing test-flash-storage-erase");
+        caliptra_mcu_romtime::println!("Executing test-flash-storage-erase");
         exit = crate::tests::flash_storage_test::test_flash_storage_erase();
     }
     #[cfg(feature = "test-mcu-rom-flash-access")]
     {
-        debug!("Executing test-mcu-rom-flash-access");
+        caliptra_mcu_romtime::println!("Executing test-mcu-rom-flash-access");
         exit = Some(0);
     }
     #[cfg(feature = "test-doe-transport-loopback")]
     {
-        debug!("Executing test-doe-transport-loopback");
+        caliptra_mcu_romtime::println!("Executing test-doe-transport-loopback");
         exit = crate::tests::doe_transport_test::test_doe_transport_loopback();
     }
     #[cfg(feature = "test-log-flash-circular")]
     {
-        debug!("Executing test-log-flash-circular");
+        caliptra_mcu_romtime::println!("Executing test-log-flash-circular");
         unsafe {
             exit = crate::tests::circular_log_test::run(
                 mux_alarm,
@@ -1042,7 +1042,7 @@ fn run_kernel_tests(
     }
     #[cfg(feature = "test-log-flash-linear")]
     {
-        debug!("Executing test-log-flash-linear");
+        caliptra_mcu_romtime::println!("Executing test-log-flash-linear");
         unsafe {
             exit = crate::tests::linear_log_test::run(
                 mux_alarm,
@@ -1052,23 +1052,23 @@ fn run_kernel_tests(
     }
     #[cfg(feature = "test-mcu-mbox-driver")]
     {
-        debug!("Executing test-mcu-mbox-driver");
+        caliptra_mcu_romtime::println!("Executing test-mcu-mbox-driver");
         exit = crate::tests::mcu_mbox_test::test_mcu_mbox();
     }
     #[cfg(feature = "test-mcu-mbox-soc-requester-loopback")]
     {
-        debug!("Executing test-mcu-mbox-soc-requester-loopback");
+        caliptra_mcu_romtime::println!("Executing test-mcu-mbox-soc-requester-loopback");
         crate::tests::mcu_mbox_driver_loopback_test::test_mcu_mbox_soc_requester_loopback();
     }
 
     #[cfg(feature = "test-mctp-capsule-loopback")]
     {
-        debug!("Executing test-mctp-capsule-loopback");
+        caliptra_mcu_romtime::println!("Executing test-mctp-capsule-loopback");
         crate::tests::mctp_test::test_mctp_capsule_loopback(mux_mctp);
     }
 
     if let Some(exit) = exit {
-        debug!("Exiting with code {}", exit);
+        caliptra_mcu_romtime::println!("[mcu-runtime] Exiting with code {}", exit);
         crate::io::exit_emulator(exit);
     }
 }

--- a/platforms/emulator/runtime/src/io.rs
+++ b/platforms/emulator/runtime/src/io.rs
@@ -5,14 +5,20 @@
 
 #![allow(static_mut_refs)]
 
+#[cfg(not(feature = "release"))]
 use crate::CHIP;
+#[cfg(not(feature = "release"))]
 use crate::PROCESSES;
+#[cfg(not(feature = "release"))]
 use crate::PROCESS_PRINTER;
 use core::cell::Cell;
 use core::fmt::Write;
 use core::panic::PanicInfo;
-use core::ptr::{addr_of, addr_of_mut};
+#[cfg(not(feature = "release"))]
+use core::ptr::addr_of;
+use core::ptr::addr_of_mut;
 use core::ptr::{read_volatile, write_volatile};
+#[cfg(not(feature = "release"))]
 use kernel::debug;
 use kernel::debug::IoWrite;
 use kernel::deferred_call::{DeferredCall, DeferredCallClient};
@@ -26,7 +32,7 @@ pub(crate) static mut WRITER: Writer = Writer {};
 ///
 /// # Safety
 /// Accesses memory-mapped registers.
-#[cfg(not(test))]
+#[cfg(all(not(test), not(feature = "release")))]
 #[no_mangle]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
@@ -39,6 +45,24 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
         &*addr_of!(CHIP),
         &*addr_of!(PROCESS_PRINTER),
     );
+    exit_emulator(1);
+}
+
+/// Panic handler (release build).
+///
+/// # Safety
+/// Accesses memory-mapped registers.
+#[cfg(all(not(test), feature = "release"))]
+#[no_mangle]
+#[panic_handler]
+pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
+    use core::fmt::Write as _;
+    let writer = &mut *addr_of_mut!(WRITER);
+    let _ = writer.write_str("PANIC");
+    if let Some(loc) = pi.location() {
+        let _ = write!(writer, " at {}:{}", loc.file(), loc.line());
+    }
+    let _ = write!(writer, ": {}\n", pi.message());
     exit_emulator(1);
 }
 

--- a/platforms/emulator/runtime/userspace/apps/user/Cargo.toml
+++ b/platforms/emulator/runtime/userspace/apps/user/Cargo.toml
@@ -60,7 +60,10 @@ pcr-quote-measurements = []
 # format paths) is stripped, and forwards to `caliptra-mcu-romtime/no-print`
 # so the romtime `print!`/`println!` macros become no-ops inside user-app's
 # private dependency build of `caliptra-mcu-romtime`.
-release = ["caliptra-mcu-romtime/no-print"]
+release = [
+    "caliptra-mcu-romtime/no-print",
+    "caliptra-mcu-libsyscall-caliptra/release",
+]
 test-caliptra-certs = []
 test-caliptra-crypto = []
 test-caliptra-mailbox = []

--- a/platforms/emulator/runtime/userspace/apps/user/src/firmware_update/flash_staging.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/firmware_update/flash_staging.rs
@@ -87,20 +87,18 @@ impl StagingMemory for SpiFlashStagingMemory {
         }
 
         if images_match {
-            writeln!(
+            crate::console_writeln!(
                 Console::<DefaultSyscalls>::writer(),
                 "[FW Upd] Staging matches Partition A, skipping copy"
-            )
-            .unwrap();
+            );
             return Ok(());
         }
 
-        writeln!(
+        crate::console_writeln!(
             Console::<DefaultSyscalls>::writer(),
             "[FW Upd] Copying image from staging to Partition A, length {}",
             img_sz
-        )
-        .unwrap();
+        );
 
         // Erase Partition A before writing
         part_a_flash.erase(0, img_sz).await?;

--- a/platforms/emulator/runtime/userspace/apps/user/src/firmware_update/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/firmware_update/mod.rs
@@ -92,7 +92,7 @@ pub async fn firmware_update<D: DMAMapping>(dma_mapping: &D) -> Result<(), Error
         updater.set_skip_activation(true);
         updater.set_verify_same_image(true);
         updater.start().await?;
-        writeln!(console_writer, "[FW Upd] Flash write-back complete").unwrap();
+        crate::console_writeln!(console_writer, "[FW Upd] Flash write-back complete");
         return Ok(());
     }
 

--- a/platforms/emulator/runtime/userspace/apps/user/src/main.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/main.rs
@@ -12,29 +12,10 @@ use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 #[allow(unused)]
 use embassy_sync::{lazy_lock::LazyLock, signal::Signal};
 
-/// Console `writeln!` that compiles to a no-op in `release` cargo-feature
-/// builds (i.e. the shipping `--profile release` build that auto-enables
-/// `--features release`).  In `devel` builds the macro is a real `writeln!`,
-/// preserving every diagnostic and informational message.
-///
-/// The `release` arm expands to a never-called closure so its arguments are
-/// type-checked (no unused-var warnings, formatting traits satisfied) but the
-/// closure body is unreachable.  LTO + lld `--gc-sections` strip the format
-/// strings, any `Debug` impls reached via `{:?}`, and the entire console
-/// syscall path from the binary.
-#[macro_export]
-macro_rules! console_writeln {
-    ($($arg:tt)*) => {{
-        #[cfg(not(feature = "release"))]
-        {
-            let _ = ::core::writeln!($($arg)*);
-        }
-        #[cfg(feature = "release")]
-        {
-            let _ = || -> ::core::fmt::Result { ::core::writeln!($($arg)*) };
-        }
-    }};
-}
+// Re-export the shared `console_writeln!` from libsyscall-caliptra so existing
+// `crate::console_writeln!(...)` call sites in this crate continue to resolve.
+#[allow(unused_imports)]
+pub use caliptra_mcu_libsyscall_caliptra::console_writeln;
 
 mod caliptra_cmd_handler;
 #[cfg(any(

--- a/platforms/emulator/runtime/userspace/apps/user/src/spdm/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/spdm/mod.rs
@@ -49,7 +49,7 @@ fn log_spdm_err<W: Write>(w: &mut W, prefix: &str, msg: &str, e: &SpdmError) {
     let path = e.error_code();
     let ext = e.ext_code();
     if ext != 0 {
-        writeln!(
+        crate::console_writeln!(
             w,
             "{}: {}: {} 0x{:08x} ext=0x{:08x}",
             prefix,
@@ -57,10 +57,9 @@ fn log_spdm_err<W: Write>(w: &mut W, prefix: &str, msg: &str, e: &SpdmError) {
             e.category(),
             path,
             ext
-        )
-        .unwrap();
+        );
     } else {
-        writeln!(w, "{}: {}: {} 0x{:08x}", prefix, msg, e.category(), path).unwrap();
+        crate::console_writeln!(w, "{}: {}: {} 0x{:08x}", prefix, msg, e.category(), path);
     }
 }
 
@@ -87,20 +86,18 @@ pub(crate) async fn spdm_task(spawner: Spawner) {
     init_target_env_claims();
 
     if spawner.spawn(spdm_mctp_responder()).is_err() {
-        writeln!(
+        crate::console_writeln!(
             console_writer,
             "SPDM_TASK: Failed to spawn spdm_mctp_responder"
-        )
-        .unwrap();
+        );
     }
 
     #[cfg(feature = "doe")]
     if spawner.spawn(spdm_doe_responder()).is_err() {
-        writeln!(
+        crate::console_writeln!(
             console_writer,
             "SPDM_TASK: Failed to spawn spdm_doe_responder"
-        )
-        .unwrap();
+        );
     }
 }
 

--- a/platforms/fpga/runtime/src/board.rs
+++ b/platforms/fpga/runtime/src/board.rs
@@ -38,7 +38,7 @@ use kernel::process;
 use kernel::scheduler::cooperative::CooperativeSched;
 use kernel::syscall;
 use kernel::utilities::registers::interfaces::ReadWriteable;
-use kernel::{create_capability, debug, static_init};
+use kernel::{create_capability, static_init};
 use rv32i::csr;
 
 // These symbols are defined in the linker script.
@@ -130,7 +130,9 @@ struct VeeR {
         'static,
         VirtualMuxAlarm<'static, InternalTimers<'static>>,
     >,
+    #[cfg_attr(feature = "release", allow(dead_code))]
     console: Option<&'static capsules_core::console::Console<'static>>,
+    #[cfg_attr(feature = "release", allow(dead_code))]
     lldb: Option<
         &'static capsules_core::low_level_debug::LowLevelDebug<
             'static,
@@ -176,9 +178,11 @@ impl SyscallDriverLookup for VeeR {
     {
         match driver_num {
             capsules_core::alarm::DRIVER_NUM => f(Some(self.alarm)),
+            #[cfg(not(feature = "release"))]
             capsules_core::console::DRIVER_NUM => f(self
                 .console
                 .map(|c| c as &dyn kernel::syscall::SyscallDriver)),
+            #[cfg(not(feature = "release"))]
             capsules_core::low_level_debug::DRIVER_NUM => {
                 f(self.lldb.map(|l| l as &dyn kernel::syscall::SyscallDriver))
             }
@@ -810,11 +814,11 @@ pub unsafe fn main() {
         .modify(csr::mie::mie::mext::SET + csr::mie::mie::msoft::SET + csr::mie::mie::BIT29::SET);
     csr::CSR.mstatus.modify(csr::mstatus::mstatus::mie::SET);
 
-    debug!("MUX MCTP enable");
+    caliptra_mcu_romtime::println!("MUX MCTP enable");
     mux_mctp.enable();
 
-    debug!("MCU initialization complete.");
-    debug!("Entering main loop.");
+    caliptra_mcu_romtime::println!("MCU initialization complete.");
+    caliptra_mcu_romtime::println!("Entering main loop.");
 
     let scheduler =
         components::sched::cooperative::CooperativeComponent::new(&*addr_of!(PROCESSES))
@@ -868,8 +872,8 @@ pub unsafe fn main() {
         &process_mgmt_cap,
     )
     .unwrap_or_else(|err| {
-        debug!("Error loading processes!");
-        debug!("{:?}", err);
+        caliptra_mcu_romtime::println!("Error loading processes!");
+        caliptra_mcu_romtime::println!("{:?}", err);
     });
 
     #[cfg(any(
@@ -891,23 +895,23 @@ pub unsafe fn main() {
     let mut exit: Option<u32> = None;
     #[cfg(feature = "test-exit-immediately")]
     {
-        debug!("Executing test-exit-immediately");
+        caliptra_mcu_romtime::println!("Executing test-exit-immediately");
         exit = Some(0);
     }
     #[cfg(feature = "test-i3c-simple")]
     {
-        debug!("Executing test-i3c-simple");
+        caliptra_mcu_romtime::println!("Executing test-i3c-simple");
         exit = crate::tests::i3c_target_test::run_test_i3c_simple();
     }
     #[cfg(feature = "test-i3c-constant-writes")]
     {
-        debug!("Executing test-i3c-constant-writes");
+        caliptra_mcu_romtime::println!("Executing test-i3c-constant-writes");
         exit = crate::tests::i3c_target_test::run_test_i3c_constant_writes();
     }
 
     #[cfg(feature = "test-mctp-capsule-loopback")]
     {
-        debug!("Executing test-mctp-capsule-loopback");
+        caliptra_mcu_romtime::println!("Executing test-mctp-capsule-loopback");
         crate::tests::mctp_test::test_mctp_capsule_loopback(mux_mctp);
     }
 

--- a/platforms/fpga/runtime/src/io.rs
+++ b/platforms/fpga/runtime/src/io.rs
@@ -5,15 +5,21 @@
 
 #![allow(static_mut_refs)]
 
+#[cfg(not(feature = "release"))]
 use crate::CHIP;
+#[cfg(not(feature = "release"))]
 use crate::PROCESSES;
+#[cfg(not(feature = "release"))]
 use crate::PROCESS_PRINTER;
 use caliptra_mcu_tock_veer::timers::InternalTimers;
 use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use core::cell::Cell;
 use core::fmt::Write;
 use core::panic::PanicInfo;
-use core::ptr::{addr_of, addr_of_mut};
+#[cfg(not(feature = "release"))]
+use core::ptr::addr_of;
+use core::ptr::addr_of_mut;
+#[cfg(not(feature = "release"))]
 use kernel::debug;
 use kernel::debug::IoWrite;
 use kernel::deferred_call::{DeferredCall, DeferredCallClient};
@@ -29,7 +35,7 @@ const FPGA_UART_OUTPUT: *mut u32 = 0xa401_1014 as *mut u32;
 ///
 /// # Safety
 /// Accesses memory-mapped registers.
-#[cfg(not(test))]
+#[cfg(all(not(test), not(feature = "release")))]
 #[no_mangle]
 #[panic_handler]
 pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
@@ -42,6 +48,24 @@ pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
         &*addr_of!(CHIP),
         &*addr_of!(PROCESS_PRINTER),
     );
+    exit_fpga(1);
+}
+
+/// Panic handler (release build).
+///
+/// # Safety
+/// Accesses memory-mapped registers.
+#[cfg(all(not(test), feature = "release"))]
+#[no_mangle]
+#[panic_handler]
+pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
+    use core::fmt::Write as _;
+    let writer = &mut *addr_of_mut!(WRITER);
+    let _ = writer.write_str("PANIC");
+    if let Some(loc) = pi.location() {
+        let _ = write!(writer, " at {}:{}", loc.file(), loc.line());
+    }
+    let _ = write!(writer, ": {}\n", pi.message());
     exit_fpga(1);
 }
 

--- a/runtime/kernel/veer/src/chip.rs
+++ b/runtime/kernel/veer/src/chip.rs
@@ -17,7 +17,6 @@ use caliptra_mcu_registers_generated::otp_ctrl;
 use capsules_core::virtualizers::virtual_alarm::MuxAlarm;
 use core::fmt::Write;
 use core::ptr::addr_of;
-use kernel::debug;
 use kernel::platform::chip::{Chip, InterruptService};
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable};
 use kernel::utilities::StaticRef;
@@ -113,7 +112,7 @@ impl<'a> InterruptService for VeeRDefaultPeripherals<'a> {
             self.mcu_mbox0.handle_interrupt();
             return true;
         }
-        debug!("Unhandled interrupt {}", interrupt);
+        let _ = interrupt;
         false
     }
 }
@@ -150,7 +149,7 @@ impl<'a, I: InterruptService + 'a> VeeR<'a, I> {
     unsafe fn handle_pic_interrupts(&self) {
         while let Some(interrupt) = self.pic.get_saved_interrupts() {
             if !self.peripherals.service_interrupt(interrupt) {
-                panic!("Unhandled interrupt {}", interrupt);
+                panic!("Unhandled interrupt");
             }
             self.atomic(|| {
                 // Safe as interrupts are disabled

--- a/runtime/userspace/api/caliptra-api/src/firmware_update/mod.rs
+++ b/runtime/userspace/api/caliptra-api/src/firmware_update/mod.rs
@@ -22,6 +22,7 @@ use caliptra_mcu_flash_image::{
     FlashHeader, ImageHeader, CALIPTRA_FMC_RT_IDENTIFIER, MCU_RT_IDENTIFIER,
     SOC_MANIFEST_IDENTIFIER,
 };
+use caliptra_mcu_libsyscall_caliptra::console_writeln;
 use caliptra_mcu_libsyscall_caliptra::dma::AXIAddr;
 use caliptra_mcu_libsyscall_caliptra::dma::{
     DMAMapping, DMASource, DMATransaction, DMA as DMASyscall,
@@ -209,11 +210,10 @@ impl<'a, D: DMAMapping> FirmwareUpdater<'a, D> {
             .map_err(|_| ErrorCode::Fail)?;
         let (flash_header, _) =
             FlashHeader::read_from_prefix(&flash_header).map_err(|_| ErrorCode::Fail)?;
-        writeln!(
+        console_writeln!(
             Console::<DefaultSyscalls>::writer(),
             "[FW Upd] Setting Manifest"
-        )
-        .unwrap();
+        );
         let (manifest_offset, manifest_len) = self
             .get_image_toc(
                 flash_header.image_count as usize,
@@ -273,13 +273,12 @@ impl<'a, D: DMAMapping> FirmwareUpdater<'a, D> {
         flash_header.verify().then_some(()).ok_or(ErrorCode::Fail)?;
 
         // Verify Caliptra bundle
-        writeln!(
+        console_writeln!(
             Console::<DefaultSyscalls>::writer(),
             "[FW Upd] Verifying Caliptra Bundle (image_count={} headers_off={})",
             flash_header.image_count,
             flash_header.image_headers_offset
-        )
-        .unwrap();
+        );
         let toc_result = self
             .get_image_toc(
                 flash_header.image_count as usize,
@@ -288,21 +287,19 @@ impl<'a, D: DMAMapping> FirmwareUpdater<'a, D> {
             )
             .await;
         if toc_result.is_err() {
-            writeln!(
+            console_writeln!(
                 Console::<DefaultSyscalls>::writer(),
                 "[FW Upd] ERROR: get_image_toc for Caliptra bundle failed"
-            )
-            .unwrap();
+            );
             return Err(ErrorCode::Fail);
         }
         let (cptra_image_offset, cptra_image_len) = toc_result.unwrap();
-        writeln!(
+        console_writeln!(
             Console::<DefaultSyscalls>::writer(),
             "[FW Upd] Caliptra bundle at offset={} len={}",
             cptra_image_offset,
             cptra_image_len
-        )
-        .unwrap();
+        );
         let verify_result = self
             .process_caliptra_fw(
                 cptra_image_offset,
@@ -311,20 +308,18 @@ impl<'a, D: DMAMapping> FirmwareUpdater<'a, D> {
             )
             .await;
         if verify_result.is_err() {
-            writeln!(
+            console_writeln!(
                 Console::<DefaultSyscalls>::writer(),
                 "[FW Upd] ERROR: process_caliptra_fw(Verify) failed"
-            )
-            .unwrap();
+            );
             return Err(ErrorCode::Fail);
         }
 
         // Verify the new Auth Manifest
-        writeln!(
+        console_writeln!(
             Console::<DefaultSyscalls>::writer(),
             "[FW Upd] Verifying Manifest"
-        )
-        .unwrap();
+        );
         let (manifest_offset, manifest_len) = self
             .get_image_toc(
                 flash_header.image_count as usize,
@@ -381,11 +376,10 @@ impl<'a, D: DMAMapping> FirmwareUpdater<'a, D> {
         &mut self,
         flash_header: &FlashHeader,
     ) -> Result<(), ErrorCode> {
-        writeln!(
+        console_writeln!(
             Console::<DefaultSyscalls>::writer(),
             "[FW Upd] Verifying image matches running firmware"
-        )
-        .unwrap();
+        );
 
         // 1. Verify Caliptra FMC+RT digests
         let (cptra_image_offset, _cptra_image_len) = self
@@ -426,21 +420,19 @@ impl<'a, D: DMAMapping> FirmwareUpdater<'a, D> {
 
         // Compare FMC digests
         if manifest.fmc.digest != fw_info.fmc_sha384_digest {
-            writeln!(
+            console_writeln!(
                 Console::<DefaultSyscalls>::writer(),
                 "[FW Upd] FMC digest mismatch"
-            )
-            .unwrap();
+            );
             return Err(ErrorCode::Fail);
         }
 
         // Compare RT digests
         if manifest.runtime.digest != fw_info.runtime_sha384_digest {
-            writeln!(
+            console_writeln!(
                 Console::<DefaultSyscalls>::writer(),
                 "[FW Upd] RT digest mismatch"
-            )
-            .unwrap();
+            );
             return Err(ErrorCode::Fail);
         }
 
@@ -500,21 +492,19 @@ impl<'a, D: DMAMapping> FirmwareUpdater<'a, D> {
                 .get_image_metadata(manifest_offset, manifest_len, image_header.identifier)
                 .await?;
             if hash != metadata.digest {
-                writeln!(
+                console_writeln!(
                     Console::<DefaultSyscalls>::writer(),
                     "[FW Upd] Image 0x{:x} digest mismatch with running firmware",
                     image_header.identifier
-                )
-                .unwrap();
+                );
                 return Err(ErrorCode::Fail);
             }
         }
 
-        writeln!(
+        console_writeln!(
             Console::<DefaultSyscalls>::writer(),
             "[FW Upd] Running image verification passed"
-        )
-        .unwrap();
+        );
         Ok(())
     }
 
@@ -590,12 +580,11 @@ impl<'a, D: DMAMapping> FirmwareUpdater<'a, D> {
                 Ok(_) => break,
                 Err(MailboxError::ErrorCode(ErrorCode::Busy)) => continue,
                 Err(_) => {
-                    writeln!(
+                    console_writeln!(
                         Console::<DefaultSyscalls>::writer(),
                         "[FW Upd] ERROR: mailbox cmd={} failed",
                         cmd
-                    )
-                    .unwrap();
+                    );
                     return Err(ErrorCode::Fail);
                 }
             }
@@ -604,24 +593,22 @@ impl<'a, D: DMAMapping> FirmwareUpdater<'a, D> {
             let resp =
                 FirmwareVerifyResp::ref_from_bytes(response_buffer).map_err(|_| ErrorCode::Fail)?;
             if resp.verify_result != FirmwareVerifyResult::Success as u32 {
-                writeln!(
+                console_writeln!(
                     Console::<DefaultSyscalls>::writer(),
                     "[FW Upd] ERROR: FIRMWARE_VERIFY result={} (expected {})",
                     resp.verify_result,
                     FirmwareVerifyResult::Success as u32
-                )
-                .unwrap();
+                );
                 return Err(ErrorCode::Fail);
             }
         }
         Ok(())
     }
     async fn update_caliptra(&mut self, flash_header: &FlashHeader) -> Result<(), ErrorCode> {
-        writeln!(
+        console_writeln!(
             Console::<DefaultSyscalls>::writer(),
             "[FW Upd] Updating Caliptra"
-        )
-        .unwrap();
+        );
         let (image_offset, image_len) = self
             .get_image_toc(
                 flash_header.image_count as usize,
@@ -787,11 +774,10 @@ impl<'a, D: DMAMapping> FirmwareUpdater<'a, D> {
     }
 
     async fn update_mcu(&mut self, flash_header: &FlashHeader) -> Result<(), ErrorCode> {
-        writeln!(
+        console_writeln!(
             Console::<DefaultSyscalls>::writer(),
             "[FW Upd] Updating MCU"
-        )
-        .unwrap();
+        );
         let (mcu_image_offset, mcu_image_len) = self
             .get_image_toc(
                 flash_header.image_count as usize,

--- a/runtime/userspace/api/mctp-vdm-lib/src/daemon.rs
+++ b/runtime/userspace/api/mctp-vdm-lib/src/daemon.rs
@@ -1,6 +1,7 @@
 // Licensed under the Apache-2.0 license
 
 use crate::cmd_interface::CmdInterface;
+use caliptra_mcu_libsyscall_caliptra::console_writeln;
 use caliptra_mcu_libsyscall_caliptra::DefaultSyscalls;
 use caliptra_mcu_libtock_console::Console;
 use core::fmt::Write;
@@ -86,12 +87,11 @@ pub async fn vdm_responder(
     while running.load(Ordering::SeqCst) {
         if let Err(e) = cmd_interface.handle_responder_msg(&mut msg_buffer).await {
             // Debug print on error
-            writeln!(
+            console_writeln!(
                 Console::<DefaultSyscalls>::writer(),
                 "vdm_responder error: {:?}",
                 e
-            )
-            .unwrap();
+            );
         }
     }
 }

--- a/runtime/userspace/api/mcu-mbox-lib/src/daemon.rs
+++ b/runtime/userspace/api/mcu-mbox-lib/src/daemon.rs
@@ -3,6 +3,7 @@
 use crate::cmd_interface::CmdInterface;
 use crate::transport::McuMboxTransport;
 use caliptra_mcu_common_commands::{CaliptraCmdHandler, CommandAuthorizer};
+use caliptra_mcu_libsyscall_caliptra::console_writeln;
 use caliptra_mcu_libsyscall_caliptra::DefaultSyscalls;
 use caliptra_mcu_libtock_console::Console;
 use caliptra_mcu_mbox_common::messages::{McuMailboxReq, McuMailboxResp};
@@ -90,12 +91,11 @@ pub async fn mcu_mbox_responder(
             .await
         {
             // Debug print on error
-            writeln!(
+            console_writeln!(
                 Console::<DefaultSyscalls>::writer(),
                 "mcu_mbox_responder error: {:?}",
                 e
-            )
-            .unwrap();
+            );
         }
     }
 }

--- a/runtime/userspace/api/pldm-lib/src/daemon.rs
+++ b/runtime/userspace/api/pldm-lib/src/daemon.rs
@@ -7,6 +7,7 @@ use crate::firmware_device::fd_ops::FdOps;
 use crate::firmware_device::transfer_session::TransferSession;
 use crate::timer::AsyncAlarm;
 use crate::transport::MctpTransport;
+use caliptra_mcu_libsyscall_caliptra::console_writeln;
 use caliptra_mcu_libsyscall_caliptra::mctp::driver_num;
 use caliptra_mcu_libsyscall_caliptra::DefaultSyscalls;
 use caliptra_mcu_libtock_console::Console;
@@ -182,12 +183,11 @@ pub async fn pldm_initiator(
                         }
                     }
                     Err(e) => {
-                        writeln!(
+                        console_writeln!(
                             console_writer,
                             "PLDM_APP: Error in optimized download: {:?}",
                             e
-                        )
-                        .unwrap();
+                        );
                         // Sync and fall back to regular path
                         cmd_interface.sync_transfer_session(sess).await;
                         session = None;
@@ -217,12 +217,11 @@ pub async fn pldm_initiator(
                         }
                     }
                     Err(e) => {
-                        writeln!(
+                        console_writeln!(
                             console_writer,
                             "PLDM_APP: Error handling initiator msg: {:?}",
                             e
-                        )
-                        .unwrap();
+                        );
                     }
                 }
 
@@ -251,12 +250,11 @@ pub async fn pldm_responder(
             Ok(crate::cmd_interface::ResponderAction::Complete) => break,
             Ok(crate::cmd_interface::ResponderAction::Continue) => {}
             Err(e) => {
-                writeln!(
+                console_writeln!(
                     console_writer,
                     "PLDM_APP: Error handling responder msg: {:?}",
                     e
-                )
-                .unwrap();
+                );
             }
         }
 

--- a/runtime/userspace/syscall/Cargo.toml
+++ b/runtime/userspace/syscall/Cargo.toml
@@ -19,3 +19,11 @@ caliptra-mcu-registers-generated.workspace = true
 
 [target.'cfg(not(target_arch = "riscv32"))'.dependencies]
 caliptra-mcu-libtock_unittest.workspace = true
+
+[features]
+default = []
+# Strip `console_writeln!` macro bodies from this crate's transitive consumers
+# in shipping builds.  Activated automatically by `xtask runtime-build
+# --profile release` via feature unification through user-app's `release`
+# feature.
+release = []

--- a/runtime/userspace/syscall/src/lib.rs
+++ b/runtime/userspace/syscall/src/lib.rs
@@ -21,3 +21,30 @@ pub type DefaultSyscalls = caliptra_mcu_libtock_runtime::TockSyscalls;
 
 #[cfg(not(target_arch = "riscv32"))]
 pub type DefaultSyscalls = caliptra_mcu_libtock_unittest::fake::Syscalls;
+
+/// `writeln!` to a `core::fmt::Write` sink that is stripped in `release` builds.
+///
+/// In default (devel) builds expands to `let _ = ::core::writeln!($($arg)*);`.
+/// With this crate's `feature = "release"` the expansion is a never-called
+/// closure so the format arguments are still type-checked but LTO +
+/// `--gc-sections` drop the format strings, any `Debug`/`Display` impls
+/// reached via `{:?}`/`{}`, and the Tock console syscall path from the
+/// linked binary.
+///
+/// The cfg is evaluated when this crate is built, so consumers do not need a
+/// `release` feature of their own — they only need to import the macro.
+#[cfg(not(feature = "release"))]
+#[macro_export]
+macro_rules! console_writeln {
+    ($($arg:tt)*) => {{
+        let _ = ::core::writeln!($($arg)*);
+    }};
+}
+
+#[cfg(feature = "release")]
+#[macro_export]
+macro_rules! console_writeln {
+    ($($arg:tt)*) => {{
+        let _ = || -> ::core::fmt::Result { ::core::writeln!($($arg)*) };
+    }};
+}


### PR DESCRIPTION
## Summary

Shrink the MCU runtime kernel image for `--profile release` builds. Measured against mainline `96aeca18` (`llvm-size .text` on the kernel ELF; `.bin` on disk):

| Platform | Mainline | This PR | Delta |
| --- | --- | --- | --- |
| FPGA kernel `.text` | 107 780 | 87 200 | **−20 580 B (−19.1%)** |
| Emu kernel `.text` | 110 424 | 91 940 | **−18 484 B (−16.7%)** |
| FPGA `.bin` | 286 720 | 263 168 | −23 552 B (−8.2%) |
| Emu `.bin` | 286 720 | 267 264 | −19 456 B (−6.8%) |

All changes are gated behind the existing `release` cargo feature (auto-enabled when building with `cargo xtask runtime-build --profile release`). The default `devel` profile is unaffected.

## Changes

### Kernel

- `Cargo.toml`: drop `debug_load_processes` from the Tock `kernel` dependency. Removes the formatting reachable from `process_loading.rs` / `process_binary.rs`.
- `runtime/kernel/veer/src/chip.rs`: drop unused `kernel::debug` import; replace the formatted `panic!("Unhandled interrupt {}", interrupt)` in `handle_pic_interrupts` with a non-formatted `panic!("Unhandled interrupt")`, and replace the unhandled-interrupt `debug!` in `service_interrupt` with `let _ = interrupt;` (callers already get `false` back, which is the meaningful signal).
- `platforms/{emulator,fpga}/runtime/src/io.rs`: add a minimal release `panic_fmt` that prints `PANIC at <file>:<line>: <msg>` and exits, bypassing the kernel `debug::panic_print` chain (CHIP / PROCESSES / PROCESS_PRINTER / UART formatting tree). `#[cfg(not(feature = "release"))]`-gate the imports that only the non-release variant needs.
- `platforms/{emulator,fpga}/runtime/src/board.rs`: swap the remaining test-arm and boot-trace `debug!()` calls to `caliptra_mcu_romtime::println!()` so the romtime `no-print` feature can strip them; drop `debug` from `use kernel::{...}`.
- `platforms/fpga/runtime/src/board.rs`: `#[cfg(not(feature = "release"))]` the `Console` / `LowLevelDebug` `SyscallDriverLookup` match arms and `#[cfg_attr(feature = "release", allow(dead_code))]` the corresponding `VeeR` fields.

### Userspace

- `runtime/userspace/syscall/src/lib.rs`: relocate the `console_writeln!` macro from the `apps/user` binary into `libsyscall-caliptra` so userspace API libraries can use it. The release-feature variant is a no-op; the non-release variant forwards to `writeln!(...)` and discards the result, so a missing/gated Console syscall driver becomes a silent no-op rather than a process-killing `.unwrap()` panic.
- `runtime/userspace/syscall/Cargo.toml`: add `release` feature.
- `platforms/emulator/runtime/userspace/apps/user/Cargo.toml`: thread `release` through to `caliptra-mcu-libsyscall-caliptra`.
- `platforms/emulator/runtime/userspace/apps/user/src/main.rs`: remove the local `console_writeln!` macro and re-export the relocated one for `crate::console_writeln!` call sites.
- Migrate 27 `writeln!(Console::<DefaultSyscalls>::writer(), …).unwrap()` sites to `console_writeln!(...)`:
  - `runtime/userspace/api/caliptra-api/src/firmware_update/mod.rs`
  - `runtime/userspace/api/mcu-mbox-lib/src/daemon.rs`
  - `runtime/userspace/api/mctp-vdm-lib/src/daemon.rs`
  - `runtime/userspace/api/pldm-lib/src/daemon.rs`
  - `platforms/emulator/runtime/userspace/apps/user/src/{spdm/mod.rs, firmware_update/{mod.rs, flash_staging.rs}}`

### CI

- `.github/workflows/fpga.yml`: add a release-profile FPGA runtime build step to exercise the new path.

## Validation

- `cargo xtask runtime-build --platform {fpga,emulator} --profile release` — clean.
- Emulator end-to-end boot under `--profile release` — runs past Caliptra cold-reset and MCU runtime download with no panic.
- Real-FPGA `test_mcu_mbox_cmds` with release-profile artifacts — boots through Caliptra cold-reset, MCU ROM firmware load, and reaches the runtime mailbox-handling phase. (A pre-rebase run reproduced the `processbuffer.rs:786` mailbox tail-word panic that was already fixed upstream by #1492; rebased onto current `main` and re-validated.)

## Notes for reviewers

- Header line of `panic_fmt`: always prints the message after the location-or-bare-`PANIC` prefix (`PANIC at <file>:<line>: <msg>\n`, or `PANIC: <msg>\n` when location is `None`). If the no-location case should be exactly `PANIC\n` instead, happy to switch — flag in review.
- The `LowLevelDebug` / `Console` / `ProcessConsole` / `ProcessPrinter` capsule gating that this PR builds on top of was already in mainline. This PR closes the remaining reachability that kept the kernel formatting/debug chain linked in release builds.
- `romtime/src/lib.rs` is intentionally not modified — the existing `no-print` feature is already sufficient once `board.rs`/`chip.rs` route through `romtime::println!`.
