### PR TITLE
rom: parse and enforce MCU Component SVN Manifest

### DIFF
--- a/builder/src/features.rs
+++ b/builder/src/features.rs
@@ -78,6 +78,7 @@ pub const ROM_ONLY_TEST_FEATURES: &[&str] = &[
     "test-i3c-services",
     "test-fw-manifest-dot",
     "test-fw-manifest-dot-hitless",
+    "test-svn-manifest",
     "test-dot-recovery",
     "test-rom-hooks",
 ];

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -473,6 +473,11 @@ impl McuError {
             "Firmware manifest DOT command processing error"
         ),
         (
+            ROM_COMPONENT_SVN_MANIFEST_ERROR,
+            0x1_001b,
+            "MCU Component SVN Manifest validation error"
+        ),
+        (
             GENERIC_EXCEPTION,
             0xF_0000,
             "Machine level exception was encountered during ROM execution"

--- a/platforms/emulator/rom/Cargo.toml
+++ b/platforms/emulator/rom/Cargo.toml
@@ -43,6 +43,7 @@ test-fw-manifest-dot-hitless = [
     "caliptra-mcu-rom-common/fw-manifest-dot",
     "caliptra-mcu-rom-common/test-force-hitless-update",
 ]
+test-svn-manifest = ["caliptra-mcu-rom-common/svn-manifest"]
 test-pldm-streaming-boot = []
 test-streaming-boot-flash-write-back = []
 active-i3c1 = ["caliptra-mcu-config-emulator/active-i3c1"]

--- a/platforms/emulator/rom/src/riscv.rs
+++ b/platforms/emulator/rom/src/riscv.rs
@@ -282,6 +282,20 @@ pub extern "C" fn rom_entry() -> ! {
             mci_mbox1_axi_users: mbox_axi_users,
             ..Default::default()
         });
