### PR TITLE
Reduce SPDM-lite User-app flash size

### DIFF
--- a/platforms/emulator/runtime/userspace/apps/user/src/spdm/caliptra_vdm.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/spdm/caliptra_vdm.rs
@@ -140,7 +140,9 @@ fn copy_bytes(src: &[u8], out: &mut [u8]) -> CaliptraVdmResult<usize> {
     if src.len() > out.len() {
         return Err(CaliptraCompletionCode::InsufficientResources);
     }
-    out[..src.len()].copy_from_slice(src);
+    for (d, s) in out.iter_mut().zip(src) {
+        *d = *s;
+    }
     Ok(src.len())
 }
 

--- a/platforms/emulator/runtime/userspace/apps/user/src/spdm/cert_store/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/spdm/cert_store/mod.rs
@@ -109,12 +109,11 @@ async fn populate_idev_from_otp<A: ApiAlloc>(alloc: &A) -> McuResult<()> {
             .map_err(|_| mcu_error::codes::INTERNAL_BUG)?;
         // Panic-free word store: fixed-size array write lowers to a memcpy with
         // no bounds/length panic (loop guard guarantees 4 bytes of room).
-        if let Some(slot) = cert_buf
+        let slot = cert_buf
             .get_mut(offset as usize..)
             .and_then(|s| s.first_chunk_mut::<4>())
-        {
-            *slot = word.to_le_bytes();
-        }
+            .ok_or(mcu_error::codes::INVARIANT)?;
+        *slot = word.to_le_bytes();
         offset += 4;
     }
     // Handle remaining 3 bytes (547 % 4 == 3).

--- a/platforms/emulator/runtime/userspace/apps/user/src/spdm/cert_store/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/spdm/cert_store/mod.rs
@@ -107,7 +107,14 @@ async fn populate_idev_from_otp<A: ApiAlloc>(alloc: &A) -> McuResult<()> {
             .read(OTP_IDEVID_ECC_PARTITION, offset)
             .await
             .map_err(|_| mcu_error::codes::INTERNAL_BUG)?;
-        cert_buf[offset as usize..offset as usize + 4].copy_from_slice(&word.to_le_bytes());
+        // Panic-free word store: fixed-size array write lowers to a memcpy with
+        // no bounds/length panic (loop guard guarantees 4 bytes of room).
+        if let Some(slot) = cert_buf
+            .get_mut(offset as usize..)
+            .and_then(|s| s.first_chunk_mut::<4>())
+        {
+            *slot = word.to_le_bytes();
+        }
         offset += 4;
     }
     // Handle remaining 3 bytes (547 % 4 == 3).
