### PR TITLE
[rom] Program OTP status register offset into SS_STRAP_GENERIC[0][15:0]

### DIFF
--- a/rom/src/rom.rs
+++ b/rom/src/rom.rs
@@ -45,6 +45,7 @@ const MLDSA_CALIPTRA_VALUE: u8 = 1;
 const LMS_CALIPTRA_VALUE: u8 = 3;
 const OTP_DAI_IDLE_BIT_OFFSET: u32 = 22;
 const OTP_DIRECT_ACCESS_CMD_REG_OFFSET: u32 = 0x60;
+const OTP_CTRL_STATUS_REG_OFFSET: u32 = 0x10;
 
 pub const MCU_SRAM_DEFAULT_PROTECTED_REGION_BLOCKS: u32 = 8; // 32 kB / 4 kB chunks
 
@@ -199,11 +200,13 @@ impl Soc {
         self.registers.ss_uds_seed_base_addr_h.set(0);
 
         caliptra_mcu_romtime::println!(
-            "[mcu-fuse-write] Setting UDS/FE DAI idle bit offset to {} and direct access cmd reg offset to {}",
+            "[mcu-fuse-write] Setting UDS/FE DAI idle bit offset to {}, status reg offset to {}, and direct access cmd reg offset to {}",
             OTP_DAI_IDLE_BIT_OFFSET,
+            OTP_CTRL_STATUS_REG_OFFSET,
             OTP_DIRECT_ACCESS_CMD_REG_OFFSET
         );
-        self.registers.ss_strap_generic[0].set(OTP_DAI_IDLE_BIT_OFFSET << 16);
+        self.registers.ss_strap_generic[0]
+            .set((OTP_DAI_IDLE_BIT_OFFSET << 16) | OTP_CTRL_STATUS_REG_OFFSET);
         self.registers.ss_strap_generic[1].set(OTP_DIRECT_ACCESS_CMD_REG_OFFSET);
 
         // Select the vendor public key slot to use.


### PR DESCRIPTION
Program the value 0x10 (the OTP_CTRL_STATUS register byte offset) so Caliptra can use it when polling DAI idle during UDS/FE programming instead of relying on a hardcoded fallback.

Fixes #1608