### PR TITLE
spdm-lite: add OCP VDM support

### DIFF
--- a/caliptra-util-host/transport/src/transports/spdm_vdm/commands.rs
+++ b/caliptra-util-host/transport/src/transports/spdm_vdm/commands.rs
@@ -98,7 +98,7 @@ pub fn handle_firmware_version(
     response_buffer: &mut [u8],
 ) -> Result<usize, TransportError> {
     // Parse internal request (may be empty → default to index 0)
-    let _area_index = if payload.len() >= core::mem::size_of::<GetFirmwareVersionRequest>() {
+    let area_index = if payload.len() >= core::mem::size_of::<GetFirmwareVersionRequest>() {
         let req = GetFirmwareVersionRequest::from_bytes(payload)
             .map_err(|_| TransportError::InvalidMessage)?;
         req.index
@@ -106,11 +106,12 @@ pub fn handle_firmware_version(
         0
     };
 
-    // VDM payload for FirmwareVersion: empty (no additional data needed)
+    // VDM payload for FirmwareVersion: area_index (u32 little-endian).
+    let area_index = area_index.to_le_bytes();
     let mut resp_buf = [0u8; MAX_VDM_RESPONSE_SIZE];
     let resp_len = send_vdm_request(
         CaliptraVdmCommand::FirmwareVersion,
-        &[],
+        &area_index,
         driver,
         &mut resp_buf,
     )?;

--- a/common/testing/src/mctp_util/common.rs
+++ b/common/testing/src/mctp_util/common.rs
@@ -138,6 +138,13 @@ impl MctpUtil {
         assert!(pkts.len() == 1, "Only one packet is expected in message");
         let mut i3c_state = I3cControllerState::Start;
         let msg_type = msg[0];
+        // SPDM/SPDM-secured and VDM responders are sensitive to duplicate requests:
+        // a retransmitted request can leave stale responses queued and cause
+        // later CHUNK_GET / VDM exchanges to consume the wrong packet. Other
+        // protocols (notably PLDM firmware update/recovery) rely on the older
+        // retry behavior when the first IBI is missed, so only suppress
+        // retransmission for stateful SPDM/VDM message types.
+        let suppress_retransmit = matches!(msg_type & 0x7f, 0x05 | 0x06 | 0x7e);
 
         let mut retry = 100;
         // Buffer for accumulating multi-packet responses. The first packet
@@ -145,10 +152,9 @@ impl MctpUtil {
         // subsequent packets without SOM are appended until EOM is seen.
         let mut resp_pkts: VecDeque<Vec<u8>> = VecDeque::new();
         let mut response_started = false;
-        // Track whether the request has been sent at least once so we do
-        // not re-send while waiting for the responder. Re-sending the same
-        // request causes duplicate responses on slow I/O paths and
-        // confuses subsequent `wait_for_responder` calls.
+        // Track whether the request has been sent at least once. For SPDM we
+        // do not re-send while waiting for the responder; for other protocols
+        // we preserve the historical retry-by-retransmit behavior.
         let mut request_sent = false;
 
         while crate::is_emulator_running() && retry > 0 {
@@ -176,12 +182,11 @@ impl MctpUtil {
                         // without rewinding to SendPrivateWrite.
                         retry -= 1;
                         sleep_emulator_ticks(100_000);
-                    } else if request_sent {
-                        // Request already on the wire — keep waiting for
+                    } else if request_sent && suppress_retransmit {
+                        // Stateful request already on the wire — keep waiting for
                         // the IBI without re-sending. Re-sending generates
-                        // duplicate responses that the responder must
-                        // process, which on slow I/O paths causes ordering
-                        // issues across `wait_for_responder` calls.
+                        // duplicate responses that can be consumed by a later
+                        // exchange or mutate stateful responder cursors.
                         retry -= 1;
                         if retry == 0 {
                             println!("MCTP_UTIL: timed out waiting for IBI");
@@ -190,18 +195,8 @@ impl MctpUtil {
                         sleep_emulator_ticks(100_000);
                     } else {
                         retry -= 1;
-                        // Wait longer for the responder to wake up and post
-                        // its first IBI. Do NOT retransmit the request: the
-                        // firmware processes every private-write as a fresh
-                        // SPDM request, and any duplicate responses end up
-                        // stuck in the I3C queue and get consumed out-of-
-                        // order by subsequent receive_response calls,
-                        // creating a hard-to-debug request/response
-                        // mis-pairing across the whole conformance run.
-                        sleep_emulator_ticks(500_000);
-                        if retry % 10 == 0 {
-                            println!("MCTP_UTIL: IBI not received. Retrying {}...", retry);
-                        }
+                        println!("MCTP_UTIL: IBI not received. Retrying {}...", retry);
+                        i3c_state = I3cControllerState::SendPrivateWrite;
                     }
                 }
                 I3cControllerState::ReceivePrivateRead => {

--- a/platforms/emulator/runtime/userspace/apps/user/Cargo.toml
+++ b/platforms/emulator/runtime/userspace/apps/user/Cargo.toml
@@ -126,6 +126,9 @@ test-streaming-boot-flash-write-back = []
 test-mctp-spdm-attestation = []
 test-mctp-spdm-attestation-pcr-quote = []
 test-mctp-spdm-responder-conformance = []
+# Disabled by default while attested-CSR-over-VDM is held back;
+# keep the large VDM response plumbing available for the other CSR commands.
+test-mctp-spdm-attested-csr-vdm = []
 # Test-only SPDM SET_CERTIFICATE path. Enables flash-backed certificate
 # installation without production authorization/key-binding.
 test-mctp-spdm-set-certificate = [

--- a/platforms/emulator/runtime/userspace/apps/user/src/caliptra_cmd_handler/debug_log.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/caliptra_cmd_handler/debug_log.rs
@@ -3,22 +3,17 @@
 extern crate alloc;
 use caliptra_mcu_common_commands::{CaliptraCompletionCode, GetLogResult};
 use caliptra_mcu_libsyscall_caliptra::logging::LoggingSyscall;
+use caliptra_mcu_libtock_platform::ErrorCode;
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_sync::mutex::Mutex;
 
-const LOG_ENTRY_SCRATCH: usize = 256;
-
 struct DebugLogState {
-    holdover_len: usize,
-    holdover: [u8; LOG_ENTRY_SCRATCH],
     cursor_at_start: bool,
 }
 
 impl DebugLogState {
     const fn new() -> Self {
         Self {
-            holdover_len: 0,
-            holdover: [0; LOG_ENTRY_SCRATCH],
             cursor_at_start: false,
         }
     }
@@ -48,43 +43,28 @@ pub async fn drain(dst: &mut [u8]) -> Result<GetLogResult, CaliptraCompletionCod
     let mut written = 0usize;
     let mut more_data = false;
 
-    // 1) Flush a held-over entry from a prior call, if any.
-    if state.holdover_len > 0 {
-        if state.holdover_len <= dst.len() {
-            let n = state.holdover_len;
-            dst[..n].copy_from_slice(&state.holdover[..n]);
-            written += n;
-            state.holdover_len = 0;
-        } else {
-            // Caller buffer cannot fit even the held entry. Per the
-            // entry-boundary contract we must not partial-copy; signal
-            // more_data and let the caller retry with a larger buffer.
-            return Ok(GetLogResult {
-                bytes_written: 0,
-                more_data: true,
-            });
-        }
-    }
-
-    // 2) Pull fresh entries from the kernel.
-    let mut scratch = [0u8; LOG_ENTRY_SCRATCH];
     loop {
-        match log.read_entry(&mut scratch).await {
+        if written == dst.len() {
+            // We cannot probe for another entry without either consuming it or
+            // violating the entry-boundary contract. Return a conservative
+            // `more_data`; a follow-up call will either drain the next entry or
+            // report an empty final chunk.
+            more_data = true;
+            break;
+        }
+
+        match log.read_entry(&mut dst[written..]).await {
             Ok(0) => break, // defensive: empty entry => treat as drained
-            Ok(n) => {
-                if written + n <= dst.len() {
-                    dst[written..written + n].copy_from_slice(&scratch[..n]);
-                    written += n;
-                } else {
-                    // Stash for the next call; this call returns short.
-                    state.holdover[..n].copy_from_slice(&scratch[..n]);
-                    state.holdover_len = n;
-                    more_data = true;
-                    break;
-                }
+            Ok(n) => written += n,
+            Err(ErrorCode::Size) => {
+                // The next entry does not fit in the remaining caller buffer.
+                // The logging capsule leaves its read cursor unchanged on
+                // SIZE, so the caller can retry and receive that entry first.
+                more_data = true;
+                break;
             }
-            // The capsule reports "no more entries" via Err. Any I/O error
-            // surfaces the same way; treat it as end-of-drain so the caller
+            // The capsule reports "no more entries" via Err. Other I/O errors
+            // surface the same way; treat them as end-of-drain so the caller
             // gets whatever was already accumulated.
             Err(_) => break,
         }
@@ -105,7 +85,6 @@ pub async fn clear() -> Result<(), CaliptraCompletionCode> {
     log.clear()
         .await
         .map_err(|_| CaliptraCompletionCode::OperationFailed)?;
-    state.holdover_len = 0;
     // Force the next `drain` to re-seek to the (now empty) head of log.
     state.cursor_at_start = false;
     Ok(())

--- a/platforms/emulator/runtime/userspace/apps/user/src/caliptra_cmd_handler/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/caliptra_cmd_handler/mod.rs
@@ -6,39 +6,897 @@ mod debug_log;
 
 use alloc::boxed::Box;
 use async_trait::async_trait;
+#[cfg(feature = "test-mctp-spdm-attested-csr-vdm")]
+use caliptra_api::mailbox::{AttestedCsrResp, GetAttestedEccCsrReq, GetAttestedMldsaCsrReq};
+use caliptra_api::mailbox::{GetIdevCsrReq, GetIdevCsrResp, MailboxRespHeader, Request};
 use caliptra_mcu_common_commands::{
     CaliptraCmdHandler, CaliptraCmdResult, CaliptraCompletionCode, DebugUnlockChallenge,
-    DeviceCapabilities, DeviceId, DeviceInfo, FirmwareVersion, GetLogResult, LogType,
+    DeviceCapabilities, DeviceId, DeviceInfo, FirmwareVersion, GetLogResult, LogType, Uid,
+    MAX_FW_VERSION_LEN, MAX_UID_LEN,
 };
 use caliptra_mcu_libapi_caliptra::certificate::{CertContext, IDEV_ECC_CSR_MAX_SIZE};
 use caliptra_mcu_libapi_caliptra::crypto::asym::AsymAlgo;
 use caliptra_mcu_libapi_caliptra::error::CaliptraApiError;
+use caliptra_mcu_libapi_caliptra::mailbox_api::execute_mailbox_cmd;
+use caliptra_mcu_libsyscall_caliptra::mailbox::Mailbox;
+use caliptra_mcu_mbox_common::config;
+use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+use embassy_sync::mutex::Mutex;
+use mcu_spdm_lite_stack::{
+    SpdmVdmBackend, StandardsBodyId, VdmLargeResponseWriter, VdmRequest, VdmResponseBuffers,
+    VdmResponseKind,
+};
+use mcu_spdm_lite_traits::SpdmPalLargeMessage;
+use zerocopy::IntoBytes;
 
 pub struct CaliptraCmdBackend;
+
+/// Size-conscious spdm-lite OCP Caliptra VDM backend.
+///
+/// This backend uses static dispatch through `SpdmVdmBackend`; it does not use
+/// `async_trait`, boxed futures, or a `dyn CaliptraCmdHandler` path.
+pub struct CaliptraOcpVdm;
+
+const OCP_VENDOR_ID: u32 = 42623;
+const CALIPTRA_VDM_COMMAND_VERSION: u8 = 0x01;
+const CSR_COMPLETION_LEN: usize = 1;
+const CSR_DATA_LEN_LEN: usize = core::mem::size_of::<u32>();
+const CSR_VDM_PAYLOAD_HEADER_LEN: usize = 2 + CSR_COMPLETION_LEN + CSR_DATA_LEN_LEN;
+
+#[cfg(feature = "test-mctp-spdm-attested-csr-vdm")]
+const CSR_MAILBOX_RESP_MAX_SIZE: usize = core::mem::size_of::<MailboxRespHeader>()
+    + core::mem::size_of::<u32>()
+    + AttestedCsrResp::DATA_MAX_SIZE;
+#[cfg(not(feature = "test-mctp-spdm-attested-csr-vdm"))]
+const CSR_MAILBOX_RESP_MAX_SIZE: usize = core::mem::size_of::<MailboxRespHeader>()
+    + core::mem::size_of::<u32>()
+    + GetIdevCsrResp::DATA_MAX_SIZE;
+
+#[repr(C, align(4))]
+struct CsrMailboxResponseBuffer([u8; CSR_MAILBOX_RESP_MAX_SIZE]);
+
+static CSR_MAILBOX_RESPONSE_BUFFER: Mutex<CriticalSectionRawMutex, CsrMailboxResponseBuffer> =
+    Mutex::new(CsrMailboxResponseBuffer([0; CSR_MAILBOX_RESP_MAX_SIZE]));
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+enum CaliptraVdmCommand {
+    FirmwareVersion = 0x01,
+    DeviceCapabilities = 0x02,
+    DeviceId = 0x03,
+    DeviceInfo = 0x04,
+    GetDebugLog = 0x05,
+    ClearDebugLog = 0x06,
+    GetAttestationLog = 0x07,
+    ClearAttestationLog = 0x08,
+    GetAttestation = 0x09,
+    RequestDebugUnlock = 0x0A,
+    AuthorizeDebugUnlockToken = 0x0B,
+    ExportIdevidCsr = 0x0C,
+    SetSlot0Cert = 0x0D,
+    GetSlot0State = 0x0E,
+    ExportAttestedCsr = 0x0F,
+    ProgramFieldEntropy = 0x10,
+    DeviceOwnershipTransfer = 0x11,
+}
+
+impl CaliptraVdmCommand {
+    const fn response_code(self) -> u8 {
+        self as u8
+    }
+}
+
+impl TryFrom<u8> for CaliptraVdmCommand {
+    type Error = ();
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0x01 => Ok(Self::FirmwareVersion),
+            0x02 => Ok(Self::DeviceCapabilities),
+            0x03 => Ok(Self::DeviceId),
+            0x04 => Ok(Self::DeviceInfo),
+            0x05 => Ok(Self::GetDebugLog),
+            0x06 => Ok(Self::ClearDebugLog),
+            0x07 => Ok(Self::GetAttestationLog),
+            0x08 => Ok(Self::ClearAttestationLog),
+            0x09 => Ok(Self::GetAttestation),
+            0x0A => Ok(Self::RequestDebugUnlock),
+            0x0B => Ok(Self::AuthorizeDebugUnlockToken),
+            0x0C => Ok(Self::ExportIdevidCsr),
+            0x0D => Ok(Self::SetSlot0Cert),
+            0x0E => Ok(Self::GetSlot0State),
+            0x0F => Ok(Self::ExportAttestedCsr),
+            0x10 => Ok(Self::ProgramFieldEntropy),
+            0x11 => Ok(Self::DeviceOwnershipTransfer),
+            _ => Err(()),
+        }
+    }
+}
+
+struct FirmwareVersionReq {
+    area_index: u32,
+}
+
+struct DeviceInfoReq {
+    info_index: u32,
+}
+
+struct ExportIdevidCsrReq {
+    algorithm: u32,
+}
+
+#[cfg(feature = "test-mctp-spdm-attested-csr-vdm")]
+struct ExportAttestedCsrReq {
+    device_key_id: u32,
+    algorithm: u32,
+    nonce: [u8; 32],
+}
+
+impl CaliptraOcpVdm {
+    fn write_completion(
+        rsp: &mut [u8],
+        command: u8,
+        completion: CaliptraCompletionCode,
+    ) -> Result<usize, mcu_spdm_lite_stack::SpdmError> {
+        let out = rsp
+            .get_mut(..3)
+            .ok_or(mcu_spdm_lite_stack::SPDM_UNSPECIFIED)?;
+        out[0] = CALIPTRA_VDM_COMMAND_VERSION;
+        out[1] = command;
+        out[2] = completion as u8;
+        Ok(3)
+    }
+
+    fn write_bytes(
+        rsp: &mut [u8],
+        offset: usize,
+        bytes: &[u8],
+    ) -> Result<usize, mcu_spdm_lite_stack::SpdmError> {
+        let end = offset
+            .checked_add(bytes.len())
+            .ok_or(mcu_spdm_lite_stack::SPDM_UNSPECIFIED)?;
+        rsp.get_mut(offset..end)
+            .ok_or(mcu_spdm_lite_stack::SPDM_UNSPECIFIED)?
+            .copy_from_slice(bytes);
+        Ok(end)
+    }
+
+    fn write_u16(
+        rsp: &mut [u8],
+        offset: usize,
+        value: u16,
+    ) -> Result<usize, mcu_spdm_lite_stack::SpdmError> {
+        Self::write_bytes(rsp, offset, &value.to_le_bytes())
+    }
+
+    fn write_u32(
+        rsp: &mut [u8],
+        offset: usize,
+        value: u32,
+    ) -> Result<usize, mcu_spdm_lite_stack::SpdmError> {
+        Self::write_bytes(rsp, offset, &value.to_le_bytes())
+    }
+
+    fn write_success(rsp: &mut [u8], command: u8) -> Result<usize, mcu_spdm_lite_stack::SpdmError> {
+        Self::write_completion(rsp, command, CaliptraCompletionCode::Success)
+    }
+
+    fn read_u32(payload: &[u8]) -> Result<u32, mcu_spdm_lite_stack::SpdmError> {
+        if payload.len() != 4 {
+            return Err(mcu_spdm_lite_stack::SPDM_INVALID_REQUEST);
+        }
+        let mut bytes = [0u8; 4];
+        bytes.copy_from_slice(payload);
+        Ok(u32::from_le_bytes(bytes))
+    }
+
+    fn read_firmware_version_req(
+        payload: &[u8],
+    ) -> Result<FirmwareVersionReq, mcu_spdm_lite_stack::SpdmError> {
+        Ok(FirmwareVersionReq {
+            area_index: Self::read_u32(payload)?,
+        })
+    }
+
+    fn read_device_info_req(
+        payload: &[u8],
+    ) -> Result<DeviceInfoReq, mcu_spdm_lite_stack::SpdmError> {
+        Ok(DeviceInfoReq {
+            info_index: Self::read_u32(payload)?,
+        })
+    }
+
+    fn read_idevid_csr_req(
+        payload: &[u8],
+    ) -> Result<ExportIdevidCsrReq, mcu_spdm_lite_stack::SpdmError> {
+        Ok(ExportIdevidCsrReq {
+            algorithm: Self::read_u32(payload)?,
+        })
+    }
+
+    #[cfg(feature = "test-mctp-spdm-attested-csr-vdm")]
+    fn read_attested_csr_req(
+        payload: &[u8],
+    ) -> Result<ExportAttestedCsrReq, mcu_spdm_lite_stack::SpdmError> {
+        if payload.len() != 40 {
+            return Err(mcu_spdm_lite_stack::SPDM_INVALID_REQUEST);
+        }
+        let mut device_key_id = [0u8; 4];
+        let mut algorithm = [0u8; 4];
+        let mut nonce = [0u8; 32];
+        device_key_id.copy_from_slice(&payload[..4]);
+        algorithm.copy_from_slice(&payload[4..8]);
+        nonce.copy_from_slice(&payload[8..40]);
+        Ok(ExportAttestedCsrReq {
+            device_key_id: u32::from_le_bytes(device_key_id),
+            algorithm: u32::from_le_bytes(algorithm),
+            nonce,
+        })
+    }
+
+    fn map_csr_error(error: CaliptraApiError) -> CaliptraCompletionCode {
+        match error {
+            CaliptraApiError::MailboxBusy => CaliptraCompletionCode::CaliptraMailboxBusy,
+            CaliptraApiError::BufferTooSmall => CaliptraCompletionCode::CaliptraBufferTooSmall,
+            CaliptraApiError::UnprovisionedCsr => CaliptraCompletionCode::InvalidState,
+            CaliptraApiError::InvalidResponse
+            | CaliptraApiError::Mailbox(_)
+            | CaliptraApiError::Syscall(_) => CaliptraCompletionCode::OperationFailed,
+            _ => CaliptraCompletionCode::GeneralError,
+        }
+    }
+
+    fn finish_csr_response(
+        out: &mut [u8],
+        command: u8,
+        max_data_size: usize,
+    ) -> CaliptraCmdResult<usize> {
+        const COMPLETION_OFFSET: usize = 2;
+        const CSR_LEN_OFFSET: usize = 3;
+        const CSR_DATA_OFFSET: usize = 7;
+
+        let hdr_size = core::mem::size_of::<MailboxRespHeader>();
+        let data_size_offset = CSR_LEN_OFFSET + hdr_size;
+        let data_offset = data_size_offset + core::mem::size_of::<u32>();
+        let size_bytes = out
+            .get(data_size_offset..data_size_offset + core::mem::size_of::<u32>())
+            .ok_or(CaliptraCompletionCode::CaliptraBufferTooSmall)?;
+        let mut size = [0u8; 4];
+        size.copy_from_slice(size_bytes);
+        let size = u32::from_le_bytes(size);
+        if size == u32::MAX {
+            return Err(CaliptraCompletionCode::InvalidState);
+        }
+        let size = size as usize;
+        if size == 0 || size > max_data_size {
+            return Err(CaliptraCompletionCode::OperationFailed);
+        }
+        let end = data_offset
+            .checked_add(size)
+            .ok_or(CaliptraCompletionCode::CaliptraBufferTooSmall)?;
+        let final_end = CSR_DATA_OFFSET
+            .checked_add(size)
+            .ok_or(CaliptraCompletionCode::CaliptraBufferTooSmall)?;
+        if end > out.len() || final_end > out.len() {
+            return Err(CaliptraCompletionCode::CaliptraBufferTooSmall);
+        }
+        out[0] = CALIPTRA_VDM_COMMAND_VERSION;
+        out[1] = command;
+        out[COMPLETION_OFFSET] = CaliptraCompletionCode::Success as u8;
+        out[CSR_LEN_OFFSET..CSR_LEN_OFFSET + core::mem::size_of::<u32>()]
+            .copy_from_slice(&(size as u32).to_le_bytes());
+        out.copy_within(data_offset..end, CSR_DATA_OFFSET);
+        Ok(final_end)
+    }
+
+    fn csr_required_len(max_data_size: usize) -> CaliptraCmdResult<usize> {
+        3usize
+            .checked_add(core::mem::size_of::<MailboxRespHeader>())
+            .and_then(|len| len.checked_add(core::mem::size_of::<u32>()))
+            .and_then(|len| len.checked_add(max_data_size))
+            .ok_or(CaliptraCompletionCode::CaliptraBufferTooSmall)
+    }
+
+    async fn execute_csr_mailbox(
+        command: u8,
+        cmd_id: u32,
+        req_bytes: &mut [u8],
+        out: &mut [u8],
+        max_data_size: usize,
+    ) -> CaliptraCmdResult<usize> {
+        let required = Self::csr_required_len(max_data_size)?;
+        if out.len() < required {
+            return Err(CaliptraCompletionCode::CaliptraBufferTooSmall);
+        }
+        let resp = out
+            .get_mut(3..)
+            .ok_or(CaliptraCompletionCode::CaliptraBufferTooSmall)?;
+        execute_mailbox_cmd(&Mailbox::new(), cmd_id, req_bytes, resp)
+            .await
+            .map_err(Self::map_csr_error)?;
+        Self::finish_csr_response(out, command, max_data_size)
+    }
+
+    fn write_csr_large_response<Storage: SpdmPalLargeMessage>(
+        large: &VdmLargeResponseWriter<'_, Storage>,
+        command: u8,
+        mailbox_resp: &[u8],
+        max_data_size: usize,
+    ) -> CaliptraCmdResult<usize> {
+        const COMPLETION_OFFSET: usize = 2;
+        const CSR_LEN_OFFSET: usize = 3;
+        const CSR_DATA_OFFSET: usize = 7;
+
+        let hdr_size = core::mem::size_of::<MailboxRespHeader>();
+        let data_size_offset = hdr_size;
+        let data_offset = data_size_offset + core::mem::size_of::<u32>();
+        let size_bytes = mailbox_resp
+            .get(data_size_offset..data_size_offset + core::mem::size_of::<u32>())
+            .ok_or(CaliptraCompletionCode::CaliptraBufferTooSmall)?;
+        let mut size = [0u8; 4];
+        size.copy_from_slice(size_bytes);
+        let size = u32::from_le_bytes(size);
+        if size == u32::MAX {
+            return Err(CaliptraCompletionCode::InvalidState);
+        }
+        let size = size as usize;
+        if size == 0 || size > max_data_size {
+            return Err(CaliptraCompletionCode::OperationFailed);
+        }
+        let end = data_offset
+            .checked_add(size)
+            .ok_or(CaliptraCompletionCode::CaliptraBufferTooSmall)?;
+        let final_end = CSR_DATA_OFFSET
+            .checked_add(size)
+            .ok_or(CaliptraCompletionCode::CaliptraBufferTooSmall)?;
+        if end > mailbox_resp.len() || final_end > large.capacity() {
+            return Err(CaliptraCompletionCode::CaliptraBufferTooSmall);
+        }
+
+        let header = [
+            CALIPTRA_VDM_COMMAND_VERSION,
+            command,
+            CaliptraCompletionCode::Success as u8,
+        ];
+        large
+            .write(0, &header)
+            .map_err(|_| CaliptraCompletionCode::InsufficientResources)?;
+        large
+            .write(CSR_LEN_OFFSET, &(size as u32).to_le_bytes())
+            .map_err(|_| CaliptraCompletionCode::InsufficientResources)?;
+        large
+            .write(CSR_DATA_OFFSET, &mailbox_resp[data_offset..end])
+            .map_err(|_| CaliptraCompletionCode::InsufficientResources)?;
+        debug_assert_eq!(COMPLETION_OFFSET, 2);
+        Ok(final_end)
+    }
+
+    async fn execute_csr_mailbox_large<Storage: SpdmPalLargeMessage>(
+        command: u8,
+        cmd_id: u32,
+        req_bytes: &mut [u8],
+        large: &VdmLargeResponseWriter<'_, Storage>,
+        max_data_size: usize,
+    ) -> CaliptraCmdResult<usize> {
+        let required = Self::csr_required_len(max_data_size)?;
+        if large.capacity() < required {
+            return Err(CaliptraCompletionCode::InsufficientResources);
+        }
+        let mailbox_resp_len = required
+            .checked_sub(CSR_COMPLETION_LEN + 2)
+            .ok_or(CaliptraCompletionCode::CaliptraBufferTooSmall)?;
+        let mut scratch = CSR_MAILBOX_RESPONSE_BUFFER.lock().await;
+        let resp = scratch
+            .0
+            .get_mut(..mailbox_resp_len)
+            .ok_or(CaliptraCompletionCode::InsufficientResources)?;
+        execute_mailbox_cmd(&Mailbox::new(), cmd_id, req_bytes, resp)
+            .await
+            .map_err(Self::map_csr_error)?;
+        Self::write_csr_large_response(large, command, resp, max_data_size)
+    }
+
+    #[cfg(feature = "test-mctp-spdm-attested-csr-vdm")]
+    async fn export_attested_csr(payload: &[u8], out: &mut [u8]) -> CaliptraCmdResult<usize> {
+        let req = Self::read_attested_csr_req(payload)
+            .map_err(|_| CaliptraCompletionCode::InvalidLength)?;
+        match AsymAlgo::try_from_u32(req.algorithm)
+            .ok_or(CaliptraCompletionCode::InvalidParameter)?
+        {
+            AsymAlgo::EccP384 => {
+                let mut mailbox_req = GetAttestedEccCsrReq {
+                    key_id: req.device_key_id,
+                    nonce: req.nonce,
+                    ..Default::default()
+                };
+                Self::execute_csr_mailbox(
+                    CaliptraVdmCommand::ExportAttestedCsr.response_code(),
+                    GetAttestedEccCsrReq::ID.0,
+                    mailbox_req.as_mut_bytes(),
+                    out,
+                    AttestedCsrResp::DATA_MAX_SIZE,
+                )
+                .await
+            }
+            AsymAlgo::MlDsa87 => {
+                let mut mailbox_req = GetAttestedMldsaCsrReq {
+                    key_id: req.device_key_id,
+                    nonce: req.nonce,
+                    ..Default::default()
+                };
+                Self::execute_csr_mailbox(
+                    CaliptraVdmCommand::ExportAttestedCsr.response_code(),
+                    GetAttestedMldsaCsrReq::ID.0,
+                    mailbox_req.as_mut_bytes(),
+                    out,
+                    AttestedCsrResp::DATA_MAX_SIZE,
+                )
+                .await
+            }
+        }
+    }
+
+    #[cfg(feature = "test-mctp-spdm-attested-csr-vdm")]
+    async fn export_attested_csr_large<Storage: SpdmPalLargeMessage>(
+        payload: &[u8],
+        large: &VdmLargeResponseWriter<'_, Storage>,
+    ) -> CaliptraCmdResult<usize> {
+        let req = Self::read_attested_csr_req(payload)
+            .map_err(|_| CaliptraCompletionCode::InvalidLength)?;
+        match AsymAlgo::try_from_u32(req.algorithm)
+            .ok_or(CaliptraCompletionCode::InvalidParameter)?
+        {
+            AsymAlgo::EccP384 => {
+                let mut mailbox_req = GetAttestedEccCsrReq {
+                    key_id: req.device_key_id,
+                    nonce: req.nonce,
+                    ..Default::default()
+                };
+                Self::execute_csr_mailbox_large(
+                    CaliptraVdmCommand::ExportAttestedCsr.response_code(),
+                    GetAttestedEccCsrReq::ID.0,
+                    mailbox_req.as_mut_bytes(),
+                    large,
+                    AttestedCsrResp::DATA_MAX_SIZE,
+                )
+                .await
+            }
+            AsymAlgo::MlDsa87 => {
+                let mut mailbox_req = GetAttestedMldsaCsrReq {
+                    key_id: req.device_key_id,
+                    nonce: req.nonce,
+                    ..Default::default()
+                };
+                Self::execute_csr_mailbox_large(
+                    CaliptraVdmCommand::ExportAttestedCsr.response_code(),
+                    GetAttestedMldsaCsrReq::ID.0,
+                    mailbox_req.as_mut_bytes(),
+                    large,
+                    AttestedCsrResp::DATA_MAX_SIZE,
+                )
+                .await
+            }
+        }
+    }
+
+    async fn export_idevid_csr(payload: &[u8], out: &mut [u8]) -> CaliptraCmdResult<usize> {
+        let req = Self::read_idevid_csr_req(payload)
+            .map_err(|_| CaliptraCompletionCode::InvalidLength)?;
+        match AsymAlgo::try_from_u32(req.algorithm)
+            .ok_or(CaliptraCompletionCode::InvalidParameter)?
+        {
+            AsymAlgo::EccP384 => {
+                let mut mailbox_req = GetIdevCsrReq::default();
+                Self::execute_csr_mailbox(
+                    CaliptraVdmCommand::ExportIdevidCsr.response_code(),
+                    GetIdevCsrReq::ID.0,
+                    mailbox_req.as_mut_bytes(),
+                    out,
+                    GetIdevCsrResp::DATA_MAX_SIZE,
+                )
+                .await
+            }
+            AsymAlgo::MlDsa87 => Err(CaliptraCompletionCode::UnsupportedOperation),
+        }
+    }
+
+    async fn export_idevid_csr_large<Storage: SpdmPalLargeMessage>(
+        payload: &[u8],
+        large: &VdmLargeResponseWriter<'_, Storage>,
+    ) -> CaliptraCmdResult<usize> {
+        let req = Self::read_idevid_csr_req(payload)
+            .map_err(|_| CaliptraCompletionCode::InvalidLength)?;
+        match AsymAlgo::try_from_u32(req.algorithm)
+            .ok_or(CaliptraCompletionCode::InvalidParameter)?
+        {
+            AsymAlgo::EccP384 => {
+                let mut mailbox_req = GetIdevCsrReq::default();
+                Self::execute_csr_mailbox_large(
+                    CaliptraVdmCommand::ExportIdevidCsr.response_code(),
+                    GetIdevCsrReq::ID.0,
+                    mailbox_req.as_mut_bytes(),
+                    large,
+                    GetIdevCsrResp::DATA_MAX_SIZE,
+                )
+                .await
+            }
+            AsymAlgo::MlDsa87 => Err(CaliptraCompletionCode::UnsupportedOperation),
+        }
+    }
+
+    async fn request_debug_unlock(payload: &[u8], out: &mut [u8]) -> CaliptraCmdResult<usize> {
+        use caliptra_api::mailbox::{
+            CommandId, MailboxReqHeader, ProductionAuthDebugUnlockChallenge,
+            ProductionAuthDebugUnlockReq,
+        };
+        use zerocopy::FromBytes;
+
+        let Some((&unlock_level, rest)) = payload.split_first() else {
+            return Err(CaliptraCompletionCode::InvalidLength);
+        };
+        if !rest.is_empty() {
+            return Err(CaliptraCompletionCode::InvalidLength);
+        }
+
+        let mut req = ProductionAuthDebugUnlockReq {
+            hdr: MailboxReqHeader::default(),
+            length: 2,
+            unlock_level,
+            reserved: [0; 3],
+        };
+        let mut resp_buf = [0u8; core::mem::size_of::<ProductionAuthDebugUnlockChallenge>()];
+        execute_mailbox_cmd(
+            &Mailbox::new(),
+            CommandId::PRODUCTION_AUTH_DEBUG_UNLOCK_REQ.0,
+            req.as_mut_bytes(),
+            &mut resp_buf,
+        )
+        .await
+        .map_err(Self::map_csr_error)?;
+
+        let resp = ProductionAuthDebugUnlockChallenge::ref_from_bytes(&resp_buf)
+            .map_err(|_| CaliptraCompletionCode::GeneralError)?;
+        let mut offset =
+            Self::write_success(out, CaliptraVdmCommand::RequestDebugUnlock.response_code())
+                .map_err(|_| CaliptraCompletionCode::CaliptraBufferTooSmall)?;
+        offset = Self::write_bytes(out, offset, &resp.unique_device_identifier)
+            .map_err(|_| CaliptraCompletionCode::CaliptraBufferTooSmall)?;
+        Self::write_bytes(out, offset, &resp.challenge)
+            .map_err(|_| CaliptraCompletionCode::CaliptraBufferTooSmall)
+    }
+
+    async fn authorize_debug_unlock_token(
+        payload: &[u8],
+        out: &mut [u8],
+    ) -> CaliptraCmdResult<usize> {
+        use caliptra_api::mailbox::{CommandId, MailboxRespHeader};
+
+        if payload.len() < core::mem::size_of::<u32>() {
+            return Err(CaliptraCompletionCode::InvalidLength);
+        }
+
+        // The SPDM VDM host sends the Caliptra mailbox request payload directly:
+        // [MailboxReqHeader(checksum) | token]. Do not prepend or recompute the
+        // header here; large-token CHUNK_SEND forwarding uses the same bytes.
+        let mut resp_buf = [0u8; core::mem::size_of::<MailboxRespHeader>()];
+        Mailbox::<caliptra_mcu_libsyscall_caliptra::DefaultSyscalls>::new()
+            .execute(
+                CommandId::PRODUCTION_AUTH_DEBUG_UNLOCK_TOKEN.0,
+                payload,
+                &mut resp_buf,
+            )
+            .await
+            .map_err(|_| CaliptraCompletionCode::OperationFailed)?;
+
+        Self::write_success(
+            out,
+            CaliptraVdmCommand::AuthorizeDebugUnlockToken.response_code(),
+        )
+        .map_err(|_| CaliptraCompletionCode::CaliptraBufferTooSmall)
+    }
+}
+
+impl SpdmVdmBackend for CaliptraOcpVdm {
+    type Error = mcu_spdm_lite_stack::SpdmError;
+
+    fn match_request(&self, req: &VdmRequest<'_>) -> bool {
+        req.standard_id == StandardsBodyId::Iana.as_u16()
+            && req.vendor_id == OCP_VENDOR_ID.to_le_bytes()
+    }
+
+    async fn handle_request<Storage: SpdmPalLargeMessage>(
+        &self,
+        req: VdmRequest<'_>,
+        rsp: VdmResponseBuffers<'_, Storage>,
+    ) -> mcu_spdm_lite_stack::SpdmResult<VdmResponseKind> {
+        let VdmResponseBuffers { inline, large } = rsp;
+        let Some((&command_version, rest)) = req.payload.split_first() else {
+            return Err(mcu_spdm_lite_stack::SPDM_INVALID_REQUEST);
+        };
+        let Some((&command, payload)) = rest.split_first() else {
+            return Err(mcu_spdm_lite_stack::SPDM_INVALID_REQUEST);
+        };
+        if command_version != CALIPTRA_VDM_COMMAND_VERSION {
+            return Self::write_completion(
+                inline,
+                command,
+                CaliptraCompletionCode::InvalidCommandVersion,
+            )
+            .map(VdmResponseKind::Inline);
+        }
+
+        let Ok(command) = CaliptraVdmCommand::try_from(command) else {
+            return Self::write_completion(
+                inline,
+                command,
+                CaliptraCompletionCode::UnsupportedOperation,
+            )
+            .map(VdmResponseKind::Inline);
+        };
+        let command_code = command.response_code();
+
+        match command {
+            CaliptraVdmCommand::FirmwareVersion => {
+                let req = Self::read_firmware_version_req(payload)?;
+                let version_str = config::TEST_FIRMWARE_VERSIONS
+                    .get(req.area_index as usize)
+                    .ok_or(CaliptraCompletionCode::InvalidParameter);
+                match version_str {
+                    Ok(version_str) if version_str.len() <= MAX_FW_VERSION_LEN => {
+                        let offset = Self::write_success(inline, command_code)?;
+                        Self::write_bytes(inline, offset, version_str.as_bytes())
+                            .map(VdmResponseKind::Inline)
+                    }
+                    Ok(_) => Self::write_completion(
+                        inline,
+                        command_code,
+                        CaliptraCompletionCode::InvalidPayloadSize,
+                    )
+                    .map(VdmResponseKind::Inline),
+                    Err(e) => {
+                        Self::write_completion(inline, command_code, e).map(VdmResponseKind::Inline)
+                    }
+                }
+            }
+            CaliptraVdmCommand::DeviceCapabilities => {
+                if !payload.is_empty() {
+                    return Err(mcu_spdm_lite_stack::SPDM_INVALID_REQUEST);
+                }
+                let caps = &config::TEST_DEVICE_CAPABILITIES;
+                let out_caps = DeviceCapabilities {
+                    caliptra_rt: caps.caliptra_rt,
+                    caliptra_fmc: caps.caliptra_fmc,
+                    caliptra_rom: caps.caliptra_rom,
+                    mcu_rt: caps.mcu_rt,
+                    mcu_rom: caps.mcu_rom,
+                    reserved: caps.reserved,
+                };
+                let offset = Self::write_success(inline, command_code)?;
+                Self::write_bytes(inline, offset, out_caps.as_bytes()).map(VdmResponseKind::Inline)
+            }
+            CaliptraVdmCommand::DeviceId => {
+                if !payload.is_empty() {
+                    return Err(mcu_spdm_lite_stack::SPDM_INVALID_REQUEST);
+                }
+                let device_id = &config::TEST_DEVICE_ID;
+                let mut offset = Self::write_success(inline, command_code)?;
+                offset = Self::write_u16(inline, offset, device_id.vendor_id)?;
+                offset = Self::write_u16(inline, offset, device_id.device_id)?;
+                offset = Self::write_u16(inline, offset, device_id.subsystem_vendor_id)?;
+                Self::write_u16(inline, offset, device_id.subsystem_id).map(VdmResponseKind::Inline)
+            }
+            CaliptraVdmCommand::DeviceInfo => {
+                let req = Self::read_device_info_req(payload)?;
+                if req.info_index != 0 {
+                    return Self::write_completion(
+                        inline,
+                        command_code,
+                        CaliptraCompletionCode::InvalidParameter,
+                    )
+                    .map(VdmResponseKind::Inline);
+                }
+                let uid = &config::TEST_UID;
+                if uid.len() > MAX_UID_LEN {
+                    return Self::write_completion(
+                        inline,
+                        command_code,
+                        CaliptraCompletionCode::InvalidPayloadSize,
+                    )
+                    .map(VdmResponseKind::Inline);
+                }
+                let offset = Self::write_success(inline, command_code)?;
+                Self::write_bytes(inline, offset, uid).map(VdmResponseKind::Inline)
+            }
+            CaliptraVdmCommand::GetDebugLog => {
+                if !payload.is_empty() {
+                    return Err(mcu_spdm_lite_stack::SPDM_INVALID_REQUEST);
+                }
+                const MORE_DATA_LEN: usize = 1;
+                const BYTES_WRITTEN_LEN: usize = core::mem::size_of::<u32>();
+                let offset = Self::write_success(inline, command_code)?;
+                let data_offset = offset + MORE_DATA_LEN + BYTES_WRITTEN_LEN;
+                if data_offset > inline.len() {
+                    return Err(mcu_spdm_lite_stack::SPDM_UNSPECIFIED);
+                }
+                match debug_log::drain(&mut inline[data_offset..]).await {
+                    Ok(log) => {
+                        inline[offset] = u8::from(log.more_data);
+                        Self::write_u32(inline, offset + MORE_DATA_LEN, log.bytes_written as u32)?;
+                        Ok(VdmResponseKind::Inline(data_offset + log.bytes_written))
+                    }
+                    Err(e) => {
+                        Self::write_completion(inline, command_code, e).map(VdmResponseKind::Inline)
+                    }
+                }
+            }
+            CaliptraVdmCommand::ClearDebugLog => {
+                if !payload.is_empty() {
+                    return Err(mcu_spdm_lite_stack::SPDM_INVALID_REQUEST);
+                }
+                match debug_log::clear().await {
+                    Ok(()) => {
+                        Self::write_success(inline, command_code).map(VdmResponseKind::Inline)
+                    }
+                    Err(e) => {
+                        Self::write_completion(inline, command_code, e).map(VdmResponseKind::Inline)
+                    }
+                }
+            }
+            CaliptraVdmCommand::GetAttestationLog | CaliptraVdmCommand::ClearAttestationLog => {
+                if !payload.is_empty() {
+                    return Err(mcu_spdm_lite_stack::SPDM_INVALID_REQUEST);
+                }
+                Self::write_completion(
+                    inline,
+                    command_code,
+                    CaliptraCompletionCode::UnsupportedOperation,
+                )
+                .map(VdmResponseKind::Inline)
+            }
+            CaliptraVdmCommand::RequestDebugUnlock => {
+                match Self::request_debug_unlock(payload, inline).await {
+                    Ok(len) => Ok(VdmResponseKind::Inline(len)),
+                    Err(e) => {
+                        Self::write_completion(inline, command_code, e).map(VdmResponseKind::Inline)
+                    }
+                }
+            }
+            CaliptraVdmCommand::AuthorizeDebugUnlockToken => {
+                match Self::authorize_debug_unlock_token(payload, inline).await {
+                    Ok(len) => Ok(VdmResponseKind::Inline(len)),
+                    Err(e) => {
+                        Self::write_completion(inline, command_code, e).map(VdmResponseKind::Inline)
+                    }
+                }
+            }
+            CaliptraVdmCommand::ExportIdevidCsr => {
+                if let Some(large) = large {
+                    if large.capacity() < CSR_VDM_PAYLOAD_HEADER_LEN {
+                        return Self::write_completion(
+                            inline,
+                            command_code,
+                            CaliptraCompletionCode::InsufficientResources,
+                        )
+                        .map(VdmResponseKind::Inline);
+                    }
+                    match Self::export_idevid_csr_large(payload, &large).await {
+                        Ok(len) => Ok(VdmResponseKind::Large(len)),
+                        Err(e) => Self::write_completion(inline, command_code, e)
+                            .map(VdmResponseKind::Inline),
+                    }
+                } else {
+                    match Self::export_idevid_csr(payload, inline).await {
+                        Ok(len) => Ok(VdmResponseKind::Inline(len)),
+                        Err(e) => Self::write_completion(inline, command_code, e)
+                            .map(VdmResponseKind::Inline),
+                    }
+                }
+            }
+            CaliptraVdmCommand::ExportAttestedCsr => {
+                #[cfg(not(feature = "test-mctp-spdm-attested-csr-vdm"))]
+                {
+                    Self::write_completion(
+                        inline,
+                        command_code,
+                        CaliptraCompletionCode::UnsupportedOperation,
+                    )
+                    .map(VdmResponseKind::Inline)
+                }
+
+                #[cfg(feature = "test-mctp-spdm-attested-csr-vdm")]
+                if let Some(large) = large {
+                    if large.capacity() < CSR_VDM_PAYLOAD_HEADER_LEN {
+                        return Self::write_completion(
+                            inline,
+                            command_code,
+                            CaliptraCompletionCode::InsufficientResources,
+                        )
+                        .map(VdmResponseKind::Inline);
+                    }
+                    match Self::export_attested_csr_large(payload, &large).await {
+                        Ok(len) => Ok(VdmResponseKind::Large(len)),
+                        Err(e) => Self::write_completion(inline, command_code, e)
+                            .map(VdmResponseKind::Inline),
+                    }
+                } else {
+                    match Self::export_attested_csr(payload, inline).await {
+                        Ok(len) => Ok(VdmResponseKind::Inline(len)),
+                        Err(e) => Self::write_completion(inline, command_code, e)
+                            .map(VdmResponseKind::Inline),
+                    }
+                }
+            }
+            CaliptraVdmCommand::GetAttestation
+            | CaliptraVdmCommand::SetSlot0Cert
+            | CaliptraVdmCommand::GetSlot0State
+            | CaliptraVdmCommand::ProgramFieldEntropy
+            | CaliptraVdmCommand::DeviceOwnershipTransfer => Self::write_completion(
+                inline,
+                command_code,
+                CaliptraCompletionCode::UnsupportedOperation,
+            )
+            .map(VdmResponseKind::Inline),
+        }
+    }
+}
 
 #[async_trait]
 impl CaliptraCmdHandler for CaliptraCmdBackend {
     async fn get_firmware_version(
         &self,
-        _index: u32,
-        _version: &mut FirmwareVersion,
+        index: u32,
+        version: &mut FirmwareVersion,
     ) -> CaliptraCmdResult<()> {
-        Err(CaliptraCompletionCode::UnsupportedOperation)
+        let version_str = config::TEST_FIRMWARE_VERSIONS
+            .get(index as usize)
+            .ok_or(CaliptraCompletionCode::InvalidParameter)?;
+        let bytes = version_str.as_bytes();
+        if bytes.len() > MAX_FW_VERSION_LEN {
+            return Err(CaliptraCompletionCode::InvalidPayloadSize);
+        }
+        version.ver_str[..bytes.len()].copy_from_slice(bytes);
+        version.len = bytes.len();
+        Ok(())
     }
 
-    async fn get_device_id(&self, _device_id: &mut DeviceId) -> CaliptraCmdResult<()> {
-        Err(CaliptraCompletionCode::UnsupportedOperation)
+    async fn get_device_id(&self, device_id: &mut DeviceId) -> CaliptraCmdResult<()> {
+        let test_device_id = &config::TEST_DEVICE_ID;
+        device_id.vendor_id = test_device_id.vendor_id;
+        device_id.device_id = test_device_id.device_id;
+        device_id.subsystem_vendor_id = test_device_id.subsystem_vendor_id;
+        device_id.subsystem_id = test_device_id.subsystem_id;
+        Ok(())
     }
 
-    async fn get_device_info(&self, _index: u32, _info: &mut DeviceInfo) -> CaliptraCmdResult<()> {
-        Err(CaliptraCompletionCode::UnsupportedOperation)
+    async fn get_device_info(&self, index: u32, info: &mut DeviceInfo) -> CaliptraCmdResult<()> {
+        if index != 0 {
+            return Err(CaliptraCompletionCode::InvalidParameter);
+        }
+        let test_uid = &config::TEST_UID;
+        if test_uid.len() > MAX_UID_LEN {
+            return Err(CaliptraCompletionCode::InvalidPayloadSize);
+        }
+        let mut unique_chip_id = [0u8; MAX_UID_LEN];
+        unique_chip_id[..test_uid.len()].copy_from_slice(test_uid);
+        *info = DeviceInfo::Uid(Uid {
+            len: test_uid.len(),
+            unique_chip_id,
+        });
+        Ok(())
     }
 
     async fn get_device_capabilities(
         &self,
-        _capabilities: &mut DeviceCapabilities,
+        capabilities: &mut DeviceCapabilities,
     ) -> CaliptraCmdResult<()> {
-        Err(CaliptraCompletionCode::UnsupportedOperation)
+        let test_capabilities = &config::TEST_DEVICE_CAPABILITIES;
+        capabilities.caliptra_rt = test_capabilities.caliptra_rt;
+        capabilities.caliptra_fmc = test_capabilities.caliptra_fmc;
+        capabilities.caliptra_rom = test_capabilities.caliptra_rom;
+        capabilities.mcu_rt = test_capabilities.mcu_rt;
+        capabilities.mcu_rom = test_capabilities.mcu_rom;
+        capabilities.reserved = test_capabilities.reserved;
+        Ok(())
     }
 
     async fn export_attested_csr(
@@ -419,5 +1277,21 @@ impl caliptra_mcu_spdm_lib::vdm_handler::VdmStreamHandler for CaliptraCmdBackend
         // Clear remainder state
         let mut remainder = STREAM_REMAINDER.lock().await;
         remainder.len = 0;
+    }
+}
+
+#[cfg(test)]
+mod ocp_vdm_tests {
+    use super::CaliptraVdmCommand;
+
+    #[test]
+    fn command_roundtrip() {
+        for code in 0x01u8..=0x11 {
+            let command = CaliptraVdmCommand::try_from(code).unwrap();
+            assert_eq!(command.response_code(), code);
+        }
+        assert!(CaliptraVdmCommand::try_from(0x00).is_err());
+        assert!(CaliptraVdmCommand::try_from(0x12).is_err());
+        assert!(CaliptraVdmCommand::try_from(0xff).is_err());
     }
 }

--- a/platforms/emulator/runtime/userspace/apps/user/src/spdm/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/spdm/mod.rs
@@ -11,6 +11,7 @@ extern crate alloc;
 mod cert_store;
 mod device_measurements;
 
+use crate::caliptra_cmd_handler::CaliptraOcpVdm;
 use caliptra_mcu_libsyscall_caliptra::doe;
 use caliptra_mcu_libsyscall_caliptra::mctp;
 use caliptra_mcu_libsyscall_caliptra::DefaultSyscalls;
@@ -32,10 +33,17 @@ use mcu_spdm_lite_transports::{McuSpdmDoeTransport, McuSpdmMctpTransport};
 /// plus transient DPE/SHA mailbox buffers (peak ~2.4 KB during
 /// certify_key for kid computation).
 const SPDM_LITE_SCRATCH_SIZE: usize = 8 * 1024;
-/// Persistent CHUNK_SEND reassembly buffer. This is kept outside the
-/// async task frame and outside the per-I/O scratch allocator because
-/// it must live across multiple received chunk messages.
-const SPDM_LITE_LARGE_MSG_SIZE: usize = 8 * 1024;
+/// Persistent large-message buffer. This is kept outside the async task frame
+/// and outside the per-I/O scratch allocator because CHUNK_SEND reassembly and
+/// buffered large responses must live across multiple received chunk messages.
+///
+/// With attested CSR VDM disabled, this only needs to cover regular Caliptra
+/// response data (9 KiB) plus VDM framing.  Opting into attested CSR VDM keeps
+/// enough room for Caliptra's 12.5 KiB attested CSR mailbox response.
+#[cfg(not(feature = "test-mctp-spdm-attested-csr-vdm"))]
+const SPDM_LITE_LARGE_MSG_SIZE: usize = 10 * 1024;
+#[cfg(feature = "test-mctp-spdm-attested-csr-vdm")]
+const SPDM_LITE_LARGE_MSG_SIZE: usize = 13 * 1024;
 
 /// Single cert store shared by all SPDM responder tasks.
 static CERT_STORE: SharedCertStore = SharedCertStore::new();
@@ -149,7 +157,8 @@ async fn spdm_mctp_responder() {
             measurement_provider(),
         )
     };
-    let mut stack: SpdmStack<_, 1> = SpdmStack::new(pal);
+    let mut stack: SpdmStack<_, 1, CaliptraOcpVdm> =
+        SpdmStack::with_vdm_backend(pal, CaliptraOcpVdm);
 
     crate::console_writeln!(cw, "SPDM_MCTP: starting spdm-lite MCTP run loop");
     if let Err(e) = stack.run().await {
@@ -201,7 +210,8 @@ async fn spdm_doe_responder() {
             measurement_provider(),
         )
     };
-    let mut stack: SpdmStack<_, 1> = SpdmStack::new(pal);
+    let mut stack: SpdmStack<_, 1, CaliptraOcpVdm> =
+        SpdmStack::with_vdm_backend(pal, CaliptraOcpVdm);
 
     crate::console_writeln!(cw, "SPDM_DOE: starting spdm-lite DOE run loop");
     if let Err(e) = stack.run().await {

--- a/runtime/userspace/api/spdm-lite/codec/src/lib.rs
+++ b/runtime/userspace/api/spdm-lite/codec/src/lib.rs
@@ -22,6 +22,7 @@ mod measurements;
 mod opaque;
 mod secured_message;
 mod set_certificate;
+mod vendor_defined;
 mod version;
 mod wire;
 
@@ -56,6 +57,7 @@ pub use measurements::{
     SPDM_MAX_MEASUREMENT_RECORD_SIZE,
 };
 pub use set_certificate::{SetCertificateReqBody, SetCertificateRsp, SetCertificateRspBody};
+pub use vendor_defined::{StandardsBodyId, VendorDefinedReqPdu, VendorDefinedRspPdu};
 pub use version::{SpdmVersion, VersionNumberEntry, VersionRsp, VersionRspBody};
 pub use wire::{WireError, WireReader, WireWriter};
 

--- a/runtime/userspace/api/spdm-lite/codec/src/vendor_defined.rs
+++ b/runtime/userspace/api/spdm-lite/codec/src/vendor_defined.rs
@@ -1,0 +1,97 @@
+// Licensed under the Apache-2.0 license
+
+//! VENDOR_DEFINED request / response wire types.
+
+use zerocopy::{little_endian::U16, FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
+
+/// SPDM Standards Body ID registry values used by VENDOR_DEFINED messages.
+#[derive(Clone, Copy, PartialEq, Eq)]
+#[repr(u16)]
+pub enum StandardsBodyId {
+    Dmtf = 0x0,
+    Tcg = 0x1,
+    Usb = 0x2,
+    PciSig = 0x3,
+    Iana = 0x4,
+    HdBaseT = 0x5,
+    Mipi = 0x6,
+    Cxl = 0x7,
+    Jedec = 0x8,
+    Vesa = 0x9,
+    IanaCbor = 0xA,
+    DmtfDsp = 0xB,
+}
+
+impl StandardsBodyId {
+    #[inline]
+    pub const fn from_u16(value: u16) -> Option<Self> {
+        match value {
+            0x0 => Some(Self::Dmtf),
+            0x1 => Some(Self::Tcg),
+            0x2 => Some(Self::Usb),
+            0x3 => Some(Self::PciSig),
+            0x4 => Some(Self::Iana),
+            0x5 => Some(Self::HdBaseT),
+            0x6 => Some(Self::Mipi),
+            0x7 => Some(Self::Cxl),
+            0x8 => Some(Self::Jedec),
+            0x9 => Some(Self::Vesa),
+            0xA => Some(Self::IanaCbor),
+            0xB => Some(Self::DmtfDsp),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub const fn vendor_id_len(self) -> Option<u8> {
+        match self {
+            Self::Dmtf | Self::Vesa => Some(0),
+            Self::Tcg
+            | Self::Usb
+            | Self::PciSig
+            | Self::Mipi
+            | Self::Cxl
+            | Self::Jedec
+            | Self::DmtfDsp => Some(2),
+            Self::Iana | Self::HdBaseT => Some(4),
+            Self::IanaCbor => None,
+        }
+    }
+
+    #[inline]
+    pub const fn as_u16(self) -> u16 {
+        self as u16
+    }
+}
+
+/// Fixed part of a VENDOR_DEFINED_REQUEST body after the common header.
+#[derive(FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+#[repr(C)]
+pub struct VendorDefinedReqPdu {
+    pub param1: u8,
+    pub param2: u8,
+    pub standard_id: U16,
+    pub vendor_id_len: u8,
+}
+
+impl VendorDefinedReqPdu {
+    pub const SIZE: usize = 5;
+}
+
+const _: () = assert!(core::mem::size_of::<VendorDefinedReqPdu>() == VendorDefinedReqPdu::SIZE);
+
+/// Fixed part of a VENDOR_DEFINED_RESPONSE body after the common header.
+#[derive(FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+#[repr(C)]
+pub struct VendorDefinedRspPdu {
+    pub param1: u8,
+    pub param2: u8,
+    pub standard_id: U16,
+    pub vendor_id_len: u8,
+}
+
+impl VendorDefinedRspPdu {
+    pub const SIZE: usize = 5;
+}
+
+const _: () = assert!(core::mem::size_of::<VendorDefinedRspPdu>() == VendorDefinedRspPdu::SIZE);

--- a/runtime/userspace/api/spdm-lite/pal/src/alloc.rs
+++ b/runtime/userspace/api/spdm-lite/pal/src/alloc.rs
@@ -76,6 +76,10 @@ impl<M: MeasurementProvider> SpdmPalAlloc for McuSpdmPal<M> {
     fn alloc_bytes(&self, _io: &impl SpdmPalIo, len: usize) -> McuResult<Self::Bytes<'_>> {
         self.allocator.alloc_bytes(len)
     }
+
+    fn shrink_bytes(bytes: &mut Self::Bytes<'_>, new_len: usize) -> McuResult<()> {
+        bytes.shrink(new_len)
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/runtime/userspace/api/spdm-lite/stack/src/chunk/send.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/chunk/send.rs
@@ -6,15 +6,16 @@ use mcu_spdm_lite_codec::{
     CapabilitiesBody, ChunkSendAckBody, ChunkSendReqBody, ReqRespCode, SpdmMsgHdrPdu, SpdmVersion,
     WireWriter, CHUNK_ACK_ATTR_EARLY_ERROR, CHUNK_ATTR_LAST_CHUNK,
 };
-use mcu_spdm_lite_traits::{PalBytes, SpdmPal, SpdmPalIo, SpdmPalIoTransport};
+use mcu_spdm_lite_traits::{PalBytes, SpdmPal, SpdmPalIo, SpdmPalIoTransport, SpdmVdmBackend};
 use zerocopy::{little_endian::U16, FromBytes};
 
 use crate::build::alloc_padded;
 use crate::error::{
-    SpdmError, SpdmResult, SPDM_INVALID_REQUEST, SPDM_UNEXPECTED_REQUEST, SPDM_UNSUPPORTED_REQUEST,
-    SPDM_VERSION_MISMATCH,
+    SpdmError, SpdmResult, SPDM_INVALID_REQUEST, SPDM_UNEXPECTED_REQUEST, SPDM_UNSPECIFIED,
+    SPDM_UNSUPPORTED_REQUEST, SPDM_VERSION_MISMATCH,
 };
 use crate::stack::{ConnectionState, Phase};
+use crate::vendor_defined;
 
 struct ChunkInfo {
     handle: u8,
@@ -22,33 +23,31 @@ struct ChunkInfo {
     complete: bool,
 }
 
-pub(crate) async fn handle_chunk_send<'a, Pal: SpdmPal>(
+pub(crate) async fn handle_chunk_send<'a, Pal, Vdm>(
     state: &mut ConnectionState<Pal::State>,
     pal: &'a Pal,
     io: &<Pal as SpdmPalIoTransport>::Io<'_>,
-) -> SpdmResult<PalBytes<'a, Pal>> {
+    vdm_backend: &Vdm,
+) -> SpdmResult<PalBytes<'a, Pal>>
+where
+    Pal: SpdmPal,
+    Vdm: SpdmVdmBackend,
+    Vdm::Error: Into<crate::error::SpdmError>,
+{
     let result = process_chunk_send(state, pal, io);
     match result {
-        Ok(info) => {
-            let mut response_to_large_request = [0u8; 4];
-            let response = if info.complete {
-                let err = build_response_to_large_request(state, pal);
-                encode_error_pdu(state.version, err, &mut response_to_large_request);
-                state.chunk.reset();
-                &response_to_large_request[..]
-            } else {
-                &[]
-            };
-            build_chunk_send_ack(
-                pal,
-                io,
-                state.version,
-                false,
-                info.handle,
-                info.chunk_seq_num,
-                response,
-            )
+        Ok(info) if info.complete => {
+            build_completed_chunk_send_ack(state, pal, io, info, vdm_backend).await
         }
+        Ok(info) => build_chunk_send_ack(
+            pal,
+            io,
+            state.version,
+            false,
+            info.handle,
+            info.chunk_seq_num,
+            &[],
+        ),
         Err(ChunkProcessError::Spdm(e)) => Err(e),
         Err(ChunkProcessError::Early {
             handle,
@@ -75,7 +74,71 @@ fn build_chunk_send_ack<'a, Pal: SpdmPal>(
     let raw_len =
         head + SpdmMsgHdrPdu::SIZE + ChunkSendAckBody::SIZE + response_to_large_request.len();
     let mut rsp = alloc_padded(pal, io, raw_len)?;
-    let mut w = WireWriter::new(&mut rsp[head..]);
+    write_chunk_send_ack_prefix(
+        &mut rsp[head..],
+        version,
+        early_error,
+        handle,
+        chunk_seq_num,
+    )?;
+    let response_offset = head + SpdmMsgHdrPdu::SIZE + ChunkSendAckBody::SIZE;
+    rsp[response_offset..response_offset + response_to_large_request.len()]
+        .copy_from_slice(response_to_large_request);
+    Ok(rsp)
+}
+
+async fn build_completed_chunk_send_ack<'a, Pal, Vdm>(
+    state: &mut ConnectionState<Pal::State>,
+    pal: &'a Pal,
+    io: &<Pal as SpdmPalIoTransport>::Io<'_>,
+    info: ChunkInfo,
+    vdm_backend: &Vdm,
+) -> SpdmResult<PalBytes<'a, Pal>>
+where
+    Pal: SpdmPal,
+    Vdm: SpdmVdmBackend,
+    Vdm::Error: Into<crate::error::SpdmError>,
+{
+    let head = pal.header_size();
+    let ack_body_len = SpdmMsgHdrPdu::SIZE + ChunkSendAckBody::SIZE;
+    let max_response_len = state
+        .effective_data_transfer_size(pal)
+        .saturating_sub(ack_body_len);
+    let mut rsp = alloc_padded(pal, io, head + ack_body_len + max_response_len)?;
+
+    let response_offset = head + ack_body_len;
+    let response = &mut rsp[response_offset..response_offset + max_response_len];
+    let response_len =
+        match build_response_to_large_request(state, pal, io, vdm_backend, response).await {
+            Ok(len) => len,
+            Err(err) => {
+                let mut error = [0u8; 4];
+                encode_error_pdu(state.version, err, &mut error);
+                response[..error.len()].copy_from_slice(&error);
+                error.len()
+            }
+        };
+    state.chunk.reset();
+
+    write_chunk_send_ack_prefix(
+        &mut rsp[head..],
+        state.version,
+        false,
+        info.handle,
+        info.chunk_seq_num,
+    )?;
+    shrink_padded(pal, &mut rsp, response_offset + response_len)?;
+    Ok(rsp)
+}
+
+fn write_chunk_send_ack_prefix(
+    out: &mut [u8],
+    version: SpdmVersion,
+    early_error: bool,
+    handle: u8,
+    chunk_seq_num: u16,
+) -> SpdmResult<()> {
+    let mut w = WireWriter::new(out);
     w.write(&SpdmMsgHdrPdu::new(version, ReqRespCode::CHUNK_SEND_ACK))?;
     w.write(&ChunkSendAckBody {
         chunk_receiver_attr: if early_error {
@@ -86,8 +149,7 @@ fn build_chunk_send_ack<'a, Pal: SpdmPal>(
         handle,
         chunk_seq_num: U16::new(chunk_seq_num),
     })?;
-    w.write_bytes(response_to_large_request)?;
-    Ok(rsp)
+    Ok(())
 }
 
 enum ChunkProcessError {
@@ -253,34 +315,72 @@ fn process_next_chunk<Pal: SpdmPal>(
     Ok(())
 }
 
-fn build_response_to_large_request<Pal: SpdmPal>(
+async fn build_response_to_large_request<Pal, Vdm>(
     state: &ConnectionState<Pal::State>,
     pal: &Pal,
-) -> SpdmError {
-    if (state.chunk.large_msg_size as usize) < SpdmMsgHdrPdu::SIZE {
-        return SPDM_INVALID_REQUEST;
+    io: &<Pal as SpdmPalIoTransport>::Io<'_>,
+    vdm_backend: &Vdm,
+    out: &mut [u8],
+) -> SpdmResult<usize>
+where
+    Pal: SpdmPal,
+    Vdm: SpdmVdmBackend,
+    Vdm::Error: Into<crate::error::SpdmError>,
+{
+    let large_req_len = state.chunk.large_msg_size as usize;
+    if large_req_len < SpdmMsgHdrPdu::SIZE {
+        return Err(SPDM_INVALID_REQUEST);
     }
-    let mut hdr_buf = [0u8; SpdmMsgHdrPdu::SIZE];
-    if pal.read(0, &mut hdr_buf).is_err() {
-        return SPDM_INVALID_REQUEST;
-    };
-    let Ok((hdr, _)) = SpdmMsgHdrPdu::ref_from_prefix(&hdr_buf) else {
-        return SPDM_INVALID_REQUEST;
-    };
+    let mut large_req = pal.alloc_bytes(io, large_req_len)?;
+    pal.read(0, &mut large_req)
+        .map_err(|_| SPDM_INVALID_REQUEST)?;
+    let (hdr, _) = SpdmMsgHdrPdu::ref_from_prefix(&large_req).map_err(|_| SPDM_INVALID_REQUEST)?;
     if hdr.version != state.version.to_u8()
         || hdr.code == ReqRespCode::CHUNK_SEND
         || hdr.code == ReqRespCode::CHUNK_GET
     {
-        return SPDM_INVALID_REQUEST;
+        return Err(SPDM_INVALID_REQUEST);
     }
-    // TODO: Dispatch supported chunked large requests from `large_req` here.
-    // SPDM-lite currently only uses chunking for large responses.
-    SPDM_UNSUPPORTED_REQUEST
+    match hdr.code {
+        ReqRespCode::VENDOR_DEFINED_REQUEST => {
+            vendor_defined::handle_large_vendor_defined_request::<Pal, Vdm>(
+                state,
+                io,
+                &large_req,
+                vdm_backend,
+                out,
+            )
+            .await
+        }
+        _ => Err(SPDM_UNSUPPORTED_REQUEST),
+    }
 }
 
 fn encode_error_pdu(version: SpdmVersion, err: SpdmError, out: &mut [u8; 4]) {
     out[0] = version.to_u8();
     out[1] = ReqRespCode::ERROR.0;
     out[2] = err.spec_byte();
-    out[3] = 0;
+    out[3] = err.error_data();
+}
+
+fn padded_len<Pal: SpdmPal>(pal: &Pal, raw_len: usize) -> SpdmResult<usize> {
+    let align = pal.send_len_alignment();
+    debug_assert!(align > 0 && align.is_power_of_two());
+    raw_len
+        .checked_add(align - 1)
+        .map(|len| len & !(align - 1))
+        .ok_or(SPDM_UNSPECIFIED)
+}
+
+fn shrink_padded<Pal: SpdmPal>(
+    pal: &Pal,
+    rsp: &mut PalBytes<'_, Pal>,
+    raw_len: usize,
+) -> SpdmResult<()> {
+    let shrink_len = padded_len(pal, raw_len)?;
+    for b in &mut rsp[raw_len..shrink_len] {
+        *b = 0;
+    }
+    Pal::shrink_bytes(rsp, shrink_len)?;
+    Ok(())
 }

--- a/runtime/userspace/api/spdm-lite/stack/src/lib.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/lib.rs
@@ -48,8 +48,14 @@ pub mod session;
 mod set_certificate;
 mod stack;
 mod transcript;
+mod vendor_defined;
 mod version;
 
 pub use error::*;
+pub use mcu_spdm_lite_codec::StandardsBodyId;
+pub use mcu_spdm_lite_traits::{
+    NoVdmBackend, SpdmVdmBackend, VdmLargeResponseWriter, VdmRequest, VdmResponseBuffers,
+    VdmResponseKind,
+};
 pub use stack::*;
 pub use transcript::*;

--- a/runtime/userspace/api/spdm-lite/stack/src/set_certificate.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/set_certificate.rs
@@ -297,8 +297,8 @@ mod tests {
     use mcu_error::McuErrorCode;
     use mcu_spdm_lite_codec::{errors as wire_errors, OtherParamSupport, ReqRespCode};
     use mcu_spdm_lite_traits::{
-        McuResult, SpdmPalAlloc, SpdmPalAsymAlgo, SpdmPalCertStore, SpdmPalHash, SpdmPalIoKind,
-        SpdmPalLargeMessage,
+        McuResult, MeasurementInfo, SpdmPalAlloc, SpdmPalAsymAlgo, SpdmPalCertStore, SpdmPalHash,
+        SpdmPalIoKind, SpdmPalLargeMessage, SpdmPalMeasurements, SPDM_NONCE_LEN,
     };
     use std::boxed::Box;
     use std::cell::RefCell;
@@ -401,6 +401,11 @@ mod tests {
 
         fn alloc_bytes(&self, _io: &impl SpdmPalIo, len: usize) -> McuResult<Self::Bytes<'_>> {
             Ok(vec![0u8; len])
+        }
+
+        fn shrink_bytes(bytes: &mut Self::Bytes<'_>, new_len: usize) -> McuResult<()> {
+            bytes.truncate(new_len);
+            Ok(())
         }
     }
 
@@ -615,6 +620,22 @@ mod tests {
         async fn generate_nonce(&self, _io: &Self::Io<'_>, out: &mut [u8]) -> McuResult<()> {
             out.fill(0xA5);
             Ok(())
+        }
+    }
+
+    impl SpdmPalMeasurements for TestPal {
+        fn measurement_info(&self) -> &[MeasurementInfo] {
+            &[]
+        }
+
+        async fn get_measurement_value(
+            &self,
+            _io: &Self::Io<'_>,
+            _index: u8,
+            _nonce: Option<&[u8; SPDM_NONCE_LEN]>,
+            _out: &mut [u8],
+        ) -> McuResult<usize> {
+            Err(mcu_error::codes::NOT_IMPLEMENTED)
         }
     }
 

--- a/runtime/userspace/api/spdm-lite/stack/src/stack.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/stack.rs
@@ -31,7 +31,7 @@ use crate::key_schedule::SessionKeyType;
 use crate::session::{SessionManager, SessionState};
 use crate::{
     algorithms, capabilities, certificate, challenge, chunk, digests, end_session, finish,
-    key_exchange, measurements, version,
+    key_exchange, measurements, vendor_defined, version,
 };
 
 /// Connection phase tracked on the responder so the dispatcher can
@@ -292,14 +292,21 @@ fn set_certificate_other_params() -> OtherParamSupport {
 /// and a fixed-size session table.
 /// Drive it with [`Self::run`], which loops forever until the
 /// transport returns a fatal error.
-pub struct SpdmStack<Pal: SpdmPal, const MAX_SESSIONS: usize = 1> {
+pub struct SpdmStack<
+    Pal: SpdmPal,
+    const MAX_SESSIONS: usize = 1,
+    Vdm: mcu_spdm_lite_traits::SpdmVdmBackend = mcu_spdm_lite_traits::NoVdmBackend,
+> {
     pub(crate) pal: Pal,
     pub(crate) state: ConnectionState<Pal::State>,
     pub(crate) sessions:
         SessionManager<<Pal as SpdmPalSessionCrypto>::Key, Pal::State, MAX_SESSIONS>,
+    vdm_backend: Vdm,
 }
 
-impl<Pal: SpdmPal, const MAX_SESSIONS: usize> SpdmStack<Pal, MAX_SESSIONS> {
+impl<Pal: SpdmPal, const MAX_SESSIONS: usize>
+    SpdmStack<Pal, MAX_SESSIONS, mcu_spdm_lite_traits::NoVdmBackend>
+{
     /// Constructs a new responder over `pal` with the default
     /// (Caliptra) local-policy advertisement. If the PAL cannot hold
     /// at least one transport-sized large message, `CHUNK` is removed
@@ -314,6 +321,18 @@ impl<Pal: SpdmPal, const MAX_SESSIONS: usize> SpdmStack<Pal, MAX_SESSIONS> {
     ///
     /// A new `SpdmStack` in [`Phase::Start`].
     pub fn new(pal: Pal) -> Self {
+        Self::with_vdm_backend(pal, mcu_spdm_lite_traits::NoVdmBackend)
+    }
+}
+
+impl<Pal, const MAX_SESSIONS: usize, Vdm> SpdmStack<Pal, MAX_SESSIONS, Vdm>
+where
+    Pal: SpdmPal,
+    Vdm: mcu_spdm_lite_traits::SpdmVdmBackend,
+    Vdm::Error: Into<crate::error::SpdmError>,
+{
+    /// Constructs a responder with a static-dispatch VDM backend.
+    pub fn with_vdm_backend(pal: Pal, vdm_backend: Vdm) -> Self {
         let mut state = ConnectionState::<Pal::State>::default();
         if pal.capacity() < pal.mtu() {
             state.cap_flags =
@@ -323,6 +342,7 @@ impl<Pal: SpdmPal, const MAX_SESSIONS: usize> SpdmStack<Pal, MAX_SESSIONS> {
             pal,
             state,
             sessions: SessionManager::new(),
+            vdm_backend,
         }
     }
 
@@ -360,7 +380,15 @@ impl<Pal: SpdmPal, const MAX_SESSIONS: usize> SpdmStack<Pal, MAX_SESSIONS> {
             match io.kind() {
                 SpdmPalIoKind::Message => {
                     let (code, req_version) = decode_header(io.request());
-                    match dispatch(&mut self.state, &mut self.sessions, &self.pal, &io, code).await
+                    match dispatch(
+                        &mut self.state,
+                        &mut self.sessions,
+                        &self.pal,
+                        &io,
+                        code,
+                        &self.vdm_backend,
+                    )
+                    .await
                     {
                         Ok(mut rsp) => {
                             #[cfg(feature = "debug-trace")]
@@ -520,13 +548,19 @@ impl<Pal: SpdmPal, const MAX_SESSIONS: usize> SpdmStack<Pal, MAX_SESSIONS> {
 ///   not handled by this responder.
 /// * Whatever the specific handler returns.
 #[inline(never)]
-async fn dispatch<'a, Pal: SpdmPal, const MAX_SESSIONS: usize>(
+async fn dispatch<'a, Pal, Vdm, const MAX_SESSIONS: usize>(
     state: &mut ConnectionState<Pal::State>,
     sessions: &mut SessionManager<<Pal as SpdmPalSessionCrypto>::Key, Pal::State, MAX_SESSIONS>,
     pal: &'a Pal,
     io: &<Pal as SpdmPalIoTransport>::Io<'_>,
     code: ReqRespCode,
-) -> SpdmResult<PalBytes<'a, Pal>> {
+    vdm_backend: &Vdm,
+) -> SpdmResult<PalBytes<'a, Pal>>
+where
+    Pal: SpdmPal,
+    Vdm: mcu_spdm_lite_traits::SpdmVdmBackend,
+    Vdm::Error: Into<crate::error::SpdmError>,
+{
     if code != ReqRespCode::CHUNK_SEND && state.chunk.in_progress() {
         state.chunk.reset();
     }
@@ -551,7 +585,7 @@ async fn dispatch<'a, Pal: SpdmPal, const MAX_SESSIONS: usize>(
         ReqRespCode::GET_DIGESTS => digests::handle_get_digests(state, pal, io).await,
         ReqRespCode::GET_CERTIFICATE => certificate::handle_get_certificate(state, pal, io).await,
         ReqRespCode::CHALLENGE => challenge::handle_challenge(state, pal, io).await,
-        ReqRespCode::CHUNK_SEND => chunk::handle_chunk_send(state, pal, io).await,
+        ReqRespCode::CHUNK_SEND => chunk::handle_chunk_send(state, pal, io, vdm_backend).await,
         ReqRespCode::CHUNK_GET => chunk::handle_chunk_get(state, pal, io).await,
         #[cfg(feature = "set-certificate")]
         ReqRespCode::SET_CERTIFICATE => {
@@ -563,6 +597,9 @@ async fn dispatch<'a, Pal: SpdmPal, const MAX_SESSIONS: usize>(
             let (resp, _) =
                 measurements::handle_get_measurements_req(state, pal, io, io.request()).await?;
             Ok(resp)
+        }
+        ReqRespCode::VENDOR_DEFINED_REQUEST => {
+            vendor_defined::handle_vendor_defined_request(state, pal, io, vdm_backend).await
         }
         ReqRespCode::KEY_EXCHANGE => {
             key_exchange::handle_key_exchange(state, sessions, pal, io).await

--- a/runtime/userspace/api/spdm-lite/stack/src/vendor_defined/decode.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/vendor_defined/decode.rs
@@ -1,0 +1,63 @@
+// Licensed under the Apache-2.0 license
+
+//! VENDOR_DEFINED request decoding.
+
+use mcu_spdm_lite_codec::{SpdmMsgHdrPdu, StandardsBodyId, VendorDefinedReqPdu, WireReader};
+use mcu_spdm_lite_traits::{SpdmPal, SpdmPalIo, SpdmPalIoKind, SpdmVdmBackend, VdmRequest};
+use zerocopy::{little_endian::U16, FromBytes};
+
+use crate::error::{
+    SpdmResult, SPDM_INVALID_REQUEST, SPDM_UNEXPECTED_REQUEST, SPDM_UNSUPPORTED_REQUEST,
+    SPDM_VERSION_MISMATCH,
+};
+use crate::stack::{ConnectionState, Phase};
+
+pub(super) fn decode_vendor_defined_request<'a, Pal, Vdm>(
+    state: &ConnectionState<Pal::State>,
+    io: &impl SpdmPalIo,
+    req: &'a [u8],
+    backend: &Vdm,
+) -> SpdmResult<VdmRequest<'a>>
+where
+    Pal: SpdmPal,
+    Vdm: SpdmVdmBackend,
+    Vdm::Error: Into<crate::error::SpdmError>,
+{
+    if (state.phase as u8) < (Phase::AfterAlgorithms as u8) {
+        return Err(SPDM_UNEXPECTED_REQUEST);
+    }
+
+    let (hdr, body) = SpdmMsgHdrPdu::ref_from_prefix(req).map_err(|_| SPDM_INVALID_REQUEST)?;
+    if hdr.version != state.version.to_u8() {
+        return Err(SPDM_VERSION_MISMATCH);
+    }
+
+    let mut reader = WireReader::new(body);
+    let req_pdu = reader.read::<VendorDefinedReqPdu>()?;
+    let standard_id =
+        StandardsBodyId::from_u16(req_pdu.standard_id.get()).ok_or(SPDM_INVALID_REQUEST)?;
+    let Some(expected_vendor_id_len) = standard_id.vendor_id_len() else {
+        return Err(SPDM_UNSUPPORTED_REQUEST);
+    };
+    if req_pdu.vendor_id_len != expected_vendor_id_len {
+        return Err(SPDM_INVALID_REQUEST);
+    }
+
+    let vendor_id = reader.take(req_pdu.vendor_id_len as usize)?;
+    let req_len = reader.read::<U16>()?.get() as usize;
+    let vdm_payload = reader.take(req_len)?;
+    if !reader.is_empty() {
+        return Err(SPDM_INVALID_REQUEST);
+    }
+
+    let vdm_req = VdmRequest {
+        standard_id: standard_id.as_u16(),
+        vendor_id,
+        secure_session: io.kind() == SpdmPalIoKind::SecuredMessage,
+        payload: vdm_payload,
+    };
+    if !backend.match_request(&vdm_req) {
+        return Err(SPDM_UNSUPPORTED_REQUEST);
+    }
+    Ok(vdm_req)
+}

--- a/runtime/userspace/api/spdm-lite/stack/src/vendor_defined/mod.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/vendor_defined/mod.rs
@@ -1,0 +1,70 @@
+// Licensed under the Apache-2.0 license
+
+//! VENDOR_DEFINED request dispatch for SPDM-Lite.
+
+mod decode;
+mod response;
+
+use mcu_spdm_lite_codec::ReqRespCode;
+use mcu_spdm_lite_traits::{PalBytes, SpdmPal, SpdmPalIo, SpdmPalIoTransport, SpdmVdmBackend};
+
+use crate::build::build_error_response;
+use crate::error::{SpdmResult, SPDM_INVALID_REQUEST, SPDM_UNSUPPORTED_REQUEST};
+use crate::stack::ConnectionState;
+
+pub(crate) async fn handle_vendor_defined_request<'a, Pal, Vdm>(
+    state: &mut ConnectionState<Pal::State>,
+    pal: &'a Pal,
+    io: &<Pal as SpdmPalIoTransport>::Io<'_>,
+    backend: &Vdm,
+) -> SpdmResult<PalBytes<'a, Pal>>
+where
+    Pal: SpdmPal,
+    Vdm: SpdmVdmBackend,
+    Vdm::Error: Into<crate::error::SpdmError>,
+{
+    if io.request().len() > pal.mtu() {
+        return Err(SPDM_INVALID_REQUEST);
+    }
+
+    let vdm_req =
+        match decode::decode_vendor_defined_request::<Pal, Vdm>(state, io, io.request(), backend) {
+            Ok(req) => req,
+            Err(e) if e == SPDM_UNSUPPORTED_REQUEST => {
+                return unsupported_request(pal, io, state.version)
+            }
+            Err(e) => return Err(e),
+        };
+    response::build_vendor_defined_response(state, pal, io, vdm_req, backend).await
+}
+
+pub(crate) async fn handle_large_vendor_defined_request<Pal, Vdm>(
+    state: &ConnectionState<Pal::State>,
+    io: &impl SpdmPalIo,
+    req: &[u8],
+    backend: &Vdm,
+    out: &mut [u8],
+) -> SpdmResult<usize>
+where
+    Pal: SpdmPal,
+    Vdm: SpdmVdmBackend,
+    Vdm::Error: Into<crate::error::SpdmError>,
+{
+    let vdm_req = decode::decode_vendor_defined_request::<Pal, Vdm>(state, io, req, backend)?;
+    response::build_vendor_defined_response_into(state, vdm_req, backend, out).await
+}
+
+fn unsupported_request<'a, Pal: SpdmPal>(
+    pal: &'a Pal,
+    io: &<Pal as SpdmPalIoTransport>::Io<'_>,
+    version: mcu_spdm_lite_codec::SpdmVersion,
+) -> SpdmResult<PalBytes<'a, Pal>> {
+    build_error_response(
+        pal,
+        io,
+        version,
+        SPDM_UNSUPPORTED_REQUEST.spec_byte(),
+        ReqRespCode::VENDOR_DEFINED_REQUEST.0,
+        &[],
+    )
+}

--- a/runtime/userspace/api/spdm-lite/stack/src/vendor_defined/response.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/vendor_defined/response.rs
@@ -1,0 +1,263 @@
+// Licensed under the Apache-2.0 license
+
+//! VENDOR_DEFINED response construction.
+
+use mcu_spdm_lite_codec::{
+    ReqRespCode, SpdmMsgHdrPdu, StandardsBodyId, VendorDefinedRspPdu, WireWriter,
+};
+use mcu_spdm_lite_traits::{
+    NoLargeResponseStorage, PalBytes, SpdmPal, SpdmPalIoTransport, SpdmVdmBackend,
+    VdmLargeResponseWriter, VdmRequest, VdmResponseBuffers, VdmResponseKind,
+};
+use zerocopy::little_endian::U16;
+
+use crate::error::{SpdmResult, SPDM_INVALID_REQUEST, SPDM_UNSPECIFIED};
+use crate::stack::ConnectionState;
+
+pub(super) async fn build_vendor_defined_response<'a, Pal, Vdm>(
+    state: &mut ConnectionState<Pal::State>,
+    pal: &'a Pal,
+    io: &<Pal as SpdmPalIoTransport>::Io<'_>,
+    req: VdmRequest<'_>,
+    backend: &Vdm,
+) -> SpdmResult<PalBytes<'a, Pal>>
+where
+    Pal: SpdmPal,
+    Vdm: SpdmVdmBackend,
+    Vdm::Error: Into<crate::error::SpdmError>,
+{
+    let vendor_id_len = req.vendor_id.len();
+    let fixed_len = SpdmMsgHdrPdu::SIZE
+        + VendorDefinedRspPdu::SIZE
+        + vendor_id_len
+        + core::mem::size_of::<U16>();
+    let max_rsp_len = state
+        .effective_data_transfer_size(pal)
+        .checked_sub(fixed_len)
+        .ok_or(SPDM_UNSPECIFIED)?;
+    if max_rsp_len > u16::MAX as usize {
+        return Err(SPDM_UNSPECIFIED);
+    }
+
+    let head = pal.header_size();
+    let mut rsp = alloc_padded(pal, io, head + fixed_len + max_rsp_len)?;
+    let payload_len_pos = payload_len_offset(vendor_id_len);
+    let payload_len_offset = head + payload_len_pos;
+    let payload_offset = payload_len_offset + core::mem::size_of::<U16>();
+
+    encode_vendor_defined_response_prefix(
+        &mut rsp[head..head + fixed_len],
+        state.version,
+        StandardsBodyId::from_u16(req.standard_id).ok_or(SPDM_INVALID_REQUEST)?,
+        req.vendor_id,
+    )?;
+
+    let large_capacity = pal.capacity();
+    let large_total_len = if large_capacity >= fixed_len {
+        pal.write(0, &rsp[head..head + fixed_len])?;
+        let large_payload_capacity = large_capacity - fixed_len;
+        let response = backend
+            .handle_request(
+                req,
+                VdmResponseBuffers {
+                    inline: &mut rsp[payload_offset..payload_offset + max_rsp_len],
+                    large: Some(VdmLargeResponseWriter::new(
+                        pal,
+                        fixed_len,
+                        large_payload_capacity,
+                    )),
+                },
+            )
+            .await
+            .map_err(Into::into)?;
+        match response {
+            VdmResponseKind::Inline(rsp_len) => {
+                finish_inline_response::<Pal>(
+                    &mut rsp,
+                    head,
+                    fixed_len,
+                    pal,
+                    payload_len_offset,
+                    max_rsp_len,
+                    rsp_len,
+                )?;
+                return Ok(rsp);
+            }
+            VdmResponseKind::Large(rsp_len) => {
+                if rsp_len > large_payload_capacity || rsp_len > u16::MAX as usize {
+                    return Err(SPDM_UNSPECIFIED);
+                }
+                pal.write(payload_len_pos, &(rsp_len as u16).to_le_bytes())?;
+                fixed_len + rsp_len
+            }
+        }
+    } else {
+        let response = backend
+            .handle_request(
+                req,
+                VdmResponseBuffers::<Pal> {
+                    inline: &mut rsp[payload_offset..payload_offset + max_rsp_len],
+                    large: None,
+                },
+            )
+            .await
+            .map_err(Into::into)?;
+        match response {
+            VdmResponseKind::Inline(rsp_len) => {
+                finish_inline_response::<Pal>(
+                    &mut rsp,
+                    head,
+                    fixed_len,
+                    pal,
+                    payload_len_offset,
+                    max_rsp_len,
+                    rsp_len,
+                )?;
+                return Ok(rsp);
+            }
+            VdmResponseKind::Large(_) => return Err(SPDM_UNSPECIFIED),
+        }
+    };
+
+    if large_total_len <= fixed_len + max_rsp_len {
+        pal.read(0, &mut rsp[head..head + large_total_len])?;
+        shrink_padded(pal, &mut rsp, head + large_total_len)?;
+        return Ok(rsp);
+    }
+
+    if !state.chunking_enabled() || large_total_len > state.effective_max_spdm_msg_size(pal) {
+        return Err(SPDM_UNSPECIFIED);
+    }
+    crate::chunk::start_buffered_large_response(state, pal, io, large_total_len)
+}
+
+pub(super) async fn build_vendor_defined_response_into<S, Vdm>(
+    state: &ConnectionState<S>,
+    req: VdmRequest<'_>,
+    backend: &Vdm,
+    out: &mut [u8],
+) -> SpdmResult<usize>
+where
+    Vdm: SpdmVdmBackend,
+    Vdm::Error: Into<crate::error::SpdmError>,
+{
+    let vendor_id_len = req.vendor_id.len();
+    let fixed_len = SpdmMsgHdrPdu::SIZE
+        + VendorDefinedRspPdu::SIZE
+        + vendor_id_len
+        + core::mem::size_of::<U16>();
+    let max_rsp_len = out.len().checked_sub(fixed_len).ok_or(SPDM_UNSPECIFIED)?;
+    if max_rsp_len > u16::MAX as usize {
+        return Err(SPDM_UNSPECIFIED);
+    }
+
+    let payload_len_pos = payload_len_offset(vendor_id_len);
+    let payload_offset = payload_len_pos + core::mem::size_of::<U16>();
+    encode_vendor_defined_response_prefix(
+        &mut out[..fixed_len],
+        state.version,
+        StandardsBodyId::from_u16(req.standard_id).ok_or(SPDM_INVALID_REQUEST)?,
+        req.vendor_id,
+    )?;
+
+    let response = backend
+        .handle_request(
+            req,
+            VdmResponseBuffers::<NoLargeResponseStorage> {
+                inline: &mut out[payload_offset..payload_offset + max_rsp_len],
+                large: None,
+            },
+        )
+        .await
+        .map_err(Into::into)?;
+    let VdmResponseKind::Inline(rsp_len) = response else {
+        return Err(SPDM_UNSPECIFIED);
+    };
+    if rsp_len > max_rsp_len || rsp_len > u16::MAX as usize {
+        return Err(SPDM_UNSPECIFIED);
+    }
+    out[payload_len_pos..payload_len_pos + core::mem::size_of::<U16>()]
+        .copy_from_slice(&(rsp_len as u16).to_le_bytes());
+    Ok(fixed_len + rsp_len)
+}
+
+#[inline]
+fn payload_len_offset(vendor_id_len: usize) -> usize {
+    SpdmMsgHdrPdu::SIZE + VendorDefinedRspPdu::SIZE + vendor_id_len
+}
+
+fn encode_vendor_defined_response_prefix(
+    buf: &mut [u8],
+    version: mcu_spdm_lite_codec::SpdmVersion,
+    standard_id: StandardsBodyId,
+    vendor_id: &[u8],
+) -> SpdmResult<()> {
+    let fixed_len = payload_len_offset(vendor_id.len()) + core::mem::size_of::<U16>();
+    let mut writer = WireWriter::new(buf.get_mut(..fixed_len).ok_or(SPDM_UNSPECIFIED)?);
+    writer.write(&SpdmMsgHdrPdu::new(
+        version,
+        ReqRespCode::VENDOR_DEFINED_RESPONSE,
+    ))?;
+    writer.write(&VendorDefinedRspPdu {
+        param1: 0,
+        param2: 0,
+        standard_id: U16::new(standard_id.as_u16()),
+        vendor_id_len: vendor_id.len() as u8,
+    })?;
+    writer.write_bytes(vendor_id)?;
+    writer.write(&U16::new(0))?;
+    Ok(())
+}
+
+fn finish_inline_response<Pal: SpdmPal>(
+    rsp: &mut PalBytes<'_, Pal>,
+    head: usize,
+    fixed_len: usize,
+    pal: &Pal,
+    payload_len_offset: usize,
+    max_rsp_len: usize,
+    rsp_len: usize,
+) -> SpdmResult<()> {
+    if rsp_len > max_rsp_len || rsp_len > u16::MAX as usize {
+        return Err(SPDM_UNSPECIFIED);
+    }
+    rsp[payload_len_offset..payload_len_offset + core::mem::size_of::<U16>()]
+        .copy_from_slice(&(rsp_len as u16).to_le_bytes());
+    shrink_padded(pal, rsp, head + fixed_len + rsp_len)?;
+    Ok(())
+}
+
+fn padded_len<Pal: SpdmPal>(pal: &Pal, raw_len: usize) -> SpdmResult<usize> {
+    let align = pal.send_len_alignment();
+    debug_assert!(align > 0 && align.is_power_of_two());
+    raw_len
+        .checked_add(align - 1)
+        .map(|len| len & !(align - 1))
+        .ok_or(SPDM_UNSPECIFIED)
+}
+
+fn alloc_padded<'a, Pal: SpdmPal>(
+    pal: &'a Pal,
+    io: &Pal::Io<'_>,
+    raw_len: usize,
+) -> SpdmResult<PalBytes<'a, Pal>> {
+    let alloc_len = padded_len(pal, raw_len)?;
+    let mut buf = pal.alloc_bytes(io, alloc_len)?;
+    for b in &mut buf[raw_len..alloc_len] {
+        *b = 0;
+    }
+    Ok(buf)
+}
+
+fn shrink_padded<Pal: SpdmPal>(
+    pal: &Pal,
+    rsp: &mut PalBytes<'_, Pal>,
+    raw_len: usize,
+) -> SpdmResult<()> {
+    let shrink_len = padded_len(pal, raw_len)?;
+    for b in &mut rsp[raw_len..shrink_len] {
+        *b = 0;
+    }
+    Pal::shrink_bytes(rsp, shrink_len)?;
+    Ok(())
+}

--- a/runtime/userspace/api/spdm-lite/traits/src/alloc.rs
+++ b/runtime/userspace/api/spdm-lite/traits/src/alloc.rs
@@ -57,4 +57,9 @@ pub trait SpdmPalAlloc {
     /// reading. Useful for response-building paths that need a
     /// variable-size buffer without using stack arrays.
     fn alloc_bytes(&self, io: &impl SpdmPalIo, len: usize) -> McuResult<Self::Bytes<'_>>;
+
+    /// Shrinks a byte buffer returned by [`Self::alloc_bytes`] to
+    /// `new_len` bytes, releasing any trailing capacity when the PAL
+    /// supports it.
+    fn shrink_bytes(bytes: &mut Self::Bytes<'_>, new_len: usize) -> McuResult<()>;
 }

--- a/runtime/userspace/api/spdm-lite/traits/src/lib.rs
+++ b/runtime/userspace/api/spdm-lite/traits/src/lib.rs
@@ -30,6 +30,7 @@ mod measurements;
 mod pal;
 mod session_crypto;
 mod transport;
+mod vendor_defined;
 
 pub use alloc::*;
 pub use cert::*;
@@ -40,6 +41,7 @@ pub use measurements::*;
 pub use pal::*;
 pub use session_crypto::*;
 pub use transport::*;
+pub use vendor_defined::*;
 
 // Re-export the workspace-wide error type/alias for convenience: users
 // of this crate get them transitively without needing `mcu-error` as a

--- a/runtime/userspace/api/spdm-lite/traits/src/vendor_defined.rs
+++ b/runtime/userspace/api/spdm-lite/traits/src/vendor_defined.rs
@@ -1,0 +1,130 @@
+// Licensed under the Apache-2.0 license
+
+//! VENDOR_DEFINED extension points implemented by platform/user code.
+
+use super::*;
+use mcu_error::domain;
+
+const VDM_INVALID_PARAMS: McuErrorCode = McuErrorCode::new(domain::SPDM, 0x00, 0x0100);
+const VDM_UNSUPPORTED: McuErrorCode = McuErrorCode::new(domain::SPDM, 0x00, 0x0101);
+
+/// Decoded VENDOR_DEFINED request context passed to a backend.
+pub struct VdmRequest<'a> {
+    /// Standards body registry value decoded from the SPDM envelope.
+    pub standard_id: u16,
+    /// Vendor ID bytes decoded from the SPDM envelope.
+    pub vendor_id: &'a [u8],
+    /// True when the transport delivered this request as a secured message.
+    pub secure_session: bool,
+    /// Vendor-defined payload, excluding the SPDM VENDOR_DEFINED envelope.
+    pub payload: &'a [u8],
+}
+
+/// Placeholder storage type for inline-only VDM responses.
+pub struct NoLargeResponseStorage;
+
+impl SpdmPalLargeMessage for NoLargeResponseStorage {
+    fn capacity(&self) -> usize {
+        0
+    }
+
+    fn write(&self, _offset: usize, _data: &[u8]) -> McuResult<()> {
+        Err(VDM_INVALID_PARAMS)
+    }
+
+    fn read(&self, _offset: usize, _out: &mut [u8]) -> McuResult<()> {
+        Err(VDM_INVALID_PARAMS)
+    }
+}
+
+/// Writer for a large VDM response payload stored in PAL persistent storage.
+pub struct VdmLargeResponseWriter<'a, Storage: SpdmPalLargeMessage> {
+    storage: &'a Storage,
+    payload_offset: usize,
+    capacity: usize,
+}
+
+impl<'a, Storage: SpdmPalLargeMessage> VdmLargeResponseWriter<'a, Storage> {
+    /// Creates a writer over `storage`, starting payload bytes at `payload_offset`.
+    pub fn new(storage: &'a Storage, payload_offset: usize, capacity: usize) -> Self {
+        Self {
+            storage,
+            payload_offset,
+            capacity,
+        }
+    }
+
+    /// Maximum payload bytes that can be written.
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    /// Copy `data` into the large response payload at `offset`.
+    pub fn write(&self, offset: usize, data: &[u8]) -> McuResult<()> {
+        let storage_offset = self.checked_storage_range(offset, data.len())?;
+        self.storage.write(storage_offset, data)
+    }
+
+    fn checked_storage_range(&self, offset: usize, len: usize) -> McuResult<usize> {
+        let end = offset.checked_add(len).ok_or(VDM_INVALID_PARAMS)?;
+        if end > self.capacity {
+            return Err(VDM_INVALID_PARAMS);
+        }
+        self.payload_offset
+            .checked_add(offset)
+            .ok_or(VDM_INVALID_PARAMS)
+    }
+}
+
+/// Response payload buffers provided to a static-dispatch VDM backend.
+pub struct VdmResponseBuffers<'a, Storage: SpdmPalLargeMessage = NoLargeResponseStorage> {
+    /// Inline VDM response payload buffer.
+    pub inline: &'a mut [u8],
+    /// Optional large VDM response payload writer.
+    pub large: Option<VdmLargeResponseWriter<'a, Storage>>,
+}
+
+/// VDM backend response location and payload length.
+pub enum VdmResponseKind {
+    /// Backend wrote this many bytes into [`VdmResponseBuffers::inline`].
+    Inline(usize),
+    /// Backend wrote this many bytes through [`VdmResponseBuffers::large`].
+    Large(usize),
+}
+
+/// Static-dispatch VDM backend used by the spdm-lite dispatcher.
+#[allow(async_fn_in_trait)]
+pub trait SpdmVdmBackend: Sync {
+    /// Error type returned by this backend.
+    type Error;
+
+    /// Returns true when this backend handles the decoded VDM request.
+    fn match_request(&self, req: &VdmRequest<'_>) -> bool;
+
+    /// Handles a matched VDM request and writes only the VDM response payload.
+    async fn handle_request<Storage: SpdmPalLargeMessage>(
+        &self,
+        req: VdmRequest<'_>,
+        rsp: VdmResponseBuffers<'_, Storage>,
+    ) -> core::result::Result<VdmResponseKind, Self::Error>;
+}
+
+/// Default VDM backend used when no platform VDM support is registered.
+#[derive(Clone, Copy, Default)]
+pub struct NoVdmBackend;
+
+impl SpdmVdmBackend for NoVdmBackend {
+    type Error = McuErrorCode;
+
+    fn match_request(&self, _req: &VdmRequest<'_>) -> bool {
+        false
+    }
+
+    async fn handle_request<Storage: SpdmPalLargeMessage>(
+        &self,
+        _req: VdmRequest<'_>,
+        _rsp: VdmResponseBuffers<'_, Storage>,
+    ) -> McuResult<VdmResponseKind> {
+        Err(VDM_UNSUPPORTED)
+    }
+}


### PR DESCRIPTION
## Summary

Add OCP Caliptra Vendor Defined Message support to `spdm-lite` while keeping the active path allocator-conscious and statically dispatched.

This ports the OCP VDM responder behavior from the existing `spdm-lib` implementation into the `spdm-lite` responder stack, including the chunking/large-message support needed by large OCP payloads.

**Current status:** rebased onto PR #1555 (`spdm-lite: add buffered large response chunking`) and updated to use its buffered large-response helper for VDM CSR responses. Marked draft while the post-rebase SPDM validator runs and memory numbers are re-collected.

## Ported from `spdm-lib` to `spdm-lite`

- OCP IANA vendor matching and VDM command dispatch.
- OCP command-code model for commands `0x01..0x11`, replacing raw command matching in the spdm-lite backend.
- Typed request parsing for fixed-layout OCP requests:
  - firmware version
  - device info
  - export IDevID CSR
  - export attested CSR
- OCP response formatting and completion-code handling.
- Firmware/device identity commands:
  - firmware version
  - device capabilities
  - device ID
  - device info
- Debug log commands:
  - get debug log
  - clear debug log
- CSR export commands:
  - export IDevID CSR
  - export attested CSR
- Production debug unlock commands:
  - request debug unlock
  - authorize debug unlock token
- Large VDM request handling for chunked debug-unlock-token payloads, returning the final response via `CHUNK_SEND_ACK`.
- Large VDM response handling for CSR responses using the spdm-lite buffered `CHUNK_GET` flow from PR #1555.

## spdm-lite-specific changes

- Adds a static-dispatch VDM backend API so Caliptra-backed VDM handlers can be async without `async_trait`, boxed futures, or dyn-async in the spdm-lite responder path.
- Wires the OCP VDM backend into both emulator MCTP and DOE spdm-lite responders.
- Reuses PAL-provided scratch and persistent large-message buffers rather than heap or large stack buffers.
- Bounds inline VDM payload buffers to negotiated transfer sizes while preserving DOE send alignment padding.
- Enforces negotiated `MaxSPDMmsgSize` before starting buffered large VDM responses.
- Keeps buffered VDM chunks out of the SPDM certificate transcript.
- Reduces the per-responder large-message buffer from 16 KiB to 13 KiB, enough for the current maximum attested CSR plus SPDM/VDM/mailbox framing.

Pending before ready-for-review:

- SPDM responder validator workflow (`.github/workflows/spdm-validator.yml`) for MCTP and DOE; pass/fail and per-transport stats will be added here.

## Memory impact

Measured with `../caliptra-mcu-sw/measure-memory.sh` on PR head `831192caf`, using `origin/spdm-lite` (`a984c9595`) as the baseline.

Memory added by this feature:
user-app: .text +12582 B .rodata +1988 B .bss +4472 B
SPDM task: .text +10784 B .rodata +0 B .bss +4464 B
kernel: .text +52 B .bss +0 B

Current totals:
kernel: .text 151792 B .bss 24536 B
user-app: .text 68138 B .rodata 14616 B .bss 65448 B
SPDM task: .text 54994 B .rodata 584 B .bss 40677 B
runtime bundle: 238592 B (+14592 B)

## Deferred scope

- IDE-KM and TDISP remain out of scope for this PR.
- True CSR response streaming without a full preallocated response buffer is not included; the current mailbox API requires a caller-provided response buffer.


