### PR TITLE
spdm-lite: add TDISP VDM support

### DIFF
--- a/.github/workflows/caliptra-sw-smoke-test.yml
+++ b/.github/workflows/caliptra-sw-smoke-test.yml
@@ -8,7 +8,10 @@ on:
 
 jobs:
   caliptra-sw-mcu-rom-smoke-test:
-    if: ${{ !startsWith(github.head_ref, 'spdm-lite') }}
+    # The caliptra-sw caliptra-2.0 smoke workflow is not compatible with
+    # spdm-lite integration branches. Skip it for PRs targeting spdm-lite,
+    # matching the existing skip for spdm-lite-named source branches.
+    if: ${{ github.base_ref != 'spdm-lite' && !startsWith(github.head_ref, 'spdm-lite') }}
     uses: chipsalliance/caliptra-sw/.github/workflows/fpga-subsystem.yml@caliptra-2.0
     with:
       mcu-commit: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/common/testing/src/spdm_responder_validator/common.rs
+++ b/common/testing/src/spdm_responder_validator/common.rs
@@ -257,12 +257,15 @@ pub fn execute_spdm_tee_io_validator(transport: &'static str) {
                     match child.try_wait() {
                         Ok(Some(status)) => {
                             println!("spdm_tee_io_validator exited with status: {:?}", status);
+                            if !status.success() {
+                                std::process::exit(1);
+                            }
                             break;
                         }
                         Ok(None) => {}
                         Err(e) => {
                             println!("Error: {:?}", e);
-                            break;
+                            std::process::exit(1);
                         }
                     }
                     std::thread::sleep(std::time::Duration::from_millis(100));
@@ -271,6 +274,7 @@ pub fn execute_spdm_tee_io_validator(transport: &'static str) {
             }
             Err(e) => {
                 println!("Error: {:?} Failed to spawn spdm_tee_io_validator!!", e);
+                std::process::exit(1);
             }
         }
     });
@@ -294,7 +298,7 @@ pub fn execute_spdm_attestation(transport: &'static str) {
                         Ok(None) => {}
                         Err(e) => {
                             println!("Error: {:?}", e);
-                            break;
+                            std::process::exit(1);
                         }
                     }
                     std::thread::sleep(std::time::Duration::from_millis(100));
@@ -332,7 +336,7 @@ pub fn execute_spdm_responder_validator(transport: &'static str) {
                         Ok(None) => {}
                         Err(e) => {
                             println!("Error: {:?}", e);
-                            break;
+                            std::process::exit(1);
                         }
                     }
                     std::thread::sleep(std::time::Duration::from_millis(100));

--- a/docs/src/tdisp.md
+++ b/docs/src/tdisp.md
@@ -1,85 +1,69 @@
 # TDISP (TEE Device Interface Security Protocol) Support
 
-Caliptra Subsystem supports handling of TDISP messages by processing them as VENDOR_DEFINED_REQUEST/VENDOR_DEFINED_RESPONSE message payloads. These messages are transported and processed within the secure session established between the host and the TDISP device as specified by Secured CMA/SPDM.
+Caliptra Subsystem handles TDISP messages as PCI-SIG SPDM
+`VENDOR_DEFINED_REQUEST` / `VENDOR_DEFINED_RESPONSE` payloads. The PCI-SIG VDM
+payload starts with protocol ID `0x01` for TDISP, followed by the TDISP message.
+TDISP is expected to be carried in an SPDM secured session, for example over DOE
+Secure SPDM.
 
-To facilitate the TDISP protocol, the devices must implement `TdispDriver` trait as defined below.
+The SPDM-Lite implementation lives under
+`runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/`:
+
+- `PciSigTdispVdm` matches PCI-SIG VDM envelopes for a configured vendor ID and
+  requires `secure_session` before dispatching TDISP.
+- `tdisp::TdispResponder` decodes TDISP wire messages from borrowed slices and
+  writes responses into caller-provided buffers.
+- `tdisp::TdispDriver` is the platform hook for device-specific TDISP
+  operations.
+
+The implementation intentionally avoids `async_trait`, boxed futures, and a
+heap-backed handler table. The stack is generic over the backend type, so async
+methods compile to concrete state machines. Driver hooks receive the current
+request-scoped PAL scratch allocator and I/O handle, matching the OCP VDM
+pattern so platform code can stage mailbox/syscall requests without heap, large
+stack buffers, or retained persistent buffers.
+
+## Platform driver interface
+
+A platform that wants to serve TDISP implements the `TdispDriver` trait and
+constructs a `TdispResponder` with the supported protocol versions. The driver
+returns `Ok(0)` on success, or `Ok(<TDISP error code>)` when the request should
+be completed with a TDISP `ERROR_RESPONSE`. Transport/allocation/internal
+failures use `Err(TdispDriverError)`.
 
 ```rust
-/// Error codes returned by TDISP driver
 pub enum TdispDriverError {
-    /// Input parameter is null or invalid.
     InvalidArgument,
-    /// Memory allocation failed.
     NoMemory,
-    /// The driver failed to get TDISP capabilities.
-    GetTdispCapabilitiesFail,
-    /// The driver failed to get the device interface state.
-    GetDeviceInterfaceStateFail,
-    /// The driver failed to lock the device interface.
-    LockInterfaceReqFail,
-    /// The driver failed to start the device interface.
-    StartInterfaceReqFail,
-    /// The driver failed to stop the device interface.
-    StopInterfaceReqFail,
-    /// The driver failed to get the device interface report.
-    GetInterfaceReportFail,
-    /// The driver failed to get the mmio ranges.
-    GetMmioRangesFail,
-    /// The driver function is not implemented.
     FunctionNotImplemented,
 }
 
 pub type TdispDriverResult<T> = Result<T, TdispDriverError>;
 
-/// FunctionID of the device hosting the TDI.
-bitfield! {
-    #[derive(FromBytes, IntoBytes, Immutable, Default)]
-    #[repr(C)]
-    pub struct FunctionId(u32);
-    impl Debug;
-    u16;
-    pub requester_id, set_requester_id: 15, 0; // Bits 15:0 Requester ID
-    u8;
-    pub requester_segment, set_requester_segment: 23, 16; // Bits 23:16 Requester Segment
-    pub requester_segment_valid, set_requester_segment_valid: 24, 24; // Bit 24 Requester Segment Valid
-    reserved, _: 31, 25; // Bits 31:25 Reserved
+pub struct FunctionId(pub u32);
+
+pub struct TdispReqCapabilities {
+    pub tsm_caps: u32,
 }
 
-/// TDISP Responder Capabilities
-pub struct TdispResponderCapabilities {
-    dsm_capabilities: u32,
-    req_msgs_supported: [u8; 16],
-    lock_interface_flags_supported: u16,
-    reserved: [u8; 3],
-    dev_addr_width: u8,
-    num_req_this: u8,
-    num_req_all: u8,
+pub struct TdispRespCapabilities {
+    pub dsm_capabilities: u32,
+    pub req_msgs_supported: [u8; 16],
+    pub lock_interface_flags_supported: u16,
+    pub dev_addr_width: u8,
+    pub num_req_this: u8,
+    pub num_req_all: u8,
 }
 
-/// Parameters passed along with the LOCK_INTERFACE_REQUEST
 pub struct TdispLockInterfaceParam {
-    flags: TdispLockInterfaceFlags,
-    default_stream_id: u8,
-    reserved: u8,
-    mmio_reporting_offset: [u8; 8],
-    bind_p2p_addr_mask: [u8; 8],
+    pub flags: TdispLockInterfaceFlags,
+    pub default_stream_id: u8,
+    pub mmio_reporting_offset: [u8; 8],
+    pub bind_p2p_addr_mask: [u8; 8],
 }
 
-/// TDISP Interface flags
-bitfield! {
-#[repr(C)]
-pub struct TdispLockInterfaceFlags(u16);
-impl Debug;
-u8;
-    pub no_fw_update, set_no_fw_update: 0, 0; // Bit 0 NO_FW_UPDATE
-    pub system_cache_line_size, set_system_cache_line_size: 1, 1; // Bits 1:1 SYSTEM_CACHE_LINE_SIZE
-    pub lock_msix, set_lock_msix: 2, 2; // Bit 2 LOCK_MSIX
-    pub bind_p2p, set_bind_p2p: 3, 3; // Bit 3 BIND_P2P
-    pub all_req_redirect, set_all_req_redirect: 4, 4; // Bit 4 ALL_REQUEST_REDIRECT
-    pub reserved, _: 15, 5; // Bits 15:5 Reserved
-}
+pub struct TdispLockInterfaceFlags(pub u16);
 
-/// TDI Status
 pub enum TdiStatus {
     ConfigUnlocked = 0,
     ConfigLocked = 1,
@@ -88,101 +72,109 @@ pub enum TdiStatus {
     Reserved,
 }
 
-/// TDISP Driver trait that defines the interface for TDISP operations.
-/// This trait is intended to be implemented by a TDISP driver
-/// that interacts with the TDISP device.
-#[async_trait]
-pub trait TdispDriver: Send + Sync {
-    /// Gets the TDISP device capabilities.
-    ///
-    /// # Arguments
-    /// * `req_caps` - Requester (TSM) capability flags
-    /// * `resp_caps` - Responder (DSM) capability flags
-    ///
-    /// # Returns
-    /// 0 on success or an error response code as per the TDISP specification on failure.
-    async fn get_capabilities(
+pub trait TdispDriver {
+    async fn generate_start_interface_nonce<Alloc, Io>(
+        &self,
+        scratch: &Alloc,
+        io: &Io,
+        out: &mut [u8; START_INTERFACE_NONCE_SIZE],
+    ) -> TdispDriverResult<()>
+    where
+        Alloc: SpdmPalAlloc,
+        Io: SpdmPalIo;
+
+    async fn get_capabilities<Alloc, Io>(
         &self,
         req_caps: TdispReqCapabilities,
+        scratch: &Alloc,
+        io: &Io,
         resp_caps: &mut TdispRespCapabilities,
-    ) -> TdispDriverResult<u32>;
+    ) -> TdispDriverResult<u32>
+    where
+        Alloc: SpdmPalAlloc,
+        Io: SpdmPalIo;
 
-    /// Lock Interface Request
-    ///
-    /// # Arguments
-    /// * `function_id` - Device Interface Function ID
-    /// * `param` - Lock Interface parameters from the request
-    ///
-    /// # Returns
-    /// 0 on success or an error response code as per the TDISP specification on failure.
-    async fn lock_interface(
-        &mut self,
-        function_id: FunctionId,
-        param: TdispLockInterfaceParam,
-    ) -> TdispDriverResult<u32>;
-
-    /// Get the length of the device interface report.
-    ///
-    /// # Arguments
-    /// * `function_id` - Device Interface Function ID
-    /// * `intf_report_len` - Total device interface report length(output)
-    ///
-    /// # Returns
-    /// Length of the device interface report on success or an error response code.
-    async fn get_device_interface_report_len(
+    async fn lock_interface<Alloc, Io>(
         &self,
         function_id: FunctionId,
-        intf_report_len: &mut u16,
-    ) -> TdispDriverResult<u32>;
+        param: TdispLockInterfaceParam,
+        scratch: &Alloc,
+        io: &Io,
+    ) -> TdispDriverResult<u32>
+    where
+        Alloc: SpdmPalAlloc,
+        Io: SpdmPalIo;
 
-    /// Get the device interface report.
-    ///
-    /// # Arguments
-    /// * `function_id` - Device Interface Function ID
-    /// * `offset` - Offset from the start of the report requested
-    /// * `report` - report buffer slice to fill
-    /// * `copied` - Length of the TDI report copied
-    ///
-    ///
-    /// # Returns
-    /// 0 on success or an error response code as per the TDISP specification on failure.
-    async fn get_device_interface_report(
+    async fn get_device_interface_report_len<Alloc, Io>(
+        &self,
+        function_id: FunctionId,
+        scratch: &Alloc,
+        io: &Io,
+        intf_report_len: &mut u16,
+    ) -> TdispDriverResult<u32>
+    where
+        Alloc: SpdmPalAlloc,
+        Io: SpdmPalIo;
+
+    async fn get_device_interface_report<Alloc, Io>(
         &self,
         function_id: FunctionId,
         offset: u16,
+        scratch: &Alloc,
+        io: &Io,
         report: &mut [u8],
         copied: &mut usize,
-    ) -> TdispDriverResult<u32>;
+    ) -> TdispDriverResult<u32>
+    where
+        Alloc: SpdmPalAlloc,
+        Io: SpdmPalIo;
 
-    /// Get the device interface state.
-    ///
-    /// # Arguments
-    /// * `function_id` - Device Interface Function ID
-    /// * `tdi_state` - Device Interface State to fill
-    ///
-    /// # Returns
-    /// 0 on success or an error response code as per the TDISP specification on failure.
-    async fn get_device_interface_state(
+    async fn get_device_interface_state<Alloc, Io>(
         &self,
         function_id: FunctionId,
+        scratch: &Alloc,
+        io: &Io,
         tdi_state: &mut TdiStatus,
-    ) -> TdispDriverResult<u32>;
+    ) -> TdispDriverResult<u32>
+    where
+        Alloc: SpdmPalAlloc,
+        Io: SpdmPalIo;
 
-    /// Start the device interface.
-    ///
-    /// # Arguments
-    /// * `function_id` - Device Interface Function ID
-    ///
-    /// # Returns
-    /// 0 on success or an error response code as per the TDISP specification on failure.
-    async fn start_interface(&mut self, function_id: FunctionId) -> TdispDriverResult<u32>;
+    async fn start_interface<Alloc, Io>(
+        &self,
+        function_id: FunctionId,
+        scratch: &Alloc,
+        io: &Io,
+    ) -> TdispDriverResult<u32>
+    where
+        Alloc: SpdmPalAlloc,
+        Io: SpdmPalIo;
 
-    /// Stop the device interface.
-    ///
-    /// # Arguments
-    /// * `function_id` - Device Interface Function ID
-    ///
-    /// # Returns
-    /// 0 on success or an error response code as per the TDISP specification on failure.
-    async fn stop_interface(&mut self, function_id: FunctionId) -> TdispDriverResult<u32>;
+    async fn stop_interface<Alloc, Io>(
+        &self,
+        function_id: FunctionId,
+        scratch: &Alloc,
+        io: &Io,
+    ) -> TdispDriverResult<u32>
+    where
+        Alloc: SpdmPalAlloc,
+        Io: SpdmPalIo;
 }
+```
+
+## Current support
+
+The current SPDM-Lite TDISP responder supports:
+
+- `GET_TDISP_VERSION`
+- `GET_TDISP_CAPABILITIES`
+- `LOCK_INTERFACE`
+- `GET_DEVICE_INTERFACE_REPORT`
+- `GET_DEVICE_INTERFACE_STATE`
+- `START_INTERFACE`
+- `STOP_INTERFACE`
+
+`BIND_P2P_STREAM`, `UNBIND_P2P_STREAM`, `SET_MMIO_ATTRIBUTE`, TDISP VDM nested
+requests, and IDE-KM are not implemented. Unsupported TDISP request opcodes are
+reported as TDISP `ERROR_RESPONSE` payloads with `UnsupportedRequest` rather than
+outer SPDM errors when a valid TDISP header is present.

