### PR TITLE
spdm-lite: add CHALLENGE handler, RNG, signing context

### DIFF
--- a/runtime/userspace/api/caliptra-api-lite/src/lib.rs
+++ b/runtime/userspace/api/caliptra-api-lite/src/lib.rs
@@ -25,6 +25,7 @@
 mod alloc;
 mod cert;
 mod dpe;
+mod rng;
 mod sha;
 mod wire;
 
@@ -34,6 +35,7 @@ pub use dpe::{
     dpe_certify_key, dpe_get_cert_chain_chunk, dpe_sign_ecc_p384, walk_dpe_chain, DpeChainSink,
     DPE_LABEL_LEN, DPE_MAX_CHUNK_SIZE, DPE_MAX_LEAF_CERT_SIZE, DPE_P384_SIGNATURE_SIZE,
 };
+pub use rng::rng_generate;
 pub use sha::{sha_finish, sha_init, sha_update, HashAlgo, HashState, SHA_CHUNK_SIZE};
 
 pub use mcu_error::{McuErrorCode, McuResult};

--- a/runtime/userspace/api/caliptra-api-lite/src/rng.rs
+++ b/runtime/userspace/api/caliptra-api-lite/src/rng.rs
@@ -1,0 +1,61 @@
+// Licensed under the Apache-2.0 license
+
+//! Random number generation via Caliptra `CM_RANDOM_GENERATE`.
+
+use core::mem::size_of;
+use mcu_error::codes::INVARIANT;
+use mcu_error::McuResult;
+use zerocopy::{little_endian::U32, FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
+
+use crate::wire::{calc_checksum, CMD_CM_RANDOM_GENERATE, MBOX_RESP_HEADER_SIZE};
+use crate::ApiAlloc;
+
+/// Maximum random bytes per call (Caliptra limit).
+const MAX_RANDOM_SIZE: usize = 48;
+
+#[repr(C)]
+#[derive(FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+struct RandomGenReq {
+    chksum: U32,
+    size: U32,
+}
+
+const REQ_SIZE: usize = size_of::<RandomGenReq>();
+const _: () = assert!(REQ_SIZE == 8);
+
+/// Response: `chksum(4) + fips_status(4) + data_len(4) + data[N]`.
+const RSP_HEADER_SIZE: usize = MBOX_RESP_HEADER_SIZE + 4; // +data_len field
+
+/// Generate `out.len()` random bytes from Caliptra RNG.
+#[inline(never)]
+pub async fn rng_generate<A: ApiAlloc>(alloc: &A, out: &mut [u8]) -> McuResult<()> {
+    if out.is_empty() || out.len() > MAX_RANDOM_SIZE {
+        return Err(INVARIANT);
+    }
+
+    let mut req = alloc.alloc(REQ_SIZE)?;
+    req.fill(0);
+    {
+        let r = RandomGenReq::mut_from_bytes(&mut req[..REQ_SIZE]).map_err(|_| INVARIANT)?;
+        r.size = U32::new(out.len() as u32);
+    }
+    let checksum = calc_checksum(CMD_CM_RANDOM_GENERATE, &req);
+    req[..4].copy_from_slice(&checksum.to_le_bytes());
+
+    let rsp_max = RSP_HEADER_SIZE + MAX_RANDOM_SIZE;
+    let mut rsp = alloc.alloc(rsp_max)?;
+    let rsp_len = crate::wire::mbox_execute(CMD_CM_RANDOM_GENERATE, &req, &mut rsp).await?;
+
+    // Parse data_len from response.
+    if rsp_len < RSP_HEADER_SIZE {
+        return Err(INVARIANT);
+    }
+    let data_len =
+        U32::ref_from_bytes(&rsp[MBOX_RESP_HEADER_SIZE..RSP_HEADER_SIZE]).map_err(|_| INVARIANT)?;
+    let n = data_len.get() as usize;
+    if n != out.len() || RSP_HEADER_SIZE + n > rsp_len {
+        return Err(INVARIANT);
+    }
+    out.copy_from_slice(&rsp[RSP_HEADER_SIZE..RSP_HEADER_SIZE + n]);
+    Ok(())
+}

--- a/runtime/userspace/api/caliptra-api-lite/src/wire.rs
+++ b/runtime/userspace/api/caliptra-api-lite/src/wire.rs
@@ -33,6 +33,7 @@ pub(crate) const CMB_SHA_CONTEXT_SIZE: usize = 200;
 pub(crate) const CMD_CM_SHA_INIT: u32 = 0x434D_5349; // "CMSI"
 pub(crate) const CMD_CM_SHA_UPDATE: u32 = 0x434D_5355; // "CMSU"
 pub(crate) const CMD_CM_SHA_FINAL: u32 = 0x434D_5346; // "CMSF"