@@ -119,8 +126,13 @@ async fn populate_idev_from_otp<A: ApiAlloc>(alloc: &A) -> McuResult<()> {
             .map_err(|_| mcu_error::codes::INTERNAL_BUG)?;
         let word_bytes = word.to_le_bytes();
         let skip = (offset - tail_offset) as usize;
-        for i in skip..4 {
-            cert_buf[tail_offset as usize + i] = word_bytes[i];
+        // Panic-free tail store: copy word_bytes[skip..] without indexing.
+        for (d, s) in cert_buf
+            .iter_mut()
+            .skip(tail_offset as usize + skip)
+            .zip(word_bytes.iter().skip(skip))
+        {
+            *d = *s;
         }
     }
 

--- a/platforms/emulator/runtime/userspace/apps/user/src/spdm/device_measurements/ocp_eat/claims.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/spdm/device_measurements/ocp_eat/claims.rs
@@ -22,12 +22,40 @@ pub async fn generate_claims(
 ) -> McuResult<usize> {
     let pcr_value = get_pcr_value(alloc, PLATFORM_STATE_PCR_INDEX).await?;
 
-    if claims_buf.len() < EAT_PAYLOAD_LEN {
-        return Err(mcu_error::codes::INTERNAL_BUG);
+    // Nonce from SPDM is variable-length; pad/truncate to 32 bytes.
+    // `iter_mut().zip(...)` avoids the `copy_from_slice` length-check
+    // panic site (and its file/Location rodata cost).
+    let mut nonce_buf = [0u8; 32];
+    for (dst, src) in nonce_buf.iter_mut().zip(nonce.iter().take(32)) {
+        *dst = *src;
     }
-    claims_buf[..EAT_PAYLOAD_LEN].copy_from_slice(&EAT_PAYLOAD_TEMPLATE);
-    claims_buf[NONCE_OFFSET..NONCE_OFFSET + SPDM_NONCE_LEN].copy_from_slice(nonce);
-    claims_buf[MEASUREMENT_DIGEST_OFFSETS[0]..MEASUREMENT_DIGEST_OFFSETS[0] + 48]
-        .copy_from_slice(&pcr_value);
+
+    // Convert the output prefix to a fixed-size array reference once;
+    // this is the only panic site for the whole function (single
+    // `Location` shared by all writes below).
+    let claims_array: &mut [u8; EAT_PAYLOAD_LEN] = claims_buf
+        .first_chunk_mut::<EAT_PAYLOAD_LEN>()
+        .ok_or(mcu_error::codes::INTERNAL_BUG)?;
+    *claims_array = EAT_PAYLOAD_TEMPLATE;
+
+    // Splice nonce and PCR digest at compile-time-known offsets.
+    const _: () = assert!(NONCE_OFFSET + 32 <= EAT_PAYLOAD_LEN);
+    const _: () = assert!(MEASUREMENT_DIGEST_OFFSETS[0] + 48 <= EAT_PAYLOAD_LEN);
+    // SAFETY: the const asserts above prove both writes stay inside
+    // the `[u8; EAT_PAYLOAD_LEN]` `claims_array`. Source slices are
+    // 32 and 48 bytes respectively, matching the copy lengths.
+    unsafe {
+        core::ptr::copy_nonoverlapping(
+            nonce_buf.as_ptr(),
+            claims_array.as_mut_ptr().add(NONCE_OFFSET),
+            32,
+        );
+        core::ptr::copy_nonoverlapping(
+            pcr_value.as_ptr(),
+            claims_array.as_mut_ptr().add(MEASUREMENT_DIGEST_OFFSETS[0]),
+            48,
+        );
+    }
+
     Ok(EAT_PAYLOAD_LEN)
 }

--- a/platforms/emulator/runtime/userspace/apps/user/src/spdm/device_measurements/ocp_eat/claims.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/spdm/device_measurements/ocp_eat/claims.rs
@@ -38,24 +38,17 @@ pub async fn generate_claims(
         .ok_or(mcu_error::codes::INTERNAL_BUG)?;
     *claims_array = EAT_PAYLOAD_TEMPLATE;
 
-    // Splice nonce and PCR digest at compile-time-known offsets.
-    const _: () = assert!(NONCE_OFFSET + 32 <= EAT_PAYLOAD_LEN);
-    const _: () = assert!(MEASUREMENT_DIGEST_OFFSETS[0] + 48 <= EAT_PAYLOAD_LEN);
-    // SAFETY: the const asserts above prove both writes stay inside
-    // the `[u8; EAT_PAYLOAD_LEN]` `claims_array`. Source slices are
-    // 32 and 48 bytes respectively, matching the copy lengths.
-    unsafe {
-        core::ptr::copy_nonoverlapping(
-            nonce_buf.as_ptr(),
-            claims_array.as_mut_ptr().add(NONCE_OFFSET),
-            32,
-        );
-        core::ptr::copy_nonoverlapping(
-            pcr_value.as_ptr(),
-            claims_array.as_mut_ptr().add(MEASUREMENT_DIGEST_OFFSETS[0]),
-            48,
-        );
-    }
+    let nonce_slot = claims_array
+        .get_mut(NONCE_OFFSET..)
+        .and_then(|s| s.first_chunk_mut::<32>())
+        .ok_or(mcu_error::codes::INTERNAL_BUG)?;
+    *nonce_slot = nonce_buf;
+
+    let digest_slot = claims_array
+        .get_mut(MEASUREMENT_DIGEST_OFFSETS[0]..)
+        .and_then(|s| s.first_chunk_mut::<48>())
+        .ok_or(mcu_error::codes::INTERNAL_BUG)?;
+    *digest_slot = pcr_value;
 
     Ok(EAT_PAYLOAD_LEN)
 }

--- a/platforms/emulator/runtime/userspace/apps/user/src/spdm/device_measurements/ocp_eat/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/spdm/device_measurements/ocp_eat/mod.rs
@@ -102,6 +102,8 @@ impl MeasurementProvider for OcpEatMeasurementProvider {
 /// Compute kid = SHA-384(pubkey_x || pubkey_y) from DPE certify_key.
 ///
 /// All mailbox buffers are allocated via `alloc` (BitmapAllocator).
+/// `pubkey_x`/`pubkey_y` are streamed directly into SHA, so no
+/// 96-byte concat buffer lives on the async stack.
 async fn compute_kid(
     key_label: &[u8; DPE_LABEL_LEN],
     alloc: &BitmapAllocator,

--- a/platforms/emulator/runtime/userspace/apps/user/src/spdm/endorsement_certs/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/spdm/endorsement_certs/mod.rs
@@ -42,7 +42,13 @@ async fn populate_idev_cert() -> CertStoreResult<()> {
             .read(0x01, offset)
             .await
             .map_err(|_| CertStoreError::CertReadError)?;
-        cert_buf[offset as usize..offset as usize + 4].copy_from_slice(&word.to_le_bytes());
+        // Panic-free word store: fixed-size array write -> memcpy, no panic.
+        if let Some(slot) = cert_buf
+            .get_mut(offset as usize..)
+            .and_then(|s| s.first_chunk_mut::<4>())
+        {
+            *slot = word.to_le_bytes();
+        }
         offset += 4;
     }
     // Handle remaining 3 bytes (547 % 4 == 3).
@@ -54,8 +60,13 @@ async fn populate_idev_cert() -> CertStoreResult<()> {
             .map_err(|_| CertStoreError::CertReadError)?;
         let word_bytes = word.to_le_bytes();
         let skip = (offset - tail_offset) as usize;
-        for i in skip..4 {
-            cert_buf[tail_offset as usize + i] = word_bytes[i];
+        // Panic-free tail store: copy word_bytes[skip..] without indexing.
+        for (d, s) in cert_buf
+            .iter_mut()
+            .skip(tail_offset as usize + skip)
+            .zip(word_bytes.iter().skip(skip))
+        {
+            *d = *s;
         }
     }
 
@@ -131,7 +142,10 @@ impl PayloadStream for OtpPayloadStream {
                 .read(self.partition_id, self.cursor as u32)
                 .await
                 .map_err(|_| ErrorCode::Fail)?;
-            buffer[written..written + 4].copy_from_slice(&word.to_le_bytes());
+            // Fixed-size array write -> memcpy, no panic.
+            if let Some(slot) = buffer.get_mut(written..).and_then(|s| s.first_chunk_mut::<4>()) {
+                *slot = word.to_le_bytes();
+            }
             written += 4;
             self.cursor += 4;
         }
@@ -145,8 +159,10 @@ impl PayloadStream for OtpPayloadStream {
                 .await
                 .map_err(|_| ErrorCode::Fail)?;
             let word_bytes = word.to_le_bytes();
-            let n = tail_len.min(buffer.len() - written);
-            buffer[written..written + n].copy_from_slice(&word_bytes[..n]);
+            let n = tail_len.min(buffer.len().saturating_sub(written));
+            for (d, s) in buffer.iter_mut().skip(written).zip(word_bytes.iter().take(n)) {
+                *d = *s;
+            }
             written += n;
             self.cursor += n;
         }
@@ -227,7 +243,8 @@ impl EndorsementCertChainTrait for EndorsementCertChain<'_> {
         if asym_algo != AsymAlgo::EccP384 {
             return Err(CertStoreError::UnsupportedAsymAlgo);
         }
-        root_hash.copy_from_slice(&self.root_cert_hash);
+        // Equal fixed-size arrays: a direct copy lowers to memcpy, no panic.
+        *root_hash = self.root_cert_hash;
         Ok(())
     }
 
@@ -257,8 +274,18 @@ impl EndorsementCertChainTrait for EndorsementCertChain<'_> {
 
         for cert in self.root_cert_chain.iter() {
             if cert_offset < cert.len() {
-                let len = (cert.len() - cert_offset).min(buf.len() - pos);
-                buf[pos..pos + len].copy_from_slice(&cert[cert_offset..cert_offset + len]);
+                let len = cert
+                    .len()
+                    .saturating_sub(cert_offset)
+                    .min(buf.len().saturating_sub(pos));
+                if let (Some(dst), Some(src)) = (
+                    buf.get_mut(pos..pos + len),
+                    cert.get(cert_offset..cert_offset + len),
+                ) {
+                    for (d, s) in dst.iter_mut().zip(src.iter()) {
+                        *d = *s;
+                    }
+                }
                 pos += len;
                 cert_offset = 0; // Reset offset for subsequent certs
                 if pos == buf.len() {

--- a/platforms/emulator/runtime/userspace/apps/user/src/spdm/endorsement_certs/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/spdm/endorsement_certs/mod.rs
@@ -43,12 +43,11 @@ async fn populate_idev_cert() -> CertStoreResult<()> {
             .await
             .map_err(|_| CertStoreError::CertReadError)?;
         // Panic-free word store: fixed-size array write -> memcpy, no panic.
-        if let Some(slot) = cert_buf
+        let slot = cert_buf
             .get_mut(offset as usize..)
             .and_then(|s| s.first_chunk_mut::<4>())
-        {
-            *slot = word.to_le_bytes();
-        }
+            .ok_or(CertStoreError::CertReadError)?;
+        *slot = word.to_le_bytes();
         offset += 4;
     }
     // Handle remaining 3 bytes (547 % 4 == 3).

--- a/runtime/userspace/api/caliptra-api-lite/src/aes_gcm.rs
+++ b/runtime/userspace/api/caliptra-api-lite/src/aes_gcm.rs
@@ -164,8 +164,8 @@ async fn spdm_init<'a, A: ApiAlloc>(
     // For SPDM secured messages the counter is always little-endian,
     // so flag bit 8 = 0.
     pfx.spdm_flags = U32::new(spdm_version as u32);
-    pfx.spdm_counter.copy_from_slice(seq_number);
-    pfx.cmk.copy_from_slice(&cmk.0);
+    pfx.spdm_counter = *seq_number;
+    pfx.cmk = cmk.0;
     pfx.aad_size = U32::new(aad.len() as u32);
     req[prefix_len..prefix_len + aad.len()].copy_from_slice(aad);
     populate_checksum(cmd, &mut req)?;
@@ -237,7 +237,7 @@ pub async fn spdm_aes_gcm_encrypt_update<'a, A: ApiAlloc>(
     req.fill(0);
     let pfx =
         EncryptDataReqPrefix::mut_from_bytes(&mut req[..prefix_len]).map_err(|_| INVARIANT)?;
-    pfx.context.copy_from_slice(ctx);
+    pfx.context = *ctx.first_chunk::<AES_GCM_CTX_SIZE>().ok_or(INVARIANT)?;
     pfx.plaintext_size = U32::new(chunk.len() as u32);
     req[prefix_len..prefix_len + chunk.len()].copy_from_slice(chunk);
     populate_checksum(CMD_CM_AES_GCM_ENCRYPT_UPDATE, &mut req)?;
@@ -287,7 +287,7 @@ pub async fn spdm_aes_gcm_encrypt_final<A: ApiAlloc>(
     req.fill(0);
     let pfx =
         EncryptDataReqPrefix::mut_from_bytes(&mut req[..prefix_len]).map_err(|_| INVARIANT)?;
-    pfx.context.copy_from_slice(ctx);
+    pfx.context = *ctx.first_chunk::<AES_GCM_CTX_SIZE>().ok_or(INVARIANT)?;
     pfx.plaintext_size = U32::new(chunk.len() as u32);
     req[prefix_len..prefix_len + chunk.len()].copy_from_slice(chunk);
     populate_checksum(CMD_CM_AES_GCM_ENCRYPT_FINAL, &mut req)?;
@@ -299,8 +299,10 @@ pub async fn spdm_aes_gcm_encrypt_final<A: ApiAlloc>(
     }
 
     // Parse tag at offset 8
-    let mut tag = [0u8; 16];
-    tag.copy_from_slice(&rsp[MBOX_RESP_HEADER_SIZE..MBOX_RESP_HEADER_SIZE + 16]);
+    let tag = *rsp
+        .get(MBOX_RESP_HEADER_SIZE..)
+        .and_then(|s| s.first_chunk::<16>())
+        .ok_or(INTERNAL_BUG)?;
 
     let ct_size_off = MBOX_RESP_HEADER_SIZE + 16;
     let ct_size = u32::from_le_bytes([
@@ -394,9 +396,9 @@ pub async fn spdm_aes_gcm_decrypt_final<A: ApiAlloc>(
     req.fill(0);
     let pfx =
         DecryptFinalReqPrefix::mut_from_bytes(&mut req[..prefix_len]).map_err(|_| INVARIANT)?;
-    pfx.context.copy_from_slice(ctx);
+    pfx.context = *ctx.first_chunk::<AES_GCM_CTX_SIZE>().ok_or(INVARIANT)?;
     pfx.tag_len = U32::new(16);
-    pfx.tag.copy_from_slice(tag);
+    pfx.tag = *tag;
     pfx.ciphertext_size = U32::new(chunk.len() as u32);
     req[prefix_len..prefix_len + chunk.len()].copy_from_slice(chunk);
     populate_checksum(CMD_CM_AES_GCM_DECRYPT_FINAL, &mut req)?;

--- a/runtime/userspace/api/caliptra-api-lite/src/device_state.rs
+++ b/runtime/userspace/api/caliptra-api-lite/src/device_state.rs
@@ -96,9 +96,8 @@ pub async fn get_pcr_value<A: ApiAlloc>(
     // Build request (zero nonce — we don't verify the quote signature).
     let mut req = alloc.alloc(REQ_SIZE)?;
     req.fill(0);
-    let (cs_slot, body): (&mut [u8; 4], &mut [u8]) = req
-        .split_first_chunk_mut::<4>()
-        .ok_or(INVARIANT)?;
+    let (cs_slot, body): (&mut [u8; 4], &mut [u8]) =
+        req.split_first_chunk_mut::<4>().ok_or(INVARIANT)?;
     *cs_slot = calc_checksum(CMD_QUOTE_PCRS_ECC384, body).to_le_bytes();
 
     // Execute mailbox command.

--- a/runtime/userspace/api/caliptra-api-lite/src/device_state.rs
+++ b/runtime/userspace/api/caliptra-api-lite/src/device_state.rs
@@ -96,8 +96,10 @@ pub async fn get_pcr_value<A: ApiAlloc>(
     // Build request (zero nonce — we don't verify the quote signature).
     let mut req = alloc.alloc(REQ_SIZE)?;
     req.fill(0);
-    let checksum = calc_checksum(CMD_QUOTE_PCRS_ECC384, &req[4..]);
-    req[..4].copy_from_slice(&checksum.to_le_bytes());
+    let (cs_slot, body): (&mut [u8; 4], &mut [u8]) = req
+        .split_first_chunk_mut::<4>()
+        .ok_or(INVARIANT)?;
+    *cs_slot = calc_checksum(CMD_QUOTE_PCRS_ECC384, body).to_le_bytes();
 
     // Execute mailbox command.
     let mut rsp = alloc.alloc(RSP_SIZE)?;
@@ -107,9 +109,11 @@ pub async fn get_pcr_value<A: ApiAlloc>(
         return Err(INVARIANT);
     }
 
-    // Extract pcrs[pcr_index] from the response.
+    // Extract pcrs[pcr_index] from the response as a 48-byte chunk.
     let offset = MBOX_RESP_HEADER_SIZE + pcr_index * PCR_VALUE_SIZE;
-    let mut digest = [0u8; PCR_VALUE_SIZE];
-    digest.copy_from_slice(&rsp[offset..offset + PCR_VALUE_SIZE]);
-    Ok(digest)
+    let digest_slot: &[u8; PCR_VALUE_SIZE] = rsp
+        .get(offset..offset + PCR_VALUE_SIZE)
+        .and_then(|s| s.try_into().ok())
+        .ok_or(INVARIANT)?;
+    Ok(*digest_slot)
 }

--- a/runtime/userspace/api/caliptra-api-lite/src/dpe.rs
+++ b/runtime/userspace/api/caliptra-api-lite/src/dpe.rs
@@ -286,8 +286,8 @@ pub async fn dpe_certify_key_pubkey<A: ApiAlloc>(
     pubkey_y: &mut [u8; 48],
 ) -> McuResult<()> {
     certify_key_response(alloc, label, |resp_prefix, _cert| {
-        pubkey_x.copy_from_slice(&resp_prefix.derived_pubkey_x);
-        pubkey_y.copy_from_slice(&resp_prefix.derived_pubkey_y);
+        *pubkey_x = resp_prefix.derived_pubkey_x;
+        *pubkey_y = resp_prefix.derived_pubkey_y;
         Ok(())
     })
     .await

--- a/runtime/userspace/api/caliptra-api-lite/src/dpe.rs
+++ b/runtime/userspace/api/caliptra-api-lite/src/dpe.rs
@@ -211,7 +211,7 @@ pub async fn dpe_get_cert_chain_chunk<A: ApiAlloc>(
         cmd.size = U32::new(size);
     }
     let checksum = calc_checksum(CMD_INVOKE_DPE, &req);
-    req[..4].copy_from_slice(&checksum.to_le_bytes());
+    *req.first_chunk_mut::<4>().ok_or(INVARIANT)? = checksum.to_le_bytes();
 
     // Allocate response: outer prefix + DPE response hdr + cert_size
     // + chain bytes (up to DPE_MAX_CHUNK_SIZE).
@@ -236,9 +236,11 @@ pub async fn dpe_get_cert_chain_chunk<A: ApiAlloc>(
         return Err(INTERNAL_BUG);
     }
 
-    let mut cert_size_buf = [0u8; 4];
-    cert_size_buf.copy_from_slice(&rsp[cert_size_off..cert_size_off + 4]);
-    let cert_size = u32::from_le_bytes(cert_size_buf) as usize;
+    let cert_size = u32::from_le_bytes(
+        *rsp.get(cert_size_off..)
+            .and_then(|s| s.first_chunk::<4>())
+            .ok_or(INTERNAL_BUG)?,
+    ) as usize;
     if cert_size > dst.len() || chain_off + cert_size > rsp_len {
         return Err(INTERNAL_BUG);
     }
@@ -362,10 +364,10 @@ fn build_certify_key_req<'a, A: ApiAlloc>(
                 .map_err(|_| INVARIANT)?;
         cmd.flags = U32::new(0);
         cmd.format = U32::new(DPE_CERTIFY_KEY_FORMAT_X509);
-        cmd.label.copy_from_slice(label);
+        cmd.label = *label;
     }
     let checksum = calc_checksum(CMD_INVOKE_DPE, &req);
-    req[..4].copy_from_slice(&checksum.to_le_bytes());
+    *req.first_chunk_mut::<4>().ok_or(INVARIANT)? = checksum.to_le_bytes();
     Ok(req)
 }
 
@@ -441,12 +443,12 @@ pub async fn dpe_sign_ecc_p384<A: ApiAlloc>(
     {
         let cmd = SignP384Cmd::mut_from_bytes(&mut req[cur..cur + size_of::<SignP384Cmd>()])
             .map_err(|_| INVARIANT)?;
-        cmd.label.copy_from_slice(label);
+        cmd.label = *label;
         cmd.flags = U32::new(0);
-        cmd.digest.copy_from_slice(&digest[..DPE_LABEL_LEN]);
+        cmd.digest = *digest.first_chunk::<DPE_LABEL_LEN>().ok_or(INVARIANT)?;
     }
     let checksum = calc_checksum(CMD_INVOKE_DPE, &req);
-    req[..4].copy_from_slice(&checksum.to_le_bytes());
+    *req.first_chunk_mut::<4>().ok_or(INVARIANT)? = checksum.to_le_bytes();
 
     let rsp_max = size_of::<InvokeDpeRespPrefix>() + size_of::<SignP384RespBody>();
     let mut rsp = alloc.alloc(rsp_max)?;
@@ -470,7 +472,9 @@ pub async fn dpe_sign_ecc_p384<A: ApiAlloc>(
         &rsp[resp_body_off..resp_body_off + size_of::<SignP384RespBody>()],
     )
     .map_err(|_| INTERNAL_BUG)?;
-    signature[..48].copy_from_slice(&sign_resp.sig_r);
-    signature[48..96].copy_from_slice(&sign_resp.sig_s);
+    let (sig_r, rest) = signature.split_first_chunk_mut::<48>().ok_or(INVARIANT)?;
+    *sig_r = sign_resp.sig_r;
+    let (sig_s, _) = rest.split_first_chunk_mut::<48>().ok_or(INVARIANT)?;
+    *sig_s = sign_resp.sig_s;
     Ok(DPE_P384_SIGNATURE_SIZE)
 }

--- a/runtime/userspace/api/caliptra-api-lite/src/ecdh.rs
+++ b/runtime/userspace/api/caliptra-api-lite/src/ecdh.rs
@@ -90,10 +90,19 @@ pub async fn ecdh_generate<A: ApiAlloc>(
 
     let ctx_start = MBOX_RESP_HEADER_SIZE;
     let ctx_end = ctx_start + CMB_ECDH_ENCRYPTED_CONTEXT_SIZE;
-    let xd_end = ctx_end + CMB_ECDH_EXCHANGE_DATA_MAX_SIZE;
 
-    context.copy_from_slice(&rsp[ctx_start..ctx_end]);
-    exchange_data.copy_from_slice(&rsp[ctx_end..xd_end]);
+    *context
+        .first_chunk_mut::<CMB_ECDH_ENCRYPTED_CONTEXT_SIZE>()
+        .ok_or(INVARIANT)? = *rsp
+        .get(ctx_start..)
+        .and_then(|s| s.first_chunk::<CMB_ECDH_ENCRYPTED_CONTEXT_SIZE>())
+        .ok_or(INTERNAL_BUG)?;
+    *exchange_data
+        .first_chunk_mut::<CMB_ECDH_EXCHANGE_DATA_MAX_SIZE>()
+        .ok_or(INVARIANT)? = *rsp
+        .get(ctx_end..)
+        .and_then(|s| s.first_chunk::<CMB_ECDH_EXCHANGE_DATA_MAX_SIZE>())
+        .ok_or(INTERNAL_BUG)?;
     Ok(())
 }
 
@@ -121,10 +130,15 @@ pub async fn ecdh_finish<A: ApiAlloc>(
     req.fill(0);
     let prefix_len = size_of::<EcdhFinishReqPrefix>();
     let pfx = EcdhFinishReqPrefix::mut_from_bytes(&mut req[..prefix_len]).map_err(|_| INVARIANT)?;
-    pfx.context.copy_from_slice(context);
+    pfx.context = *context
+        .first_chunk::<CMB_ECDH_ENCRYPTED_CONTEXT_SIZE>()
+        .ok_or(INVARIANT)?;
     pfx.key_usage = U32::new(key_usage as u32);
-    req[prefix_len..prefix_len + CMB_ECDH_EXCHANGE_DATA_MAX_SIZE]
-        .copy_from_slice(peer_exchange_data);
+    *req.get_mut(prefix_len..)
+        .and_then(|s| s.first_chunk_mut::<CMB_ECDH_EXCHANGE_DATA_MAX_SIZE>())
+        .ok_or(INVARIANT)? = *peer_exchange_data
+        .first_chunk::<CMB_ECDH_EXCHANGE_DATA_MAX_SIZE>()
+        .ok_or(INVARIANT)?;
     populate_checksum(CMD_CM_ECDH_FINISH, &mut req)?;
 
     let mut rsp = alloc.alloc(FINISH_RSP_SIZE)?;
@@ -133,8 +147,9 @@ pub async fn ecdh_finish<A: ApiAlloc>(
         return Err(INTERNAL_BUG);
     }
 
-    let mut cmk = Cmk::default();
-    cmk.0
-        .copy_from_slice(&rsp[MBOX_RESP_HEADER_SIZE..FINISH_RSP_SIZE]);
+    let cmk = Cmk(*rsp
+        .get(MBOX_RESP_HEADER_SIZE..)
+        .and_then(|s| s.first_chunk::<CMK_SIZE>())
+        .ok_or(INTERNAL_BUG)?);
     Ok(cmk)
 }

--- a/runtime/userspace/api/caliptra-api-lite/src/hmac.rs
+++ b/runtime/userspace/api/caliptra-api-lite/src/hmac.rs
@@ -128,7 +128,7 @@ pub async fn cm_hmac<A: ApiAlloc>(
     let mut req = alloc.alloc(wire_len)?;
     req.fill(0);
     let pfx = HmacReqPrefix::mut_from_bytes(&mut req[..prefix_len]).map_err(|_| INVARIANT)?;
-    pfx.cmk.copy_from_slice(&cmk.0);
+    pfx.cmk = cmk.0;
     pfx.hash_algorithm = U32::new(CM_HASH_ALGO_SHA384);
     pfx.data_size = U32::new(data.len() as u32);
     req[prefix_len..prefix_len + data.len()].copy_from_slice(data);
@@ -171,8 +171,8 @@ pub async fn hkdf_extract<A: ApiAlloc>(alloc: &A, salt: HkdfSalt<'_>, ikm: &Cmk)
     req.fill(0);
     let r = HkdfExtractReq::mut_from_bytes(&mut req[..req_size]).map_err(|_| INVARIANT)?;
     r.hash_algorithm = U32::new(CM_HASH_ALGO_SHA384);
-    r.salt.copy_from_slice(&salt_cmk.0);
-    r.ikm.copy_from_slice(&ikm.0);
+    r.salt = salt_cmk.0;
+    r.ikm = ikm.0;
     populate_checksum(CMD_CM_HKDF_EXTRACT, &mut req)?;
 
     let mut rsp = alloc.alloc(HKDF_EXTRACT_RSP_SIZE)?;
@@ -182,9 +182,10 @@ pub async fn hkdf_extract<A: ApiAlloc>(alloc: &A, salt: HkdfSalt<'_>, ikm: &Cmk)
         return Err(INTERNAL_BUG);
     }
 
-    let mut prk = Cmk::default();
-    prk.0
-        .copy_from_slice(&rsp[MBOX_RESP_HEADER_SIZE..HKDF_EXTRACT_RSP_SIZE]);
+    let prk = Cmk(*rsp
+        .get(MBOX_RESP_HEADER_SIZE..)
+        .and_then(|s| s.first_chunk::<CMK_SIZE>())
+        .ok_or(INTERNAL_BUG)?);
     Ok(prk)
 }
 
@@ -206,7 +207,7 @@ pub async fn hkdf_expand<A: ApiAlloc>(
     let mut req = alloc.alloc(wire_len)?;
     req.fill(0);
     let pfx = HkdfExpandReqPrefix::mut_from_bytes(&mut req[..prefix_len]).map_err(|_| INVARIANT)?;
-    pfx.prk.copy_from_slice(&prk.0);
+    pfx.prk = prk.0;
     pfx.hash_algorithm = U32::new(CM_HASH_ALGO_SHA384);
     pfx.key_usage = U32::new(key_usage as u32);
     pfx.key_size = U32::new(key_size);
@@ -220,8 +221,9 @@ pub async fn hkdf_expand<A: ApiAlloc>(
         return Err(INTERNAL_BUG);
     }
 
-    let mut okm = Cmk::default();
-    okm.0
-        .copy_from_slice(&rsp[MBOX_RESP_HEADER_SIZE..HKDF_EXPAND_RSP_SIZE]);
+    let okm = Cmk(*rsp
+        .get(MBOX_RESP_HEADER_SIZE..)
+        .and_then(|s| s.first_chunk::<CMK_SIZE>())
+        .ok_or(INTERNAL_BUG)?);
     Ok(okm)
 }

--- a/runtime/userspace/api/caliptra-api-lite/src/import.rs
+++ b/runtime/userspace/api/caliptra-api-lite/src/import.rs
@@ -79,9 +79,10 @@ pub async fn cm_import<A: ApiAlloc>(alloc: &A, usage: CmKeyUsage, data: &[u8]) -
         return Err(INTERNAL_BUG);
     }
 
-    let mut cmk = Cmk::default();
-    cmk.0
-        .copy_from_slice(&rsp[MBOX_RESP_HEADER_SIZE..IMPORT_RSP_SIZE]);
+    let cmk = Cmk(*rsp
+        .get(MBOX_RESP_HEADER_SIZE..)
+        .and_then(|s| s.first_chunk::<CMK_SIZE>())
+        .ok_or(INTERNAL_BUG)?);
     Ok(cmk)
 }
 
@@ -93,7 +94,7 @@ pub async fn cm_delete<A: ApiAlloc>(alloc: &A, cmk: &Cmk) -> McuResult<()> {
     let mut req = alloc.alloc(wire_len)?;
     req.fill(0);
     let r = DeleteReq::mut_from_bytes(&mut req[..wire_len]).map_err(|_| INVARIANT)?;
-    r.cmk.copy_from_slice(&cmk.0);
+    r.cmk = cmk.0;
     populate_checksum(CMD_CM_DELETE, &mut req)?;
 
     let mut rsp = alloc.alloc(DELETE_RSP_SIZE)?;

--- a/runtime/userspace/api/caliptra-api-lite/src/rng.rs
+++ b/runtime/userspace/api/caliptra-api-lite/src/rng.rs
@@ -40,7 +40,7 @@ pub async fn rng_generate<A: ApiAlloc>(alloc: &A, out: &mut [u8]) -> McuResult<(
         r.size = U32::new(out.len() as u32);
     }
     let checksum = calc_checksum(CMD_CM_RANDOM_GENERATE, &req);
-    req[..4].copy_from_slice(&checksum.to_le_bytes());
+    *req.first_chunk_mut::<4>().ok_or(INVARIANT)? = checksum.to_le_bytes();
 
     let rsp_max = RSP_HEADER_SIZE + MAX_RANDOM_SIZE;
     let mut rsp = alloc.alloc(rsp_max)?;

--- a/runtime/userspace/api/caliptra-api-lite/src/sha.rs
+++ b/runtime/userspace/api/caliptra-api-lite/src/sha.rs
@@ -239,7 +239,7 @@ async fn sha_call<A: ApiAlloc, B: Deref<Target = [u8]> + DerefMut>(
     if is_init {
         let prefix =
             ShaInitPrefix::mut_from_bytes(&mut req[..prefix_len]).map_err(|_| INVARIANT)?;
-        prefix.hash_algorithm = U32::new(algo.unwrap());
+        prefix.hash_algorithm = U32::new(algo.unwrap_or(0));
         prefix.input_size = U32::new(chunk_len as u32);
     } else {
         let prefix =

--- a/runtime/userspace/api/caliptra-api-lite/src/signed_eat.rs
+++ b/runtime/userspace/api/caliptra-api-lite/src/signed_eat.rs
@@ -113,8 +113,7 @@ impl<'a> SignedEatLite<'a> {
         *preamble_slot = COSE_PREAMBLE;
         let (kid_slot, rest) = rest.split_first_chunk_mut::<KID_LEN>().ok_or(INVARIANT)?;
         *kid_slot = *kid_arr;
-        let pl_hdr_len =
-            write_cose_payload_bstr_len(rest, payload.len()).ok_or(INVARIANT)?;
+        let pl_hdr_len = write_cose_payload_bstr_len(rest, payload.len()).ok_or(INVARIANT)?;
         let rest = rest.get_mut(pl_hdr_len..).ok_or(INVARIANT)?;
         let (payload_slot, rest) = rest.split_at_mut_checked(payload.len()).ok_or(INVARIANT)?;
         // Variable-length payload: still requires `copy_from_slice`,

--- a/runtime/userspace/api/caliptra-api-lite/src/signed_eat.rs
+++ b/runtime/userspace/api/caliptra-api-lite/src/signed_eat.rs
@@ -97,39 +97,50 @@ impl<'a> SignedEatLite<'a> {
         kid: &[u8],
         eat_buffer: &mut [u8],
     ) -> McuResult<usize> {
-        if kid.len() != KID_LEN {
-            return Err(INVARIANT);
-        }
+        let kid_arr: &[u8; KID_LEN] = kid.try_into().map_err(|_| INVARIANT)?;
         let cose_len = cose_sign1_len(payload.len());
         if eat_buffer.len() < cose_len {
             return Err(INVARIANT);
         }
 
-        let signature = self.sign_cose_sig_context(alloc, payload).await?;
+        // Walk `eat_buffer` with `split_first_chunk_mut` so each
+        // fixed-size write becomes a panic-free `*chunk = SRC` array
+        // assignment instead of a `copy_from_slice` length-check.
+        let rest = eat_buffer;
+        let (preamble_slot, rest) = rest
+            .split_first_chunk_mut::<{ COSE_PREAMBLE.len() }>()
+            .ok_or(INVARIANT)?;
+        *preamble_slot = COSE_PREAMBLE;
+        let (kid_slot, rest) = rest.split_first_chunk_mut::<KID_LEN>().ok_or(INVARIANT)?;
+        *kid_slot = *kid_arr;
+        let pl_hdr_len =
+            write_cose_payload_bstr_len(rest, payload.len()).ok_or(INVARIANT)?;
+        let rest = rest.get_mut(pl_hdr_len..).ok_or(INVARIANT)?;
+        let (payload_slot, rest) = rest.split_at_mut_checked(payload.len()).ok_or(INVARIANT)?;
+        // Variable-length payload: still requires `copy_from_slice`,
+        // but only one panic site for this entire function.
+        payload_slot.copy_from_slice(payload);
+        let (sig_hdr_slot, rest) = rest
+            .split_first_chunk_mut::<{ SIGNATURE_BSTR_HEADER.len() }>()
+            .ok_or(INVARIANT)?;
+        *sig_hdr_slot = SIGNATURE_BSTR_HEADER;
+        let (sig_slot, _) = rest
+            .split_first_chunk_mut::<ECDSA_P384_SIGNATURE_LEN>()
+            .ok_or(INVARIANT)?;
+        self.sign_cose_sig_context(alloc, payload, sig_slot).await?;
 
-        let mut pos = 0;
-        eat_buffer[pos..pos + COSE_PREAMBLE.len()].copy_from_slice(&COSE_PREAMBLE);
-        pos += COSE_PREAMBLE.len();
-        eat_buffer[pos..pos + KID_LEN].copy_from_slice(kid);
-        pos += KID_LEN;
-        pos +=
-            write_cose_payload_bstr_len(&mut eat_buffer[pos..], payload.len()).ok_or(INVARIANT)?;
-        eat_buffer[pos..pos + payload.len()].copy_from_slice(payload);
-        pos += payload.len();
-        eat_buffer[pos..pos + SIGNATURE_BSTR_HEADER.len()].copy_from_slice(&SIGNATURE_BSTR_HEADER);
-        pos += SIGNATURE_BSTR_HEADER.len();
-        eat_buffer[pos..pos + ECDSA_P384_SIGNATURE_LEN].copy_from_slice(&signature);
-        pos += ECDSA_P384_SIGNATURE_LEN;
-
-        Ok(pos)
+        Ok(cose_len)
     }
 
     /// Hash the COSE Sig_structure and sign via DPE — all alloc-backed.
+    /// Writes the signature directly into `sig_out` to avoid an extra
+    /// 96-byte buffer in the caller's async frame.
     async fn sign_cose_sig_context<A: ApiAlloc>(
         &self,
         alloc: &A,
         payload: &[u8],
-    ) -> McuResult<[u8; DPE_P384_SIGNATURE_SIZE]> {
+        sig_out: &mut [u8; DPE_P384_SIGNATURE_SIZE],
+    ) -> McuResult<()> {
         let sha_buf = alloc.alloc(SHA_CONTEXT_SIZE)?;
         let mut state = sha_init(alloc, sha_buf, HashAlgo::Sha384, &SIG_PREAMBLE).await?;
         let mut payload_header = [0u8; 9];
@@ -140,9 +151,8 @@ impl<'a> SignedEatLite<'a> {
         let mut hash = [0u8; 48];
         sha_finish(alloc, &mut state, &mut hash).await?;
 
-        let mut sig = [0u8; DPE_P384_SIGNATURE_SIZE];
-        dpe_sign_ecc_p384(alloc, self.key_label, &hash, &mut sig).await?;
-        Ok(sig)
+        dpe_sign_ecc_p384(alloc, self.key_label, &hash, sig_out).await?;
+        Ok(())
     }
 }
 

--- a/runtime/userspace/api/spdm-lite/codec/src/secured_message.rs
+++ b/runtime/userspace/api/spdm-lite/codec/src/secured_message.rs
@@ -55,10 +55,12 @@ impl SecuredMessageHeader {
 /// AAD = session_id(4, LE) || length(2, LE).
 /// Returns 6 (= `SECURED_MSG_HDR_SIZE`).
 pub fn encode_aad(session_id: u32, length: u16, out: &mut [u8]) -> Result<usize, WireError> {
-    if out.len() < SECURED_MSG_HDR_SIZE {
-        return Err(WireError);
-    }
-    out[0..4].copy_from_slice(&session_id.to_le_bytes());
-    out[4..6].copy_from_slice(&length.to_le_bytes());
+    let hdr = out
+        .first_chunk_mut::<SECURED_MSG_HDR_SIZE>()
+        .ok_or(WireError)?;
+    let (session, rest) = hdr.split_first_chunk_mut::<4>().ok_or(WireError)?;
+    *session = session_id.to_le_bytes();
+    let (len, _) = rest.split_first_chunk_mut::<2>().ok_or(WireError)?;
+    *len = length.to_le_bytes();
     Ok(SECURED_MSG_HDR_SIZE)
 }

--- a/runtime/userspace/api/spdm-lite/codec/src/wire.rs
+++ b/runtime/userspace/api/spdm-lite/codec/src/wire.rs
@@ -15,7 +15,7 @@
 //! Errors are a single ZST so `Result<T, WireError>` shares the same
 //! niche as `McuResult<T>` after enum-niche optimisation.
 
-use core::mem::{size_of, size_of_val};
+use core::mem::size_of;
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -48,20 +48,21 @@ impl<'b> WireWriter<'b> {
     /// payloads or crypto output buffers).
     #[inline]
     pub fn reserve(&mut self, n: usize) -> Result<&mut [u8], WireError> {
-        if self.remaining() < n {
-            return Err(WireError);
-        }
         let start = self.pos;
-        self.pos += n;
-        Ok(&mut self.buf[start..start + n])
+        let end = start.checked_add(n).ok_or(WireError)?;
+        let slice = self.buf.get_mut(start..end).ok_or(WireError)?;
+        self.pos = end;
+        Ok(slice)
     }
 
     /// Write a whole zerocopy value at the current position.
     #[inline]
     pub fn write<T: IntoBytes + Immutable + ?Sized>(&mut self, v: &T) -> Result<(), WireError> {
-        let n = size_of_val(v);
-        let dst = self.reserve(n)?;
-        dst.copy_from_slice(v.as_bytes());
+        let bytes = v.as_bytes();
+        let dst = self.reserve(bytes.len())?;
+        for (d, s) in dst.iter_mut().zip(bytes) {
+            *d = *s;
+        }
         Ok(())
     }
 

--- a/runtime/userspace/api/spdm-lite/pal/src/cert/endorsement.rs
+++ b/runtime/userspace/api/spdm-lite/pal/src/cert/endorsement.rs
@@ -211,8 +211,11 @@ impl ReadOnlyEndorsement {
     }
 
     fn root_cert_hash(&self, _algo: SpdmPalAsymAlgo, out: &mut [u8]) -> McuResult<()> {
-        let n = out.len().min(self.root_cert_hash.len());
-        out[..n].copy_from_slice(&self.root_cert_hash[..n]);
+        // Copies `min(out.len(), root_cert_hash.len())` bytes with no
+        // length-equality check, so no `copy_from_slice` panic path.
+        for (d, s) in out.iter_mut().zip(&self.root_cert_hash) {
+            *d = *s;
+        }
         Ok(())
     }
 
@@ -225,8 +228,18 @@ impl ReadOnlyEndorsement {
         let mut pos = 0;
         for cert in self.chain.iter() {
             if cert_offset < cert.len() {
-                let len = (cert.len() - cert_offset).min(buf.len() - pos);
-                buf[pos..pos + len].copy_from_slice(&cert[cert_offset..cert_offset + len]);
+                let len = cert
+                    .len()
+                    .saturating_sub(cert_offset)
+                    .min(buf.len().saturating_sub(pos));
+                if let (Some(dst), Some(src)) = (
+                    buf.get_mut(pos..pos + len),
+                    cert.get(cert_offset..cert_offset + len),
+                ) {
+                    for (d, s) in dst.iter_mut().zip(src) {
+                        *d = *s;
+                    }
+                }
                 pos += len;
                 cert_offset = 0;
                 if pos == buf.len() {

--- a/runtime/userspace/api/spdm-lite/pal/src/cert/endorsement.rs
+++ b/runtime/userspace/api/spdm-lite/pal/src/cert/endorsement.rs
@@ -515,33 +515,69 @@ struct ManagedRecord {
 #[cfg(feature = "set-certificate")]
 impl ManagedRecord {
     fn encode(&self, out: &mut [u8; MANAGED_HEADER_SIZE]) {
-        out[0..4].copy_from_slice(&MANAGED_MAGIC);
-        out[4..6].copy_from_slice(&self.version.to_le_bytes());
-        out[6..8].copy_from_slice(&self.header_size.to_le_bytes());
-        out[8] = self.slot;
-        out[9] = self.algo;
-        out[10] = self.key_pair_id;
-        out[11] = self.cert_info;
-        out[12..14].copy_from_slice(&self.key_usage_mask.to_le_bytes());
-        out[16..20].copy_from_slice(&(self.cert_len as u32).to_le_bytes());
-        out[20..24].copy_from_slice(&self.data_checksum.to_le_bytes());
-        out[24..72].copy_from_slice(&self.root_hash);
+        // Layout (matches decode below):
+        //   [0..4]   magic
+        //   [4..6]   version (LE)
+        //   [6..8]   header_size (LE)
+        //   [8]      slot
+        //   [9]      algo
+        //   [10]     key_pair_id
+        //   [11]     cert_info
+        //   [12..14] key_usage_mask (LE)
+        //   [14..16] reserved (zero)
+        //   [16..20] cert_len (LE u32)
+        //   [20..24] data_checksum (LE)
+        //   [24..72] root_hash
+        //   [72..80] reserved (zero)
+        let (magic, rest) = out.split_first_chunk_mut::<4>().unwrap();
+        *magic = MANAGED_MAGIC;
+        let (version, rest) = rest.split_first_chunk_mut::<2>().unwrap();
+        *version = self.version.to_le_bytes();
+        let (hdr_size, rest) = rest.split_first_chunk_mut::<2>().unwrap();
+        *hdr_size = self.header_size.to_le_bytes();
+        rest[0] = self.slot;
+        rest[1] = self.algo;
+        rest[2] = self.key_pair_id;
+        rest[3] = self.cert_info;
+        let rest = &mut rest[4..];
+        let (kum, rest) = rest.split_first_chunk_mut::<2>().unwrap();
+        *kum = self.key_usage_mask.to_le_bytes();
+        // skip [14..16] reserved (already MANAGED_ERASED_BYTE-filled)
+        let rest = &mut rest[2..];
+        let (len, rest) = rest.split_first_chunk_mut::<4>().unwrap();
+        *len = (self.cert_len as u32).to_le_bytes();
+        let (chk, rest) = rest.split_first_chunk_mut::<4>().unwrap();
+        *chk = self.data_checksum.to_le_bytes();
+        let (rh, _) = rest.split_first_chunk_mut::<48>().unwrap();
+        *rh = self.root_hash;
     }
 
     fn decode(input: &[u8; MANAGED_HEADER_SIZE]) -> Option<Self> {
-        let mut root_hash = [0u8; 48];
-        root_hash.copy_from_slice(&input[24..72]);
+        let (magic, rest) = input.split_first_chunk::<4>()?;
+        let (version, rest) = rest.split_first_chunk::<2>()?;
+        let (header_size, rest) = rest.split_first_chunk::<2>()?;
+        let (slot, rest) = rest.split_first()?;
+        let (algo, rest) = rest.split_first()?;
+        let (key_pair_id, rest) = rest.split_first()?;
+        let (cert_info, rest) = rest.split_first()?;
+        let (kum, rest) = rest.split_first_chunk::<2>()?;
+        let (_reserved, rest) = rest.split_first_chunk::<2>()?;
+        let (cert_len, rest) = rest.split_first_chunk::<4>()?;
+        let (data_checksum, rest) = rest.split_first_chunk::<4>()?;
+        let (root_hash, _) = rest.split_first_chunk::<48>()?;
+        // magic is not parsed here; caller checks it before invoking decode.
+        let _ = magic;
         Some(Self {
-            version: u16::from_le_bytes(input[4..6].try_into().ok()?),
-            header_size: u16::from_le_bytes(input[6..8].try_into().ok()?),
-            slot: input[8],
-            algo: input[9],
-            key_pair_id: input[10],
-            cert_info: input[11],
-            key_usage_mask: u16::from_le_bytes(input[12..14].try_into().ok()?),
-            cert_len: u32::from_le_bytes(input[16..20].try_into().ok()?) as usize,
-            data_checksum: u32::from_le_bytes(input[20..24].try_into().ok()?),
-            root_hash,
+            version: u16::from_le_bytes(*version),
+            header_size: u16::from_le_bytes(*header_size),
+            slot: *slot,
+            algo: *algo,
+            key_pair_id: *key_pair_id,
+            cert_info: *cert_info,
+            key_usage_mask: u16::from_le_bytes(*kum),
+            cert_len: u32::from_le_bytes(*cert_len) as usize,
+            data_checksum: u32::from_le_bytes(*data_checksum),
+            root_hash: *root_hash,
         })
     }
 }

--- a/runtime/userspace/api/spdm-lite/pal/src/cert/mod.rs
+++ b/runtime/userspace/api/spdm-lite/pal/src/cert/mod.rs
@@ -313,7 +313,7 @@ impl<M: MeasurementProvider> SpdmPalCertStore for McuSpdmPal<M> {
             let managed = managed
                 .write_updated(algo, key_pair_id, cert_info, root_hash, data)
                 .await?;
-            let cert_slot = self.cert_store.cert_slot_mut(idx);
+            let cert_slot = self.cert_store.cert_slot_mut(idx).ok_or(INVARIANT)?;
             cert_slot.endorsement = endorsement::SlotEndorsement::Managed(managed);
             cert_slot.key_pair_id = Some(key_pair_id);
             cert_slot.cert_info = Some(cert_info);
@@ -344,7 +344,7 @@ impl<M: MeasurementProvider> SpdmPalCertStore for McuSpdmPal<M> {
                 endorsement::SlotEndorsement::Empty => return Err(INVARIANT),
             };
             let managed = managed.erase_updated(algo).await?;
-            let cert_slot = self.cert_store.cert_slot_mut(idx);
+            let cert_slot = self.cert_store.cert_slot_mut(idx).ok_or(INVARIANT)?;
             cert_slot.endorsement = endorsement::SlotEndorsement::Managed(managed);
             cert_slot.clear_metadata();
             self.cert_store.invalidate_cache(slot);

--- a/runtime/userspace/api/spdm-lite/pal/src/cert/store.rs
+++ b/runtime/userspace/api/spdm-lite/pal/src/cert/store.rs
@@ -59,9 +59,9 @@ impl SharedCertStore {
     }
 
     #[allow(clippy::mut_from_ref)]
-    pub(crate) fn cert_slot_mut(&self, idx: usize) -> &mut CertSlot {
+    pub(crate) fn cert_slot_mut(&self, idx: usize) -> Option<&mut CertSlot> {
         // SAFETY: single-task invariant.
-        unsafe { &mut (*self.cert_slots.get())[idx] }
+        unsafe { (*self.cert_slots.get()).get_mut(idx) }
     }
 
     // ---------------------------------------------------------------
@@ -104,7 +104,9 @@ impl SharedCertStore {
             return;
         }
         let mut entry = [0u8; 48];
-        entry[..digest.len()].copy_from_slice(digest);
+        for (d, s) in entry.iter_mut().zip(digest) {
+            *d = *s;
+        }
         unsafe {
             (*self.cached_chain_digest.get())[slot as usize] = Some(entry);
         }
@@ -147,7 +149,7 @@ impl SharedCertStore {
         let mut hash = [0u8; 48];
         sha_finish(alloc, &mut state, &mut hash).await?;
 
-        let slot = self.cert_slot_mut(idx);
+        let slot = self.cert_slot_mut(idx).ok_or(mcu_error::codes::INVARIANT)?;
         slot.endorsement = SlotEndorsement::ReadOnly(ReadOnlyEndorsement::new(chain, hash));
         slot.key_pair_id = Some(key_pair_id);
         slot.cert_info = Some(DEFAULT_CERT_INFO);
@@ -171,7 +173,7 @@ impl SharedCertStore {
         }
         let mut endorsement = ManagedEndorsement::new(spdm_slot, driver_num, base, capacity);
         endorsement.load().await?;
-        let slot = self.cert_slot_mut(idx);
+        let slot = self.cert_slot_mut(idx).ok_or(mcu_error::codes::INVARIANT)?;
         slot.key_pair_id = endorsement.key_pair_id();
         slot.cert_info = endorsement.cert_info();
         slot.endorsement = SlotEndorsement::Managed(endorsement);

--- a/runtime/userspace/api/spdm-lite/stack/src/build.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/build.rs
@@ -17,6 +17,20 @@ use mcu_spdm_lite_traits::{PalBytes, SpdmPal};
 
 use crate::error::SpdmResult;
 
+/// Copy a fixed-size array `src` into `buf` at `pos`, returning the advanced
+/// cursor.
+///
+/// Bounds are checked once via [`slice::first_chunk_mut`]; the const-`M` copy
+/// then carries no length check. An out-of-range write (unreachable for the
+/// fixed-layout signing-context builders) is a no-op rather than a panic, so
+/// this stays free of `panic_bounds_check` in the RoT codepath.
+pub(crate) fn write_fixed<const M: usize>(buf: &mut [u8], pos: usize, src: &[u8; M]) -> usize {
+    if let Some(slot) = buf.get_mut(pos..).and_then(|s| s.first_chunk_mut::<M>()) {
+        *slot = *src;
+    }
+    pos.saturating_add(M)
+}
+
 /// Allocate a buffer of `raw_len` bytes, rounded up to the transport's
 /// [`send_len_alignment`](SpdmPalIoTransport::send_len_alignment).
 /// Padding bytes are zeroed.

--- a/runtime/userspace/api/spdm-lite/stack/src/challenge.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/challenge.rs
@@ -106,28 +106,35 @@ pub(crate) async fn handle_challenge<'a, Pal: SpdmPal>(
         None
     };
 
-    // Build response body (without signature — appended after M1 finalize).
-    let body_no_sig = ChallengeAuthRsp {
+    // Build the full response with a zeroed signature placeholder, then sign
+    // into the trailing signature slot in place. This avoids a 96-byte stack
+    // buffer that would live across the sign `.await`, and avoids building the
+    // response twice.
+    const ZERO_SIG: [u8; ECC_P384_SIGNATURE_SIZE] = [0u8; ECC_P384_SIGNATURE_SIZE];
+    let body = ChallengeAuthRsp {
         slot_id,
         cert_chain_hash: &cert_chain_hash,
         nonce: &nonce,
         meas_summary_hash: meas_hash_ref,
         opaque_len: 0,
         requester_context: requester_context.as_ref(),
-        signature: &[],
+        signature: &ZERO_SIG,
     };
 
-    let resp =
-        build_response(pal, io, state.version, &body_no_sig).map_err(|_| SPDM_UNSPECIFIED)?;
+    let mut resp = build_response(pal, io, state.version, &body).map_err(|_| SPDM_UNSPECIFIED)?;
+
+    let head = pal.header_size();
+    // The signature is the trailing field; everything before it is the
+    // no-signature message that gets appended to M1.
+    let no_sig_len = body
+        .encoded_size()
+        .checked_sub(ECC_P384_SIGNATURE_SIZE)
+        .ok_or(SPDM_UNSPECIFIED)?;
 
     // Append CHALLENGE_AUTH response (without signature) to M1.
     // Only the SPDM message bytes, not transport padding.
-    let head = pal.header_size();
-    let spdm_len = body_no_sig.encoded_size();
-    state
-        .transcript
-        .append_m1(pal, io, &resp[head..head + spdm_len])
-        .await?;
+    let prefix = resp.get(head..head + no_sig_len).ok_or(SPDM_UNSPECIFIED)?;
+    state.transcript.append_m1(pal, io, prefix).await?;
 
     // Finalize M1 transcript hash.
     let mut m1_hash = [0u8; SHA384_HASH_SIZE];
@@ -139,37 +146,25 @@ pub(crate) async fn handle_challenge<'a, Pal: SpdmPal>(
         .await
         .map_err(|_| SPDM_UNSPECIFIED)?;
 
-    // Sign the TBS hash.
-    let mut signature = [0u8; ECC_P384_SIGNATURE_SIZE];
+    // Sign the TBS hash directly into the response's signature slot.
+    let sig_slot = resp
+        .get_mut(head + no_sig_len..head + no_sig_len + ECC_P384_SIGNATURE_SIZE)
+        .ok_or(SPDM_UNSPECIFIED)?;
     let sig_len = pal
-        .sign_hash(io, slot_id, asym_algo, &tbs_hash, &mut signature)
+        .sign_hash(io, slot_id, asym_algo, &tbs_hash, sig_slot)
         .await
         .map_err(|_| SPDM_UNSPECIFIED)?;
     if sig_len != ECC_P384_SIGNATURE_SIZE {
         return Err(SPDM_UNSPECIFIED);
     }
 
-    // Now rebuild the full response with signature.
-    let full_body = ChallengeAuthRsp {
-        slot_id,
-        cert_chain_hash: &cert_chain_hash,
-        nonce: &nonce,
-        meas_summary_hash: meas_hash_ref,
-        opaque_len: 0,
-        requester_context: requester_context.as_ref(),
-        signature: &signature,
-    };
-
-    let full_resp =
-        build_response(pal, io, state.version, &full_body).map_err(|_| SPDM_UNSPECIFIED)?;
-
     // Transition to authenticated.
     state.phase = Phase::AfterCertificate; // TODO: add Phase::Authenticated
 
-    Ok(full_resp)
+    Ok(resp)
 }
 
-/// Build the 100-byte SPDM signing context for CHALLENGE_AUTH.
+/// Build the SPDM signing context for CHALLENGE_AUTH.
 fn build_signing_context(version: SpdmVersion) -> [u8; SPDM_SIGNING_CONTEXT_LEN] {
     let mut ctx = [0u8; SPDM_SIGNING_CONTEXT_LEN];
 
@@ -183,17 +178,15 @@ fn build_signing_context(version: SpdmVersion) -> [u8; SPDM_SIGNING_CONTEXT_LEN]
     };
     let mut pos = 0;
     for _ in 0..4 {
-        ctx[pos..pos + base.len()].copy_from_slice(base);
-        pos += base.len();
-        ctx[pos..pos + ver.len()].copy_from_slice(ver);
-        pos += ver.len();
         // Each block is 16 bytes: 11 + 5 = 16.
+        pos = crate::build::write_fixed(&mut ctx, pos, base);
+        pos = crate::build::write_fixed(&mut ctx, pos, ver);
     }
 
     // Operation context: zero-padded on the left, string at the end.
     let op = b"responder-challenge_auth signing";
-    let pad = SPDM_CONTEXT_LEN - op.len();
-    ctx[SPDM_PREFIX_LEN + pad..SPDM_PREFIX_LEN + pad + op.len()].copy_from_slice(op);
+    let pad = SPDM_CONTEXT_LEN.saturating_sub(op.len());
+    crate::build::write_fixed(&mut ctx, SPDM_PREFIX_LEN + pad, op);
 
     ctx
 }

--- a/runtime/userspace/api/spdm-lite/stack/src/challenge.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/challenge.rs
@@ -56,8 +56,9 @@ pub(crate) async fn handle_challenge<'a, Pal: SpdmPal>(
         if after.len() < REQUESTER_CONTEXT_LEN {
             return Err(SPDM_INVALID_REQUEST);
         }
-        let mut ctx = [0u8; REQUESTER_CONTEXT_LEN];
-        ctx.copy_from_slice(&after[..REQUESTER_CONTEXT_LEN]);
+        let ctx = *after
+            .first_chunk::<REQUESTER_CONTEXT_LEN>()
+            .ok_or(SPDM_INVALID_REQUEST)?;
         requester_context = Some(ctx);
     }
 

--- a/runtime/userspace/api/spdm-lite/stack/src/chunk/get.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/chunk/get.rs
@@ -109,7 +109,9 @@ pub(crate) async fn handle_chunk_get<'a, Pal: SpdmPal>(
                 let src = large
                     .get(bytes_sent..end)
                     .ok_or(crate::error::SPDM_UNSPECIFIED)?;
-                chunk.copy_from_slice(src);
+                for (d, s) in chunk.iter_mut().zip(src) {
+                    *d = *s;
+                }
             }
         }
     }

--- a/runtime/userspace/api/spdm-lite/stack/src/chunk/mod.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/chunk/mod.rs
@@ -168,7 +168,9 @@ impl<L: core::ops::DerefMut<Target = [u8]>> LargeMessageCtx<L> {
         let dest = rent_buf
             .get_mut(..initial_chunk.len())
             .ok_or(SPDM_INVALID_REQUEST)?;
-        dest.copy_from_slice(initial_chunk);
+        for (d, s) in dest.iter_mut().zip(initial_chunk) {
+            *d = *s;
+        }
         self.buf = Some(rent_buf);
         Ok(())
     }
@@ -194,7 +196,9 @@ impl<L: core::ops::DerefMut<Target = [u8]>> LargeMessageCtx<L> {
 
         let buf = self.buf.as_deref_mut().ok_or(SPDM_UNSPECIFIED)?;
         let destination = buf.get_mut(start..end).ok_or(SPDM_UNSPECIFIED)?;
-        destination.copy_from_slice(chunk);
+        for (d, s) in destination.iter_mut().zip(chunk) {
+            *d = *s;
+        }
 
         self.state.bytes_received = end as u32;
         self.state.seq_num = seq_num;

--- a/runtime/userspace/api/spdm-lite/stack/src/chunk/send.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/chunk/send.rs
@@ -186,15 +186,13 @@ fn process_first_chunk<Pal: SpdmPal>(
     last_chunk: bool,
     rest: &[u8],
 ) -> Result<(), ChunkProcessError> {
-    let Some(size_bytes) = rest.get(..4) else {
+    let Some(size_bytes) = rest.first_chunk::<4>() else {
         return Err(ChunkProcessError::Early {
             handle,
             chunk_seq_num,
         });
     };
-    let mut large_msg_size = [0u8; 4];
-    large_msg_size.copy_from_slice(size_bytes);
-    let large_msg_size = u32::from_le_bytes(large_msg_size) as usize;
+    let large_msg_size = u32::from_le_bytes(*size_bytes) as usize;
     let chunk_data = &rest[4..];
 
     // Require exact chunk body length match inside rest payload (no trailing junk bytes).

--- a/runtime/userspace/api/spdm-lite/stack/src/digests.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/digests.rs
@@ -7,14 +7,14 @@
 //! array. Chunk buffers come from the per-IO bitmap pool — no
 //! stack-allocated `[u8; N]` arrays for cert content.
 
-use mcu_spdm_lite_codec::{DigestsRsp, ResponseBody, SpdmMsgHdrPdu};
+use mcu_spdm_lite_codec::{DigestsRsp, ResponseBody, SpdmMsgHdrPdu, SHA384_HASH_SIZE};
 use mcu_spdm_lite_traits::{
     PalBytes, SpdmPal, SpdmPalAlloc, SpdmPalAsymAlgo, SpdmPalHashAlgo, SpdmPalIo,
     SpdmPalIoTransport, MAX_SLOTS,
 };
 use zerocopy::FromBytes;
 
-use crate::build::build_response;
+use crate::build::{build_response, write_fixed};
 use crate::error::{SpdmResult, SPDM_INVALID_REQUEST, SPDM_UNEXPECTED_REQUEST, SPDM_UNSPECIFIED};
 use crate::stack::{multi_key_conn_rsp, ConnectionState, Phase};
 
@@ -62,9 +62,14 @@ pub(crate) async fn handle_get_digests<'a, Pal: SpdmPal>(
         if provisioned & (1 << slot) == 0 {
             continue;
         }
-        let dst = &mut tail[cursor..cursor + digest_size];
+        let dst = tail
+            .get_mut(cursor..cursor + digest_size)
+            .ok_or(SPDM_UNSPECIFIED)?;
         if let Some(cached) = pal.cached_chain_digest(slot, SpdmPalHashAlgo::Sha384) {
-            dst.copy_from_slice(&cached[..digest_size]);
+            let dst = dst
+                .first_chunk_mut::<SHA384_HASH_SIZE>()
+                .ok_or(SPDM_UNSPECIFIED)?;
+            *dst = cached;
         } else {
             cert_chain_hash(pal, io, slot, asym_algo, SpdmPalHashAlgo::Sha384, dst)
                 .await
@@ -111,8 +116,11 @@ fn fill_multi_key_conn_rsp_data<Pal: SpdmPal>(pal: &Pal, provisioned: u8, dst: &
         key_pair_ids[index] = pal.key_pair_id(slot).unwrap_or_default();
         cert_infos[index] = pal.cert_info(slot).unwrap_or_default() & 0x07;
         let usage = index * 2;
-        key_usage_masks[usage..usage + 2]
-            .copy_from_slice(&pal.key_usage_mask(slot).unwrap_or_default().to_le_bytes());
+        write_fixed(
+            key_usage_masks,
+            usage,
+            &pal.key_usage_mask(slot).unwrap_or_default().to_le_bytes(),
+        );
         index += 1;
     }
 }
@@ -140,7 +148,7 @@ pub(crate) async fn cert_chain_hash<Pal: SpdmPal>(
     // allocating 52 B on the stack is fine.
     let mut hdr = [0u8; 4 + 48];
     let total = (hdr.len() + der_len) as u16;
-    hdr[0..2].copy_from_slice(&total.to_le_bytes());
+    write_fixed(&mut hdr, 0, &total.to_le_bytes());
     // bytes 2..4 (Reserved) already zero
     pal.root_cert_hash(io, slot, asym_algo, algo, &mut hdr[4..4 + digest_size])
         .await?;

--- a/runtime/userspace/api/spdm-lite/stack/src/key_exchange.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/key_exchange.rs
@@ -22,7 +22,7 @@ use mcu_spdm_lite_codec::{
 use mcu_spdm_lite_traits::*;
 use zerocopy::FromBytes;
 
-use crate::build::build_response;
+use crate::build::{build_response, write_fixed};
 use crate::error::{
     SpdmError, SpdmResult, SPDM_INVALID_REQUEST, SPDM_UNEXPECTED_REQUEST, SPDM_UNSPECIFIED,
 };
@@ -220,7 +220,7 @@ async fn key_exchange_inner<'a, Pal: SpdmPal, const N: usize>(
     let asym_algo = state.asym_algo();
     let cert_chain_hash = &mut *hash_scratch;
     if let Some(cached) = pal.cached_chain_digest(slot_id, SpdmPalHashAlgo::Sha384) {
-        cert_chain_hash.copy_from_slice(&cached);
+        *cert_chain_hash = cached;
     } else {
         crate::digests::cert_chain_hash(
             pal,
@@ -240,17 +240,17 @@ async fn key_exchange_inner<'a, Pal: SpdmPal, const N: usize>(
 
     // ── Feed TH: full KEY_EXCHANGE request ──────────────────────────
     // Use only the actual SPDM bytes (not transport padding).
+    let opaque_len_offset = SpdmMsgHdrPdu::SIZE + core::mem::size_of::<KeyExchangeReqBody>();
+    let opaque_len_bytes: &[u8; 2] = req
+        .get(opaque_len_offset..opaque_len_offset + 2)
+        .and_then(|s| s.try_into().ok())
+        .ok_or(SPDM_INVALID_REQUEST)?;
     let spdm_req_len = SpdmMsgHdrPdu::SIZE
         + core::mem::size_of::<KeyExchangeReqBody>()
         + 2 // opaque_len field
-        + u16::from_le_bytes([
-            req[SpdmMsgHdrPdu::SIZE + core::mem::size_of::<KeyExchangeReqBody>()],
-            req[SpdmMsgHdrPdu::SIZE + core::mem::size_of::<KeyExchangeReqBody>() + 1],
-        ]) as usize;
-    session
-        .transcript
-        .append(pal, io, &req[..spdm_req_len])
-        .await?;
+        + u16::from_le_bytes(*opaque_len_bytes) as usize;
+    let spdm_req = req.get(..spdm_req_len).ok_or(SPDM_INVALID_REQUEST)?;
+    session.transcript.append(pal, io, spdm_req).await?;
 
     // ── Generate random + summary hash ──────────────────────────────
     pal.generate_nonce(io, nonce)
@@ -285,10 +285,10 @@ async fn key_exchange_inner<'a, Pal: SpdmPal, const N: usize>(
     // Feed partial response (SPDM bytes only) to TH.
     let head = pal.header_size();
     let spdm_rsp_len = partial_body.encoded_size();
-    session
-        .transcript
-        .append(pal, io, &partial_resp[head..head + spdm_rsp_len])
-        .await?;
+    let partial_spdm = partial_resp
+        .get(head..head + spdm_rsp_len)
+        .ok_or(SPDM_UNSPECIFIED)?;
+    session.transcript.append(pal, io, partial_spdm).await?;
     drop(partial_resp);
 
     // ── TH1 = clone-and-finalize (for signing) ─────────────────────
@@ -370,13 +370,14 @@ fn build_signing_context(version: SpdmVersion, ctx: &mut [u8; SPDM_SIGNING_CONTE
         SpdmVersion::V12 => KEY_EXCHANGE_SIGNING_PREFIX_V12,
         SpdmVersion::V13 => KEY_EXCHANGE_SIGNING_PREFIX_V13,
     };
-    for dst in ctx[..SPDM_PREFIX_LEN].chunks_exact_mut(KEY_EXCHANGE_SIGNING_PREFIX_CHUNK_LEN) {
-        dst.copy_from_slice(prefix);
+    let mut pos = 0;
+    for _ in 0..4 {
+        pos = write_fixed(ctx, pos, prefix);
     }
 
     ctx[SPDM_PREFIX_LEN] = 0;
     ctx[SPDM_PREFIX_LEN + 1] = 0;
-    ctx[SPDM_PREFIX_LEN + 2..].copy_from_slice(KEY_EXCHANGE_SIGNING_OP);
+    write_fixed(ctx, SPDM_PREFIX_LEN + 2, KEY_EXCHANGE_SIGNING_OP);
 }
 
 async fn compute_tbs_hash<Pal: SpdmPal>(

--- a/runtime/userspace/api/spdm-lite/stack/src/key_schedule.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/key_schedule.rs
@@ -465,7 +465,8 @@ async fn hkdf_expand_bin_str<P: SpdmPalAlloc + SpdmPalSessionCrypto>(
         context,
         &mut info,
     )?;
-    pal.hkdf_expand(io, prk, SHA384_HASH_SIZE as u32, &info[..len])
+    let info = info.get(..len).ok_or(mcu_error::codes::INVARIANT)?;
+    pal.hkdf_expand(io, prk, SHA384_HASH_SIZE as u32, info)
         .await
 }
 
@@ -488,21 +489,28 @@ fn bin_concat(
         return Err(mcu_error::codes::INVARIANT);
     }
 
-    let len_bytes = length.to_le_bytes();
-    buf[pos..pos + 2].copy_from_slice(&len_bytes);
-    pos += 2;
+    write_bin_str_bytes(buf, &mut pos, &length.to_le_bytes())?;
 
-    buf[pos..pos + version_str.len()].copy_from_slice(version_str);
-    pos += version_str.len();
+    write_bin_str_bytes(buf, &mut pos, version_str)?;
 
     let label = bin_str.label();
-    buf[pos..pos + label.len()].copy_from_slice(label);
-    pos += label.len();
+    write_bin_str_bytes(buf, &mut pos, label)?;
 
     if let Some(ctx) = context {
-        buf[pos..pos + ctx.len()].copy_from_slice(ctx);
-        pos += ctx.len();
+        write_bin_str_bytes(buf, &mut pos, ctx)?;
     }
 
     Ok(pos)
+}
+
+fn write_bin_str_bytes(buf: &mut [u8], pos: &mut usize, src: &[u8]) -> McuResult<()> {
+    let end = pos
+        .checked_add(src.len())
+        .ok_or(mcu_error::codes::INVARIANT)?;
+    let dst = buf.get_mut(*pos..end).ok_or(mcu_error::codes::INVARIANT)?;
+    for (d, s) in dst.iter_mut().zip(src) {
+        *d = *s;
+    }
+    *pos = end;
+    Ok(())
 }

--- a/runtime/userspace/api/spdm-lite/stack/src/measurements.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/measurements.rs
@@ -219,8 +219,8 @@ pub(crate) async fn handle_get_measurements_req<'a, Pal: SpdmPal>(
     state.transcript.finalize_l1(pal, io, &mut hash).await?;
 
     // Build signing context and compute TBS hash.
-    let signing_ctx = build_signing_context(state.version);
-    compute_tbs_hash(pal, io, &signing_ctx, &mut hash)
+    let signing_ctx = signing_context(state.version);
+    compute_tbs_hash(pal, io, signing_ctx, &mut hash)
         .await
         .map_err(|_| SPDM_UNSPECIFIED)?;
 
@@ -294,8 +294,8 @@ async fn handle_large_measurements_response<'a, Pal: SpdmPal>(
         let mut hash = [0u8; SHA384_HASH_SIZE];
         state.transcript.finalize_l1(pal, io, &mut hash).await?;
 
-        let signing_ctx = build_signing_context(state.version);
-        compute_tbs_hash(pal, io, &signing_ctx, &mut hash)
+        let signing_ctx = signing_context(state.version);
+        compute_tbs_hash(pal, io, signing_ctx, &mut hash)
             .await
             .map_err(|_| SPDM_UNSPECIFIED)?;
 
@@ -563,30 +563,51 @@ fn write_into_slice(out: &mut [u8], offset: usize, bytes: &[u8]) -> SpdmResult<u
     Ok(next)
 }
 
-/// Build the 100-byte SPDM signing context for MEASUREMENTS.
-fn build_signing_context(version: SpdmVersion) -> [u8; SPDM_SIGNING_CONTEXT_LEN] {
+/// Precomputed 100-byte SPDM signing contexts for "responder-measurements signing".
+/// Layout: 4 × "dmtf-spdm-v<x>.<y>.*" (prefix) || zero-pad || "responder-measurements signing".
+const SIGNING_CTX_V10: [u8; SPDM_SIGNING_CONTEXT_LEN] = build_signing_context_const(b"1.0.*");
+const SIGNING_CTX_V11: [u8; SPDM_SIGNING_CONTEXT_LEN] = build_signing_context_const(b"1.1.*");
+const SIGNING_CTX_V12: [u8; SPDM_SIGNING_CONTEXT_LEN] = build_signing_context_const(b"1.2.*");
+const SIGNING_CTX_V13: [u8; SPDM_SIGNING_CONTEXT_LEN] = build_signing_context_const(b"1.3.*");
+
+const fn build_signing_context_const(ver: &[u8; 5]) -> [u8; SPDM_SIGNING_CONTEXT_LEN] {
     let mut ctx = [0u8; SPDM_SIGNING_CONTEXT_LEN];
-
     let base = b"dmtf-spdm-v";
-    let ver = match version {
-        SpdmVersion::V10 => b"1.0.*",
-        SpdmVersion::V11 => b"1.1.*",
-        SpdmVersion::V12 => b"1.2.*",
-        SpdmVersion::V13 => b"1.3.*",
-    };
     let mut pos = 0;
-    for _ in 0..4 {
-        ctx[pos..pos + base.len()].copy_from_slice(base);
+    let mut i = 0;
+    while i < 4 {
+        let mut j = 0;
+        while j < base.len() {
+            ctx[pos + j] = base[j];
+            j += 1;
+        }
         pos += base.len();
-        ctx[pos..pos + ver.len()].copy_from_slice(ver);
+        let mut j = 0;
+        while j < ver.len() {
+            ctx[pos + j] = ver[j];
+            j += 1;
+        }
         pos += ver.len();
+        i += 1;
     }
-
-    // Operation context for measurements.
     let op = b"responder-measurements signing";
     let pad = SPDM_CONTEXT_LEN - op.len();
-    ctx[SPDM_PREFIX_LEN + pad..SPDM_PREFIX_LEN + pad + op.len()].copy_from_slice(op);
+    let mut j = 0;
+    while j < op.len() {
+        ctx[SPDM_PREFIX_LEN + pad + j] = op[j];
+        j += 1;
+    }
     ctx
+}
+
+/// Returns the 100-byte SPDM signing context for MEASUREMENTS, by version.
+fn signing_context(version: SpdmVersion) -> &'static [u8; SPDM_SIGNING_CONTEXT_LEN] {
+    match version {
+        SpdmVersion::V10 => &SIGNING_CTX_V10,
+        SpdmVersion::V11 => &SIGNING_CTX_V11,
+        SpdmVersion::V12 => &SIGNING_CTX_V12,
+        SpdmVersion::V13 => &SIGNING_CTX_V13,
+    }
 }
 
 /// Hash(signing_context || L1_hash) → TBS digest for signing.

--- a/runtime/userspace/api/spdm-lite/stack/src/measurements.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/measurements.rs
@@ -224,11 +224,13 @@ pub(crate) async fn handle_get_measurements_req<'a, Pal: SpdmPal>(
         .await
         .map_err(|_| SPDM_UNSPECIFIED)?;
 
-    // Sign the TBS hash.
+    // Sign the TBS hash directly into the response's signature slot, avoiding
+    // a 96-byte stack buffer that would otherwise live across the sign .await.
     let asym_algo = state.asym_algo();
-    let signature = &mut resp[signature_offset..signature_offset + ECC_P384_SIGNATURE_SIZE];
-    let sig_len = pal
-        .sign_hash(io, slot_id, asym_algo, &hash, signature)
+    let sig_slot = resp
+        .get_mut(signature_offset..signature_offset + ECC_P384_SIGNATURE_SIZE)
+        .ok_or(SPDM_UNSPECIFIED)?;
+    let sig_len = pal.sign_hash(io, slot_id, asym_algo, &hash, sig_slot)
         .await
         .map_err(|_| SPDM_UNSPECIFIED)?;
     if sig_len != ECC_P384_SIGNATURE_SIZE {

--- a/runtime/userspace/api/spdm-lite/stack/src/measurements.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/measurements.rs
@@ -230,7 +230,8 @@ pub(crate) async fn handle_get_measurements_req<'a, Pal: SpdmPal>(
     let sig_slot = resp
         .get_mut(signature_offset..signature_offset + ECC_P384_SIGNATURE_SIZE)
         .ok_or(SPDM_UNSPECIFIED)?;
-    let sig_len = pal.sign_hash(io, slot_id, asym_algo, &hash, sig_slot)
+    let sig_len = pal
+        .sign_hash(io, slot_id, asym_algo, &hash, sig_slot)
         .await
         .map_err(|_| SPDM_UNSPECIFIED)?;
     if sig_len != ECC_P384_SIGNATURE_SIZE {
@@ -535,7 +536,9 @@ async fn write_measurement_block<Pal: SpdmPal>(
     // Build and write the block header.
     let block_hdr =
         DmtfMeasurementBlockHeader::new(info.index, info.is_raw, info.value_type, info.value_size);
-    out[..MEAS_BLOCK_METADATA_SIZE].copy_from_slice(block_hdr.as_bytes());
+    for (d, s) in out.iter_mut().zip(block_hdr.as_bytes()) {
+        *d = *s;
+    }
 
     Ok(MEAS_BLOCK_METADATA_SIZE + value_size)
 }

--- a/runtime/userspace/api/spdm-lite/stack/src/set_certificate.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/set_certificate.rs
@@ -196,9 +196,7 @@ fn validate_negotiated_set_certificate_algorithms<S, L>(
     Ok(())
 }
 
-fn validate_spdm_cert_chain(
-    payload: &[u8],
-) -> SpdmResult<(&[u8; SHA384_DIGEST_SIZE], &[u8])> {
+fn validate_spdm_cert_chain(payload: &[u8]) -> SpdmResult<(&[u8; SHA384_DIGEST_SIZE], &[u8])> {
     if payload.len() < SPDM_CERT_CHAIN_HDR_LEN {
         return Err(SPDM_INVALID_REQUEST);
     }

--- a/runtime/userspace/api/spdm-lite/stack/src/set_certificate.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/set_certificate.rs
@@ -96,13 +96,13 @@ pub(crate) async fn handle_set_certificate_request<Pal: SpdmPal>(
         }
         pal.erase_cert_chain(io, slot_id, state.asym_algo()).await?;
     } else {
-        let (root_hash, der) = validate_spdm_cert_chain(pal, io, payload).await?;
+        let (root_hash, der) = validate_spdm_cert_chain(payload)?;
         pal.validate_set_certificate_chain(
             io,
             slot_id,
             req_body.key_pair_id,
             cert_model,
-            &root_hash,
+            root_hash,
             der,
         )
         .await
@@ -113,7 +113,7 @@ pub(crate) async fn handle_set_certificate_request<Pal: SpdmPal>(
             state.asym_algo(),
             req_body.key_pair_id,
             cert_model,
-            &root_hash,
+            root_hash,
             der,
         )
         .await?;
@@ -196,11 +196,9 @@ fn validate_negotiated_set_certificate_algorithms<S, L>(
     Ok(())
 }
 
-async fn validate_spdm_cert_chain<'payload, Pal: SpdmPal>(
-    pal: &Pal,
-    io: &<Pal as SpdmPalIoTransport>::Io<'_>,
-    payload: &'payload [u8],
-) -> SpdmResult<([u8; SHA384_DIGEST_SIZE], &'payload [u8])> {
+fn validate_spdm_cert_chain(
+    payload: &[u8],
+) -> SpdmResult<(&[u8; SHA384_DIGEST_SIZE], &[u8])> {
     if payload.len() < SPDM_CERT_CHAIN_HDR_LEN {
         return Err(SPDM_INVALID_REQUEST);
     }
@@ -215,11 +213,14 @@ async fn validate_spdm_cert_chain<'payload, Pal: SpdmPal>(
     if der.is_empty() {
         return Err(SPDM_INVALID_REQUEST);
     }
+    // Validate DER framing of the chain; PAL re-walks and is responsible
+    // for verifying SHA-384(root cert) == root_hash.
+    let _root_cert_len = validate_der_chain(der)?;
 
-    let root_cert_len = validate_der_chain(der)?;
-    let mut root_hash = [0u8; SHA384_DIGEST_SIZE];
-    root_hash.copy_from_slice(&payload[4..SPDM_CERT_CHAIN_HDR_LEN]);
-    validate_root_hash(pal, io, &root_hash, &der[..root_cert_len]).await?;
+    let root_hash: &[u8; SHA384_DIGEST_SIZE] = payload
+        .get(4..SPDM_CERT_CHAIN_HDR_LEN)
+        .and_then(|s| s.try_into().ok())
+        .ok_or(SPDM_INVALID_REQUEST)?;
     Ok((root_hash, der))
 }
 
@@ -264,35 +265,10 @@ fn der_sequence_len(input: &[u8]) -> Option<usize> {
     (total_len <= input.len()).then_some(total_len)
 }
 
-async fn validate_root_hash<Pal: SpdmPal>(
-    pal: &Pal,
-    io: &<Pal as SpdmPalIoTransport>::Io<'_>,
-    expected: &[u8; SHA384_DIGEST_SIZE],
-    root_cert: &[u8],
-) -> SpdmResult<()> {
-    let mut actual = [0u8; SHA384_DIGEST_SIZE];
-    let mut hash = pal.hash_init(io, SpdmPalHashAlgo::Sha384, &[]).await?;
-    pal.hash_update(io, &mut hash, root_cert).await?;
-    pal.hash_finish(io, &mut hash, &mut actual).await?;
-    if constant_time_eq(expected, &actual) {
-        Ok(())
-    } else {
-        Err(SPDM_INVALID_REQUEST)
-    }
-}
-
 fn map_set_cert_validation_error(err: McuErrorCode) -> SpdmError {
     as_spdm_wire(err)
         .map(SpdmError::new)
         .unwrap_or(SPDM_INVALID_REQUEST)
-}
-
-fn constant_time_eq(a: &[u8; SHA384_DIGEST_SIZE], b: &[u8; SHA384_DIGEST_SIZE]) -> bool {
-    let mut diff = 0u8;
-    for i in 0..SHA384_DIGEST_SIZE {
-        diff |= a[i] ^ b[i];
-    }
-    diff == 0
 }
 
 #[cfg(test)]

--- a/runtime/userspace/api/spdm-lite/stack/src/stack.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/stack.rs
@@ -955,8 +955,11 @@ async fn encrypt_secured_spdm_response<'a, Pal: SpdmPal>(
     }
 
     let mut rsp_plaintext = pal.alloc_bytes(io, rsp_pt_len)?;
-    rsp_plaintext[0..2].copy_from_slice(&(spdm_response.len() as u16).to_le_bytes());
-    rsp_plaintext[2..2 + spdm_response.len()].copy_from_slice(spdm_response);
+    let (len, body) = rsp_plaintext
+        .split_first_chunk_mut::<2>()
+        .ok_or(SPDM_UNSPECIFIED)?;
+    *len = (spdm_response.len() as u16).to_le_bytes();
+    copy_exact(body, spdm_response).map_err(|_| SPDM_UNSPECIFIED)?;
 
     let rsp_length = rsp_length_len as u16;
     let mut rsp_aad = pal.alloc_bytes(io, SECURED_MSG_HDR_SIZE)?;
@@ -996,13 +999,31 @@ fn build_secured_response_wire<'a, Pal: SpdmPal>(
     let raw_len = pal.header_size() + wire_body_len;
     let mut buf = alloc_padded(pal, io, raw_len).map_err(|_| SPDM_UNSPECIFIED)?;
     let hdr_off = pal.header_size();
-    buf[hdr_off..hdr_off + 4].copy_from_slice(&session_id.to_le_bytes());
-    buf[hdr_off + 4..hdr_off + 6].copy_from_slice(&rsp_length.to_le_bytes());
-    buf[hdr_off + 6..hdr_off + 6 + ciphertext.len()].copy_from_slice(ciphertext);
-    buf[hdr_off + 6 + ciphertext.len()..hdr_off + 6 + ciphertext.len() + AES_256_GCM_TAG_SIZE]
-        .copy_from_slice(tag);
+    let wire = buf.get_mut(hdr_off..raw_len).ok_or(SPDM_UNSPECIFIED)?;
+    let (hdr, body) = wire
+        .split_first_chunk_mut::<SECURED_MSG_HDR_SIZE>()
+        .ok_or(SPDM_UNSPECIFIED)?;
+    let (session, rest) = hdr.split_first_chunk_mut::<4>().ok_or(SPDM_UNSPECIFIED)?;
+    *session = session_id.to_le_bytes();
+    let (len, _) = rest.split_first_chunk_mut::<2>().ok_or(SPDM_UNSPECIFIED)?;
+    *len = rsp_length.to_le_bytes();
+    let (ct_out, tag_out) = body.split_at_mut(ciphertext.len());
+    copy_exact(ct_out, ciphertext).map_err(|_| SPDM_UNSPECIFIED)?;
+    *tag_out
+        .first_chunk_mut::<AES_256_GCM_TAG_SIZE>()
+        .ok_or(SPDM_UNSPECIFIED)? = *tag;
 
     Ok(buf)
+}
+
+fn copy_exact(dst: &mut [u8], src: &[u8]) -> Result<(), ()> {
+    if dst.len() != src.len() {
+        return Err(());
+    }
+    for (d, s) in dst.iter_mut().zip(src) {
+        *d = *s;
+    }
+    Ok(())
 }
 /// Decodes the SPDM common header from a raw request buffer.
 ///

--- a/runtime/userspace/api/spdm-lite/stack/src/vendor_defined.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/vendor_defined.rs
@@ -10,13 +10,13 @@
 
 use mcu_spdm_lite_codec::{
     decode_vendor_defined_req, ReqRespCode, ResponseBody, SpdmMsgHdrPdu, SpdmVersion,
-    VendorDefinedRspBody,
+    VendorDefinedRspBody, WireWriter,
 };
 use mcu_spdm_lite_traits::{
     PalBytes, SpdmPal, SpdmPalAlloc, SpdmPalIoTransport, SpdmVdmBackend, VdmRegistry, VdmResponse,
     VdmResponseBuffer,
 };
-use zerocopy::{FromBytes, IntoBytes};
+use zerocopy::FromBytes;
 
 use crate::build::build_response;
 use crate::chunk;
@@ -90,7 +90,11 @@ pub(crate) async fn handle_vendor_defined_request<'a, Pal: SpdmPal, V: SpdmVdmBa
 
     let outcome = {
         let large_slice: &mut [u8] = match large_guard.as_mut() {
-            Some(guard) => &mut guard.buf.as_deref_mut().unwrap()[envelope..envelope + large_cap],
+            Some(guard) => guard
+                .buf
+                .as_deref_mut()
+                .and_then(|buf| buf.get_mut(envelope..envelope + large_cap))
+                .ok_or(SPDM_UNSPECIFIED)?,
             None => &mut [],
         };
         let rsp = VdmResponseBuffer {
@@ -168,21 +172,15 @@ fn write_vendor_defined_envelope(
     let resp_len = u16::try_from(payload_len).map_err(|_| SPDM_UNSPECIFIED)?;
     let hdr = SpdmMsgHdrPdu::new(version, ReqRespCode::VENDOR_DEFINED_RESPONSE);
 
-    let mut o = 0usize;
-    let mut put = |bytes: &[u8]| -> SpdmResult<()> {
-        let end = o.checked_add(bytes.len()).ok_or(SPDM_UNSPECIFIED)?;
-        out.get_mut(o..end)
-            .ok_or(SPDM_UNSPECIFIED)?
-            .copy_from_slice(bytes);
-        o = end;
-        Ok(())
-    };
-
-    put(hdr.as_bytes())?;
-    put(&[0u8, 0u8])?; // param1, param2
-    put(&standard_id.to_le_bytes())?;
-    put(&[vendor_id.len() as u8])?;
-    put(vendor_id)?;
-    put(&resp_len.to_le_bytes())?;
+    let mut w = WireWriter::new(out);
+    w.write(&hdr).map_err(|_| SPDM_UNSPECIFIED)?;
+    w.write_bytes(&[0u8, 0u8]).map_err(|_| SPDM_UNSPECIFIED)?; // param1, param2
+    w.write_bytes(&standard_id.to_le_bytes())
+        .map_err(|_| SPDM_UNSPECIFIED)?;
+    w.write_bytes(&[vendor_id.len() as u8])
+        .map_err(|_| SPDM_UNSPECIFIED)?;
+    w.write_bytes(vendor_id).map_err(|_| SPDM_UNSPECIFIED)?;
+    w.write_bytes(&resp_len.to_le_bytes())
+        .map_err(|_| SPDM_UNSPECIFIED)?;
     Ok(())
 }

--- a/runtime/userspace/api/spdm-lite/traits/src/cert.rs
+++ b/runtime/userspace/api/spdm-lite/traits/src/cert.rs
@@ -98,6 +98,12 @@ pub trait SpdmPalCertStore: crate::SpdmPalIoTransport {
     }
 
     /// Validate an incoming SET_CERTIFICATE chain before it is committed.
+    ///
+    /// The PAL implementation **must** verify that `SHA-384(first DER
+    /// certificate in `cert_chain`) == *root_hash`. The stack no longer
+    /// performs this check, since the PAL already has access to hashing
+    /// machinery and avoids a duplicate async hash pass at the SPDM
+    /// responder layer.
     async fn validate_set_certificate_chain(
         &self,
         _io: &Self::Io<'_>,

--- a/runtime/userspace/api/spdm-lite/transports/src/doe.rs
+++ b/runtime/userspace/api/spdm-lite/transports/src/doe.rs
@@ -150,14 +150,17 @@ impl SpdmPalTransport for McuSpdmDoeTransport {
 
 /// Write DOE header into the first 8 bytes of `buf`.
 fn buf_write_doe_header(buf: &mut [u8], data_object_type: u8, length_dw: u32) {
+    let Some(hdr) = buf.first_chunk_mut::<8>() else {
+        return;
+    };
     // bytes 0..1: vendor_id (LE)
-    buf[0..2].copy_from_slice(&DOE_PCI_SIG_VENDOR_ID.to_le_bytes());
+    hdr[0..2].copy_from_slice(&DOE_PCI_SIG_VENDOR_ID.to_le_bytes());
     // byte 2: data_object_type
-    buf[2] = data_object_type;
+    hdr[2] = data_object_type;
     // byte 3: reserved
-    buf[3] = 0;
+    hdr[3] = 0;
     // bytes 4..7: length in DWORDs (18 bits, LE) + reserved (14 bits)
     // Low 18 bits = length_dw, upper 14 bits = 0
     let length_field = length_dw & 0x0003_FFFF;
-    buf[4..8].copy_from_slice(&length_field.to_le_bytes());
+    hdr[4..8].copy_from_slice(&length_field.to_le_bytes());
 }

--- a/runtime/userspace/api/spdm-lite/transports/src/mctp.rs
+++ b/runtime/userspace/api/spdm-lite/transports/src/mctp.rs
@@ -124,7 +124,7 @@ impl McuSpdmMctpTransport {
         let expected_driver = match msg_type {
             MCTP_MSG_TYPE_SPDM => driver_num::MCTP_SPDM,
             MCTP_MSG_TYPE_SECURED_SPDM => driver_num::MCTP_SECURE,
-            _ => unreachable!(),
+            _ => return Err(error_code::UNEXPECTED_MESSAGE_TYPE),
         };
         if driver_num != expected_driver {
             return Err(error_code::UNEXPECTED_MESSAGE_TYPE);
@@ -210,7 +210,9 @@ impl SpdmPalTransport for McuSpdmMctpTransport {
             .take()
             .ok_or(error_code::NO_REQUEST_IN_FLIGHT)?;
 
-        msg[0] = self.msg_type & MCTP_MSG_TYPE_MASK;
+        if let Some(first) = msg.first_mut() {
+            *first = self.msg_type & MCTP_MSG_TYPE_MASK;
+        }
 
         self.mctp.send_response(msg, msg_info).await?;
         Ok(())


### PR DESCRIPTION
## Summary

 Reduce SPDM-lite user-app flash by removing implicit panic sites and avoiding temporary buffers on SPDM signing/hash paths.

 Changes include:
 - Replaced panic-prone slice/copy/index paths with checked access or fixed-size writes in SPDM-lite codec, transports, cert-store, endorsement handling, and user-app cert copy paths.
 - Signed directly into response/output buffers for `CHALLENGE_AUTH`, `GET_MEASUREMENTS`, and signed EAT.
 - Removed temporary hash/input buffers and precomputed measurement signing contexts.
 - Moved SET_CERTIFICATE root-hash verification responsibility to the PAL contract.

 ## Size impact

Measured against `spdm-lite` using the same release user-app build flow for both baseline and PR.

PR: `spdm-lite-code-size` @ `764842c8` + review fixes
 
 | Section | `origin/spdm-lite` | This PR | Delta |
 |---|---:|---:|---:|
 | `.text` | 100,554 | 99,674 | **−880 B** |
 | `.rodata` | 19,764 | 17,672 | **−2,092 B** |
 | `.data` | 12 | 12 | 0 |
 | `.bss` | 53,344 | 53,008 | **−336 B** |
 | **Flash (`.text + .rodata + .data`)** | **120,330** | **117,358** | **−2,972 B** |