--- a/platforms/emulator/runtime/userspace/apps/user/Cargo.toml
+++ b/platforms/emulator/runtime/userspace/apps/user/Cargo.toml
@@ -133,6 +133,6 @@ test-mctp-spdm-set-certificate = [
   "mcu-spdm-lite-pal/set-certificate",
   "mcu-spdm-lite-stack/set-certificate",
 ]
-test-doe-spdm-tdisp-ide-validator = []
+test-doe-spdm-tdisp-ide-validator = ["mcu-spdm-lite-vdm-handler/emulated-tdisp"]
 test-mcu-mbox-fips-periodic = ["caliptra-mcu-mbox-lib/periodic-fips-self-test"]
 active-i3c1 = []

--- a/platforms/emulator/runtime/userspace/apps/user/src/spdm/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/spdm/mod.rs
@@ -27,6 +27,11 @@ use mcu_spdm_lite_pal::{McuSpdmPal, BITMAP_SLOT_SIZE};
 use mcu_spdm_lite_stack::SpdmStack;
 use mcu_spdm_lite_transports::{McuSpdmDoeTransport, McuSpdmMctpTransport};
 use mcu_spdm_lite_vdm_handler::iana::ocp::caliptra_vdm::CaliptraVdm;
+#[cfg(feature = "test-doe-spdm-tdisp-ide-validator")]
+use mcu_spdm_lite_vdm_handler::pci_sig::{
+    tdisp::{EmulatedTdispDriver, TdispResponder, TdispVersion},
+    PciSigTdispVdm,
+};
 
 /// Bitmap allocator pool size per responder task.
 ///
@@ -39,6 +44,11 @@ const SPDM_LITE_SCRATCH_SIZE: usize = 8 * 1024;
 /// scratch pool so it survives the per-request allocator reset; its length caps
 /// `MaxSPDMmsgSize`.
 const SPDM_LITE_LARGE_MSG_SIZE: usize = 8 * 1024;
+
+#[cfg(feature = "test-doe-spdm-tdisp-ide-validator")]
+const TEST_PCI_SIG_VENDOR_ID: u16 = 0x0001;
+#[cfg(feature = "test-doe-spdm-tdisp-ide-validator")]
+const SUPPORTED_TDISP_VERSIONS: &[TdispVersion] = &[TdispVersion::V10];
 
 /// Single cert store shared by all SPDM responder tasks.
 static CERT_STORE: SharedCertStore = SharedCertStore::new();
@@ -152,8 +162,8 @@ async fn spdm_mctp_responder() {
             measurement_provider(),
         )
     };
-    // MCTP hosts the IANA / Caliptra VDM backend (plaintext today). DOE hosts
-    // PCI-SIG and stays on the default NoVdmBackend.
+    // MCTP hosts the IANA / Caliptra VDM backend (plaintext today). DOE uses
+    // the default NoVdmBackend unless the TDISP validator feature wires PCI-SIG.
     static MCTP_VDM_HOOK: caliptra_vdm::CaliptraVdmHook = caliptra_vdm::CaliptraVdmHook;
     let vdm = CaliptraVdm::new(&MCTP_VDM_HOOK);
     let mut stack = SpdmStack::<_, 1, _>::with_vdm_backend(pal, vdm);
@@ -208,6 +218,15 @@ async fn spdm_doe_responder() {
             measurement_provider(),
         )
     };
+    #[cfg(feature = "test-doe-spdm-tdisp-ide-validator")]
+    let mut stack = SpdmStack::<_, 1, _>::with_vdm_backend(
+        pal,
+        PciSigTdispVdm::new(
+            TEST_PCI_SIG_VENDOR_ID,
+            TdispResponder::new(SUPPORTED_TDISP_VERSIONS, EmulatedTdispDriver::new()),
+        ),
+    );
+    #[cfg(not(feature = "test-doe-spdm-tdisp-ide-validator"))]
     let mut stack: SpdmStack<_, 1> = SpdmStack::new(pal);
 
     crate::console_writeln!(cw, "SPDM_DOE: starting spdm-lite DOE run loop");

--- a/runtime/userspace/api/spdm-lite/vdm-handler/Cargo.toml
+++ b/runtime/userspace/api/spdm-lite/vdm-handler/Cargo.toml
@@ -6,6 +6,10 @@ version.workspace = true
 authors.workspace = true
 edition.workspace = true
 
+[features]
+default = []
+emulated-tdisp = []
+
 [dependencies]
 mcu-spdm-lite-traits = { workspace = true }
 mcu-spdm-lite-codec = { workspace = true }

--- a/runtime/userspace/api/spdm-lite/vdm-handler/src/lib.rs
+++ b/runtime/userspace/api/spdm-lite/vdm-handler/src/lib.rs
@@ -13,7 +13,7 @@
 //! used by the full `spdm-lib` stack:
 //!
 //! * [`iana`] — IANA-registered vendors (OCP / Caliptra VDM).
-//! * [`pci_sig`] — PCI-SIG protocols (IDE_KM, TDISP) — reserved.
+//! * [`pci_sig`] — PCI-SIG protocols (TDISP; IDE-KM reserved for future support).
 #![no_std]
 #![allow(async_fn_in_trait)]
 

--- a/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/mod.rs
+++ b/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/mod.rs
@@ -2,8 +2,626 @@
 
 //! PCI-SIG VENDOR_DEFINED protocols (Standards Body ID `PciSig`, 0x03).
 //!