+pub(crate) const CMD_CM_RANDOM_GENERATE: u32 = 0x434D_5247; // "CMRG"
 
 // ---- DPE (Caliptra `InvokeDpeCommand`) ------------------------------------
 

--- a/runtime/userspace/api/spdm-lite/codec/src/challenge.rs
+++ b/runtime/userspace/api/spdm-lite/codec/src/challenge.rs
@@ -1,0 +1,85 @@
+// Licensed under the Apache-2.0 license
+
+//! CHALLENGE / CHALLENGE_AUTH wire types.
+
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
+
+use crate::{
+    ReqRespCode, ResponseBody, WireError, WireWriter, REQUESTER_CONTEXT_LEN, SHA384_HASH_SIZE,
+    SPDM_NONCE_LEN,
+};
+
+// ---- Request ---------------------------------------------------------------
+
+/// CHALLENGE request body (after SPDM header).
+#[derive(FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned, Copy, Clone, Debug)]
+#[repr(C)]
+pub struct ChallengeReqBody {
+    pub slot_id: u8,
+    pub meas_summary_hash_type: u8,
+    pub nonce: [u8; SPDM_NONCE_LEN],
+}
+
+const _: () = assert!(core::mem::size_of::<ChallengeReqBody>() == 34);
+
+// ---- Response builder ------------------------------------------------------
+
+/// CHALLENGE_AUTH response builder.
+pub struct ChallengeAuthRsp<'a> {
+    pub slot_id: u8,
+    pub cert_chain_hash: &'a [u8; SHA384_HASH_SIZE],
+    pub nonce: &'a [u8; SPDM_NONCE_LEN],
+    /// If Some, a 48-byte measurement summary hash is included.
+    pub meas_summary_hash: Option<&'a [u8; SHA384_HASH_SIZE]>,
+    pub opaque_len: u16,
+    pub requester_context: Option<&'a [u8; REQUESTER_CONTEXT_LEN]>,
+    pub signature: &'a [u8],
+}
+
+impl ResponseBody for ChallengeAuthRsp<'_> {
+    const RESPONSE_CODE: ReqRespCode = ReqRespCode::CHALLENGE_AUTH;
+
+    fn body_size(&self) -> usize {
+        1 + 1
+            + SHA384_HASH_SIZE
+            + SPDM_NONCE_LEN
+            + self.meas_hash_len()
+            + 2
+            + self.requester_context_len()
+            + self.signature.len()
+    }
+
+    fn encode_body(&self, w: &mut WireWriter<'_>) -> Result<(), WireError> {
+        w.write_bytes(&[self.slot_id & 0x0F])?;
+        w.write_bytes(&[1u8 << self.slot_id])?;
+        w.write_bytes(self.cert_chain_hash)?;
+        w.write_bytes(self.nonce)?;
+        if let Some(mh) = self.meas_summary_hash {
+            w.write_bytes(mh)?;
+        }
+        w.write_bytes(&self.opaque_len.to_le_bytes())?;
+        if let Some(ctx) = self.requester_context {
+            w.write_bytes(ctx)?;
+        }
+        w.write_bytes(self.signature)?;
+        Ok(())
+    }
+}
+
+impl ChallengeAuthRsp<'_> {
+    fn requester_context_len(&self) -> usize {
+        if self.requester_context.is_some() {
+            REQUESTER_CONTEXT_LEN
+        } else {
+            0
+        }
+    }
+
+    fn meas_hash_len(&self) -> usize {
+        if self.meas_summary_hash.is_some() {
+            SHA384_HASH_SIZE
+        } else {
+            0
+        }
+    }
+}

