### PR TITLE
Cherry pick smoke tests (#1372)

### DIFF
--- a/.github/workflows/caliptra-sw-smoke-test.yml
+++ b/.github/workflows/caliptra-sw-smoke-test.yml
@@ -1,0 +1,16 @@
+# Licensed under the Apache-2.0 license
+
+name: Caliptra SW Smoke Test
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  caliptra-sw-mcu-rom-smoke-test:
+    uses: chipsalliance/caliptra-sw/.github/workflows/fpga-subsystem.yml@main
+    with:
+      mcu-commit: ${{ github.event.pull_request.head.sha || github.sha }}
+      branch: main
+      fpga-itrng: true
+      extra-features: itrng,ocp-lock


### PR DESCRIPTION
* [CI]: Add caliptra-sw smoke test (#854)

Add an optional CI flow that runs the Caliptra Subsystem FPGA tests with the MCU ROM from the PR.

This will help catch incompatibilities sooner

(cherry picked from commit d98c80847121da84444863555df8462be63e16be)

* Use 2.1 for the smoke test