### PR TITLE
rom: reset start_cycle and next_print_offset between image transfers

### DIFF
--- a/rom/src/recovery.rs
+++ b/rom/src/recovery.rs
@@ -321,6 +321,8 @@ pub fn load_flash_image_to_recovery(
                     state_machine.context_mut().flash_offset = image_info.0;
                     state_machine.context_mut().image_size = image_info.1;
                     state_machine.context_mut().transfer_offset = 0;
+                    start_cycle = None;
+                    next_print_offset = 0;
                     i3c_periph
                         .sec_fw_recovery_if_indirect_fifo_ctrl_1
                         .set(state_machine.context().image_size / 4);


### PR DESCRIPTION
These variables were not reset when the state machine looped back for a second image transfer, causing incorrect cycle measurements and missing progress messages for subsequent images.

Fixes #1592 