+    } else if cfg!(feature = "test-svn-manifest") {
+        caliptra_mcu_rom_common::rom_start(RomParameters {
+            dot_flash: Some(dot_flash),
+            svn_manifest_enabled: true,
+            otp_enable_integrity_check: true,
+            otp_enable_consistency_check: true,
+            cptra_mbox_axi_users: mbox_axi_users,
+            cptra_fuse_axi_user: axi_user0,
+            cptra_trng_axi_user: axi_user0,
+            cptra_dma_axi_user: axi_user0,
+            mci_mbox0_axi_users: mbox_axi_users,
+            mci_mbox1_axi_users: mbox_axi_users,
+            ..Default::default()
+        });
     } else if cfg!(feature = "hw-2-1") {
         // Simple flash-based boot for hw-2-1 without partition tables.
         // Uses flash image starting at offset 0.

--- a/rom/Cargo.toml
+++ b/rom/Cargo.toml
@@ -34,6 +34,7 @@ default = []   # default is 2.0
 hw-2-1 = []
 core_test = ["caliptra-mcu-romtime/core_test"]
 fw-manifest-dot = []
+svn-manifest = []
 # Test-only: at the end of cold boot, rewrite the reset-reason register to
 # force the next boot entry to `FirmwareHitlessUpdate` instead of
 # `FirmwareBootReset`. Used by the DOT manifest hitless-update integration

--- a/rom/src/firmware_headers.rs
+++ b/rom/src/firmware_headers.rs
@@ -1,0 +1,265 @@
+// Licensed under the Apache-2.0 license
+
+//! Optional headers that may precede the MCU firmware in SRAM.
+//!
+//! Each header is independently optional and detected by its magic.
+//! [`process_firmware_headers`] runs the active processors in a fixed
+//! order, advancing an offset past each header that is present so the
+//! caller knows where the firmware entry point lives.
+
+#[cfg(any(feature = "fw-manifest-dot", feature = "svn-manifest"))]
+use crate::{fatal_error, MCU_MEMORY_MAP};
+use crate::{RomEnv, RomParameters};
+#[cfg(feature = "svn-manifest")]
+use caliptra_mcu_error::McuError;
+#[cfg(any(feature = "fw-manifest-dot", feature = "svn-manifest"))]
+use caliptra_mcu_romtime::HexWord;
+#[cfg(any(feature = "fw-manifest-dot", feature = "svn-manifest"))]
+use caliptra_mcu_romtime::McuRomBootStatus;
+#[cfg(any(feature = "fw-manifest-dot", feature = "svn-manifest"))]
+use core::fmt::Write;
+
+/// Run all enabled firmware-header processors in order, returning the
+/// final offset (relative to `sram_offset`) at which the firmware entry
+/// point lives.
+///
+/// Each processor inspects SRAM at the current offset, looks for its
+/// own magic, and either advances the offset past its header or leaves
+/// it unchanged. A processor that finds its magic but fails validation
+/// is a fatal boot error.
+pub(crate) fn process_firmware_headers(
+    env: &mut RomEnv,
+    params: &RomParameters,
+    base_offset: u32,
+) -> u32 {
+    #[cfg_attr(
+        not(any(feature = "fw-manifest-dot", feature = "svn-manifest")),
+        allow(unused_mut)
+    )]
+    let mut offset = base_offset;
+
+    #[cfg(feature = "fw-manifest-dot")]
+    if params.fw_manifest_dot_enabled {
+        offset += process_fw_manifest_dot(env, params, offset);
+    }
+
+    #[cfg(feature = "svn-manifest")]
+    if params.svn_manifest_enabled {
+        offset += process_svn_manifest(env, offset);
+    }
+
+    // Suppress unused-parameter warnings when neither feature is enabled.
+    let _ = (env, params);
+    offset
+}
+
+#[cfg(feature = "fw-manifest-dot")]
+fn process_fw_manifest_dot(env: &mut RomEnv, params: &RomParameters, offset: u32) -> u32 {
+    use crate::device_ownership_transfer;
+    use zerocopy::FromBytes;
+
+    let manifest_size = core::mem::size_of::<device_ownership_transfer::FwManifestDotSection>();
+    // Safety: `MCU_MEMORY_MAP.sram_offset + offset` points into MCU SRAM,
+    // which has been mapped and populated by Caliptra Core before this
+    // function runs. `manifest_size` bytes are within the SRAM region
+    // (callers only invoke us after the static header, well below the
+    // SRAM size). Byte alignment is trivially satisfied for `*const u8`.
+    // We borrow the bytes immutably for the duration of the surrounding
+    // header check and no aliasing mutable references exist while ROM
+    // owns SRAM.
+    let sram = unsafe {
+        core::slice::from_raw_parts(
+            (MCU_MEMORY_MAP.sram_offset + offset) as *const u8,
+            manifest_size,
+        )
+    };
+
+    let Ok((section, _)) = device_ownership_transfer::FwManifestDotSection::ref_from_prefix(sram)
+    else {
+        return 0;
+    };
+    if section.magic != device_ownership_transfer::FW_MANIFEST_DOT_MAGIC {
+        return 0;
+    }
+
+    env.mci
+        .set_flow_checkpoint(McuRomBootStatus::FwManifestDotProcessingStarted.into());
+    if let Err(err) =
+        device_ownership_transfer::process_fw_manifest_dot_commands(env, section, params.dot_flash)
+    {
+        caliptra_mcu_romtime::println!(
+            "[mcu-rom] Error in firmware manifest DOT: {}",
+            HexWord(err.into())
+        );
+        fatal_error(err);
+    }
+    env.mci
+        .set_flow_checkpoint(McuRomBootStatus::FwManifestDotProcessingComplete.into());
+    manifest_size as u32
+}
+
+/// Look for an MCU Component SVN Manifest header at `sram_offset +
+/// offset`. If the magic is present and the manifest is valid and not
+/// rolled back, returns the manifest size; otherwise returns 0.
+///
+/// Side effects when the manifest is present: validates the structural
+/// constraints, reads `MCU_COMPONENT_SVN_MANIFEST_MIN_SVN` from OTP,
+/// rejects the boot if `manifest.current_svn < fuse_min_svn`, and
+/// burns the fuse up to `manifest.min_svn` when it requests a higher
+/// floor. All fuse interaction is gated by
+/// `CPTRA_CORE_ANTI_ROLLBACK_DISABLE`.
+#[cfg(feature = "svn-manifest")]
+fn process_svn_manifest(env: &mut RomEnv, offset: u32) -> u32 {
+    use crate::component_svn_manifest::{
+        McuComponentSvnManifest, SvnLimits, MCU_COMPONENT_SVN_MANIFEST_SIZE,
+    };
+
+    // Safety: see `process_fw_manifest_dot` — same SRAM contract. The
+    // 1024-byte manifest fits well within SRAM, and the caller invokes
+    // us only after the static header (and any DOT section), so the
+    // computed pointer stays inside the populated runtime image.
+    let sram = unsafe {
+        core::slice::from_raw_parts(
+            (MCU_MEMORY_MAP.sram_offset + offset) as *const u8,
+            MCU_COMPONENT_SVN_MANIFEST_SIZE,
+        )
+    };
+
+    let manifest = match McuComponentSvnManifest::parse_if_present(sram) {
+        Ok(Some(m)) => m,
+        Ok(None) => return 0,
+        Err(_) => {
+            caliptra_mcu_romtime::println!("[mcu-rom] Component SVN Manifest header truncated");
+            fatal_error(McuError::ROM_COMPONENT_SVN_MANIFEST_ERROR);
+        }
+    };
+
+    env.mci
+        .set_flow_checkpoint(McuRomBootStatus::ComponentSvnManifestProcessingStarted.into());
+
+    let limits = SvnLimits {
+        manifest_min_svn_max: svn_manifest_min_svn_max(),
+    };
+    if let Err(err) = manifest.validate(&limits) {
+        caliptra_mcu_romtime::println!(
+            "[mcu-rom] Component SVN Manifest validation failed: {:?}",
+            err
+        );
+        fatal_error(McuError::ROM_COMPONENT_SVN_MANIFEST_ERROR);
+    }
+
+    let anti_rollback_on = match anti_rollback_enabled(&env.otp) {
+        Ok(v) => v,
+        Err(err) => {
+            caliptra_mcu_romtime::println!(
+                "[mcu-rom] Error reading anti-rollback disable: {}",
+                HexWord(err.into())
+            );
+            fatal_error(err);
+        }
+    };
+
+    if anti_rollback_on {
+        enforce_and_burn_manifest_min_svn(env, manifest);
+    }
+
+    env.mci
+        .set_flow_checkpoint(McuRomBootStatus::ComponentSvnManifestProcessingComplete.into());
+    MCU_COMPONENT_SVN_MANIFEST_SIZE as u32
+}
+
+/// Enforce manifest-self rollback and apply any requested
+/// `MCU_COMPONENT_SVN_MANIFEST_MIN_SVN` advance:
+///
+/// - Reject the boot if `manifest.current_svn < fuse_min_svn`.
+/// - Burn the fuse up to `manifest.min_svn` (with readback verification)
+///   when the manifest requests a higher floor.
+///
+/// Caller must have already verified that
+/// `CPTRA_CORE_ANTI_ROLLBACK_DISABLE` is not set.
+#[cfg(feature = "svn-manifest")]
+fn enforce_and_burn_manifest_min_svn(
+    env: &mut RomEnv,
+    manifest: &crate::component_svn_manifest::McuComponentSvnManifest,
+) {
+    use caliptra_mcu_registers_generated::fuses::MCU_COMPONENT_SVN_MANIFEST_MIN_SVN;
+
+    let fuse_min_svn = match env.otp.read_entry(MCU_COMPONENT_SVN_MANIFEST_MIN_SVN) {
+        Ok(v) => v,
+        Err(err) => {
+            caliptra_mcu_romtime::println!(
+                "[mcu-rom] Error reading MCU_COMPONENT_SVN_MANIFEST_MIN_SVN: {}",
+                HexWord(err.into())
+            );
+            fatal_error(err);
+        }
+    };
+
+    if u32::from(manifest.current_svn) < fuse_min_svn {
+        caliptra_mcu_romtime::println!(
+            "[mcu-rom] Component SVN Manifest rolled back: current_svn {} < fuse {}",
+            manifest.current_svn,
+            fuse_min_svn
+        );
+        fatal_error(McuError::ROM_COMPONENT_SVN_MANIFEST_ERROR);
+    }
+
+    if u32::from(manifest.min_svn) <= fuse_min_svn {
+        return;
+    }
+
+    if let Err(err) = env
+        .otp
+        .write_entry(MCU_COMPONENT_SVN_MANIFEST_MIN_SVN, manifest.min_svn.into())
+    {
+        caliptra_mcu_romtime::println!(
+            "[mcu-rom] Error burning MCU_COMPONENT_SVN_MANIFEST_MIN_SVN: {}",
+            HexWord(err.into())
+        );
+        fatal_error(err);
+    }
+    let new_fuse = match env.otp.read_entry(MCU_COMPONENT_SVN_MANIFEST_MIN_SVN) {
+        Ok(v) => v,
+        Err(err) => {
+            caliptra_mcu_romtime::println!(
+                "[mcu-rom] Error reading back MCU_COMPONENT_SVN_MANIFEST_MIN_SVN: {}",
+                HexWord(err.into())
+            );
+            fatal_error(err);
+        }
+    };
+    if new_fuse < u32::from(manifest.min_svn) {
+        caliptra_mcu_romtime::println!(
+            "[mcu-rom] MCU_COMPONENT_SVN_MANIFEST_MIN_SVN readback failed: requested {}, read {}",
+            manifest.min_svn,
+            new_fuse
+        );
+        fatal_error(McuError::ROM_COMPONENT_SVN_MANIFEST_ERROR);
+    }
+    caliptra_mcu_romtime::println!(
+        "[mcu-rom] Burned MCU_COMPONENT_SVN_MANIFEST_MIN_SVN: {} -> {}",
+        fuse_min_svn,
+        new_fuse
+    );
+}
+
+/// Returns true iff `CPTRA_CORE_ANTI_ROLLBACK_DISABLE` is *not* set,
+/// i.e., anti-rollback enforcement is active.
+#[cfg(feature = "svn-manifest")]
+fn anti_rollback_enabled(otp: &caliptra_mcu_romtime::Otp) -> Result<bool, McuError> {
+    let raw = otp.read_cptra_core_anti_rollback_disable()?;
+    Ok(raw.iter().all(|b| *b == 0))
+}
+
+#[cfg(feature = "svn-manifest")]
+fn svn_manifest_min_svn_max() -> u32 {
+    use caliptra_mcu_registers_generated::fuses::{
+        FuseLayoutType, MCU_COMPONENT_SVN_MANIFEST_MIN_SVN,
+    };
+    match MCU_COMPONENT_SVN_MANIFEST_MIN_SVN.layout {
+        FuseLayoutType::OneHot { bits }
+        | FuseLayoutType::OneHotLinearMajorityVote { bits, .. }
+        | FuseLayoutType::OneHotLinearOr { bits, .. } => bits,
+        _ => 0,
+    }
+}

