### PR TITLE
[firmware-update] Add FirmwareUpdateHooks trait

### DIFF
--- a/platforms/emulator/runtime/userspace/apps/user/src/firmware_update/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/firmware_update/mod.rs
@@ -23,6 +23,9 @@ use crate::EXECUTOR;
 ))]
 use caliptra_mcu_libapi_caliptra::firmware_update::{FirmwareUpdater, PldmFirmwareDeviceParams};
 
+#[cfg(feature = "test-firmware-update-flash")]
+use caliptra_mcu_libapi_caliptra::firmware_update::FirmwareUpdateHooks;
+
 use caliptra_mcu_libtock_platform::ErrorCode;
 const RESET_REASON_FW_HITLESS_UPD_RESET_MASK: u32 = 0x1;
 
@@ -52,12 +55,39 @@ pub async fn firmware_update<D: DMAMapping>(dma_mapping: &D) -> Result<(), Error
             &fw_params,
             dma_mapping,
             EXECUTOR.get().spawner(),
+            None,
         );
         updater.start().await?;
     }
 
     #[cfg(feature = "test-firmware-update-flash")]
     {
+        use alloc::boxed::Box;
+        use core::sync::atomic::{AtomicBool, Ordering};
+
+        struct TestFwUpdateHooks {
+            pre_caliptra_called: AtomicBool,
+        }
+
+        #[async_trait::async_trait]
+        impl FirmwareUpdateHooks for TestFwUpdateHooks {
+            async fn pre_caliptra_activation(&self) -> Result<(), ErrorCode> {
+                self.pre_caliptra_called.store(true, Ordering::SeqCst);
+                Ok(())
+            }
+
+            async fn pre_mcu_activation(&self) -> Result<(), ErrorCode> {
+                if !self.pre_caliptra_called.load(Ordering::SeqCst) {
+                    crate::console_writeln!(
+                        Console::<DefaultSyscalls>::writer(),
+                        "[FW Upd] ERROR: pre_caliptra_activation hook not called"
+                    );
+                    return Err(ErrorCode::Fail);
+                }
+                Ok(())
+            }
+        }
+
         let fw_params = PldmFirmwareDeviceParams {
             descriptors: &config::fw_update_consts::DESCRIPTOR.get()[..],
             fw_params: config::fw_update_consts::FIRMWARE_PARAMS.get(),
@@ -65,11 +95,15 @@ pub async fn firmware_update<D: DMAMapping>(dma_mapping: &D) -> Result<(), Error
         let mut staging_memory = flash_memory::ExternalFlash::new().await?;
         let staging_memory: &'static flash_memory::ExternalFlash =
             unsafe { core::mem::transmute(&mut staging_memory) };
+        let hooks = TestFwUpdateHooks {
+            pre_caliptra_called: AtomicBool::new(false),
+        };
         let mut updater = FirmwareUpdater::new(
             staging_memory,
             &fw_params,
             dma_mapping,
             EXECUTOR.get().spawner(),
+            Some(&hooks),
         );
         updater.start().await?;
     }
@@ -88,6 +122,7 @@ pub async fn firmware_update<D: DMAMapping>(dma_mapping: &D) -> Result<(), Error
             &fw_params,
             dma_mapping,
             EXECUTOR.get().spawner(),
+            None,
         );
         updater.set_skip_activation(true);
         updater.set_verify_same_image(true);

--- a/runtime/userspace/api/caliptra-api/src/firmware_update/mod.rs
+++ b/runtime/userspace/api/caliptra-api/src/firmware_update/mod.rs
@@ -55,6 +55,7 @@ pub struct FirmwareUpdater<'a, D: DMAMapping> {
     spawner: Spawner,
     skip_activation: bool,
     verify_same_image: bool,