-//! Reserved for the PCI-SIG VDM handlers — IDE_KM and TDISP — which are always
-//! delivered inside a secure session on the DOE transport. Not yet implemented.
-//!
-//! TODO: add `ide_km` and `tdisp` submodules implementing
-//! [`mcu_spdm_lite_traits::SpdmVdmBackend`].
+//! PCI-SIG protocols such as IDE-KM and TDISP are carried as SPDM
+//! VENDOR_DEFINED messages and, for TDISP, are expected inside a secured
+//! session on DOE.
+
+pub mod tdisp;
+
+use mcu_spdm_lite_codec::errors::{
+    SPDM_INVALID_REQUEST, SPDM_UNSPECIFIED, SPDM_UNSUPPORTED_REQUEST,
+};
+use mcu_spdm_lite_codec::StandardsBodyId;
+use mcu_spdm_lite_traits::{
+    McuResult, SpdmPalAlloc, SpdmPalIo, SpdmVdmBackend, VdmRegistry, VdmResponse, VdmResponseBuffer,
+};
+
+/// PCI-SIG protocol identifier for IDE-KM.
+pub const IDE_KM_PROTOCOL_ID: u8 = 0x00;
+/// PCI-SIG protocol identifier for TDISP.
+pub const TDISP_PROTOCOL_ID: u8 = 0x01;
+
+/// PCI-SIG VDM backend that dispatches protocol-id `0x01` to TDISP.
+///
+/// The first byte of the PCI-SIG VDM payload is the PCI-SIG protocol id. This
+/// backend preserves that top-level byte and delegates the remaining payload to
+/// the size-conscious TDISP responder.
+pub struct PciSigTdispVdm<D> {
+    vendor_id: u16,
+    tdisp: tdisp::TdispResponder<D>,
+}
+
+impl<D> PciSigTdispVdm<D> {
+    /// Creates a PCI-SIG/TDISP VDM backend for `vendor_id`.
+    pub const fn new(vendor_id: u16, tdisp: tdisp::TdispResponder<D>) -> Self {
+        Self { vendor_id, tdisp }
+    }
+
+    #[inline]
+    fn matches_envelope(&self, registry: &VdmRegistry<'_>) -> bool {
+        registry.standard_id == StandardsBodyId::PciSig.as_u16()
+            && registry.vendor_id == self.vendor_id.to_le_bytes()
+            && registry.secure_session
+    }
+}
+
+impl<D> SpdmVdmBackend for PciSigTdispVdm<D>
+where
+    D: tdisp::TdispDriver,
+{
+    fn match_id(&self, registry: &VdmRegistry<'_>) -> bool {
+        self.matches_envelope(registry)
+    }
+
+    async fn handle_request<Alloc, Io>(
+        &self,
+        req: &[u8],
+        rsp: VdmResponseBuffer<'_, Alloc, Io>,
+    ) -> McuResult<VdmResponse>
+    where
+        Alloc: SpdmPalAlloc,
+        Io: SpdmPalIo,
+    {
+        let VdmResponseBuffer {
+            inline, alloc, io, ..
+        } = rsp;
+        let Some((&protocol_id, payload)) = req.split_first() else {
+            return Err(SPDM_INVALID_REQUEST);
+        };
+        if protocol_id != TDISP_PROTOCOL_ID {
+            return Err(SPDM_UNSUPPORTED_REQUEST);
+        }
+        let Some(tdisp_inline) = inline.get_mut(1..) else {
+            return Err(SPDM_UNSPECIFIED);
+        };
+        let response = self
+            .tdisp
+            .handle_tdisp_payload(payload, alloc, io, tdisp_inline)
+            .await?;
+        match response {
+            VdmResponse::Inline(len) => {
+                inline[0] = protocol_id;
+                Ok(VdmResponse::Inline(len + 1))
+            }
+            VdmResponse::Large(_) => Err(SPDM_UNSPECIFIED),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+
+    use core::future::Future;
+    use core::marker::PhantomData;
+    use core::ops::{Deref, DerefMut};
+    use core::pin::Pin;
+    use core::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
+
+    use mcu_spdm_lite_codec::errors::SPDM_VERSION_MISMATCH;
+    use mcu_spdm_lite_traits::{SpdmPalIoKind, VdmResponse};
+    use std::boxed::Box;
+    use std::vec;
+    use std::vec::Vec;
+
+    use super::*;
+    use crate::pci_sig::tdisp::{
+        EmulatedTdispDriver, TdispCommand, TdispErrorCode, TdispResponder, TdispVersion,
+        TDISP_ERROR_INVALID_INTERFACE_STATE, TDISP_ERROR_INVALID_REQUEST, TDISP_VERSION_1_0,
+    };
+
+    const TEST_VENDOR_ID: u16 = 0x0001;
+    const TDISP_HEADER_LEN: usize = 16;
+    const TDISP_ERROR_RSP_LEN: usize = TDISP_HEADER_LEN + 8;
+    const SUPPORTED_TDISP_VERSIONS: &[TdispVersion] = &[TdispVersion::V10];
+
+    struct TestIo;
+
+    impl SpdmPalIo for TestIo {
+        fn kind(&self) -> SpdmPalIoKind {
+            SpdmPalIoKind::SecuredMessage
+        }
+
+        fn request(&self) -> &[u8] {
+            &[]
+        }
+    }
+
+    struct TestBox<'a, T: 'a> {
+        value: Box<T>,
+        _lifetime: PhantomData<&'a ()>,
+    }
+
+    impl<T> Deref for TestBox<'_, T> {
+        type Target = T;
+
+        fn deref(&self) -> &Self::Target {
+            &self.value
+        }
+    }
+
+    impl<T> DerefMut for TestBox<'_, T> {
+        fn deref_mut(&mut self) -> &mut Self::Target {
+            &mut self.value
+        }
+    }
+
+    struct TestAlloc;
+
+    impl mcu_caliptra_api_lite::ApiAlloc for TestAlloc {
+        type Buf<'a>
+            = Vec<u8>
+        where
+            Self: 'a;
+
+        fn alloc(&self, len: usize) -> McuResult<Self::Buf<'_>> {
+            Ok(vec![0; len])
+        }
+    }
+
+    impl SpdmPalAlloc for TestAlloc {
+        type Box<'a, T>
+            = TestBox<'a, T>
+        where
+            Self: 'a,
+            T: 'a;
+        type Bytes<'a>
+            = Vec<u8>
+        where
+            Self: 'a;
+        type LargeBuf<'a>
+            = Vec<u8>
+        where
+            Self: 'a;
+
+        fn alloc<T: Sized>(&self, _io: &impl SpdmPalIo, value: T) -> McuResult<Self::Box<'_, T>> {
+            Ok(TestBox {
+                value: Box::new(value),
+                _lifetime: PhantomData,
+            })
+        }
+
+        fn alloc_bytes(&self, _io: &impl SpdmPalIo, len: usize) -> McuResult<Self::Bytes<'_>> {
+            Ok(vec![0; len])
+        }
+
+        fn large_capacity(&self) -> usize {
+            0
+        }
+
+        fn large_begin(&self, _len: usize) -> McuResult<()> {
+            Ok(())
+        }
+
+        fn large_write(&self, _offset: usize, _data: &[u8]) -> McuResult<()> {
+            Ok(())
+        }
+
+        fn large_read(&self, _offset: usize, _out: &mut [u8]) -> McuResult<()> {
+            Ok(())
+        }
+
+        fn large_end(&self) {}
+
+        fn large_take(&self, len: usize) -> McuResult<Self::LargeBuf<'_>> {
+            Ok(vec![0; len])
+        }
+    }
+
+    fn block_on<F: Future>(future: F) -> F::Output {
+        fn raw_waker() -> RawWaker {
+            fn clone(_: *const ()) -> RawWaker {
+                raw_waker()
+            }
+            fn wake(_: *const ()) {}
+            fn wake_by_ref(_: *const ()) {}
+            fn drop(_: *const ()) {}
+            RawWaker::new(
+                core::ptr::null(),
+                &RawWakerVTable::new(clone, wake, wake_by_ref, drop),
+            )
+        }
+
+        // SAFETY: The no-op waker never dereferences the data pointer; these
+        // tests only poll futures that complete synchronously.
+        let waker = unsafe { Waker::from_raw(raw_waker()) };
+        let mut context = Context::from_waker(&waker);
+        let mut future = Box::pin(future);
+        loop {
+            match Future::poll(Pin::as_mut(&mut future), &mut context) {
+                Poll::Ready(output) => return output,
+                Poll::Pending => core::hint::spin_loop(),
+            }
+        }
+    }
+
+    fn backend() -> PciSigTdispVdm<EmulatedTdispDriver> {
+        PciSigTdispVdm::new(
+            TEST_VENDOR_ID,
+            TdispResponder::new(SUPPORTED_TDISP_VERSIONS, EmulatedTdispDriver::new()),
+        )
+    }
+
+    fn registry(secure_session: bool) -> VdmRegistry<'static> {
+        static VENDOR_ID: [u8; 2] = TEST_VENDOR_ID.to_le_bytes();
+        VdmRegistry {
+            standard_id: StandardsBodyId::PciSig.as_u16(),
+            vendor_id: &VENDOR_ID,
+            secure_session,
+        }
+    }
+
+    fn request(message_type: u8, payload: &[u8]) -> Vec<u8> {
+        let mut req = Vec::with_capacity(1 + TDISP_HEADER_LEN + payload.len());
+        req.push(TDISP_PROTOCOL_ID);
+        req.push(TDISP_VERSION_1_0);
+        req.push(message_type);
+        req.extend_from_slice(&0u16.to_le_bytes());
+        req.extend_from_slice(&1u32.to_le_bytes());
+        req.extend_from_slice(&0u64.to_le_bytes());
+        req.extend_from_slice(payload);
+        req
+    }
+
+    fn dispatch(
+        backend: &PciSigTdispVdm<EmulatedTdispDriver>,
+        req: &[u8],
+        inline_len: usize,
+    ) -> McuResult<(VdmResponse, Vec<u8>)> {
+        let alloc = TestAlloc;
+        let io = TestIo;
+        let mut inline = vec![0; inline_len];
+        let mut large = [];
+        let response = block_on(backend.handle_request(
+            req,
+            VdmResponseBuffer {
+                inline: &mut inline,
+                large: &mut large,
+                alloc: &alloc,
+                io: &io,
+            },
+        ))?;
+        Ok((response, inline))
+    }
+
+    fn assert_inline(response: VdmResponse, expected_len: usize) {
+        match response {
+            VdmResponse::Inline(len) => assert_eq!(len, expected_len),
+            VdmResponse::Large(_) => panic!("expected inline response"),
+        }
+    }
+
+    fn assert_tdisp_error(out: &[u8], error: TdispErrorCode, error_data: u32) {
+        assert_tdisp_error_with_version(out, TDISP_VERSION_1_0, error, error_data);
+    }
+
+    fn assert_tdisp_error_with_version(
+        out: &[u8],
+        version: u8,
+        error: TdispErrorCode,
+        error_data: u32,
+    ) {
+        assert_eq!(out[0], TDISP_PROTOCOL_ID);
+        assert_eq!(out[1], version);
+        assert_eq!(out[2], TdispCommand::ErrorResponse as u8);
+        assert_eq!(u32::from_le_bytes(out[17..21].try_into().unwrap()), error);
+        assert_eq!(
+            u32::from_le_bytes(out[21..25].try_into().unwrap()),
+            error_data
+        );
+    }
+
+    #[test]
+    fn secure_session_get_tdisp_version_matches_and_frames_response() {
+        let backend = backend();
+        assert!(backend.match_id(&registry(true)));
+
+        let req = request(TdispCommand::GetTdispVersion as u8, &[]);
+        let (response, out) = dispatch(&backend, &req, 64).expect("GET_TDISP_VERSION succeeds");
+
+        assert_inline(response, 1 + TDISP_HEADER_LEN + 2);
+        assert_eq!(out[0], TDISP_PROTOCOL_ID);
+        assert_eq!(out[1], TDISP_VERSION_1_0);
+        assert_eq!(out[2], TdispCommand::TdispVersion as u8);
+        assert_eq!(out[17], 1);
+        assert_eq!(out[18], TDISP_VERSION_1_0);
+    }
+
+    #[test]
+    fn get_capabilities_matches_libspdm_sample_after_get_version() {
+        let backend = backend();
+        let get_version = request(TdispCommand::GetTdispVersion as u8, &[]);
+        dispatch(&backend, &get_version, 64).expect("interface initialized");
+
+        let req = request(TdispCommand::GetTdispCapabilities as u8, &[0; 4]);
+        let (response, out) =
+            dispatch(&backend, &req, 64).expect("GET_TDISP_CAPABILITIES succeeds");
+
+        assert_inline(response, 1 + TDISP_HEADER_LEN + 28);
+        assert_eq!(out[0], TDISP_PROTOCOL_ID);
+        assert_eq!(out[2], TdispCommand::TdispCapabilities as u8);
+        assert_eq!(u32::from_le_bytes(out[17..21].try_into().unwrap()), 0);
+        let req_msgs_supported = &out[21..37];
+        assert_eq!(req_msgs_supported[0], 0xfe);
+        assert_eq!(&req_msgs_supported[1..], &[0u8; 15]);
+        assert_eq!(u16::from_le_bytes(out[37..39].try_into().unwrap()), 0x07);
+        assert_eq!(out[42], 48);
+        assert_eq!(out[43], 0);
+        assert_eq!(out[44], 0);
+    }
+
+    #[test]
+    fn get_version_initializes_interface_unlocked() {
+        let backend = backend();
+        let get_version = request(TdispCommand::GetTdispVersion as u8, &[]);
+        dispatch(&backend, &get_version, 64).expect("interface initialized");
+
+        let state = request(TdispCommand::GetDeviceInterfaceState as u8, &[]);
+        let (response, out) = dispatch(&backend, &state, 64).expect("state succeeds");
+        assert_inline(response, 1 + TDISP_HEADER_LEN + 1);
+        assert_eq!(out[2], TdispCommand::DeviceInterfaceState as u8);
+        assert_eq!(out[17], 0);
+    }
+
+    #[test]
+    fn commands_match_spdm_lib_interface_initialization_rules() {
+        let backend = backend();
+        let caps = request(TdispCommand::GetTdispCapabilities as u8, &[0; 4]);
+        let (response, out) = dispatch(&backend, &caps, 64).expect("capabilities succeeds");
+        assert_inline(response, 1 + TDISP_HEADER_LEN + 28);
+        assert_eq!(out[2], TdispCommand::TdispCapabilities as u8);
+
+        let state = request(TdispCommand::GetDeviceInterfaceState as u8, &[]);
+        let (response, out) = dispatch(&backend, &state, 64).expect("state succeeds");
+        assert_inline(response, 1 + TDISP_HEADER_LEN + 1);
+        assert_eq!(out[2], TdispCommand::DeviceInterfaceState as u8);
+        assert_eq!(out[17], 0);
+
+        let stop = request(TdispCommand::StopInterfaceRequest as u8, &[]);
+        let (response, out) = dispatch(&backend, &stop, 64).expect("TDISP error is framed");
+        assert_inline(response, 1 + TDISP_ERROR_RSP_LEN);
+        assert_tdisp_error(&out, TDISP_ERROR_INVALID_INTERFACE_STATE, 0);
+    }
+
+    #[test]
+    fn plaintext_tdisp_registry_is_not_matched() {
+        let backend = backend();
+        assert!(!backend.match_id(&registry(false)));
+    }
+
+    #[test]
+    fn unsupported_pci_sig_protocol_id_is_rejected() {
+        let backend = backend();
+        let mut req = request(TdispCommand::GetTdispVersion as u8, &[]);
+        req[0] = IDE_KM_PROTOCOL_ID;
+
+        let err = match dispatch(&backend, &req, 64) {
+            Ok(_) => panic!("IDE-KM protocol id is unsupported"),
+            Err(err) => err,
+        };
+        assert_eq!(err, SPDM_UNSUPPORTED_REQUEST);
+    }
+
+    #[test]
+    fn response_opcode_returns_invalid_request_error() {
+        let backend = backend();
+        let req = request(TdispCommand::TdispVersion as u8, &[]);
+        let err = match dispatch(&backend, &req, 64) {
+            Ok(_) => panic!("response opcode is invalid"),
+            Err(err) => err,
+        };
+        assert_eq!(err, SPDM_INVALID_REQUEST);
+    }
+
+    #[test]
+    fn unsupported_request_opcode_checks_payload_length_before_error_classification() {
+        let backend = backend();
+        let req = request(TdispCommand::BindP2PStreamRequest as u8, &[1, 2, 3]);
+        let (response, out) = dispatch(&backend, &req, 64).expect("TDISP error is framed");
+
+        assert_inline(response, 1 + TDISP_ERROR_RSP_LEN);
+        assert_tdisp_error(&out, TDISP_ERROR_INVALID_REQUEST, 0);
+    }
+
+    #[test]
+    fn bad_version_unsupported_opcode_returns_spdm_error_without_tdisp_response() {
+        const BAD_VERSION: u8 = 0xff;
+        let backend = backend();
+        let mut req = request(TdispCommand::BindP2PStreamRequest as u8, &[]);
+        req[1] = BAD_VERSION;
+        let err = match dispatch(&backend, &req, 64) {
+            Ok(_) => panic!("bad TDISP version should not frame a TDISP response"),
+            Err(err) => err,
+        };
+
+        assert_eq!(err, SPDM_VERSION_MISMATCH);
+    }
+
+    #[test]
+    fn bad_version_malformed_supported_request_returns_spdm_error_without_tdisp_response() {
+        const BAD_VERSION: u8 = 0xff;
+        let backend = backend();
+        let mut req = request(TdispCommand::GetTdispCapabilities as u8, &[0]);
+        req[1] = BAD_VERSION;
+        let err = match dispatch(&backend, &req, 64) {
+            Ok(_) => panic!("bad TDISP version should not frame a TDISP response"),
+            Err(err) => err,
+        };
+
+        assert_eq!(err, SPDM_VERSION_MISMATCH);
+    }
+
+    #[test]
+    fn bad_version_well_formed_supported_request_returns_spdm_error_without_tdisp_response() {
+        const BAD_VERSION: u8 = 0xff;
+        let backend = backend();
+        let mut req = request(TdispCommand::GetTdispCapabilities as u8, &[0; 4]);
+        req[1] = BAD_VERSION;
+        let err = match dispatch(&backend, &req, 64) {
+            Ok(_) => panic!("bad TDISP version should not frame a TDISP response"),
+            Err(err) => err,
+        };
+
+        assert_eq!(err, SPDM_VERSION_MISMATCH);
+    }
+
+    #[test]
+    fn lock_start_stop_nonce_flow_reports_invalid_interface_state_for_nonce_mismatch() {
+        let backend = backend();
+        let get_version = request(TdispCommand::GetTdispVersion as u8, &[]);
+        dispatch(&backend, &get_version, 64).expect("interface initialized");
+
+        let lock = request(TdispCommand::LockInterface as u8, &[0; 20]);
+        let (response, out) = dispatch(&backend, &lock, 64).expect("LOCK_INTERFACE succeeds");
+        assert_inline(response, 1 + TDISP_HEADER_LEN + 32);
+        assert_eq!(out[2], TdispCommand::LockInterfaceResponse as u8);
+        let mut nonce = [0u8; 32];
+        nonce.copy_from_slice(&out[17..49]);
+
+        let mut wrong_nonce = nonce;
+        wrong_nonce[0] ^= 0xff;
+        let start_wrong = request(TdispCommand::StartInterfaceRequest as u8, &wrong_nonce);
+        let (response, out) = dispatch(&backend, &start_wrong, 64).expect("TDISP error is framed");
+        assert_inline(response, 1 + TDISP_ERROR_RSP_LEN);
+        assert_tdisp_error(&out, TDISP_ERROR_INVALID_INTERFACE_STATE, 0);
+
+        let start = request(TdispCommand::StartInterfaceRequest as u8, &nonce);
+        let (response, out) = dispatch(&backend, &start, 64).expect("START_INTERFACE succeeds");
+        assert_inline(response, 1 + TDISP_HEADER_LEN);
+        assert_eq!(out[2], TdispCommand::StartInterfaceResponse as u8);
+
+        let stop = request(TdispCommand::StopInterfaceRequest as u8, &[]);
+        let (response, out) = dispatch(&backend, &stop, 64).expect("STOP_INTERFACE succeeds");
+        assert_inline(response, 1 + TDISP_HEADER_LEN);
+        assert_eq!(out[2], TdispCommand::StopInterfaceResponse as u8);
+
+        let (response, out) = dispatch(&backend, &stop, 64).expect("TDISP error is framed");
+        assert_inline(response, 1 + TDISP_ERROR_RSP_LEN);
+        assert_tdisp_error(&out, TDISP_ERROR_INVALID_INTERFACE_STATE, 0);
+    }
+
+    #[test]
+    fn repeated_get_version_resets_pending_start_nonce() {
+        let backend = backend();
+        let get_version = request(TdispCommand::GetTdispVersion as u8, &[]);
+        dispatch(&backend, &get_version, 64).expect("interface initialized");
+
+        let lock = request(TdispCommand::LockInterface as u8, &[0; 20]);
+        let (_response, out) = dispatch(&backend, &lock, 64).expect("LOCK_INTERFACE succeeds");
+        let mut nonce = [0u8; 32];
+        nonce.copy_from_slice(&out[17..49]);
+
+        dispatch(&backend, &get_version, 64).expect("GET_TDISP_VERSION succeeds again");
+
+        let start = request(TdispCommand::StartInterfaceRequest as u8, &nonce);
+        let (response, out) = dispatch(&backend, &start, 64).expect("TDISP error is framed");
+        assert_inline(response, 1 + TDISP_ERROR_RSP_LEN);
+        assert_tdisp_error(&out, TDISP_ERROR_INVALID_INTERFACE_STATE, 0);
+    }
+
+    #[test]
+    fn stop_rejects_initialized_unlocked_interface() {
+        let backend = backend();
+        let get_version = request(TdispCommand::GetTdispVersion as u8, &[]);
+        dispatch(&backend, &get_version, 64).expect("interface initialized");
+
+        let stop = request(TdispCommand::StopInterfaceRequest as u8, &[]);
+        let (response, out) = dispatch(&backend, &stop, 64).expect("TDISP error is framed");
+        assert_inline(response, 1 + TDISP_ERROR_RSP_LEN);
+        assert_tdisp_error(&out, TDISP_ERROR_INVALID_INTERFACE_STATE, 0);
+    }
+
+    #[test]
+    fn device_report_response_is_bounded_by_request_and_remaining_report() {
+        let backend = backend();
+        let get_version = request(TdispCommand::GetTdispVersion as u8, &[]);
+        dispatch(&backend, &get_version, 64).expect("interface initialized");
+        let lock = request(TdispCommand::LockInterface as u8, &[0; 20]);
+        dispatch(&backend, &lock, 64).expect("LOCK_INTERFACE succeeds");
+
+        let mut report_req = Vec::new();
+        report_req.extend_from_slice(&4u16.to_le_bytes());
+        report_req.extend_from_slice(&20u16.to_le_bytes());
+        let report = request(TdispCommand::GetDeviceInterfaceReport as u8, &report_req);
+        let (response, out) = dispatch(&backend, &report, 64).expect("report succeeds");
+
+        assert_inline(response, 1 + TDISP_HEADER_LEN + 4 + 16);
+        assert_eq!(out[2], TdispCommand::DeviceInterfaceReport as u8);
+        assert_eq!(u16::from_le_bytes(out[17..19].try_into().unwrap()), 16);
+        assert_eq!(u16::from_le_bytes(out[19..21].try_into().unwrap()), 0);
+    }
+
+    #[test]
+    fn device_report_response_is_bounded_by_response_buffer_after_header() {
+        let backend = backend();
+        let get_version = request(TdispCommand::GetTdispVersion as u8, &[]);
+        dispatch(&backend, &get_version, 64).expect("interface initialized");
+        let lock = request(TdispCommand::LockInterface as u8, &[0; 20]);
+        dispatch(&backend, &lock, 64).expect("LOCK_INTERFACE succeeds");
+
+        let mut report_req = Vec::new();
+        report_req.extend_from_slice(&0u16.to_le_bytes());
+        report_req.extend_from_slice(&20u16.to_le_bytes());
+        let report = request(TdispCommand::GetDeviceInterfaceReport as u8, &report_req);
+        let (response, out) = dispatch(&backend, &report, 29).expect("report succeeds");
+
+        assert_inline(response, 1 + TDISP_HEADER_LEN + 4 + 8);
+        assert_eq!(out[2], TdispCommand::DeviceInterfaceReport as u8);
+        assert_eq!(u16::from_le_bytes(out[17..19].try_into().unwrap()), 8);
+        assert_eq!(u16::from_le_bytes(out[19..21].try_into().unwrap()), 12);
+    }
+
+    #[test]
+    fn device_report_rejects_zero_length_request() {
+        let backend = backend();
+        let get_version = request(TdispCommand::GetTdispVersion as u8, &[]);
+        dispatch(&backend, &get_version, 64).expect("interface initialized");
+
+        let mut report_req = Vec::new();
+        report_req.extend_from_slice(&0u16.to_le_bytes());
+        report_req.extend_from_slice(&0u16.to_le_bytes());
+        let report = request(TdispCommand::GetDeviceInterfaceReport as u8, &report_req);
+        let (response, out) = dispatch(&backend, &report, 64).expect("TDISP error is framed");
+
+        assert_inline(response, 1 + TDISP_ERROR_RSP_LEN);
+        assert_tdisp_error(&out, TDISP_ERROR_INVALID_REQUEST, 0);
+    }
+
+    #[test]
+    fn emulated_device_report_before_lock_returns_invalid_request() {
+        let backend = backend();
+        let get_version = request(TdispCommand::GetTdispVersion as u8, &[]);
+        dispatch(&backend, &get_version, 64).expect("interface initialized");
+
+        let mut report_req = Vec::new();
+        report_req.extend_from_slice(&0u16.to_le_bytes());
+        report_req.extend_from_slice(&0x40u16.to_le_bytes());
+        let report = request(TdispCommand::GetDeviceInterfaceReport as u8, &report_req);
+        let (response, out) = dispatch(&backend, &report, 64).expect("TDISP error is framed");
+
+        assert_inline(response, 1 + TDISP_ERROR_RSP_LEN);
+        assert_tdisp_error(&out, TDISP_ERROR_INVALID_REQUEST, 0);
+    }
+
+    #[test]
+    fn emulated_device_report_after_lock_is_valid_zero_mmio_structure() {
+        let backend = backend();
+        let get_version = request(TdispCommand::GetTdispVersion as u8, &[]);
+        dispatch(&backend, &get_version, 64).expect("interface initialized");
+        let lock = request(TdispCommand::LockInterface as u8, &[0; 20]);
+        dispatch(&backend, &lock, 64).expect("LOCK_INTERFACE succeeds");
+
+        let mut report_req = Vec::new();
+        report_req.extend_from_slice(&0u16.to_le_bytes());
+        report_req.extend_from_slice(&0x40u16.to_le_bytes());
+        let report = request(TdispCommand::GetDeviceInterfaceReport as u8, &report_req);
+        let (response, out) = dispatch(&backend, &report, 64).expect("report succeeds");
+
+        assert_inline(response, 1 + TDISP_HEADER_LEN + 4 + 20);
+        assert_eq!(u16::from_le_bytes(out[17..19].try_into().unwrap()), 20);
+        assert_eq!(u16::from_le_bytes(out[19..21].try_into().unwrap()), 0);
+        let report = &out[21..41];
+        assert_eq!(u32::from_le_bytes(report[12..16].try_into().unwrap()), 0);
+        assert_eq!(u32::from_le_bytes(report[16..20].try_into().unwrap()), 0);
+    }
+}

