### PR TITLE
rom: introduce MCU ROM patching preview stub

### DIFF
--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -493,6 +493,26 @@ impl McuError {
             "Caliptra runtime SVN fuse burn failed"
         ),
         (
+            ROM_PATCH_SOURCE_READ_ERROR,
+            0x6_0000,
+            "Reading the patch payload from the patch source (OTP/eFuse) failed"
+        ),
+        (
+            ROM_PATCH_AUTH_ERROR,
+            0x6_0001,
+            "Patch payload failed authentication"
+        ),
+        (
+            ROM_PATCH_MALFORMED,
+            0x6_0002,
+            "Patch structural validation failed (header, opcode, terminator)"
+        ),
+        (
+            ROM_PATCH_ADDRESS_OUT_OF_RANGE,
+            0x6_0003,
+            "Patch operation targets an address outside the legal range"
+        ),
+        (
             GENERIC_EXCEPTION,
             0xF_0000,
             "Machine level exception was encountered during ROM execution"

--- a/rom/src/lib.rs
+++ b/rom/src/lib.rs
@@ -34,6 +34,7 @@ mod hooks;
 pub use hooks::*;
 pub mod image_verifier;
 pub use image_verifier::ImageVerifier;
+pub mod patch;
 mod rom;
 pub use rom::*;
 mod rom_env;

--- a/rom/src/patch.rs
+++ b/rom/src/patch.rs
@@ -1,0 +1,150 @@
+/*++
+
+Licensed under the Apache-2.0 license.
+
+File Name:
+
+    patch.rs
+
+Abstract:
+
+    Preview API surface for MCU ROM patching. The patcher consumes a patch
+    payload stored in OTP/eFuse, authenticates it, and applies the contained
+    in-place overwrites and appended bodies to the in-RAM copy of the ROM
+    image before normal ROM execution begins. The full design is tracked in
+    upstream RFC chipsalliance/caliptra-sw#3399 and discussed in this PR's
+    description; the body of this module is intentionally a set of TODO
+    stubs so that the API shape can be reviewed before any implementation
+    lands.
+
+--*/
+
+#![allow(dead_code)]
+
+use caliptra_mcu_error::McuResult;
+
+/// Opcodes that may appear in a patch binary.
+///
+/// The numeric encodings below are placeholders; final values are
+/// implementation-defined and will be locked once the patch format is
+/// finalized. The *set* of operations is expected to remain stable: a
+/// start header, an end header, in-place overwrites of the (RAM-copied)
+/// instruction and data regions, and an append operation that carries the
+/// patched function bodies (and any other supplementary code or data)
+/// referenced by the overwrites.
+#[repr(u32)]
+pub enum PatchOpcode {
+    /// Start-of-patch header. First word of every patch.
+    StartHdr = 0x0,
+    /// In-place overwrite of one or more words in the instruction region of
+    /// the (RAM-copied) ROM image. Typical use: replace the first instruction
+    /// of a buggy function with an unconditional branch to a patched body
+    /// emitted via [`PatchOpcode::Append`].
+    OverwriteInstRam = 0x1,
+    /// In-place overwrite of one or more words in the data region of the
+    /// (RAM-copied) ROM image.
+    OverwriteDataRam = 0x2,
+    /// Patched function body (or other supplementary code/data) appended after
+    /// the (RAM-copied) ROM image and reached via a branch installed by
+    /// [`PatchOpcode::OverwriteInstRam`].
+    Append = 0x3,
+    /// End-of-patch header. Last word of every patch.
+    EndHdr = 0xF,
+}
+
+/// Apply any patches present in the platform's patch source.
+///
+/// Top-level entry point of the patcher. Drives the read -> authenticate ->
+/// validate -> apply pipeline below. Returns `Ok(())` when no patch is
+/// present, on successful apply of a valid patch, or (currently) from the
+/// stub.
+///
+/// The function signature is intentionally argument-free for now. The
+/// abstraction over the patch source will be introduced in the follow-up PR
+/// that wires this into a platform's `rom_entry`.
+///
+/// # Errors
+///
+/// Returns the corresponding `McuError::ROM_PATCH_*` constant on any
+/// source-read, authentication, or validation failure. Callers are expected
+/// to treat a non-`Ok` return as fatal.
+#[inline(always)]
+pub fn apply_patches() -> McuResult<()> {
+    let payload = read_patch_from_source()?;
+    authenticate_patch(payload)?;
+    validate_patch_headers(payload)?;
+    apply_operations(payload)?;
+    Ok(())
+}
+
+/// Read the patch payload from the patch source (OTP/eFuse) into a staging
+/// buffer in RAM.
+///
+/// Returns an opaque handle/slice to the staged payload on success. The
+/// return type is a placeholder and will be revised once a real patch source
+/// is wired up.
+///
+/// # Errors
+///
+/// `McuError::ROM_PATCH_SOURCE_READ_ERROR` if the underlying OTP/eFuse read
+/// fails or the payload exceeds the staging region.
+fn read_patch_from_source() -> McuResult<&'static [u8]> {
+    // TODO: read the patch payload from the platform's patch source into a
+    // staging buffer and return a reference to it. On platforms with no patch
+    // present, return an empty slice so the rest of the pipeline becomes a
+    // no-op.
+    Ok(&[])
+}
+
+/// Verify the authenticity and integrity of the patch payload.
+///
+/// Implementation-defined; the exact authentication mechanism (signature
+/// scheme, MAC, etc.) is TBD and will be resolved before any non-stub
+/// implementation lands. The code that performs this check is intended to
+/// itself be non-patchable.
+///
+/// # Errors
+///
+/// `McuError::ROM_PATCH_AUTH_ERROR` if the payload fails authentication.
+fn authenticate_patch(_payload: &[u8]) -> McuResult<()> {
+    // TODO: authenticate the patch payload. Mechanism TBD.
+    Ok(())
+}
+
+/// Structurally validate the patch: walk the start header, every operation
+/// header, the end header, and ensure declared lengths/opcodes are sane.
+///
+/// Performed after authentication so that the bytes being walked have already
+/// been proven to come from a trusted source.
+///
+/// # Errors
+///
+/// `McuError::ROM_PATCH_MALFORMED` for missing/duplicated headers, unknown
+/// opcodes, or inconsistent length fields.
+///
+/// `McuError::ROM_PATCH_ADDRESS_OUT_OF_RANGE` if any operation's target
+/// address or implied length falls outside the legal patchable range.
+fn validate_patch_headers(_payload: &[u8]) -> McuResult<()> {
+    // TODO: walk start/op/end headers, validate opcodes and lengths, and
+    // verify each operation's address range fits within the patchable region.
+    Ok(())
+}
+
+/// Walk the validated payload and execute each operation in the order it
+/// appears, dispatching on [`PatchOpcode`]:
+///
+/// * [`PatchOpcode::OverwriteInstRam`] / [`PatchOpcode::OverwriteDataRam`]:
+///   write the new words into the (RAM-copied) ROM image.
+/// * [`PatchOpcode::Append`]: copy the supplementary code/data body into the
+///   append region adjacent to the (RAM-copied) ROM image, so the branches
+///   installed by the overwrite operations reach it.
+///
+/// # Errors
+///
+/// `McuError::ROM_PATCH_ADDRESS_OUT_OF_RANGE` if any operation's target (or,
+/// for an append, the cumulative payload) falls outside the legal range.
+fn apply_operations(_payload: &[u8]) -> McuResult<()> {
+    // TODO: iterate operations in payload order, dispatching on PatchOpcode
+    // and writing into the in-RAM ROM image / append region accordingly.
+    Ok(())
+}


### PR DESCRIPTION
Adds the initial API surface for MCU ROM patching, tracked in upstream RFC chipsalliance/caliptra-sw#3399. Every function body is an `Ok(())` TODO stub so the API shape can be reviewed before any implementation lands. New module `caliptra_mcu_rom_common::patch` (rom/src/patch.rs, exposed via a `pub mod patch;` line in rom/src/lib.rs):

* `PatchOpcode` enum (`StartHdr`, `OverwriteInstRam`, `OverwriteDataRam`, `Append`, `EndHdr`); numeric encodings are placeholders, the operation set is the stable part.

* `apply_patches()` chains the patcher phases: read -> authenticate ->
  validate -> apply. `apply_operations` walks the validated payload and dispatches on `PatchOpcode` sequentially.

In error/src/lib.rs:
reserves the `0x6_xxxx` namespace and adds four `ROM_PATCH_*` constants (source-read, auth, malformed, address out of range). `apply_patches()` returns `McuResult<()>`.