### PR TITLE
[rom] Add more unique error codes

### DIFF
--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -88,14 +88,14 @@ impl McuError {
             "Cold boot reset to firmware boot error"
         ),
         (
-            ROM_COLD_BOOT_FIELD_ENTROPY_PROG_START,
+            ROM_COLD_BOOT_FIELD_ENTROPY_PROG_START_MBOX_CMD_FAILED,
             0x1_0007,
-            "Cold boot failed to start field entropy program"
+            "Cold boot failed to start field entropy program (mailbox command failed)"
         ),
         (
-            ROM_COLD_BOOT_FIELD_ENTROPY_PROG_FINISH,
+            ROM_COLD_BOOT_FIELD_ENTROPY_PROG_FINISH_MBOX_CMD_FAILED,
             0x1_0008,
-            "Cold boot failed to finish field entropy program"
+            "Cold boot failed to finish field entropy program (mailbox command failed)"
         ),
         (
             ROM_FW_BOOT_INVALID_FIRMWARE,
@@ -103,9 +103,9 @@ impl McuError {
             "Firmware boot reset invalid firmware"
         ),
         (
-            ROM_FW_HITLESS_UPDATE_CLEAR_MB_ERROR,
+            ROM_FW_HITLESS_UPDATE_CLEAR_MB_CMD_FAILED,
             0x1_000a,
-            "Hitless update failed to clear the Caliptra mailbox"
+            "Hitless update failed to clear the Caliptra mailbox (command failed)"
         ),
         (
             ROM_WARM_BOOT_INVALID_FIRMWARE,
@@ -119,9 +119,9 @@ impl McuError {
             "Invalid reset reason"
         ),
         (
-            ROM_COLD_BOOT_DOT_ERROR,
+            ROM_DOT_DERIVE_STABLE_KEY_FAILED,
             0x1_000e,
-            "Device Ownership Transfer generic error"
+            "Device Ownership Transfer failed to derive stable key"
         ),
         (
             ROM_COLD_BOOT_DOT_BLOB_CORRUPT_ERROR,
@@ -288,14 +288,14 @@ impl McuError {
             "OTP fuse provisioning: invalid partition"
         ),
         (
-            ROM_OTP_FUSE_ENTRY_OUT_OF_BOUNDS,
+            ROM_OTP_FUSE_READ_ENTRY_OUT_OF_BOUNDS,
             0x3_000e,
-            "OTP fuse provisioning: entry out of bounds"
+            "OTP fuse provisioning: read entry out of bounds"
         ),
         (
-            ROM_OTP_FUSE_INVALID_LENGTH,
+            ROM_MCI_MBOX_FUSE_REQ_INVALID_LENGTH,
             0x3_000f,
-            "OTP fuse provisioning: invalid length"
+            "MCI mailbox fuse request invalid length"
         ),
         (
             ROM_OTP_FUSE_INVALID_START_BIT,
@@ -338,9 +338,9 @@ impl McuError {
             "OTP fuse provisioning: data too large"
         ),
         (
-            ROM_OTP_FUSE_INPUT_TOO_SHORT,
+            ROM_MCI_MBOX_FUSE_WRITE_HDR_TOO_SHORT,
             0x3_0018,
-            "OTP fuse provisioning: input too short"
+            "MCI mailbox fuse write header too short"
         ),
         (
             ROM_MCI_MBOX_UNKNOWN_COMMAND,
@@ -366,6 +366,96 @@ impl McuError {
             ROM_OTP_READ_CPTRA_ITRNG_CONFIG1_ERROR,
             0x3_001d,
             "Failed to read CPTRA_ITRNG_ENTROPY_CONFIG_1 from OTP"
+        ),
+        (
+            ROM_MCI_MBOX_FUSE_READ_REQ_INVALID_LENGTH,
+            0x3_001E,
+            "MCI mailbox fuse read request invalid length"
+        ),
+        (
+            ROM_MCI_MBOX_FUSE_READ_REQ_PARSE_FAILED,
+            0x3_001F,
+            "MCI mailbox fuse read request parse failed"
+        ),
+        (
+            ROM_MCI_MBOX_FUSE_READ_RESP_PARSE_FAILED,
+            0x3_0020,
+            "MCI mailbox fuse read response parse failed"
+        ),
+        (
+            ROM_MCI_MBOX_FUSE_WRITE_REQ_PARSE_FAILED,
+            0x3_0021,
+            "MCI mailbox fuse write request parse failed"
+        ),
+        (
+            ROM_MCI_MBOX_FUSE_WRITE_DLEN_OVERFLOW,
+            0x3_0022,
+            "MCI mailbox fuse write expected length overflow"
+        ),
+        (
+            ROM_MCI_MBOX_FUSE_WRITE_INPUT_TOO_LONG,
+            0x3_0023,
+            "MCI mailbox fuse write input too long"
+        ),
+        (
+            ROM_MCI_MBOX_FUSE_LOCK_REQ_INVALID_LENGTH,
+            0x3_0024,
+            "MCI mailbox fuse lock request invalid length"
+        ),
+        (
+            ROM_MCI_MBOX_FUSE_LOCK_REQ_PARSE_FAILED,
+            0x3_0025,
+            "MCI mailbox fuse lock request parse failed"
+        ),
+        (
+            ROM_OTP_FUSE_WRITE_LEN_ZERO,
+            0x3_0026,
+            "OTP fuse write length is zero"
+        ),
+        (
+            ROM_OTP_FUSE_WRITE_DATA_LEN_TOO_SHORT,
+            0x3_0027,
+            "OTP fuse write data length too short"
+        ),
+        (
+            ROM_OTP_FUSE_WRITE_ENTRY_OUT_OF_BOUNDS,
+            0x3_0028,
+            "OTP fuse write entry out of bounds or unaligned"
+        ),
+        (
+            ROM_OTP_FUSE_WRITE_OVERFLOW,
+            0x3_0029,
+            "OTP fuse write overflow: start_bit + length wraps u32"
+        ),
+        (
+            ROM_OTP_FUSE_WRITE_OUT_OF_BOUNDS,
+            0x3_002A,
+            "OTP fuse write out of bounds"
+        ),
+        (
+            ROM_MCI_MBOX_FUSE_WRITE_DATA_TOO_SHORT,
+            0x3_002B,
+            "MCI mailbox fuse write data too short"
+        ),
+        (
+            ROM_OTP_PARTITION_NO_SW_DIGEST,
+            0x3_002C,
+            "OTP partition does not support software digest"
+        ),
+        (
+            ROM_OTP_PARTITION_TOO_SMALL_FOR_DIGEST,
+            0x3_002D,
+            "OTP partition is too small for digest"
+        ),
+        (
+            ROM_OTP_PARTITION_NOT_8BYTE_ALIGNED_FOR_DIGEST,
+            0x3_002E,
+            "OTP partition data is not 8-byte aligned for digest"
+        ),
+        (
+            ROM_OTP_PARTITION_NO_DIGEST_OFFSET,
+            0x3_002F,
+            "OTP partition does not have a digest offset"
         ),
         (
             ROM_I3C_CONFIG_RING_HEADER_ERROR,
@@ -448,14 +538,14 @@ impl McuError {
             "SOC tried to lock an Mbox user out of range"
         ),
         (
-            ROM_SOC_PK_HASH_VERIFY_FAILED,
+            ROM_SOC_PK_HASH_VERIFY_MISMATCH,
             0x5_000E,
-            "Production debug unlock PK hash verification failed after locking"
+            "Production debug unlock PK hash verification failed (mismatch)"
         ),
         (
-            ROM_SOC_MCU_MBOX_AXI_USER_VERIFY_FAILED,
+            ROM_SOC_MCU_MBOX0_AXI_USER_VERIFY_FAILED,
             0x5_000F,
-            "MCU mailbox AXI user verification failed after locking"
+            "MCU mailbox 0 AXI user verification failed after locking"
         ),
         (
             ROM_SOC_SS_CONFIG_DONE_VERIFY_FAILED,
@@ -473,12 +563,12 @@ impl McuError {
             "SOC field entropy length mismatch"
         ),
         (
-            ROM_COLD_BOOT_ENCRYPTED_FW_DECRYPT_START_ERROR,
+            ROM_COLD_BOOT_ENCRYPTED_FW_DECRYPT_DMA_START_FAILED,
             0x1_0011,
             "Cold boot encrypted firmware decrypt DMA start error"
         ),
         (
-            ROM_COLD_BOOT_ENCRYPTED_FW_DECRYPT_FINISH_ERROR,
+            ROM_COLD_BOOT_ENCRYPTED_FW_DECRYPT_DMA_FINISH_FAILED,
             0x1_0012,
             "Cold boot encrypted firmware decrypt DMA finish error"
         ),
@@ -488,12 +578,12 @@ impl McuError {
             "Cold boot encrypted firmware GCM tag verification failed"
         ),
         (
-            ROM_COLD_BOOT_ENCRYPTED_FW_ACTIVATE_START_ERROR,
+            ROM_COLD_BOOT_ENCRYPTED_FW_ACTIVATE_START_FAILED,
             0x1_0014,
             "Cold boot encrypted firmware activate start error"
         ),
         (
-            ROM_COLD_BOOT_ENCRYPTED_FW_ACTIVATE_FINISH_ERROR,
+            ROM_COLD_BOOT_ENCRYPTED_FW_ACTIVATE_FINISH_FAILED,
             0x1_0015,
             "Cold boot encrypted firmware activate finish error"
         ),
@@ -503,9 +593,9 @@ impl McuError {
             "Cold boot ROM integrity check failed"
         ),
         (
-            ROM_COLD_BOOT_FW_MANIFEST_DOT_ERROR,
+            ROM_FW_MANIFEST_DOT_CHECKSUM_MISMATCH,
             0x1_0018,
-            "Firmware manifest DOT command processing error"
+            "Firmware manifest DOT checksum mismatch"
         ),
         (
             OCP_LOCK_ROM_MISSING_CONFIG,
@@ -513,7 +603,7 @@ impl McuError {
             "Missing OCP LOCK ROM Config"
         ),
         (
-            ROM_COLD_BOOT_STABLE_OWNER_KEY_DERIVATION_ERROR,
+            ROM_STABLE_OWNER_KEY_DERIVATION_FAILED,
             0x1_0022,
             "Stable owner key derivation failed during cold boot"
         ),
@@ -541,6 +631,162 @@ impl McuError {
             ROM_SOC_DCCM_ECC_UNC,
             0x5_0017,
             "DCCM uncorrectable ECC error"
+        ),
+        (
+            ROM_SOC_MCU_MBOX0_AXI_USER_LOCK_VERIFY_FAILED,
+            0x5_0018,
+            "MCU mailbox 0 AXI user lock verification failed after locking"
+        ),
+        (
+            ROM_SOC_MCU_MBOX1_AXI_USER_VERIFY_FAILED,
+            0x5_0019,
+            "MCU mailbox 1 AXI user verification failed after locking"
+        ),
+        (
+            ROM_SOC_MCU_MBOX1_AXI_USER_LOCK_VERIFY_FAILED,
+            0x5_001A,
+            "MCU mailbox 1 AXI user lock verification failed after locking"
+        ),
+        (
+            ROM_DOT_HMAC_FAILED,
+            0x1_0023,
+            "DOT blob HMAC verification failed"
+        ),
+        (
+            ROM_DOT_NO_MORE_FUSE_BITS,
+            0x1_0024,
+            "No more DOT fuse bits available"
+        ),
+        (
+            ROM_DOT_FLASH_WRITE_FAILED,
+            0x1_0025,
+            "Failed to write DOT blob to flash"
+        ),
+        (
+            ROM_COLD_BOOT_DOT_NO_RECOVERY_HANDLERS,
+            0x1_0026,
+            "No DOT locked-state recovery handlers configured"
+        ),
+        (
+            ROM_COLD_BOOT_DOT_FLASH_READ_FAILED,
+            0x1_0027,
+            "Failed to read DOT blob from flash"
+        ),
+        (ROM_I3C_SERVICES_TIMEOUT, 0x1_0028, "I3C services timed out"),
+        (
+            ROM_FW_HITLESS_UPDATE_CLEAR_MB_FAILED,
+            0x1_0029,
+            "Hitless update failed to clear the Caliptra mailbox (other error)"
+        ),
+        (
+            ROM_COLD_BOOT_ENCRYPTED_FW_DECRYPT_SIZE_ZERO,
+            0x1_002A,
+            "Encrypted firmware ciphertext size is zero"
+        ),
+        (
+            ROM_COLD_BOOT_ENCRYPTED_FW_DECRYPT_KEY_IMPORT_INTERNAL_FAILED,
+            0x1_002B,
+            "Failed to import AES key (internal error)"
+        ),
+        (
+            ROM_COLD_BOOT_ENCRYPTED_FW_DECRYPT_KEY_IMPORT_START_FAILED,
+            0x1_002C,
+            "Failed to start AES key import"
+        ),
+        (
+            ROM_COLD_BOOT_ENCRYPTED_FW_DECRYPT_KEY_IMPORT_FINISH_FAILED,
+            0x1_002D,
+            "Failed to finish AES key import"
+        ),
+        (
+            ROM_COLD_BOOT_ENCRYPTED_FW_DECRYPT_KEY_IMPORT_RESP_INVALID,
+            0x1_002E,
+            "AES key import response was invalid"
+        ),
+        (
+            ROM_COLD_BOOT_ENCRYPTED_FW_DECRYPT_DMA_RESP_INVALID,
+            0x1_002F,
+            "AES GCM decrypt DMA response was invalid"
+        ),
+        (
+            ROM_COLD_BOOT_GET_FW_SIZE_START_FAILED,
+            0x1_0030,
+            "Failed to start GET_MCU_FW_SIZE command"
+        ),
+        (
+            ROM_COLD_BOOT_GET_FW_SIZE_FINISH_FAILED,
+            0x1_0031,
+            "Failed to finish GET_MCU_FW_SIZE command"
+        ),
+        (
+            ROM_COLD_BOOT_GET_FW_SIZE_RESP_INVALID,
+            0x1_0032,
+            "GET_MCU_FW_SIZE response was invalid (too short)"
+        ),
+        (
+            ROM_COLD_BOOT_GET_FW_SIZE_RESP_MISSING_SHA384,
+            0x1_0033,
+            "GET_MCU_FW_SIZE response was missing SHA-384 digest"
+        ),
+        (
+            ROM_FW_MANIFEST_DOT_UNSUPPORTED_VERSION,
+            0x1_0034,
+            "Unsupported firmware manifest DOT version"
+        ),
+        (
+            ROM_FW_MANIFEST_DOT_TOO_MANY_COMMANDS,
+            0x1_0035,
+            "Firmware manifest DOT contains too many commands"
+        ),
+        (
+            ROM_FW_MANIFEST_DOT_COMMANDS_INVALID,
+            0x1_0036,
+            "Firmware manifest DOT commands slice is invalid"
+        ),
+        (
+            ROM_FW_MANIFEST_DOT_CONFLICTING_COMMANDS,
+            0x1_0037,
+            "Firmware manifest DOT contains conflicting commands"
+        ),
+        (
+            ROM_FW_MANIFEST_DOT_UNKNOWN_COMMAND,
+            0x1_0038,
+            "Unknown DOT command in firmware manifest"
+        ),
+        (
+            ROM_STABLE_OWNER_KEY_PERSONALIZATION_SEED_SIZE_MISMATCH,
+            0x1_0039,
+            "Stable owner key personalization seed size mismatch"
+        ),
+        (
+            ROM_STABLE_OWNER_KEY_PERSONALIZATION_SEED_READ_FAILED,
+            0x1_003A,
+            "Failed to read stable owner key personalization seed from OTP"
+        ),
+        (
+            ROM_COLD_BOOT_FIELD_ENTROPY_PROG_START_FAILED,
+            0x1_003B,
+            "Cold boot failed to start field entropy program (other error)"
+        ),
+        (
+            ROM_COLD_BOOT_FIELD_ENTROPY_PROG_FINISH_FAILED,
+            0x1_003C,
+            "Cold boot failed to finish field entropy program (other error)"
+        ),
+        (
+            ROM_SOC_PK_HASH_VERIFY_INTERNAL_ERROR,
+            0x5_001B,
+            "Production debug unlock PK hash verification internal error"
+        ),
+        (
+            ROM_SOC_PK_HASH_VERIFY_OTP_READ_FAILED,
+            0x5_001C,
+            "Production debug unlock PK hash verification OTP read failed"
+        ),
+        (
+            ROM_SOC_PK_HASH_VERIFY_LEN_MISMATCH,
+            0x5_001D,
+            "Production debug unlock PK hash verification length mismatch"
         ),
         (
             GENERIC_EXCEPTION,

--- a/rom/src/cold_boot.rs
+++ b/rom/src/cold_boot.rs
@@ -189,35 +189,29 @@ impl ColdBoot {
                 soc_manager.start_mailbox_req_bytes(CommandId::FE_PROG.into(), req.as_bytes())
             {
                 match err {
-                    CaliptraApiError::MailboxCmdFailed(code) => {
-                        caliptra_mcu_romtime::println!(
-                            "[mcu-rom] Error sending mailbox command: {}",
-                            HexWord(code)
+                    CaliptraApiError::MailboxCmdFailed(_) => {
+                        fatal_error(
+                            McuError::ROM_COLD_BOOT_FIELD_ENTROPY_PROG_START_MBOX_CMD_FAILED,
                         );
                     }
                     _ => {
-                        caliptra_mcu_romtime::println!("[mcu-rom] Error sending mailbox command");
+                        fatal_error(McuError::ROM_COLD_BOOT_FIELD_ENTROPY_PROG_START_FAILED);
                     }
                 }
-                fatal_error(McuError::ROM_COLD_BOOT_FIELD_ENTROPY_PROG_START);
             }
             {
                 let mut resp_buf = [0u8; core::mem::size_of::<MailboxRespHeader>()];
                 if let Err(err) = soc_manager.finish_mailbox_resp_bytes(&mut resp_buf) {
                     match err {
-                        CaliptraApiError::MailboxCmdFailed(code) => {
-                            caliptra_mcu_romtime::println!(
-                                "[mcu-rom] Error finishing mailbox command: {}",
-                                HexWord(code)
+                        CaliptraApiError::MailboxCmdFailed(_) => {
+                            fatal_error(
+                                McuError::ROM_COLD_BOOT_FIELD_ENTROPY_PROG_FINISH_MBOX_CMD_FAILED,
                             );
                         }
                         _ => {
-                            caliptra_mcu_romtime::println!(
-                                "[mcu-rom] Error finishing mailbox command"
-                            );
+                            fatal_error(McuError::ROM_COLD_BOOT_FIELD_ENTROPY_PROG_FINISH_FAILED);
                         }
                     }
-                    fatal_error(McuError::ROM_COLD_BOOT_FIELD_ENTROPY_PROG_FINISH);
                 }
             }
 
@@ -246,8 +240,7 @@ impl ColdBoot {
     /// After decryption the plaintext replaces the ciphertext in SRAM.
     fn decrypt_firmware(soc_manager: &mut CaliptraSoC, ciphertext_size: u32, sha384: &[u8; 48]) {
         if ciphertext_size == 0 {
-            caliptra_mcu_romtime::println!("[mcu-rom] Encrypted firmware ciphertext size is zero");
-            fatal_error(McuError::ROM_COLD_BOOT_ENCRYPTED_FW_DECRYPT_START_ERROR);
+            fatal_error(McuError::ROM_COLD_BOOT_ENCRYPTED_FW_DECRYPT_SIZE_ZERO);
         }
         let sram_base = unsafe { MCU_MEMORY_MAP.sram_offset } as usize;
 
@@ -362,7 +355,9 @@ impl ColdBoot {
         let mut input = [0u8; 64]; // MAX_KEY_SIZE = 64
         match input.get_mut(..32) {
             Some(dst) => dst.copy_from_slice(&MCU_TEST_AES_KEY),
-            None => fatal_error(McuError::ROM_COLD_BOOT_ENCRYPTED_FW_DECRYPT_START_ERROR),
+            None => {
+                fatal_error(McuError::ROM_COLD_BOOT_ENCRYPTED_FW_DECRYPT_KEY_IMPORT_INTERNAL_FAILED)
+            }
         }
 
         let mut req = CmImportReq {
@@ -375,28 +370,28 @@ impl ColdBoot {
         let chksum = calc_checksum(cmd, &req.as_bytes()[4..]);
         req.hdr.chksum = chksum;
 
-        if let Err(err) = soc_manager.start_mailbox_req_bytes(cmd, req.as_bytes()) {
-            caliptra_mcu_romtime::println!(
-                "[mcu-rom] CM_IMPORT start error: {}",
-                HexWord(Self::err_code(&err))
-            );
-            fatal_error(McuError::ROM_COLD_BOOT_ENCRYPTED_FW_DECRYPT_START_ERROR);
+        if soc_manager
+            .start_mailbox_req_bytes(cmd, req.as_bytes())
+            .is_err()
+        {
+            fatal_error(McuError::ROM_COLD_BOOT_ENCRYPTED_FW_DECRYPT_KEY_IMPORT_START_FAILED);
         }
 
         let mut resp_buf = [0u8; core::mem::size_of::<CmImportResp>()];
-        if let Err(err) = soc_manager.finish_mailbox_resp_bytes(&mut resp_buf) {
-            caliptra_mcu_romtime::println!(
-                "[mcu-rom] CM_IMPORT finish error: {}",
-                HexWord(Self::err_code(&err))
-            );
-            fatal_error(McuError::ROM_COLD_BOOT_ENCRYPTED_FW_DECRYPT_START_ERROR);
+        if soc_manager
+            .finish_mailbox_resp_bytes(&mut resp_buf)
+            .is_err()
+        {
+            fatal_error(McuError::ROM_COLD_BOOT_ENCRYPTED_FW_DECRYPT_KEY_IMPORT_FINISH_FAILED);
         }
 
         // Extract CMK from response: hdr(8) + cmk(128)
         let mut cmk_bytes = [0u8; CMK_SIZE_BYTES];
         match resp_buf.get(8..8 + CMK_SIZE_BYTES) {
             Some(src) => cmk_bytes.copy_from_slice(src),
-            None => fatal_error(McuError::ROM_COLD_BOOT_ENCRYPTED_FW_DECRYPT_START_ERROR),
+            None => {
+                fatal_error(McuError::ROM_COLD_BOOT_ENCRYPTED_FW_DECRYPT_KEY_IMPORT_RESP_INVALID)
+            }
         }
         Cmk(cmk_bytes)
     }
@@ -429,31 +424,26 @@ impl ColdBoot {
         let chksum = calc_checksum(cmd, &req.as_bytes()[4..]);
         req.hdr.chksum = chksum;
 
-        if let Err(err) = soc_manager.start_mailbox_req_bytes(cmd, req.as_bytes()) {
-            caliptra_mcu_romtime::println!(
-                "[mcu-rom] CM_AES_GCM_DECRYPT_DMA start error: {}",
-                HexWord(Self::err_code(&err))
-            );
-            fatal_error(McuError::ROM_COLD_BOOT_ENCRYPTED_FW_DECRYPT_START_ERROR);
+        if soc_manager
+            .start_mailbox_req_bytes(cmd, req.as_bytes())
+            .is_err()
+        {
+            fatal_error(McuError::ROM_COLD_BOOT_ENCRYPTED_FW_DECRYPT_DMA_START_FAILED);
         }
 
         let mut resp_buf = [0u8; core::mem::size_of::<CmAesGcmDecryptDmaResp>()];
-        if let Err(err) = soc_manager.finish_mailbox_resp_bytes(&mut resp_buf) {
-            caliptra_mcu_romtime::println!(
-                "[mcu-rom] CM_AES_GCM_DECRYPT_DMA finish error: {}",
-                HexWord(Self::err_code(&err))
-            );
-            fatal_error(McuError::ROM_COLD_BOOT_ENCRYPTED_FW_DECRYPT_FINISH_ERROR);
+        if soc_manager
+            .finish_mailbox_resp_bytes(&mut resp_buf)
+            .is_err()
+        {
+            fatal_error(McuError::ROM_COLD_BOOT_ENCRYPTED_FW_DECRYPT_DMA_FINISH_FAILED);
         }
 
         // CmAesGcmDecryptDmaResp: hdr(8) + tag_verified(4)
         let tag_verified = match resp_buf.get(8..12) {
             Some(b) => u32::from_le_bytes([b[0], b[1], b[2], b[3]]),
             None => {
-                caliptra_mcu_romtime::println!(
-                    "[mcu-rom] CM_AES_GCM_DECRYPT_DMA response too short"
-                );
-                fatal_error(McuError::ROM_COLD_BOOT_ENCRYPTED_FW_DECRYPT_FINISH_ERROR);
+                fatal_error(McuError::ROM_COLD_BOOT_ENCRYPTED_FW_DECRYPT_DMA_RESP_INVALID);
             }
         };
         if tag_verified != 1 {
@@ -489,21 +479,19 @@ impl ColdBoot {
         let chksum = calc_checksum(cmd, &req.as_bytes()[4..]);
         req.hdr.chksum = chksum;
 
-        if let Err(err) = soc_manager.start_mailbox_req_bytes(cmd, req.as_bytes()) {
-            caliptra_mcu_romtime::println!(
-                "[mcu-rom] ACTIVATE_FIRMWARE start error: {}",
-                HexWord(Self::err_code(&err))
-            );
-            fatal_error(McuError::ROM_COLD_BOOT_ENCRYPTED_FW_ACTIVATE_START_ERROR);
+        if soc_manager
+            .start_mailbox_req_bytes(cmd, req.as_bytes())
+            .is_err()
+        {
+            fatal_error(McuError::ROM_COLD_BOOT_ENCRYPTED_FW_ACTIVATE_START_FAILED);
         }
 
         let mut resp_buf = [0u8; core::mem::size_of::<ActivateFirmwareResp>()];
-        if let Err(err) = soc_manager.finish_mailbox_resp_bytes(&mut resp_buf) {
-            caliptra_mcu_romtime::println!(
-                "[mcu-rom] ACTIVATE_FIRMWARE finish error: {}",
-                HexWord(Self::err_code(&err))
-            );
-            fatal_error(McuError::ROM_COLD_BOOT_ENCRYPTED_FW_ACTIVATE_FINISH_ERROR);
+        if soc_manager
+            .finish_mailbox_resp_bytes(&mut resp_buf)
+            .is_err()
+        {
+            fatal_error(McuError::ROM_COLD_BOOT_ENCRYPTED_FW_ACTIVATE_FINISH_FAILED);
         }
     }
 
@@ -519,37 +507,33 @@ impl ColdBoot {
         let chksum = calc_checksum(CMD_GET_MCU_FW_SIZE, &[]);
         req.chksum = chksum;
 
-        if let Err(err) = soc_manager.start_mailbox_req_bytes(CMD_GET_MCU_FW_SIZE, req.as_bytes()) {
-            caliptra_mcu_romtime::println!(
-                "[mcu-rom] GET_MCU_FW_SIZE start error: {}",
-                HexWord(Self::err_code(&err))
-            );
-            fatal_error(McuError::ROM_COLD_BOOT_ENCRYPTED_FW_ACTIVATE_START_ERROR);
+        if soc_manager
+            .start_mailbox_req_bytes(CMD_GET_MCU_FW_SIZE, req.as_bytes())
+            .is_err()
+        {
+            fatal_error(McuError::ROM_COLD_BOOT_GET_FW_SIZE_START_FAILED);
         }
 
         let mut resp_buf = [0u8; core::mem::size_of::<GetMcuFwSizeResp>()];
-        if let Err(err) = soc_manager.finish_mailbox_resp_bytes(&mut resp_buf) {
-            caliptra_mcu_romtime::println!(
-                "[mcu-rom] GET_MCU_FW_SIZE finish error: {}",
-                HexWord(Self::err_code(&err))
-            );
-            fatal_error(McuError::ROM_COLD_BOOT_ENCRYPTED_FW_ACTIVATE_FINISH_ERROR);
+        if soc_manager
+            .finish_mailbox_resp_bytes(&mut resp_buf)
+            .is_err()
+        {
+            fatal_error(McuError::ROM_COLD_BOOT_GET_FW_SIZE_FINISH_FAILED);
         }
 
         // GetMcuFwSizeResp: hdr(8) + size(4) + sha384(48)
         let size = match resp_buf.get(8..12) {
             Some(b) => u32::from_le_bytes([b[0], b[1], b[2], b[3]]),
             None => {
-                caliptra_mcu_romtime::println!("[mcu-rom] GET_MCU_FW_SIZE response too short");
-                fatal_error(McuError::ROM_COLD_BOOT_ENCRYPTED_FW_ACTIVATE_FINISH_ERROR);
+                fatal_error(McuError::ROM_COLD_BOOT_GET_FW_SIZE_RESP_INVALID);
             }
         };
         let mut sha384 = [0u8; 48];
         match resp_buf.get(12..60) {
             Some(src) => sha384.copy_from_slice(src),
             None => {
-                caliptra_mcu_romtime::println!("[mcu-rom] GET_MCU_FW_SIZE response missing sha384");
-                fatal_error(McuError::ROM_COLD_BOOT_ENCRYPTED_FW_ACTIVATE_FINISH_ERROR);
+                fatal_error(McuError::ROM_COLD_BOOT_GET_FW_SIZE_RESP_MISSING_SHA384);
             }
         }
         (size, sha384)
@@ -730,7 +714,7 @@ fn attempt_dot_locked_recovery(
     use crate::device_ownership_transfer::{DotLockedRecoveryContext, DotLockedRecoveryManager};
 
     if params.dot_locked_recovery_handlers.is_empty() {
-        return McuError::ROM_COLD_BOOT_DOT_ERROR;
+        return McuError::ROM_COLD_BOOT_DOT_NO_RECOVERY_HANDLERS;
     }
 
     let ctx = DotLockedRecoveryContext {
@@ -1238,12 +1222,8 @@ impl BootFlow for ColdBoot {
         let owner_pk_hash = if let Some(dot_flash) = params.dot_flash {
             caliptra_mcu_romtime::println!("[mcu-rom] Reading DOT blob");
             let mut dot_blob = [0u8; device_ownership_transfer::DOT_BLOB_SIZE];
-            if let Err(err) = dot_flash.read(&mut dot_blob, 0) {
-                caliptra_mcu_romtime::println!(
-                    "[mcu-rom] Fatal error reading DOT blob from flash: {}",
-                    HexWord(usize::from(err) as u32)
-                );
-                fatal_error(McuError::ROM_COLD_BOOT_DOT_ERROR);
+            if dot_flash.read(&mut dot_blob, 0).is_err() {
+                fatal_error(McuError::ROM_COLD_BOOT_DOT_FLASH_READ_FAILED);
             }
             mci.set_flow_checkpoint(McuRomBootStatus::DeviceOwnershipTransferFlashRead.into());
 

--- a/rom/src/device_ownership_transfer.rs
+++ b/rom/src/device_ownership_transfer.rs
@@ -303,16 +303,15 @@ pub(crate) fn cm_derive_stable_key_impl(
     };
     let mut req32: [u32; core::mem::size_of::<CmDeriveStableKeyReq>() / 4] = transmute!(req);
 
-    if let Err(err) = soc_manager.exec_mailbox_req_u32(
-        CommandId::CM_DERIVE_STABLE_KEY.into(),
-        &mut req32,
-        &mut resp,
-    ) {
-        caliptra_mcu_romtime::println!(
-            "[mcu-rom] Error deriving DOT stable key: {}",
-            HexWord(crate::err_code(&err))
-        );
-        return Err(McuError::ROM_COLD_BOOT_DOT_ERROR);
+    if soc_manager
+        .exec_mailbox_req_u32(
+            CommandId::CM_DERIVE_STABLE_KEY.into(),
+            &mut req32,
+            &mut resp,
+        )
+        .is_err()
+    {
+        return Err(McuError::ROM_DOT_DERIVE_STABLE_KEY_FAILED);
     }
     let resp: CmDeriveStableKeyResp = transmute!(resp);
     let dot_effective_key = DotEffectiveKey(Cmk(transmute!(resp.cmk)));
@@ -346,14 +345,11 @@ pub(crate) fn cm_hmac(
     };
     let mut req: [u32; core::mem::size_of::<CmHmacDotBlobReq>() / 4] = transmute!(req);
 
-    if let Err(err) =
-        soc_manager.exec_mailbox_req_u32(CommandId::CM_HMAC.into(), &mut req, &mut resp)
+    if soc_manager
+        .exec_mailbox_req_u32(CommandId::CM_HMAC.into(), &mut req, &mut resp)
+        .is_err()
     {
-        caliptra_mcu_romtime::println!(
-            "[mcu-rom] Error computing HMAC: {}",
-            HexWord(crate::err_code(&err))
-        );
-        return Err(McuError::ROM_COLD_BOOT_DOT_ERROR);
+        return Err(McuError::ROM_DOT_HMAC_FAILED);
     }
     let resp: CmHmacResp = transmute!(resp);
     Ok(transmute!(resp.mac))
@@ -520,8 +516,7 @@ pub(crate) fn burn_dot_lock_fuse(otp: &Otp, dot_fuses: &DotFuses) -> McuResult<(
     // Each state transition burns the next sequential bit in the dot_fuse_array.
     let next_bit = dot_fuses.burned as u32;
     if next_bit >= (dot_fuses.total as u32) {
-        caliptra_mcu_romtime::println!("[mcu-rom-dot] No more DOT fuse bits available");
-        return Err(McuError::ROM_COLD_BOOT_DOT_ERROR);
+        return Err(McuError::ROM_DOT_NO_MORE_FUSE_BITS);
     }
 
     // Calculate which word and bit within that word to burn.
@@ -1176,12 +1171,8 @@ fn create_and_seal_dot_blob(
 
     // Write the sealed DOT blob to flash.
     if let Some(flash) = dot_flash {
-        if let Err(err) = flash.write(blob.as_bytes(), 0) {
-            caliptra_mcu_romtime::println!(
-                "[mcu-rom-dot] Failed to write DOT blob to flash: {}",
-                caliptra_mcu_romtime::HexWord(usize::from(err) as u32)
-            );
-            return Err(McuError::ROM_COLD_BOOT_DOT_ERROR);
+        if flash.write(blob.as_bytes(), 0).is_err() {
+            return Err(McuError::ROM_DOT_FLASH_WRITE_FAILED);
         }
     }
 
@@ -1315,40 +1306,32 @@ pub fn process_fw_manifest_dot_commands(
     }
 
     if !section.verify_checksum() {
-        caliptra_mcu_romtime::println!("[mcu-rom-dot] Firmware manifest DOT checksum mismatch");
-        return Err(McuError::ROM_COLD_BOOT_FW_MANIFEST_DOT_ERROR);
+        return Err(McuError::ROM_FW_MANIFEST_DOT_CHECKSUM_MISMATCH);
     }
 
     if section.version != 1 {
-        caliptra_mcu_romtime::println!(
-            "[mcu-rom-dot] Unsupported fw manifest DOT version: {}",
-            section.version
-        );
-        return Err(McuError::ROM_COLD_BOOT_FW_MANIFEST_DOT_ERROR);
+        return Err(McuError::ROM_FW_MANIFEST_DOT_UNSUPPORTED_VERSION);
     }
 
     caliptra_mcu_romtime::println!("[mcu-rom-dot] Processing manifest DOT commands");
 
     let num_commands = section.num_commands as usize;
     if num_commands > MAX_FW_MANIFEST_DOT_COMMANDS {
-        return Err(McuError::ROM_COLD_BOOT_FW_MANIFEST_DOT_ERROR);
+        return Err(McuError::ROM_FW_MANIFEST_DOT_TOO_MANY_COMMANDS);
     }
 
     // Reject manifests that contain both LOCK and UNLOCK commands.
     // Allowing both would rapidly burn through DOT fuses on every reset.
     let cmds = match section.commands.get(..num_commands) {
         Some(c) => c,
-        None => return Err(McuError::ROM_COLD_BOOT_FW_MANIFEST_DOT_ERROR),
+        None => return Err(McuError::ROM_FW_MANIFEST_DOT_COMMANDS_INVALID),
     };
     let has_lock = cmds
         .iter()
         .any(|&c| c == FW_MANIFEST_DOT_CMD_LOCK || c == FW_MANIFEST_DOT_CMD_DISABLE);
     let has_unlock = cmds.iter().any(|&c| c == FW_MANIFEST_DOT_CMD_UNLOCK);
     if has_lock && has_unlock {
-        caliptra_mcu_romtime::println!(
-            "[mcu-rom-dot] Fatal: both LOCK/DISABLE and UNLOCK present in manifest"
-        );
-        return Err(McuError::ROM_COLD_BOOT_FW_MANIFEST_DOT_ERROR);
+        return Err(McuError::ROM_FW_MANIFEST_DOT_CONFLICTING_COMMANDS);
     }
 
     for &cmd in cmds {
@@ -1433,8 +1416,7 @@ pub fn process_fw_manifest_dot_commands(
             }
 
             _ => {
-                caliptra_mcu_romtime::println!("[mcu-rom-dot] Unknown DOT command: {}", cmd);
-                return Err(McuError::ROM_COLD_BOOT_FW_MANIFEST_DOT_ERROR);
+                return Err(McuError::ROM_FW_MANIFEST_DOT_UNKNOWN_COMMAND);
             }
         }
     }
@@ -1497,7 +1479,7 @@ impl<'a> DotLockedRecoveryManager<'a> {
     /// first successful handler.  Returns the last error if all are
     /// exhausted.
     pub fn run(&mut self, env: &mut RomEnv, ctx: &DotLockedRecoveryContext<'_>) -> McuResult<()> {
-        let mut last_err = McuError::ROM_COLD_BOOT_DOT_ERROR;
+        let mut last_err = McuError::ROM_COLD_BOOT_DOT_NO_RECOVERY_HANDLERS;
         while self.current < self.entries.len() {
             let entry = &self.entries[self.current];
             match entry.handler.attempt(env, ctx) {

--- a/rom/src/fw_hitless_update.rs
+++ b/rom/src/fw_hitless_update.rs
@@ -23,7 +23,6 @@ use crate::{fatal_error, BootFlow, RomEnv, RomParameters};
 use caliptra_api::{mailbox::MailboxRespHeader, CaliptraApiError};
 #[cfg(not(feature = "test-force-hitless-update"))]
 use caliptra_mcu_error::McuError;
-use caliptra_mcu_romtime::HexWord;
 use core::fmt::Write;
 #[cfg(all(target_arch = "riscv32", feature = "fw-manifest-dot"))]
 use zerocopy::FromBytes;
@@ -49,17 +48,13 @@ impl BootFlow for FwHitlessUpdate {
             core::mem::size_of::<MailboxRespHeader>(),
         ) {
             match err {
-                CaliptraApiError::MailboxCmdFailed(code) => {
-                    caliptra_mcu_romtime::println!(
-                        "[mcu-rom] Error finishing mailbox command: {}",
-                        HexWord(code)
-                    );
+                CaliptraApiError::MailboxCmdFailed(_) => {
+                    fatal_error(McuError::ROM_FW_HITLESS_UPDATE_CLEAR_MB_CMD_FAILED);
                 }
                 _ => {
-                    caliptra_mcu_romtime::println!("[mcu-rom] Error finishing mailbox command");
+                    fatal_error(McuError::ROM_FW_HITLESS_UPDATE_CLEAR_MB_FAILED);
                 }
             }
-            fatal_error(McuError::ROM_FW_HITLESS_UPDATE_CLEAR_MB_ERROR);
         };
 
         #[cfg(not(feature = "test-force-hitless-update"))]
@@ -111,10 +106,6 @@ impl BootFlow for FwHitlessUpdate {
                                 _params.dot_flash,
                             )
                         {
-                            caliptra_mcu_romtime::println!(
-                                "[mcu-rom] Error in firmware manifest DOT: {}",
-                                HexWord(err.into())
-                            );
                             fatal_error(err);
                         }
                         env.mci.set_flow_checkpoint(

--- a/rom/src/i3c_mailbox.rs
+++ b/rom/src/i3c_mailbox.rs
@@ -168,8 +168,7 @@ impl<'a> I3cMailboxHandler<'a> {
             }
         }
 
-        caliptra_mcu_romtime::println!("[mcu-rom-i3c-svc] I3C services timed out");
-        Err(McuError::ROM_COLD_BOOT_DOT_ERROR)
+        Err(McuError::ROM_I3C_SERVICES_TIMEOUT)
     }
 
     /// Check whether DOT commands are available.

--- a/rom/src/rom.rs
+++ b/rom/src/rom.rs
@@ -767,11 +767,7 @@ pub fn verify_prod_debug_unlock_pk_hash(
     // Verify length matches: 384 bytes = 96 u32 words
     let pk_hash_len = mci.prod_debug_unlock_pk_hash_len();
     if pk_hash_len != 96 {
-        caliptra_mcu_romtime::println!(
-            "[mcu-rom] PK hash length mismatch: expected 96, got {}",
-            pk_hash_len
-        );
-        return Err(McuError::ROM_SOC_PK_HASH_VERIFY_FAILED);
+        return Err(McuError::ROM_SOC_PK_HASH_VERIFY_LEN_MISMATCH);
     }
 
     // Compare word-by-word to minimize stack usage
@@ -780,13 +776,13 @@ pub fn verify_prod_debug_unlock_pk_hash(
     for hash_idx in 0..8 {
         let entry = PROD_DEBUG_UNLOCK_PK_ENTRIES
             .get(hash_idx)
-            .ok_or(McuError::ROM_SOC_PK_HASH_VERIFY_FAILED)?;
+            .ok_or(McuError::ROM_SOC_PK_HASH_VERIFY_INTERNAL_ERROR)?;
         let hash_base_offset = entry.byte_offset;
         for word_idx in 0..12 {
             let reg_idx = hash_idx * 12 + word_idx;
             let expected = otp
                 .read_u32_at(hash_base_offset + word_idx * 4)
-                .map_err(|_| McuError::ROM_SOC_PK_HASH_VERIFY_FAILED)?;
+                .map_err(|_| McuError::ROM_SOC_PK_HASH_VERIFY_OTP_READ_FAILED)?;
             let actual = mci.read_prod_debug_unlock_pk_hash(reg_idx).unwrap_or(0);
             // Use bitwise OR to accumulate mismatches (constant-time)
             mismatch |= expected != actual;
@@ -794,8 +790,7 @@ pub fn verify_prod_debug_unlock_pk_hash(
     }
 
     if mismatch {
-        caliptra_mcu_romtime::println!("[mcu-rom] Prod debug unlock PK hash verification failed");
-        return Err(McuError::ROM_SOC_PK_HASH_VERIFY_FAILED);
+        return Err(McuError::ROM_SOC_PK_HASH_VERIFY_MISMATCH);
     }
     caliptra_mcu_romtime::println!("[mcu-rom] Prod debug unlock PK hash verification passed");
     Ok(())
@@ -818,25 +813,13 @@ pub fn verify_mcu_mbox_axi_users(
         if let Some(expected_val) = *expected_user {
             let actual_val = mci.read_mbox0_valid_axi_user(i).unwrap_or(0);
             if expected_val != actual_val {
-                caliptra_mcu_romtime::println!(
-                    "[mcu-rom] MCU mailbox 0 user {} verification failed: expected {}, got {}",
-                    i,
-                    HexWord(expected_val),
-                    HexWord(actual_val)
-                );
-                return Err(McuError::ROM_SOC_MCU_MBOX_AXI_USER_VERIFY_FAILED);
+                return Err(McuError::ROM_SOC_MCU_MBOX0_AXI_USER_VERIFY_FAILED);
             }
         }
         // Verify lock status matches expected
         let actual_locked = mci.read_mbox0_axi_user_lock(i).unwrap_or(false);
         if *expected_lock != actual_locked {
-            caliptra_mcu_romtime::println!(
-                "[mcu-rom] MCU mailbox 0 user {} lock verification failed: expected {}, got {}",
-                i,
-                expected_lock,
-                actual_locked
-            );
-            return Err(McuError::ROM_SOC_MCU_MBOX_AXI_USER_VERIFY_FAILED);
+            return Err(McuError::ROM_SOC_MCU_MBOX0_AXI_USER_LOCK_VERIFY_FAILED);
         }
     }
 
@@ -851,25 +834,13 @@ pub fn verify_mcu_mbox_axi_users(
         if let Some(expected_val) = *expected_user {
             let actual_val = mci.read_mbox1_valid_axi_user(i).unwrap_or(0);
             if expected_val != actual_val {
-                caliptra_mcu_romtime::println!(
-                    "[mcu-rom] MCU mailbox 1 user {} verification failed: expected {}, got {}",
-                    i,
-                    HexWord(expected_val),
-                    HexWord(actual_val)
-                );
-                return Err(McuError::ROM_SOC_MCU_MBOX_AXI_USER_VERIFY_FAILED);
+                return Err(McuError::ROM_SOC_MCU_MBOX1_AXI_USER_VERIFY_FAILED);
             }
         }
         // Verify lock status matches expected
         let actual_locked = mci.read_mbox1_axi_user_lock(i).unwrap_or(false);
         if *expected_lock != actual_locked {
-            caliptra_mcu_romtime::println!(
-                "[mcu-rom] MCU mailbox 1 user {} lock verification failed: expected {}, got {}",
-                i,
-                expected_lock,
-                actual_locked
-            );
-            return Err(McuError::ROM_SOC_MCU_MBOX_AXI_USER_VERIFY_FAILED);
+            return Err(McuError::ROM_SOC_MCU_MBOX1_AXI_USER_LOCK_VERIFY_FAILED);
         }
     }
 

--- a/rom/src/stable_owner_key.rs
+++ b/rom/src/stable_owner_key.rs
@@ -122,11 +122,11 @@ fn read_personalization_seed(
 ) -> McuResult<[u8; STABLE_OWNER_KEY_PERSONALIZATION_SEED_SIZE]> {
     let mut seed = [0u8; STABLE_OWNER_KEY_PERSONALIZATION_SEED_SIZE];
     if fuses::STABLE_OWNER_KEY_PERSONALIZATION_SEED.byte_size != seed.len() {
-        return Err(McuError::ROM_COLD_BOOT_STABLE_OWNER_KEY_DERIVATION_ERROR);
+        return Err(McuError::ROM_STABLE_OWNER_KEY_PERSONALIZATION_SEED_SIZE_MISMATCH);
     }
     env.otp
         .read_entry_raw(fuses::STABLE_OWNER_KEY_PERSONALIZATION_SEED, &mut seed)
-        .map_err(|_| McuError::ROM_COLD_BOOT_STABLE_OWNER_KEY_DERIVATION_ERROR)?;
+        .map_err(|_| McuError::ROM_STABLE_OWNER_KEY_PERSONALIZATION_SEED_READ_FAILED)?;
     Ok(seed)
 }
 
@@ -144,13 +144,16 @@ pub(crate) fn derive_stable_owner_key(env: &mut RomEnv) -> McuResult<Cmk> {
     };
     let mut req32: [u32; core::mem::size_of::<CmDeriveStableKeyReq>() / 4] = transmute!(req);
 
-    if let Err(err) = env.soc_manager.exec_mailbox_req_u32(
-        CommandId::CM_DERIVE_STABLE_KEY.into(),
-        &mut req32,
-        &mut resp,
-    ) {
-        caliptra_mcu_romtime::println!("[mcu-rom] Error deriving stable owner key: {:?}", err);
-        return Err(McuError::ROM_COLD_BOOT_STABLE_OWNER_KEY_DERIVATION_ERROR);
+    if env
+        .soc_manager
+        .exec_mailbox_req_u32(
+            CommandId::CM_DERIVE_STABLE_KEY.into(),
+            &mut req32,
+            &mut resp,
+        )
+        .is_err()
+    {
+        return Err(McuError::ROM_STABLE_OWNER_KEY_DERIVATION_FAILED);
     }
 
     let resp: CmDeriveStableKeyResp = transmute!(resp);

--- a/rom/src/warm_boot.rs
+++ b/rom/src/warm_boot.rs
@@ -115,14 +115,12 @@ impl BootFlow for WarmBoot {
 
         // Verify that SS_CONFIG_DONE_STICKY and SS_CONFIG_DONE are actually set
         if !mci.is_ss_config_done_sticky() || !mci.is_ss_config_done() {
-            caliptra_mcu_romtime::println!("[mcu-rom] SS_CONFIG_DONE verification failed");
             fatal_error(McuError::ROM_SOC_SS_CONFIG_DONE_VERIFY_FAILED);
         }
 
         // Verify MCU mailbox AXI users haven't been tampered with after locking
         caliptra_mcu_romtime::println!("[mcu-rom] Verifying MCU mailbox AXI users");
         if let Err(err) = verify_mcu_mbox_axi_users(mci, &mcu_mbox_config) {
-            caliptra_mcu_romtime::println!("[mcu-rom] MCU mailbox AXI user verification failed");
             fatal_error(err);
         }
         mci.set_flow_checkpoint(McuRomBootStatus::McuMboxAxiUsersVerified.into());
@@ -153,7 +151,6 @@ impl BootFlow for WarmBoot {
         };
         // Safety: this address is valid
         if unsafe { core::ptr::read_volatile(firmware_ptr) } == 0 {
-            caliptra_mcu_romtime::println!("Invalid firmware detected; halting");
             fatal_error(McuError::ROM_WARM_BOOT_INVALID_FIRMWARE);
         }
 
@@ -163,7 +160,6 @@ impl BootFlow for WarmBoot {
         mci.set_flow_milestone(McuBootMilestones::WARM_RESET_FLOW_COMPLETE.into());
         crate::call_hook(params.hooks, |h| h.post_warm_boot());
         mci.trigger_warm_reset();
-        caliptra_mcu_romtime::println!("[mcu-rom] ERROR: Still running after reset request!");
         fatal_error(McuError::ROM_WARM_BOOT_RESET_ERROR);
     }
 }

--- a/romtime/src/lifecycle.rs
+++ b/romtime/src/lifecycle.rs
@@ -199,35 +199,27 @@ impl Lifecycle {
                 return Ok(());
             }
             if status.is_set(lc_ctrl::bits::Status::TransitionError) {
-                crate::println!("[mcu-rom-lcc] Transition error detected.");
                 return Err(McuError::ROM_LC_TRANSITION_ERROR);
             }
             if status.is_set(lc_ctrl::bits::Status::TokenError) {
-                crate::println!("[mcu-rom-lcc] Token error detected.");
                 return Err(McuError::ROM_LC_TOKEN_ERROR);
             }
             if status.is_set(lc_ctrl::bits::Status::OtpError) {
-                crate::println!("[mcu-rom-lcc] OTP error detected.");
                 return Err(McuError::ROM_LC_OTP_ERROR);
             }
             if status.is_set(lc_ctrl::bits::Status::FlashRmaError) {
-                crate::println!("[mcu-rom-lcc] FLASH RMA error detected.");
                 return Err(McuError::ROM_LC_FLASH_RMA_ERROR);
             }
             if status.is_set(lc_ctrl::bits::Status::TransitionCountError) {
-                crate::println!("[mcu-rom-lcc] Transition count error detected.");
                 return Err(McuError::ROM_LC_TRANSITION_COUNT_ERROR);
             }
             if status.is_set(lc_ctrl::bits::Status::StateError) {
-                crate::println!("[mcu-rom-lcc] State error detected.");
                 return Err(McuError::ROM_LC_STATE_ERROR);
             }
             if status.is_set(lc_ctrl::bits::Status::BusIntegError) {
-                crate::println!("[mcu-rom-lcc] Bus integrity error detected.");
                 return Err(McuError::ROM_LC_BUS_INTEG_ERROR);
             }
             if status.is_set(lc_ctrl::bits::Status::OtpPartitionError) {
-                crate::println!("[mcu-rom-lcc] OTP partition error detected.");
                 return Err(McuError::ROM_LC_OTP_PARTITION_ERROR);
             }
         }

--- a/romtime/src/mci_mbox_cmd.rs
+++ b/romtime/src/mci_mbox_cmd.rs
@@ -125,26 +125,20 @@ fn dispatch_fuse_command(
     otp: &Otp,
 ) -> Result<usize, McuError> {
     if input_dlen < size_of::<u32>() || input_dlen > MAX_FUSE_REQ_BYTES {
-        crate::println!(
-            "[mci-mbox] Invalid dlen {} (must be {}..={})",
-            input_dlen,
-            size_of::<u32>(),
-            MAX_FUSE_REQ_BYTES
-        );
-        return Err(McuError::ROM_OTP_FUSE_INVALID_LENGTH);
+        return Err(McuError::ROM_MCI_MBOX_FUSE_REQ_INVALID_LENGTH);
     }
 
     sram_to_buf(sram, buf, input_dlen);
 
     let chksum_bytes: [u8; 4] = buf
         .get(..size_of::<u32>())
-        .ok_or(McuError::ROM_OTP_FUSE_INVALID_LENGTH)?
+        .ok_or(McuError::ROM_MCI_MBOX_FUSE_REQ_INVALID_LENGTH)?
         .try_into()
         .unwrap();
     let chksum = u32::from_le_bytes(chksum_bytes);
     let payload = buf
         .get(size_of::<u32>()..input_dlen)
-        .ok_or(McuError::ROM_OTP_FUSE_INVALID_LENGTH)?;
+        .ok_or(McuError::ROM_MCI_MBOX_FUSE_REQ_INVALID_LENGTH)?;
     if !verify_checksum(chksum, cmd, payload) {
         crate::println!("[mci-mbox] Checksum mismatch");
         return Err(McuError::ROM_OTP_FUSE_CHECKSUM_ERROR);
@@ -173,16 +167,11 @@ fn handle_fuse_read(buf: &mut [u8], dlen: usize, otp: &Otp) -> Result<usize, Mcu
     crate::println!("[mci-mbox] Processing MC_FUSE_READ (IFPR)");
 
     if dlen != size_of::<FuseReadReq>() {
-        crate::println!(
-            "[mci-mbox] IFPR: unexpected dlen {} (expected {})",
-            dlen,
-            size_of::<FuseReadReq>()
-        );
-        return Err(McuError::ROM_OTP_FUSE_INVALID_LENGTH);
+        return Err(McuError::ROM_MCI_MBOX_FUSE_READ_REQ_INVALID_LENGTH);
     }
 
     let req = FuseReadReq::ref_from_bytes(&buf[..size_of::<FuseReadReq>()])
-        .map_err(|_| McuError::ROM_OTP_FUSE_INVALID_LENGTH)?;
+        .map_err(|_| McuError::ROM_MCI_MBOX_FUSE_READ_REQ_PARSE_FAILED)?;
     let partition = req.partition;
     let entry = req.entry;
     crate::println!(
@@ -194,19 +183,12 @@ fn handle_fuse_read(buf: &mut [u8], dlen: usize, otp: &Otp) -> Result<usize, Mcu
     let params = fuse_read_dai_params(partition, entry, MAX_FUSE_DATA_WORDS)?;
 
     let resp = FuseReadResp::mut_from_bytes(&mut buf[..size_of::<FuseReadResp>()])
-        .map_err(|_| McuError::ROM_OTP_FUSE_INVALID_LENGTH)?;
+        .map_err(|_| McuError::ROM_MCI_MBOX_FUSE_READ_RESP_PARSE_FAILED)?;
     resp.valid_bits = params.valid_bits;
     for i in 0..params.words_to_read {
-        match otp.read_word(params.base_word_addr + i) {
-            Ok(word) => resp.data[i] = word,
-            Err(_) => {
-                crate::println!(
-                    "[mci-mbox] IFPR: DAI read error at word addr {}",
-                    params.base_word_addr + i
-                );
-                return Err(McuError::ROM_OTP_FUSE_DAI_READ_ERROR);
-            }
-        }
+        resp.data[i] = otp
+            .read_word(params.base_word_addr + i)
+            .map_err(|_| McuError::ROM_OTP_FUSE_DAI_READ_ERROR)?;
     }
 
     let resp_bytes = RESP_HDR_BYTES + size_of::<u32>() + params.words_to_read * size_of::<u32>();
@@ -219,16 +201,11 @@ fn handle_fuse_write(buf: &mut [u8], dlen: usize, otp: &Otp) -> Result<usize, Mc
 
     let hdr_size = size_of::<FuseWriteReqHdr>();
     if dlen < hdr_size {
-        crate::println!(
-            "[mci-mbox] IFPW: dlen too short {} (minimum {})",
-            dlen,
-            hdr_size
-        );
-        return Err(McuError::ROM_OTP_FUSE_INPUT_TOO_SHORT);
+        return Err(McuError::ROM_MCI_MBOX_FUSE_WRITE_HDR_TOO_SHORT);
     }
 
     let req = FuseWriteReqHdr::ref_from_bytes(&buf[..hdr_size])
-        .map_err(|_| McuError::ROM_OTP_FUSE_INVALID_LENGTH)?;
+        .map_err(|_| McuError::ROM_MCI_MBOX_FUSE_WRITE_REQ_PARSE_FAILED)?;
     let partition = req.partition;
     let entry = req.entry;
     let start_bit = req.start_bit;
@@ -254,27 +231,16 @@ fn handle_fuse_write(buf: &mut [u8], dlen: usize, otp: &Otp) -> Result<usize, Mc
         return Err(McuError::ROM_OTP_FUSE_DATA_TOO_LARGE);
     }
 
-    let expected_dlen = hdr_size.checked_add(data_bytes).ok_or_else(|| {
-        crate::println!("[mci-mbox] IFPW: expected dlen overflow");
-        McuError::ROM_OTP_FUSE_INVALID_LENGTH
-    })?;
+    let expected_dlen = hdr_size
+        .checked_add(data_bytes)
+        .ok_or(McuError::ROM_MCI_MBOX_FUSE_WRITE_DLEN_OVERFLOW)?;
 
     match dlen.cmp(&expected_dlen) {
         Ordering::Less => {
-            crate::println!(
-                "[mci-mbox] IFPW: input too short for data ({} < {})",
-                dlen,
-                expected_dlen
-            );
-            return Err(McuError::ROM_OTP_FUSE_INPUT_TOO_SHORT);
+            return Err(McuError::ROM_MCI_MBOX_FUSE_WRITE_DATA_TOO_SHORT);
         }
         Ordering::Greater => {
-            crate::println!(
-                "[mci-mbox] IFPW: input too long for data ({} > {})",
-                dlen,
-                expected_dlen
-            );
-            return Err(McuError::ROM_OTP_FUSE_INVALID_LENGTH);
+            return Err(McuError::ROM_MCI_MBOX_FUSE_WRITE_INPUT_TOO_LONG);
         }
         Ordering::Equal => {}
     }
@@ -295,16 +261,11 @@ fn handle_fuse_lock_partition(buf: &mut [u8], dlen: usize, otp: &Otp) -> Result<
     crate::println!("[mci-mbox] Processing MC_FUSE_LOCK_PARTITION (IFPK)");
 
     if dlen != size_of::<FuseLockPartitionReq>() {
-        crate::println!(
-            "[mci-mbox] IFPK: unexpected dlen {} (expected {})",
-            dlen,
-            size_of::<FuseLockPartitionReq>()
-        );
-        return Err(McuError::ROM_OTP_FUSE_INVALID_LENGTH);
+        return Err(McuError::ROM_MCI_MBOX_FUSE_LOCK_REQ_INVALID_LENGTH);
     }
 
     let req = FuseLockPartitionReq::ref_from_bytes(&buf[..size_of::<FuseLockPartitionReq>()])
-        .map_err(|_| McuError::ROM_OTP_FUSE_INVALID_LENGTH)?;
+        .map_err(|_| McuError::ROM_MCI_MBOX_FUSE_LOCK_REQ_PARSE_FAILED)?;
     let partition = req.partition;
     crate::println!("[mci-mbox] IFPK: partition={}", HexWord(partition));
 

--- a/romtime/src/otp.rs
+++ b/romtime/src/otp.rs
@@ -87,16 +87,11 @@ impl Otp {
                 return Ok(());
             }
         }
-        crate::println!("[mcu-rom-otp] OTP pending check exceeded maximum iterations");
         Err(McuError::ROM_OTP_PENDING_TIMEOUT)
     }
 
     pub fn check_error_and_idle(&self) -> McuResult<()> {
         if self.registers.otp_status.get() & OTP_STATUS_ERROR_MASK != 0 {
-            crate::println!(
-                "[mcu-rom-otp] OTP error: {}",
-                self.registers.otp_status.get()
-            );
             return Err(McuError::ROM_OTP_INIT_STATUS_ERROR);
         }
 
@@ -106,7 +101,6 @@ impl Otp {
             .otp_status
             .is_set(otp_ctrl::bits::OtpStatus::DaiIdle)
         {
-            crate::println!("[mcu-rom-otp] OTP not idle");
             return Err(McuError::ROM_OTP_INIT_NOT_IDLE);
         }
 
@@ -194,8 +188,7 @@ impl Otp {
             .is_set(otp_ctrl::bits::OtpStatus::DaiIdle)
         {}
 
-        if let Some(err) = self.check_error() {
-            crate::println!("Error reading fuses: {}", HexWord(err));
+        if self.check_error().is_some() {
             return Err(McuError::ROM_OTP_READ_ERROR);
         }
         Ok(self.registers.dai_rdata_rf_direct_access_rdata_0.get())
@@ -221,8 +214,7 @@ impl Otp {
             .is_set(otp_ctrl::bits::OtpStatus::DaiIdle)
         {}
 
-        if let Some(err) = self.check_error() {
-            crate::println!("Error reading fuses: {}", HexWord(err));
+        if self.check_error().is_some() {
             return Err(McuError::ROM_OTP_READ_ERROR);
         }
         let lo = self.registers.dai_rdata_rf_direct_access_rdata_0.get() as u64;
@@ -261,9 +253,7 @@ impl Otp {
             .is_set(otp_ctrl::bits::OtpStatus::DaiIdle)
         {}
 
-        if let Some(err) = self.check_error() {
-            crate::println!("Error writing fuses: {}", HexWord(err));
-            self.print_errors();
+        if self.check_error().is_some() {
             return Err(McuError::ROM_OTP_WRITE_DWORD_ERROR);
         }
         Ok(self.registers.dai_rdata_rf_direct_access_rdata_0.get())
@@ -295,9 +285,7 @@ impl Otp {
             .is_set(otp_ctrl::bits::OtpStatus::DaiIdle)
         {}
 
-        if let Some(err) = self.check_error() {
-            crate::println!("[mcu-rom] Error writing fuses: {}", HexWord(err));
-            self.print_errors();
+        if self.check_error().is_some() {
             return Err(McuError::ROM_OTP_WRITE_WORD_ERROR);
         }
         Ok(self.registers.dai_rdata_rf_direct_access_rdata_0.get())
@@ -331,9 +319,7 @@ impl Otp {
             .is_set(otp_ctrl::bits::OtpStatus::DaiIdle)
         {}
 
-        if let Some(err) = self.check_error() {
-            crate::println!("[mcu-rom] Error writing digest: {}", HexWord(err));
-            self.print_errors();
+        if self.check_error().is_some() {
             return Err(McuError::ROM_OTP_FINALIZE_DIGEST_ERROR);
         }
         Ok(())
@@ -736,18 +722,15 @@ impl Otp {
         cnst: u128,
     ) -> McuResult<u64> {
         if !partition.sw_digest {
-            crate::println!("[mcu-rom-otp] Partition does not support sw_digest");
-            return Err(McuError::ROM_OTP_INVALID_DATA_ERROR);
+            return Err(McuError::ROM_OTP_PARTITION_NO_SW_DIGEST);
         }
         if partition.byte_size <= DIGEST_SIZE {
-            crate::println!("[mcu-rom-otp] Partition too small for digest");
-            return Err(McuError::ROM_OTP_INVALID_DATA_ERROR);
+            return Err(McuError::ROM_OTP_PARTITION_TOO_SMALL_FOR_DIGEST);
         }
 
         let data_size = partition.byte_size - DIGEST_SIZE;
         if data_size % 8 != 0 {
-            crate::println!("[mcu-rom-otp] Partition data not 8-byte aligned for digest");
-            return Err(McuError::ROM_OTP_INVALID_DATA_ERROR);
+            return Err(McuError::ROM_OTP_PARTITION_NOT_8BYTE_ALIGNED_FOR_DIGEST);
         }
 
         // Read two words at a time from OTP, yielding u64 blocks to the
@@ -801,7 +784,7 @@ impl Otp {
     ) -> McuResult<u64> {
         let digest_offset = partition
             .digest_offset
-            .ok_or(McuError::ROM_OTP_INVALID_DATA_ERROR)?;
+            .ok_or(McuError::ROM_OTP_PARTITION_NO_DIGEST_OFFSET)?;
 
         let digest = self.compute_sw_digest(partition, iv, cnst)?;
         crate::println!(
@@ -818,11 +801,6 @@ impl Otp {
         // Read back the digest using 64-bit granule (matching the write)
         let readback = self.read_dword(digest_offset / 8)?;
         if readback != digest {
-            crate::println!(
-                "[mcu-rom-otp] Digest verify failed: wrote {:#x}, read {:#x}",
-                digest,
-                readback
-            );
             return Err(McuError::ROM_OTP_DIGEST_VERIFY_ERROR);
         }
 

--- a/romtime/src/otp_provision.rs
+++ b/romtime/src/otp_provision.rs
@@ -240,21 +240,12 @@ pub fn fuse_read_dai_params(
     let info = PartitionId::try_from(partition)?.info();
 
     if info.is_secret {
-        crate::println!(
-            "[otp-provision] Read denied: partition {} is secret",
-            partition
-        );
         return Err(McuError::ROM_OTP_FUSE_SECRET_READ_DENIED);
     }
 
     let entry_offset = entry as usize;
     if entry_offset >= info.byte_size || entry_offset % 4 != 0 {
-        crate::println!(
-            "[otp-provision] Entry out of bounds or unaligned: offset={}, size={}",
-            entry_offset,
-            info.byte_size
-        );
-        return Err(McuError::ROM_OTP_FUSE_ENTRY_OUT_OF_BOUNDS);
+        return Err(McuError::ROM_OTP_FUSE_READ_ENTRY_OUT_OF_BOUNDS);
     }
 
     let remaining_bytes = info.byte_size - entry_offset;
@@ -292,10 +283,6 @@ pub fn fuse_read_dai(
         match otp.read_word(params.base_word_addr + i) {
             Ok(word) => *slot = word,
             Err(_) => {
-                crate::println!(
-                    "[otp-provision] DAI read error at word addr {}",
-                    params.base_word_addr + i
-                );
                 return Err(McuError::ROM_OTP_FUSE_DAI_READ_ERROR);
             }
         }
@@ -330,35 +317,28 @@ pub fn fuse_write_dai(
     let info = PartitionId::try_from(partition)?.info();
 
     if length == 0 {
-        return Err(McuError::ROM_OTP_FUSE_INVALID_LENGTH);
+        return Err(McuError::ROM_OTP_FUSE_WRITE_LEN_ZERO);
     }
 
     let entry_offset = entry as usize;
     if entry_offset >= info.byte_size || entry_offset % 4 != 0 {
-        return Err(McuError::ROM_OTP_FUSE_ENTRY_OUT_OF_BOUNDS);
+        return Err(McuError::ROM_OTP_FUSE_WRITE_ENTRY_OUT_OF_BOUNDS);
     }
 
     let data_area_bits = ((info.byte_size - entry_offset) * 8) as u32;
     let end_bit_excl = match start_bit.checked_add(length) {
         Some(v) => v,
         None => {
-            crate::println!("[otp-provision] Write overflow: start_bit + length wraps u32");
-            return Err(McuError::ROM_OTP_FUSE_ENTRY_OUT_OF_BOUNDS);
+            return Err(McuError::ROM_OTP_FUSE_WRITE_OVERFLOW);
         }
     };
     if end_bit_excl > data_area_bits {
-        crate::println!(
-            "[otp-provision] Write out of bounds: start_bit({}) + length({}) > {}",
-            start_bit,
-            length,
-            data_area_bits
-        );
-        return Err(McuError::ROM_OTP_FUSE_ENTRY_OUT_OF_BOUNDS);
+        return Err(McuError::ROM_OTP_FUSE_WRITE_OUT_OF_BOUNDS);
     }
 
     let required_data_words = ((length + 31) / 32) as usize;
     if data_len < required_data_words {
-        return Err(McuError::ROM_OTP_FUSE_INVALID_LENGTH);
+        return Err(McuError::ROM_OTP_FUSE_WRITE_DATA_LEN_TOO_SHORT);
     }
 
     let base_word_addr = (info.byte_offset + entry_offset) / 4;
@@ -421,18 +401,11 @@ pub fn fuse_write_dai(
         let current = match otp.read_word(word_addr) {
             Ok(v) => v,
             Err(_) => {
-                crate::println!("[otp-provision] DAI read error at word addr {}", word_addr);
                 return Err(McuError::ROM_OTP_FUSE_DAI_READ_ERROR);
             }
         };
 
         if (current & mask) & !new_bits != 0 {
-            crate::println!(
-                "[otp-provision] Bit-clear conflict at word {}: current={}, requested={}",
-                word_addr,
-                HexWord(current & mask),
-                HexWord(new_bits)
-            );
             return Err(McuError::ROM_OTP_FUSE_BIT_CLEAR_NOT_ALLOWED);
         }
 
@@ -441,7 +414,6 @@ pub fn fuse_write_dai(
             match otp.write_word(word_addr, write_value) {
                 Ok(_) => {}
                 Err(_) => {
-                    crate::println!("[otp-provision] DAI write error at word addr {}", word_addr);
                     return Err(McuError::ROM_OTP_FUSE_DAI_WRITE_ERROR);
                 }
             }
@@ -477,9 +449,6 @@ pub fn fuse_lock_partition_dai(otp: &Otp, partition: u32) -> Result<(), McuError
             );
             Ok(())
         }
-        Err(_) => {
-            crate::println!("[otp-provision] Failed to lock partition {}", partition);
-            Err(McuError::ROM_OTP_FUSE_LOCK_ERROR)
-        }
+        Err(_) => Err(McuError::ROM_OTP_FUSE_LOCK_ERROR),
     }
 }

--- a/tests/integration/src/test_dot.rs
+++ b/tests/integration/src/test_dot.rs
@@ -739,10 +739,10 @@ mod test {
 
         // Verify it's the correct error
         let error_code = fatal_error.unwrap();
-        let expected_error: u32 = McuError::ROM_COLD_BOOT_DOT_ERROR.into();
+        let expected_error: u32 = McuError::ROM_COLD_BOOT_DOT_NO_RECOVERY_HANDLERS.into();
         assert_eq!(
             error_code, expected_error,
-            "Expected ROM_COLD_BOOT_DOT_ERROR (0x{:x}), got 0x{:x}",
+            "Expected ROM_COLD_BOOT_DOT_NO_RECOVERY_HANDLERS (0x{:x}), got 0x{:x}",
             expected_error, error_code
         );
 
@@ -1738,8 +1738,8 @@ mod test {
         );
         assert_eq!(
             fatal_error.unwrap(),
-            u32::from(caliptra_mcu_error::McuError::ROM_COLD_BOOT_FW_MANIFEST_DOT_ERROR),
-            "Expected ROM_COLD_BOOT_FW_MANIFEST_DOT_ERROR, got 0x{:x}",
+            u32::from(caliptra_mcu_error::McuError::ROM_FW_MANIFEST_DOT_UNSUPPORTED_VERSION),
+            "Expected ROM_FW_MANIFEST_DOT_UNSUPPORTED_VERSION, got 0x{:x}",
             fatal_error.unwrap()
         );
 
@@ -2304,13 +2304,13 @@ mod test {
         );
         assert_eq!(
             fatal_error.unwrap(),
-            u32::from(caliptra_mcu_error::McuError::ROM_COLD_BOOT_FW_MANIFEST_DOT_ERROR),
-            "Expected ROM_COLD_BOOT_FW_MANIFEST_DOT_ERROR for unknown command, got 0x{:x}",
+            u32::from(caliptra_mcu_error::McuError::ROM_FW_MANIFEST_DOT_UNKNOWN_COMMAND),
+            "Expected ROM_FW_MANIFEST_DOT_UNKNOWN_COMMAND for unknown command, got 0x{:x}",
             fatal_error.unwrap()
         );
 
         println!(
-            "[TEST] Unknown DOT command correctly triggers ROM_COLD_BOOT_FW_MANIFEST_DOT_ERROR"
+            "[TEST] Unknown DOT command correctly triggers ROM_FW_MANIFEST_DOT_UNKNOWN_COMMAND"
         );
         lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     }


### PR DESCRIPTION
Previously many of the error paths re-used error codes and distinguished the error using print statements. This added a lot of unnecessary codespace for those strings and formatting logic. This adds more unique error codes and removes the corresponding print statements.

This saves ~2.5KB in ROM.