--- a/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/tdisp/commands/device_interface_report.rs
+++ b/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/tdisp/commands/device_interface_report.rs
@@ -1,0 +1,91 @@
+// Licensed under the Apache-2.0 license
+
+//! GET_DEVICE_INTERFACE_REPORT command handler.
+
+use mcu_spdm_lite_codec::errors::SPDM_UNSPECIFIED;
+use mcu_spdm_lite_traits::{McuResult, SpdmPalAlloc, SpdmPalIo};
+
+use crate::pci_sig::tdisp::protocol::{
+    tdisp_error_code, DeviceInterfaceReportReq, TdispMessageHeader,
+    DEVICE_INTERFACE_REPORT_RSP_HDR_LEN, TDISP_ERROR_INVALID_INTERFACE,
+    TDISP_ERROR_INVALID_REQUEST, TDISP_ERROR_UNSPECIFIED, TDISP_HEADER_LEN,
+};
+use crate::pci_sig::tdisp::{TdispDriver, TdispHandlerResult, TdispResponder};
+
+pub(crate) async fn handle<D, Alloc, Io>(
+    tdisp: &TdispResponder<D>,
+    req_hdr: TdispMessageHeader,
+    req_payload: &[u8],
+    scratch: &Alloc,
+    io: &Io,
+    out: &mut [u8],
+) -> McuResult<TdispHandlerResult>
+where
+    D: TdispDriver,
+    Alloc: SpdmPalAlloc,
+    Io: SpdmPalIo,
+{
+    if tdisp.state.interface_state(req_hdr.interface_id).is_none() {
+        return Ok(TdispHandlerResult::Error(TDISP_ERROR_INVALID_INTERFACE, 0));
+    }
+    let req = DeviceInterfaceReportReq::decode(req_payload)?;
+
+    let mut report_len = 0u16;
+    match tdisp
+        .driver
+        .get_device_interface_report_len(
+            req_hdr.interface_id.function_id,
+            scratch,
+            io,
+            &mut report_len,
+        )
+        .await
+    {
+        Ok(0) if req.offset as usize >= report_len as usize => {
+            return Ok(TdispHandlerResult::Error(TDISP_ERROR_INVALID_REQUEST, 0));
+        }
+        Ok(0) => {}
+        Ok(e) => return Ok(TdispHandlerResult::Error(tdisp_error_code(e), 0)),
+        Err(_) => return Ok(TdispHandlerResult::Error(TDISP_ERROR_UNSPECIFIED, 0)),
+    }
+
+    let payload = out.get_mut(TDISP_HEADER_LEN..).ok_or(SPDM_UNSPECIFIED)?;
+    let max_report = payload
+        .len()
+        .checked_sub(DEVICE_INTERFACE_REPORT_RSP_HDR_LEN)
+        .ok_or(SPDM_UNSPECIFIED)?;
+    let max_report = max_report.min(u16::MAX as usize) as u16;
+    let remaining = report_len.saturating_sub(req.offset);
+    let portion = remaining.min(req.length).min(max_report);
+    let rsp_hdr = payload
+        .get_mut(..DEVICE_INTERFACE_REPORT_RSP_HDR_LEN)
+        .ok_or(SPDM_UNSPECIFIED)?;
+    rsp_hdr[0..2].copy_from_slice(&portion.to_le_bytes());
+    rsp_hdr[2..4].copy_from_slice(&remaining.saturating_sub(portion).to_le_bytes());
+
+    let portion = portion as usize;
+    let report_portion = payload
+        .get_mut(DEVICE_INTERFACE_REPORT_RSP_HDR_LEN..DEVICE_INTERFACE_REPORT_RSP_HDR_LEN + portion)
+        .ok_or(SPDM_UNSPECIFIED)?;
+
+    let mut copied = 0usize;
+    match tdisp
+        .driver
+        .get_device_interface_report(
+            req_hdr.interface_id.function_id,
+            req.offset,
+            scratch,
+            io,
+            report_portion,
+            &mut copied,
+        )
+        .await
+    {
+        Ok(0) if copied == portion => Ok(TdispHandlerResult::Response(
+            DEVICE_INTERFACE_REPORT_RSP_HDR_LEN + copied,
+        )),
+        Ok(0) => Ok(TdispHandlerResult::Error(TDISP_ERROR_UNSPECIFIED, 0)),
+        Ok(e) => Ok(TdispHandlerResult::Error(tdisp_error_code(e), 0)),
+        Err(_) => Ok(TdispHandlerResult::Error(TDISP_ERROR_UNSPECIFIED, 0)),
+    }
+}

