### PR TITLE
rom: install owner PK hash via mailbox and allow forcing the fused owner

### DIFF
--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -179,6 +179,16 @@ impl McuError {
             "Cold boot ROM integrity check failed"
         ),
         (
+            ROM_DOT_INSTALL_OWNER_PK_HASH_FAILED,
+            0x1_001c,
+            "INSTALL_OWNER_PK_HASH mailbox command failed"
+        ),
+        (
+            ROM_DOT_FORCE_FUSE_OWNER_NOT_PROVISIONED,
+            0x1_001d,
+            "Forced fuse owner requested but CPTRA_SS_OWNER_PK_HASH is not provisioned"
+        ),
+        (
             ROM_LC_TRANSITION_ERROR,
             0x2_0000,
             "Lifecycle transition error"

--- a/hw/model/src/lib.rs
+++ b/hw/model/src/lib.rs
@@ -224,6 +224,10 @@ pub struct InitParams<'a> {
 
     pub flash_boot: bool,
 
+    /// When true, drive the MCI generic input wire strap that forces the ROM
+    /// to use the `CPTRA_SS_OWNER_PK_HASH` fuse as the owner, bypassing DOT.
+    pub force_fuse_owner_pk_hash: bool,
+
     pub active_i3c1: bool,
 
     /// Initial contents of the vendor test partition in OTP.
@@ -304,6 +308,7 @@ impl Default for InitParams<'_> {
             check_booted_to_runtime: true,
             caliptra_soc_axi_user: None,
             flash_boot: false,
+            force_fuse_owner_pk_hash: false,
             active_i3c1: false,
             vendor_test_partition: None,
             use_strap_secrets: false,

--- a/hw/model/src/model_emulated.rs
+++ b/hw/model/src/model_emulated.rs
@@ -339,10 +339,15 @@ impl McuHwModel for ModelEmulated {
         let mci_irq = pic.register_irq(McuRootBus::MCI_IRQ);
         // Start with go-bit unset so ROM-based tests can configure
         // wires before the ROM proceeds (matching FPGA behavior).
-        let mci_generic_input_wires = if params.flash_boot {
-            [0, 1 << 29]
-        } else {
-            [0, 0]
+        let mci_generic_input_wires = {
+            let mut wire1 = 0u32;
+            if params.flash_boot {
+                wire1 |= 1 << 29;
+            }
+            if params.force_fuse_owner_pk_hash {
+                wire1 |= 1 << 28;
+            }
+            [0, wire1]
         };
         let mci_regs = ext_mci.regs.clone();
         let mci = Mci::new(

--- a/platforms/emulator/rom/src/riscv.rs
+++ b/platforms/emulator/rom/src/riscv.rs
@@ -90,6 +90,26 @@ fn record_hook_bit(bit: u32) {
     }
 }
 
+/// Read the MCI generic-input-wire strap selecting the owner PK hash source.
+fn read_owner_pk_hash_policy() -> caliptra_mcu_rom_common::OwnerPkHashPolicy {
+    use tock_registers::interfaces::Readable;
+    // Safety: `MCU_MEMORY_MAP.mci_offset` is the linker-provided MCI register
+    // block base; the resulting reference is only used for typed reads.
+    let mci: caliptra_mcu_romtime::StaticRef<caliptra_mcu_registers_generated::mci::regs::Mci> = unsafe {
+        caliptra_mcu_romtime::StaticRef::new(
+            MCU_MEMORY_MAP.mci_offset as *const caliptra_mcu_registers_generated::mci::regs::Mci,
+        )
+    };
+    if mci.mci_reg_generic_input_wires[1].get()
+        & caliptra_mcu_rom_common::FORCE_FUSE_OWNER_PK_HASH_WIRE_BIT
+        != 0
+    {
+        caliptra_mcu_rom_common::OwnerPkHashPolicy::ForceFuse
+    } else {
+        caliptra_mcu_rom_common::OwnerPkHashPolicy::DotThenFuse
+    }
+}
+
 impl RomHooks for LoggingRomHooks {
     fn pre_cold_boot(&self) {
         caliptra_mcu_romtime::println!("[mcu-rom-hook] pre_cold_boot");
@@ -234,6 +254,7 @@ pub extern "C" fn rom_entry() -> ! {
         caliptra_mcu_rom_common::rom_start(RomParameters {
             flash_partition_driver: Some(&mut flash_image_partition_driver),
             dot_flash: Some(dot_flash),
+            owner_pk_hash_policy: read_owner_pk_hash_policy(),
             request_flash_boot: true,
             cptra_mbox_axi_users: mbox_axi_users,
             cptra_fuse_axi_user: axi_user0,
@@ -254,6 +275,7 @@ pub extern "C" fn rom_entry() -> ! {
             mcu_image_header_size: core::mem::size_of::<caliptra_mcu_image_header::McuImageHeader>(
             ),
             dot_flash: Some(dot_flash),
+            owner_pk_hash_policy: read_owner_pk_hash_policy(),
             otp_enable_integrity_check: true,
             otp_enable_consistency_check: true,
             cptra_mbox_axi_users: mbox_axi_users,
@@ -271,6 +293,7 @@ pub extern "C" fn rom_entry() -> ! {
     )) {
         caliptra_mcu_rom_common::rom_start(RomParameters {
             dot_flash: Some(dot_flash),
+            owner_pk_hash_policy: read_owner_pk_hash_policy(),
             fw_manifest_dot_enabled: true,
             otp_enable_integrity_check: true,
             otp_enable_consistency_check: true,
@@ -285,6 +308,7 @@ pub extern "C" fn rom_entry() -> ! {
     } else if cfg!(feature = "test-svn-manifest") {
         caliptra_mcu_rom_common::rom_start(RomParameters {
             dot_flash: Some(dot_flash),
+            owner_pk_hash_policy: read_owner_pk_hash_policy(),
             svn_manifest_enabled: true,
             otp_enable_integrity_check: true,
             otp_enable_consistency_check: true,
@@ -315,6 +339,7 @@ pub extern "C" fn rom_entry() -> ! {
         caliptra_mcu_rom_common::rom_start(RomParameters {
             flash_partition_driver: Some(&mut flash_partition),
             dot_flash: Some(dot_flash),
+            owner_pk_hash_policy: read_owner_pk_hash_policy(),
             // Let the generic wire (bit 29 of mci_reg_generic_input_wires[1]) control flash boot
             // request_flash_boot defaults to false - emulator sets the wire when flash boot is requested
             cptra_mbox_axi_users: mbox_axi_users,
@@ -374,6 +399,7 @@ pub extern "C" fn rom_entry() -> ! {
 
         caliptra_mcu_rom_common::rom_start(RomParameters {
             dot_flash: Some(dot_flash),
+            owner_pk_hash_policy: read_owner_pk_hash_policy(),
             cptra_mbox_axi_users: mbox_axi_users,
             cptra_fuse_axi_user: axi_user0,
             cptra_trng_axi_user: axi_user0,

--- a/platforms/fpga/rom/src/riscv.rs
+++ b/platforms/fpga/rom/src/riscv.rs
@@ -50,6 +50,26 @@ fn record_hook_bit(bit: u32) {
     }
 }
 
+/// Read the MCI generic-input-wire strap selecting the owner PK hash source.
+fn read_owner_pk_hash_policy() -> caliptra_mcu_rom_common::OwnerPkHashPolicy {
+    use tock_registers::interfaces::Readable;
+    // Safety: `MCU_MEMORY_MAP.mci_offset` is the linker-provided MCI register
+    // block base; the resulting reference is only used for typed reads.
+    let mci: caliptra_mcu_romtime::StaticRef<caliptra_mcu_registers_generated::mci::regs::Mci> = unsafe {
+        caliptra_mcu_romtime::StaticRef::new(
+            MCU_MEMORY_MAP.mci_offset as *const caliptra_mcu_registers_generated::mci::regs::Mci,
+        )
+    };
+    if mci.mci_reg_generic_input_wires[1].get()
+        & caliptra_mcu_rom_common::FORCE_FUSE_OWNER_PK_HASH_WIRE_BIT
+        != 0
+    {
+        caliptra_mcu_rom_common::OwnerPkHashPolicy::ForceFuse
+    } else {
+        caliptra_mcu_rom_common::OwnerPkHashPolicy::DotThenFuse
+    }
+}
+
 impl RomHooks for LoggingRomHooks {
     fn pre_cold_boot(&self) {
         caliptra_mcu_romtime::println!("[mcu-rom-hook] pre_cold_boot");
@@ -223,6 +243,7 @@ pub extern "C" fn rom_entry() -> ! {
         otp_enable_consistency_check: true,
         flash_partition_driver: Some(&mut flash_partition),
         dot_flash: Some(dot_flash),
+        owner_pk_hash_policy: read_owner_pk_hash_policy(),
         cptra_mbox_axi_users: mbox_axi_users,
         cptra_fuse_axi_user: axi_user0,
         cptra_trng_axi_user: axi_user0,

--- a/rom/src/cold_boot.rs
+++ b/rom/src/cold_boot.rs
@@ -643,8 +643,22 @@ impl BootFlow for ColdBoot {
             }
         };
 
-        // Determine owner PK hash: from DOT flow if available, otherwise from fuses
-        let owner_pk_hash = if let Some(dot_flash) = params.dot_flash {
+        // Determine owner PK hash: forced from fuse, or from DOT flow with fuse fallback
+        let owner_pk_hash = if params.owner_pk_hash_policy
+            == device_ownership_transfer::OwnerPkHashPolicy::ForceFuse
+        {
+            caliptra_mcu_romtime::println!(
+                "[mcu-rom] Forcing fused owner PK hash, bypassing DOT blob"
+            );
+            let owner = device_ownership_transfer::load_owner_pkhash(&env.otp);
+            if owner.as_ref().is_none_or(|h| h.0.iter().all(|&w| w == 0)) {
+                caliptra_mcu_romtime::println!(
+                    "[mcu-rom] Forced fuse owner requested but CPTRA_SS_OWNER_PK_HASH is not provisioned"
+                );
+                fatal_error(McuError::ROM_DOT_FORCE_FUSE_OWNER_NOT_PROVISIONED);
+            }
+            owner
+        } else if let Some(dot_flash) = params.dot_flash {
             caliptra_mcu_romtime::println!("[mcu-rom] Reading DOT blob");
             let mut dot_blob = [0u8; device_ownership_transfer::DOT_BLOB_SIZE];
             if let Err(err) = dot_flash.read(&mut dot_blob, 0) {
@@ -705,10 +719,22 @@ impl BootFlow for ColdBoot {
             device_ownership_transfer::load_owner_pkhash(&env.otp)
         };
 
-        // Write owner PK hash to Caliptra if available
+        // Deliver the owner PK hash via mailbox; the cptra_owner_pk_hash register
+        // is locked once fuse write done is set. An all-zero hash means no owner
+        // is provisioned and must not be installed (it would make Caliptra reject
+        // every image).
         if let Some(ref owner) = owner_pk_hash {
-            env.soc.set_owner_pk_hash(owner);
-            env.soc.lock_owner_pk_hash();
+            if owner.0.iter().any(|&word| word != 0) {
+                if let Err(err) =
+                    device_ownership_transfer::install_owner_pk_hash(&mut env.soc_manager, owner)
+                {
+                    caliptra_mcu_romtime::println!(
+                        "[mcu-rom] Fatal error installing owner PK hash: {}",
+                        HexWord(err.into())
+                    );
+                    fatal_error(err);
+                }
+            }
         }
 
         // Enter I3C services unconditionally if force_i3c_services is set

--- a/rom/src/device_ownership_transfer.rs
+++ b/rom/src/device_ownership_transfer.rs
@@ -17,7 +17,8 @@ use crate::hil::FlashStorage;
 use crate::RomEnv;
 use caliptra_api::mailbox::{
     CmDeriveStableKeyReq, CmDeriveStableKeyResp, CmHashAlgorithm, CmHmacResp, CmShaReqHdr,
-    CmShaResp, CmStableKeyType, CommandId, EcdsaVerifyReq, MailboxReqHeader, MailboxRespHeader,
+    CmShaResp, CmStableKeyType, CommandId, EcdsaVerifyReq, InstallOwnerPkHashReq,
+    InstallOwnerPkHashResp, MailboxReqHeader, MailboxRespHeader,
 };
 use caliptra_mcu_error::{McuError, McuResult};
 use caliptra_mcu_romtime::Otp;
@@ -30,7 +31,22 @@ pub const DOT_BLOB_SIZE: usize = core::mem::size_of::<DotBlob>();
 #[derive(Clone, Debug, FromBytes, IntoBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct LakPkHash(pub [u32; 12]);
 
-pub trait OwnerPolicy {}
+/// Controls where the owner PK hash comes from during cold boot.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum OwnerPkHashPolicy {
+    /// Use the owner determined by the DOT flow, falling back to the
+    /// `CPTRA_SS_OWNER_PK_HASH` fuse when DOT yields no owner.
+    #[default]
+    DotThenFuse,
+    /// Bypass the DOT blob entirely and use the `CPTRA_SS_OWNER_PK_HASH` fuse.
+    /// Intended as an integrator-controlled recovery escape hatch.
+    ForceFuse,
+}
+
+/// MCI `generic_input_wires[1]` bit reserved for the force-fuse-owner strap.
+/// Platform ROMs that support it read this bit and set
+/// [`crate::RomParameters::owner_pk_hash_policy`] to [`OwnerPkHashPolicy::ForceFuse`].
+pub const FORCE_FUSE_OWNER_PK_HASH_WIRE_BIT: u32 = 1 << 28;
 
 #[derive(Clone, FromBytes, IntoBytes, Immutable, KnownLayout)]
 pub struct RecoveryPkHash(pub [u32; 12]);
@@ -126,6 +142,42 @@ pub fn load_owner_pkhash(otp: &Otp) -> Option<OwnerPkHash> {
     let hash: [u8; 48] = otp.read_cptra_ss_owner_pk_hash().ok()?;
     let hash: [u32; 12] = transmute!(hash);
     Some(OwnerPkHash(hash))
+}
+
+/// Installs the owner public key hash into Caliptra core via the
+/// `INSTALL_OWNER_PK_HASH` mailbox command, used because the
+/// `cptra_owner_pk_hash` register is locked once `cptra_fuse_wr_done` is set.
+///
+/// The `digest` payload uses the same word layout as the register, so the
+/// `OwnerPkHash` words are forwarded unchanged.
+pub(crate) fn install_owner_pk_hash(
+    soc_manager: &mut caliptra_mcu_romtime::CaliptraSoC,
+    owner_pk_hash: &OwnerPkHash,
+) -> McuResult<()> {
+    caliptra_mcu_romtime::print!("[mcu-rom-dot] Installing owner PK hash: ");
+    for word in owner_pk_hash.0.iter() {
+        caliptra_mcu_romtime::print!("{}", HexWord(*word));
+    }
+    caliptra_mcu_romtime::println!("");
+
+    let req = InstallOwnerPkHashReq {
+        hdr: MailboxReqHeader::default(),
+        digest: owner_pk_hash.0,
+    };
+    let mut req32: [u32; core::mem::size_of::<InstallOwnerPkHashReq>() / 4] = transmute!(req);
+    let mut resp32: [u32; core::mem::size_of::<InstallOwnerPkHashResp>() / 4] =
+        transmute!(InstallOwnerPkHashResp::default());
+
+    if let Err(err) = soc_manager.exec_mailbox_req_u32(
+        CommandId::INSTALL_OWNER_PK_HASH.into(),
+        &mut req32,
+        &mut resp32,
+    ) {
+        let _ = err;
+        caliptra_mcu_romtime::println!("[mcu-rom-dot] INSTALL_OWNER_PK_HASH failed");
+        return Err(McuError::ROM_DOT_INSTALL_OWNER_PK_HASH_FAILED);
+    }
+    Ok(())
 }
 
 /// Caliptra Cryptographic Mailbox Key (CMK) handle.

--- a/rom/src/rom.rs
+++ b/rom/src/rom.rs
@@ -302,8 +302,8 @@ impl Soc {
             .unwrap_or_else(|_| fatal_error(McuError::ROM_OTP_READ_ERROR));
         self.registers.fuse_mldsa_revocation.set(word);
 
-        // Owner PK Hash is written separately after Device Ownership Transfer flow.
-        // See set_owner_pk_hash() method.
+        // Owner PK hash is sent via mailbox after the DOT flow; see
+        // device_ownership_transfer::install_owner_pk_hash().
 
         // TODO: load HEK Seed CSRs.
         // SoC Stepping ID (only 16-bits are relevant).
@@ -443,29 +443,6 @@ impl Soc {
             caliptra_mcu_romtime::println!("[mcu-rom] Setting DMA user");
             self.set_ss_caliptra_dma_axi_user(dma_user);
         }
-    }
-
-    /// Sets the owner public key hash in Caliptra's SoC interface registers.
-    ///
-    /// This is called after Device Ownership Transfer (DOT) flow completes to set
-    /// the owner PK hash from either the DOT blob or the fuses.
-    ///
-    /// # Arguments
-    /// * `owner_pk_hash` - The owner public key hash to set.
-    pub fn set_owner_pk_hash(&self, owner_pk_hash: &crate::fuses::OwnerPkHash) {
-        caliptra_mcu_romtime::print!("[mcu-fuse-write] Writing owner PK hash: ");
-        for (i, word) in owner_pk_hash.0.iter().enumerate() {
-            caliptra_mcu_romtime::print!("{}", HexWord(*word));
-            self.registers.cptra_owner_pk_hash[i].set(*word);
-        }
-        caliptra_mcu_romtime::println!("");
-    }
-
-    /// Locks the owner public key hash register.
-    ///
-    /// Once locked, the owner PK hash cannot be modified until the next reset.
-    pub fn lock_owner_pk_hash(&self) {
-        self.registers.cptra_owner_pk_hash_lock.set(1);
     }
 
     pub fn fuse_write_done(&self) {
@@ -739,6 +716,10 @@ pub struct RomParameters<'a> {
     pub dot_stable_key_type: Option<CmStableKeyType>,
     /// Flash storage interface for DOT blob.
     pub dot_flash: Option<&'a dyn FlashStorage>,
+    /// Selects whether the owner PK hash comes from the DOT flow (with fuse
+    /// fallback) or is forced to the `CPTRA_SS_OWNER_PK_HASH` fuse, bypassing
+    /// the DOT blob. Default: [`OwnerPkHashPolicy::DotThenFuse`].
+    pub owner_pk_hash_policy: crate::device_ownership_transfer::OwnerPkHashPolicy,
     /// Recovery handler for recovering from corrupted DOT blob in ODD state (backup blob flow).
     pub dot_recovery_handler: Option<&'a dyn crate::DotRecoveryHandler>,
     /// Whether to attempt backup-blob recovery.

--- a/tests/integration/src/lib.rs
+++ b/tests/integration/src/lib.rs
@@ -80,6 +80,9 @@ mod test {
         /// Custom OTP memory contents. If provided, takes precedence over dot_enabled.
         pub otp_memory: Option<Vec<u8>>,
         pub flash_boot: bool,
+        /// If true, drive the MCI generic input wire strap that forces the ROM
+        /// to use the `CPTRA_SS_OWNER_PK_HASH` fuse as the owner, bypassing DOT.
+        pub force_fuse_owner_pk_hash: bool,
         /// ROM feature flag. If set, compiles a ROM with this feature enabled.
         pub rom_feature: Option<&'a str>,
         pub active_i3c1: bool,
@@ -118,6 +121,7 @@ mod test {
                 custom_caliptra_fw: None,
                 otp_memory: None,
                 flash_boot: false,
+                force_fuse_owner_pk_hash: false,
                 rom_feature: None,
                 active_i3c1: false,
                 lifecycle_controller_state: None,
@@ -1179,6 +1183,7 @@ mod test {
             lifecycle_controller_state: params.lifecycle_controller_state,
             primary_flash_initial_contents,
             flash_boot: params.flash_boot,
+            force_fuse_owner_pk_hash: params.force_fuse_owner_pk_hash,
             active_i3c1: params.active_i3c1,
             debug_intent: params.debug_intent,
             prod_dbg_unlock_keypairs: params

--- a/tests/integration/src/test_dot.rs
+++ b/tests/integration/src/test_dot.rs
@@ -137,6 +137,20 @@ mod test {
         blob.with_hmac(&hmac)
     }
 
+    /// Build OTP memory with DOT enabled and the `CPTRA_SS_OWNER_PK_HASH` fuse
+    /// provisioned to `owner`, so the forced-fuse owner path has a value to use.
+    fn build_dot_otp_with_owner_pk_hash(owner: [u8; 48]) -> Vec<u8> {
+        use caliptra_mcu_registers_generated::fuses::{
+            OTP_CPTRA_SS_OWNER_PK_HASH, VENDOR_NON_SECRET_PROD_PARTITION_BYTE_OFFSET,
+        };
+        let mut otp = vec![0u8; VENDOR_NON_SECRET_PROD_PARTITION_BYTE_OFFSET + 256];
+        // dot_initialized = 1 (backed by 3 bits) at the start of the partition.
+        otp[VENDOR_NON_SECRET_PROD_PARTITION_BYTE_OFFSET] = 0x7;
+        let off = OTP_CPTRA_SS_OWNER_PK_HASH.byte_offset;
+        otp[off..off + OTP_CPTRA_SS_OWNER_PK_HASH.byte_size].copy_from_slice(&owner);
+        otp
+    }
+
     fn compute_hmac_cached(blob: &[u8]) -> Vec<u8> {
         compute_hmac(blob)
     }
@@ -687,6 +701,86 @@ mod test {
             fatal_error.is_none(),
             "Empty DOT blob in EVEN state should not be a fatal error, got: 0x{:x}",
             fatal_error.unwrap_or(0)
+        );
+
+        lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// The force-fuse-owner strap (MCI generic input wire bit 28) makes the ROM
+    /// bypass a valid DOT blob and use the `CPTRA_SS_OWNER_PK_HASH` fuse instead.
+    #[test]
+    fn test_dot_force_fuse_owner_bypasses_blob() {
+        let lock = TEST_LOCK.lock().unwrap();
+        lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
+        // A valid DOT blob whose CAK would normally be processed by the DOT flow.
+        let blob = create_valid_dot_blob(get_owner_pk_hash(), test_lak());
+        let flash_contents = blob.to_flash_contents();
+
+        // Provision a non-zero owner PK hash fuse so the forced fuse owner exists.
+        let otp = build_dot_otp_with_owner_pk_hash([0x11u8; 48]);
+
+        let mut hw = start_runtime_hw_model(TestParams {
+            dot_flash_initial_contents: Some(flash_contents),
+            otp_memory: Some(otp),
+            rom_only: true,
+            force_fuse_owner_pk_hash: true,
+            ..Default::default()
+        });
+
+        // Run until the bypass is logged, a fatal error occurs, or we time out.
+        hw.step_until(|m| {
+            m.output().peek().contains("Forcing fused owner PK hash")
+                || m.mci_fw_fatal_error().is_some()
+                || m.cycle_count() > 50_000_000
+        });
+
+        let fatal_error = hw.mci_fw_fatal_error();
+        assert!(
+            fatal_error.is_none(),
+            "Forced fuse owner boot should not fatal: 0x{:x}",
+            fatal_error.unwrap_or(0)
+        );
+
+        let output = hw.output().peek().to_string();
+        assert!(
+            output.contains("Forcing fused owner PK hash"),
+            "Expected force-fuse bypass message in ROM output"
+        );
+        // The DOT flow must be skipped entirely.
+        assert!(
+            !output.contains("Performing Device Ownership Transfer flow"),
+            "DOT flow should be bypassed when force-fuse-owner is set"
+        );
+
+        lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// Forcing the fuse owner with an unprovisioned (all-zero)
+    /// `CPTRA_SS_OWNER_PK_HASH` fuse is a fatal error.
+    #[test]
+    fn test_dot_force_fuse_owner_unprovisioned_fails() {
+        let lock = TEST_LOCK.lock().unwrap();
+        lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
+        let blob = create_valid_dot_blob(get_owner_pk_hash(), test_lak());
+        let flash_contents = blob.to_flash_contents();
+
+        // dot_enabled auto-OTP leaves CPTRA_SS_OWNER_PK_HASH all-zero.
+        let mut hw = start_runtime_hw_model(TestParams {
+            dot_flash_initial_contents: Some(flash_contents),
+            rom_only: true,
+            dot_enabled: true,
+            force_fuse_owner_pk_hash: true,
+            ..Default::default()
+        });
+
+        hw.step_until(|m| m.mci_fw_fatal_error().is_some() || m.cycle_count() > 20_000_000);
+
+        assert_eq!(
+            u32::from(McuError::ROM_DOT_FORCE_FUSE_OWNER_NOT_PROVISIONED),
+            hw.mci_fw_fatal_error().unwrap_or(0),
+            "Expected force-fuse unprovisioned fatal error"
         );
 
         lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);


### PR DESCRIPTION
The cptra_owner_pk_hash register is locked once fuse write done is set, so
writing it directly dropped the value; send it via INSTALL_OWNER_PK_HASH
instead, skipping the all-zero unprovisioned case.
    
Also add an OwnerPkHashPolicy RomParameter (DotThenFuse default / ForceFuse).
ForceFuse bypasses the DOT blob and uses CPTRA_SS_OWNER_PK_HASH, fataling if
that fuse is unprovisioned; the emulator and FPGA ROMs select it from MCI
generic input wire bit 28.