+    hooks: Option<&'a dyn FirmwareUpdateHooks>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -75,6 +76,7 @@ impl<'a, D: DMAMapping> FirmwareUpdater<'a, D> {
         params: &'a PldmFirmwareDeviceParams,
         dma_mapping: &'a D,
         spawner: Spawner,
+        hooks: Option<&'a dyn FirmwareUpdateHooks>,
     ) -> Self {
         Self {
             staging_memory,
@@ -84,6 +86,7 @@ impl<'a, D: DMAMapping> FirmwareUpdater<'a, D> {
             spawner,
             skip_activation: false,
             verify_same_image: false,
+            hooks,
         }
     }
 
@@ -93,6 +96,10 @@ impl<'a, D: DMAMapping> FirmwareUpdater<'a, D> {
 
     pub fn set_verify_same_image(&mut self, verify: bool) {
         self.verify_same_image = verify;
+    }
+
+    pub fn set_hooks(&mut self, hooks: &'a dyn FirmwareUpdateHooks) {
+        self.hooks = Some(hooks);
     }
 
     pub async fn start(&mut self) -> Result<(), ErrorCode> {
@@ -143,15 +150,25 @@ impl<'a, D: DMAMapping> FirmwareUpdater<'a, D> {
         }
 
         // Update Caliptra
+        if let Some(hooks) = self.hooks {
+            hooks.pre_caliptra_activation().await?;
+        }
         let result = self.update_caliptra(&flash_header).await;
         if result.is_err() {
             // Abort firmware update
             return Err(ErrorCode::Fail);
         }
 
+        // Set SoC authorization manifest
+        if let Some(hooks) = self.hooks {
+            hooks.pre_auth_manifest_activation().await?;
+        }
         self.set_auth_manifest().await?;
 
         // Update MCU and reboot
+        if let Some(hooks) = self.hooks {
+            hooks.pre_mcu_activation().await?;
+        }
         self.update_mcu(&flash_header).await?;
 
         Ok(())
@@ -878,6 +895,30 @@ pub trait StagingMemory: core::fmt::Debug + Send + Sync {
     async fn read(&self, offset: usize, data: &mut [u8]) -> Result<(), ErrorCode>;
     async fn image_valid(&self, img_sz: usize) -> Result<(), ErrorCode>;
     fn size(&self) -> usize;
+}
+
+/// Trait for platform-specific hooks invoked during the firmware update flow.
+///
+/// Platforms can implement this trait to inject SoC-specific actions at key
+/// points in the update sequence (e.g., quiescing host I/O before activation).
+/// All methods have default no-op implementations, so platforms only need to
+/// override the hooks they care about.
+#[async_trait]
+pub trait FirmwareUpdateHooks: Send + Sync {
+    /// Called before updating the Caliptra firmware. Returning an error aborts the update.
+    async fn pre_caliptra_activation(&self) -> Result<(), ErrorCode> {
+        Ok(())
+    }
+
+    /// Called before setting the SoC authorization manifest. Returning an error aborts the update.
+    async fn pre_auth_manifest_activation(&self) -> Result<(), ErrorCode> {
+        Ok(())
+    }
+
+    /// Called before updating the MCU firmware and activating. Returning an error aborts the update.
+    async fn pre_mcu_activation(&self) -> Result<(), ErrorCode> {
+        Ok(())
+    }
 }
 
 pub struct MailboxPayloadStream {


### PR DESCRIPTION
Add an async FirmwareUpdateHooks trait that allows platform integrators to inject SoC-specific logic at key points in the firmware update activation sequence. The trait provides three hooks, each with a default no-op:

- pre_caliptra_activation: called before updating Caliptra firmware
- pre_auth_manifest_activation: called before setting the SoC auth manifest
- pre_mcu_activation: called before updating MCU firmware and activating

The hooks are passed as an optional parameter to FirmwareUpdater::new(). Returning an error from any hook aborts the firmware update.

Add a test hook implementation in the emulator test-firmware-update-flash test that verifies hooks are called in the expected order.

Resolves #1337