--- a/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/tdisp/commands/device_interface_state.rs
+++ b/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/tdisp/commands/device_interface_state.rs
@@ -1,0 +1,48 @@
+// Licensed under the Apache-2.0 license
+
+//! GET_DEVICE_INTERFACE_STATE command handler.
+
+use mcu_spdm_lite_codec::errors::SPDM_UNSPECIFIED;
+use mcu_spdm_lite_traits::{McuResult, SpdmPalAlloc, SpdmPalIo};
+
+use crate::pci_sig::tdisp::protocol::{
+    tdisp_error_code, TdiStatus, TdispMessageHeader, TDISP_ERROR_INVALID_INTERFACE_STATE,
+    TDISP_ERROR_UNSPECIFIED, TDISP_HEADER_LEN,
+};
+use crate::pci_sig::tdisp::{TdispDriver, TdispHandlerResult, TdispResponder};
+
+pub(crate) async fn handle<D, Alloc, Io>(
+    tdisp: &TdispResponder<D>,
+    req_hdr: TdispMessageHeader,
+    scratch: &Alloc,
+    io: &Io,
+    out: &mut [u8],
+) -> McuResult<TdispHandlerResult>
+where
+    D: TdispDriver,
+    Alloc: SpdmPalAlloc,
+    Io: SpdmPalIo,
+{
+    let mut tdi_status = TdiStatus::Reserved;
+    match tdisp
+        .driver
+        .get_device_interface_state(
+            req_hdr.interface_id.function_id,
+            scratch,
+            io,
+            &mut tdi_status,
+        )
+        .await
+    {
+        Ok(0) if tdi_status != TdiStatus::Reserved => {
+            *out.get_mut(TDISP_HEADER_LEN).ok_or(SPDM_UNSPECIFIED)? = tdi_status as u8;
+            Ok(TdispHandlerResult::Response(1))
+        }
+        Ok(0) => Ok(TdispHandlerResult::Error(
+            TDISP_ERROR_INVALID_INTERFACE_STATE,
+            0,
+        )),
+        Ok(e) => Ok(TdispHandlerResult::Error(tdisp_error_code(e), 0)),
+        Err(_) => Ok(TdispHandlerResult::Error(TDISP_ERROR_UNSPECIFIED, 0)),
+    }
+}

--- a/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/tdisp/commands/error_rsp.rs
+++ b/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/tdisp/commands/error_rsp.rs
@@ -1,0 +1,24 @@
+// Licensed under the Apache-2.0 license
+
+//! TDISP ERROR response generation.
+
+use mcu_spdm_lite_codec::errors::SPDM_UNSPECIFIED;
+use mcu_spdm_lite_traits::{McuResult, VdmResponse};
+
+use crate::pci_sig::tdisp::protocol::{
+    InterfaceId, TdispCommand, TdispErrorCode, TdispMessageHeader, ERROR_RSP_LEN, TDISP_HEADER_LEN,
+};
+
+pub(crate) fn write_error(
+    version: u8,
+    interface_id: InterfaceId,
+    error: TdispErrorCode,
+    error_data: u32,
+    out: &mut [u8],
+) -> McuResult<VdmResponse> {
+    let out = out.get_mut(..ERROR_RSP_LEN).ok_or(SPDM_UNSPECIFIED)?;
+    TdispMessageHeader::new(version, TdispCommand::ErrorResponse, interface_id).encode(out)?;
+    out[TDISP_HEADER_LEN..TDISP_HEADER_LEN + 4].copy_from_slice(&error.to_le_bytes());
+    out[TDISP_HEADER_LEN + 4..TDISP_HEADER_LEN + 8].copy_from_slice(&error_data.to_le_bytes());
+    Ok(VdmResponse::Inline(ERROR_RSP_LEN))
+}

--- a/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/tdisp/commands/get_tdisp_capabilities.rs
+++ b/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/tdisp/commands/get_tdisp_capabilities.rs
@@ -1,0 +1,44 @@
+// Licensed under the Apache-2.0 license
+
+//! GET_TDISP_CAPABILITIES command handler.
+
+use mcu_spdm_lite_codec::errors::SPDM_UNSPECIFIED;
+use mcu_spdm_lite_traits::{McuResult, SpdmPalAlloc, SpdmPalIo};
+
+use crate::pci_sig::tdisp::protocol::{
+    tdisp_error_code, TdispMessageHeader, TdispReqCapabilities, TdispRespCapabilities,
+    TDISP_CAPS_RSP_LEN, TDISP_ERROR_UNSPECIFIED, TDISP_HEADER_LEN,
+};
+use crate::pci_sig::tdisp::{TdispDriver, TdispHandlerResult, TdispResponder};
+
+pub(crate) async fn handle<D, Alloc, Io>(
+    tdisp: &TdispResponder<D>,
+    _req_hdr: TdispMessageHeader,
+    req_payload: &[u8],
+    scratch: &Alloc,
+    io: &Io,
+    out: &mut [u8],
+) -> McuResult<TdispHandlerResult>
+where
+    D: TdispDriver,
+    Alloc: SpdmPalAlloc,
+    Io: SpdmPalIo,
+{
+    let req_caps = TdispReqCapabilities::decode(req_payload)?;
+    let mut rsp_caps = TdispRespCapabilities::default();
+    match tdisp
+        .driver
+        .get_capabilities(req_caps, scratch, io, &mut rsp_caps)
+        .await
+    {
+        Ok(0) => {
+            rsp_caps.encode(
+                out.get_mut(TDISP_HEADER_LEN..TDISP_HEADER_LEN + TDISP_CAPS_RSP_LEN)
+                    .ok_or(SPDM_UNSPECIFIED)?,
+            )?;
+            Ok(TdispHandlerResult::Response(TDISP_CAPS_RSP_LEN))
+        }
+        Ok(e) => Ok(TdispHandlerResult::Error(tdisp_error_code(e), 0)),
+        Err(_) => Ok(TdispHandlerResult::Error(TDISP_ERROR_UNSPECIFIED, 0)),
+    }
+}

--- a/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/tdisp/commands/get_tdisp_version.rs
+++ b/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/tdisp/commands/get_tdisp_version.rs
@@ -1,0 +1,32 @@
+// Licensed under the Apache-2.0 license
+
+//! GET_TDISP_VERSION command handler.
+
+use mcu_spdm_lite_codec::errors::SPDM_UNSPECIFIED;
+use mcu_spdm_lite_traits::McuResult;
+
+use crate::pci_sig::tdisp::protocol::{
+    TdispMessageHeader, TDISP_ERROR_INVALID_INTERFACE, TDISP_HEADER_LEN,
+};
+use crate::pci_sig::tdisp::{TdispHandlerResult, TdispResponder};
+
+pub(crate) fn handle<D>(
+    tdisp: &TdispResponder<D>,
+    req_hdr: TdispMessageHeader,
+    out: &mut [u8],
+) -> McuResult<TdispHandlerResult> {
+    if tdisp.supported_versions.is_empty() || !tdisp.state.init_interface(req_hdr.interface_id) {
+        return Ok(TdispHandlerResult::Error(TDISP_ERROR_INVALID_INTERFACE, 0));
+    }
+
+    let payload = out.get_mut(TDISP_HEADER_LEN..).ok_or(SPDM_UNSPECIFIED)?;
+    let needed = 1usize
+        .checked_add(tdisp.supported_versions.len())
+        .ok_or(SPDM_UNSPECIFIED)?;
+    let payload = payload.get_mut(..needed).ok_or(SPDM_UNSPECIFIED)?;
+    payload[0] = tdisp.supported_versions.len() as u8;
+    for (dst, version) in payload[1..].iter_mut().zip(tdisp.supported_versions.iter()) {
+        *dst = version.to_u8();
+    }
+    Ok(TdispHandlerResult::Response(needed))
+}

--- a/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/tdisp/commands/lock_interface.rs
+++ b/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/tdisp/commands/lock_interface.rs
@@ -1,0 +1,60 @@
+// Licensed under the Apache-2.0 license
+
+//! LOCK_INTERFACE command handler.
+
+use mcu_spdm_lite_codec::errors::SPDM_UNSPECIFIED;
+use mcu_spdm_lite_traits::{McuResult, SpdmPalAlloc, SpdmPalIo};
+
+use crate::pci_sig::tdisp::protocol::{
+    tdisp_error_code, TdispLockInterfaceParam, TdispMessageHeader, START_INTERFACE_NONCE_SIZE,
+    TDISP_ERROR_INSUFFICIENT_ENTROPY, TDISP_ERROR_INVALID_INTERFACE, TDISP_ERROR_UNSPECIFIED,
+    TDISP_HEADER_LEN,
+};
+use crate::pci_sig::tdisp::{TdispDriver, TdispHandlerResult, TdispResponder};
+
+pub(crate) async fn handle<D, Alloc, Io>(
+    tdisp: &TdispResponder<D>,
+    req_hdr: TdispMessageHeader,
+    req_payload: &[u8],
+    scratch: &Alloc,
+    io: &Io,
+    out: &mut [u8],
+) -> McuResult<TdispHandlerResult>
+where
+    D: TdispDriver,
+    Alloc: SpdmPalAlloc,
+    Io: SpdmPalIo,
+{
+    if tdisp.state.interface_state(req_hdr.interface_id).is_none() {
+        return Ok(TdispHandlerResult::Error(TDISP_ERROR_INVALID_INTERFACE, 0));
+    }
+
+    let nonce = out
+        .get_mut(TDISP_HEADER_LEN..TDISP_HEADER_LEN + START_INTERFACE_NONCE_SIZE)
+        .ok_or(SPDM_UNSPECIFIED)?;
+    let nonce: &mut [u8; START_INTERFACE_NONCE_SIZE] =
+        nonce.try_into().map_err(|_| SPDM_UNSPECIFIED)?;
+    if tdisp
+        .driver
+        .generate_start_interface_nonce(scratch, io, nonce)
+        .await
+        .is_err()
+    {
+        return Ok(TdispHandlerResult::Error(
+            TDISP_ERROR_INSUFFICIENT_ENTROPY,
+            0,
+        ));
+    }
+    tdisp.state.set_nonce(req_hdr.interface_id, Some(*nonce));
+
+    let param = TdispLockInterfaceParam::decode(req_payload)?;
+    match tdisp
+        .driver
+        .lock_interface(req_hdr.interface_id.function_id, param, scratch, io)
+        .await
+    {
+        Ok(0) => Ok(TdispHandlerResult::Response(START_INTERFACE_NONCE_SIZE)),
+        Ok(e) => Ok(TdispHandlerResult::Error(tdisp_error_code(e), 0)),
+        Err(_) => Ok(TdispHandlerResult::Error(TDISP_ERROR_UNSPECIFIED, 0)),
+    }
+}

--- a/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/tdisp/commands/mod.rs
+++ b/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/tdisp/commands/mod.rs
@@ -1,0 +1,12 @@
+// Licensed under the Apache-2.0 license
+
+//! TDISP command handlers split to mirror spdm-lib organization.
+
+pub(crate) mod device_interface_report;
+pub(crate) mod device_interface_state;
+pub(crate) mod error_rsp;
+pub(crate) mod get_tdisp_capabilities;
+pub(crate) mod get_tdisp_version;
+pub(crate) mod lock_interface;
+pub(crate) mod start_interface;
+pub(crate) mod stop_interface;

--- a/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/tdisp/commands/start_interface.rs
+++ b/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/tdisp/commands/start_interface.rs
@@ -1,0 +1,52 @@
+// Licensed under the Apache-2.0 license
+
+//! START_INTERFACE command handler.
+
+use mcu_spdm_lite_traits::{McuResult, SpdmPalAlloc, SpdmPalIo};
+
+use crate::pci_sig::tdisp::protocol::{
+    ct_eq, tdisp_error_code, TdispMessageHeader, TDISP_ERROR_INVALID_INTERFACE,
+    TDISP_ERROR_INVALID_INTERFACE_STATE, TDISP_ERROR_UNSPECIFIED,
+};
+use crate::pci_sig::tdisp::{TdispDriver, TdispHandlerResult, TdispResponder};
+
+pub(crate) async fn handle<D, Alloc, Io>(
+    tdisp: &TdispResponder<D>,
+    req_hdr: TdispMessageHeader,
+    req_payload: &[u8],
+    scratch: &Alloc,
+    io: &Io,
+) -> McuResult<TdispHandlerResult>
+where
+    D: TdispDriver,
+    Alloc: SpdmPalAlloc,
+    Io: SpdmPalIo,
+{
+    let Some(interface_state) = tdisp.state.interface_state(req_hdr.interface_id) else {
+        return Ok(TdispHandlerResult::Error(TDISP_ERROR_INVALID_INTERFACE, 0));
+    };
+    let Some(expected_nonce) = interface_state.start_interface_nonce else {
+        return Ok(TdispHandlerResult::Error(
+            TDISP_ERROR_INVALID_INTERFACE_STATE,
+            0,
+        ));
+    };
+    if !ct_eq(&expected_nonce, req_payload) {
+        return Ok(TdispHandlerResult::Error(
+            TDISP_ERROR_INVALID_INTERFACE_STATE,
+            0,
+        ));
+    }
+    match tdisp
+        .driver
+        .start_interface(req_hdr.interface_id.function_id, scratch, io)
+        .await
+    {
+        Ok(0) => {
+            tdisp.state.set_nonce(req_hdr.interface_id, None);
+            Ok(TdispHandlerResult::Response(0))
+        }
+        Ok(e) => Ok(TdispHandlerResult::Error(tdisp_error_code(e), 0)),
+        Err(_) => Ok(TdispHandlerResult::Error(TDISP_ERROR_UNSPECIFIED, 0)),
+    }
+}

--- a/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/tdisp/commands/stop_interface.rs
+++ b/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/tdisp/commands/stop_interface.rs
@@ -1,0 +1,32 @@
+// Licensed under the Apache-2.0 license
+
+//! STOP_INTERFACE command handler.
+
+use mcu_spdm_lite_traits::{McuResult, SpdmPalAlloc, SpdmPalIo};
+
+use crate::pci_sig::tdisp::protocol::{
+    tdisp_error_code, TdispMessageHeader, TDISP_ERROR_UNSPECIFIED,
+};
+use crate::pci_sig::tdisp::{TdispDriver, TdispHandlerResult, TdispResponder};
+
+pub(crate) async fn handle<D, Alloc, Io>(
+    tdisp: &TdispResponder<D>,
+    req_hdr: TdispMessageHeader,
+    scratch: &Alloc,
+    io: &Io,
+) -> McuResult<TdispHandlerResult>
+where
+    D: TdispDriver,
+    Alloc: SpdmPalAlloc,
+    Io: SpdmPalIo,
+{
+    match tdisp
+        .driver
+        .stop_interface(req_hdr.interface_id.function_id, scratch, io)
+        .await
+    {
+        Ok(0) => Ok(TdispHandlerResult::Response(0)),
+        Ok(e) => Ok(TdispHandlerResult::Error(tdisp_error_code(e), 0)),
+        Err(_) => Ok(TdispHandlerResult::Error(TDISP_ERROR_UNSPECIFIED, 0)),
+    }
+}

