### PR TITLE
rom: reject ODD-state DOT blobs with no LAK in dot_determine_owner

### DIFF
--- a/rom/src/device_ownership_transfer.rs
+++ b/rom/src/device_ownership_transfer.rs
@@ -448,6 +448,15 @@ fn dot_determine_owner(
         } else {
             // Disabled state: ODD with no CAK means ownership is locked but no code
             // authentication is enforced. The owner retains control via LAK.
+            // A valid Disabled blob must always carry a LAK so the owner can issue
+            // DOT_UNLOCK. A blob with neither CAK nor LAK has no recovery path and
+            // must be treated as corrupt to avoid silently locking out the owner.
+            if blob.lak().is_none() {
+                caliptra_mcu_romtime::println!(
+                    "[mcu-rom-dot] Corrupt blob: ODD state with neither CAK nor LAK"
+                );
+                return Err(McuError::ROM_COLD_BOOT_DOT_BLOB_CORRUPT_ERROR);
+            }
             caliptra_mcu_romtime::println!("[mcu-rom-dot] Device in Disabled state (ODD, no CAK)");
             Ok(None)
         }


### PR DESCRIPTION
A blob in ODD state with CAK=0 and LAK=0 passes HMAC verification and was silently accepted as Disabled, leaving the owner with no key to issue DOT_UNLOCK -- a permanent lockout.

Now any ODD-state blob lacking both CAK and LAK is rejected with ROM_COLD_BOOT_DOT_BLOB_CORRUPT_ERROR, triggering recovery instead.

Fixes #1570 