### PR TITLE
rom: burn CPTRA_CORE_RUNTIME_SVN from Caliptra FW_INFO

### DIFF
--- a/docs/src/svn.md
+++ b/docs/src/svn.md
@@ -21,9 +21,9 @@ This document covers four categories of components:
    (the same value Caliptra Core authenticates and binds into the MCU
    Runtime's DPE context). Enforcement and the fuse floor are owned by
    Caliptra Core (`CPTRA_CORE_SOC_MANIFEST_SVN`). MCU ROM, as the OTP
-   writer for the subsystem, performs the actual OTP burn on Caliptra
-   Core's behalf when the authenticated SoC manifest SVN advances; it
-   does not maintain a separate MCU-side floor.
+   writer for the subsystem, performs the actual OTP burn when the
+   integrator provides the new floor; it does not maintain a separate
+   MCU-side floor.
 3. **MCU Component SVN Manifest** — its own SVN, enforced by MCU ROM against
    `MCU_COMPONENT_SVN_MANIFEST_MIN_SVN`.
 4. **SoC component images** — manifest-level SVN enforced by Caliptra Core;
@@ -39,12 +39,13 @@ independently of the SoC manifest: there is exactly one SVN per release
 for MCU Runtime, and it lives in the SoC manifest.
 
 The fuse-backed floor for this SVN is `CPTRA_CORE_SOC_MANIFEST_SVN`,
-which Caliptra Core both enforces and owns the policy for. Because all
-OTP writes in the subsystem go through MCU, MCU ROM is the entity that
-physically burns this fuse; it does so when Caliptra Core has
-authenticated a SoC manifest with a higher SVN than the current fuse
-value. There is no separate MCU-side floor or MCU-side burn request for
-the MCU Runtime SVN.
+which Caliptra Core both enforces and owns the policy for. Caliptra
+Core cannot burn its own fuses, so MCU ROM owns the OTP write. Today,
+the SoC manifest SVN is provisioned out-of-band; an integrator-driven
+`RomParameters` hook for the MCU-ROM-driven burn is planned (see
+[Cold Boot — Caliptra Core SVNs](#cold-boot--caliptra-core-svns)).
+There is no separate MCU-side floor or MCU-side burn request for the
+MCU Runtime SVN.
 
 ## Threat Model
 
@@ -231,17 +232,58 @@ sequenceDiagram
 
 MCU ROM reads the Caliptra Core SVN fuses from OTP and writes them to
 Caliptra's fuse registers (`CPTRA_CORE_FMC_KEY_MANIFEST_SVN` is forwarded but
-unused; see the note above). Caliptra Core ROM authenticates its firmware,
-compares image SVN against fuse SVN, rejects on mismatch, and asks MCU ROM
-(the OTP writer for the subsystem) to advance the corresponding SVN fuse if
-the image SVN is higher and `CPTRA_CORE_ANTI_ROLLBACK_DISABLE` is not set.
-MCU ROM has no SVN-policy role; it only transports fuse reads to Caliptra
-registers and burns the OTP word Caliptra Core asks for.
+unused; see the note above). Caliptra Core ROM authenticates its firmware
+and compares image SVN against fuse SVN, rejecting on mismatch.
 
-The same applies to the SoC manifest SVN (used for both MCU Runtime and
-SoC components covered by the SoC manifest): the floor lives in
-`CPTRA_CORE_SOC_MANIFEST_SVN`, the enforcement decision is Caliptra
-Core's, and MCU ROM performs the OTP burn.
+Caliptra Core cannot burn its own fuses. After Caliptra Core's runtime
+mailbox is ready, MCU ROM issues a `FW_INFO` mailbox command, reads
+the `min_fw_svn` value Caliptra Core has computed for the running
+firmware bundle, and advances `CPTRA_CORE_RUNTIME_SVN` to that value
+when it exceeds the current fuse value and
+`CPTRA_CORE_ANTI_ROLLBACK_DISABLE` is not set. The burned floor takes
+effect on the next cold boot; this boot continues with the
+already-loaded fuse values that Caliptra Core consulted at
+authentication time.
+
+On **cold reset** Caliptra Core sets `data_vault.fw_min_svn = info.fw_svn`,
+so MCU ROM's `FW_INFO`-driven burn here advances the OTP floor to the
+running firmware's SVN.
+
+The SoC manifest SVN (used for the SoC manifest itself, and which also
+serves as the MCU Runtime SVN) is owned by Caliptra Core. As with
+`CPTRA_CORE_RUNTIME_SVN`, Caliptra cannot persist the floor itself;
+MCU ROM owns the OTP burn. Caliptra's `FW_INFO` does not currently
+expose the SoC manifest SVN separately, so integrators that wish MCU
+ROM to also advance `CPTRA_CORE_SOC_MANIFEST_SVN` must arrange the
+value to be passed in via a `RomParameters` field (planned future
+work). Until then, that fuse is provisioned out-of-band at manufacture
+or by the integrator's recovery flow.
+
+### Hitless Update — Caliptra Core SVNs
+
+When the bundle is delivered via a hitless update, Caliptra Core and
+MCU reset together. Caliptra Core takes its **update reset** path,
+which intentionally preserves rollback capability by clamping its
+internal floor:
+`data_vault.fw_min_svn = min(old_min_svn, new_fw_svn)`. After Caliptra
+authenticates the new bundle and its runtime is ready, MCU ROM enters
+`FwHitlessUpdate`, waits for `soc.fw_ready()`, and issues the same
+`FW_INFO`-driven burn as the cold-boot path.
+
+Because update reset can only hold the floor steady or lower it, the
+hitless-update burn is typically a no-op when the new firmware has a
+higher SVN. **Deployers commit the floor forward explicitly** via the
+runtime `FuseIncreaseCaliptraMinSvn` MCU mailbox command (which reads
+the running firmware's `fw_svn` via `FW_INFO` and burns the
+corresponding OTP fuses). This separation lets a deployer roll out a
+new release, validate it in the field, and then close the door on
+rolling back to the previous one as a separate decision.
+
+Note: Caliptra fuse registers are latched at cold-boot fuse-write time
+and cannot be re-written during a warm/update reset. Any OTP burn that
+MCU ROM performs after a hitless update therefore only gates Caliptra
+authentication on the *next* cold boot — power-fail safe via the OTP
+one-hot encoding.
 
 ### Cold Boot and Hitless Update — MCU Component SVN Manifest burn
 
@@ -350,23 +392,32 @@ mutable firmware has control. This applies to both MCU-owned fuses
 Caliptra-owned fuses like `CPTRA_CORE_SOC_MANIFEST_SVN` —
 all OTP writes in the subsystem go through MCU.
 
-Burns are triggered exclusively by authenticated firmware images: Caliptra
-Core requests the SoC manifest SVN burn once it has authenticated a manifest
-with a higher SVN than the current fuse value; the MCU Component SVN
-Manifest header's `min_svn` drives the manifest-self burn; and per-entry
-`min_svn` fields drive SoC component burns. ROM only burns when the
-requested `min_svn` strictly exceeds the current fuse value.
+Burns are triggered exclusively by authenticated firmware images. For
+Caliptra Core's runtime SVN, MCU ROM queries `FW_INFO` after Caliptra's
+runtime mailbox is ready and uses the reported `min_fw_svn` as the
+burn target — on both cold boot and hitless update. The MCU Component
+SVN Manifest header's `min_svn` drives the manifest-self burn, and
+per-entry `min_svn` fields drive SoC component burns. ROM only burns
+when the requested `min_svn` strictly exceeds the current fuse value.
+
+For the Caliptra runtime SVN specifically, `FW_INFO.min_fw_svn` reaches
+the new firmware's SVN only after Caliptra's *cold reset*; update reset
+clamps it down to preserve rollback. The hitless-update burn is
+therefore typically a no-op for higher-SVN updates; explicit forward
+commits are issued by deployer-controlled runtime mailbox traffic
+(`FuseIncreaseCaliptraMinSvn`).
 
 The burn is power-fail safe: one-hot encoding plus OR semantics mean a partial
 burn can never decrease the fuse value, and any incomplete burn will be
 re-attempted (and complete) on the next boot.
 
-| Component | Burned by | Source of `min_svn` |
-|---|---|---|
-| Caliptra Core FMC/RT | MCU ROM (on Caliptra Core's request) | Caliptra image SVN |
-| SoC manifest / MCU Runtime | MCU ROM (on Caliptra Core's request) | SoC manifest SVN |
-| MCU Component SVN Manifest | MCU ROM | manifest header's `min_svn` |
-| SoC images (optional) | MCU ROM | MCU Component SVN Manifest entry |
+| Component | Burned by | Source of `min_svn` | Trigger |
+|---|---|---|---|
+| Caliptra Core FMC/RT | MCU ROM | `FW_INFO.min_fw_svn` | cold boot and hitless update (no-op on hitless if floor unchanged) |
+| Caliptra Core FMC/RT | MCU Runtime → OTP syscall | running `FW_INFO.fw_svn` | `FuseIncreaseCaliptraMinSvn` mailbox command (deployer-driven) |
+| SoC manifest / MCU Runtime | MCU ROM | (planned) integrator-provided via `RomParameters` | cold boot |
+| MCU Component SVN Manifest | MCU ROM | manifest header's `min_svn` | cold boot and hitless update |
+| SoC images (optional) | MCU ROM | MCU Component SVN Manifest entry | cold boot and hitless update |
 
 ## Platform Configuration
 
@@ -425,7 +476,7 @@ leaking the running version through OTP state. A release can carry a high
 the SoC manifest SVN. Caliptra Core uses this value for the MCU Runtime
 DPE context and enforces it against `CPTRA_CORE_SOC_MANIFEST_SVN`. There
 is no separate MCU-side floor: MCU ROM only acts as the OTP writer for
-Caliptra Core's burn requests, so the value bound into DPE, the value
+the Caliptra-owned floor, so the value bound into DPE, the value
 enforced against the fuse, and the value physically burned are all the
 same single attested SVN — there is no way for the manifest signer to
 declare a different version to MCU than the one bound into DPE.

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -478,6 +478,11 @@ impl McuError {
             "MCU Component SVN Manifest validation error"
         ),
         (
+            ROM_CALIPTRA_RUNTIME_SVN_BURN_ERROR,
+            0x1_001c,
+            "Caliptra runtime SVN fuse burn failed"
+        ),
+        (
             GENERIC_EXCEPTION,
             0xF_0000,
             "Machine level exception was encountered during ROM execution"

--- a/rom/src/caliptra_svn.rs
+++ b/rom/src/caliptra_svn.rs
@@ -1,0 +1,153 @@
+// Licensed under the Apache-2.0 license
+
+//! Persist Caliptra Core's runtime SVN floor into OTP.
+//!
+//! Caliptra Core cannot write its own fuses, so after Caliptra's
+//! runtime mailbox is ready MCU ROM queries `FW_INFO` and advances
+//! `CPTRA_CORE_RUNTIME_SVN` to the reported `min_fw_svn`. Skipped
+//! when `CPTRA_CORE_ANTI_ROLLBACK_DISABLE` is set.
+
+use crate::fatal_error;
+use caliptra_api::mailbox::{CommandId, FwInfoResp, MailboxReqHeader};
+use caliptra_mcu_error::McuError;
+use caliptra_mcu_registers_generated::fuses;
+use caliptra_mcu_romtime::{CaliptraSoC, Otp};
+use core::fmt::Write;
+use zerocopy::{FromBytes, IntoBytes};
+
+/// `CPTRA_CORE_RUNTIME_SVN`: 128 raw bits, linear-OR.
+const RUNTIME_SVN_BITS: u32 = 128;
+
+/// Must only be called after Caliptra Core's runtime mailbox is ready.
+pub(crate) fn process_caliptra_runtime_svn_burn(otp: &Otp, soc_manager: &mut CaliptraSoC) {
+    if !anti_rollback_enabled(otp) {
+        caliptra_mcu_romtime::println!(
+            "[mcu-rom] anti-rollback off; skipping CPTRA_CORE_RUNTIME_SVN burn"
+        );
+        return;
+    }
+
+    let min_fw_svn = query_min_fw_svn(soc_manager);
+    if min_fw_svn > RUNTIME_SVN_BITS {
+        caliptra_mcu_romtime::println!("[mcu-rom] FW_INFO min_fw_svn {} too large", min_fw_svn);
+        fatal_error(McuError::ROM_CALIPTRA_RUNTIME_SVN_BURN_ERROR);
+    }
+
+    let current_words = read_runtime_svn_words(otp);
+    let current = decode_runtime_svn(&current_words);
+    if min_fw_svn <= current {
+        return;
+    }
+
+    let target_words = encode_runtime_svn(min_fw_svn);
+    let base_word = fuses::OTP_CPTRA_CORE_RUNTIME_SVN.byte_offset / 4;
+    for (i, (cur, tgt)) in current_words.iter().zip(target_words.iter()).enumerate() {
+        if *cur != *tgt && otp.write_word(base_word + i, *tgt).is_err() {
+            burn_fatal();
+        }
+    }
+
+    let new_svn = decode_runtime_svn(&read_runtime_svn_words(otp));
+    if new_svn < min_fw_svn {
+        burn_fatal();
+    }
+    caliptra_mcu_romtime::println!(
+        "[mcu-rom] Burned CPTRA_CORE_RUNTIME_SVN: {} -> {}",
+        current,
+        new_svn
+    );
+}
+
+fn burn_fatal() -> ! {
+    caliptra_mcu_romtime::println!("[mcu-rom] CPTRA_CORE_RUNTIME_SVN burn failed");
+    fatal_error(McuError::ROM_CALIPTRA_RUNTIME_SVN_BURN_ERROR);
+}
+
+fn anti_rollback_enabled(otp: &Otp) -> bool {
+    match otp.read_cptra_core_anti_rollback_disable() {
+        Ok(raw) => raw.iter().all(|b| *b == 0),
+        Err(_) => burn_fatal(),
+    }
+}
+
+fn query_min_fw_svn(soc_manager: &mut CaliptraSoC) -> u32 {
+    // Safety: `MailboxReqHeader` is `repr(C)` with size 4; transmuting
+    // an all-zero header to `[u32; 1]` is sound.
+    let mut req_u32: [u32; core::mem::size_of::<MailboxReqHeader>() / 4] =
+        unsafe { core::mem::transmute(MailboxReqHeader { chksum: 0 }) };
+    let mut resp_u32 = [0u32; core::mem::size_of::<FwInfoResp>() / 4];
+
+    if soc_manager
+        .exec_mailbox_req_u32(CommandId::FW_INFO.into(), &mut req_u32, &mut resp_u32)
+        .is_err()
+    {
+        burn_fatal();
+    }
+
+    match FwInfoResp::ref_from_bytes(resp_u32.as_bytes()) {
+        Ok(resp) => resp.min_fw_svn,
+        Err(_) => burn_fatal(),
+    }
+}
+
+fn read_runtime_svn_words(otp: &Otp) -> [u32; 4] {
+    let bytes = match otp.read_cptra_core_runtime_svn() {
+        Ok(v) => v,
+        Err(_) => burn_fatal(),
+    };
+    let mut words = [0u32; 4];
+    for (i, w) in words.iter_mut().enumerate() {
+        *w = u32::from_le_bytes(bytes[i * 4..i * 4 + 4].try_into().unwrap());
+    }
+    words
+}
+
+fn decode_runtime_svn(words: &[u32; 4]) -> u32 {
+    let mut total = 0u32;
+    for w in words.iter() {
+        let ones = (!*w).trailing_zeros();
+        total += ones;
+        if ones < 32 {
+            return total;
+        }
+    }
+    total
+}
+
+fn encode_runtime_svn(svn: u32) -> [u32; 4] {
+    let mut words = [0u32; 4];
+    let mut remaining = svn.min(RUNTIME_SVN_BITS);
+    for w in words.iter_mut() {
+        let n = remaining.min(32);
+        *w = if n == 32 { u32::MAX } else { (1u32 << n) - 1 };
+        remaining -= n;
+    }
+    words
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decode_runtime_svn_handles_zero() {
+        assert_eq!(decode_runtime_svn(&[0; 4]), 0);
+    }
+
+    #[test]
+    fn encode_runtime_svn_zero_is_empty() {
+        assert_eq!(encode_runtime_svn(0), [0; 4]);
+    }
+
+    #[test]
+    fn encode_decode_roundtrip() {
+        for svn in [1u32, 7, 31, 32, 33, 63, 64, 65, 127, 128] {
+            assert_eq!(decode_runtime_svn(&encode_runtime_svn(svn)), svn);
+        }
+    }
+
+    #[test]
+    fn encode_runtime_svn_max_is_all_ones() {
+        assert_eq!(encode_runtime_svn(RUNTIME_SVN_BITS), [u32::MAX; 4]);
+    }
+}

--- a/rom/src/cold_boot.rs
+++ b/rom/src/cold_boot.rs
@@ -852,6 +852,9 @@ impl BootFlow for ColdBoot {
         let stash_rom_digest = params.stash_rom_digest.unwrap_or(false);
         Self::rom_digest_integrity(soc_manager, stash_rom_digest);
 
+        crate::caliptra_svn::process_caliptra_runtime_svn_burn(&env.otp, soc_manager);
+        mci.set_flow_checkpoint(McuRomBootStatus::CaliptraRuntimeSvnBurnComplete.into());
+
         // NOTE: Firmware manifest DOT command processing is intentionally
         // handled in FwBoot (fw_boot.rs), not here.  FwBoot runs after the
         // warm-reset chain, so firmware in MCU SRAM is always decrypted by

--- a/rom/src/fw_hitless_update.rs
+++ b/rom/src/fw_hitless_update.rs
@@ -66,8 +66,16 @@ impl BootFlow for FwHitlessUpdate {
         #[cfg(not(feature = "test-force-hitless-update"))]
         while !soc.fw_ready() {}
 
-        // Silence unused-variable warnings when the test feature elides the
-        // mailbox release and fw-ready wait above.
+        // Same FW_INFO-driven CPTRA_CORE_RUNTIME_SVN burn as cold boot.
+        // Caliptra's update_reset clamps min_fw_svn = min(old, new), so
+        // this is typically a no-op for higher-SVN updates; explicit
+        // forward commits are driven by the runtime
+        // FuseIncreaseCaliptraMinSvn mailbox command. Burns committed
+        // here take effect on the next cold boot (Caliptra fuse
+        // registers are latched at cold boot).
+        #[cfg(not(feature = "test-force-hitless-update"))]
+        crate::caliptra_svn::process_caliptra_runtime_svn_burn(&env.otp, soc_manager);
+
         #[cfg(feature = "test-force-hitless-update")]
         {
             let _ = soc_manager;

--- a/rom/src/lib.rs
+++ b/rom/src/lib.rs
@@ -43,6 +43,7 @@ mod mailbox;
 mod recovery;
 
 // Boot flow modules
+mod caliptra_svn;
 mod cold_boot;
 mod firmware_headers;
 mod fw_boot;

--- a/romtime/src/boot_status.rs
+++ b/romtime/src/boot_status.rs
@@ -83,6 +83,7 @@ pub enum McuRomBootStatus {
     FwManifestDotProcessingComplete = FIRMWARE_LOADING_BASE + 8,
     ComponentSvnManifestProcessingStarted = FIRMWARE_LOADING_BASE + 9,
     ComponentSvnManifestProcessingComplete = FIRMWARE_LOADING_BASE + 10,
+    CaliptraRuntimeSvnBurnComplete = FIRMWARE_LOADING_BASE + 11,
 
     // Field Entropy Programming
     FieldEntropyProgrammingStarted = FIELD_ENTROPY_BASE,

--- a/tests/integration/src/lib.rs
+++ b/tests/integration/src/lib.rs
@@ -9,6 +9,7 @@ mod rom;
 mod runtime;
 mod test_active_i3c;
 mod test_bare_metal;
+mod test_caliptra_runtime_svn_burn;
 mod test_caliptra_util_host_mcu_mailbox_validator;
 mod test_caliptra_util_host_spdm_vdm_validator;
 mod test_dot;

--- a/tests/integration/src/test_caliptra_runtime_svn_burn.rs
+++ b/tests/integration/src/test_caliptra_runtime_svn_burn.rs
@@ -1,0 +1,140 @@
+// Licensed under the Apache-2.0 license
+
+//! Cold-boot tests for MCU ROM's FW_INFO-driven `CPTRA_CORE_RUNTIME_SVN` burn.
+
+#[cfg(test)]
+mod test {
+    use crate::test::{compile_runtime, start_runtime_hw_model, CustomCaliptraFw, TestParams};
+    use anyhow::Result;
+    use caliptra_mcu_builder::{CaliptraBuildArgs, CaliptraBuilder, FirmwareBinaries};
+    use caliptra_mcu_hw_model::McuHwModel;
+    use caliptra_mcu_registers_generated::fuses::{
+        FuseEntryInfo, OTP_CPTRA_CORE_ANTI_ROLLBACK_DISABLE, OTP_CPTRA_CORE_RUNTIME_SVN,
+    };
+    use caliptra_mcu_romtime::McuBootMilestones;
+
+    /// Decode `CPTRA_CORE_RUNTIME_SVN` (linear-OR over 128 bits).
+    fn runtime_svn_from_otp(otp: &[u8]) -> u32 {
+        const SIZE: usize = OTP_CPTRA_CORE_RUNTIME_SVN.byte_size;
+        let off = OTP_CPTRA_CORE_RUNTIME_SVN.byte_offset;
+        let mut bytes = [0u8; SIZE];
+        bytes.copy_from_slice(&otp[off..off + SIZE]);
+        128 - u128::from_le_bytes(bytes).leading_zeros()
+    }
+
+    fn set_single_fuse(otp: &mut Vec<u8>, entry: &FuseEntryInfo, value: u32) {
+        let end = entry.byte_offset + entry.byte_size;
+        if otp.len() < end {
+            otp.resize(end, 0);
+        }
+        otp[entry.byte_offset..entry.byte_offset + 4].copy_from_slice(&value.to_le_bytes());
+    }
+
+    fn load_caliptra_fw_svn7() -> Result<(Vec<u8>, [u8; 48], Vec<u8>)> {
+        let mcu_runtime_path = compile_runtime(Some("test-mcu-mbox-cmds"), false);
+        if let Ok(binaries) = FirmwareBinaries::from_env() {
+            let fw = binaries.caliptra_fw_svn7.clone();
+            let pk_hash = binaries.vendor_pk_hash().unwrap();
+            let manifest = binaries.test_soc_manifest("test-mcu-mbox-cmds").unwrap();
+            return Ok((fw, pk_hash, manifest));
+        }
+        let mut builder = CaliptraBuilder::new(&CaliptraBuildArgs {
+            svn: Some(7),
+            mcu_firmware: Some(mcu_runtime_path),
+            ..Default::default()
+        });
+        let fw = std::fs::read(builder.get_caliptra_fw()?).unwrap();
+        let pk_hash_str = builder.get_vendor_pk_hash()?.to_string();
+        let pk_hash = hex::decode(&pk_hash_str).unwrap();
+        let mut pk_hash_arr = [0u8; 48];
+        pk_hash_arr.copy_from_slice(&pk_hash);
+        let manifest = std::fs::read(builder.get_soc_manifest(None)?).unwrap();
+        Ok((fw, pk_hash_arr, manifest))
+    }
+
+    #[test]
+    fn test_cold_boot_burns_caliptra_runtime_svn() -> Result<()> {
+        let (fw_svn7, vendor_pk_hash, soc_manifest) = load_caliptra_fw_svn7()?;
+        let mut hw = start_runtime_hw_model(TestParams {
+            feature: Some("test-mcu-mbox-cmds"),
+            custom_caliptra_fw: Some(CustomCaliptraFw {
+                fw_bytes: fw_svn7.clone(),
+                vendor_pk_hash,
+                soc_manifest: soc_manifest.clone(),
+            }),
+            ..Default::default()
+        });
+
+        hw.step_until(|hw| {
+            hw.mci_boot_milestones()
+                .contains(McuBootMilestones::FIRMWARE_MAILBOX_READY)
+        });
+
+        let otp_after_first_boot = hw.read_otp_memory();
+        let burned = runtime_svn_from_otp(&otp_after_first_boot);
+        assert!(
+            burned >= 7,
+            "CPTRA_CORE_RUNTIME_SVN not advanced: {}",
+            burned
+        );
+
+        // Reboot with the same firmware and the OTP from the first
+        // boot. The burn is idempotent: ROM must not error out trying
+        // to re-burn an already-burned floor, the boot must reach the
+        // mailbox-ready milestone, and the OTP value must be unchanged.
+        // This is the same code path FwHitlessUpdate runs after Caliptra's
+        // update_reset (where FW_INFO.min_fw_svn is typically <=
+        // current_fuse so the burn is a no-op).
+        let mut hw = start_runtime_hw_model(TestParams {
+            feature: Some("test-mcu-mbox-cmds"),
+            custom_caliptra_fw: Some(CustomCaliptraFw {
+                fw_bytes: fw_svn7,
+                vendor_pk_hash,
+                soc_manifest,
+            }),
+            otp_memory: Some(otp_after_first_boot.clone()),
+            ..Default::default()
+        });
+
+        hw.step_until(|hw| {
+            hw.mci_boot_milestones()
+                .contains(McuBootMilestones::FIRMWARE_MAILBOX_READY)
+        });
+
+        let otp_after_second_boot = hw.read_otp_memory();
+        assert_eq!(
+            runtime_svn_from_otp(&otp_after_second_boot),
+            runtime_svn_from_otp(&otp_after_first_boot),
+            "second boot should not change the burned floor"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_cold_boot_skips_burn_when_anti_rollback_disabled() -> Result<()> {
+        let (fw_svn7, vendor_pk_hash, soc_manifest) = load_caliptra_fw_svn7()?;
+
+        let mut otp = Vec::new();
+        set_single_fuse(&mut otp, OTP_CPTRA_CORE_ANTI_ROLLBACK_DISABLE, 1);
+
+        let mut hw = start_runtime_hw_model(TestParams {
+            feature: Some("test-mcu-mbox-cmds"),
+            custom_caliptra_fw: Some(CustomCaliptraFw {
+                fw_bytes: fw_svn7,
+                vendor_pk_hash,
+                soc_manifest,
+            }),
+            otp_memory: Some(otp),
+            ..Default::default()
+        });
+
+        hw.step_until(|hw| {
+            hw.mci_boot_milestones()
+                .contains(McuBootMilestones::FIRMWARE_MAILBOX_READY)
+        });
+
+        let burned = runtime_svn_from_otp(&hw.read_otp_memory());
+        assert_eq!(burned, 0, "expected no burn, read {}", burned);
+        Ok(())
+    }
+}


### PR DESCRIPTION
Caliptra Core cannot write its own fuses. After Caliptra's runtime mailbox is ready in cold boot and hitless update, MCU ROM issues FW_INFO and advances CPTRA_CORE_RUNTIME_SVN to the reported min_fw_svn (read-back verified). Skipped when
CPTRA_CORE_ANTI_ROLLBACK_DISABLE is set or the floor is unchanged.

- New rom::caliptra_svn module with linear-OR encode/decode helpers for the 128-bit fuse.
- Wired into ColdBoot::run after stash measurement and into FwHitlessUpdate::run after the activate response is released. Adds CaliptraRuntimeSvnBurnComplete boot checkpoint.
- Adds ROM_CALIPTRA_RUNTIME_SVN_BURN_ERROR (0x1_001c).
- docs/src/svn.md: Caliptra Core does not request the burn; MCU ROM drives it via FW_INFO. SoC manifest SVN burn is called out as planned future work.
- 4 unit tests; 2 integration tests covering burn and skip paths.