--- a/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/tdisp/driver.rs
+++ b/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/tdisp/driver.rs
@@ -1,0 +1,314 @@
+// Licensed under the Apache-2.0 license
+
+//! TDISP platform driver abstraction.
+
+#[cfg(any(test, feature = "emulated-tdisp"))]
+use core::cell::Cell;
+
+use mcu_spdm_lite_traits::{SpdmPalAlloc, SpdmPalIo};
+
+use super::protocol::{
+    FunctionId, TdiStatus, TdispLockInterfaceParam, TdispReqCapabilities, TdispRespCapabilities,
+    START_INTERFACE_NONCE_SIZE,
+};
+#[cfg(any(test, feature = "emulated-tdisp"))]
+use super::protocol::{TDISP_ERROR_INVALID_INTERFACE_STATE, TDISP_ERROR_INVALID_REQUEST};
+
+#[cfg(any(test, feature = "emulated-tdisp"))]
+const EMULATED_REQ_MSGS_SUPPORTED: [u8; 16] = [
+    0xfe, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+];
+#[cfg(any(test, feature = "emulated-tdisp"))]
+const EMULATED_ZERO_MMIO_REPORT: [u8; 20] = [0; 20];
+
+/// Error codes returned by a TDISP platform driver.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum TdispDriverError {
+    InvalidArgument = 0x01,
+    NoMemory = 0x02,
+    GetTdispCapabilitiesFail = 0x03,
+    GetDeviceInterfaceStateFail = 0x04,
+    LockInterfaceReqFail = 0x05,
+    StartInterfaceReqFail = 0x06,
+    StopInterfaceReqFail = 0x07,
+    GetInterfaceReportFail = 0x08,
+    GetMmioRangesFail = 0x09,
+    FunctionNotImplemented = 0x0A,
+    InsufficientEntropy = 0x0B,
+}
+
+/// Result type returned by TDISP drivers.
+pub type TdispDriverResult<T> = Result<T, TdispDriverError>;
+
+/// Platform abstraction used by the TDISP responder.
+#[allow(async_fn_in_trait)]
+pub trait TdispDriver {
+    /// Fills `out` with a START_INTERFACE nonce.
+    async fn generate_start_interface_nonce<Alloc, Io>(
+        &self,
+        scratch: &Alloc,
+        io: &Io,
+        out: &mut [u8; START_INTERFACE_NONCE_SIZE],
+    ) -> TdispDriverResult<()>
+    where
+        Alloc: SpdmPalAlloc,
+        Io: SpdmPalIo;
+
+    /// Gets responder capabilities.
+    async fn get_capabilities<Alloc, Io>(
+        &self,
+        req_caps: TdispReqCapabilities,
+        scratch: &Alloc,
+        io: &Io,
+        resp_caps: &mut TdispRespCapabilities,
+    ) -> TdispDriverResult<u32>
+    where
+        Alloc: SpdmPalAlloc,
+        Io: SpdmPalIo;
+
+    /// Locks an interface.
+    async fn lock_interface<Alloc, Io>(
+        &self,
+        function_id: FunctionId,
+        param: TdispLockInterfaceParam,
+        scratch: &Alloc,
+        io: &Io,
+    ) -> TdispDriverResult<u32>
+    where
+        Alloc: SpdmPalAlloc,
+        Io: SpdmPalIo;
+
+    /// Returns the total device interface report length.
+    async fn get_device_interface_report_len<Alloc, Io>(
+        &self,
+        function_id: FunctionId,
+        scratch: &Alloc,
+        io: &Io,
+        intf_report_len: &mut u16,
+    ) -> TdispDriverResult<u32>
+    where
+        Alloc: SpdmPalAlloc,
+        Io: SpdmPalIo;
+
+    /// Copies a device interface report portion.
+    async fn get_device_interface_report<Alloc, Io>(
+        &self,
+        function_id: FunctionId,
+        offset: u16,
+        scratch: &Alloc,
+        io: &Io,
+        report: &mut [u8],
+        copied: &mut usize,
+    ) -> TdispDriverResult<u32>
+    where
+        Alloc: SpdmPalAlloc,
+        Io: SpdmPalIo;
+
+    /// Gets the current device interface state.
+    async fn get_device_interface_state<Alloc, Io>(
+        &self,
+        function_id: FunctionId,
+        scratch: &Alloc,
+        io: &Io,
+        tdi_state: &mut TdiStatus,
+    ) -> TdispDriverResult<u32>
+    where
+        Alloc: SpdmPalAlloc,
+        Io: SpdmPalIo;
+
+    /// Starts an interface.
+    async fn start_interface<Alloc, Io>(
+        &self,
+        function_id: FunctionId,
+        scratch: &Alloc,
+        io: &Io,
+    ) -> TdispDriverResult<u32>
+    where
+        Alloc: SpdmPalAlloc,
+        Io: SpdmPalIo;
+
+    /// Stops an interface.
+    async fn stop_interface<Alloc, Io>(
+        &self,
+        function_id: FunctionId,
+        scratch: &Alloc,
+        io: &Io,
+    ) -> TdispDriverResult<u32>
+    where
+        Alloc: SpdmPalAlloc,
+        Io: SpdmPalIo;
+}
+
+/// Minimal emulator implementation for DOE/SPDM TDISP validation.
+#[cfg(any(test, feature = "emulated-tdisp"))]
+pub struct EmulatedTdispDriver {
+    state: Cell<TdiStatus>,
+    nonce_counter: Cell<u8>,
+}
+
+#[cfg(any(test, feature = "emulated-tdisp"))]
+impl EmulatedTdispDriver {
+    /// Creates an emulator driver in CONFIG_UNLOCKED state.
+    pub const fn new() -> Self {
+        Self {
+            state: Cell::new(TdiStatus::ConfigUnlocked),
+            nonce_counter: Cell::new(0),
+        }
+    }
+}
+
+#[cfg(any(test, feature = "emulated-tdisp"))]
+impl Default for EmulatedTdispDriver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(any(test, feature = "emulated-tdisp"))]
+impl TdispDriver for EmulatedTdispDriver {
+    async fn generate_start_interface_nonce<Alloc, Io>(
+        &self,
+        _scratch: &Alloc,
+        _io: &Io,
+        out: &mut [u8; START_INTERFACE_NONCE_SIZE],
+    ) -> TdispDriverResult<()>
+    where
+        Alloc: SpdmPalAlloc,
+        Io: SpdmPalIo,
+    {
+        let start = self.nonce_counter.get().wrapping_add(1);
+        self.nonce_counter.set(start);
+        for (i, byte) in out.iter_mut().enumerate() {
+            *byte = start.wrapping_add(i as u8);
+        }
+        Ok(())
+    }
+
+    async fn get_capabilities<Alloc, Io>(
+        &self,
+        _req_caps: TdispReqCapabilities,
+        _scratch: &Alloc,
+        _io: &Io,
+        resp_caps: &mut TdispRespCapabilities,
+    ) -> TdispDriverResult<u32>
+    where
+        Alloc: SpdmPalAlloc,
+        Io: SpdmPalIo,
+    {
+        *resp_caps = TdispRespCapabilities::new(0, EMULATED_REQ_MSGS_SUPPORTED, 0x07, 48, 0, 0);
+        Ok(0)
+    }
+
+    async fn lock_interface<Alloc, Io>(
+        &self,
+        _function_id: FunctionId,
+        _param: TdispLockInterfaceParam,
+        _scratch: &Alloc,
+        _io: &Io,
+    ) -> TdispDriverResult<u32>
+    where
+        Alloc: SpdmPalAlloc,
+        Io: SpdmPalIo,
+    {
+        if self.state.get() != TdiStatus::ConfigUnlocked {
+            return Ok(TDISP_ERROR_INVALID_INTERFACE_STATE);
+        }
+        self.state.set(TdiStatus::ConfigLocked);
+        Ok(0)
+    }
+
+    async fn get_device_interface_report_len<Alloc, Io>(
+        &self,
+        _function_id: FunctionId,
+        _scratch: &Alloc,
+        _io: &Io,
+        intf_report_len: &mut u16,
+    ) -> TdispDriverResult<u32>
+    where
+        Alloc: SpdmPalAlloc,
+        Io: SpdmPalIo,
+    {
+        *intf_report_len = if self.state.get() == TdiStatus::ConfigUnlocked {
+            0
+        } else {
+            EMULATED_ZERO_MMIO_REPORT.len() as u16
+        };
+        Ok(0)
+    }
+
+    async fn get_device_interface_report<Alloc, Io>(
+        &self,
+        _function_id: FunctionId,
+        offset: u16,
+        _scratch: &Alloc,
+        _io: &Io,
+        report: &mut [u8],
+        copied: &mut usize,
+    ) -> TdispDriverResult<u32>
+    where
+        Alloc: SpdmPalAlloc,
+        Io: SpdmPalIo,
+    {
+        let offset = offset as usize;
+        if self.state.get() == TdiStatus::ConfigUnlocked
+            || offset >= EMULATED_ZERO_MMIO_REPORT.len()
+            || offset + report.len() > EMULATED_ZERO_MMIO_REPORT.len()
+        {
+            return Ok(TDISP_ERROR_INVALID_REQUEST);
+        }
+        let end = offset + report.len();
+        report.copy_from_slice(&EMULATED_ZERO_MMIO_REPORT[offset..end]);
+        *copied = report.len();
+        Ok(0)
+    }
+
+    async fn get_device_interface_state<Alloc, Io>(
+        &self,
+        _function_id: FunctionId,
+        _scratch: &Alloc,
+        _io: &Io,
+        tdi_state: &mut TdiStatus,
+    ) -> TdispDriverResult<u32>
+    where
+        Alloc: SpdmPalAlloc,
+        Io: SpdmPalIo,
+    {
+        *tdi_state = self.state.get();
+        Ok(0)
+    }
+
+    async fn start_interface<Alloc, Io>(
+        &self,
+        _function_id: FunctionId,
+        _scratch: &Alloc,
+        _io: &Io,
+    ) -> TdispDriverResult<u32>
+    where
+        Alloc: SpdmPalAlloc,
+        Io: SpdmPalIo,
+    {
+        if self.state.get() != TdiStatus::ConfigLocked {
+            return Ok(TDISP_ERROR_INVALID_INTERFACE_STATE);
+        }
+        self.state.set(TdiStatus::Run);
+        Ok(0)
+    }
+
+    async fn stop_interface<Alloc, Io>(
+        &self,
+        _function_id: FunctionId,
+        _scratch: &Alloc,
+        _io: &Io,
+    ) -> TdispDriverResult<u32>
+    where
+        Alloc: SpdmPalAlloc,
+        Io: SpdmPalIo,
+    {
+        if self.state.get() == TdiStatus::ConfigUnlocked {
+            return Ok(TDISP_ERROR_INVALID_INTERFACE_STATE);
+        }
+        self.state.set(TdiStatus::ConfigUnlocked);
+        Ok(0)
+    }
+}

