### PR TITLE
Phase 9 @parvathib cherry-picks to main-2.1

### DIFF
--- a/.github/workflows/attestation.yml
+++ b/.github/workflows/attestation.yml
@@ -21,6 +21,10 @@ jobs:
       # Change this to a new random value if you suspect the cache is corrupted
       SCCACHE_C_CUSTOM_CACHE_BUSTER: 8b42a6e70ec4
 
+      # Vendor / Device identity (used across build, CoRIM, and verification)
+      ATTESTATION_VENDOR: "ACME Corp"
+      ATTESTATION_MODEL: "DeviceX"
+
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -97,13 +101,16 @@ jobs:
       # ---- Build firmware with test features enabled -------------------------------
       - name: Build firmware with test SPDM responder features
         run: |
-          cargo xtask all-build --runtime-features test-mctp-spdm-attestation
+          cargo xtask all-build --runtime-features test-mctp-spdm-attestation \
+            --vendor "$ATTESTATION_VENDOR" --model "$ATTESTATION_MODEL"
 
       # ---- Generate reference CoRIM values -------------------------------
       - name: Generate reference-value CoRIM
         run: |
-          cat > /tmp/corim-config.json << 'EOF'
+          cat > /tmp/corim-config.json << EOF
           {
+            "vendor": "${ATTESTATION_VENDOR}",
+            "model": "${ATTESTATION_MODEL}",
             "output_dir": "attestation-artifacts/refval-corim",
             "signing": {
               "test_key": "caliptra-corim-test-signing-key"

--- a/.github/workflows/attestation.yml
+++ b/.github/workflows/attestation.yml
@@ -38,7 +38,8 @@ jobs:
         id: sccache_bin_restore
         with:
           path: ~/.cargo/bin/sccache
-          key: sccache-bin-${{ env.SCCACHE_VERSION }}-${{ env.SCCACHE_C_CUSTOM_CACHE_BUSTER }}
+          key: sccache-bin-${{ env.SCCACHE_VERSION }}-${{
+            env.SCCACHE_C_CUSTOM_CACHE_BUSTER }}
 
       - name: Install sccache
         if: steps.sccache_bin_restore.outputs.cache-hit != 'true'
@@ -129,7 +130,7 @@ jobs:
         env:
           SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-emu/build/bin
         run: |
-          cargo t -p tests-integration -- --test test_mctp_spdm_attestation --nocapture  --include-ignored
+          cargo t -p caliptra-mcu-tests-integration -- --test test_mctp_spdm_attestation --nocapture  --include-ignored
 
       - name: Upload attestation logs
         if: always()

--- a/.github/workflows/spdm-validator.yml
+++ b/.github/workflows/spdm-validator.yml
@@ -50,7 +50,8 @@ jobs:
         id: sccache_bin_restore
         with:
           path: ~/.cargo/bin/sccache
-          key: sccache-bin-${{ env.SCCACHE_VERSION }}-${{ env.SCCACHE_C_CUSTOM_CACHE_BUSTER }}
+          key: sccache-bin-${{ env.SCCACHE_VERSION }}-${{
+            env.SCCACHE_C_CUSTOM_CACHE_BUSTER }}
 
       - name: Install sccache
         if: steps.sccache_bin_restore.outputs.cache-hit != 'true'
@@ -105,7 +106,7 @@ jobs:
           echo "SPDM_NONCE in MCTP stage: ${SPDM_NONCE}"
           echo "SPDM_NONCE length: ${#SPDM_NONCE}"
           cargo xtask all-build
-          cargo t -p tests-integration -- --test test_mctp_spdm_responder_conformance --nocapture  --include-ignored
+          cargo t -p caliptra-mcu-tests-integration -- --test test_mctp_spdm_responder_conformance --nocapture  --include-ignored
           sccache --show-stats
 
       - name: Upload logs and traces for MCTP transport
@@ -151,7 +152,7 @@ jobs:
           SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-emu/build/bin
         run: |
           cargo xtask all-build
-          cargo t -p tests-integration -- --test test_doe_spdm_responder_conformance --nocapture  --include-ignored
+          cargo t -p caliptra-mcu-tests-integration -- --test test_doe_spdm_responder_conformance --nocapture  --include-ignored
           sccache --show-stats
 
       - name: Upload logs and traces for DOE transport
@@ -203,7 +204,7 @@ jobs:
           SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-rs/target/debug
         run: |
           cargo xtask all-build
-          cargo t -p tests-integration -- --test test_doe_spdm_tdisp_ide_validator --nocapture --include-ignored
+          cargo t -p caliptra-mcu-tests-integration -- --test test_doe_spdm_tdisp_ide_validator --nocapture --include-ignored
           sccache --show-stats
 
       - name: Display CCC spdm-requester-emu test results for TDISP+IDE

--- a/builder/src/all.rs
+++ b/builder/src/all.rs
@@ -470,6 +470,8 @@ pub struct AllBuildArgs<'a> {
     pub soc_images: Option<Vec<ImageCfg>>,
     pub mcu_cfgs: Option<Vec<ImageCfg>>,
     pub pldm_manifest: Option<&'a str>,
+    pub vendor: Option<&'a str>,
+    pub model: Option<&'a str>,
 }
 
 /// Build Caliptra ROM and firmware bundle, MCU ROM and runtime, and SoC manifest, and package them all together in a ZIP file.
@@ -485,6 +487,8 @@ pub fn all_build(args: AllBuildArgs) -> Result<()> {
         soc_images,
         mcu_cfgs,
         pldm_manifest,
+        vendor,
+        model,
     } = args;
 
     // TODO: use temp files
@@ -580,8 +584,8 @@ pub fn all_build(args: AllBuildArgs) -> Result<()> {
         soc_images.clone(),
         mcu_image_cfg,
         None,
-        None,
-        None,
+        vendor.map(|s| s.to_string()),
+        model.map(|s| s.to_string()),
     );
     let caliptra_rom = caliptra_builder.get_caliptra_rom()?;
     let caliptra_fw = caliptra_builder.get_caliptra_fw()?;
@@ -734,8 +738,8 @@ pub fn all_build(args: AllBuildArgs) -> Result<()> {
             feature_soc_images.clone(),
             mcu_image_cfg.clone(),
             None,
-            None,
-            None,
+            vendor.map(|s| s.to_string()),
+            model.map(|s| s.to_string()),
         );
         let feature_soc_manifest_file = tempfile::NamedTempFile::new().unwrap();
         caliptra_builder.get_soc_manifest(feature_soc_manifest_file.path().to_str())?;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -187,6 +187,14 @@ enum Commands {
         /// Path to the PLDM manifest TOML file
         #[arg(short, long, value_name = "MANIFEST", required = false)]
         pldm_manifest: Option<String>,
+
+        /// Vendor string for firmware components (e.g. "ACME Corp")
+        #[arg(long, value_name = "VENDOR")]
+        vendor: Option<String>,
+
+        /// Device model string for firmware components (e.g. "DeviceX")
+        #[arg(long, value_name = "MODEL")]
+        model: Option<String>,
     },
     /// Generate CoRIM (Concise Reference Integrity Manifest) from build artifacts
     Corim {
@@ -492,6 +500,8 @@ fn main() {
             soc_images,
             mcu_cfgs,
             pldm_manifest,
+            vendor,
+            model,
         } => caliptra_mcu_builder::all_build(caliptra_mcu_builder::AllBuildArgs {
             output: output.as_deref(),
             platform: platform.as_deref(),
@@ -503,6 +513,8 @@ fn main() {
             soc_images: soc_images.clone(),
             mcu_cfgs: mcu_cfgs.clone(),
             pldm_manifest: pldm_manifest.as_deref(),
+            vendor: vendor.as_deref(),
+            model: model.as_deref(),
         }),
         Commands::EmulatorBuild { output, features } => {
             caliptra_mcu_builder::emulator_build(caliptra_mcu_builder::EmulatorBuildArgs {


### PR DESCRIPTION
Cherry-pick of @parvathib PRs from phase 9 (issue #762):

- #1280 Fix test package name in spdm validation workflows
- #1287 Add --vendor/--model args to all-build and attestation CI

**Depends on:** #1518 (Phase 7 cherry-picks)

**Conflict resolutions:**
- `builder/src/all.rs`: Adapted struct-based `CaliptraBuildArgs` construction on main to positional-arg `CaliptraBuilder::new` on main-2.1 — passed `vendor`/`model` args in both the main build and per-feature build CaliptraBuilder calls
- Kept main-2.1's `create_flash_image` code path (different from main's refactored approach)