### PR TITLE
fix(mctp): handle unsupported control commands without leaking TX buffer

### DIFF
--- a/emulator/app/src/tests/mctp_ctrl_cmd.rs
+++ b/emulator/app/src/tests/mctp_ctrl_cmd.rs
@@ -37,6 +37,8 @@ pub(crate) enum MCTPCtrlCmdTests {
     GetMctpVersionSupportUnspecified,
     GetMctpVersionSupportUnsupported,
     GetMsgTypeSupport,
+    UnsupportedCmd,
+    GetEIDAfterUnsupported,
 }
 
 impl MCTPCtrlCmdTests {
@@ -85,6 +87,12 @@ impl MCTPCtrlCmdTests {
                 vec![0x01]
             }
             MCTPCtrlCmdTests::GetMsgTypeSupport => {
+                vec![]
+            }
+            MCTPCtrlCmdTests::UnsupportedCmd => {
+                vec![]
+            }
+            MCTPCtrlCmdTests::GetEIDAfterUnsupported => {
                 vec![]
             }
         };
@@ -161,6 +169,15 @@ impl MCTPCtrlCmdTests {
                 ];
                 generate_msg_type_support_resp_bytes(CmdCompletionCode::Success as u8, &msg_types)
             }
+            // Issue #1138: Unsupported command should return completion code 0x05
+            // and not leak the TX buffer
+            MCTPCtrlCmdTests::UnsupportedCmd => {
+                vec![CmdCompletionCode::ErrorNotSupportedCmd as u8]
+            }
+            // Issue #1138: Verify MCU still responds after receiving an unsupported command
+            MCTPCtrlCmdTests::GetEIDAfterUnsupported => {
+                get_eid_resp_bytes(CmdCompletionCode::Success, TEST_TARGET_EID + 1)
+            }
         };
 
         MCTPCtrlCmdTests::generate_msg((mctp_common_msg_hdr, mctp_ctrl_msg_hdr, resp_data))
@@ -203,6 +220,9 @@ impl MCTPCtrlCmdTests {
                 MCTPCtrlCmd::GetMctpVersionSupport as u8
             }
             MCTPCtrlCmdTests::GetMsgTypeSupport => MCTPCtrlCmd::GetMsgTypeSupport as u8,
+            // Command code 0x06 (GetVendorDefinedMessageSupport) is not implemented
+            MCTPCtrlCmdTests::UnsupportedCmd => 0x06,
+            MCTPCtrlCmdTests::GetEIDAfterUnsupported => MCTPCtrlCmd::GetEID as u8,
         }
     }
 }

--- a/runtime/kernel/capsules/src/mctp/control_msg.rs
+++ b/runtime/kernel/capsules/src/mctp/control_msg.rs
@@ -70,7 +70,7 @@ impl MCTPCtrlCmd {
             MCTPCtrlCmd::GetEID => 4,
             MCTPCtrlCmd::GetVersionSupport => 18, // 2 bytes header + 4 entries * 4 bytes each
             MCTPCtrlCmd::GetMsgTypeSupport => 2 + MCTP_NUM_MSG_TYPES_SUPPORTED, // 1 byte for completion code + 1 byte for count + supported message types
-            MCTPCtrlCmd::Unsupported => 0,
+            MCTPCtrlCmd::Unsupported => 1, // 1 byte for completion code
         }
     }
 

--- a/runtime/kernel/capsules/src/mctp/mux.rs
+++ b/runtime/kernel/capsules/src/mctp/mux.rs
@@ -3,7 +3,9 @@
 use crate::mctp::base_protocol::{
     MCTPHeader, MessageType, MCTP_BASELINE_TRANSMISSION_UNIT, MCTP_HDR_SIZE,
 };
-use crate::mctp::control_msg::{MCTPCtrlCmd, MCTPCtrlMsgHdr, MCTP_CTRL_MSG_HEADER_LEN};
+use crate::mctp::control_msg::{
+    CmdCompletionCode, MCTPCtrlCmd, MCTPCtrlMsgHdr, MCTP_CTRL_MSG_HEADER_LEN,
+};
 use crate::mctp::recv::MCTPRxState;
 use crate::mctp::send::MCTPTxState;
 use crate::mctp::transport_binding::{MCTPTransportBinding, TransportRxClient, TransportTxClient};
@@ -233,7 +235,10 @@ impl<'a, A: Alarm<'a>, M: MCTPTransportBinding<'a>> MuxMCTPDriver<'a, A, M> {
 
                     MCTPCtrlCmd::GetMsgTypeSupport => mctp_ctrl_cmd
                         .process_get_msg_type_support(req_buf, &mut resp_buf[msg_payload_start..]),
-                    _ => return Err(ErrorCode::NOSUPPORT),
+                    MCTPCtrlCmd::Unsupported => {
+                        resp_buf[msg_payload_start] = CmdCompletionCode::ErrorNotSupportedCmd as u8;
+                        Ok(())
+                    }
                 };
 
                 match result {


### PR DESCRIPTION
When the MCU receives an MCTP control command it does not handle (e.g., GetVendorDefinedMessageSupport 0x06), the default match branch returned Err(ErrorCode::NOSUPPORT) from inside the tx_pkt_buffer.take() closure. This caused the taken TX buffer to be dropped without being returned to the pool, permanently blocking all subsequent MCTP TX responses.

Fix:
- Replace the early-return error with a proper Unsupported handler that writes completion code 0x05 (ErrorNotSupportedCmd) per DSP0236 and returns Ok(()), allowing the normal response path to transmit the reply and manage the buffer correctly.
- Set resp_data_len for Unsupported to 1 to account for the completion code byte.
- Add integration tests that send an unsupported command (0x06) and verify the MCU responds with the correct completion code and continues to handle subsequent commands.

Fixes #1138