### PR TITLE
[OCP-LOCK]: Make HEK Perma bit state platform specific

### DIFF
--- a/platforms/emulator/rom/src/riscv.rs
+++ b/platforms/emulator/rom/src/riscv.rs
@@ -228,6 +228,15 @@ pub extern "C" fn rom_entry() -> ! {
             8
         }
 
+        fn is_perma_bit_set(
+            &self,
+            otp: &caliptra_mcu_romtime::otp::Otp,
+        ) -> Result<bool, caliptra_mcu_romtime::ocp_lock::Error> {
+            otp.read_entry(&caliptra_mcu_registers_generated::fuses::PERMA_HEK_EN)
+                .map(|val| val != 0)
+                .map_err(|_| caliptra_mcu_romtime::ocp_lock::Error::INVALID_HEK_SLOT)
+        }
+
         fn get_slot_state(
             &mut self,
             otp: &caliptra_mcu_romtime::otp::Otp,

--- a/platforms/fpga/rom/src/riscv.rs
+++ b/platforms/fpga/rom/src/riscv.rs
@@ -280,6 +280,15 @@ pub extern "C" fn rom_entry() -> ! {
             8
         }
 
+        fn is_perma_bit_set(
+            &self,
+            otp: &caliptra_mcu_romtime::otp::Otp,
+        ) -> Result<bool, caliptra_mcu_romtime::ocp_lock::Error> {
+            otp.read_entry(&caliptra_mcu_registers_generated::fuses::PERMA_HEK_EN)
+                .map(|val| val != 0)
+                .map_err(|_| caliptra_mcu_romtime::ocp_lock::Error::INVALID_HEK_SLOT)
+        }
+
         fn get_slot_state(
             &mut self,
             otp: &caliptra_mcu_romtime::otp::Otp,

--- a/rom/src/rom.rs
+++ b/rom/src/rom.rs
@@ -492,8 +492,8 @@ impl Soc {
             .ss_key_release_base_addr_l
             .set(config.key_release_addr as u32);
 
-        let perma_status = if otp
-            .is_hek_perma_set()
+        let perma_status = if config
+            .is_perma_bit_set(otp)
             .unwrap_or_else(|_| fatal_error(McuError::ROM_OTP_READ_ERROR))
         {
             caliptra_mcu_romtime::ocp_lock::PermaBitStatus::Set

--- a/romtime/src/ocp_lock.rs
+++ b/romtime/src/ocp_lock.rs
@@ -133,6 +133,9 @@ pub trait Platform {
     /// Total number of HEK Seed Slots
     fn get_total_slots(&self) -> usize;
 
+    /// Check if the HEK perma bit is set.
+    fn is_perma_bit_set(&self, otp: &crate::otp::Otp) -> Result<bool, Error>;
+
     /// The current HEK Seed Status of `slot`. `seed` is the fuse value of the slot.
     fn get_slot_state(
         &mut self,
@@ -158,6 +161,14 @@ pub struct RomConfig<'a> {
 }
 
 impl RomConfig<'_> {
+    pub fn is_perma_bit_set(&mut self, otp: &crate::otp::Otp) -> Result<bool, Error> {
+        let platform = self
+            .platform
+            .as_mut()
+            .ok_or(Error::MISSING_PLATFORM_IMPLEMENTATION)?;
+        platform.is_perma_bit_set(otp)
+    }
+
     pub fn get_active_slot(
         &mut self,
         otp: &crate::otp::Otp,

--- a/romtime/src/otp.rs
+++ b/romtime/src/otp.rs
@@ -720,18 +720,6 @@ impl Otp {
         Ok(set_bit_count == 0)
     }
 
-    /// Check if the HEK perma bit is set in the last non-secret vendor fuse (Slot 15).
-    /// NOTE: Integrators should consider a dedicated fuse.
-    pub fn is_hek_perma_set(&self) -> McuResult<bool> {
-        Ok(self.read_entry(fuses::PERMA_HEK_EN)? != 0)
-    }
-
-    /// Sets the HEK perma bit.
-    pub fn set_hek_perma(&self) -> McuResult<()> {
-        self.write_entry(fuses::PERMA_HEK_EN, 1)?;
-        Ok(())
-    }
-
     /// Compute the software digest of an OTP partition by reading its data
     /// (excluding the trailing 8-byte digest field) and hashing it with the
     /// PRESENT-based OTP digest algorithm.


### PR DESCRIPTION
We don't need to implement this logic in the core ROM. This makes it easier for integrators to tweak this logic bit.