### PR TITLE
gitignore: ignore local Vivado scratch, FPGA build dirs, and sim_run/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,19 @@ subsystem.pdi
 # CoRIM test signing keys (generated on-the-fly, never commit)
 fake_keys/
 attestation-artifacts/*
+
+# Vivado scratch / logs (local FPGA build outputs)
+**/.Xil/
+**/vivado.jou
+**/vivado.log
+**/vivado_*.backup.jou
+**/vivado_*.backup.log
+**/vivado_*.str
+
+# Local FPGA build directories + per-build console logs
+hw/fpga/caliptra_build*/
+hw/fpga/caliptra_build*_console.log
+hw/fpga/cdc_fix_output/
+
+# Simulation run dirs
+sim_run/


### PR DESCRIPTION
## Summary

Running Vivado or VCS in-tree accumulates untracked junk (`.Xil/`,
`vivado.{jou,log}`, `vivado_*.backup.*`, `hw/fpga/caliptra_build*/`,
`hw/fpga/cdc_fix_output/`, `sim_run/`). Add patterns so `git status`
stays clean and accidental commits of multi-GB build dirs aren't
possible.

No code change.

## Test plan

- [ ] Run a local Vivado/VCS build; confirm `git status` is clean afterward.