--- a/runtime/userspace/api/spdm-lite/codec/src/header.rs
+++ b/runtime/userspace/api/spdm-lite/codec/src/header.rs
@@ -98,3 +98,26 @@ impl SpdmMsgHdrPdu {
 
 const _: () = assert!(core::mem::size_of::<SpdmMsgHdrPdu>() == SpdmMsgHdrPdu::SIZE);
 const _: () = assert!(core::mem::align_of::<SpdmMsgHdrPdu>() == 1);
+
+// ---- Protocol-wide constants ------------------------------------------------
+
+/// SPDM nonce length (32 bytes).
+pub const SPDM_NONCE_LEN: usize = 32;
+
+/// SHA-384 digest size (48 bytes).
+pub const SHA384_HASH_SIZE: usize = 48;
+
+/// RequesterContext length (SPDM V1.3+, 8 bytes).
+pub const REQUESTER_CONTEXT_LEN: usize = 8;
+
+/// ECC P-384 signature size (r || s, 96 bytes).
+pub const ECC_P384_SIGNATURE_SIZE: usize = 96;
+
+/// SPDM signing context prefix length (4 × 16 bytes).
+pub const SPDM_PREFIX_LEN: usize = 64;
+
+/// SPDM signing context operation string length.
+pub const SPDM_CONTEXT_LEN: usize = 36;
+
+/// Total signing context length.
+pub const SPDM_SIGNING_CONTEXT_LEN: usize = SPDM_PREFIX_LEN + SPDM_CONTEXT_LEN;

--- a/runtime/userspace/api/spdm-lite/codec/src/lib.rs
+++ b/runtime/userspace/api/spdm-lite/codec/src/lib.rs
@@ -9,6 +9,7 @@ mod algorithms;
 mod builder;
 mod capabilities;
 mod certificate;
+mod challenge;
 mod digests;
 pub mod errors;
 mod flag_macros;
@@ -26,7 +27,11 @@ pub use capabilities::{CapFlags, CapabilitiesBody, CapabilitiesRsp};
 pub use certificate::{
     CertificateRsp, CertificateRspBody, GetCertificateReqBody, ATTR_SLOT_SIZE_REQUESTED,
 };
+pub use challenge::{ChallengeAuthRsp, ChallengeReqBody};
 pub use digests::{DigestsRsp, DigestsRspBody};
-pub use header::{ReqRespCode, SpdmMsgHdrPdu, SPDM_MSG_HDR_SIZE};
+pub use header::{
+    ReqRespCode, SpdmMsgHdrPdu, ECC_P384_SIGNATURE_SIZE, REQUESTER_CONTEXT_LEN, SHA384_HASH_SIZE,
+    SPDM_CONTEXT_LEN, SPDM_MSG_HDR_SIZE, SPDM_NONCE_LEN, SPDM_PREFIX_LEN, SPDM_SIGNING_CONTEXT_LEN,
+};
 pub use version::{SpdmVersion, VersionNumberEntry, VersionRsp, VersionRspBody};
 pub use wire::{WireError, WireReader, WireWriter};

--- a/runtime/userspace/api/spdm-lite/pal/src/cert/mod.rs
+++ b/runtime/userspace/api/spdm-lite/pal/src/cert/mod.rs
@@ -260,6 +260,10 @@ impl SpdmPalCertStore for McuSpdmPal {
     fn cache_chain_digest(&self, slot: u8, _algo: SpdmPalHashAlgo, digest: &[u8]) {
         self.cert_store.cache_chain_digest(slot, digest);
     }
+
+    async fn generate_nonce(&self, _io: &Self::Io<'_>, out: &mut [u8]) -> McuResult<()> {
+        mcu_caliptra_api_lite::rng_generate(self, out).await
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/runtime/userspace/api/spdm-lite/stack/src/algorithms.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/algorithms.rs
@@ -24,7 +24,7 @@
 
 use mcu_spdm_lite_codec::{
     alg_type, AeadAlgos, AlgStructEntry, AlgorithmsRsp, DheAlgos, KeyScheduleAlgos,
-    NegotiateAlgorithmsReqBodyFixed, SpdmMsgHdrPdu,
+    NegotiateAlgorithmsReqBodyFixed, ResponseBody, SpdmMsgHdrPdu,
 };
 use mcu_spdm_lite_traits::{PalBytes, SpdmPal, SpdmPalIo, SpdmPalIoTransport};
 use zerocopy::FromBytes;
@@ -87,13 +87,16 @@ pub(crate) async fn handle_negotiate_algorithms<'a, Pal: SpdmPal>(
     let alg_structs = locate_alg_structs(fixed, body)?;
     let peer = parse_peer_algs(alg_structs)?;
     let rsp_body = build_response_body(state, fixed, &peer);
-
+    let spdm_len = rsp_body.encoded_size();
     let resp = build_response(pal, io, state.version, &rsp_body)?;
 
     // DSP0274 §10.4.1: NEGOTIATE_ALGORITHMS + ALGORITHMS contribute to VCA.
     let head = pal.header_size();
     state.transcript.append_vca(pal, io, io.request()).await?;
-    state.transcript.append_vca(pal, io, &resp[head..]).await?;
+    state
+        .transcript
+        .append_vca(pal, io, &resp[head..head + spdm_len])
+        .await?;
 
     state.phase = Phase::AfterAlgorithms;
     Ok(resp)

--- a/runtime/userspace/api/spdm-lite/stack/src/capabilities.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/capabilities.rs
@@ -15,7 +15,7 @@
 //!    local policy, then transitions to [`Phase::AfterCapabilities`].
 
 use mcu_spdm_lite_codec::{
-    CapFlags, CapabilitiesBody, CapabilitiesRsp, SpdmMsgHdrPdu, SpdmVersion,
+    CapFlags, CapabilitiesBody, CapabilitiesRsp, ResponseBody, SpdmMsgHdrPdu, SpdmVersion,
 };
 use mcu_spdm_lite_traits::{PalBytes, SpdmPal, SpdmPalIo, SpdmPalIoTransport};
 use zerocopy::FromBytes;
@@ -79,22 +79,22 @@ pub(crate) async fn handle_get_capabilities<'a, Pal: SpdmPal>(
 
     // DataTransferSize == MaxSPDMmsgSize since we don't yet advertise CHUNK.
     let mtu = pal.mtu() as u32;
-    let resp = build_response(
-        pal,
-        io,
-        version,
-        &CapabilitiesRsp {
-            ct_exponent: state.ct_exponent,
-            flags: state.cap_flags,
-            data_transfer_size: mtu,
-            max_spdm_msg_size: mtu,
-        },
-    )?;
+    let body = CapabilitiesRsp {
+        ct_exponent: state.ct_exponent,
+        flags: state.cap_flags,
+        data_transfer_size: mtu,
+        max_spdm_msg_size: mtu,
+    };
+    let spdm_len = body.encoded_size();
+    let resp = build_response(pal, io, version, &body)?;
 
     // DSP0274 §10.4.1: GET_CAPABILITIES + CAPABILITIES contribute to VCA.
     let head = pal.header_size();
     state.transcript.append_vca(pal, io, io.request()).await?;
-    state.transcript.append_vca(pal, io, &resp[head..]).await?;
+    state
+        .transcript
+        .append_vca(pal, io, &resp[head..head + spdm_len])
+        .await?;
 
     state.phase = Phase::AfterCapabilities;
     Ok(resp)

--- a/runtime/userspace/api/spdm-lite/stack/src/certificate.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/certificate.rs
@@ -11,7 +11,8 @@
 //! stack-allocated `[u8; N]` array for cert payload.
 
 use mcu_spdm_lite_codec::{
-    CertificateRsp, GetCertificateReqBody, SpdmMsgHdrPdu, SpdmVersion, ATTR_SLOT_SIZE_REQUESTED,
+    CertificateRsp, GetCertificateReqBody, ResponseBody, SpdmMsgHdrPdu, SpdmVersion,
+    ATTR_SLOT_SIZE_REQUESTED,
 };
 use mcu_spdm_lite_traits::{
     PalBytes, SpdmPal, SpdmPalAsymAlgo, SpdmPalIo, SpdmPalIoTransport, MAX_SLOTS,
@@ -96,26 +97,23 @@ pub(crate) async fn handle_get_certificate<'a, Pal: SpdmPal>(
     let mut portion = pal.alloc_bytes(io, portion_len as usize)?;
     fill_cert_chain_portion(pal, io, slot_id, asym_algo, offset as usize, &mut portion).await?;
 
-    let resp = build_response(
-        pal,
-        io,
-        state.version,
-        &CertificateRsp {
-            slot_id,
-            // Param2: we don't yet expose CertModel — leave 0
-            // (Reserved on V1.0-V1.2; CertModel=0 on V1.3).
-            param2: 0,
-            portion_length: portion_len,
-            remainder_length: remainder_len,
-            chain_portion: &portion,
-        },
-    )?;
+    let cert_body = CertificateRsp {
+        slot_id,
+        param2: 0,
+        portion_length: portion_len,
+        remainder_length: remainder_len,
+        chain_portion: &portion,
+    };
+    let spdm_len = cert_body.encoded_size();
 
-    // DSP0274 Table 47: GET_CERTIFICATE + CERTIFICATE contribute
-    // to `M1` (the `B` portion of `M1 = A ∥ B ∥ C`).
+    let resp = build_response(pal, io, state.version, &cert_body)?;
+
     let head = pal.header_size();
     state.transcript.append_m1(pal, io, io.request()).await?;
-    state.transcript.append_m1(pal, io, &resp[head..]).await?;
+    state
+        .transcript
+        .append_m1(pal, io, &resp[head..head + spdm_len])
+        .await?;
 
     state.phase = Phase::AfterCertificate;
     Ok(resp)

--- a/runtime/userspace/api/spdm-lite/stack/src/challenge.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/challenge.rs
@@ -1,0 +1,207 @@
+// Licensed under the Apache-2.0 license
+
+//! CHALLENGE / CHALLENGE_AUTH handler.
+
+use mcu_spdm_lite_codec::{
+    ChallengeAuthRsp, ChallengeReqBody, ResponseBody, SpdmMsgHdrPdu, SpdmVersion,
+    ECC_P384_SIGNATURE_SIZE, REQUESTER_CONTEXT_LEN, SHA384_HASH_SIZE, SPDM_CONTEXT_LEN,
+    SPDM_NONCE_LEN, SPDM_PREFIX_LEN, SPDM_SIGNING_CONTEXT_LEN,
+};
+use mcu_spdm_lite_traits::*;
+use zerocopy::FromBytes;
+
+use crate::build::build_response;
+use crate::error::{SpdmResult, SPDM_INVALID_REQUEST, SPDM_UNEXPECTED_REQUEST, SPDM_UNSPECIFIED};
+use crate::stack::{ConnectionState, Phase};
+
+pub(crate) async fn handle_challenge<'a, Pal: SpdmPal>(
+    state: &mut ConnectionState<Pal::State>,
+    pal: &'a Pal,
+    io: &<Pal as SpdmPalIoTransport>::Io<'_>,
+) -> SpdmResult<PalBytes<'a, Pal>> {
+    // Phase: must be after algorithms negotiation.
+    // GET_DIGESTS and GET_CERTIFICATE are optional before CHALLENGE.
+    if (state.phase as u8) < (Phase::AfterAlgorithms as u8) {
+        return Err(SPDM_UNEXPECTED_REQUEST);
+    }
+
+    // Validate version matches negotiated.
+    let req = io.request();
+    let (hdr, rest) = SpdmMsgHdrPdu::ref_from_prefix(req).map_err(|_| SPDM_INVALID_REQUEST)?;
+    if hdr.version != state.version.to_u8() {
+        return Err(crate::error::SPDM_VERSION_MISMATCH);
+    }
+
+    // Decode CHALLENGE body.
+    let (challenge_req, after) =
+        ChallengeReqBody::ref_from_prefix(rest).map_err(|_| SPDM_INVALID_REQUEST)?;
+
+    let slot_id = challenge_req.slot_id & 0x0F;
+    let meas_hash_type = challenge_req.meas_summary_hash_type;
+
+    // Validate slot_id.
+    if slot_id >= MAX_SLOTS || (pal.provisioned_slots() & (1 << slot_id)) == 0 {
+        return Err(SPDM_INVALID_REQUEST);
+    }
+
+    // Validate meas_summary_hash_type: 0, 1, or 0xFF.
+    if meas_hash_type != 0 && meas_hash_type != 1 && meas_hash_type != 0xFF {
+        return Err(SPDM_INVALID_REQUEST);
+    }
+
+    // Parse RequesterContext for V1.3+.
+    let mut requester_context = None;
+    if state.version >= SpdmVersion::V13 {
+        if after.len() < REQUESTER_CONTEXT_LEN {
+            return Err(SPDM_INVALID_REQUEST);
+        }
+        let mut ctx = [0u8; REQUESTER_CONTEXT_LEN];
+        ctx.copy_from_slice(&after[..REQUESTER_CONTEXT_LEN]);
+        requester_context = Some(ctx);
+    }
+
+    // Append CHALLENGE request to M1 transcript.
+    state.transcript.append_m1(pal, io, req).await?;
+
+    let asym_algo = state.asym_algo();
+
+    // Get cert chain hash — use cache if available, else compute.
+    let mut cert_chain_hash = [0u8; SHA384_HASH_SIZE];
+    if let Some(cached) = pal.cached_chain_digest(slot_id, SpdmPalHashAlgo::Sha384) {
+        cert_chain_hash = cached;
+    } else {
+        crate::digests::cert_chain_hash(
+            pal,
+            io,
+            slot_id,
+            asym_algo,
+            SpdmPalHashAlgo::Sha384,
+            &mut cert_chain_hash,
+        )
+        .await
+        .map_err(|_| SPDM_UNSPECIFIED)?;
+        pal.cache_chain_digest(slot_id, SpdmPalHashAlgo::Sha384, &cert_chain_hash);
+    }
+
+    // Generate nonce via PAL RNG.
+    let mut nonce = [0u8; SPDM_NONCE_LEN];
+    pal.generate_nonce(io, &mut nonce)
+        .await
+        .map_err(|_| SPDM_UNSPECIFIED)?;
+
+    // Measurement summary hash: zero-filled placeholder until
+    // GET_MEASUREMENTS is implemented. Omitted when type=0.
+    let meas_summary_hash = [0u8; SHA384_HASH_SIZE];
+    let meas_hash_ref = if meas_hash_type != 0 {
+        Some(&meas_summary_hash)
+    } else {
+        None
+    };
+
+    // Build response body (without signature — appended after M1 finalize).
+    let body_no_sig = ChallengeAuthRsp {
+        slot_id,
+        cert_chain_hash: &cert_chain_hash,
+        nonce: &nonce,
+        meas_summary_hash: meas_hash_ref,
+        opaque_len: 0,
+        requester_context: requester_context.as_ref(),
+        signature: &[],
+    };
+
+    let resp =
+        build_response(pal, io, state.version, &body_no_sig).map_err(|_| SPDM_UNSPECIFIED)?;
+
+    // Append CHALLENGE_AUTH response (without signature) to M1.
+    // Only the SPDM message bytes, not transport padding.
+    let head = pal.header_size();
+    let spdm_len = body_no_sig.encoded_size();
+    state
+        .transcript
+        .append_m1(pal, io, &resp[head..head + spdm_len])
+        .await?;
+
+    // Finalize M1 transcript hash.
+    let mut m1_hash = [0u8; SHA384_HASH_SIZE];
+    state.transcript.finalize_m1(pal, io, &mut m1_hash).await?;
+
+    // Build signing context and compute TBS hash.
+    let signing_ctx = build_signing_context(state.version);
+    let tbs_hash = compute_tbs_hash(pal, io, &signing_ctx, &m1_hash)
+        .await
+        .map_err(|_| SPDM_UNSPECIFIED)?;
+
+    // Sign the TBS hash.
+    let mut signature = [0u8; ECC_P384_SIGNATURE_SIZE];
+    let sig_len = pal
+        .sign_hash(io, slot_id, asym_algo, &tbs_hash, &mut signature)
+        .await
+        .map_err(|_| SPDM_UNSPECIFIED)?;
+    if sig_len != ECC_P384_SIGNATURE_SIZE {
+        return Err(SPDM_UNSPECIFIED);
+    }
+
+    // Now rebuild the full response with signature.
+    let full_body = ChallengeAuthRsp {
+        slot_id,
+        cert_chain_hash: &cert_chain_hash,
+        nonce: &nonce,
+        meas_summary_hash: meas_hash_ref,
+        opaque_len: 0,
+        requester_context: requester_context.as_ref(),
+        signature: &signature,
+    };
+
+    let full_resp =
+        build_response(pal, io, state.version, &full_body).map_err(|_| SPDM_UNSPECIFIED)?;
+
+    // Transition to authenticated.
+    state.phase = Phase::AfterCertificate; // TODO: add Phase::Authenticated
+
+    Ok(full_resp)
+}
+
+/// Build the 100-byte SPDM signing context for CHALLENGE_AUTH.
+fn build_signing_context(version: SpdmVersion) -> [u8; SPDM_SIGNING_CONTEXT_LEN] {
+    let mut ctx = [0u8; SPDM_SIGNING_CONTEXT_LEN];
+
+    // Prefix: "dmtf-spdm-v" + version + ".*" repeated 4× = 64 bytes.
+    let base = b"dmtf-spdm-v";
+    let ver = match version {
+        SpdmVersion::V10 => b"1.0.*",
+        SpdmVersion::V11 => b"1.1.*",
+        SpdmVersion::V12 => b"1.2.*",
+        SpdmVersion::V13 => b"1.3.*",
+    };
+    let mut pos = 0;
+    for _ in 0..4 {
+        ctx[pos..pos + base.len()].copy_from_slice(base);
+        pos += base.len();
+        ctx[pos..pos + ver.len()].copy_from_slice(ver);
+        pos += ver.len();
+        // Each block is 16 bytes: 11 + 5 = 16.
+    }
+
+    // Operation context: zero-padded on the left, string at the end.
+    let op = b"responder-challenge_auth signing";
+    let pad = SPDM_CONTEXT_LEN - op.len();
+    ctx[SPDM_PREFIX_LEN + pad..SPDM_PREFIX_LEN + pad + op.len()].copy_from_slice(op);
+
+    ctx
+}
+
+/// Hash(signing_context || M1_hash) → TBS digest for signing.
+async fn compute_tbs_hash<Pal: SpdmPal>(
+    pal: &Pal,
+    io: &<Pal as SpdmPalIoTransport>::Io<'_>,
+    signing_ctx: &[u8; SPDM_SIGNING_CONTEXT_LEN],
+    m1_hash: &[u8; SHA384_HASH_SIZE],
+) -> mcu_error::McuResult<[u8; SHA384_HASH_SIZE]> {
+    let mut state = pal
+        .hash_init(io, SpdmPalHashAlgo::Sha384, signing_ctx)
+        .await?;
+    pal.hash_update(io, &mut state, m1_hash).await?;
+    let mut tbs = [0u8; SHA384_HASH_SIZE];
+    pal.hash_finish(io, &mut state, &mut tbs).await?;
+    Ok(tbs)
+}

--- a/runtime/userspace/api/spdm-lite/stack/src/digests.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/digests.rs
@@ -7,7 +7,7 @@
 //! array. Chunk buffers come from the per-IO bitmap pool — no
 //! stack-allocated `[u8; N]` arrays for cert content.
 
-use mcu_spdm_lite_codec::{DigestsRsp, SpdmMsgHdrPdu};
+use mcu_spdm_lite_codec::{DigestsRsp, ResponseBody, SpdmMsgHdrPdu};
 use mcu_spdm_lite_traits::{
     PalBytes, SpdmPal, SpdmPalAsymAlgo, SpdmPalHashAlgo, SpdmPalIo, SpdmPalIoTransport, MAX_SLOTS,
 };
@@ -19,7 +19,7 @@ use crate::stack::{ConnectionState, Phase};
 
 /// Streaming chunk size when hashing a cert chain — comes from the
 /// per-IO bitmap pool, not the stack.
-const CERT_CHUNK_SIZE: usize = 256;
+const CERT_CHUNK_SIZE: usize = 1024;
 
 pub(crate) async fn handle_get_digests<'a, Pal: SpdmPal>(
     state: &mut ConnectionState<Pal::State>,
@@ -71,23 +71,21 @@ pub(crate) async fn handle_get_digests<'a, Pal: SpdmPal>(
         cursor += digest_size;
     }
 
-    let resp = build_response(
-        pal,
-        io,
-        state.version,
-        &DigestsRsp {
-            supported_slots: supported,
-            provisioned_slots: provisioned,
-            digests: &digests,
-        },
-    )?;
+    let digests_body = DigestsRsp {
+        supported_slots: supported,
+        provisioned_slots: provisioned,
+        digests: &digests,
+    };
+    let spdm_len = digests_body.encoded_size();
 
-    // DSP0274 Table 47: GET_DIGESTS + DIGESTS contribute to M1 (the
-    // `B` portion of `M1 = A ∥ B ∥ C`). The first append forks M1
-    // from VCA via `Transcript::append_m1`.
+    let resp = build_response(pal, io, state.version, &digests_body)?;
+
     let head = pal.header_size();
     state.transcript.append_m1(pal, io, io.request()).await?;
-    state.transcript.append_m1(pal, io, &resp[head..]).await?;
+    state
+        .transcript
+        .append_m1(pal, io, &resp[head..head + spdm_len])
+        .await?;
 
     state.phase = Phase::AfterDigests;
     Ok(resp)
@@ -102,7 +100,7 @@ pub(crate) async fn handle_get_digests<'a, Pal: SpdmPal>(
 /// allowed this small allocation) and stream the variable-length
 /// DER bytes from a pool-allocated chunk buffer.
 #[inline(never)]
-async fn cert_chain_hash<Pal: SpdmPal>(
+pub(crate) async fn cert_chain_hash<Pal: SpdmPal>(
     pal: &Pal,
     io: &<Pal as SpdmPalIoTransport>::Io<'_>,
     slot: u8,

--- a/runtime/userspace/api/spdm-lite/stack/src/lib.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/lib.rs
@@ -33,6 +33,7 @@ mod algorithms;
 mod build;
 mod capabilities;
 mod certificate;
+mod challenge;
 mod digests;
 mod error;
 mod stack;

--- a/runtime/userspace/api/spdm-lite/stack/src/stack.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/stack.rs
@@ -24,7 +24,7 @@ use crate::build::build_error_response;
 use crate::error::{
     SpdmError, SpdmResult, SPDM_INVALID_REQUEST, SPDM_UNSUPPORTED_REQUEST, SPDM_VERSION_MISMATCH,
 };
-use crate::{algorithms, capabilities, certificate, digests, version};
+use crate::{algorithms, capabilities, certificate, challenge, digests, version};
 
 /// Connection phase tracked on the responder so the dispatcher can
 /// enforce the DSP0274 §10 ordering
@@ -371,6 +371,7 @@ async fn dispatch<'a, Pal: SpdmPal>(
         }
         ReqRespCode::GET_DIGESTS => digests::handle_get_digests(state, pal, io).await,
         ReqRespCode::GET_CERTIFICATE => certificate::handle_get_certificate(state, pal, io).await,
+        ReqRespCode::CHALLENGE => challenge::handle_challenge(state, pal, io).await,
         ReqRespCode(0) => Err(SPDM_INVALID_REQUEST),
         _ => Err(SPDM_UNSUPPORTED_REQUEST),
     }

--- a/runtime/userspace/api/spdm-lite/stack/src/version.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/version.rs
@@ -8,7 +8,7 @@
 //! [`ConnectionState::reset_negotiation`] before invoking us so that
 //! GET_VERSION always resets the connection.
 
-use mcu_spdm_lite_codec::{SpdmMsgHdrPdu, SpdmVersion, VersionRsp};
+use mcu_spdm_lite_codec::{ResponseBody, SpdmMsgHdrPdu, SpdmVersion, VersionRsp};
 use mcu_spdm_lite_traits::{PalBytes, SpdmPal, SpdmPalIo};
 use zerocopy::FromBytes;
 
@@ -68,19 +68,20 @@ pub(crate) async fn handle_get_version<'a, Pal: SpdmPal>(
         return Err(SPDM_INVALID_REQUEST);
     }
 
