### PR TITLE
rom: install owner PK hash via mailbox instead of locked register

### DIFF
--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -179,6 +179,11 @@ impl McuError {
             "Cold boot ROM integrity check failed"
         ),
         (
+            ROM_DOT_INSTALL_OWNER_PK_HASH_FAILED,
+            0x1_001a,
+            "INSTALL_OWNER_PK_HASH mailbox command failed"
+        ),
+        (
             ROM_LC_TRANSITION_ERROR,
             0x2_0000,
             "Lifecycle transition error"

--- a/rom/src/cold_boot.rs
+++ b/rom/src/cold_boot.rs
@@ -705,10 +705,22 @@ impl BootFlow for ColdBoot {
             device_ownership_transfer::load_owner_pkhash(&env.otp)
         };
 
-        // Write owner PK hash to Caliptra if available
+        // Deliver the owner PK hash via mailbox; the cptra_owner_pk_hash register
+        // is locked once fuse write done is set. An all-zero hash means no owner
+        // is provisioned and must not be installed (it would make Caliptra reject
+        // every image).
         if let Some(ref owner) = owner_pk_hash {
-            env.soc.set_owner_pk_hash(owner);
-            env.soc.lock_owner_pk_hash();
+            if owner.0.iter().any(|&word| word != 0) {
+                if let Err(err) =
+                    device_ownership_transfer::install_owner_pk_hash(&mut env.soc_manager, owner)
+                {
+                    caliptra_mcu_romtime::println!(
+                        "[mcu-rom] Fatal error installing owner PK hash: {}",
+                        HexWord(err.into())
+                    );
+                    fatal_error(err);
+                }
+            }
         }
 
         // Enter I3C services unconditionally if force_i3c_services is set

--- a/rom/src/device_ownership_transfer.rs
+++ b/rom/src/device_ownership_transfer.rs
@@ -17,7 +17,8 @@ use crate::hil::FlashStorage;
 use crate::RomEnv;
 use caliptra_api::mailbox::{
     CmDeriveStableKeyReq, CmDeriveStableKeyResp, CmHashAlgorithm, CmHmacResp, CmShaReqHdr,
-    CmShaResp, CmStableKeyType, CommandId, EcdsaVerifyReq, MailboxReqHeader, MailboxRespHeader,
+    CmShaResp, CmStableKeyType, CommandId, EcdsaVerifyReq, InstallOwnerPkHashReq,
+    InstallOwnerPkHashResp, MailboxReqHeader, MailboxRespHeader,
 };
 use caliptra_mcu_error::{McuError, McuResult};
 use caliptra_mcu_romtime::Otp;
@@ -126,6 +127,42 @@ pub fn load_owner_pkhash(otp: &Otp) -> Option<OwnerPkHash> {
     let hash: [u8; 48] = otp.read_cptra_ss_owner_pk_hash().ok()?;
     let hash: [u32; 12] = transmute!(hash);
     Some(OwnerPkHash(hash))
+}
+
+/// Installs the owner public key hash into Caliptra core via the
+/// `INSTALL_OWNER_PK_HASH` mailbox command, used because the
+/// `cptra_owner_pk_hash` register is locked once `cptra_fuse_wr_done` is set.
+///
+/// The `digest` payload uses the same word layout as the register, so the
+/// `OwnerPkHash` words are forwarded unchanged.
+pub(crate) fn install_owner_pk_hash(
+    soc_manager: &mut caliptra_mcu_romtime::CaliptraSoC,
+    owner_pk_hash: &OwnerPkHash,
+) -> McuResult<()> {
+    caliptra_mcu_romtime::print!("[mcu-rom-dot] Installing owner PK hash: ");
+    for word in owner_pk_hash.0.iter() {
+        caliptra_mcu_romtime::print!("{}", HexWord(*word));
+    }
+    caliptra_mcu_romtime::println!("");
+
+    let req = InstallOwnerPkHashReq {
+        hdr: MailboxReqHeader::default(),
+        digest: owner_pk_hash.0,
+    };
+    let mut req32: [u32; core::mem::size_of::<InstallOwnerPkHashReq>() / 4] = transmute!(req);
+    let mut resp32: [u32; core::mem::size_of::<InstallOwnerPkHashResp>() / 4] =
+        transmute!(InstallOwnerPkHashResp::default());
+
+    if let Err(err) = soc_manager.exec_mailbox_req_u32(
+        CommandId::INSTALL_OWNER_PK_HASH.into(),
+        &mut req32,
+        &mut resp32,
+    ) {
+        let _ = err;
+        caliptra_mcu_romtime::println!("[mcu-rom-dot] INSTALL_OWNER_PK_HASH failed");
+        return Err(McuError::ROM_DOT_INSTALL_OWNER_PK_HASH_FAILED);
+    }
+    Ok(())
 }
 
 /// Caliptra Cryptographic Mailbox Key (CMK) handle.

--- a/rom/src/rom.rs
+++ b/rom/src/rom.rs
@@ -302,8 +302,8 @@ impl Soc {
             .unwrap_or_else(|_| fatal_error(McuError::ROM_OTP_READ_ERROR));
         self.registers.fuse_mldsa_revocation.set(word);
 
-        // Owner PK Hash is written separately after Device Ownership Transfer flow.
-        // See set_owner_pk_hash() method.
+        // Owner PK hash is sent via mailbox after the DOT flow; see
+        // device_ownership_transfer::install_owner_pk_hash().
 
         // TODO: load HEK Seed CSRs.
         // SoC Stepping ID (only 16-bits are relevant).
@@ -443,29 +443,6 @@ impl Soc {
             caliptra_mcu_romtime::println!("[mcu-rom] Setting DMA user");
             self.set_ss_caliptra_dma_axi_user(dma_user);
         }
-    }
-
-    /// Sets the owner public key hash in Caliptra's SoC interface registers.
-    ///
-    /// This is called after Device Ownership Transfer (DOT) flow completes to set
-    /// the owner PK hash from either the DOT blob or the fuses.
-    ///
-    /// # Arguments
-    /// * `owner_pk_hash` - The owner public key hash to set.
-    pub fn set_owner_pk_hash(&self, owner_pk_hash: &crate::fuses::OwnerPkHash) {
-        caliptra_mcu_romtime::print!("[mcu-fuse-write] Writing owner PK hash: ");
-        for (i, word) in owner_pk_hash.0.iter().enumerate() {
-            caliptra_mcu_romtime::print!("{}", HexWord(*word));
-            self.registers.cptra_owner_pk_hash[i].set(*word);
-        }
-        caliptra_mcu_romtime::println!("");
-    }
-
-    /// Locks the owner public key hash register.
-    ///
-    /// Once locked, the owner PK hash cannot be modified until the next reset.
-    pub fn lock_owner_pk_hash(&self) {
-        self.registers.cptra_owner_pk_hash_lock.set(1);
     }
 
     pub fn fuse_write_done(&self) {


### PR DESCRIPTION
The cptra_owner_pk_hash register is locked once fuse write done is set, so writing it directly dropped the value; send it via INSTALL_OWNER_PK_HASH instead, skipping the all-zero unprovisioned case.