### PR TITLE
spdm-lite: chunk SET_CERTIFICATE requests

### DIFF
--- a/runtime/userspace/api/spdm-lite/pal/src/cert/mod.rs
+++ b/runtime/userspace/api/spdm-lite/pal/src/cert/mod.rs
@@ -75,7 +75,7 @@ impl<M: MeasurementProvider> SpdmPalCertStore for McuSpdmPal<M> {
 
     async fn cert_chain_slot_size(
         &self,
-        _io: &Self::Io<'_>,
+        _io: &impl SpdmPalIo,
         slot: u8,
         _algo: SpdmPalAsymAlgo,
     ) -> McuResult<usize> {
@@ -100,7 +100,7 @@ impl<M: MeasurementProvider> SpdmPalCertStore for McuSpdmPal<M> {
     #[inline]
     fn set_certificate_authorized(
         &self,
-        _io: &Self::Io<'_>,
+        _io: &impl SpdmPalIo,
         slot: u8,
         _key_pair_id: u8,
         _cert_model: u8,
@@ -122,7 +122,7 @@ impl<M: MeasurementProvider> SpdmPalCertStore for McuSpdmPal<M> {
 
     async fn cert_chain_len(
         &self,
-        _io: &Self::Io<'_>,
+        _io: &impl SpdmPalIo,
         slot: u8,
         _algo: SpdmPalAsymAlgo,
     ) -> McuResult<usize> {
@@ -152,7 +152,7 @@ impl<M: MeasurementProvider> SpdmPalCertStore for McuSpdmPal<M> {
 
     async fn root_cert_hash(
         &self,
-        _io: &Self::Io<'_>,
+        _io: &impl SpdmPalIo,
         slot: u8,
         _algo: SpdmPalAsymAlgo,
         _hash_algo: SpdmPalHashAlgo,
@@ -167,7 +167,7 @@ impl<M: MeasurementProvider> SpdmPalCertStore for McuSpdmPal<M> {
 
     async fn read_cert_chain(
         &self,
-        _io: &Self::Io<'_>,
+        _io: &impl SpdmPalIo,
         slot: u8,
         _algo: SpdmPalAsymAlgo,
         offset: usize,
@@ -261,7 +261,7 @@ impl<M: MeasurementProvider> SpdmPalCertStore for McuSpdmPal<M> {
 
     async fn sign_hash(
         &self,
-        _io: &Self::Io<'_>,
+        _io: &impl SpdmPalIo,
         slot: u8,
         _algo: SpdmPalAsymAlgo,
         digest: &[u8],
@@ -273,7 +273,7 @@ impl<M: MeasurementProvider> SpdmPalCertStore for McuSpdmPal<M> {
 
     async fn write_cert_chain(
         &self,
-        _io: &Self::Io<'_>,
+        _io: &impl SpdmPalIo,
         slot: u8,
         algo: SpdmPalAsymAlgo,
         key_pair_id: u8,
@@ -310,7 +310,7 @@ impl<M: MeasurementProvider> SpdmPalCertStore for McuSpdmPal<M> {
 
     async fn erase_cert_chain(
         &self,
-        _io: &Self::Io<'_>,
+        _io: &impl SpdmPalIo,
         slot: u8,
         algo: SpdmPalAsymAlgo,
     ) -> McuResult<()> {
@@ -380,7 +380,7 @@ impl<M: MeasurementProvider> SpdmPalCertStore for McuSpdmPal<M> {
         self.cert_store.cache_chain_digest(slot, digest);
     }
 
-    async fn generate_nonce(&self, _io: &Self::Io<'_>, out: &mut [u8]) -> McuResult<()> {
+    async fn generate_nonce(&self, _io: &impl SpdmPalIo, out: &mut [u8]) -> McuResult<()> {
         mcu_caliptra_api_lite::rng_generate(self, out).await
     }
 }

--- a/runtime/userspace/api/spdm-lite/pal/src/large_message.rs
+++ b/runtime/userspace/api/spdm-lite/pal/src/large_message.rs
@@ -40,4 +40,12 @@ impl<M: MeasurementProvider> SpdmPalLargeMessage for McuSpdmPal<M> {
         self.large_msg.set(large_msg);
         result
     }
+
+    fn take(&self) -> McuResult<&'static mut [u8]> {
+        self.large_msg.take().ok_or(INVARIANT)
+    }
+
+    fn replace(&self, buf: &'static mut [u8]) {
+        self.large_msg.set(Some(buf));
+    }
 }

--- a/runtime/userspace/api/spdm-lite/stack/src/build.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/build.rs
@@ -13,7 +13,7 @@
 //! reserve the transport-framing header.
 
 use mcu_spdm_lite_codec::{ResponseBody, SpdmVersion, WireWriter};
-use mcu_spdm_lite_traits::{PalBytes, SpdmPal};
+use mcu_spdm_lite_traits::{PalBytes, SpdmPal, SpdmPalIo};
 
 use crate::error::SpdmResult;
 
@@ -22,7 +22,7 @@ use crate::error::SpdmResult;
 /// Padding bytes are zeroed.
 pub(crate) fn alloc_padded<'a, Pal: SpdmPal>(
     pal: &'a Pal,
-    io: &Pal::Io<'_>,
+    io: &impl SpdmPalIo,
     raw_len: usize,
 ) -> SpdmResult<PalBytes<'a, Pal>> {
     let align = pal.send_len_alignment();
@@ -79,7 +79,7 @@ pub(crate) fn alloc_padded<'a, Pal: SpdmPal>(
 #[inline(never)]
 pub(crate) fn build_response<'a, Pal, B>(
     pal: &'a Pal,
-    io: &Pal::Io<'_>,
+    io: &impl SpdmPalIo,
     version: SpdmVersion,
     body: &B,
 ) -> SpdmResult<PalBytes<'a, Pal>>
@@ -101,7 +101,7 @@ where
 #[inline(never)]
 pub(crate) fn build_error_response<'a, Pal: SpdmPal>(
     pal: &'a Pal,
-    io: &Pal::Io<'_>,
+    io: &impl SpdmPalIo,
     version: SpdmVersion,
     error_code: u8,
     error_data: u8,

--- a/runtime/userspace/api/spdm-lite/stack/src/chunk.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/chunk.rs
@@ -2,23 +2,29 @@
 
 //! SPDM large-message chunking.
 
+#[cfg(feature = "set-certificate")]
+use mcu_spdm_lite_codec::SetCertificateRspBody;
 use mcu_spdm_lite_codec::{
     CapabilitiesBody, CertificateRspBody, ChunkGetReqBody, ChunkSendReqBody, ReqRespCode,
     SpdmMsgHdrPdu, SpdmVersion, WireWriter, CHUNK_ACK_ATTR_EARLY_ERROR, CHUNK_ATTR_LAST_CHUNK,
     CHUNK_RESPONSE_FIXED_BODY_SIZE, LARGE_RESPONSE_SIZE_FIELD_SIZE,
 };
+#[cfg(feature = "set-certificate")]
+use mcu_spdm_lite_traits::{McuResult, SpdmPalIoKind};
 use mcu_spdm_lite_traits::{PalBytes, SpdmPal, SpdmPalAsymAlgo, SpdmPalIo, SpdmPalIoTransport};
 use zerocopy::{little_endian::U16, little_endian::U32, FromBytes};
 
 use crate::build::alloc_padded;
 use crate::certificate;
 use crate::error::{
-    SpdmError, SpdmResult, SPDM_INVALID_REQUEST, SPDM_UNEXPECTED_REQUEST, SPDM_UNSUPPORTED_REQUEST,
-    SPDM_VERSION_MISMATCH,
+    SpdmError, SpdmResult, SPDM_INVALID_REQUEST, SPDM_UNEXPECTED_REQUEST, SPDM_UNSPECIFIED,
+    SPDM_UNSUPPORTED_REQUEST, SPDM_VERSION_MISMATCH,
 };
 use crate::stack::{ConnectionState, Phase};
 
 const CERTIFICATE_RESPONSE_HEADER_SIZE: usize = SpdmMsgHdrPdu::SIZE + CertificateRspBody::SIZE;
+#[cfg(feature = "set-certificate")]
+const SET_CERTIFICATE_RESPONSE_SIZE: usize = SpdmMsgHdrPdu::SIZE + SetCertificateRspBody::SIZE;
 
 #[derive(Copy, Clone)]
 pub(crate) struct LargeResponseState {
@@ -179,6 +185,12 @@ impl ChunkState {
     pub(crate) fn in_progress(&self) -> bool {
         self.in_use
     }
+
+    #[inline]
+    #[cfg_attr(not(feature = "set-certificate"), allow(dead_code))]
+    pub(crate) fn large_msg_size(&self) -> u32 {
+        self.large_msg_size
+    }
 }
 
 struct ChunkInfo {
@@ -195,24 +207,106 @@ pub(crate) async fn handle_chunk_send<'a, Pal: SpdmPal>(
     let result = process_chunk_send(state, pal, io);
     match result {
         Ok(info) => {
-            let mut response_to_large_request = [0u8; 4];
-            let response = if info.complete {
-                let err = build_response_to_large_request(state, pal);
-                encode_error_pdu(state.version, err, &mut response_to_large_request);
+            if info.complete {
+                let response = build_response_to_large_request(state, pal, io).await;
                 state.chunk.reset();
-                &response_to_large_request[..]
+                match response {
+                    LargeRequestOutcome::Response { response, spdm_len } => {
+                        let head = pal.header_size();
+                        let mut response_to_large_request = [0u8; 4];
+                        if spdm_len > response_to_large_request.len() {
+                            let mut error = [0u8; 4];
+                            encode_error_pdu(state.version, SPDM_UNSPECIFIED, &mut error);
+                            drop(response);
+                            build_chunk_send_ack(
+                                pal,
+                                io,
+                                state.version,
+                                false,
+                                info.handle,
+                                info.chunk_seq_num,
+                                &error,
+                            )
+                        } else {
+                            let Some(response_end) = head.checked_add(spdm_len) else {
+                                let mut error = [0u8; 4];
+                                encode_error_pdu(state.version, SPDM_UNSPECIFIED, &mut error);
+                                drop(response);
+                                return build_chunk_send_ack(
+                                    pal,
+                                    io,
+                                    state.version,
+                                    false,
+                                    info.handle,
+                                    info.chunk_seq_num,
+                                    &error,
+                                );
+                            };
+                            let Some(response_payload) = response.get(head..response_end) else {
+                                let mut error = [0u8; 4];
+                                encode_error_pdu(state.version, SPDM_UNSPECIFIED, &mut error);
+                                drop(response);
+                                return build_chunk_send_ack(
+                                    pal,
+                                    io,
+                                    state.version,
+                                    false,
+                                    info.handle,
+                                    info.chunk_seq_num,
+                                    &error,
+                                );
+                            };
+                            response_to_large_request[..spdm_len].copy_from_slice(response_payload);
+                            drop(response);
+                            build_chunk_send_ack(
+                                pal,
+                                io,
+                                state.version,
+                                false,
+                                info.handle,
+                                info.chunk_seq_num,
+                                &response_to_large_request[..spdm_len],
+                            )
+                        }
+                    }
+                    LargeRequestOutcome::Error(err) => {
+                        let mut error = [0u8; 4];
+                        encode_error_pdu(state.version, err, &mut error);
+                        build_chunk_send_ack(
+                            pal,
+                            io,
+                            state.version,
+                            false,
+                            info.handle,
+                            info.chunk_seq_num,
+                            &error,
+                        )
+                    }
+                    LargeRequestOutcome::EarlyError(err) => {
+                        let mut error = [0u8; 4];
+                        encode_error_pdu(state.version, err, &mut error);
+                        build_chunk_send_ack(
+                            pal,
+                            io,
+                            state.version,
+                            true,
+                            info.handle,
+                            info.chunk_seq_num,
+                            &error,
+                        )
+                    }
+                }
             } else {
-                &[]
-            };
-            build_chunk_send_ack(
-                pal,
-                io,
-                state.version,
-                false,
-                info.handle,
-                info.chunk_seq_num,
-                response,
-            )
+                build_chunk_send_ack(
+                    pal,
+                    io,
+                    state.version,
+                    false,
+                    info.handle,
+                    info.chunk_seq_num,
+                    &[],
+                )
+            }
         }
         Err(ChunkProcessError::Spdm(e)) => Err(e),
         Err(ChunkProcessError::Early {
@@ -237,10 +331,8 @@ fn build_chunk_send_ack<'a, Pal: SpdmPal>(
     response_to_large_request: &[u8],
 ) -> SpdmResult<PalBytes<'a, Pal>> {
     let head = pal.header_size();
-    let mut rsp = pal.alloc_bytes(
-        io,
-        head + SpdmMsgHdrPdu::SIZE + 4 + response_to_large_request.len(),
-    )?;
+    let raw_len = head + SpdmMsgHdrPdu::SIZE + 4 + response_to_large_request.len();
+    let mut rsp = alloc_padded(pal, io, raw_len)?;
     let mut w = WireWriter::new(&mut rsp[head..]);
     w.write(&SpdmMsgHdrPdu::new(version, ReqRespCode::CHUNK_SEND_ACK))?;
     let attr = if early_error {
@@ -335,11 +427,11 @@ pub(crate) async fn handle_chunk_get<'a, Pal: SpdmPal>(
     Ok(rsp)
 }
 
-fn valid_transport_padding<Pal: SpdmPal>(pal: &Pal, spdm_len: usize, padding: &[u8]) -> bool {
-    if padding.is_empty() {
-        return true;
-    }
-
+pub(crate) fn valid_transport_padding<Pal: SpdmPal>(
+    pal: &Pal,
+    spdm_len: usize,
+    padding: &[u8],
+) -> bool {
     let align = pal.send_len_alignment();
     let expected = if align <= 1 {
         0
@@ -510,19 +602,43 @@ fn process_first_chunk<Pal: SpdmPal>(
     let mut large_msg_size = [0u8; 4];
     large_msg_size.copy_from_slice(size_bytes);
     let large_msg_size = u32::from_le_bytes(large_msg_size) as usize;
-    let chunk = &rest[4..];
+    let chunk_start = 4usize;
+    let Some(chunk_end) = chunk_start.checked_add(chunk_size) else {
+        return Err(ChunkProcessError::Early {
+            handle,
+            chunk_seq_num,
+        });
+    };
+    let Some(chunk) = rest.get(chunk_start..chunk_end) else {
+        return Err(ChunkProcessError::Early {
+            handle,
+            chunk_seq_num,
+        });
+    };
+    let padding = rest.get(chunk_end..).ok_or(ChunkProcessError::Early {
+        handle,
+        chunk_seq_num,
+    })?;
     let min_chunk_size = CapabilitiesBody::MIN_DATA_TRANSFER_SIZE as usize
         - SpdmMsgHdrPdu::SIZE
         - ChunkSendReqBody::SIZE
         - 4;
+    let spdm_len = SpdmMsgHdrPdu::SIZE
+        .checked_add(ChunkSendReqBody::SIZE)
+        .and_then(|n| n.checked_add(4))
+        .and_then(|n| n.checked_add(chunk_size))
+        .ok_or(ChunkProcessError::Early {
+            handle,
+            chunk_seq_num,
+        })?;
 
     let invalid = chunk_seq_num != 0
         || last_chunk
-        || chunk_size != chunk.len()
+        || !valid_transport_padding(pal, spdm_len, padding)
         || chunk_size < min_chunk_size
         || chunk_size >= large_msg_size
         || large_msg_size <= CapabilitiesBody::MIN_DATA_TRANSFER_SIZE as usize
-        || large_msg_size > pal.capacity();
+        || large_msg_size > effective_max_spdm_msg_size(state, pal);
     if invalid || pal.write(0, chunk).is_err() {
         return Err(ChunkProcessError::Early {
             handle,
@@ -547,18 +663,35 @@ fn process_next_chunk<Pal: SpdmPal>(
     chunk_seq_num: u16,
     chunk_size: usize,
     last_chunk: bool,
-    chunk: &[u8],
+    rest: &[u8],
 ) -> Result<(), ChunkProcessError> {
     let bytes_received = state.chunk.bytes_received as usize;
     let large_msg_size = state.chunk.large_msg_size as usize;
     let end = bytes_received.saturating_add(chunk_size);
+    let Some(chunk) = rest.get(..chunk_size) else {
+        return Err(ChunkProcessError::Early {
+            handle,
+            chunk_seq_num,
+        });
+    };
+    let padding = rest.get(chunk_size..).ok_or(ChunkProcessError::Early {
+        handle,
+        chunk_seq_num,
+    })?;
     let min_chunk_size = CapabilitiesBody::MIN_DATA_TRANSFER_SIZE as usize
         - SpdmMsgHdrPdu::SIZE
         - ChunkSendReqBody::SIZE;
+    let spdm_len = SpdmMsgHdrPdu::SIZE
+        .checked_add(ChunkSendReqBody::SIZE)
+        .and_then(|n| n.checked_add(chunk_size))
+        .ok_or(ChunkProcessError::Early {
+            handle,
+            chunk_seq_num,
+        })?;
     let invalid = chunk_seq_num == 0
         || state.chunk.handle != handle
         || state.chunk.seq_num.wrapping_add(1) != chunk_seq_num
-        || chunk_size != chunk.len()
+        || !valid_transport_padding(pal, spdm_len, padding)
         || end > large_msg_size
         || (last_chunk && end != large_msg_size)
         || (!last_chunk && (end >= large_msg_size || chunk_size < min_chunk_size));
@@ -574,34 +707,137 @@ fn process_next_chunk<Pal: SpdmPal>(
     Ok(())
 }
 
-fn build_response_to_large_request<Pal: SpdmPal>(
-    state: &ConnectionState<Pal::State>,
-    pal: &Pal,
-) -> SpdmError {
-    if (state.chunk.large_msg_size as usize) < SpdmMsgHdrPdu::SIZE {
-        return SPDM_INVALID_REQUEST;
+#[cfg(feature = "set-certificate")]
+struct LargeRequestIo<'a> {
+    kind: SpdmPalIoKind,
+    request: &'a [u8],
+}
+
+#[cfg(feature = "set-certificate")]
+impl SpdmPalIo for LargeRequestIo<'_> {
+    fn kind(&self) -> SpdmPalIoKind {
+        self.kind
+    }
+
+    fn request(&self) -> &[u8] {
+        self.request
+    }
+}
+
+enum LargeRequestOutcome<'a, Pal: SpdmPal + 'a> {
+    #[cfg_attr(not(feature = "set-certificate"), allow(dead_code))]
+    Response {
+        response: PalBytes<'a, Pal>,
+        spdm_len: usize,
+    },
+    Error(SpdmError),
+    EarlyError(SpdmError),
+}
+
+async fn build_response_to_large_request<'a, Pal: SpdmPal>(
+    state: &mut ConnectionState<Pal::State>,
+    pal: &'a Pal,
+    io: &impl SpdmPalIo,
+) -> LargeRequestOutcome<'a, Pal> {
+    let large_msg_size = state.chunk.large_msg_size as usize;
+    if large_msg_size < SpdmMsgHdrPdu::SIZE {
+        return LargeRequestOutcome::Error(SPDM_INVALID_REQUEST);
     }
     let mut hdr_buf = [0u8; SpdmMsgHdrPdu::SIZE];
     if pal.read(0, &mut hdr_buf).is_err() {
-        return SPDM_INVALID_REQUEST;
+        return LargeRequestOutcome::Error(SPDM_INVALID_REQUEST);
     };
     let Ok((hdr, _)) = SpdmMsgHdrPdu::ref_from_prefix(&hdr_buf) else {
-        return SPDM_INVALID_REQUEST;
+        return LargeRequestOutcome::Error(SPDM_INVALID_REQUEST);
     };
-    if hdr.version != state.version.to_u8()
-        || hdr.code == ReqRespCode::CHUNK_SEND
-        || hdr.code == ReqRespCode::CHUNK_GET
-    {
-        return SPDM_INVALID_REQUEST;
+    if hdr.version != state.version.to_u8() {
+        return LargeRequestOutcome::Error(SPDM_VERSION_MISMATCH);
     }
-    // TODO: Dispatch supported chunked large requests from `large_req` here.
-    // SPDM-lite currently only uses chunking for large responses.
-    SPDM_UNSUPPORTED_REQUEST
+
+    match hdr.code {
+        ReqRespCode::CHUNK_SEND | ReqRespCode::CHUNK_GET => {
+            LargeRequestOutcome::EarlyError(SPDM_INVALID_REQUEST)
+        }
+        ReqRespCode(0) => LargeRequestOutcome::Error(SPDM_INVALID_REQUEST),
+        ReqRespCode::SET_CERTIFICATE => {
+            handle_large_set_certificate(state, pal, io, large_msg_size).await
+        }
+        code => LargeRequestOutcome::Error(SPDM_UNSUPPORTED_REQUEST.with_data(code.0)),
+    }
+}
+
+#[cfg(feature = "set-certificate")]
+async fn handle_large_set_certificate<'a, Pal: SpdmPal>(
+    state: &mut ConnectionState<Pal::State>,
+    pal: &'a Pal,
+    io: &impl SpdmPalIo,
+    large_msg_size: usize,
+) -> LargeRequestOutcome<'a, Pal> {
+    let guard = match LargeMessageBufferGuard::take(pal) {
+        Ok(guard) => guard,
+        Err(err) => return LargeRequestOutcome::Error(err.into()),
+    };
+    let result = {
+        let Some(request) = guard.request(large_msg_size) else {
+            return LargeRequestOutcome::Error(SPDM_INVALID_REQUEST);
+        };
+        let large_io = LargeRequestIo {
+            kind: io.kind(),
+            request,
+        };
+        match crate::set_certificate::handle_set_certificate(state, pal, &large_io).await {
+            Ok(response) => LargeRequestOutcome::Response {
+                response,
+                spdm_len: SET_CERTIFICATE_RESPONSE_SIZE,
+            },
+            Err(err) => LargeRequestOutcome::Error(err),
+        }
+    };
+    result
+}
+
+#[cfg(not(feature = "set-certificate"))]
+async fn handle_large_set_certificate<'a, Pal: SpdmPal>(
+    _state: &mut ConnectionState<Pal::State>,
+    _pal: &'a Pal,
+    _io: &impl SpdmPalIo,
+    _large_msg_size: usize,
+) -> LargeRequestOutcome<'a, Pal> {
+    LargeRequestOutcome::Error(SPDM_UNSUPPORTED_REQUEST.with_data(ReqRespCode::SET_CERTIFICATE.0))
+}
+
+#[cfg(feature = "set-certificate")]
+struct LargeMessageBufferGuard<'pal, Pal: SpdmPal> {
+    pal: &'pal Pal,
+    buf: Option<&'static mut [u8]>,
+}
+
+#[cfg(feature = "set-certificate")]
+impl<'pal, Pal: SpdmPal> LargeMessageBufferGuard<'pal, Pal> {
+    fn take(pal: &'pal Pal) -> McuResult<Self> {
+        Ok(Self {
+            pal,
+            buf: Some(pal.take()?),
+        })
+    }
+
+    fn request(&self, large_msg_size: usize) -> Option<&[u8]> {
+        self.buf.as_deref()?.get(..large_msg_size)
+    }
+}
+
+#[cfg(feature = "set-certificate")]
+impl<Pal: SpdmPal> Drop for LargeMessageBufferGuard<'_, Pal> {
+    fn drop(&mut self) {
+        if let Some(buf) = self.buf.take() {
+            self.pal.replace(buf);
+        }
+    }
 }
 
 fn encode_error_pdu(version: SpdmVersion, err: SpdmError, out: &mut [u8; 4]) {
     out[0] = version.to_u8();
     out[1] = ReqRespCode::ERROR.0;
     out[2] = err.spec_byte();
-    out[3] = 0;
+    out[3] = err.error_data();
 }

--- a/runtime/userspace/api/spdm-lite/stack/src/set_certificate.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/set_certificate.rs
@@ -13,9 +13,7 @@ use mcu_spdm_lite_codec::{
     SpdmMsgHdrPdu, SpdmVersion,
 };
 use mcu_spdm_lite_errors::as_spdm_wire;
-use mcu_spdm_lite_traits::{
-    PalBytes, SpdmPal, SpdmPalHashAlgo, SpdmPalIo, SpdmPalIoTransport, MAX_SLOTS,
-};
+use mcu_spdm_lite_traits::{PalBytes, SpdmPal, SpdmPalHashAlgo, SpdmPalIo, MAX_SLOTS};
 use zerocopy::FromBytes;
 
 use crate::build::build_response;
@@ -34,7 +32,7 @@ const CERT_MODEL_GENERIC_CERT: u8 = 3;
 pub(crate) async fn handle_set_certificate<'a, Pal: SpdmPal>(
     state: &mut ConnectionState<Pal::State>,
     pal: &'a Pal,
-    io: &<Pal as SpdmPalIoTransport>::Io<'_>,
+    io: &impl SpdmPalIo,
 ) -> SpdmResult<PalBytes<'a, Pal>> {
     if (state.phase as u8) < (Phase::AfterAlgorithms as u8) {
         return Err(SPDM_UNEXPECTED_REQUEST);
@@ -44,7 +42,12 @@ pub(crate) async fn handle_set_certificate<'a, Pal: SpdmPal>(
     }
 
     let req = io.request();
-    if req.len() > pal.mtu() {
+    let max_request_len = if state.chunk.in_progress() {
+        state.chunk.large_msg_size() as usize
+    } else {
+        pal.mtu()
+    };
+    if req.len() > max_request_len {
         return Err(SPDM_INVALID_REQUEST);
     }
     let (hdr, body) = SpdmMsgHdrPdu::ref_from_prefix(req).map_err(|_| SPDM_INVALID_REQUEST)?;
@@ -86,6 +89,7 @@ pub(crate) async fn handle_set_certificate<'a, Pal: SpdmPal>(
         }
         pal.erase_cert_chain(io, slot_id, state.asym_algo()).await?;
     } else {
+        let payload = split_cert_payload(state, pal, payload)?;
         let (root_hash, der) = validate_spdm_cert_chain(pal, io, payload).await?;
         pal.validate_set_certificate_chain(
             io,
@@ -186,9 +190,42 @@ fn validate_negotiated_set_certificate_algorithms<S: Clone>(
     Ok(())
 }
 
+fn split_cert_payload<'payload, Pal: SpdmPal, S: Clone>(
+    state: &ConnectionState<S>,
+    pal: &Pal,
+    payload: &'payload [u8],
+) -> SpdmResult<&'payload [u8]> {
+    if payload.len() < SPDM_CERT_CHAIN_HDR_LEN {
+        return Err(SPDM_INVALID_REQUEST);
+    }
+
+    let length = u16::from_le_bytes([payload[0], payload[1]]) as usize;
+    if length < SPDM_CERT_CHAIN_HDR_LEN || length > payload.len() {
+        return Err(SPDM_INVALID_REQUEST);
+    }
+
+    let cert_payload = &payload[..length];
+    let padding = &payload[length..];
+    if state.chunk.in_progress() {
+        if !padding.is_empty() {
+            return Err(SPDM_INVALID_REQUEST);
+        }
+    } else {
+        let spdm_len = SpdmMsgHdrPdu::SIZE
+            .checked_add(SetCertificateReqBody::SIZE)
+            .and_then(|n| n.checked_add(length))
+            .ok_or(SPDM_INVALID_REQUEST)?;
+        if !crate::chunk::valid_transport_padding(pal, spdm_len, padding) {
+            return Err(SPDM_INVALID_REQUEST);
+        }
+    }
+
+    Ok(cert_payload)
+}
+
 async fn validate_spdm_cert_chain<'payload, Pal: SpdmPal>(
     pal: &Pal,
-    io: &<Pal as SpdmPalIoTransport>::Io<'_>,
+    io: &impl SpdmPalIo,
     payload: &'payload [u8],
 ) -> SpdmResult<([u8; SHA384_DIGEST_SIZE], &'payload [u8])> {
     if payload.len() < SPDM_CERT_CHAIN_HDR_LEN {
@@ -256,7 +293,7 @@ fn der_sequence_len(input: &[u8]) -> Option<usize> {
 
 async fn validate_root_hash<Pal: SpdmPal>(
     pal: &Pal,
-    io: &<Pal as SpdmPalIoTransport>::Io<'_>,
+    io: &impl SpdmPalIo,
     expected: &[u8; SHA384_DIGEST_SIZE],
     root_cert: &[u8],
 ) -> SpdmResult<()> {
@@ -290,15 +327,22 @@ mod tests {
     extern crate std;
 
     use super::*;
-    use crate::error::{SPDM_BUSY, SPDM_OPERATION_FAILED, SPDM_RESET_REQUIRED, SPDM_UNSPECIFIED};
+    use crate::error::{
+        SPDM_BUSY, SPDM_INVALID_REQUEST, SPDM_OPERATION_FAILED, SPDM_RESET_REQUIRED,
+        SPDM_UNSPECIFIED, SPDM_VERSION_MISMATCH,
+    };
     use core::marker::PhantomData;
     use core::ops::{Deref, DerefMut};
     use futures::executor::block_on;
     use mcu_error::McuErrorCode;
-    use mcu_spdm_lite_codec::{errors as wire_errors, OtherParamSupport, ReqRespCode};
+    use mcu_spdm_lite_codec::{
+        errors as wire_errors, OtherParamSupport, ReqRespCode, CHUNK_ACK_ATTR_EARLY_ERROR,
+        CHUNK_ATTR_LAST_CHUNK,
+    };
     use mcu_spdm_lite_traits::{
-        McuResult, SpdmPalAlloc, SpdmPalAsymAlgo, SpdmPalCertStore, SpdmPalHash, SpdmPalIoKind,
-        SpdmPalLargeMessage,
+        McuResult, MeasurementInfo, SpdmPalAlloc, SpdmPalAsymAlgo, SpdmPalCertStore, SpdmPalHash,
+        SpdmPalIoKind, SpdmPalIoTransport, SpdmPalLargeMessage, SpdmPalMeasurements,
+        SPDM_NONCE_LEN,
     };
     use std::boxed::Box;
     use std::cell::RefCell;
@@ -359,24 +403,30 @@ mod tests {
 
     struct TestPal {
         mtu: usize,
+        header_size: usize,
+        send_len_alignment: usize,
         supported_slots: u8,
         authorized: bool,
         validate_error: Option<McuErrorCode>,
         write_error: Option<McuErrorCode>,
         erase_error: Option<McuErrorCode>,
         op: RefCell<Option<StoreOp>>,
+        large_msg: RefCell<Option<&'static mut [u8]>>,
     }
 
     impl Default for TestPal {
         fn default() -> Self {
             Self {
                 mtu: 1024,
+                header_size: 0,
+                send_len_alignment: 1,
                 supported_slots: u8::MAX,
                 authorized: true,
                 validate_error: None,
                 write_error: None,
                 erase_error: None,
                 op: RefCell::new(None),
+                large_msg: RefCell::new(None),
             }
         }
     }
@@ -415,7 +465,11 @@ mod tests {
         }
 
         fn header_size(&self) -> usize {
-            0
+            self.header_size
+        }
+
+        fn send_len_alignment(&self) -> usize {
+            self.send_len_alignment
         }
 
         fn mtu(&self) -> usize {
@@ -438,16 +492,47 @@ mod tests {
 
     impl SpdmPalLargeMessage for TestPal {
         fn capacity(&self) -> usize {
-            self.mtu
+            self.large_msg
+                .borrow()
+                .as_ref()
+                .map_or(self.mtu, |buf| buf.len())
         }
 
-        fn write(&self, _offset: usize, _data: &[u8]) -> McuResult<()> {
+        fn write(&self, offset: usize, data: &[u8]) -> McuResult<()> {
+            let mut large_msg = self.large_msg.borrow_mut();
+            let buf = large_msg
+                .as_deref_mut()
+                .ok_or(mcu_error::codes::INVARIANT)?;
+            let end = offset
+                .checked_add(data.len())
+                .ok_or(mcu_error::codes::INVARIANT)?;
+            let dst = buf
+                .get_mut(offset..end)
+                .ok_or(mcu_error::codes::INVARIANT)?;
+            dst.copy_from_slice(data);
             Ok(())
         }
 
-        fn read(&self, _offset: usize, out: &mut [u8]) -> McuResult<()> {
-            out.fill(0);
+        fn read(&self, offset: usize, out: &mut [u8]) -> McuResult<()> {
+            let large_msg = self.large_msg.borrow();
+            let buf = large_msg.as_deref().ok_or(mcu_error::codes::INVARIANT)?;
+            let end = offset
+                .checked_add(out.len())
+                .ok_or(mcu_error::codes::INVARIANT)?;
+            let src = buf.get(offset..end).ok_or(mcu_error::codes::INVARIANT)?;
+            out.copy_from_slice(src);
             Ok(())
+        }
+
+        fn take(&self) -> McuResult<&'static mut [u8]> {
+            self.large_msg
+                .borrow_mut()
+                .take()
+                .ok_or(mcu_error::codes::INVARIANT)
+        }
+
+        fn replace(&self, buf: &'static mut [u8]) {
+            self.large_msg.replace(Some(buf));
         }
     }
 
@@ -486,6 +571,22 @@ mod tests {
         }
     }
 
+    impl SpdmPalMeasurements for TestPal {
+        fn measurement_info(&self) -> &[MeasurementInfo] {
+            &[]
+        }
+
+        async fn get_measurement_value(
+            &self,
+            _io: &Self::Io<'_>,
+            _index: u8,
+            _nonce: Option<&[u8; SPDM_NONCE_LEN]>,
+            _out: &mut [u8],
+        ) -> McuResult<usize> {
+            Err(mcu_error::codes::NOT_IMPLEMENTED)
+        }
+    }
+
     impl SpdmPalCertStore for TestPal {
         fn provisioned_slots(&self) -> u8 {
             0
@@ -497,7 +598,7 @@ mod tests {
 
         fn set_certificate_authorized(
             &self,
-            _io: &Self::Io<'_>,
+            _io: &impl SpdmPalIo,
             _slot: u8,
             _key_pair_id: u8,
             _cert_model: u8,
@@ -508,7 +609,7 @@ mod tests {
 
         async fn validate_set_certificate_chain(
             &self,
-            _io: &Self::Io<'_>,
+            _io: &impl SpdmPalIo,
             _slot: u8,
             _key_pair_id: u8,
             _cert_model: u8,
@@ -524,7 +625,7 @@ mod tests {
 
         async fn cert_chain_len(
             &self,
-            _io: &Self::Io<'_>,
+            _io: &impl SpdmPalIo,
             _slot: u8,
             _algo: SpdmPalAsymAlgo,
         ) -> McuResult<usize> {
@@ -533,7 +634,7 @@ mod tests {
 
         async fn root_cert_hash(
             &self,
-            _io: &Self::Io<'_>,
+            _io: &impl SpdmPalIo,
             _slot: u8,
             _algo: SpdmPalAsymAlgo,
             _hash_algo: SpdmPalHashAlgo,
@@ -544,7 +645,7 @@ mod tests {
 
         async fn read_cert_chain(
             &self,
-            _io: &Self::Io<'_>,
+            _io: &impl SpdmPalIo,
             _slot: u8,
             _algo: SpdmPalAsymAlgo,
             _offset: usize,
@@ -555,7 +656,7 @@ mod tests {
 
         async fn sign_hash(
             &self,
-            _io: &Self::Io<'_>,
+            _io: &impl SpdmPalIo,
             _slot: u8,
             _algo: SpdmPalAsymAlgo,
             _digest: &[u8],
@@ -566,7 +667,7 @@ mod tests {
 
         async fn write_cert_chain(
             &self,
-            _io: &Self::Io<'_>,
+            _io: &impl SpdmPalIo,
             slot: u8,
             _algo: SpdmPalAsymAlgo,
             key_pair_id: u8,
@@ -589,7 +690,7 @@ mod tests {
 
         async fn erase_cert_chain(
             &self,
-            _io: &Self::Io<'_>,
+            _io: &impl SpdmPalIo,
             slot: u8,
             _algo: SpdmPalAsymAlgo,
         ) -> McuResult<()> {
@@ -612,7 +713,7 @@ mod tests {
             None
         }
 
-        async fn generate_nonce(&self, _io: &Self::Io<'_>, out: &mut [u8]) -> McuResult<()> {
+        async fn generate_nonce(&self, _io: &impl SpdmPalIo, out: &mut [u8]) -> McuResult<()> {
             out.fill(0xA5);
             Ok(())
         }
@@ -670,6 +771,647 @@ mod tests {
         TestIo { request }
     }
 
+    fn chunk_send(
+        version: SpdmVersion,
+        handle: u8,
+        seq: u16,
+        last: bool,
+        large_msg_size: Option<usize>,
+        chunk: &[u8],
+    ) -> TestIo {
+        chunk_send_with_padding(version, handle, seq, last, large_msg_size, chunk, &[])
+    }
+
+    fn chunk_send_with_padding(
+        version: SpdmVersion,
+        handle: u8,
+        seq: u16,
+        last: bool,
+        large_msg_size: Option<usize>,
+        chunk: &[u8],
+        padding: &[u8],
+    ) -> TestIo {
+        let mut request = vec![version.to_u8(), ReqRespCode::CHUNK_SEND.0];
+        request.push(if last { CHUNK_ATTR_LAST_CHUNK } else { 0 });
+        request.push(handle);
+        request.extend_from_slice(&seq.to_le_bytes());
+        request.extend_from_slice(&0u16.to_le_bytes());
+        request.extend_from_slice(&(chunk.len() as u32).to_le_bytes());
+        if let Some(size) = large_msg_size {
+            request.extend_from_slice(&(size as u32).to_le_bytes());
+        }
+        request.extend_from_slice(chunk);
+        request.extend_from_slice(padding);
+        TestIo { request }
+    }
+
+    fn chunk_test_pal(mtu: usize) -> TestPal {
+        let pal = TestPal {
+            mtu,
+            ..TestPal::default()
+        };
+        pal.large_msg
+            .replace(Some(Box::leak(vec![0u8; 128].into_boxed_slice())));
+        pal
+    }
+
+    fn run_two_chunk_request(
+        state: &mut ConnectionState<TestHashState>,
+        pal: &TestPal,
+        handle: u8,
+        large_request: &[u8],
+    ) -> Vec<u8> {
+        assert!(large_request.len() > pal.mtu());
+        let (first, second) = large_request.split_at(30);
+
+        let first_io = chunk_send(
+            state.version,
+            handle,
+            0,
+            false,
+            Some(large_request.len()),
+            first,
+        );
+        let first_ack = block_on(crate::chunk::handle_chunk_send(state, pal, &first_io)).unwrap();
+        assert_eq!(
+            &first_ack[..],
+            &[
+                state.version.to_u8(),
+                ReqRespCode::CHUNK_SEND_ACK.0,
+                0,
+                handle,
+                0,
+                0
+            ]
+        );
+        assert!(state.chunk.in_progress());
+
+        let second_io = chunk_send(state.version, handle, 1, true, None, second);
+        block_on(crate::chunk::handle_chunk_send(state, pal, &second_io)).unwrap()
+    }
+
+    #[test]
+    fn test_chunk_send_ack_respects_transport_padding() {
+        let pal = TestPal {
+            mtu: 48,
+            header_size: 1,
+            send_len_alignment: 4,
+            ..TestPal::default()
+        };
+        pal.large_msg
+            .replace(Some(Box::leak(vec![0u8; 128].into_boxed_slice())));
+        let mut state = state(SpdmVersion::V12);
+        state.peer_cap_flags = CapFlags::CHUNK;
+        let mut large_request = vec![0u8; 50];
+        large_request[0] = SpdmVersion::V12.to_u8();
+        large_request[1] = ReqRespCode::SET_CERTIFICATE.0;
+        let (first, second) = large_request.split_at(30);
+
+        let first_io =
+            chunk_send_with_padding(SpdmVersion::V12, 14, 0, false, Some(50), first, &[0, 0]);
+        let first_ack =
+            block_on(crate::chunk::handle_chunk_send(&mut state, &pal, &first_io)).unwrap();
+        assert_eq!(first_ack.len(), 8);
+        assert_eq!(first_ack[0], 0);
+        assert_eq!(
+            &first_ack[1..7],
+            &[
+                SpdmVersion::V12.to_u8(),
+                ReqRespCode::CHUNK_SEND_ACK.0,
+                0,
+                14,
+                0,
+                0,
+            ]
+        );
+        assert_eq!(first_ack[7], 0);
+        assert!(state.chunk.in_progress());
+
+        let second_io = chunk_send(SpdmVersion::V12, 14, 1, true, None, second);
+        let second_ack = block_on(crate::chunk::handle_chunk_send(
+            &mut state, &pal, &second_io,
+        ))
+        .unwrap();
+        assert_eq!(second_ack.len(), 12);
+        assert_eq!(second_ack[0], 0);
+        assert_eq!(
+            &second_ack[1..11],
+            &[
+                SpdmVersion::V12.to_u8(),
+                ReqRespCode::CHUNK_SEND_ACK.0,
+                0,
+                14,
+                1,
+                0,
+                SpdmVersion::V12.to_u8(),
+                ReqRespCode::ERROR.0,
+                SPDM_INVALID_REQUEST.spec_byte(),
+                0,
+            ]
+        );
+        assert_eq!(second_ack[11], 0);
+        assert!(!state.chunk.in_progress());
+    }
+
+    #[test]
+    fn test_chunk_send_accepts_doe_padding_on_set_certificate_chunks() {
+        let pal = TestPal {
+            mtu: 48,
+            send_len_alignment: 4,
+            ..TestPal::default()
+        };
+        pal.large_msg
+            .replace(Some(Box::leak(vec![0u8; 128].into_boxed_slice())));
+        let mut state = state(SpdmVersion::V12);
+        state.peer_cap_flags = CapFlags::CHUNK;
+        let der = der_chain();
+        let root_hash = test_digest(&der[..5]);
+        let payload = cert_payload(&der, root_hash);
+        let large_request = request(SpdmVersion::V12, 1, 0, &payload).request;
+        assert_eq!(large_request.len(), 64);
+        let (first, second) = large_request.split_at(30);
+
+        // First CHUNK_SEND SPDM length: common header(2) + body(10) +
+        // LargeMessageSize(4) + ChunkSize(30) = 46, so DOE pads 2 bytes.
+        let first_io = chunk_send_with_padding(
+            SpdmVersion::V12,
+            15,
+            0,
+            false,
+            Some(large_request.len()),
+            first,
+            &[0, 0],
+        );
+        let first_ack =
+            block_on(crate::chunk::handle_chunk_send(&mut state, &pal, &first_io)).unwrap();
+        assert_eq!(first_ack.len(), 8);
+        assert_eq!(
+            &first_ack[..6],
+            &[
+                SpdmVersion::V12.to_u8(),
+                ReqRespCode::CHUNK_SEND_ACK.0,
+                0,
+                15,
+                0,
+                0,
+            ]
+        );
+        assert_eq!(&first_ack[6..], &[0, 0]);
+        assert!(state.chunk.in_progress());
+
+        // Final CHUNK_SEND SPDM length: common header(2) + body(10) +
+        // ChunkSize(34) = 46, so DOE pads 2 bytes. The reassembled request
+        // must use only ChunkSize bytes, not the trailing padding.
+        let second_io =
+            chunk_send_with_padding(SpdmVersion::V12, 15, 1, true, None, second, &[0, 0]);
+        let second_ack = block_on(crate::chunk::handle_chunk_send(
+            &mut state, &pal, &second_io,
+        ))
+        .unwrap();
+
+        assert_eq!(second_ack.len(), 12);
+        assert_eq!(
+            &second_ack[..10],
+            &[
+                SpdmVersion::V12.to_u8(),
+                ReqRespCode::CHUNK_SEND_ACK.0,
+                0,
+                15,
+                1,
+                0,
+                SpdmVersion::V12.to_u8(),
+                ReqRespCode::SET_CERTIFICATE_RSP.0,
+                1,
+                0,
+            ]
+        );
+        assert_eq!(&second_ack[10..], &[0, 0]);
+        assert!(!state.chunk.in_progress());
+        assert_eq!(
+            pal.op.take(),
+            Some(StoreOp::Write {
+                slot: 1,
+                key_pair_id: 0,
+                cert_model: CERT_MODEL_ALIAS_CERT,
+                root_hash,
+                cert_chain: der,
+            })
+        );
+    }
+
+    #[test]
+    fn test_chunk_send_rejects_nonzero_doe_padding() {
+        let pal = TestPal {
+            mtu: 48,
+            send_len_alignment: 4,
+            ..TestPal::default()
+        };
+        pal.large_msg
+            .replace(Some(Box::leak(vec![0u8; 128].into_boxed_slice())));
+        let mut state = state(SpdmVersion::V12);
+        state.peer_cap_flags = CapFlags::CHUNK;
+        let mut large_request = vec![0u8; 64];
+        large_request[0] = SpdmVersion::V12.to_u8();
+        large_request[1] = ReqRespCode::SET_CERTIFICATE.0;
+        let first = &large_request[..30];
+
+        let first_io = chunk_send_with_padding(
+            SpdmVersion::V12,
+            16,
+            0,
+            false,
+            Some(large_request.len()),
+            first,
+            &[0, 1],
+        );
+        let ack = block_on(crate::chunk::handle_chunk_send(&mut state, &pal, &first_io)).unwrap();
+
+        assert_eq!(ack.len(), 12);
+        assert_eq!(
+            &ack[..10],
+            &[
+                SpdmVersion::V12.to_u8(),
+                ReqRespCode::CHUNK_SEND_ACK.0,
+                CHUNK_ACK_ATTR_EARLY_ERROR,
+                16,
+                0,
+                0,
+                SpdmVersion::V12.to_u8(),
+                ReqRespCode::ERROR.0,
+                SPDM_INVALID_REQUEST.spec_byte(),
+                0,
+            ]
+        );
+        assert_eq!(&ack[10..], &[0, 0]);
+        assert!(!state.chunk.in_progress());
+        assert_eq!(pal.op.take(), None);
+    }
+
+    #[test]
+    fn test_chunk_send_rejects_incorrect_doe_padding_length() {
+        let pal = TestPal {
+            mtu: 48,
+            send_len_alignment: 4,
+            ..TestPal::default()
+        };
+        pal.large_msg
+            .replace(Some(Box::leak(vec![0u8; 128].into_boxed_slice())));
+        let mut state = state(SpdmVersion::V12);
+        state.peer_cap_flags = CapFlags::CHUNK;
+        let mut large_request = vec![0u8; 64];
+        large_request[0] = SpdmVersion::V12.to_u8();
+        large_request[1] = ReqRespCode::SET_CERTIFICATE.0;
+        let first = &large_request[..30];
+
+        // SPDM length is 46, so a 4-byte-aligned transport may only append
+        // exactly 2 padding bytes; a single zero byte is malformed padding.
+        let first_io = chunk_send_with_padding(
+            SpdmVersion::V12,
+            17,
+            0,
+            false,
+            Some(large_request.len()),
+            first,
+            &[0],
+        );
+        let ack = block_on(crate::chunk::handle_chunk_send(&mut state, &pal, &first_io)).unwrap();
+
+        assert_eq!(ack.len(), 12);
+        assert_eq!(
+            &ack[..10],
+            &[
+                SpdmVersion::V12.to_u8(),
+                ReqRespCode::CHUNK_SEND_ACK.0,
+                CHUNK_ACK_ATTR_EARLY_ERROR,
+                17,
+                0,
+                0,
+                SpdmVersion::V12.to_u8(),
+                ReqRespCode::ERROR.0,
+                SPDM_INVALID_REQUEST.spec_byte(),
+                0,
+            ]
+        );
+        assert_eq!(&ack[10..], &[0, 0]);
+        assert!(!state.chunk.in_progress());
+        assert_eq!(pal.op.take(), None);
+    }
+
+    #[test]
+    fn test_chunk_send_rejects_missing_doe_padding_on_first_chunk() {
+        let pal = TestPal {
+            mtu: 48,
+            send_len_alignment: 4,
+            ..TestPal::default()
+        };
+        pal.large_msg
+            .replace(Some(Box::leak(vec![0u8; 128].into_boxed_slice())));
+        let mut state = state(SpdmVersion::V12);
+        state.peer_cap_flags = CapFlags::CHUNK;
+        let mut large_request = vec![0u8; 64];
+        large_request[0] = SpdmVersion::V12.to_u8();
+        large_request[1] = ReqRespCode::SET_CERTIFICATE.0;
+        let first = &large_request[..30];
+
+        // First CHUNK_SEND SPDM length is 46, so DOE must append two zeros.
+        let first_io = chunk_send(
+            SpdmVersion::V12,
+            18,
+            0,
+            false,
+            Some(large_request.len()),
+            first,
+        );
+        let ack = block_on(crate::chunk::handle_chunk_send(&mut state, &pal, &first_io)).unwrap();
+
+        assert_eq!(ack.len(), 12);
+        assert_eq!(
+            &ack[..10],
+            &[
+                SpdmVersion::V12.to_u8(),
+                ReqRespCode::CHUNK_SEND_ACK.0,
+                CHUNK_ACK_ATTR_EARLY_ERROR,
+                18,
+                0,
+                0,
+                SpdmVersion::V12.to_u8(),
+                ReqRespCode::ERROR.0,
+                SPDM_INVALID_REQUEST.spec_byte(),
+                0,
+            ]
+        );
+        assert_eq!(&ack[10..], &[0, 0]);
+        assert!(!state.chunk.in_progress());
+        assert_eq!(pal.op.take(), None);
+    }
+
+    #[test]
+    fn test_chunk_send_rejects_missing_doe_padding_on_final_chunk() {
+        let pal = TestPal {
+            mtu: 48,
+            send_len_alignment: 4,
+            ..TestPal::default()
+        };
+        pal.large_msg
+            .replace(Some(Box::leak(vec![0u8; 128].into_boxed_slice())));
+        let mut state = state(SpdmVersion::V12);
+        state.peer_cap_flags = CapFlags::CHUNK;
+        let der = der_chain();
+        let root_hash = test_digest(&der[..5]);
+        let payload = cert_payload(&der, root_hash);
+        let large_request = request(SpdmVersion::V12, 1, 0, &payload).request;
+        assert_eq!(large_request.len(), 64);
+        let (first, second) = large_request.split_at(30);
+
+        let first_io = chunk_send_with_padding(
+            SpdmVersion::V12,
+            19,
+            0,
+            false,
+            Some(large_request.len()),
+            first,
+            &[0, 0],
+        );
+        let first_ack =
+            block_on(crate::chunk::handle_chunk_send(&mut state, &pal, &first_io)).unwrap();
+        assert_eq!(
+            &first_ack[..6],
+            &[
+                SpdmVersion::V12.to_u8(),
+                ReqRespCode::CHUNK_SEND_ACK.0,
+                0,
+                19,
+                0,
+                0,
+            ]
+        );
+        assert!(state.chunk.in_progress());
+
+        // Final CHUNK_SEND SPDM length is 46, so DOE must append two zeros.
+        let second_io = chunk_send(SpdmVersion::V12, 19, 1, true, None, second);
+        let ack = block_on(crate::chunk::handle_chunk_send(
+            &mut state, &pal, &second_io,
+        ))
+        .unwrap();
+
+        assert_eq!(ack.len(), 12);
+        assert_eq!(
+            &ack[..10],
+            &[
+                SpdmVersion::V12.to_u8(),
+                ReqRespCode::CHUNK_SEND_ACK.0,
+                CHUNK_ACK_ATTR_EARLY_ERROR,
+                19,
+                1,
+                0,
+                SpdmVersion::V12.to_u8(),
+                ReqRespCode::ERROR.0,
+                SPDM_INVALID_REQUEST.spec_byte(),
+                0,
+            ]
+        );
+        assert_eq!(&ack[10..], &[0, 0]);
+        assert!(!state.chunk.in_progress());
+        assert_eq!(pal.op.take(), None);
+    }
+
+    #[test]
+    fn test_chunked_set_certificate_v12_writes_cert_chain() {
+        let pal = TestPal {
+            mtu: 48,
+            ..TestPal::default()
+        };
+        pal.large_msg
+            .replace(Some(Box::leak(vec![0u8; 128].into_boxed_slice())));
+        let mut state = state(SpdmVersion::V12);
+        state.peer_cap_flags = CapFlags::CHUNK;
+        let der = der_chain();
+        let root_hash = test_digest(&der[..5]);
+        let payload = cert_payload(&der, root_hash);
+        let large_request = request(SpdmVersion::V12, 1, 0, &payload).request;
+        assert!(large_request.len() > pal.mtu());
+        let (first, second) = large_request.split_at(30);
+
+        let first_io = chunk_send(
+            SpdmVersion::V12,
+            9,
+            0,
+            false,
+            Some(large_request.len()),
+            first,
+        );
+        let first_ack =
+            block_on(crate::chunk::handle_chunk_send(&mut state, &pal, &first_io)).unwrap();
+        assert_eq!(
+            &first_ack[..],
+            &[
+                SpdmVersion::V12.to_u8(),
+                ReqRespCode::CHUNK_SEND_ACK.0,
+                0,
+                9,
+                0,
+                0
+            ]
+        );
+        assert!(state.chunk.in_progress());
+
+        let second_io = chunk_send(SpdmVersion::V12, 9, 1, true, None, second);
+        let second_ack = block_on(crate::chunk::handle_chunk_send(
+            &mut state, &pal, &second_io,
+        ))
+        .unwrap();
+
+        assert_eq!(
+            &second_ack[..],
+            &[
+                SpdmVersion::V12.to_u8(),
+                ReqRespCode::CHUNK_SEND_ACK.0,
+                0,
+                9,
+                1,
+                0,
+                SpdmVersion::V12.to_u8(),
+                ReqRespCode::SET_CERTIFICATE_RSP.0,
+                1,
+                0,
+            ]
+        );
+        assert!(!state.chunk.in_progress());
+        assert_eq!(
+            pal.op.take(),
+            Some(StoreOp::Write {
+                slot: 1,
+                key_pair_id: 0,
+                cert_model: CERT_MODEL_ALIAS_CERT,
+                root_hash,
+                cert_chain: der,
+            })
+        );
+        assert!(pal.large_msg.borrow().is_some());
+    }
+
+    #[test]
+    fn test_chunked_nested_chunk_send_returns_early_error_ack() {
+        let pal = chunk_test_pal(48);
+        let mut state = state(SpdmVersion::V12);
+        state.peer_cap_flags = CapFlags::CHUNK;
+        let mut large_request = vec![0u8; 50];
+        large_request[0] = SpdmVersion::V12.to_u8();
+        large_request[1] = ReqRespCode::CHUNK_SEND.0;
+
+        let ack = run_two_chunk_request(&mut state, &pal, 10, &large_request);
+
+        assert_eq!(
+            &ack[..],
+            &[
+                SpdmVersion::V12.to_u8(),
+                ReqRespCode::CHUNK_SEND_ACK.0,
+                CHUNK_ACK_ATTR_EARLY_ERROR,
+                10,
+                1,
+                0,
+                SpdmVersion::V12.to_u8(),
+                ReqRespCode::ERROR.0,
+                SPDM_INVALID_REQUEST.spec_byte(),
+                0,
+            ]
+        );
+        assert!(!state.chunk.in_progress());
+        assert!(pal.large_msg.borrow().is_some());
+    }
+
+    #[test]
+    fn test_chunked_nested_chunk_get_returns_early_error_ack() {
+        let pal = chunk_test_pal(48);
+        let mut state = state(SpdmVersion::V12);
+        state.peer_cap_flags = CapFlags::CHUNK;
+        let mut large_request = vec![0u8; 50];
+        large_request[0] = SpdmVersion::V12.to_u8();
+        large_request[1] = ReqRespCode::CHUNK_GET.0;
+
+        let ack = run_two_chunk_request(&mut state, &pal, 11, &large_request);
+
+        assert_eq!(
+            &ack[..],
+            &[
+                SpdmVersion::V12.to_u8(),
+                ReqRespCode::CHUNK_SEND_ACK.0,
+                CHUNK_ACK_ATTR_EARLY_ERROR,
+                11,
+                1,
+                0,
+                SpdmVersion::V12.to_u8(),
+                ReqRespCode::ERROR.0,
+                SPDM_INVALID_REQUEST.spec_byte(),
+                0,
+            ]
+        );
+        assert!(!state.chunk.in_progress());
+        assert!(pal.large_msg.borrow().is_some());
+    }
+
+    #[test]
+    fn test_chunked_set_certificate_version_mismatch_embeds_error() {
+        let pal = chunk_test_pal(48);
+        let mut state = state(SpdmVersion::V12);
+        state.peer_cap_flags = CapFlags::CHUNK;
+        let mut large_request = vec![0u8; 50];
+        large_request[0] = SpdmVersion::V13.to_u8();
+        large_request[1] = ReqRespCode::SET_CERTIFICATE.0;
+
+        let ack = run_two_chunk_request(&mut state, &pal, 12, &large_request);
+
+        assert_eq!(
+            &ack[..],
+            &[
+                SpdmVersion::V12.to_u8(),
+                ReqRespCode::CHUNK_SEND_ACK.0,
+                0,
+                12,
+                1,
+                0,
+                SpdmVersion::V12.to_u8(),
+                ReqRespCode::ERROR.0,
+                SPDM_VERSION_MISMATCH.spec_byte(),
+                0,
+            ]
+        );
+        assert!(!state.chunk.in_progress());
+        assert_eq!(pal.op.take(), None);
+        assert!(pal.large_msg.borrow().is_some());
+    }
+
+    #[test]
+    fn test_chunked_set_certificate_validation_error_embeds_error_and_returns_buffer() {
+        let pal = chunk_test_pal(48);
+        let mut state = state(SpdmVersion::V12);
+        state.peer_cap_flags = CapFlags::CHUNK;
+        let der = der_chain();
+        let payload = cert_payload(&der, [0xa5; SHA384_DIGEST_SIZE]);
+        let large_request = request(SpdmVersion::V12, 1, 0, &payload).request;
+
+        let ack = run_two_chunk_request(&mut state, &pal, 13, &large_request);
+
+        assert_eq!(
+            &ack[..],
+            &[
+                SpdmVersion::V12.to_u8(),
+                ReqRespCode::CHUNK_SEND_ACK.0,
+                0,
+                13,
+                1,
+                0,
+                SpdmVersion::V12.to_u8(),
+                ReqRespCode::ERROR.0,
+                SPDM_INVALID_REQUEST.spec_byte(),
+                0,
+            ]
+        );
+        assert!(!state.chunk.in_progress());
+        assert_eq!(pal.op.take(), None);
+        assert!(pal.large_msg.borrow().is_some());
+    }
+
     #[test]
     fn test_handle_set_certificate_v12_writes_cert_chain() {
         let pal = TestPal::default();
@@ -700,6 +1442,63 @@ mod tests {
                 cert_chain: der,
             })
         );
+    }
+
+    #[test]
+    fn test_handle_set_certificate_accepts_doe_padding() {
+        let pal = TestPal {
+            send_len_alignment: 4,
+            ..TestPal::default()
+        };
+        let mut state = state(SpdmVersion::V12);
+        let der = vec![0x30, 0x02, 1, 2, 0x30, 0x01, 4];
+        let root_hash = test_digest(&der[..4]);
+        let payload = cert_payload(&der, root_hash);
+        let mut io = request(SpdmVersion::V12, 1, 0, &payload);
+        assert_eq!(io.request.len() % 4, 3);
+        io.request.push(0);
+
+        let rsp = block_on(handle_set_certificate(&mut state, &pal, &io)).unwrap();
+
+        assert_eq!(
+            &rsp[..],
+            &[
+                SpdmVersion::V12.to_u8(),
+                ReqRespCode::SET_CERTIFICATE_RSP.0,
+                1,
+                0
+            ]
+        );
+        assert_eq!(
+            pal.op.take(),
+            Some(StoreOp::Write {
+                slot: 1,
+                key_pair_id: 0,
+                cert_model: CERT_MODEL_ALIAS_CERT,
+                root_hash,
+                cert_chain: der,
+            })
+        );
+    }
+
+    #[test]
+    fn test_handle_set_certificate_rejects_bad_doe_padding() {
+        let pal = TestPal {
+            send_len_alignment: 4,
+            ..TestPal::default()
+        };
+        let mut state = state(SpdmVersion::V12);
+        let der = vec![0x30, 0x02, 1, 2, 0x30, 0x01, 4];
+        let root_hash = test_digest(&der[..4]);
+        let payload = cert_payload(&der, root_hash);
+        let mut io = request(SpdmVersion::V12, 1, 0, &payload);
+        assert_eq!(io.request.len() % 4, 3);
+        io.request.push(1);
+
+        let err = block_on(handle_set_certificate(&mut state, &pal, &io)).unwrap_err();
+
+        assert_eq!(err, SPDM_INVALID_REQUEST);
+        assert_eq!(pal.op.take(), None);
     }
 
     #[test]

--- a/runtime/userspace/api/spdm-lite/traits/src/cert.rs
+++ b/runtime/userspace/api/spdm-lite/traits/src/cert.rs
@@ -77,7 +77,7 @@ pub trait SpdmPalCertStore: crate::SpdmPalIoTransport {
     /// chain length so existing read-only stores preserve behavior.
     async fn cert_chain_slot_size(
         &self,
-        io: &Self::Io<'_>,
+        io: &impl crate::SpdmPalIo,
         slot: u8,
         algo: SpdmPalAsymAlgo,
     ) -> McuResult<usize> {
@@ -88,7 +88,7 @@ pub trait SpdmPalCertStore: crate::SpdmPalIoTransport {
     #[inline]
     fn set_certificate_authorized(
         &self,
-        _io: &Self::Io<'_>,
+        _io: &impl crate::SpdmPalIo,
         _slot: u8,
         _key_pair_id: u8,
         _cert_model: u8,
@@ -100,7 +100,7 @@ pub trait SpdmPalCertStore: crate::SpdmPalIoTransport {
     /// Validate an incoming SET_CERTIFICATE chain before it is committed.
     async fn validate_set_certificate_chain(
         &self,
-        _io: &Self::Io<'_>,
+        _io: &impl crate::SpdmPalIo,
         _slot: u8,
         _key_pair_id: u8,
         _cert_model: u8,
@@ -114,7 +114,7 @@ pub trait SpdmPalCertStore: crate::SpdmPalIoTransport {
     /// algorithm (excludes the 52-byte SPDM cert-chain header).
     async fn cert_chain_len(
         &self,
-        io: &Self::Io<'_>,
+        io: &impl crate::SpdmPalIo,
         slot: u8,
         algo: SpdmPalAsymAlgo,
     ) -> McuResult<usize>;
@@ -122,7 +122,7 @@ pub trait SpdmPalCertStore: crate::SpdmPalIoTransport {
     /// Write the digest of slot's **root certificate** into `out`.
     async fn root_cert_hash(
         &self,
-        io: &Self::Io<'_>,
+        io: &impl crate::SpdmPalIo,
         slot: u8,
         algo: SpdmPalAsymAlgo,
         hash_algo: SpdmPalHashAlgo,
@@ -133,7 +133,7 @@ pub trait SpdmPalCertStore: crate::SpdmPalIoTransport {
     /// for the given algorithm at `offset` into `dst`.
     async fn read_cert_chain(
         &self,
-        io: &Self::Io<'_>,
+        io: &impl crate::SpdmPalIo,
         slot: u8,
         algo: SpdmPalAsymAlgo,
         offset: usize,
@@ -143,7 +143,7 @@ pub trait SpdmPalCertStore: crate::SpdmPalIoTransport {
     /// Sign `digest` using the key in `slot` for the given algorithm.
     async fn sign_hash(
         &self,
-        io: &Self::Io<'_>,
+        io: &impl crate::SpdmPalIo,
         slot: u8,
         algo: SpdmPalAsymAlgo,
         digest: &[u8],
@@ -155,7 +155,7 @@ pub trait SpdmPalCertStore: crate::SpdmPalIoTransport {
     #[allow(clippy::too_many_arguments)]
     async fn write_cert_chain(
         &self,
-        io: &Self::Io<'_>,
+        io: &impl crate::SpdmPalIo,
         slot: u8,
         algo: SpdmPalAsymAlgo,
         key_pair_id: u8,
@@ -167,7 +167,7 @@ pub trait SpdmPalCertStore: crate::SpdmPalIoTransport {
     /// Erase the cert chain in `slot` for the given algorithm.
     async fn erase_cert_chain(
         &self,
-        io: &Self::Io<'_>,
+        io: &impl crate::SpdmPalIo,
         slot: u8,
         algo: SpdmPalAsymAlgo,
     ) -> McuResult<()>;
@@ -200,5 +200,5 @@ pub trait SpdmPalCertStore: crate::SpdmPalIoTransport {
     fn cache_chain_digest(&self, _slot: u8, _algo: SpdmPalHashAlgo, _digest: &[u8]) {}
 
     /// Fill `out` with random bytes from the platform RNG.
-    async fn generate_nonce(&self, io: &Self::Io<'_>, out: &mut [u8]) -> McuResult<()>;
+    async fn generate_nonce(&self, io: &impl crate::SpdmPalIo, out: &mut [u8]) -> McuResult<()>;
 }

--- a/runtime/userspace/api/spdm-lite/traits/src/large_message.rs
+++ b/runtime/userspace/api/spdm-lite/traits/src/large_message.rs
@@ -17,4 +17,15 @@ pub trait SpdmPalLargeMessage {
 
     /// Copy bytes from the persistent large-message buffer into `out`.
     fn read(&self, offset: usize, out: &mut [u8]) -> McuResult<()>;
+
+    /// Take ownership of the persistent large-message buffer.
+    ///
+    /// The caller must return it with [`Self::replace`] before handling the
+    /// next large-message operation. This lets the stack borrow a reassembled
+    /// request in place without copying certificate-sized payloads into the
+    /// per-I/O scratch allocator.
+    fn take(&self) -> McuResult<&'static mut [u8]>;
+
+    /// Return a buffer previously acquired with [`Self::take`].
+    fn replace(&self, buf: &'static mut [u8]);
 }


### PR DESCRIPTION
## Summary
- support chunked SET_CERTIFICATE requests in spdm-lite
- validate CHUNK_SEND padding and dispatch reassembled SET_CERTIFICATE requests
- handle DOE padding for SET_CERTIFICATE payloads and responses cleanly

Memory added by this commit:
    user-app: .text +468 B  .rodata +864 B  .bss no change
    SPDM task: .text +468 B  .rodata no change  .bss no change
    kernel: .text +340 B  .bss no change

    Current totals:
    kernel: .text 152,028 B  .bss 24,536 B
    user-app: .text 56,024 B  .rodata 13,368 B  .bss 60,976 B