-    let resp = build_response(
-        pal,
-        io,
-        SpdmVersion::V10,
-        &VersionRsp {
-            versions: SUPPORTED_VERSIONS,
-        },
-    )?;
+    let body = VersionRsp {
+        versions: SUPPORTED_VERSIONS,
+    };
+    let spdm_len = body.encoded_size();
+    let resp = build_response(pal, io, SpdmVersion::V10, &body)?;
 
     // DSP0274 §10.4.1: GET_VERSION + VERSION contribute to VCA.
+    // Use spdm_len to exclude any transport-layer padding (e.g. DOE DWORD alignment).
     let head = pal.header_size();
     state.transcript.append_vca(pal, io, io.request()).await?;
-    state.transcript.append_vca(pal, io, &resp[head..]).await?;
+    state
+        .transcript
+        .append_vca(pal, io, &resp[head..head + spdm_len])
+        .await?;
 
     state.phase = Phase::AfterVersion;
     Ok(resp)

--- a/runtime/userspace/api/spdm-lite/traits/src/cert.rs
+++ b/runtime/userspace/api/spdm-lite/traits/src/cert.rs
@@ -157,4 +157,7 @@ pub trait SpdmPalCertStore: crate::SpdmPalIoTransport {
     /// Default impl is a no-op.
     #[inline]
     fn cache_chain_digest(&self, _slot: u8, _algo: SpdmPalHashAlgo, _digest: &[u8]) {}
+
+    /// Fill `out` with random bytes from the platform RNG.
+    async fn generate_nonce(&self, io: &Self::Io<'_>, out: &mut [u8]) -> McuResult<()>;
 }


### PR DESCRIPTION
SPDM responder validator results:
DOE: pass: 501, fail: 0
MCTP: pass: 501, fail: 0

group 1 (version): pass: 6, fail: 0
group 2 (capabilities): pass: 58, fail: 0
group 3 (algorithms): pass: 70, fail: 0
group 4 (digests): pass: 15, fail: 0
group 5 (certificate): pass: 113, fail: 0
group 6 (challenge_auth): pass: 239, fail: 0

Memory added by this commit:
user-app: .text +5,560 B  .rodata +1,000 B  .bss +144 B SPDM task: .text +5,598 B  .rodata +16 B  .bss +168 B kernel: no change

Current totals:
kernel: .text 149,856 B  .bss 24,536 B
user-app: .text 38,540 B  .rodata 10,668 B  .bss 43,456 B