--- a/rom/src/fw_boot.rs
+++ b/rom/src/fw_boot.rs
@@ -12,17 +12,11 @@ Abstract:
 
 --*/
 
+use crate::firmware_headers::process_firmware_headers;
 use crate::{fatal_error, BootFlow, RomEnv, RomParameters, MCU_MEMORY_MAP};
 use caliptra_mcu_error::McuError;
-#[cfg(feature = "fw-manifest-dot")]
-use caliptra_mcu_romtime::HexWord;
 use caliptra_mcu_romtime::{McuBootMilestones, McuRomBootStatus};
 use core::fmt::Write;
-#[cfg(feature = "fw-manifest-dot")]
-use zerocopy::FromBytes;
-
-#[cfg(feature = "fw-manifest-dot")]
-use crate::device_ownership_transfer;
 
 pub struct FwBoot {}
 
@@ -33,48 +27,10 @@ impl BootFlow for FwBoot {
         env.mci
             .set_flow_checkpoint(McuRomBootStatus::FirmwareBootFlowStarted.into());
 
-        // Start with the static header offset; the DOT section (if present)
-        // is detected dynamically and added below.
-        #[allow(unused_mut)]
-        let mut firmware_offset = params.mcu_image_header_size as u32;
-
-        // --- Process optional firmware manifest DOT commands ---
-        // Compile-gated by the fw-manifest-dot feature so ROMs that do not
-        // need this feature stay panic-free and pay no code-size cost.
-        // Additionally gated at runtime by fw_manifest_dot_enabled.
-        #[cfg(feature = "fw-manifest-dot")]
-        if params.fw_manifest_dot_enabled {
-            let manifest_size =
-                core::mem::size_of::<device_ownership_transfer::FwManifestDotSection>();
-            let sram = unsafe {
-                core::slice::from_raw_parts(MCU_MEMORY_MAP.sram_offset as *const u8, manifest_size)
-            };
-            if let Ok((section, _)) =
-                device_ownership_transfer::FwManifestDotSection::ref_from_prefix(sram)
-            {
-                if section.magic == device_ownership_transfer::FW_MANIFEST_DOT_MAGIC {
-                    firmware_offset += manifest_size as u32;
-
-                    env.mci.set_flow_checkpoint(
-                        McuRomBootStatus::FwManifestDotProcessingStarted.into(),
-                    );
-                    if let Err(err) = device_ownership_transfer::process_fw_manifest_dot_commands(
-                        env,
-                        section,
-                        params.dot_flash,
-                    ) {
-                        caliptra_mcu_romtime::println!(
-                            "[mcu-rom] Error in firmware manifest DOT: {}",
-                            HexWord(err.into())
-                        );
-                        fatal_error(err);
-                    }
-                    env.mci.set_flow_checkpoint(
-                        McuRomBootStatus::FwManifestDotProcessingComplete.into(),
-                    );
-                }
-            }
-        }
+        // Walk past any optional headers (DOT section, MCU Component
+        // SVN Manifest, ...) to find the firmware entry point.
+        let firmware_offset =
+            process_firmware_headers(env, &params, params.mcu_image_header_size as u32);
 
         // Check that the firmware was actually loaded before jumping to it
         let firmware_ptr = unsafe { (MCU_MEMORY_MAP.sram_offset + firmware_offset) as *const u32 };

--- a/rom/src/fw_hitless_update.rs
+++ b/rom/src/fw_hitless_update.rs
@@ -14,23 +14,23 @@ Abstract:
 
 #![allow(clippy::empty_loop)]
 
-#[cfg(all(target_arch = "riscv32", feature = "fw-manifest-dot"))]
-use crate::device_ownership_transfer;
+#[cfg(not(feature = "test-force-hitless-update"))]
+use crate::fatal_error;
+#[cfg(target_arch = "riscv32")]
+use crate::firmware_headers::process_firmware_headers;
 #[cfg(target_arch = "riscv32")]
 use crate::MCU_MEMORY_MAP;
-use crate::{fatal_error, BootFlow, RomEnv, RomParameters};
+use crate::{BootFlow, RomEnv, RomParameters};
 #[cfg(not(feature = "test-force-hitless-update"))]
 use caliptra_api::{mailbox::MailboxRespHeader, CaliptraApiError};
 #[cfg(not(feature = "test-force-hitless-update"))]
 use caliptra_mcu_error::McuError;
+#[cfg(not(feature = "test-force-hitless-update"))]
 use caliptra_mcu_romtime::HexWord;
 #[cfg(target_arch = "riscv32")]
 use caliptra_mcu_romtime::McuBootMilestones;
-#[cfg(all(target_arch = "riscv32", feature = "fw-manifest-dot"))]
-use caliptra_mcu_romtime::McuRomBootStatus;
+#[cfg(not(feature = "test-force-hitless-update"))]
 use core::fmt::Write;
-#[cfg(all(target_arch = "riscv32", feature = "fw-manifest-dot"))]
-use zerocopy::FromBytes;
 
 pub struct FwHitlessUpdate {}
 
@@ -80,49 +80,12 @@ impl BootFlow for FwHitlessUpdate {
 
         #[cfg(target_arch = "riscv32")]
         unsafe {
-            #[cfg_attr(not(feature = "fw-manifest-dot"), allow(unused_mut))]
-            let mut firmware_offset = _params.mcu_image_header_size as u32;
-
-            // Process optional firmware manifest DOT section, mirroring the
-            // cold-boot FwBoot path so that a hitless update carrying a new
-            // DOT header applies its commands on this boot rather than
-            // deferring them to the next cold reset.
-            #[cfg(feature = "fw-manifest-dot")]
-            if _params.fw_manifest_dot_enabled {
-                let manifest_size =
-                    core::mem::size_of::<device_ownership_transfer::FwManifestDotSection>();
-                let sram = core::slice::from_raw_parts(
-                    MCU_MEMORY_MAP.sram_offset as *const u8,
-                    manifest_size,
-                );
-                if let Ok((section, _)) =
-                    device_ownership_transfer::FwManifestDotSection::ref_from_prefix(sram)
-                {
-                    if section.magic == device_ownership_transfer::FW_MANIFEST_DOT_MAGIC {
-                        firmware_offset += manifest_size as u32;
-
-                        env.mci.set_flow_checkpoint(
-                            McuRomBootStatus::FwManifestDotProcessingStarted.into(),
-                        );
-                        if let Err(err) =
-                            device_ownership_transfer::process_fw_manifest_dot_commands(
-                                env,
-                                section,
-                                _params.dot_flash,
-                            )
-                        {
-                            caliptra_mcu_romtime::println!(
-                                "[mcu-rom] Error in firmware manifest DOT: {}",
-                                HexWord(err.into())
-                            );
-                            fatal_error(err);
-                        }
-                        env.mci.set_flow_checkpoint(
-                            McuRomBootStatus::FwManifestDotProcessingComplete.into(),
-                        );
-                    }
-                }
-            }
+            // Walk past any optional headers (DOT section, MCU
+            // Component SVN Manifest, ...) — same as the cold-boot
+            // path — so a hitless update applies any new header on
+            // this boot rather than deferring it to the next reset.
+            let firmware_offset =
+                process_firmware_headers(env, &_params, _params.mcu_image_header_size as u32);
 
             env.mci
                 .set_flow_milestone(McuBootMilestones::FIRMWARE_BOOT_FLOW_COMPLETE.into());

--- a/rom/src/lib.rs
+++ b/rom/src/lib.rs
@@ -44,6 +44,7 @@ mod recovery;
 
 // Boot flow modules
 mod cold_boot;
+mod firmware_headers;
 mod fw_boot;
 mod warm_boot;
 pub use cold_boot::ColdBoot;

--- a/rom/src/rom.rs
+++ b/rom/src/rom.rs
@@ -748,6 +748,12 @@ pub struct RomParameters<'a> {
     /// of MCU SRAM during FwBoot and process any DOT commands found.
     /// Default: false (opt-in by platform integrators).
     pub fw_manifest_dot_enabled: bool,
+    /// Whether to check for and process the MCU Component SVN Manifest header.
+    /// When true, ROM looks for the manifest magic after the static
+    /// `mcu_image_header_size` plus any DOT section, validates it, and
+    /// advances the firmware entry offset past it. See `docs/src/svn.md`.
+    /// Default: false (opt-in by platform integrators).
+    pub svn_manifest_enabled: bool,
     /// Recovery/override transport for DOT challenge/response protocol (e.g., MCI mbox0, I3C).
     pub dot_recovery_transport: Option<&'a dyn crate::RecoveryTransport>,
     /// DOT recovery/override watchdog timeout in clock cycles. If non-zero,

--- a/romtime/src/boot_status.rs
+++ b/romtime/src/boot_status.rs
@@ -81,6 +81,8 @@ pub enum McuRomBootStatus {
     CaliptraRuntimeReady = FIRMWARE_LOADING_BASE + 6,
     FwManifestDotProcessingStarted = FIRMWARE_LOADING_BASE + 7,
     FwManifestDotProcessingComplete = FIRMWARE_LOADING_BASE + 8,
+    ComponentSvnManifestProcessingStarted = FIRMWARE_LOADING_BASE + 9,
+    ComponentSvnManifestProcessingComplete = FIRMWARE_LOADING_BASE + 10,
 
     // Field Entropy Programming
     FieldEntropyProgrammingStarted = FIELD_ENTROPY_BASE,

--- a/tests/integration/src/lib.rs
+++ b/tests/integration/src/lib.rs
@@ -29,6 +29,7 @@ mod test_mcu_mbox;
 mod test_pldm_fw_update;
 mod test_raw_lifecycle_boot;
 mod test_soc_boot;
+mod test_svn_manifest;
 
 pub fn platform() -> &'static str {
     if cfg!(feature = "fpga_realtime") {
@@ -982,7 +983,7 @@ mod test {
         )
         .unwrap();
 
-        let mcu_rom = if params.firmware_prefix.is_some() {
+        let mcu_rom = if params.firmware_prefix.is_some() && params.rom_feature.is_none() {
             if params.fw_manifest_dot_hitless {
                 ROM_FW_MANIFEST_DOT_HITLESS.clone()
             } else {

--- a/tests/integration/src/test_svn_manifest.rs
+++ b/tests/integration/src/test_svn_manifest.rs
@@ -1,0 +1,282 @@
+// Licensed under the Apache-2.0 license
+
+#[cfg(test)]
+mod test {
+    use crate::test::{start_runtime_hw_model, TestParams, TEST_LOCK};
+    use caliptra_mcu_error::McuError;
+    use caliptra_mcu_hw_model::McuHwModel;
+    use caliptra_mcu_registers_generated::fuses::OTP_CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_5;
+    use caliptra_mcu_rom_common::{
+        McuComponentSvnEntry, McuComponentSvnManifest, MCU_COMPONENT_SVN_MANIFEST_MAGIC,
+        MCU_COMPONENT_SVN_MANIFEST_SIZE, MCU_COMPONENT_SVN_MANIFEST_VERSION,
+    };
+    use caliptra_mcu_romtime::{McuBootMilestones, McuRomBootStatus};
+    use zerocopy::IntoBytes;
+
+    fn manifest_bytes(
+        current_svn: u8,
+        min_svn: u8,
+        entries: &[(usize, McuComponentSvnEntry)],
+    ) -> Vec<u8> {
+        let mut m = McuComponentSvnManifest {
+            magic: MCU_COMPONENT_SVN_MANIFEST_MAGIC,
+            format_version: MCU_COMPONENT_SVN_MANIFEST_VERSION,
+            current_svn,
+            min_svn,
+            entries: [McuComponentSvnEntry::default(); 127],
+        };
+        for (i, e) in entries {
+            m.entries[*i] = *e;
+        }
+        m.as_bytes().to_vec()
+    }
+
+    /// Build an OTP image that pre-burns `value` into
+    /// `MCU_COMPONENT_SVN_MANIFEST_MIN_SVN` (OneHotLinearOr / dupe=3).
+    fn otp_with_manifest_min_svn(value: u8) -> Vec<u8> {
+        let entry = OTP_CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_5;
+        let end = entry.byte_offset + entry.byte_size;
+        let mut otp = vec![0u8; end];
+        // OneHotLinearOr writes (value * dupe) consecutive bits starting at
+        // bit 0 of the entry. dupe = 3 for this fuse.
+        let total_bits = value as usize * 3;
+        for i in 0..total_bits {
+            otp[entry.byte_offset + i / 8] |= 1 << (i % 8);
+        }
+        otp
+    }
+
+    /// Read the logical (decoded) value of `MCU_COMPONENT_SVN_MANIFEST_MIN_SVN`
+    /// from `otp`. The fuse uses OneHotLinearOr / dupe=3, so the logical
+    /// value is `(consecutive_set_bits / 3)`.
+    fn manifest_min_svn_from_otp(otp: &[u8]) -> u32 {
+        let entry = OTP_CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_5;
+        let mut bits = 0u32;
+        // Read the 4-byte raw window we use; the fuse's effective range
+        // fits in one 32-bit word.
+        let mut word_bytes = [0u8; 4];
+        word_bytes.copy_from_slice(&otp[entry.byte_offset..entry.byte_offset + 4]);
+        let mut raw = u32::from_le_bytes(word_bytes);
+        while raw & 1 != 0 {
+            bits += 1;
+            raw >>= 1;
+        }
+        bits / 3
+    }
+
+    /// A well-formed manifest passes validation and ROM skips past it,
+    /// reaching the firmware-boot-flow-complete milestone.
+    #[test]
+    fn test_svn_manifest_valid_skipped() {
+        let lock = TEST_LOCK.lock().unwrap();
+        lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
+        let manifest = manifest_bytes(
+            3,
+            0,
+            &[(
+                0,
+                McuComponentSvnEntry {
+                    component_id: 0x1000,
+                    current_svn: 5,
+                    min_svn: 2,
+                },
+            )],
+        );
+        assert_eq!(manifest.len(), MCU_COMPONENT_SVN_MANIFEST_SIZE);
+
+        let mut hw = start_runtime_hw_model(TestParams {
+            rom_feature: Some("test-svn-manifest"),
+            firmware_prefix: Some(manifest),
+            ..Default::default()
+        });
+
+        hw.step_until(|m| {
+            m.mci_boot_milestones()
+                .contains(McuBootMilestones::FIRMWARE_BOOT_FLOW_COMPLETE)
+                || m.mci_fw_fatal_error().is_some()
+                || m.cycle_count() > 100_000_000
+        });
+
+        assert_eq!(
+            hw.mci_fw_fatal_error(),
+            None,
+            "unexpected fatal error during boot"
+        );
+        assert!(
+            hw.mci_boot_milestones()
+                .contains(McuBootMilestones::FIRMWARE_BOOT_FLOW_COMPLETE),
+            "firmware boot did not complete (checkpoint = {})",
+            hw.mci_boot_checkpoint()
+        );
+        assert!(
+            hw.mci_boot_checkpoint()
+                >= McuRomBootStatus::ComponentSvnManifestProcessingComplete.into(),
+            "manifest processing did not complete (checkpoint = {})",
+            hw.mci_boot_checkpoint()
+        );
+
+        lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// If the bytes at the manifest's location don't carry the magic,
+    /// the manifest is silently skipped and the boot proceeds as usual.
+    /// (The runtime begins right at the existing firmware offset.)
+    #[test]
+    fn test_svn_manifest_magic_absent_skipped() {
+        let lock = TEST_LOCK.lock().unwrap();
+        lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
+        let mut hw = start_runtime_hw_model(TestParams {
+            rom_feature: Some("test-svn-manifest"),
+            // No firmware_prefix: the test ROM enables the manifest
+            // path, but the first 4 bytes of the runtime are not the
+            // SVN magic, so it's skipped.
+            ..Default::default()
+        });
+
+        hw.step_until(|m| {
+            m.mci_boot_milestones()
+                .contains(McuBootMilestones::FIRMWARE_BOOT_FLOW_COMPLETE)
+                || m.mci_fw_fatal_error().is_some()
+                || m.cycle_count() > 100_000_000
+        });
+
+        assert_eq!(hw.mci_fw_fatal_error(), None);
+        assert!(hw
+            .mci_boot_milestones()
+            .contains(McuBootMilestones::FIRMWARE_BOOT_FLOW_COMPLETE));
+
+        lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// A manifest with `min_svn > current_svn` is rejected with
+    /// `ROM_COMPONENT_SVN_MANIFEST_ERROR`.
+    #[test]
+    fn test_svn_manifest_invalid_header() {
+        let lock = TEST_LOCK.lock().unwrap();
+        lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
+        let manifest = manifest_bytes(2, 3, &[]);
+
+        let mut hw = start_runtime_hw_model(TestParams {
+            rom_feature: Some("test-svn-manifest"),
+            firmware_prefix: Some(manifest),
+            rom_only: true,
+            ..Default::default()
+        });
+
+        hw.step_until(|m| m.mci_fw_fatal_error().is_some() || m.cycle_count() > 100_000_000);
+
+        assert_eq!(
+            hw.mci_fw_fatal_error(),
+            Some(u32::from(McuError::ROM_COMPONENT_SVN_MANIFEST_ERROR)),
+            "expected ROM_COMPONENT_SVN_MANIFEST_ERROR, got {:?}",
+            hw.mci_fw_fatal_error()
+        );
+
+        lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// `manifest.current_svn < MCU_COMPONENT_SVN_MANIFEST_MIN_SVN` halts
+    /// boot with `ROM_COMPONENT_SVN_MANIFEST_ERROR`.
+    #[test]
+    fn test_svn_manifest_rolled_back_rejected() {
+        let lock = TEST_LOCK.lock().unwrap();
+        lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
+        // Manifest declares current_svn = 1, but the fuse is at 3.
+        let manifest = manifest_bytes(1, 0, &[]);
+
+        let mut hw = start_runtime_hw_model(TestParams {
+            rom_feature: Some("test-svn-manifest"),
+            firmware_prefix: Some(manifest),
+            otp_memory: Some(otp_with_manifest_min_svn(3)),
+            rom_only: true,
+            ..Default::default()
+        });
+
+        hw.step_until(|m| m.mci_fw_fatal_error().is_some() || m.cycle_count() > 100_000_000);
+
+        assert_eq!(
+            hw.mci_fw_fatal_error(),
+            Some(u32::from(McuError::ROM_COMPONENT_SVN_MANIFEST_ERROR)),
+            "expected ROM_COMPONENT_SVN_MANIFEST_ERROR, got {:?}",
+            hw.mci_fw_fatal_error()
+        );
+
+        lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// `manifest.current_svn == MCU_COMPONENT_SVN_MANIFEST_MIN_SVN` is
+    /// accepted (boundary case).
+    #[test]
+    fn test_svn_manifest_at_fuse_boundary_accepted() {
+        let lock = TEST_LOCK.lock().unwrap();
+        lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
+        let manifest = manifest_bytes(3, 0, &[]);
+
+        let mut hw = start_runtime_hw_model(TestParams {
+            rom_feature: Some("test-svn-manifest"),
+            firmware_prefix: Some(manifest),
+            otp_memory: Some(otp_with_manifest_min_svn(3)),
+            ..Default::default()
+        });
+
+        hw.step_until(|m| {
+            m.mci_boot_milestones()
+                .contains(McuBootMilestones::FIRMWARE_BOOT_FLOW_COMPLETE)
+                || m.mci_fw_fatal_error().is_some()
+                || m.cycle_count() > 100_000_000
+        });
+
+        assert_eq!(hw.mci_fw_fatal_error(), None);
+        assert!(hw
+            .mci_boot_milestones()
+            .contains(McuBootMilestones::FIRMWARE_BOOT_FLOW_COMPLETE));
+
+        lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// `manifest.min_svn > fuse_min_svn` triggers a burn; readback shows
+    /// the new floor.
+    #[test]
+    fn test_svn_manifest_burn_min_svn() {
+        let lock = TEST_LOCK.lock().unwrap();
+        lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
+        // Fuse starts at 1; manifest requests floor of 4. Boot should
+        // succeed (current_svn 5 >= fuse 1) and ROM should burn 1 -> 4.
+        let manifest = manifest_bytes(5, 4, &[]);
+
+        let mut hw = start_runtime_hw_model(TestParams {
+            rom_feature: Some("test-svn-manifest"),
+            firmware_prefix: Some(manifest),
+            otp_memory: Some(otp_with_manifest_min_svn(1)),
+            ..Default::default()
+        });
+
+        hw.step_until(|m| {
+            m.mci_boot_milestones()
+                .contains(McuBootMilestones::FIRMWARE_BOOT_FLOW_COMPLETE)
+                || m.mci_fw_fatal_error().is_some()
+                || m.cycle_count() > 100_000_000
+        });
+
+        assert_eq!(hw.mci_fw_fatal_error(), None, "unexpected fatal error");
+        assert!(hw
+            .mci_boot_milestones()
+            .contains(McuBootMilestones::FIRMWARE_BOOT_FLOW_COMPLETE));
+
+        let otp = hw.read_otp_memory();
+        let burned = manifest_min_svn_from_otp(&otp);
+        assert!(
+            burned >= 4,
+            "MCU_COMPONENT_SVN_MANIFEST_MIN_SVN was not advanced: read {}",
+            burned
+        );
+
+        lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+}


### PR DESCRIPTION
When `svn_manifest_enabled` is set on RomParameters, ROM searches MCU SRAM for the manifest magic after the static MCU image header (and any DOT section), validates the header, reads
MCU_COMPONENT_SVN_MANIFEST_MIN_SVN from OTP (gated by CPTRA_CORE_ANTI_ROLLBACK_DISABLE), rejects rolled-back manifests, burns the fuse up to `header.min_svn` with readback verification, and advances the firmware entry offset past the 1024-byte manifest.

Compile-gated by the new `svn-manifest` feature on rom-common.

The DOT and SVN per-header processors now live in a new `firmware_headers` module behind a single `process_firmware_headers()` entry point that both `FwBoot` and `FwHitlessUpdate` call, so future optional headers can plug in alongside them.

Integration tests in `tests/integration/src/test_svn_manifest.rs` cover magic-absent skip, well-formed parse, bad header, rolled-back reject, fuse boundary, and burn (with OTP readback).