### PR TITLE
[fuses] Add vendor fuses tracking field entropy partition status

### DIFF
--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -222,6 +222,16 @@ impl McuError {
             "FIPS zeroization failed to finish ZEROIZE_UDS_FE command"
         ),
         (
+            ROM_FIPS_ZEROIZATION_WRITE_FIELD_ENTROPY_STATE_ZEROIZED_ERROR,
+            0x2_000b,
+            "FIPS zeroization failed to write FIELD_ENTROPY_STATE (zeroized) to OTP"
+        ),
+        (
+            ROM_FIPS_ZEROIZATION_READ_FIELD_ENTROPY_STATE_ERROR,
+            0x2_000c,
+            "FIPS zeroization failed to read FIELD_ENTROPY_STATE from OTP"
+        ),
+        (
             ROM_OTP_INIT_STATUS_ERROR,
             0x3_0000,
             "OTP controller status error during initialization"
@@ -788,6 +798,36 @@ impl McuError {
             ROM_COLD_BOOT_FIELD_ENTROPY_PROG_FINISH_FAILED,
             0x1_003C,
             "Cold boot failed to finish field entropy program (other error)"
+        ),
+        (
+            ROM_COLD_BOOT_FIELD_ENTROPY_ZEROIZED,
+            0x1_003D,
+            "Field entropy slot is zeroized"
+        ),
+        (
+            ROM_COLD_BOOT_FIELD_ENTROPY_PARTIAL,
+            0x1_003E,
+            "Field entropy slot is partially programmed"
+        ),
+        (
+            ROM_COLD_BOOT_FIELD_ENTROPY_INVALID_PARTITION,
+            0x1_003F,
+            "Field entropy partition is invalid"
+        ),
+        (
+            ROM_COLD_BOOT_READ_FIELD_ENTROPY_STATE_ERROR,
+            0x1_0040,
+            "Failed to read FIELD_ENTROPY_STATE from OTP"
+        ),
+        (
+            ROM_COLD_BOOT_WRITE_FIELD_ENTROPY_STATE_STARTED_ERROR,
+            0x1_0041,
+            "Failed to write FIELD_ENTROPY_STATE (started) to OTP"
+        ),
+        (
+            ROM_COLD_BOOT_WRITE_FIELD_ENTROPY_STATE_FINISHED_ERROR,
+            0x1_0042,
+            "Failed to write FIELD_ENTROPY_STATE (finished) to OTP"
         ),
         (
             ROM_SOC_PK_HASH_VERIFY_INTERNAL_ERROR,

--- a/hw/fuses.hjson
+++ b/hw/fuses.hjson
@@ -31,6 +31,7 @@
     {"mcu_component_svn_manifest_min_svn": 4},
     {"soc_image_min_svn_0": 4},
     {"soc_image_min_svn_1": 4},
+    {"field_entropy_state": 48},
     {"fpga_test_uds_seed_lo": 32},
     {"fpga_test_uds_seed_hi": 32},
     {"fpga_test_field_entropy": 32},
@@ -652,6 +653,14 @@
         partition: "VENDOR_HASHES_PROD_PARTITION",
         otp_item: "CPTRA_CORE_PQC_KEY_TYPE_15",
         layout: {type: "OneHotLinearOr", duplication: 3},
+    },
+    {
+        name: "field_entropy_state",
+        bits: 384,
+        description: "Status of field entropy slots. 32 bits per flag (word 3N: started, word 3N+1: finished, word 3N+2: zeroized for slot N).",
+        partition: "VENDOR_NON_SECRET_PROD_PARTITION",
+        otp_item: "CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_7",
+        layout: {type: "Single"},
     },
     {
         name: "fpga_test_uds_seed_lo",

--- a/registers/generated-firmware/src/fuse_map.md
+++ b/registers/generated-firmware/src/fuse_map.md
@@ -397,6 +397,7 @@
 | vendor_pqc_key_type_13 | 2 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_13 | OneHotLinearOr(3x) | One-hot encoded PQC key type for slot 13 (1: MLDSA, 2: LMS). |
 | vendor_pqc_key_type_14 | 2 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_14 | OneHotLinearOr(3x) | One-hot encoded PQC key type for slot 14 (1: MLDSA, 2: LMS). |
 | vendor_pqc_key_type_15 | 2 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_15 | OneHotLinearOr(3x) | One-hot encoded PQC key type for slot 15 (1: MLDSA, 2: LMS). |
+| field_entropy_state | 384 | VENDOR_NON_SECRET_PROD_PARTITION | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_7 | Single | Status of field entropy slots. 32 bits per flag (word 3N: started, word 3N+1: finished, word 3N+2: zeroized for slot N). |
 | fpga_test_uds_seed_lo | 256 | VENDOR_NON_SECRET_PROD_PARTITION | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_8 | Single | UDS Seed low 256 bits (for FPGA test harness handoff only) |
 | fpga_test_uds_seed_hi | 256 | VENDOR_NON_SECRET_PROD_PARTITION | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_9 | Single | UDS Seed high 256 bits (for FPGA test harness handoff only) |
 | fpga_test_field_entropy | 256 | VENDOR_NON_SECRET_PROD_PARTITION | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_10 | Single | Field Entropy (for FPGA test harness handoff only) |

--- a/registers/generated-firmware/src/fuses.rs
+++ b/registers/generated-firmware/src/fuses.rs
@@ -504,6 +504,10 @@ pub const NON_SECRET_VENDOR_FUSES: &[Fuse] = &[
         size: Bytes(4),
     },
     Fuse {
+        name: "field_entropy_state",
+        size: Bytes(48),
+    },
+    Fuse {
         name: "fpga_test_uds_seed_lo",
         size: Bytes(32),
     },
@@ -820,6 +824,10 @@ pub const FUSE_FIELDS: &[FuseField] = &[
     FuseField {
         name: "vendor_pqc_key_type_15",
         bits: Bits(2),
+    },
+    FuseField {
+        name: "field_entropy_state",
+        bits: Bits(384),
     },
     FuseField {
         name: "fpga_test_uds_seed_lo",
@@ -1727,6 +1735,15 @@ pub const VENDOR_PQC_KEY_TYPE_15: &FuseEntryInfo = &FuseEntryInfo {
         bits: 2,
         duplication: 3,
     },
+};
+/// Fuse entry for `field_entropy_state`.
+pub const FIELD_ENTROPY_STATE: &FuseEntryInfo = &FuseEntryInfo {
+    partition_num: 14,
+    entry_num: 7,
+    byte_offset: 0xb88,
+    byte_size: 32,
+    name: "field_entropy_state",
+    layout: FuseLayoutType::Single { bits: 384 },
 };
 /// Fuse entry for `fpga_test_uds_seed_lo`.
 pub const FPGA_TEST_UDS_SEED_LO: &FuseEntryInfo = &FuseEntryInfo {
@@ -3222,17 +3239,14 @@ pub const OTP_CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_6: &FuseEntryInfo = &Fuse
         duplication: 3,
     },
 };
-/// OTP item entry for `soc_image_min_svn_1`.
+/// OTP item entry for `field_entropy_state`.
 pub const OTP_CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_7: &FuseEntryInfo = &FuseEntryInfo {
     partition_num: 14,
     entry_num: 7,
     byte_offset: 0xb88,
     byte_size: 32,
-    name: "soc_image_min_svn_1",
-    layout: FuseLayoutType::OneHotLinearOr {
-        bits: 10,
-        duplication: 3,
-    },
+    name: "field_entropy_state",
+    layout: FuseLayoutType::Single { bits: 384 },
 };
 /// OTP item entry for `fpga_test_uds_seed_lo`.
 pub const OTP_CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_8: &FuseEntryInfo = &FuseEntryInfo {

--- a/rom/src/cold_boot.rs
+++ b/rom/src/cold_boot.rs
@@ -41,8 +41,8 @@ use caliptra_mcu_registers_generated::mci::bits::{MboxExecute, MboxLock};
 #[cfg(feature = "ocp-lock")]
 use caliptra_mcu_romtime::ocp_lock::HekState;
 use caliptra_mcu_romtime::{
-    CaliptraSoC, HexBytes, HexWord, LifecycleControllerState, LifecycleToken, McuBootMilestones,
-    McuRomBootStatus,
+    CaliptraSoC, FieldEntropySlot, FieldEntropyState, HexBytes, HexWord, LifecycleControllerState,
+    LifecycleToken, McuBootMilestones, McuRomBootStatus, Otp,
 };
 use core::fmt::Write;
 use core::ops::Deref;
@@ -168,66 +168,112 @@ impl ColdBoot {
         program_field_entropy: &[bool; 4],
         soc_manager: &mut CaliptraSoC,
         mci: &caliptra_mcu_romtime::Mci,
+        otp: &Otp,
     ) {
         for (partition, _) in program_field_entropy
             .iter()
             .enumerate()
             .filter(|(_, partition)| **partition)
         {
+            // Convert partition index to FieldEntropySlot enum safely
+            let slot = FieldEntropySlot::try_from(partition).unwrap_or_else(|_| {
+                fatal_error(McuError::ROM_COLD_BOOT_FIELD_ENTROPY_INVALID_PARTITION);
+            });
+            let state = FieldEntropyState::read(otp, slot).unwrap_or_else(|_| {
+                fatal_error(McuError::ROM_COLD_BOOT_READ_FIELD_ENTROPY_STATE_ERROR);
+            });
+
+            match state {
+                // Started but not finished means the previous programming attempt was interrupted.
+                // This is an error state because we don't know if the field entropy is valid or
+                // not. Restarting a partially programmed slot risks overwriting valid entropy, but
+                // skipping it risks leaving the system without necessary entropy. Given these
+                // risks, we choose to treat this as a fatal error that requires manual
+                // intervention.
+                FieldEntropyState::Started => {
+                    fatal_error(McuError::ROM_COLD_BOOT_FIELD_ENTROPY_PARTIAL);
+                }
+                // Zeroized means the field entropy has been cleared and is not available.
+                FieldEntropyState::Zeroized => {
+                    fatal_error(McuError::ROM_COLD_BOOT_FIELD_ENTROPY_ZEROIZED);
+                }
+                // If slot is fully programmed, skip it and mark it as successful.
+                FieldEntropyState::Finished => {
+                    Self::set_field_entropy_prog_flow_checkpoint(mci, partition);
+                    continue;
+                }
+                FieldEntropyState::Empty => (),
+            }
+
+            // Only execute the command if the slot is empty.
             caliptra_mcu_romtime::println!(
                 "[mcu-rom] Executing FE_PROG command for partition {}",
                 partition
             );
 
-            let mut req = FeProgReq {
-                partition: partition as u32,
-                ..Default::default()
-            };
-            let chksum = caliptra_api::calc_checksum(
-                CommandId::FE_PROG.into(),
-                &req.as_bytes()[core::mem::size_of::<MailboxReqHeader>()..],
-            );
-            req.hdr.chksum = chksum;
-            if let Err(err) =
-                soc_manager.start_mailbox_req_bytes(CommandId::FE_PROG.into(), req.as_bytes())
-            {
+            // Before starting the command to caliptra mark the slot as started
+            otp.mark_field_entropy_started(slot).unwrap_or_else(|_| {
+                fatal_error(McuError::ROM_COLD_BOOT_WRITE_FIELD_ENTROPY_STATE_STARTED_ERROR);
+            });
+
+            Self::send_program_field_entropy_mailbox_cmd(soc_manager, partition);
+
+            // mark it as finished when Caliptra returns success
+            otp.mark_field_entropy_finished(slot).unwrap_or_else(|_| {
+                fatal_error(McuError::ROM_COLD_BOOT_WRITE_FIELD_ENTROPY_STATE_FINISHED_ERROR);
+            });
+
+            Self::set_field_entropy_prog_flow_checkpoint(mci, partition);
+        }
+    }
+
+    fn send_program_field_entropy_mailbox_cmd(soc_manager: &mut CaliptraSoC, partition: usize) {
+        let mut req = FeProgReq {
+            partition: partition as u32,
+            ..Default::default()
+        };
+        let chksum = caliptra_api::calc_checksum(
+            CommandId::FE_PROG.into(),
+            &req.as_bytes()[core::mem::size_of::<MailboxReqHeader>()..],
+        );
+        req.hdr.chksum = chksum;
+        if let Err(err) =
+            soc_manager.start_mailbox_req_bytes(CommandId::FE_PROG.into(), req.as_bytes())
+        {
+            match err {
+                CaliptraApiError::MailboxCmdFailed(_) => {
+                    fatal_error(McuError::ROM_COLD_BOOT_FIELD_ENTROPY_PROG_START_MBOX_CMD_FAILED);
+                }
+                _ => {
+                    fatal_error(McuError::ROM_COLD_BOOT_FIELD_ENTROPY_PROG_START_FAILED);
+                }
+            }
+        }
+        {
+            let mut resp_buf = [0u8; core::mem::size_of::<MailboxRespHeader>()];
+            if let Err(err) = soc_manager.finish_mailbox_resp_bytes(&mut resp_buf) {
                 match err {
                     CaliptraApiError::MailboxCmdFailed(_) => {
                         fatal_error(
-                            McuError::ROM_COLD_BOOT_FIELD_ENTROPY_PROG_START_MBOX_CMD_FAILED,
+                            McuError::ROM_COLD_BOOT_FIELD_ENTROPY_PROG_FINISH_MBOX_CMD_FAILED,
                         );
                     }
                     _ => {
-                        fatal_error(McuError::ROM_COLD_BOOT_FIELD_ENTROPY_PROG_START_FAILED);
+                        fatal_error(McuError::ROM_COLD_BOOT_FIELD_ENTROPY_PROG_FINISH_FAILED);
                     }
                 }
             }
-            {
-                let mut resp_buf = [0u8; core::mem::size_of::<MailboxRespHeader>()];
-                if let Err(err) = soc_manager.finish_mailbox_resp_bytes(&mut resp_buf) {
-                    match err {
-                        CaliptraApiError::MailboxCmdFailed(_) => {
-                            fatal_error(
-                                McuError::ROM_COLD_BOOT_FIELD_ENTROPY_PROG_FINISH_MBOX_CMD_FAILED,
-                            );
-                        }
-                        _ => {
-                            fatal_error(McuError::ROM_COLD_BOOT_FIELD_ENTROPY_PROG_FINISH_FAILED);
-                        }
-                    }
-                }
-            }
-
-            // Set status for each partition completion
-            let partition_status = match partition {
-                0 => McuRomBootStatus::FieldEntropyPartition0Complete.into(),
-                1 => McuRomBootStatus::FieldEntropyPartition1Complete.into(),
-                2 => McuRomBootStatus::FieldEntropyPartition2Complete.into(),
-                3 => McuRomBootStatus::FieldEntropyPartition3Complete.into(),
-                _ => mci.flow_checkpoint(),
-            };
-            mci.set_flow_checkpoint(partition_status);
         }
+    }
+
+    fn set_field_entropy_prog_flow_checkpoint(mci: &caliptra_mcu_romtime::Mci, partition: usize) {
+        let base = McuRomBootStatus::FieldEntropyProgrammingStarted as u16;
+        let partition_status = if partition < 4 {
+            base + 1 + partition as u16
+        } else {
+            mci.flow_checkpoint()
+        };
+        mci.set_flow_checkpoint(partition_status);
     }
 
     /// Decrypt the encrypted MCU firmware in SRAM using DMA-based decryption:
@@ -354,6 +400,17 @@ impl ColdBoot {
             );
             fatal_error(McuError::GENERIC_EXCEPTION);
         }
+    }
+
+    /// Measure the field_entropy_state fuses and stash it to DPE.
+    fn report_field_entropy_state(soc_manager: &mut CaliptraSoC, otp: &Otp) {
+        let Ok(words) = otp.read_entry_multi::<12>(fuses::FIELD_ENTROPY_STATE) else {
+            fatal_error(McuError::ROM_COLD_BOOT_READ_FIELD_ENTROPY_STATE_ERROR);
+        };
+
+        let measurement = mailbox::cm_sha384(soc_manager, &words);
+
+        Self::stash_measurement(soc_manager, &measurement);
     }
 
     /// Import the test AES key via CM_IMPORT and return the CMK handle.
@@ -571,6 +628,7 @@ impl ColdBoot {
         mci: &caliptra_mcu_romtime::Mci,
         lc: &caliptra_mcu_romtime::Lifecycle,
         soc_manager: &mut CaliptraSoC,
+        otp: &Otp,
     ) -> ! {
         caliptra_mcu_romtime::println!("[mcu-rom] Executing FIPS zeroization flow");
 
@@ -604,7 +662,8 @@ impl ColdBoot {
             fatal_error(McuError::ROM_FIPS_ZEROIZATION_UDS_FE_START_ERROR);
         }
         {
-            let mut resp_buf = [0u8; core::mem::size_of::<MailboxRespHeader>()];
+            let mut resp_buf =
+                [0u8; core::mem::size_of::<caliptra_api::mailbox::ZeroizeUdsFeResp>()];
             if let Err(err) = soc_manager.finish_mailbox_resp_bytes(&mut resp_buf) {
                 caliptra_mcu_romtime::println!(
                     "[mcu-rom] FIPS zeroization: ZEROIZE_UDS_FE finish failed: {}",
@@ -615,6 +674,21 @@ impl ColdBoot {
         }
         caliptra_mcu_romtime::println!("[mcu-rom] ZEROIZE_UDS_FE completed successfully");
         mci.set_flow_checkpoint(McuRomBootStatus::FipsZeroizationUdsFeComplete.into());
+
+        // Set the zeroized bits for all field entropy slots in OTP.
+        let all_slots = [
+            FieldEntropySlot::Slot0,
+            FieldEntropySlot::Slot1,
+            FieldEntropySlot::Slot2,
+            FieldEntropySlot::Slot3,
+        ];
+        for slot in all_slots {
+            otp.mark_field_entropy_zeroized(slot).unwrap_or_else(|_| {
+                fatal_error(
+                    McuError::ROM_FIPS_ZEROIZATION_WRITE_FIELD_ENTROPY_STATE_ZEROIZED_ERROR,
+                );
+            });
+        }
 
         // Note: FC_FIPS_ZEROZATION mask was already set before
         // SS_CONFIG_DONE_STICKY (in ColdBoot::run) because the register is
@@ -1224,7 +1298,7 @@ impl BootFlow for ColdBoot {
         // Execute full FIPS zeroization flow now that Caliptra is ready for
         // mailbox commands. This never returns (halts for cold reset).
         if fips_zeroization {
-            ColdBoot::handle_fips_zeroization(mci, lc, &mut env.soc_manager);
+            ColdBoot::handle_fips_zeroization(mci, lc, &mut env.soc_manager, otp);
         }
 
         // Report HEK metadata to Caliptra ROM
@@ -1529,9 +1603,16 @@ impl BootFlow for ColdBoot {
         if params.program_field_entropy.iter().any(|x| *x) {
             caliptra_mcu_romtime::println!("[mcu-rom] Programming field entropy");
             mci.set_flow_checkpoint(McuRomBootStatus::FieldEntropyProgrammingStarted.into());
-            Self::program_field_entropy(&params.program_field_entropy, &mut env.soc_manager, mci);
+            Self::program_field_entropy(
+                &params.program_field_entropy,
+                &mut env.soc_manager,
+                mci,
+                &env.otp,
+            );
             mci.set_flow_checkpoint(McuRomBootStatus::FieldEntropyProgrammingComplete.into());
         }
+
+        Self::report_field_entropy_state(&mut env.soc_manager, &env.otp);
 
         if params.recovery_status_open {
             caliptra_mcu_romtime::println!("[mcu-rom] Leaving recovery interface open");

--- a/rom/src/mailbox.rs
+++ b/rom/src/mailbox.rs
@@ -58,22 +58,17 @@ fn ctx_as_u32(ctx: &[u8; CMB_SHA_CONTEXT_SIZE]) -> &[u32; CTX_DWORDS] {
 /// the ~4 KiB stack allocations that the request structs would otherwise
 /// require.
 pub fn cm_sha384(soc_manager: &mut CaliptraSoC, data: &[u32]) -> [u8; 48] {
-    let mut offset = 0;
     let first_chunk = data.len().min(CHUNK_DWORDS);
 
-    let mut sha_context = cm_sha_init(soc_manager, &data[..first_chunk]);
-    offset += first_chunk;
+    let (first_chunk, rest) = data.split_at(first_chunk);
 
-    while data.len() - offset > CHUNK_DWORDS {
-        cm_sha_update(
-            soc_manager,
-            &data[offset..offset + CHUNK_DWORDS],
-            &mut sha_context,
-        );
-        offset += CHUNK_DWORDS;
+    let mut sha_context = cm_sha_init(soc_manager, first_chunk);
+
+    for chunk in rest.chunks(CHUNK_DWORDS) {
+        cm_sha_update(soc_manager, chunk, &mut sha_context);
     }
 
-    cm_sha_final(soc_manager, &data[offset..], sha_context)
+    cm_sha_final(soc_manager, &[], sha_context)
 }
 
 /// Send CM_SHA_INIT with the first data chunk and return the SHA context.

--- a/rom/src/rom.rs
+++ b/rom/src/rom.rs
@@ -28,6 +28,7 @@ use caliptra_api::mailbox::CmStableKeyType;
 #[cfg(all(not(test), feature = "cfi"))]
 use caliptra_cfi_derive::{cfi_impl_fn, cfi_mod_fn};
 use caliptra_cfi_lib::{cfi_assert_eq, cfi_launder, CfiCounter, CfiError};
+use caliptra_drivers::AxiAddr;
 use caliptra_mcu_error::McuError;
 use caliptra_mcu_registers_generated::fuses;
 use caliptra_mcu_registers_generated::mci;
@@ -226,13 +227,20 @@ impl Soc {
         // secret fuses are populated by a hardware state machine, so we can skip those
 
         // UDS partition base address. (FE offset is calculated automatically by Caliptra ROM.)
-        let offset = fuses::SECRET_MANUF_PARTITION_BYTE_OFFSET;
-        caliptra_mcu_romtime::println!(
-            "[mcu-fuse-write] Setting UDS/FE base address to {:x}",
-            offset
-        );
-        self.registers.ss_uds_seed_base_addr_l.set(offset as u32);
-        self.registers.ss_uds_seed_base_addr_h.set(0);
+        // Only set it if it's not already configured.
+        let current_uds_addr = AxiAddr {
+            lo: self.registers.ss_uds_seed_base_addr_l.get(),
+            hi: self.registers.ss_uds_seed_base_addr_h.get(),
+        };
+        if current_uds_addr == 0u64.into() {
+            let offset = fuses::SECRET_MANUF_PARTITION_BYTE_OFFSET;
+            caliptra_mcu_romtime::println!(
+                "[mcu-fuse-write] Setting UDS/FE base address to {:x}",
+                offset
+            );
+            self.registers.ss_uds_seed_base_addr_l.set(offset as u32);
+            self.registers.ss_uds_seed_base_addr_h.set(0);
+        }
 
         caliptra_mcu_romtime::println!(
             "[mcu-fuse-write] Setting UDS/FE DAI idle bit offset to {} and direct access cmd reg offset to {}",

--- a/romtime/src/otp.rs
+++ b/romtime/src/otp.rs
@@ -946,6 +946,54 @@ impl Otp {
         }
         Ok(())
     }
+
+    /// Check if a field entropy slot is started in OTP memory.
+    pub fn is_field_entropy_started(&self, slot: FieldEntropySlot) -> McuResult<bool> {
+        let base_word = fuses::FIELD_ENTROPY_STATE.byte_offset / 4;
+        let word_index = (slot as usize) * 3;
+        let val = self.read_word(base_word + word_index)?;
+        Ok(val == FieldEntropySlot::STARTED_MAGIC)
+    }
+
+    /// Check if a field entropy slot is finished in OTP memory.
+    pub fn is_field_entropy_finished(&self, slot: FieldEntropySlot) -> McuResult<bool> {
+        let base_word = fuses::FIELD_ENTROPY_STATE.byte_offset / 4;
+        let word_index = (slot as usize) * 3 + 1;
+        let val = self.read_word(base_word + word_index)?;
+        Ok(val == FieldEntropySlot::FINISHED_MAGIC)
+    }
+
+    /// Check if a field entropy slot is zeroized in OTP memory.
+    pub fn is_field_entropy_zeroized(&self, slot: FieldEntropySlot) -> McuResult<bool> {
+        let base_word = fuses::FIELD_ENTROPY_STATE.byte_offset / 4;
+        let word_index = (slot as usize) * 3 + 2;
+        let val = self.read_word(base_word + word_index)?;
+        Ok(val == FieldEntropySlot::ZEROIZED_MAGIC)
+    }
+
+    /// Mark a field entropy slot as started in OTP memory.
+    pub fn mark_field_entropy_started(&self, slot: FieldEntropySlot) -> McuResult<()> {
+        let base_word = fuses::FIELD_ENTROPY_STATE.byte_offset / 4;
+        let word_index = (slot as usize) * 3;
+        self.write_word(base_word + word_index, FieldEntropySlot::STARTED_MAGIC)?;
+        Ok(())
+    }
+
+    /// Mark a field entropy slot as finished in OTP memory.
+    pub fn mark_field_entropy_finished(&self, slot: FieldEntropySlot) -> McuResult<()> {
+        let base_word = fuses::FIELD_ENTROPY_STATE.byte_offset / 4;
+        let word_index = (slot as usize) * 3 + 1;
+        self.write_word(base_word + word_index, FieldEntropySlot::FINISHED_MAGIC)?;
+        Ok(())
+    }
+
+    /// Mark a field entropy slot as zeroized in OTP memory.
+    pub fn mark_field_entropy_zeroized(&self, slot: FieldEntropySlot) -> McuResult<()> {
+        let base_word = fuses::FIELD_ENTROPY_STATE.byte_offset / 4;
+        let word_index = (slot as usize) * 3 + 2;
+        self.write_word(base_word + word_index, FieldEntropySlot::ZEROIZED_MAGIC)?;
+        Ok(())
+    }
 }
 
 /// Returns the FuseEntryInfo for the given vendor PK hash slot.
@@ -1060,5 +1108,56 @@ pub fn vendor_mldsa_revocation_entry(index: usize) -> McuResult<&'static FuseEnt
         14 => Ok(fuses::VENDOR_MLDSA_REVOCATION_14),
         15 => Ok(fuses::VENDOR_MLDSA_REVOCATION_15),
         _ => Err(McuError::ROM_OTP_INVALID_DATA_ERROR),
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FieldEntropySlot {
+    Slot0 = 0,
+    Slot1 = 1,
+    Slot2 = 2,
+    Slot3 = 3,
+}
+
+impl TryFrom<usize> for FieldEntropySlot {
+    type Error = ();
+    fn try_from(value: usize) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Self::Slot0),
+            1 => Ok(Self::Slot1),
+            2 => Ok(Self::Slot2),
+            3 => Ok(Self::Slot3),
+            _ => Err(()),
+        }
+    }
+}
+
+impl FieldEntropySlot {
+    pub const STARTED_MAGIC: u32 = 0x5354_5254; // "STRT"
+    pub const FINISHED_MAGIC: u32 = 0x4649_4E53; // "FINS"
+    pub const ZEROIZED_MAGIC: u32 = 0x5A45_524F; // "ZERO"
+}
+
+pub enum FieldEntropyState {
+    Empty,
+    Started,
+    Finished,
+    Zeroized,
+}
+
+impl FieldEntropyState {
+    pub fn read(otp: &Otp, slot: FieldEntropySlot) -> McuResult<FieldEntropyState> {
+        let started = otp.is_field_entropy_started(slot)?;
+        let finished = otp.is_field_entropy_finished(slot)?;
+        let zeroized = otp.is_field_entropy_zeroized(slot)?;
+        if zeroized {
+            Ok(FieldEntropyState::Zeroized)
+        } else if started && !finished {
+            Ok(FieldEntropyState::Started)
+        } else if started && finished {
+            Ok(FieldEntropyState::Finished)
+        } else {
+            Ok(FieldEntropyState::Empty)
+        }
     }
 }

--- a/tests/integration/src/test_fips_zeroization.rs
+++ b/tests/integration/src/test_fips_zeroization.rs
@@ -4,6 +4,8 @@
 mod test {
     use crate::test::{start_runtime_hw_model, TestParams, TEST_LOCK};
     use caliptra_mcu_hw_model::{McuHwModel, McuManager};
+    use caliptra_mcu_registers_generated::fuses::FIELD_ENTROPY_STATE;
+    use caliptra_mcu_romtime::otp::FieldEntropySlot;
     use std::sync::atomic::Ordering;
 
     const MAX_ZEROIZATION_CYCLES: u64 = 500_000_000;
@@ -33,10 +35,9 @@ mod test {
         // 385) are numerically larger than the zeroization checkpoints and
         // would satisfy the condition before the mask is actually written.
         hw.step_until(|hw| {
-            let mask = hw
-                .mcu_manager()
-                .with_mci(|mci| mci.fc_fips_zerozation().read());
-            mask == 0xFFFF_FFFF || hw.cycle_count() >= MAX_ZEROIZATION_CYCLES
+            hw.mci_boot_checkpoint()
+                == u16::from(caliptra_mcu_romtime::McuRomBootStatus::FipsZeroizationComplete)
+                || hw.cycle_count() >= MAX_ZEROIZATION_CYCLES
         });
 
         let mask = hw
@@ -103,6 +104,23 @@ mod test {
                      all 0xFF after zeroization, but found non-0xFF bytes",
                 );
             }
+        }
+
+        // Check that FIELD_ENTROPY_STATE has all slots marked as ZEROIZED.
+        let otp_mem = hw.read_otp_memory();
+        let field_entropy_offset = FIELD_ENTROPY_STATE.byte_offset;
+        for slot in 0..4 {
+            let zeroized_word_offset = field_entropy_offset + (slot * 3 + 2) * 4;
+            let zeroized_word = u32::from_le_bytes(
+                otp_mem[zeroized_word_offset..zeroized_word_offset + 4]
+                    .try_into()
+                    .unwrap(),
+            );
+            assert_eq!(
+                zeroized_word,
+                FieldEntropySlot::ZEROIZED_MAGIC,
+                "FIELD_ENTROPY_STATE for slot {slot} should be marked as ZEROIZED"
+            );
         }
 
         lock.fetch_add(1, Ordering::Relaxed);


### PR DESCRIPTION
This adds three 32 bit words per field entropy partition to keep track of the state of each slot. One word is used to indicate it has started burning fuses for a given slot. Another indicates the burning has completed. The last indicates the fuses have been zeroized. This allows us to check the state before attempting to burn fuses as well as attest to their state because hardware does not allow ROM or FW to view these fuses.

These are written as words instead of bits because the vendor partition is ECC protected.

This also adds checks to the field entropy programming and zeroizing APIs in ROM.