--- a/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/tdisp/mod.rs
+++ b/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/tdisp/mod.rs
@@ -1,0 +1,175 @@
+// Licensed under the Apache-2.0 license
+
+//! TDISP protocol responder for SPDM-Lite PCI-SIG VDMs.
+//!
+//! This module ports the spdm-lib TDISP command set using static dispatch,
+//! no boxed futures, no heap-backed handler tables, and no spdm-lib wire types. Request
+//! decoding and response generation intentionally follow spdm-lib's validation
+//! order and error responses command-by-command.
+
+mod commands;
+mod driver;
+mod protocol;
+mod state;
+
+use mcu_spdm_lite_codec::errors::{SPDM_INVALID_REQUEST, SPDM_VERSION_MISMATCH};
+use mcu_spdm_lite_traits::{McuResult, SpdmPalAlloc, SpdmPalIo, VdmResponse};
+
+#[cfg(any(test, feature = "emulated-tdisp"))]
+pub use driver::EmulatedTdispDriver;
+pub use driver::{TdispDriver, TdispDriverError, TdispDriverResult};
+pub use protocol::{
+    FunctionId, InterfaceId, TdiStatus, TdispCommand, TdispErrorCode, TdispLockInterfaceFlags,
+    TdispLockInterfaceParam, TdispReqCapabilities, TdispRespCapabilities, TdispVersion,
+    START_INTERFACE_NONCE_SIZE, TDISP_ERROR_BUSY, TDISP_ERROR_INSUFFICIENT_ENTROPY,
+    TDISP_ERROR_INVALID_DEVICE_CONFIGURATION, TDISP_ERROR_INVALID_INTERFACE,
+    TDISP_ERROR_INVALID_INTERFACE_STATE, TDISP_ERROR_INVALID_NONCE, TDISP_ERROR_INVALID_REQUEST,
+    TDISP_ERROR_UNSPECIFIED, TDISP_ERROR_UNSUPPORTED_REQUEST, TDISP_ERROR_VENDOR_SPECIFIC_ERROR,
+    TDISP_ERROR_VERSION_MISMATCH, TDISP_VERSION_1_0,
+};
+pub use state::MAX_TDISP_INTERFACES;
+
+use protocol::{TdispMessageHeader, TDISP_HEADER_LEN};
+use state::TdispState;
+
+/// TDISP responder with fixed-size state storage.
+pub struct TdispResponder<D> {
+    pub(crate) supported_versions: &'static [TdispVersion],
+    pub(crate) driver: D,
+    pub(crate) state: TdispState,
+}
+
+impl<D> TdispResponder<D> {
+    /// Creates a TDISP responder.
+    pub const fn new(supported_versions: &'static [TdispVersion], driver: D) -> Self {
+        Self {
+            supported_versions,
+            driver,
+            state: TdispState::new(),
+        }
+    }
+
+    /// Returns the inner driver.
+    pub fn driver(&self) -> &D {
+        &self.driver
+    }
+}
+
+impl<D> TdispResponder<D>
+where
+    D: TdispDriver,
+{
+    /// Handles a TDISP payload excluding the PCI-SIG protocol id byte.
+    pub async fn handle_tdisp_payload<Alloc, Io>(
+        &self,
+        payload: &[u8],
+        scratch: &Alloc,
+        io: &Io,
+        out: &mut [u8],
+    ) -> McuResult<VdmResponse>
+    where
+        Alloc: SpdmPalAlloc,
+        Io: SpdmPalIo,
+    {
+        let (req_hdr, req_payload) = TdispMessageHeader::decode(payload)?;
+
+        if TdispVersion::try_from(req_hdr.version).is_err() {
+            return Err(SPDM_VERSION_MISMATCH);
+        }
+
+        let req_code = match TdispCommand::try_from(req_hdr.message_type) {
+            Ok(command) => command,
+            Err(_) => {
+                return commands::error_rsp::write_error(
+                    req_hdr.version,
+                    req_hdr.interface_id,
+                    TDISP_ERROR_UNSUPPORTED_REQUEST,
+                    req_hdr.message_type as u32,
+                    out,
+                );
+            }
+        };
+
+        if req_payload.len() != req_code.payload_len() {
+            return commands::error_rsp::write_error(
+                req_hdr.version,
+                req_hdr.interface_id,
+                TDISP_ERROR_INVALID_REQUEST,
+                0,
+                out,
+            );
+        }
+
+        let result = match req_code {
+            TdispCommand::GetTdispVersion => {
+                commands::get_tdisp_version::handle(self, req_hdr, out)
+            }
+            TdispCommand::GetTdispCapabilities => {
+                commands::get_tdisp_capabilities::handle(
+                    self,
+                    req_hdr,
+                    req_payload,
+                    scratch,
+                    io,
+                    out,
+                )
+                .await
+            }
+            TdispCommand::LockInterface => {
+                commands::lock_interface::handle(self, req_hdr, req_payload, scratch, io, out).await
+            }
+            TdispCommand::GetDeviceInterfaceReport => {
+                commands::device_interface_report::handle(
+                    self,
+                    req_hdr,
+                    req_payload,
+                    scratch,
+                    io,
+                    out,
+                )
+                .await
+            }
+            TdispCommand::GetDeviceInterfaceState => {
+                commands::device_interface_state::handle(self, req_hdr, scratch, io, out).await
+            }
+            TdispCommand::StartInterfaceRequest => {
+                commands::start_interface::handle(self, req_hdr, req_payload, scratch, io).await
+            }
+            TdispCommand::StopInterfaceRequest => {
+                commands::stop_interface::handle(self, req_hdr, scratch, io).await
+            }
+            TdispCommand::BindP2PStreamRequest
+            | TdispCommand::UnbindP2PStreamRequest
+            | TdispCommand::SetMmioAttributeRequest
+            | TdispCommand::VdmRequest => Ok(TdispHandlerResult::Error(
+                TDISP_ERROR_UNSUPPORTED_REQUEST,
+                req_hdr.message_type as u32,
+            )),
+            _ => Err(SPDM_INVALID_REQUEST),
+        }?;
+
+        match result {
+            TdispHandlerResult::Response(payload_len) => {
+                let Some(response_code) = req_code.response() else {
+                    return Err(SPDM_INVALID_REQUEST);
+                };
+                TdispMessageHeader::new(req_hdr.version, response_code, req_hdr.interface_id)
+                    .encode(out)?;
+                Ok(VdmResponse::Inline(TDISP_HEADER_LEN + payload_len))
+            }
+            TdispHandlerResult::Error(error, data) => commands::error_rsp::write_error(
+                req_hdr.version,
+                req_hdr.interface_id,
+                error,
+                data,
+                out,
+            ),
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum TdispHandlerResult {
+    Response(usize),
+    Error(TdispErrorCode, u32),
+}

--- a/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/tdisp/protocol.rs
+++ b/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/tdisp/protocol.rs
@@ -1,0 +1,446 @@
+// Licensed under the Apache-2.0 license
+
+//! Shared TDISP wire protocol types.
+
+use mcu_spdm_lite_codec::errors::{SPDM_INVALID_REQUEST, SPDM_UNSPECIFIED};
+use mcu_spdm_lite_traits::McuResult;
+
+/// TDISP version 1.0 wire value.
+pub const TDISP_VERSION_1_0: u8 = 0x10;
+/// Size of the START_INTERFACE nonce.
+pub const START_INTERFACE_NONCE_SIZE: usize = 32;
+/// TDISP common message header length.
+pub const TDISP_HEADER_LEN: usize = 16;
+/// GET_TDISP_CAPABILITIES request payload length.
+pub const TDISP_CAPS_REQ_LEN: usize = 4;
+/// GET_TDISP_CAPABILITIES response payload length.
+pub const TDISP_CAPS_RSP_LEN: usize = 28;
+/// LOCK_INTERFACE request payload length.
+pub const LOCK_INTERFACE_PARAM_LEN: usize = 20;
+/// GET_DEVICE_INTERFACE_REPORT request payload length.
+pub const DEVICE_INTERFACE_REPORT_REQ_LEN: usize = 4;
+/// GET_DEVICE_INTERFACE_REPORT response payload header length.
+pub const DEVICE_INTERFACE_REPORT_RSP_HDR_LEN: usize = 4;
+/// TDISP ERROR response total length including the TDISP header.
+pub const ERROR_RSP_LEN: usize = TDISP_HEADER_LEN + 8;
+
+/// TDISP wire error code type.
+pub type TdispErrorCode = u32;
+
+/// INVALID_REQUEST TDISP wire error code.
+pub const TDISP_ERROR_INVALID_REQUEST: TdispErrorCode = 0x01;
+/// BUSY TDISP wire error code.
+pub const TDISP_ERROR_BUSY: TdispErrorCode = 0x03;
+/// INVALID_INTERFACE_STATE TDISP wire error code.
+pub const TDISP_ERROR_INVALID_INTERFACE_STATE: TdispErrorCode = 0x04;
+/// UNSPECIFIED TDISP wire error code.
+pub const TDISP_ERROR_UNSPECIFIED: TdispErrorCode = 0x05;
+/// UNSUPPORTED_REQUEST TDISP wire error code.
+pub const TDISP_ERROR_UNSUPPORTED_REQUEST: TdispErrorCode = 0x07;
+/// VERSION_MISMATCH TDISP wire error code.
+pub const TDISP_ERROR_VERSION_MISMATCH: TdispErrorCode = 0x41;
+/// VENDOR_SPECIFIC_ERROR TDISP wire error code.
+pub const TDISP_ERROR_VENDOR_SPECIFIC_ERROR: TdispErrorCode = 0xff;
+/// INVALID_INTERFACE TDISP wire error code.
+pub const TDISP_ERROR_INVALID_INTERFACE: TdispErrorCode = 0x101;
+/// INVALID_NONCE TDISP wire error code.
+pub const TDISP_ERROR_INVALID_NONCE: TdispErrorCode = 0x102;
+/// INSUFFICIENT_ENTROPY TDISP wire error code.
+pub const TDISP_ERROR_INSUFFICIENT_ENTROPY: TdispErrorCode = 0x103;
+/// INVALID_DEVICE_CONFIGURATION TDISP wire error code.
+pub const TDISP_ERROR_INVALID_DEVICE_CONFIGURATION: TdispErrorCode = 0x104;
+
+/// Maps a driver-provided TDISP wire error value to a supported response code.
+pub const fn tdisp_error_code(value: u32) -> TdispErrorCode {
+    match value {
+        TDISP_ERROR_INVALID_REQUEST
+        | TDISP_ERROR_BUSY
+        | TDISP_ERROR_INVALID_INTERFACE_STATE
+        | TDISP_ERROR_UNSPECIFIED
+        | TDISP_ERROR_UNSUPPORTED_REQUEST
+        | TDISP_ERROR_VERSION_MISMATCH
+        | TDISP_ERROR_VENDOR_SPECIFIC_ERROR
+        | TDISP_ERROR_INVALID_INTERFACE
+        | TDISP_ERROR_INVALID_NONCE
+        | TDISP_ERROR_INSUFFICIENT_ENTROPY
+        | TDISP_ERROR_INVALID_DEVICE_CONFIGURATION => value,
+        _ => TDISP_ERROR_UNSPECIFIED,
+    }
+}
+
+/// Supported TDISP protocol versions.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum TdispVersion {
+    /// TDISP 1.0.
+    V10 = TDISP_VERSION_1_0,
+}
+
+impl TdispVersion {
+    /// Converts the version to the wire value.
+    pub const fn to_u8(self) -> u8 {
+        self as u8
+    }
+}
+
+impl TryFrom<u8> for TdispVersion {
+    type Error = TdispErrorCode;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            TDISP_VERSION_1_0 => Ok(Self::V10),
+            _ => Err(TDISP_ERROR_VERSION_MISMATCH),
+        }
+    }
+}
+
+/// TDISP command and response codes.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum TdispCommand {
+    GetTdispVersion = 0x81,
+    TdispVersion = 0x01,
+    GetTdispCapabilities = 0x82,
+    TdispCapabilities = 0x02,
+    LockInterface = 0x83,
+    LockInterfaceResponse = 0x03,
+    GetDeviceInterfaceReport = 0x84,
+    DeviceInterfaceReport = 0x04,
+    GetDeviceInterfaceState = 0x85,
+    DeviceInterfaceState = 0x05,
+    StartInterfaceRequest = 0x86,
+    StartInterfaceResponse = 0x06,
+    StopInterfaceRequest = 0x87,
+    StopInterfaceResponse = 0x07,
+    BindP2PStreamRequest = 0x88,
+    BindP2PStreamResponse = 0x08,
+    UnbindP2PStreamRequest = 0x89,
+    UnbindP2PStreamResponse = 0x09,
+    SetMmioAttributeRequest = 0x8A,
+    SetMmioAttributeResponse = 0x0A,
+    VdmRequest = 0x8B,
+    VdmResponse = 0x0B,
+    ErrorResponse = 0x7F,
+}
+
+impl TdispCommand {
+    /// Returns the matching response command for a request command.
+    pub(crate) const fn response(self) -> Option<Self> {
+        match self {
+            Self::GetTdispVersion => Some(Self::TdispVersion),
+            Self::GetTdispCapabilities => Some(Self::TdispCapabilities),
+            Self::LockInterface => Some(Self::LockInterfaceResponse),
+            Self::GetDeviceInterfaceReport => Some(Self::DeviceInterfaceReport),
+            Self::GetDeviceInterfaceState => Some(Self::DeviceInterfaceState),
+            Self::StartInterfaceRequest => Some(Self::StartInterfaceResponse),
+            Self::StopInterfaceRequest => Some(Self::StopInterfaceResponse),
+            Self::BindP2PStreamRequest => Some(Self::BindP2PStreamResponse),
+            Self::UnbindP2PStreamRequest => Some(Self::UnbindP2PStreamResponse),
+            Self::SetMmioAttributeRequest => Some(Self::SetMmioAttributeResponse),
+            Self::VdmRequest => Some(Self::VdmResponse),
+            _ => None,
+        }
+    }
+
+    /// Returns the exact request payload length used by spdm-lib.
+    pub(crate) const fn payload_len(self) -> usize {
+        match self {
+            Self::GetTdispVersion => 0,
+            Self::GetTdispCapabilities => TDISP_CAPS_REQ_LEN,
+            Self::LockInterface => LOCK_INTERFACE_PARAM_LEN,
+            Self::GetDeviceInterfaceReport => DEVICE_INTERFACE_REPORT_REQ_LEN,
+            Self::GetDeviceInterfaceState => 0,
+            Self::StartInterfaceRequest => START_INTERFACE_NONCE_SIZE,
+            Self::StopInterfaceRequest => 0,
+            Self::BindP2PStreamRequest
+            | Self::UnbindP2PStreamRequest
+            | Self::SetMmioAttributeRequest => 0,
+            _ => 0,
+        }
+    }
+}
+
+impl TryFrom<u8> for TdispCommand {
+    type Error = TdispErrorCode;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0x81 => Ok(Self::GetTdispVersion),
+            0x01 => Ok(Self::TdispVersion),
+            0x82 => Ok(Self::GetTdispCapabilities),
+            0x02 => Ok(Self::TdispCapabilities),
+            0x83 => Ok(Self::LockInterface),
+            0x03 => Ok(Self::LockInterfaceResponse),
+            0x84 => Ok(Self::GetDeviceInterfaceReport),
+            0x04 => Ok(Self::DeviceInterfaceReport),
+            0x85 => Ok(Self::GetDeviceInterfaceState),
+            0x05 => Ok(Self::DeviceInterfaceState),
+            0x86 => Ok(Self::StartInterfaceRequest),
+            0x06 => Ok(Self::StartInterfaceResponse),
+            0x87 => Ok(Self::StopInterfaceRequest),
+            0x07 => Ok(Self::StopInterfaceResponse),
+            0x88 => Ok(Self::BindP2PStreamRequest),
+            0x08 => Ok(Self::BindP2PStreamResponse),
+            0x89 => Ok(Self::UnbindP2PStreamRequest),
+            0x09 => Ok(Self::UnbindP2PStreamResponse),
+            0x8A => Ok(Self::SetMmioAttributeRequest),
+            0x0A => Ok(Self::SetMmioAttributeResponse),
+            0x8B => Ok(Self::VdmRequest),
+            0x0B => Ok(Self::VdmResponse),
+            0x7F => Ok(Self::ErrorResponse),
+            _ => Err(TDISP_ERROR_UNSUPPORTED_REQUEST),
+        }
+    }
+}
+
+/// FunctionID of the device hosting the TDI.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct FunctionId(pub u32);
+
+impl FunctionId {
+    /// Returns the PCIe requester id field.
+    pub const fn requester_id(self) -> u16 {
+        (self.0 & 0xffff) as u16
+    }
+
+    /// Returns the requester segment field.
+    pub const fn requester_segment(self) -> u8 {
+        ((self.0 >> 16) & 0xff) as u8
+    }
+
+    /// Returns true when the requester segment is valid.
+    pub const fn requester_segment_valid(self) -> bool {
+        ((self.0 >> 24) & 1) != 0
+    }
+}
+
+/// Interface identifier carried in every TDISP message header.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct InterfaceId {
+    /// PCI function identifier.
+    pub function_id: FunctionId,
+    /// Reserved 64-bit field preserved as decoded.
+    pub reserved: u64,
+}
+
+/// TDISP common message header.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct TdispMessageHeader {
+    /// TDISP wire version.
+    pub version: u8,
+    /// TDISP command code.
+    pub message_type: u8,
+    /// Reserved header field.
+    pub reserved: u16,
+    /// Target interface id.
+    pub interface_id: InterfaceId,
+}
+
+impl TdispMessageHeader {
+    /// Creates a response header.
+    pub const fn new(version: u8, message_type: TdispCommand, interface_id: InterfaceId) -> Self {
+        Self {
+            version,
+            message_type: message_type as u8,
+            reserved: 0,
+            interface_id,
+        }
+    }
+
+    pub(crate) fn decode(input: &[u8]) -> McuResult<(Self, &[u8])> {
+        let hdr = input.get(..TDISP_HEADER_LEN).ok_or(SPDM_INVALID_REQUEST)?;
+        Ok((
+            Self {
+                version: hdr[0],
+                message_type: hdr[1],
+                reserved: read_u16(&hdr[2..4]),
+                interface_id: InterfaceId {
+                    function_id: FunctionId(read_u32(&hdr[4..8])),
+                    reserved: read_u64(&hdr[8..16]),
+                },
+            },
+            &input[TDISP_HEADER_LEN..],
+        ))
+    }
+
+    pub(crate) fn encode(self, out: &mut [u8]) -> McuResult<()> {
+        let out = out.get_mut(..TDISP_HEADER_LEN).ok_or(SPDM_UNSPECIFIED)?;
+        out[0] = self.version;
+        out[1] = self.message_type;
+        out[2..4].copy_from_slice(&self.reserved.to_le_bytes());
+        out[4..8].copy_from_slice(&self.interface_id.function_id.0.to_le_bytes());
+        out[8..16].copy_from_slice(&self.interface_id.reserved.to_le_bytes());
+        Ok(())
+    }
+}
+
+/// GET_TDISP_CAPABILITIES request payload.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct TdispReqCapabilities {
+    /// Requester TSM capabilities.
+    pub tsm_caps: u32,
+}
+
+impl TdispReqCapabilities {
+    pub(crate) fn decode(input: &[u8]) -> McuResult<Self> {
+        if input.len() != TDISP_CAPS_REQ_LEN {
+            return Err(SPDM_INVALID_REQUEST);
+        }
+        Ok(Self {
+            tsm_caps: read_u32(input),
+        })
+    }
+}
+
+/// TDISP responder capabilities payload.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct TdispRespCapabilities {
+    /// Responder DSM capability bits.
+    pub dsm_capabilities: u32,
+    /// Supported request message bitmap.
+    pub req_msgs_supported: [u8; 16],
+    /// Supported LOCK_INTERFACE flags.
+    pub lock_interface_flags_supported: u16,
+    /// Device address width.
+    pub dev_addr_width: u8,
+    /// Number of requesters for this interface.
+    pub num_req_this: u8,
+    /// Number of requesters across all interfaces.
+    pub num_req_all: u8,
+}
+
+impl TdispRespCapabilities {
+    /// Creates a capabilities payload.
+    pub const fn new(
+        dsm_capabilities: u32,
+        req_msgs_supported: [u8; 16],
+        lock_interface_flags_supported: u16,
+        dev_addr_width: u8,
+        num_req_this: u8,
+        num_req_all: u8,
+    ) -> Self {
+        Self {
+            dsm_capabilities,
+            req_msgs_supported,
+            lock_interface_flags_supported,
+            dev_addr_width,
+            num_req_this,
+            num_req_all,
+        }
+    }
+
+    pub(crate) fn encode(self, out: &mut [u8]) -> McuResult<()> {
+        let out = out.get_mut(..TDISP_CAPS_RSP_LEN).ok_or(SPDM_UNSPECIFIED)?;
+        out[0..4].copy_from_slice(&self.dsm_capabilities.to_le_bytes());
+        out[4..20].copy_from_slice(&self.req_msgs_supported);
+        out[20..22].copy_from_slice(&self.lock_interface_flags_supported.to_le_bytes());
+        out[22..25].fill(0);
+        out[25] = self.dev_addr_width;
+        out[26] = self.num_req_this;
+        out[27] = self.num_req_all;
+        Ok(())
+    }
+}
+
+/// LOCK_INTERFACE_REQUEST flags.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct TdispLockInterfaceFlags(pub u16);
+
+/// LOCK_INTERFACE_REQUEST payload.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct TdispLockInterfaceParam {
+    /// Requested lock flags.
+    pub flags: TdispLockInterfaceFlags,
+    /// Default stream id.
+    pub default_stream_id: u8,
+    /// Reserved byte.
+    pub reserved: u8,
+    /// MMIO reporting offset.
+    pub mmio_reporting_offset: [u8; 8],
+    /// P2P address mask.
+    pub bind_p2p_addr_mask: [u8; 8],
+}
+
+impl TdispLockInterfaceParam {
+    pub(crate) fn decode(input: &[u8]) -> McuResult<Self> {
+        if input.len() != LOCK_INTERFACE_PARAM_LEN {
+            return Err(SPDM_INVALID_REQUEST);
+        }
+        let mut mmio_reporting_offset = [0u8; 8];
+        let mut bind_p2p_addr_mask = [0u8; 8];
+        mmio_reporting_offset.copy_from_slice(&input[4..12]);
+        bind_p2p_addr_mask.copy_from_slice(&input[12..20]);
+        Ok(Self {
+            flags: TdispLockInterfaceFlags(read_u16(&input[0..2])),
+            default_stream_id: input[2],
+            reserved: input[3],
+            mmio_reporting_offset,
+            bind_p2p_addr_mask,
+        })
+    }
+}
+
+/// GET_DEVICE_INTERFACE_REPORT request payload.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct DeviceInterfaceReportReq {
+    pub(crate) offset: u16,
+    pub(crate) length: u16,
+}
+
+impl DeviceInterfaceReportReq {
+    pub(crate) fn decode(input: &[u8]) -> McuResult<Self> {
+        if input.len() != DEVICE_INTERFACE_REPORT_REQ_LEN {
+            return Err(SPDM_INVALID_REQUEST);
+        }
+        Ok(Self {
+            offset: read_u16(&input[0..2]),
+            length: read_u16(&input[2..4]),
+        })
+    }
+}
+
+/// TDI state values.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[repr(u8)]
+pub enum TdiStatus {
+    /// CONFIG_UNLOCKED state.
+    #[default]
+    ConfigUnlocked = 0,
+    /// CONFIG_LOCKED state.
+    ConfigLocked = 1,
+    /// RUN state.
+    Run = 2,
+    /// ERROR state.
+    Error = 3,
+    /// Reserved/invalid state.
+    Reserved = 0xff,
+}
+
+pub(crate) fn read_u16(input: &[u8]) -> u16 {
+    let mut bytes = [0u8; 2];
+    bytes.copy_from_slice(&input[..2]);
+    u16::from_le_bytes(bytes)
+}
+
+fn read_u32(input: &[u8]) -> u32 {
+    let mut bytes = [0u8; 4];
+    bytes.copy_from_slice(&input[..4]);
+    u32::from_le_bytes(bytes)
+}
+
+fn read_u64(input: &[u8]) -> u64 {
+    let mut bytes = [0u8; 8];
+    bytes.copy_from_slice(&input[..8]);
+    u64::from_le_bytes(bytes)
+}
+
+pub(crate) fn ct_eq(a: &[u8; START_INTERFACE_NONCE_SIZE], b: &[u8]) -> bool {
+    if b.len() != START_INTERFACE_NONCE_SIZE {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (a, b) in a.iter().zip(b.iter()) {
+        diff |= *a ^ *b;
+    }
+    diff == 0
+}

--- a/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/tdisp/state.rs
+++ b/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/tdisp/state.rs
@@ -1,0 +1,79 @@
+// Licensed under the Apache-2.0 license
+
+//! Fixed-size TDISP responder state.
+
+use core::cell::Cell;
+
+use super::protocol::{InterfaceId, START_INTERFACE_NONCE_SIZE};
+
+/// Maximum number of TDISP interfaces tracked by the responder.
+pub const MAX_TDISP_INTERFACES: usize = 64;
+
+pub(crate) struct TdispState {
+    interfaces: [Cell<Option<TdispInterfaceState>>; MAX_TDISP_INTERFACES],
+}
+
+impl TdispState {
+    pub(crate) const fn new() -> Self {
+        Self {
+            interfaces: [const { Cell::new(None) }; MAX_TDISP_INTERFACES],
+        }
+    }
+
+    pub(crate) fn interface_state(&self, interface_id: InterfaceId) -> Option<TdispInterfaceState> {
+        self.interfaces.iter().find_map(|slot| match slot.get() {
+            Some(state) if state.interface_id == interface_id => Some(state),
+            _ => None,
+        })
+    }
+
+    pub(crate) fn init_interface(&self, interface_id: InterfaceId) -> bool {
+        if let Some(slot) = self
+            .interfaces
+            .iter()
+            .find(|slot| matches!(slot.get(), Some(state) if state.interface_id == interface_id))
+        {
+            slot.set(Some(TdispInterfaceState::new(interface_id)));
+            return true;
+        }
+        if let Some(slot) = self.interfaces.iter().find(|slot| slot.get().is_none()) {
+            slot.set(Some(TdispInterfaceState::new(interface_id)));
+            return true;
+        }
+        false
+    }
+
+    pub(crate) fn set_nonce(
+        &self,
+        interface_id: InterfaceId,
+        nonce: Option<[u8; START_INTERFACE_NONCE_SIZE]>,
+    ) -> bool {
+        if let Some(slot) = self
+            .interfaces
+            .iter()
+            .find(|slot| matches!(slot.get(), Some(state) if state.interface_id == interface_id))
+        {
+            slot.set(Some(TdispInterfaceState {
+                interface_id,
+                start_interface_nonce: nonce,
+            }));
+            return true;
+        }
+        false
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct TdispInterfaceState {
+    interface_id: InterfaceId,
+    pub(crate) start_interface_nonce: Option<[u8; START_INTERFACE_NONCE_SIZE]>,
+}
+
+impl TdispInterfaceState {
+    const fn new(interface_id: InterfaceId) -> Self {
+        Self {
+            interface_id,
+            start_interface_nonce: None,
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add PCI-SIG TDISP handling on top of the spdm-lite VDM backend
- add a size-conscious TDISP responder with borrowed request decoding and caller-provided response buffers
- wire the DOE emulator validator feature to the TDISP VDM backend
- document the SPDM-Lite TDISP driver interface and supported requests

## Validation
- `cargo test -p mcu-spdm-lite-vdm-handler --features emulated-tdisp`
- `cargo check -p user-app --features test-doe-spdm-tdisp-ide-validator`
- `cargo fmt --check`
- `git diff --check`

## Memory report
Generated locally with `../caliptra-mcu-sw/measure-memory.sh` (`profile=devel`).

### Kernel (`mcu-runtime-emulator`)
| Section | Size |
| --- | ---: |
| `.text` | 142,252 B |
| `.data` | 36 B |
| `.bss` | 24,536 B |

### User-app
| Section | Size |
| --- | ---: |
| `.text` | 98,556 B |
| `.rodata` | 20,764 B |
| `.data` | 12 B |
| `.bss` | 61,384 B |
| FLASH | 119,332 B |
| RAM | 61,396 B |

### SPDM task (symbol attribution from user-app)
| Section | Size |
| --- | ---: |
| `.text` | 84,680 B |
| `.rodata` | 732 B |
| `.data` | 0 B |
| `.bss` | 36,569 B |
| FLASH | 85,412 B |
| RAM | 36,569 B |

| Bundle | Size |
| --- | ---: |
| Runtime bundle | 262,912 B |
