### PR TITLE
[xtask] support building multiple bare metal binaries

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -36,6 +36,7 @@ default-filter = """
     - test(model_emulated::test::test_new_unbooted)) |
 (package(caliptra-mcu-tests-integration) and test(test_axi_bypass)) |
 (package(caliptra-mcu-tests-integration) and test(test_jtag_taps)) |
+(package(caliptra-mcu-tests-integration) and test(test_bare_metal_jtag_sideload)) |
 (package(caliptra-mcu-tests-integration) and test(test_lc_transitions)) |
 (package(caliptra-mcu-tests-integration) and test(test_prod_debug_unlock)) |
 (package(caliptra-mcu-tests-integration) and test(test_imaginary_flash_controller)) |

--- a/builder/src/all.rs
+++ b/builder/src/all.rs
@@ -716,13 +716,8 @@ pub fn all_build(args: AllBuildArgs) -> Result<()> {
         ..Default::default()
     })?;
 
-    // Only build the bare-metal runtime for the emulator platform, as it
-    // is currently only configured and supported for the emulator.
-    let mcu_bare_metal_runtime = if platform == "emulator" {
-        Some(crate::bare_metal_build()?)
-    } else {
-        None
-    };
+    let mcu_bare_metal_runtime =
+        crate::bare_metal_build(Some(platform), "caliptra-mcu-bare-metal")?;
 
     let mcu_image_cfg = get_image_cfg_feature(&mcu_cfgs.clone().unwrap_or_default(), "none");
     let mut caliptra_builder = crate::CaliptraBuilder::new(&CaliptraBuildArgs {
@@ -1039,14 +1034,12 @@ pub fn all_build(args: AllBuildArgs) -> Result<()> {
         &mut zip,
         options,
     )?;
-    if let Some(bare_metal) = mcu_bare_metal_runtime {
-        add_to_zip(
-            &bare_metal,
-            FirmwareBinaries::MCU_BARE_METAL_RUNTIME_NAME,
-            &mut zip,
-            options,
-        )?;
-    }
+    add_to_zip(
+        &mcu_bare_metal_runtime,
+        FirmwareBinaries::MCU_BARE_METAL_RUNTIME_NAME,
+        &mut zip,
+        options,
+    )?;
     add_to_zip(
         &soc_manifest,
         FirmwareBinaries::SOC_MANIFEST_NAME,

--- a/builder/src/all.rs
+++ b/builder/src/all.rs
@@ -258,7 +258,6 @@ pub struct FirmwareBinaries {
     pub caliptra_fw_key2: Vec<u8>,
     pub mcu_rom: Vec<u8>,
     pub mcu_runtime: Vec<u8>,
-    pub mcu_bare_metal_runtime: Vec<u8>,
     pub soc_manifest: Vec<u8>,
     pub test_roms: Vec<(String, Vec<u8>)>,
     pub caliptra_test_roms: Vec<(String, Vec<u8>)>,
@@ -268,6 +267,7 @@ pub struct FirmwareBinaries {
     pub test_flash_images: Vec<(String, Vec<u8>)>,
     /// Update flash images without partition table (for PLDM update packages)
     pub test_update_flash_images: Vec<(String, Vec<u8>)>,
+    pub bare_metal_images: Vec<(String, Vec<u8>)>,
 }
 
 impl FirmwareBinaries {
@@ -278,7 +278,6 @@ impl FirmwareBinaries {
     const CALIPTRA_FW_KEY2_NAME: &'static str = "caliptra_fw_key2.bin";
     const MCU_ROM_NAME: &'static str = "mcu_rom.bin";
     const MCU_RUNTIME_NAME: &'static str = "mcu_runtime.bin";
-    const MCU_BARE_METAL_RUNTIME_NAME: &'static str = "mcu_bare_metal_runtime.bin";
     const SOC_MANIFEST_NAME: &'static str = "soc_manifest.bin";
     const FLASH_IMAGE_NAME: &'static str = "flash_image.bin";
     const PLDM_FW_PKG_NAME: &'static str = "pldm_fw_pkg.bin";
@@ -321,7 +320,6 @@ impl FirmwareBinaries {
                 Self::CALIPTRA_FW_KEY2_NAME => binaries.caliptra_fw_key2 = data,
                 Self::MCU_ROM_NAME => binaries.mcu_rom = data,
                 Self::MCU_RUNTIME_NAME => binaries.mcu_runtime = data,
-                Self::MCU_BARE_METAL_RUNTIME_NAME => binaries.mcu_bare_metal_runtime = data,
                 Self::SOC_MANIFEST_NAME => binaries.soc_manifest = data,
                 name if name.contains("mcu-test-soc-manifest") => {
                     binaries.test_soc_manifests.push((name.to_string(), data));
@@ -346,11 +344,30 @@ impl FirmwareBinaries {
                 name if name.contains("mcu-test-flash-image") => {
                     binaries.test_flash_images.push((name.to_string(), data));
                 }
+                name if name.starts_with("bare_metal/") => {
+                    let stripped_name = name.strip_prefix("bare_metal/").unwrap();
+                    let stripped_name = stripped_name
+                        .strip_suffix(".bin")
+                        .unwrap_or(stripped_name)
+                        .to_string();
+                    binaries.bare_metal_images.push((stripped_name, data));
+                }
                 _ => continue,
             }
         }
 
         Ok(binaries)
+    }
+
+    pub fn get_bare_metal(&self, name: &str) -> Result<Vec<u8>> {
+        for (bin_name, data) in self.bare_metal_images.iter() {
+            if bin_name == name {
+                return Ok(data.clone());
+            }
+        }
+        Err(anyhow::anyhow!(
+            "Bare-metal binary {name} not found in bundle"
+        ))
     }
 
     pub fn vendor_pk_hash(&self) -> Option<[u8; 48]> {
@@ -716,8 +733,11 @@ pub fn all_build(args: AllBuildArgs) -> Result<()> {
         ..Default::default()
     })?;
 
-    let mcu_bare_metal_runtime =
-        crate::bare_metal_build(Some(platform), "caliptra-mcu-bare-metal")?;
+    let mut bare_metal_paths = vec![];
+    for package in crate::features::BARE_METAL_BINARIES {
+        let path = crate::bare_metal_build(Some(platform), package)?;
+        bare_metal_paths.push((package.to_string(), path));
+    }
 
     let mcu_image_cfg = get_image_cfg_feature(&mcu_cfgs.clone().unwrap_or_default(), "none");
     let mut caliptra_builder = crate::CaliptraBuilder::new(&CaliptraBuildArgs {
@@ -1034,12 +1054,10 @@ pub fn all_build(args: AllBuildArgs) -> Result<()> {
         &mut zip,
         options,
     )?;
-    add_to_zip(
-        &mcu_bare_metal_runtime,
-        FirmwareBinaries::MCU_BARE_METAL_RUNTIME_NAME,
-        &mut zip,
-        options,
-    )?;
+    for (package, path) in bare_metal_paths {
+        let zip_name = format!("bare_metal/{}.bin", package);
+        add_to_zip(&path, &zip_name, &mut zip, options)?;
+    }
     add_to_zip(
         &soc_manifest,
         FirmwareBinaries::SOC_MANIFEST_NAME,

--- a/builder/src/features.rs
+++ b/builder/src/features.rs
@@ -87,6 +87,8 @@ pub const ROM_ONLY_TEST_FEATURES: &[&str] = &[
     "test-usb-ocp-recovery",
 ];
 
+pub const BARE_METAL_BINARIES: &[&str] = &["caliptra-mcu-bare-metal"];
+
 /// A single ROM build target (platform + feature combo). Shared between
 /// `cargo xtask sizes` (size reporting), `test_panic_missing` (panic-free
 /// audit), and any other per-variant build check.

--- a/builder/src/runtime.rs
+++ b/builder/src/runtime.rs
@@ -6,12 +6,13 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-use crate::utils::manifest_file_for_profile;
-use crate::{CaliptraBuildArgs, PROJECT_ROOT};
+use crate::utils::{bare_metal_manifest_file, manifest_file_for_profile};
+use crate::CaliptraBuildArgs;
 use anyhow::Result;
 use caliptra_mcu_firmware_bundler::args::{
     BuildArgs, BundleArgs, Commands as BundleCommands, Common, LdArgs,
 };
+use std::io::Write;
 use std::path::PathBuf;
 
 pub fn runtime_build_with_apps(args: &CaliptraBuildArgs) -> Result<PathBuf> {
@@ -64,20 +65,44 @@ pub fn runtime_build_with_apps(args: &CaliptraBuildArgs) -> Result<PathBuf> {
     Ok(runtime_bin)
 }
 
-pub fn bare_metal_build() -> Result<PathBuf> {
-    let manifest = PROJECT_ROOT.join("runtime/bare-metal/manifest.toml");
-    let output_name = "runtime-bare-metal.bin".to_string();
+pub fn bare_metal_build(platform: Option<&str>, package_name: &str) -> Result<PathBuf> {
+    let base_manifest_path = bare_metal_manifest_file(platform)?;
+    let platform_str = platform.unwrap_or("emulator");
+    let output_name = format!("{}-{}.bin", package_name, platform_str);
+
+    let manifest_content = std::fs::read_to_string(&base_manifest_path)?;
+    let new_manifest_content = manifest_content.replace("{{BARE_METAL_NAME}}", package_name);
+
+    if new_manifest_content == manifest_content {
+        anyhow::bail!(
+            "Failed to find {{BARE_METAL_NAME}} placeholder in manifest template {:?}",
+            base_manifest_path
+        );
+    }
+
+    let mut temp_manifest = tempfile::NamedTempFile::new()?;
+    temp_manifest.write_all(new_manifest_content.as_bytes())?;
+    temp_manifest.flush()?;
 
     let common = Common {
-        manifest,
+        manifest: temp_manifest.path().to_path_buf(),
         ..Default::default()
     };
     let runtime_bin = common.release_dir()?.join(&output_name);
 
+    let runtime_features = if platform == Some("fpga") {
+        Some("fpga".to_string())
+    } else {
+        None
+    };
+
     let bundle_cmd = BundleCommands::Bundle {
         common,
         ld: LdArgs::default(),
-        build: BuildArgs::default(),
+        build: BuildArgs {
+            runtime_features,
+            ..Default::default()
+        },
         bundle: BundleArgs {
             bundle_name: Some(output_name),
         },

--- a/builder/src/utils.rs
+++ b/builder/src/utils.rs
@@ -21,6 +21,8 @@ const EMU_EXAMPLE_APP_MANIFEST_DEVEL: &str =
     "firmware-bundler/reference/emulator/example-app-devel.toml";
 const FPGA_USER_APP_MANIFEST: &str = "firmware-bundler/reference/fpga/user-app.toml";
 const FPGA_EXAMPLE_APP_MANIFEST: &str = "firmware-bundler/reference/fpga/example-app.toml";
+const EMU_BARE_METAL_MANIFEST: &str = "firmware-bundler/reference/emulator/bare-metal.toml";
+const FPGA_BARE_METAL_MANIFEST: &str = "firmware-bundler/reference/fpga/bare-metal.toml";
 
 pub fn manifest_file(platform: Option<&str>, example_app: bool) -> Result<PathBuf> {
     manifest_file_for_profile(platform, example_app, None)
@@ -53,6 +55,16 @@ pub fn manifest_file_for_profile(
                 FPGA_USER_APP_MANIFEST
             }
         }
+        _ => bail!("Invalid platform {platform:?}, supported options are 'emulator' or 'fpga'"),
+    };
+
+    find_workspace_directory().map(|w| w.join(manifest))
+}
+
+pub fn bare_metal_manifest_file(platform: Option<&str>) -> Result<PathBuf> {
+    let manifest = match platform {
+        Some("emulator") | None => EMU_BARE_METAL_MANIFEST,
+        Some("fpga") => FPGA_BARE_METAL_MANIFEST,
         _ => bail!("Invalid platform {platform:?}, supported options are 'emulator' or 'fpga'"),
     };
 

--- a/firmware-bundler/reference/emulator/bare-metal.toml
+++ b/firmware-bundler/reference/emulator/bare-metal.toml
@@ -22,6 +22,6 @@ offset = 0x3BFE_0000
 size = 0x2_0000
 
 [bare_metal]
-name = "caliptra-mcu-bare-metal"
+name = "{{BARE_METAL_NAME}}"
 stack = 0x4000
 exception_stack = 0x400

--- a/firmware-bundler/reference/fpga/bare-metal.toml
+++ b/firmware-bundler/reference/fpga/bare-metal.toml
@@ -18,6 +18,6 @@ offset = 0x5000_0000
 size = 0x4000 # 16KB
 
 [bare_metal]
-name = "caliptra-mcu-bare-metal"
+name = "{{BARE_METAL_NAME}}"
 stack = 0x4000
 exception_stack = 0x400

--- a/tests/integration/src/jtag/test_bare_metal_jtag.rs
+++ b/tests/integration/src/jtag/test_bare_metal_jtag.rs
@@ -16,8 +16,6 @@ mod test {
 
     use anyhow::{bail, Result};
 
-    const DCSR_SET_EBREAKM: u32 = 0x8003; // to enable debug mode on an ebreak
-
     fn sideload_bare_metal(tap: &mut OpenOcdJtagTap, bytes: &[u8]) -> Result<()> {
         // SRAM base offset
         let sram_base = FPGA_MEMORY_MAP.sram_offset;
@@ -64,14 +62,16 @@ mod test {
 
         // Pull bare-metal bytes from prebuilt bundle environment.
         let binaries = FirmwareBinaries::from_env().expect("Firmware bundle not found");
-        let bare_metal_bytes = &binaries.mcu_bare_metal_runtime;
+        let bare_metal_bytes = binaries
+            .get_bare_metal("caliptra-mcu-bare-metal")
+            .expect("mcu_bare_metal binary not found");
         assert!(
             !bare_metal_bytes.is_empty(),
             "mcu_bare_metal binary is empty"
         );
 
         // Sideload and execute bare metal binary
-        sideload_bare_metal(&mut *mcu_tap, bare_metal_bytes)
+        sideload_bare_metal(&mut *mcu_tap, &bare_metal_bytes)
             .expect("Failed to sideload and execute bare metal binary");
 
         // the ROM throws an error and the sim attempts to exit due to the lack

--- a/xtask/src/fpga/mod.rs
+++ b/xtask/src/fpga/mod.rs
@@ -410,7 +410,6 @@ pub(crate) fn fpga_run(args: crate::Commands) -> Result<()> {
         FirmwareBinaries {
             mcu_rom,
             mcu_runtime: blank.to_vec(),
-            mcu_bare_metal_runtime: blank.to_vec(),
             caliptra_rom,
             caliptra_fw: blank.to_vec(),
             caliptra_fw_key2: blank.to_vec(),
@@ -424,6 +423,7 @@ pub(crate) fn fpga_run(args: crate::Commands) -> Result<()> {
             test_pldm_fw_pkgs: vec![],
             test_flash_images: vec![],
             test_update_flash_images: vec![],
+            bare_metal_images: vec![],
         }
     };
     let otp_memory = if otp_file.is_some() && otp_file.unwrap().exists() {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -116,8 +116,8 @@ enum Commands {
         platform: Option<String>,
 
         /// Build bare metal runtime instead of TockOS runtime
-        #[arg(long, default_value_t = false)]
-        bare_metal: bool,
+        #[arg(long, default_missing_value = "caliptra-mcu-bare-metal", num_args = 0..=1)]
+        bare_metal: Option<String>,
 
         /// Cargo profile to build with.  Default: `devel` (1 MB SRAM, all
         /// debug components present, `release` cargo feature OFF — suitable for
@@ -615,8 +615,9 @@ fn main() {
             bare_metal,
             profile,
         } => {
-            if *bare_metal {
-                caliptra_mcu_builder::bare_metal_build().map(|_| ())
+            if let Some(bare_metal_pkg) = bare_metal {
+                caliptra_mcu_builder::bare_metal_build(platform.as_deref(), bare_metal_pkg)
+                    .map(|_| ())
             } else {
                 // The opt-in `release` cargo profile auto-enables the `release` cargo
                 // feature, which strips the kernel `debug!()` macro, romtime


### PR DESCRIPTION
Support building multiple bare metal binaries in one firmware bundle instead of just the template binary.

This will become necessary as we will have multiple provisioning binaries that we need to compile.

Add an integration test for the template bare metal binary and include it in CI (the test is < 10 seconds, so shouldn't bloat time much)