### PR TITLE
[mcu-mbox] Fixes for rotating vendor PK hashes

### DIFF
--- a/platforms/emulator/runtime/userspace/apps/user/src/mcu_mbox/cmd_auth_mock.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/mcu_mbox/cmd_auth_mock.rs
@@ -4,8 +4,8 @@ use caliptra_mcu_common_commands::{AuthorizationError, AuthorizationResult, Comm
 use caliptra_mcu_libapi_caliptra::crypto::hmac::Hmac;
 use caliptra_mcu_libapi_caliptra::crypto::import::{CmKeyUsage, Import};
 use caliptra_mcu_mbox_common::messages::{
-    CommandId, FuseIncreaseCaliptraMinSvnReq, FuseRevokeVendorPubKeyReq, MailboxReqHeader,
-    McuFeProgReq, ProvisionVendorPkHashReq,
+    CommandId, FuseIncreaseCaliptraMinSvnReq, FuseRevokeVendorPkHashReq, FuseRevokeVendorPubKeyReq,
+    MailboxReqHeader, McuFeProgReq, ProvisionVendorPkHashReq,
 };
 use constant_time_eq::constant_time_eq;
 use core::mem::size_of;
@@ -42,6 +42,7 @@ impl CommandAuthorizer for MockCommandAuthorizer {
             }
             CommandId::MC_FE_PROG => size_of::<McuFeProgReq>(),
             CommandId::MC_FUSE_REVOKE_VENDOR_PUB_KEY => size_of::<FuseRevokeVendorPubKeyReq>(),
+            CommandId::MC_FUSE_REVOKE_VENDOR_PK_HASH => size_of::<FuseRevokeVendorPkHashReq>(),
             _ => Err(AuthorizationError)?,
         };
 

--- a/runtime/kernel/capsules/src/otp.rs
+++ b/runtime/kernel/capsules/src/otp.rs
@@ -7,6 +7,7 @@ use caliptra_mcu_registers_generated::fuses::{
     OTP_CPTRA_CORE_RUNTIME_SVN, OTP_CPTRA_CORE_VENDOR_PK_HASH_0,
     OTP_CPTRA_CORE_VENDOR_PK_HASH_VALID,
 };
+use caliptra_mcu_romtime::println;
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::{ErrorCode, ProcessId};
@@ -266,7 +267,10 @@ impl Otp {
                     .write_entry(OTP_CPTRA_CORE_VENDOR_PK_HASH_VALID, value)
                 {
                     Ok(_) => CommandReturn::success(),
-                    Err(_) => CommandReturn::failure(ErrorCode::FAIL),
+                    Err(e) => {
+                        capsule_error!("OTP", "Error Writing vendor PK hash valid mask: {:?}", e);
+                        CommandReturn::failure(ErrorCode::FAIL)
+                    }
                 }
             }
             vendor_pk_hash @ reg::VENDOR_PK_HASH_0

--- a/runtime/kernel/capsules/src/otp.rs
+++ b/runtime/kernel/capsules/src/otp.rs
@@ -262,10 +262,11 @@ impl Otp {
                 }
             }
             reg::VENDOR_PK_HASH_VALID => {
-                match self
-                    .driver
-                    .write_entry(OTP_CPTRA_CORE_VENDOR_PK_HASH_VALID, value)
-                {
+                const RAW_FUSE_BYTE_SIZE: usize = OTP_CPTRA_CORE_VENDOR_PK_HASH_VALID.byte_size;
+                match self.driver.write_entry_multi::<1, RAW_FUSE_BYTE_SIZE>(
+                    OTP_CPTRA_CORE_VENDOR_PK_HASH_VALID,
+                    &[value],
+                ) {
                     Ok(_) => CommandReturn::success(),
                     Err(e) => {
                         capsule_error!("OTP", "Error Writing vendor PK hash valid mask: {:?}", e);

--- a/runtime/userspace/api/mcu-mbox-lib/src/cmd_interface.rs
+++ b/runtime/userspace/api/mcu-mbox-lib/src/cmd_interface.rs
@@ -12,8 +12,6 @@ use caliptra_mcu_libsyscall_caliptra::mcu_mbox::MbxCmdStatus;
 use caliptra_mcu_libsyscall_caliptra::otp::Otp;
 use caliptra_mcu_libsyscall_caliptra::{caliptra, otp};
 use caliptra_mcu_libsyscall_caliptra::{mailbox::Mailbox, DefaultSyscalls};
-use caliptra_mcu_libtock_console::{Console, ConsoleWriter};
-use caliptra_mcu_libtock_platform::DefaultConfig;
 use caliptra_mcu_mbox_common::messages::{
     ClearLogReq, ClearLogResp, CommandId, DeviceCapsReq, DeviceCapsResp, DeviceIdReq, DeviceIdResp,
     DeviceInfoReq, DeviceInfoResp, ExportAttestedCsrReq, ExportAttestedCsrResp, FirmwareVersionReq,
@@ -32,7 +30,6 @@ use caliptra_mcu_mbox_common::messages::{
     McuFipsPeriodicStatusResp,
 };
 use caliptra_mcu_romtime::{fuse_read_dai_params, PartitionId};
-use core::fmt::Write;
 use core::sync::atomic::{AtomicBool, Ordering};
 use zerocopy::{FromBytes, IntoBytes};
 
@@ -828,8 +825,6 @@ impl<'a> CmdInterface<'a> {
         req: &[u8],
         resp_buf: &'r mut [u8],
     ) -> Result<(&'r mut [u8], MbxCmdStatus), MsgHandlerError> {
-        let mut wr: ConsoleWriter<DefaultSyscalls> = Console::<_, DefaultConfig>::writer();
-        let _ = writeln!(wr, "[mcu-mbox] revoking vendor PK hash...");
         // Decode the request
         let req = FuseRevokeVendorPkHashReq::ref_from_bytes(req)
             .map_err(|_| MsgHandlerError::InvalidParams)?;
@@ -854,21 +849,11 @@ impl<'a> CmdInterface<'a> {
         };
 
         if same_key_used_to_boot()? {
-            let _ = writeln!(
-                wr,
-                "[mcu-mbox] revoke vendor PK hash failed: same key used to boot"
-            );
             Err(MsgHandlerError::InvalidParams)?;
         }
 
         otp.revoke_vendor_pk_hash(req.vendor_pk_hash_slot)
-            .map_err(|_| {
-                let _ = writeln!(
-                    wr,
-                    "[mcu-mbox] revoke vendor PK hash failed: failed to revoke pk hash"
-                );
-                MsgHandlerError::McuMboxCommon
-            })?;
+            .map_err(|_| MsgHandlerError::McuMboxCommon)?;
 
         *resp = FuseRevokeVendorPkHashResp::default();
         let resp_len = resp.as_bytes().len();

--- a/runtime/userspace/api/mcu-mbox-lib/src/cmd_interface.rs
+++ b/runtime/userspace/api/mcu-mbox-lib/src/cmd_interface.rs
@@ -12,6 +12,8 @@ use caliptra_mcu_libsyscall_caliptra::mcu_mbox::MbxCmdStatus;
 use caliptra_mcu_libsyscall_caliptra::otp::Otp;
 use caliptra_mcu_libsyscall_caliptra::{caliptra, otp};
 use caliptra_mcu_libsyscall_caliptra::{mailbox::Mailbox, DefaultSyscalls};
+use caliptra_mcu_libtock_console::{Console, ConsoleWriter};
+use caliptra_mcu_libtock_platform::DefaultConfig;
 use caliptra_mcu_mbox_common::messages::{
     ClearLogReq, ClearLogResp, CommandId, DeviceCapsReq, DeviceCapsResp, DeviceIdReq, DeviceIdResp,
     DeviceInfoReq, DeviceInfoResp, ExportAttestedCsrReq, ExportAttestedCsrResp, FirmwareVersionReq,
@@ -30,6 +32,7 @@ use caliptra_mcu_mbox_common::messages::{
     McuFipsPeriodicStatusResp,
 };
 use caliptra_mcu_romtime::{fuse_read_dai_params, PartitionId};
+use core::fmt::Write;
 use core::sync::atomic::{AtomicBool, Ordering};
 use zerocopy::{FromBytes, IntoBytes};
 
@@ -825,6 +828,8 @@ impl<'a> CmdInterface<'a> {
         req: &[u8],
         resp_buf: &'r mut [u8],
     ) -> Result<(&'r mut [u8], MbxCmdStatus), MsgHandlerError> {
+        let mut wr: ConsoleWriter<DefaultSyscalls> = Console::<_, DefaultConfig>::writer();
+        let _ = writeln!(wr, "[mcu-mbox] revoking vendor PK hash...");
         // Decode the request
         let req = FuseRevokeVendorPkHashReq::ref_from_bytes(req)
             .map_err(|_| MsgHandlerError::InvalidParams)?;
@@ -849,11 +854,21 @@ impl<'a> CmdInterface<'a> {
         };
 
         if same_key_used_to_boot()? {
+            let _ = writeln!(
+                wr,
+                "[mcu-mbox] revoke vendor PK hash failed: same key used to boot"
+            );
             Err(MsgHandlerError::InvalidParams)?;
         }
 
         otp.revoke_vendor_pk_hash(req.vendor_pk_hash_slot)
-            .map_err(|_| MsgHandlerError::McuMboxCommon)?;
+            .map_err(|_| {
+                let _ = writeln!(
+                    wr,
+                    "[mcu-mbox] revoke vendor PK hash failed: failed to revoke pk hash"
+                );
+                MsgHandlerError::McuMboxCommon
+            })?;
 
         *resp = FuseRevokeVendorPkHashResp::default();
         let resp_len = resp.as_bytes().len();

--- a/runtime/userspace/syscall/src/otp.rs
+++ b/runtime/userspace/syscall/src/otp.rs
@@ -240,7 +240,7 @@ impl<S: Syscalls> Otp<S> {
 
         // Check if the slot is provisioned to not burn an empty slot
         let pk_hash = self.read_vendor_pk_hash(vendor_pk_hash_slot)?;
-        if pk_hash.iter().eq(repeat(&0)) {
+        if pk_hash.iter().eq(repeat(&0).take(pk_hash.len())) {
             let _ = writeln!(
                 wr,
                 "[otp-syscall] Error revoking vendor PK hash: slot {} is not provisioned",

--- a/runtime/userspace/syscall/src/otp.rs
+++ b/runtime/userspace/syscall/src/otp.rs
@@ -3,10 +3,8 @@
 //! # OTP: An Interface for accessing the OTP fuses
 
 use crate::DefaultSyscalls;
-use caliptra_mcu_libtock_console::{Console, ConsoleWriter};
-use caliptra_mcu_libtock_platform::{DefaultConfig, ErrorCode, Syscalls};
+use caliptra_mcu_libtock_platform::{ErrorCode, Syscalls};
 use caliptra_mcu_mbox_common::messages::RevokeVendorPubKeyType;
-use core::fmt::Write;
 use core::{iter::repeat, marker::PhantomData};
 
 pub const VENDOR_PK_HASH_SIZE: usize =
@@ -154,13 +152,7 @@ impl<S: Syscalls> Otp<S> {
         slot: u32,
         new_hash: &[u8; VENDOR_PK_HASH_SIZE],
     ) -> Result<(), ErrorCode> {
-        let mut wr: ConsoleWriter<DefaultSyscalls> = Console::<_, DefaultConfig>::writer();
         if slot > 15 {
-            let _ = writeln!(
-                wr,
-                "[otp-syscall] Error provisioning vendor PK hash: invalid slot number ({})",
-                slot
-            );
             return Err(ErrorCode::Invalid);
         }
 
@@ -168,10 +160,6 @@ impl<S: Syscalls> Otp<S> {
 
         if !self.valid_vendor_pk_hash_slot(slot) {
             // Error when the slot was already marked as invalid
-            let _ = writeln!(
-                wr,
-                "[otp-syscall] Error provisioning vendor PK hash: slot alreay marked invalid"
-            );
             return Err(ErrorCode::Invalid);
         }
 
@@ -182,33 +170,18 @@ impl<S: Syscalls> Otp<S> {
         }
         if fuse_value.iter().ne(repeat(&0).take(fuse_value.len())) {
             // Error if the fuse is already containing something
-            let _ = writeln!(
-                wr,
-                "[otp-syscall] Error provisioning vendor PK hash: slot {} not empty",
-                slot
-            );
             return Err(ErrorCode::Invalid);
         }
 
         // Write fuse
         for (i, chunk) in new_hash.chunks_exact(4).enumerate() {
             let word = u32::from_le_bytes(chunk.try_into().map_err(|_| ErrorCode::Fail)?);
-            self.write(reg, i as u32, word).inspect_err(|e| {
-                let _ = writeln!(
-                    wr,
-                    "[otp-syscall] Error provisioning vendor PK hash: write failed {:?}",
-                    e
-                );
-            })?;
+            self.write(reg, i as u32, word)?;
         }
 
         // Read back the fuse and compare to validate writing was successfull
         let fuse_value = self.read_vendor_pk_hash(slot)?;
         if new_hash != &fuse_value {
-            let _ = writeln!(
-                wr,
-                "[otp-syscall] Error provisioning vendor PK hash: fuse does not match new pk hash after write",
-            );
             return Err(ErrorCode::Fail);
         }
 
@@ -223,13 +196,7 @@ impl<S: Syscalls> Otp<S> {
     /// - Returns `Invalid` when the slot is invalid
     /// - Returns `Fail` when writing the fuse failed
     pub fn revoke_vendor_pk_hash(&self, vendor_pk_hash_slot: u32) -> Result<(), ErrorCode> {
-        let mut wr: ConsoleWriter<DefaultSyscalls> = Console::<_, DefaultConfig>::writer();
         if vendor_pk_hash_slot as usize >= MAX_NUM_VENDOR_PK_HASH {
-            let _ = writeln!(
-                wr,
-                "[otp-syscall] Error revoking vendor PK hash: invalid slot number ({})",
-                vendor_pk_hash_slot
-            );
             Err(ErrorCode::Invalid)?
         }
 
@@ -241,31 +208,13 @@ impl<S: Syscalls> Otp<S> {
         // Check if the slot is provisioned to not burn an empty slot
         let pk_hash = self.read_vendor_pk_hash(vendor_pk_hash_slot)?;
         if pk_hash.iter().eq(repeat(&0).take(pk_hash.len())) {
-            let _ = writeln!(
-                wr,
-                "[otp-syscall] Error revoking vendor PK hash: slot {} is not provisioned",
-                vendor_pk_hash_slot
-            );
             Err(ErrorCode::Invalid)?
         }
 
-        let valid_mask = self.read(reg::VENDOR_PK_HASH_VALID, 0).inspect_err(|e| {
-            let _ = writeln!(
-                wr,
-                "[otp-syscall] Error revoking vendor PK hash: failed to read mask {e:?}"
-            );
-        })?;
+        let valid_mask = self.read(reg::VENDOR_PK_HASH_VALID, 0)?;
 
         let valid_mask = valid_mask | (1 << vendor_pk_hash_slot);
-        let _ = writeln!(wr, "[otp-syscall] Writing new mask: {valid_mask:032b}");
-
         self.write(reg::VENDOR_PK_HASH_VALID, 0, valid_mask)
-            .inspect_err(|e| {
-                let _ = writeln!(
-                    wr,
-                    "[otp-syscall] Error revoking vendor PK hash: failed to write mask {e:?}"
-                );
-            })
     }
 
     /// Lock a partition

--- a/runtime/userspace/syscall/src/otp.rs
+++ b/runtime/userspace/syscall/src/otp.rs
@@ -3,8 +3,10 @@
 //! # OTP: An Interface for accessing the OTP fuses
 
 use crate::DefaultSyscalls;
-use caliptra_mcu_libtock_platform::{ErrorCode, Syscalls};
+use caliptra_mcu_libtock_console::{Console, ConsoleWriter};
+use caliptra_mcu_libtock_platform::{DefaultConfig, ErrorCode, Syscalls};
 use caliptra_mcu_mbox_common::messages::RevokeVendorPubKeyType;
+use core::fmt::Write;
 use core::{iter::repeat, marker::PhantomData};
 
 pub const VENDOR_PK_HASH_SIZE: usize =
@@ -152,7 +154,13 @@ impl<S: Syscalls> Otp<S> {
         slot: u32,
         new_hash: &[u8; VENDOR_PK_HASH_SIZE],
     ) -> Result<(), ErrorCode> {
+        let mut wr: ConsoleWriter<DefaultSyscalls> = Console::<_, DefaultConfig>::writer();
         if slot > 15 {
+            let _ = writeln!(
+                wr,
+                "[otp-syscall] Error provisioning vendor PK hash: invalid slot number ({})",
+                slot
+            );
             return Err(ErrorCode::Invalid);
         }
 
@@ -160,6 +168,10 @@ impl<S: Syscalls> Otp<S> {
 
         if !self.valid_vendor_pk_hash_slot(slot) {
             // Error when the slot was already marked as invalid
+            let _ = writeln!(
+                wr,
+                "[otp-syscall] Error provisioning vendor PK hash: slot alreay marked invalid"
+            );
             return Err(ErrorCode::Invalid);
         }
 
@@ -168,20 +180,35 @@ impl<S: Syscalls> Otp<S> {
             // Return early when the fuse already contains the hash
             return Ok(());
         }
-        if fuse_value.iter().ne(repeat(&0)) {
+        if fuse_value.iter().ne(repeat(&0).take(fuse_value.len())) {
             // Error if the fuse is already containing something
+            let _ = writeln!(
+                wr,
+                "[otp-syscall] Error provisioning vendor PK hash: slot {} not empty",
+                slot
+            );
             return Err(ErrorCode::Invalid);
         }
 
         // Write fuse
         for (i, chunk) in new_hash.chunks_exact(4).enumerate() {
             let word = u32::from_le_bytes(chunk.try_into().map_err(|_| ErrorCode::Fail)?);
-            self.write(reg, i as u32, word)?;
+            self.write(reg, i as u32, word).inspect_err(|e| {
+                let _ = writeln!(
+                    wr,
+                    "[otp-syscall] Error provisioning vendor PK hash: write failed {:?}",
+                    e
+                );
+            })?;
         }
 
         // Read back the fuse and compare to validate writing was successfull
         let fuse_value = self.read_vendor_pk_hash(slot)?;
         if new_hash != &fuse_value {
+            let _ = writeln!(
+                wr,
+                "[otp-syscall] Error provisioning vendor PK hash: fuse does not match new pk hash after write",
+            );
             return Err(ErrorCode::Fail);
         }
 
@@ -196,7 +223,13 @@ impl<S: Syscalls> Otp<S> {
     /// - Returns `Invalid` when the slot is invalid
     /// - Returns `Fail` when writing the fuse failed
     pub fn revoke_vendor_pk_hash(&self, vendor_pk_hash_slot: u32) -> Result<(), ErrorCode> {
+        let mut wr: ConsoleWriter<DefaultSyscalls> = Console::<_, DefaultConfig>::writer();
         if vendor_pk_hash_slot as usize >= MAX_NUM_VENDOR_PK_HASH {
+            let _ = writeln!(
+                wr,
+                "[otp-syscall] Error revoking vendor PK hash: invalid slot number ({})",
+                vendor_pk_hash_slot
+            );
             Err(ErrorCode::Invalid)?
         }
 
@@ -208,14 +241,31 @@ impl<S: Syscalls> Otp<S> {
         // Check if the slot is provisioned to not burn an empty slot
         let pk_hash = self.read_vendor_pk_hash(vendor_pk_hash_slot)?;
         if pk_hash.iter().eq(repeat(&0)) {
+            let _ = writeln!(
+                wr,
+                "[otp-syscall] Error revoking vendor PK hash: slot {} is not provisioned",
+                vendor_pk_hash_slot
+            );
             Err(ErrorCode::Invalid)?
         }
 
-        let valid_mask = self.read(reg::VENDOR_PK_HASH_VALID, 0)?;
+        let valid_mask = self.read(reg::VENDOR_PK_HASH_VALID, 0).inspect_err(|e| {
+            let _ = writeln!(
+                wr,
+                "[otp-syscall] Error revoking vendor PK hash: failed to read mask {e:?}"
+            );
+        })?;
 
         let valid_mask = valid_mask | (1 << vendor_pk_hash_slot);
+        let _ = writeln!(wr, "[otp-syscall] Writing new mask: {valid_mask:032b}");
 
         self.write(reg::VENDOR_PK_HASH_VALID, 0, valid_mask)
+            .inspect_err(|e| {
+                let _ = writeln!(
+                    wr,
+                    "[otp-syscall] Error revoking vendor PK hash: failed to write mask {e:?}"
+                );
+            })
     }
 
     /// Lock a partition

--- a/tests/integration/src/runtime/test_revoke_vendor_pub_key.rs
+++ b/tests/integration/src/runtime/test_revoke_vendor_pub_key.rs
@@ -5,10 +5,13 @@ use crate::{
     test::{compile_runtime, start_runtime_hw_model, CustomCaliptraFw, TestParams},
 };
 use anyhow::Result;
-use caliptra_api::{error::CaliptraError, SocManager};
+use caliptra_api::{error::CaliptraError, mailbox::MailboxReqHeader, SocManager};
 use caliptra_mcu_builder::{CaliptraBuildArgs, CaliptraBuilder, FirmwareBinaries};
 use caliptra_mcu_hw_model::{LifecycleControllerState, McuHwModel};
-use caliptra_mcu_mbox_common::messages::{FuseRevokeVendorPubKeyReq, RevokeVendorPubKeyType};
+use caliptra_mcu_mbox_common::messages::{
+    FuseRevokeVendorPkHashReq, FuseRevokeVendorPubKeyReq, ProvisionVendorPkHashReq,
+    RevokeVendorPubKeyType,
+};
 use caliptra_mcu_romtime::McuBootMilestones;
 
 fn get_fw() -> Result<(Vec<u8>, Vec<u8>, [u8; 48], Vec<u8>)> {
@@ -201,5 +204,84 @@ fn test_revoke_vendor_pub_key0_lms() -> Result<()> {
             .read(),
         u32::from(CaliptraError::IMAGE_VERIFIER_ERR_VENDOR_PQC_PUB_KEY_REVOKED)
     );
+    Ok(())
+}
+
+#[test]
+fn test_rotate_vendor_pk_hash() -> Result<()> {
+    let (caliptra_fw, _caliptra_fw_key2, vendor_pk_hash_arr, soc_manifest) = get_fw()?;
+
+    // Boot with default caliptra_fw
+    let mut hw = start_runtime_hw_model(TestParams {
+        feature: Some("test-mcu-mbox-cmds"),
+        custom_caliptra_fw: Some(CustomCaliptraFw {
+            fw_bytes: caliptra_fw.clone(),
+            vendor_pk_hash: vendor_pk_hash_arr,
+            soc_manifest: soc_manifest.clone(),
+        }),
+        lifecycle_controller_state: Some(LifecycleControllerState::Prod),
+        ..Default::default()
+    });
+
+    hw.step_until(|hw| {
+        hw.mci_boot_milestones()
+            .contains(McuBootMilestones::FIRMWARE_MAILBOX_READY)
+    });
+
+    // Check revoking the active PK hash fails
+    let cmd = FuseRevokeVendorPkHashReq {
+        vendor_pk_hash_slot: 0,
+        ..Default::default()
+    };
+    let result = execute_authorized_req(&mut hw, cmd);
+    assert!(result.is_err());
+
+    // We can reuse the existing pk hash,
+    // but have to change something for revocation to succeed.
+    let mut new_pk_hash = vendor_pk_hash_arr;
+    new_pk_hash[0] = 0x42;
+    // Provision a new vendor PK hash
+    let cmd = ProvisionVendorPkHashReq {
+        slot: 1,
+        hash: new_pk_hash,
+        hdr: MailboxReqHeader::default(),
+    };
+    let resp = execute_authorized_req(&mut hw, cmd);
+    assert!(resp.is_ok(), "{:?}", resp);
+
+    // Check revoking a pk hash that isn't active succeeds
+    let cmd = FuseRevokeVendorPkHashReq {
+        vendor_pk_hash_slot: 1,
+        ..Default::default()
+    };
+    let resp = execute_authorized_req(&mut hw, cmd);
+    assert!(resp.is_ok());
+
+    // Read OTP memory so we can use the same config in later boots.
+    let otp = hw.read_otp_memory();
+
+    // Boot with caliptra_fw again
+    let mut hw = start_runtime_hw_model(TestParams {
+        feature: Some("test-mcu-mbox-cmds"),
+        custom_caliptra_fw: Some(CustomCaliptraFw {
+            fw_bytes: caliptra_fw,
+            vendor_pk_hash: vendor_pk_hash_arr,
+            soc_manifest: soc_manifest.clone(),
+        }),
+        otp_memory: Some(otp),
+        lifecycle_controller_state: Some(LifecycleControllerState::Prod),
+        ..Default::default()
+    });
+
+    // Wait for the mailbox to become ready, indicating the runtime has booted.
+    hw.step_until(|hw| {
+        hw.mci_boot_milestones()
+            .contains(McuBootMilestones::FIRMWARE_MAILBOX_READY)
+    });
+
+    // TODO: Boot firmware for new vendor key, then revoke the old key in slot 0.
+    //       (For this, an image with new keys has to be created first.
+    //       The current key 2 image uses the same PK hash.)
+
     Ok(())
 }


### PR DESCRIPTION
- Adds an integration test for rotating a vendor PK hash.
For now the test only provisions a PK hash that is immediately revoked.
For a more thorough test an image that ueses a PK hash different from
the default one still needs to be added.
- Fix a few smaller bugs that emerged
  - When checking a fuse is all `0` the Iter `eq` method wasn't used correctly
  - `write_entry_multi` has to be used for `VENDOR_PK_HASH_VALID` since it's encoded raw representation is > 32 bit