### PR TITLE
spdm-lite: add PCI-SIG IDE-KM VDM support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4074,10 +4074,12 @@ dependencies = [
 name = "mcu-spdm-lite-vdm-handler"
 version = "0.1.0"
 dependencies = [
+ "futures",
  "mcu-caliptra-api-lite",
  "mcu-error",
  "mcu-spdm-lite-codec",
  "mcu-spdm-lite-traits",
+ "zerocopy",
 ]
 
 [[package]]

--- a/platforms/emulator/runtime/userspace/apps/user/Cargo.toml
+++ b/platforms/emulator/runtime/userspace/apps/user/Cargo.toml
@@ -133,6 +133,6 @@ test-mctp-spdm-set-certificate = [
   "mcu-spdm-lite-pal/set-certificate",
   "mcu-spdm-lite-stack/set-certificate",
 ]
-test-doe-spdm-tdisp-ide-validator = []
+test-doe-spdm-tdisp-ide-validator = ["mcu-spdm-lite-vdm-handler/emulated-ide-km"]
 test-mcu-mbox-fips-periodic = ["caliptra-mcu-mbox-lib/periodic-fips-self-test"]
 active-i3c1 = []

--- a/platforms/emulator/runtime/userspace/apps/user/src/spdm/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/spdm/mod.rs
@@ -27,6 +27,8 @@ use mcu_spdm_lite_pal::{McuSpdmPal, BITMAP_SLOT_SIZE};
 use mcu_spdm_lite_stack::SpdmStack;
 use mcu_spdm_lite_transports::{McuSpdmDoeTransport, McuSpdmMctpTransport};
 use mcu_spdm_lite_vdm_handler::iana::ocp::caliptra_vdm::CaliptraVdm;
+#[cfg(feature = "test-doe-spdm-tdisp-ide-validator")]
+use mcu_spdm_lite_vdm_handler::pci_sig::{EmulatedIdeDriver, PciSigIdeKmVdm};
 
 /// Bitmap allocator pool size per responder task.
 ///
@@ -39,6 +41,9 @@ const SPDM_LITE_SCRATCH_SIZE: usize = 8 * 1024;
 /// scratch pool so it survives the per-request allocator reset; its length caps
 /// `MaxSPDMmsgSize`.
 const SPDM_LITE_LARGE_MSG_SIZE: usize = 8 * 1024;
+/// PCI vendor ID used by Caliptra emulator PCI-SIG VDMs.
+#[cfg(feature = "test-doe-spdm-tdisp-ide-validator")]
+const CALIPTRA_PCI_VENDOR_ID: u16 = 0x1414;
 
 /// Single cert store shared by all SPDM responder tasks.
 static CERT_STORE: SharedCertStore = SharedCertStore::new();
@@ -152,8 +157,8 @@ async fn spdm_mctp_responder() {
             measurement_provider(),
         )
     };
-    // MCTP hosts the IANA / Caliptra VDM backend (plaintext today). DOE hosts
-    // PCI-SIG and stays on the default NoVdmBackend.
+    // MCTP hosts the IANA / Caliptra VDM backend (plaintext today). DOE uses
+    // the default NoVdmBackend unless the TDISP/IDE validator feature wires PCI-SIG.
     static MCTP_VDM_HOOK: caliptra_vdm::CaliptraVdmHook = caliptra_vdm::CaliptraVdmHook;
     let vdm = CaliptraVdm::new(&MCTP_VDM_HOOK);
     let mut stack = SpdmStack::<_, 1, _>::with_vdm_backend(pal, vdm);
@@ -208,6 +213,12 @@ async fn spdm_doe_responder() {
             measurement_provider(),
         )
     };
+    #[cfg(feature = "test-doe-spdm-tdisp-ide-validator")]
+    let mut stack = SpdmStack::<_, 1, _>::with_vdm_backend(
+        pal,
+        PciSigIdeKmVdm::new(CALIPTRA_PCI_VENDOR_ID, EmulatedIdeDriver::default()),
+    );
+    #[cfg(not(feature = "test-doe-spdm-tdisp-ide-validator"))]
     let mut stack: SpdmStack<_, 1> = SpdmStack::new(pal);
 
     crate::console_writeln!(cw, "SPDM_DOE: starting spdm-lite DOE run loop");

--- a/runtime/userspace/api/spdm-lite/codec/src/ide_km.rs
+++ b/runtime/userspace/api/spdm-lite/codec/src/ide_km.rs
@@ -1,0 +1,860 @@
+// Licensed under the Apache-2.0 license
+
+//! PCI-SIG IDE-KM protocol wire types.
+
+use core::mem::size_of;
+
+use zerocopy::{
+    little_endian::U16, little_endian::U32, FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned,
+};
+
+use crate::{WireError, WireWriter};
+
+/// IDE stream key size in DWORDs.
+pub const IDE_STREAM_KEY_SIZE_DW: usize = 8;
+/// IDE stream IV size in DWORDs.
+pub const IDE_STREAM_IV_SIZE_DW: usize = 2;
+/// Maximum selective IDE address-association register blocks.
+pub const MAX_SELECTIVE_IDE_ADDR_ASSOC_BLOCK_COUNT: usize = 15;
+
+/// PCI-SIG IDE-KM protocol ID within PCI-SIG VDMs.
+pub const IDE_KM_PROTOCOL_ID: u8 = 0x00;
+
+/// IDE-KM object IDs used as command and response codes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum IdeKmCommand {
+    Query = 0x00,
+    QueryResp = 0x01,
+    KeyProg = 0x02,
+    KeyProgAck = 0x03,
+    KeySetGo = 0x04,
+    KeySetStop = 0x05,
+    KeyGoStopAck = 0x06,
+}
+
+impl IdeKmCommand {
+    /// Returns the IDE-KM response object ID for a request object ID.
+    pub const fn response(self) -> Option<Self> {
+        match self {
+            Self::Query => Some(Self::QueryResp),
+            Self::KeyProg => Some(Self::KeyProgAck),
+            Self::KeySetGo | Self::KeySetStop => Some(Self::KeyGoStopAck),
+            _ => None,
+        }
+    }
+
+    /// Returns the expected request payload size after [`IdeKmHdr`].
+    pub const fn payload_len(self) -> usize {
+        match self {
+            Self::Query => Query::SIZE,
+            Self::KeyProg => KeyProg::SIZE + KeyData::SIZE,
+            Self::KeySetGo | Self::KeySetStop => KeySetGoStop::SIZE,
+            _ => 0,
+        }
+    }
+
+    /// Decodes an IDE-KM object ID.
+    pub const fn from_u8(value: u8) -> Option<Self> {
+        match value {
+            0x00 => Some(Self::Query),
+            0x01 => Some(Self::QueryResp),
+            0x02 => Some(Self::KeyProg),
+            0x03 => Some(Self::KeyProgAck),
+            0x04 => Some(Self::KeySetGo),
+            0x05 => Some(Self::KeySetStop),
+            0x06 => Some(Self::KeyGoStopAck),
+            _ => None,
+        }
+    }
+}
+
+/// IDE-KM command header.
+#[derive(FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned, Copy, Clone, Debug)]
+#[repr(C)]
+pub struct IdeKmHdr {
+    /// IDE-KM object ID.
+    pub object_id: u8,
+}
+
+impl IdeKmHdr {
+    /// Size of the IDE-KM header on the wire.
+    pub const SIZE: usize = 1;
+}
+
+const _: () = assert!(size_of::<IdeKmHdr>() == IdeKmHdr::SIZE);
+
+/// Key Information field: Key Sub-stream | Reserved | RxTxB | Key Set.
+#[derive(
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+)]
+#[repr(transparent)]
+pub struct KeyInfo(pub u8);
+
+impl KeyInfo {
+    /// Creates a KeyInfo field from key-set, direction, and sub-stream values.
+    pub fn new(key_set_bit: bool, key_direction: bool, key_sub_stream: u8) -> Self {
+        let mut info = Self(0);
+        info.set_key_set_bit(key_set_bit as u8);
+        info.set_key_direction(key_direction as u8);
+        info.set_key_sub_stream(key_sub_stream);
+        info
+    }
+
+    /// Returns the Key Set bit.
+    pub const fn key_set_bit(self) -> u8 {
+        self.0 & 0x1
+    }
+
+    /// Sets the Key Set bit.
+    pub fn set_key_set_bit(&mut self, value: u8) {
+        self.0 = set_field_u8(self.0, 0, 1, value);
+    }
+
+    /// Returns the RxTxB key direction bit.
+    pub const fn key_direction(self) -> u8 {
+        (self.0 >> 1) & 0x1
+    }
+
+    /// Sets the RxTxB key direction bit.
+    pub fn set_key_direction(&mut self, value: u8) {
+        self.0 = set_field_u8(self.0, 1, 1, value);
+    }
+
+    /// Returns the key sub-stream nibble.
+    pub const fn key_sub_stream(self) -> u8 {
+        (self.0 >> 4) & 0x0f
+    }
+
+    /// Sets the key sub-stream nibble.
+    pub fn set_key_sub_stream(&mut self, value: u8) {
+        self.0 = set_field_u8(self.0, 4, 4, value);
+    }
+
+    /// Returns the raw wire byte.
+    pub const fn raw(self) -> u8 {
+        self.0
+    }
+}
+
+/// IDE Capability Register.
+#[derive(
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+)]
+#[repr(transparent)]
+pub struct IdeCapabilityReg(pub U32);
+
+impl IdeCapabilityReg {
+    /// Creates a register from raw bits.
+    pub const fn new(bits: u32) -> Self {
+        Self(U32::new(bits))
+    }
+
+    /// Returns raw register bits.
+    pub fn raw(self) -> u32 {
+        self.0.get()
+    }
+
+    pub fn link_ide_stream_supported(self) -> u8 {
+        get_bit(self.raw(), 0)
+    }
+    pub fn set_link_ide_stream_supported(&mut self, value: u8) {
+        self.set_bits(set_field(self.raw(), 0, 1, value as u32));
+    }
+    pub fn selective_ide_stream_supported(self) -> u8 {
+        get_bit(self.raw(), 1)
+    }
+    pub fn set_selective_ide_stream_supported(&mut self, value: u8) {
+        self.set_bits(set_field(self.raw(), 1, 1, value as u32));
+    }
+    pub fn flow_through_ide_stream_supported(self) -> u8 {
+        get_field(self.raw(), 2, 2) as u8
+    }
+    pub fn set_flow_through_ide_stream_supported(&mut self, value: u8) {
+        self.set_bits(set_field(self.raw(), 2, 2, value as u32));
+    }
+    pub fn aggregation_supported(self) -> u8 {
+        get_bit(self.raw(), 4)
+    }
+    pub fn set_aggregation_supported(&mut self, value: u8) {
+        self.set_bits(set_field(self.raw(), 4, 1, value as u32));
+    }
+    pub fn pcrc_supported(self) -> u8 {
+        get_bit(self.raw(), 5)
+    }
+    pub fn set_pcrc_supported(&mut self, value: u8) {
+        self.set_bits(set_field(self.raw(), 5, 1, value as u32));
+    }
+    pub fn ide_km_protocol_supported(self) -> u8 {
+        get_bit(self.raw(), 6)
+    }
+    pub fn set_ide_km_protocol_supported(&mut self, value: u8) {
+        self.set_bits(set_field(self.raw(), 6, 1, value as u32));
+    }
+    pub fn selective_ide_for_config_req_supported(self) -> u8 {
+        get_bit(self.raw(), 7)
+    }
+    pub fn set_selective_ide_for_config_req_supported(&mut self, value: u8) {
+        self.set_bits(set_field(self.raw(), 7, 1, value as u32));
+    }
+    pub fn supported_algorithms(self) -> u8 {
+        get_field(self.raw(), 8, 5) as u8
+    }
+    pub fn set_supported_algorithms(&mut self, value: u8) {
+        self.set_bits(set_field(self.raw(), 8, 5, value as u32));
+    }
+    pub fn num_tcs_supported_for_link_ide(self) -> u8 {
+        get_field(self.raw(), 13, 3) as u8
+    }
+    pub fn set_num_tcs_supported_for_link_ide(&mut self, value: u8) {
+        self.set_bits(set_field(self.raw(), 13, 3, value as u32));
+    }
+    pub fn num_selective_ide_streams_supported(self) -> u8 {
+        get_field(self.raw(), 16, 8) as u8
+    }
+    pub fn set_num_selective_ide_streams_supported(&mut self, value: u8) {
+        self.set_bits(set_field(self.raw(), 16, 8, value as u32));
+    }
+
+    fn set_bits(&mut self, bits: u32) {
+        self.0 = U32::new(bits);
+    }
+}
+
+/// IDE Control Register.
+#[derive(
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+)]
+#[repr(transparent)]
+pub struct IdeControlReg(pub U32);
+
+impl IdeControlReg {
+    pub const fn new(bits: u32) -> Self {
+        Self(U32::new(bits))
+    }
+    pub fn raw(self) -> u32 {
+        self.0.get()
+    }
+    pub fn flow_through_ide_stream_enabled(self) -> u8 {
+        get_bit(self.raw(), 2)
+    }
+    pub fn set_flow_through_ide_stream_enabled(&mut self, value: u8) {
+        self.0 = U32::new(set_field(self.raw(), 2, 1, value as u32));
+    }
+}
+
+/// Link IDE Stream Control Register.
+#[derive(
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+)]
+#[repr(transparent)]
+pub struct LinkIdeStreamControlReg(pub U32);
+
+impl LinkIdeStreamControlReg {
+    pub const fn new(bits: u32) -> Self {
+        Self(U32::new(bits))
+    }
+    pub fn raw(self) -> u32 {
+        self.0.get()
+    }
+    pub fn link_ide_stream_enable(self) -> u8 {
+        get_bit(self.raw(), 0)
+    }
+    pub fn set_link_ide_stream_enable(&mut self, value: u8) {
+        self.set_bits(set_field(self.raw(), 0, 1, value as u32));
+    }
+    pub fn tx_aggregation_mode_npr(self) -> u8 {
+        get_field(self.raw(), 2, 2) as u8
+    }
+    pub fn set_tx_aggregation_mode_npr(&mut self, value: u8) {
+        self.set_bits(set_field(self.raw(), 2, 2, value as u32));
+    }
+    pub fn tx_aggregation_mode_pr(self) -> u8 {
+        get_field(self.raw(), 4, 2) as u8
+    }
+    pub fn set_tx_aggregation_mode_pr(&mut self, value: u8) {
+        self.set_bits(set_field(self.raw(), 4, 2, value as u32));
+    }
+    pub fn tx_aggregation_mode_cpl(self) -> u8 {
+        get_field(self.raw(), 6, 2) as u8
+    }
+    pub fn set_tx_aggregation_mode_cpl(&mut self, value: u8) {
+        self.set_bits(set_field(self.raw(), 6, 2, value as u32));
+    }
+    pub fn pcrc_enable(self) -> u8 {
+        get_bit(self.raw(), 8)
+    }
+    pub fn set_pcrc_enable(&mut self, value: u8) {
+        self.set_bits(set_field(self.raw(), 8, 1, value as u32));
+    }
+    pub fn selected_algorithm(self) -> u8 {
+        get_field(self.raw(), 14, 5) as u8
+    }
+    pub fn set_selected_algorithm(&mut self, value: u8) {
+        self.set_bits(set_field(self.raw(), 14, 5, value as u32));
+    }
+    pub fn tc(self) -> u8 {
+        get_field(self.raw(), 19, 3) as u8
+    }
+    pub fn set_tc(&mut self, value: u8) {
+        self.set_bits(set_field(self.raw(), 19, 3, value as u32));
+    }
+    pub fn stream_id(self) -> u8 {
+        get_field(self.raw(), 24, 8) as u8
+    }
+    pub fn set_stream_id(&mut self, value: u8) {
+        self.set_bits(set_field(self.raw(), 24, 8, value as u32));
+    }
+    fn set_bits(&mut self, bits: u32) {
+        self.0 = U32::new(bits);
+    }
+}
+
+/// Link IDE Stream Status Register.
+#[derive(
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+)]
+#[repr(transparent)]
+pub struct LinkIdeStreamStatusReg(pub U32);
+
+impl LinkIdeStreamStatusReg {
+    pub const fn new(bits: u32) -> Self {
+        Self(U32::new(bits))
+    }
+    pub fn raw(self) -> u32 {
+        self.0.get()
+    }
+    pub fn link_ide_stream_state(self) -> u8 {
+        get_field(self.raw(), 0, 4) as u8
+    }
+    pub fn set_link_ide_stream_state(&mut self, value: u8) {
+        self.0 = U32::new(set_field(self.raw(), 0, 4, value as u32));
+    }
+}
+
+/// Selective IDE Stream Capability Register.
+#[derive(
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+)]
+#[repr(transparent)]
+pub struct SelectiveIdeStreamCapabilityReg(pub U32);
+
+impl SelectiveIdeStreamCapabilityReg {
+    pub const fn new(bits: u32) -> Self {
+        Self(U32::new(bits))
+    }
+    pub fn raw(self) -> u32 {
+        self.0.get()
+    }
+    pub fn num_addr_association_reg_blocks(self) -> u8 {
+        get_field(self.raw(), 0, 4) as u8
+    }
+    pub fn set_num_addr_association_reg_blocks(&mut self, value: u8) {
+        self.0 = U32::new(set_field(self.raw(), 0, 4, value as u32));
+    }
+}
+
+/// Selective IDE Stream Control Register.
+#[derive(
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+)]
+#[repr(transparent)]
+pub struct SelectiveIdeStreamControlReg(pub U32);
+
+impl SelectiveIdeStreamControlReg {
+    pub const fn new(bits: u32) -> Self {
+        Self(U32::new(bits))
+    }
+    pub fn raw(self) -> u32 {
+        self.0.get()
+    }
+    pub fn selective_ide_stream_enable(self) -> u8 {
+        get_bit(self.raw(), 0)
+    }
+    pub fn set_selective_ide_stream_enable(&mut self, value: u8) {
+        self.set_bits(set_field(self.raw(), 0, 1, value as u32));
+    }
+    pub fn tx_aggregation_mode_npr(self) -> u8 {
+        get_field(self.raw(), 2, 2) as u8
+    }
+    pub fn set_tx_aggregation_mode_npr(&mut self, value: u8) {
+        self.set_bits(set_field(self.raw(), 2, 2, value as u32));
+    }
+    pub fn tx_aggregation_mode_pr(self) -> u8 {
+        get_field(self.raw(), 4, 2) as u8
+    }
+    pub fn set_tx_aggregation_mode_pr(&mut self, value: u8) {
+        self.set_bits(set_field(self.raw(), 4, 2, value as u32));
+    }
+    pub fn tx_aggregation_mode_cpl(self) -> u8 {
+        get_field(self.raw(), 6, 2) as u8
+    }
+    pub fn set_tx_aggregation_mode_cpl(&mut self, value: u8) {
+        self.set_bits(set_field(self.raw(), 6, 2, value as u32));
+    }
+    pub fn pcrc_enable(self) -> u8 {
+        get_bit(self.raw(), 8)
+    }
+    pub fn set_pcrc_enable(&mut self, value: u8) {
+        self.set_bits(set_field(self.raw(), 8, 1, value as u32));
+    }
+    pub fn selective_ide_for_config_req_enable(self) -> u8 {
+        get_bit(self.raw(), 9)
+    }
+    pub fn set_selective_ide_for_config_req_enable(&mut self, value: u8) {
+        self.set_bits(set_field(self.raw(), 9, 1, value as u32));
+    }
+    pub fn selected_algorithm(self) -> u8 {
+        get_field(self.raw(), 14, 5) as u8
+    }
+    pub fn set_selected_algorithm(&mut self, value: u8) {
+        self.set_bits(set_field(self.raw(), 14, 5, value as u32));
+    }
+    pub fn tc(self) -> u8 {
+        get_field(self.raw(), 19, 3) as u8
+    }
+    pub fn set_tc(&mut self, value: u8) {
+        self.set_bits(set_field(self.raw(), 19, 3, value as u32));
+    }
+    pub fn default_stream(self) -> u8 {
+        get_bit(self.raw(), 22)
+    }
+    pub fn set_default_stream(&mut self, value: u8) {
+        self.set_bits(set_field(self.raw(), 22, 1, value as u32));
+    }
+    pub fn stream_id(self) -> u8 {
+        get_field(self.raw(), 24, 8) as u8
+    }
+    pub fn set_stream_id(&mut self, value: u8) {
+        self.set_bits(set_field(self.raw(), 24, 8, value as u32));
+    }
+    fn set_bits(&mut self, bits: u32) {
+        self.0 = U32::new(bits);
+    }
+}
+
+/// Selective IDE Stream Status Register.
+#[derive(
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+)]
+#[repr(transparent)]
+pub struct SelectiveIdeStreamStatusReg(pub U32);
+
+impl SelectiveIdeStreamStatusReg {
+    pub const fn new(bits: u32) -> Self {
+        Self(U32::new(bits))
+    }
+    pub fn raw(self) -> u32 {
+        self.0.get()
+    }
+    pub fn selective_ide_stream_state(self) -> u8 {
+        get_field(self.raw(), 0, 4) as u8
+    }
+    pub fn set_selective_ide_stream_state(&mut self, value: u8) {
+        self.set_bits(set_field(self.raw(), 0, 4, value as u32));
+    }
+    pub fn received_integrity_check_fail_msg(self) -> u32 {
+        get_field(self.raw(), 4, 28)
+    }
+    pub fn set_received_integrity_check_fail_msg(&mut self, value: u32) {
+        self.set_bits(set_field(self.raw(), 4, 28, value));
+    }
+    fn set_bits(&mut self, bits: u32) {
+        self.0 = U32::new(bits);
+    }
+}
+
+/// Selective IDE RID Association Register 1.
+#[derive(
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+)]
+#[repr(transparent)]
+pub struct SelectiveIdeRidAssociationReg1(pub U32);
+
+impl SelectiveIdeRidAssociationReg1 {
+    pub const fn new(bits: u32) -> Self {
+        Self(U32::new(bits))
+    }
+    pub fn raw(self) -> u32 {
+        self.0.get()
+    }
+    pub fn rid_limit(self) -> u16 {
+        get_field(self.raw(), 8, 16) as u16
+    }
+    pub fn set_rid_limit(&mut self, value: u16) {
+        self.0 = U32::new(set_field(self.raw(), 8, 16, value as u32));
+    }
+}
+
+/// Selective IDE RID Association Register 2.
+#[derive(
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+)]
+#[repr(transparent)]
+pub struct SelectiveIdeRidAssociationReg2(pub U32);
+
+impl SelectiveIdeRidAssociationReg2 {
+    pub const fn new(bits: u32) -> Self {
+        Self(U32::new(bits))
+    }
+    pub fn raw(self) -> u32 {
+        self.0.get()
+    }
+    pub fn valid(self) -> u8 {
+        get_bit(self.raw(), 0)
+    }
+    pub fn set_valid(&mut self, value: u8) {
+        self.set_bits(set_field(self.raw(), 0, 1, value as u32));
+    }
+    pub fn rid_base(self) -> u16 {
+        get_field(self.raw(), 8, 16) as u16
+    }
+    pub fn set_rid_base(&mut self, value: u16) {
+        self.set_bits(set_field(self.raw(), 8, 16, value as u32));
+    }
+    fn set_bits(&mut self, bits: u32) {
+        self.0 = U32::new(bits);
+    }
+}
+
+/// Selective IDE Address Association Register 1.
+#[derive(
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+)]
+#[repr(transparent)]
+pub struct IdeAddrAssociationReg1(pub U32);
+
+impl IdeAddrAssociationReg1 {
+    pub const fn new(bits: u32) -> Self {
+        Self(U32::new(bits))
+    }
+    pub fn raw(self) -> u32 {
+        self.0.get()
+    }
+    pub fn valid(self) -> u8 {
+        get_bit(self.raw(), 0)
+    }
+    pub fn set_valid(&mut self, value: u8) {
+        self.set_bits(set_field(self.raw(), 0, 1, value as u32));
+    }
+    pub fn memory_base_lower(self) -> u16 {
+        get_field(self.raw(), 8, 12) as u16
+    }
+    pub fn set_memory_base_lower(&mut self, value: u16) {
+        self.set_bits(set_field(self.raw(), 8, 12, value as u32));
+    }
+    pub fn memory_limit_lower(self) -> u16 {
+        get_field(self.raw(), 20, 12) as u16
+    }
+    pub fn set_memory_limit_lower(&mut self, value: u16) {
+        self.set_bits(set_field(self.raw(), 20, 12, value as u32));
+    }
+    fn set_bits(&mut self, bits: u32) {
+        self.0 = U32::new(bits);
+    }
+}
+
+/// Selective IDE Address Association Register 2.
+#[derive(FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned, Copy, Clone, Debug, Default)]
+#[repr(C)]
+pub struct IdeAddrAssociationReg2 {
+    pub memory_limit_upper: U32,
+}
+
+/// Selective IDE Address Association Register 3.
+#[derive(FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned, Copy, Clone, Debug, Default)]
+#[repr(C)]
+pub struct IdeAddrAssociationReg3 {
+    pub memory_base_upper: U32,
+}
+
+/// IDE Port configuration.
+#[derive(FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned, Copy, Clone, Debug, Default)]
+#[repr(C)]
+pub struct PortConfig {
+    pub function_num: u8,
+    pub bus_num: u8,
+    pub segment: u8,
+    pub max_port_index: u8,
+}
+
+impl PortConfig {
+    pub const SIZE: usize = 4;
+}
+
+/// IDE Capability and Control register block.
+#[derive(FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned, Copy, Clone, Debug, Default)]
+#[repr(C)]
+pub struct IdeRegBlock {
+    pub ide_cap_reg: IdeCapabilityReg,
+    pub ide_ctrl_reg: IdeControlReg,
+}
+
+impl IdeRegBlock {
+    pub const SIZE: usize = 8;
+}
+
+/// Link IDE Stream register block.
+#[derive(FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned, Copy, Clone, Debug, Default)]
+#[repr(C)]
+pub struct LinkIdeStreamRegBlock {
+    pub ctrl_reg: LinkIdeStreamControlReg,
+    pub status_reg: LinkIdeStreamStatusReg,
+}
+
+impl LinkIdeStreamRegBlock {
+    pub const SIZE: usize = 8;
+}
+
+/// Selective IDE Stream register block.
+#[derive(FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned, Copy, Clone, Debug)]
+#[repr(C)]
+pub struct SelectiveIdeStreamRegBlock {
+    pub capability_reg: SelectiveIdeStreamCapabilityReg,
+    pub ctrl_reg: SelectiveIdeStreamControlReg,
+    pub status_reg: SelectiveIdeStreamStatusReg,
+    pub rid_association_reg_1: SelectiveIdeRidAssociationReg1,
+    pub rid_association_reg_2: SelectiveIdeRidAssociationReg2,
+    pub addr_association_reg_block:
+        [AddrAssociationRegBlock; MAX_SELECTIVE_IDE_ADDR_ASSOC_BLOCK_COUNT],
+}
+
+impl SelectiveIdeStreamRegBlock {
+    /// Size of the fixed fields before variable address-association blocks.
+    pub const FIXED_SIZE: usize = 20;
+
+    /// Encodes this block with the variable address-association count from capability_reg.
+    pub fn encode(&self, writer: &mut WireWriter<'_>) -> Result<(), WireError> {
+        let count = self.capability_reg.num_addr_association_reg_blocks() as usize;
+        if count > MAX_SELECTIVE_IDE_ADDR_ASSOC_BLOCK_COUNT {
+            return Err(WireError);
+        }
+        writer.write(&self.capability_reg)?;
+        writer.write(&self.ctrl_reg)?;
+        writer.write(&self.status_reg)?;
+        writer.write(&self.rid_association_reg_1)?;
+        writer.write(&self.rid_association_reg_2)?;
+        for reg in self.addr_association_reg_block.iter().take(count) {
+            writer.write(reg)?;
+        }
+        Ok(())
+    }
+}
+
+impl Default for SelectiveIdeStreamRegBlock {
+    fn default() -> Self {
+        Self {
+            capability_reg: SelectiveIdeStreamCapabilityReg::default(),
+            ctrl_reg: SelectiveIdeStreamControlReg::default(),
+            status_reg: SelectiveIdeStreamStatusReg::default(),
+            rid_association_reg_1: SelectiveIdeRidAssociationReg1::default(),
+            rid_association_reg_2: SelectiveIdeRidAssociationReg2::default(),
+            addr_association_reg_block: [AddrAssociationRegBlock::default();
+                MAX_SELECTIVE_IDE_ADDR_ASSOC_BLOCK_COUNT],
+        }
+    }
+}
+
+/// Selective IDE Address Association register block.
+#[derive(FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned, Copy, Clone, Debug, Default)]
+#[repr(C)]
+pub struct AddrAssociationRegBlock {
+    pub reg1: IdeAddrAssociationReg1,
+    pub reg2: IdeAddrAssociationReg2,
+    pub reg3: IdeAddrAssociationReg3,
+}
+
+impl AddrAssociationRegBlock {
+    pub const SIZE: usize = 12;
+}
+
+/// IDE-KM QUERY request payload.
+#[derive(FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned, Copy, Clone, Debug, Default)]
+#[repr(C)]
+pub struct Query {
+    pub reserved: u8,
+    pub port_index: u8,
+}
+
+impl Query {
+    pub const SIZE: usize = 2;
+}
+
+/// IDE-KM KEY_PROG request/ack payload before key material.
+#[derive(FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned, Copy, Clone, Debug, Default)]
+#[repr(C)]
+pub struct KeyProg {
+    pub reserved: U16,
+    pub stream_id: u8,
+    pub status: u8,
+    pub key_info: KeyInfo,
+    pub port_index: u8,
+}
+
+impl KeyProg {
+    pub const SIZE: usize = 6;
+}
+
+/// IDE-KM key material payload.
+#[derive(FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned, Copy, Clone)]
+#[repr(C)]
+pub struct KeyData {
+    pub key: [U32; IDE_STREAM_KEY_SIZE_DW],
+    pub iv: [U32; IDE_STREAM_IV_SIZE_DW],
+}
+
+impl KeyData {
+    pub const SIZE: usize = 40;
+}
+
+/// IDE-KM KEY_SET_GO / KEY_SET_STOP request and ACK payload.
+#[derive(FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned, Copy, Clone, Debug, Default)]
+#[repr(C)]
+pub struct KeySetGoStop {
+    pub reserved1: U16,
+    pub stream_id: u8,
+    pub reserved2: u8,
+    pub key_info: KeyInfo,
+    pub port_index: u8,
+}
+
+impl KeySetGoStop {
+    pub const SIZE: usize = 6;
+}
+
+const _: () = assert!(size_of::<PortConfig>() == PortConfig::SIZE);
+const _: () = assert!(size_of::<IdeRegBlock>() == IdeRegBlock::SIZE);
+const _: () = assert!(size_of::<LinkIdeStreamRegBlock>() == LinkIdeStreamRegBlock::SIZE);
+const _: () = assert!(size_of::<AddrAssociationRegBlock>() == AddrAssociationRegBlock::SIZE);
+const _: () = assert!(size_of::<Query>() == Query::SIZE);
+const _: () = assert!(size_of::<KeyProg>() == KeyProg::SIZE);
+const _: () = assert!(size_of::<KeyData>() == KeyData::SIZE);
+const _: () = assert!(size_of::<KeySetGoStop>() == KeySetGoStop::SIZE);
+
+const fn set_field_u8(bits: u8, shift: u8, width: u8, value: u8) -> u8 {
+    let mask = ((1u16 << width) - 1) as u8;
+    (bits & !(mask << shift)) | ((value & mask) << shift)
+}
+
+fn get_bit(bits: u32, shift: u8) -> u8 {
+    ((bits >> shift) & 1) as u8
+}
+
+fn get_field(bits: u32, shift: u8, width: u8) -> u32 {
+    (bits >> shift) & ((1u32 << width) - 1)
+}
+
+fn set_field(bits: u32, shift: u8, width: u8, value: u32) -> u32 {
+    let mask = (1u32 << width) - 1;
+    (bits & !(mask << shift)) | ((value & mask) << shift)
+}

--- a/runtime/userspace/api/spdm-lite/codec/src/lib.rs
+++ b/runtime/userspace/api/spdm-lite/codec/src/lib.rs
@@ -17,9 +17,11 @@ pub mod errors;
 mod finish;
 mod flag_macros;
 mod header;
+mod ide_km;
 mod key_exchange;
 mod measurements;
 mod opaque;
+mod pci_sig;
 mod secured_message;
 mod set_certificate;
 mod vendor_defined;
@@ -49,6 +51,15 @@ pub use header::{
     ReqRespCode, SpdmMsgHdrPdu, ECC_P384_SIGNATURE_SIZE, REQUESTER_CONTEXT_LEN, SHA384_HASH_SIZE,
     SPDM_CONTEXT_LEN, SPDM_MSG_HDR_SIZE, SPDM_NONCE_LEN, SPDM_PREFIX_LEN, SPDM_SIGNING_CONTEXT_LEN,
 };
+pub use ide_km::{
+    AddrAssociationRegBlock, IdeAddrAssociationReg1, IdeAddrAssociationReg2,
+    IdeAddrAssociationReg3, IdeCapabilityReg, IdeControlReg, IdeKmCommand, IdeKmHdr, IdeRegBlock,
+    KeyData, KeyInfo, KeyProg, KeySetGoStop, LinkIdeStreamControlReg, LinkIdeStreamRegBlock,
+    LinkIdeStreamStatusReg, PortConfig, Query, SelectiveIdeRidAssociationReg1,
+    SelectiveIdeRidAssociationReg2, SelectiveIdeStreamCapabilityReg, SelectiveIdeStreamControlReg,
+    SelectiveIdeStreamRegBlock, SelectiveIdeStreamStatusReg, IDE_KM_PROTOCOL_ID,
+    IDE_STREAM_IV_SIZE_DW, IDE_STREAM_KEY_SIZE_DW, MAX_SELECTIVE_IDE_ADDR_ASSOC_BLOCK_COUNT,
+};
 pub use key_exchange::{
     KeyExchangeReqBody, KeyExchangeRsp, ECDH_P384_EXCHANGE_DATA_SIZE, KEY_EXCHANGE_RANDOM_DATA_LEN,
 };
@@ -56,6 +67,7 @@ pub use measurements::{
     DmtfMeasurementBlockHeader, GetMeasurementsReqBody, MeasurementsRsp, MEAS_BLOCK_METADATA_SIZE,
     SPDM_MAX_MEASUREMENT_RECORD_SIZE,
 };
+pub use pci_sig::PciSigProtocolHdr;
 pub use set_certificate::{SetCertificateReqBody, SetCertificateRsp, SetCertificateRspBody};
 pub use vendor_defined::{
     decode_vendor_defined_req, StandardsBodyId, VendorDefinedReq, VendorDefinedReqPdu,

--- a/runtime/userspace/api/spdm-lite/codec/src/pci_sig.rs
+++ b/runtime/userspace/api/spdm-lite/codec/src/pci_sig.rs
@@ -1,0 +1,20 @@
+// Licensed under the Apache-2.0 license
+
+//! PCI-SIG VDM protocol wire types.
+
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
+
+/// PCI-SIG protocol selector byte that prefixes PCI-SIG VDM payloads.
+#[derive(FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned, Copy, Clone, Debug)]
+#[repr(C)]
+pub struct PciSigProtocolHdr {
+    /// PCI-SIG protocol ID (0 = IDE-KM).
+    pub protocol_id: u8,
+}
+
+impl PciSigProtocolHdr {
+    /// Size of the PCI-SIG protocol header on the wire.
+    pub const SIZE: usize = 1;
+}
+
+const _: () = assert!(core::mem::size_of::<PciSigProtocolHdr>() == PciSigProtocolHdr::SIZE);

--- a/runtime/userspace/api/spdm-lite/stack/src/chunk/mod.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/chunk/mod.rs
@@ -8,12 +8,18 @@ mod send;
 pub(crate) use get::handle_chunk_get;
 pub(crate) use send::handle_chunk_send;
 
+use mcu_spdm_lite_codec::SpdmMsgHdrPdu;
 use mcu_spdm_lite_traits::{PalBytes, SpdmPal, SpdmPalIoTransport};
 
 use crate::build::build_error_response;
 use crate::certificate::CertificateLargeResponse;
 use crate::error::{SpdmResult, SPDM_LARGE_RESPONSE, SPDM_UNSPECIFIED};
 use crate::stack::ConnectionState;
+
+/// SPDM payload length of the `ERROR(LargeResponse)` handshake returned before
+/// a buffered response is read with `CHUNK_GET`: SPDM header + param1/param2 +
+/// one-byte large-response handle.
+pub(crate) const LARGE_RESPONSE_HANDSHAKE_LEN: usize = SpdmMsgHdrPdu::SIZE + 2 + 1;
 
 #[derive(Copy, Clone)]
 pub(crate) struct LargeResponseState {

--- a/runtime/userspace/api/spdm-lite/stack/src/measurements.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/measurements.rs
@@ -310,7 +310,7 @@ async fn handle_large_measurements_response<'a, Pal: SpdmPal>(
     }
 
     let resp = chunk::start_buffered_large_response(state, pal, io, plan.large_resp_len)?;
-    Ok((resp, 0))
+    Ok((resp, chunk::LARGE_RESPONSE_HANDSHAKE_LEN))
 }
 
 fn measurement_record_shape(info: &[MeasurementInfo], meas_op: u8) -> SpdmResult<(usize, u8)> {

--- a/runtime/userspace/api/spdm-lite/stack/src/vendor_defined.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/vendor_defined.rs
@@ -64,16 +64,20 @@ pub(crate) async fn handle_vendor_defined_request<'a, Pal: SpdmPal, V: SpdmVdmBa
     let inline_cap = frame.saturating_sub(envelope);
     let mut inline_buf = pal.alloc_bytes(io, inline_cap)?;
 
-    // Large staging buffer: provisioned only when the backend can emit responses
-    // that overflow a single frame AND chunking is available. Sized so the full
-    // buffered message (envelope + payload) fits both the large-response store and
-    // the negotiated max SPDM message size; empty otherwise (forcing inline).
+    // Large staging buffer: provisioned only when chunking is available and the
+    // matched backend says this request can emit a response that overflows one
+    // frame. This keeps inline-only VDMs from consuming scarce scratch space.
     let large_cap = if V::USES_LARGE_RESPONSE && state.chunking_enabled() {
-        state
-            .effective_max_spdm_msg_size(pal)
-            .min(pal.large_capacity())
-            .saturating_sub(envelope)
-            .min(V::LARGE_RESPONSE_CAPACITY)
+        let requested = vdm.large_response_capacity(decoded.payload);
+        if requested > inline_cap {
+            state
+                .effective_max_spdm_msg_size(pal)
+                .min(pal.large_capacity())
+                .saturating_sub(envelope)
+                .min(requested)
+        } else {
+            0
+        }
     } else {
         0
     };
@@ -142,7 +146,7 @@ pub(crate) async fn handle_vendor_defined_request<'a, Pal: SpdmPal, V: SpdmVdmBa
             drop(guard);
             chunk::validate_buffered_large_response(state, pal, full_len)?;
             let resp = chunk::start_buffered_large_response(state, pal, io, full_len)?;
-            Ok((resp, 0))
+            Ok((resp, chunk::LARGE_RESPONSE_HANDSHAKE_LEN))
         }
     }
 }

--- a/runtime/userspace/api/spdm-lite/traits/src/vendor_defined.rs
+++ b/runtime/userspace/api/spdm-lite/traits/src/vendor_defined.rs
@@ -26,11 +26,14 @@ pub enum VdmResponse {
 pub struct VdmResponseBuffer<'a, Alloc: SpdmPalAlloc, Io: SpdmPalIo> {
     /// Per-request payload buffer sized to fit a single transport frame.
     pub inline: &'a mut [u8],
-    /// Buffer for responses that do not fit `inline`; the stack transmits it via
-    /// chunking. Non-empty only when [`SpdmVdmBackend::USES_LARGE_RESPONSE`] is set (and
-    /// chunking is available). Its backing memory is owned by the stack (today a
-    /// persistent large-message store; planned: the per-task scratch allocator) and is
-    /// not the handler's concern.
+    /// Buffer for responses that do not fit `inline`; when the handler returns
+    /// [`VdmResponse::Large`], the stack transmits these bytes via chunking.
+    /// Empty when chunking is unavailable or the backend indicates this request
+    /// cannot produce a large response.
+    ///
+    /// The backing storage is chosen by the stack and may be the persistent
+    /// large-message store directly, so handlers must only write the returned
+    /// byte count and must not assume this is disposable scratch.
     pub large: &'a mut [u8],
     /// Allocator for per-request VDM working scratch (e.g. staging a mailbox call).
     pub alloc: &'a Alloc,
@@ -42,18 +45,32 @@ pub struct VdmResponseBuffer<'a, Alloc: SpdmPalAlloc, Io: SpdmPalIo> {
 #[allow(async_fn_in_trait)]
 pub trait SpdmVdmBackend {
     /// True when this backend can emit a response that does not fit the inline
-    /// transport frame and must use [`VdmResponseBuffer::large`]. PCI-SIG IDE_KM/TDISP
-    /// set this `false` (they chunk large reports at the protocol level); OCP sets it
-    /// `true`.
+    /// transport frame and must use [`VdmResponseBuffer::large`]. Backends should
+    /// keep this `false` unless at least one response can overflow one SPDM frame
+    /// and should still choose [`VdmResponse::Inline`] whenever the actual
+    /// response fits inline.
     const USES_LARGE_RESPONSE: bool = false;
 
-    /// Maximum VDM payload bytes this backend needs for a large response.
+    /// Maximum VDM payload bytes this backend needs for any large response.
     ///
     /// The stack still caps this by the negotiated maximum SPDM message size and
     /// PAL large-message capacity, but this backend-specific bound avoids
     /// reserving a worst-case SPDM-sized scratch buffer for small vendor command
     /// sets.
     const LARGE_RESPONSE_CAPACITY: usize = usize::MAX;
+
+    /// Returns the large-response capacity needed for this request.
+    ///
+    /// Backends that can cheaply identify only some large-capable requests should
+    /// override this to avoid reserving the persistent large-message buffer for
+    /// requests that will stay inline.
+    fn large_response_capacity(&self, _req: &[u8]) -> usize {
+        if Self::USES_LARGE_RESPONSE {
+            Self::LARGE_RESPONSE_CAPACITY
+        } else {
+            0
+        }
+    }
 
     /// Returns true when this backend owns the decoded VDM registry ID.
     fn match_id(&self, registry: &VdmRegistry<'_>) -> bool;

--- a/runtime/userspace/api/spdm-lite/vdm-handler/Cargo.toml
+++ b/runtime/userspace/api/spdm-lite/vdm-handler/Cargo.toml
@@ -10,6 +10,13 @@ edition.workspace = true
 mcu-spdm-lite-traits = { workspace = true }
 mcu-spdm-lite-codec = { workspace = true }
 mcu-error = { workspace = true }
+zerocopy = { workspace = true }
+
+[features]
+default = []
+# Enables the no-allocation IDE-KM emulator driver used by DOE validator tests.
+emulated-ide-km = []
 
 [dev-dependencies]
+futures = { workspace = true }
 mcu-caliptra-api-lite = { workspace = true }

--- a/runtime/userspace/api/spdm-lite/vdm-handler/src/lib.rs
+++ b/runtime/userspace/api/spdm-lite/vdm-handler/src/lib.rs
@@ -13,7 +13,7 @@
 //! used by the full `spdm-lib` stack:
 //!
 //! * [`iana`] — IANA-registered vendors (OCP / Caliptra VDM).
-//! * [`pci_sig`] — PCI-SIG protocols (IDE_KM, TDISP) — reserved.
+//! * [`pci_sig`] — PCI-SIG protocols (IDE-KM today; TDISP can be added alongside it).
 #![no_std]
 #![allow(async_fn_in_trait)]
 

--- a/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/ide_km.rs
+++ b/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/ide_km.rs
@@ -1,0 +1,1277 @@
+// Licensed under the Apache-2.0 license
+
+//! PCI-SIG IDE-KM VDM responder for SPDM-Lite.
+
+use mcu_spdm_lite_codec::{
+    AddrAssociationRegBlock, IdeKmCommand, IdeKmHdr, IdeRegBlock, KeyInfo, LinkIdeStreamRegBlock,
+    PciSigProtocolHdr, PortConfig, Query, SelectiveIdeStreamRegBlock, StandardsBodyId, WireReader,
+    WireWriter, IDE_KM_PROTOCOL_ID, IDE_STREAM_IV_SIZE_DW, IDE_STREAM_KEY_SIZE_DW,
+    MAX_SELECTIVE_IDE_ADDR_ASSOC_BLOCK_COUNT,
+};
+#[cfg(any(test, feature = "emulated-ide-km"))]
+use mcu_spdm_lite_codec::{
+    IdeCapabilityReg, IdeControlReg, LinkIdeStreamControlReg, LinkIdeStreamStatusReg,
+    SelectiveIdeRidAssociationReg1, SelectiveIdeRidAssociationReg2,
+    SelectiveIdeStreamCapabilityReg, SelectiveIdeStreamControlReg, SelectiveIdeStreamStatusReg,
+};
+use zerocopy::little_endian::U32;
+
+use mcu_spdm_lite_codec::errors::{
+    SPDM_INVALID_REQUEST, SPDM_UNSPECIFIED, SPDM_UNSUPPORTED_REQUEST,
+};
+use mcu_spdm_lite_traits::{
+    McuErrorCode, McuResult, SpdmPalAlloc, SpdmPalIo, SpdmVdmBackend, VdmRegistry, VdmResponse,
+    VdmResponseBuffer,
+};
+
+const MAX_IDE_KM_QUERY_RESPONSE_SIZE: usize = PciSigProtocolHdr::SIZE
+    + IdeKmHdr::SIZE
+    + Query::SIZE
+    + PortConfig::SIZE
+    + IdeRegBlock::SIZE
+    + (7 * LinkIdeStreamRegBlock::SIZE)
+    + (255
+        * (SelectiveIdeStreamRegBlock::FIXED_SIZE
+            + MAX_SELECTIVE_IDE_ADDR_ASSOC_BLOCK_COUNT * AddrAssociationRegBlock::SIZE));
+
+/// IDE-KM driver-level failures.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum IdeDriverError {
+    InvalidPortIndex = 0x01,
+    UnsupportedPortIndex = 0x02,
+    InvalidStreamId = 0x03,
+    InvalidArgument = 0x04,
+    GetPortConfigFail = 0x05,
+    KeyProgFail = 0x06,
+    KeySetGoFail = 0x07,
+    KeySetStopFail = 0x08,
+    NoMemory = 0x09,
+}
+
+/// IDE-KM driver result alias.
+pub type IdeDriverResult<T> = core::result::Result<T, IdeDriverError>;
+
+/// Platform abstraction for PCIe IDE key-management hardware.
+///
+/// The trait mirrors the libspdm IDE-KM driver API but uses static dispatch and
+/// borrowed little-endian key arrays so spdm-lite does not allocate or copy the
+/// KEY_PROG key material before handing it to the platform.
+#[allow(async_fn_in_trait)]
+pub trait IdeDriver: Sync {
+    /// Gets the port configuration for a given port index.
+    fn port_config(&self, port_index: u8) -> IdeDriverResult<PortConfig>;
+
+    /// Gets the IDE capability/control register block.
+    fn ide_reg_block(&self, port_index: u8) -> IdeDriverResult<IdeRegBlock>;
+
+    /// Gets one Link IDE stream register block.
+    fn link_ide_reg_block(
+        &self,
+        port_index: u8,
+        block_index: u8,
+    ) -> IdeDriverResult<LinkIdeStreamRegBlock>;
+
+    /// Gets one Selective IDE stream register block.
+    fn selective_ide_reg_block(
+        &self,
+        port_index: u8,
+        block_index: u8,
+    ) -> IdeDriverResult<SelectiveIdeStreamRegBlock>;
+
+    /// Programs a stream key and IV.
+    async fn key_prog(
+        &self,
+        stream_id: u8,
+        key_info: KeyInfo,
+        port_index: u8,
+        key: &[U32; IDE_STREAM_KEY_SIZE_DW],
+        iv: &[U32; IDE_STREAM_IV_SIZE_DW],
+    ) -> IdeDriverResult<u8>;
+
+    /// Starts using a key set for a stream.
+    ///
+    /// The IDE-KM `KEY_GO_STOP_ACK` response echoes the request `KeyInfo` for
+    /// libspdm compatibility, so this hook reports only operation success or
+    /// failure.
+    async fn key_set_go(
+        &self,
+        stream_id: u8,
+        key_info: KeyInfo,
+        port_index: u8,
+    ) -> IdeDriverResult<()>;
+
+    /// Stops using a key set for a stream.
+    ///
+    /// The IDE-KM `KEY_GO_STOP_ACK` response echoes the request `KeyInfo` for
+    /// libspdm compatibility, so this hook reports only operation success or
+    /// failure.
+    async fn key_set_stop(
+        &self,
+        stream_id: u8,
+        key_info: KeyInfo,
+        port_index: u8,
+    ) -> IdeDriverResult<()>;
+}
+
+impl<T: IdeDriver + ?Sized> IdeDriver for &T {
+    fn port_config(&self, port_index: u8) -> IdeDriverResult<PortConfig> {
+        (**self).port_config(port_index)
+    }
+
+    fn ide_reg_block(&self, port_index: u8) -> IdeDriverResult<IdeRegBlock> {
+        (**self).ide_reg_block(port_index)
+    }
+
+    fn link_ide_reg_block(
+        &self,
+        port_index: u8,
+        block_index: u8,
+    ) -> IdeDriverResult<LinkIdeStreamRegBlock> {
+        (**self).link_ide_reg_block(port_index, block_index)
+    }
+
+    fn selective_ide_reg_block(
+        &self,
+        port_index: u8,
+        block_index: u8,
+    ) -> IdeDriverResult<SelectiveIdeStreamRegBlock> {
+        (**self).selective_ide_reg_block(port_index, block_index)
+    }
+
+    async fn key_prog(
+        &self,
+        stream_id: u8,
+        key_info: KeyInfo,
+        port_index: u8,
+        key: &[U32; IDE_STREAM_KEY_SIZE_DW],
+        iv: &[U32; IDE_STREAM_IV_SIZE_DW],
+    ) -> IdeDriverResult<u8> {
+        (**self)
+            .key_prog(stream_id, key_info, port_index, key, iv)
+            .await
+    }
+
+    async fn key_set_go(
+        &self,
+        stream_id: u8,
+        key_info: KeyInfo,
+        port_index: u8,
+    ) -> IdeDriverResult<()> {
+        (**self).key_set_go(stream_id, key_info, port_index).await
+    }
+
+    async fn key_set_stop(
+        &self,
+        stream_id: u8,
+        key_info: KeyInfo,
+        port_index: u8,
+    ) -> IdeDriverResult<()> {
+        (**self).key_set_stop(stream_id, key_info, port_index).await
+    }
+}
+
+/// IDE-KM protocol responder.
+pub struct IdeKmResponder<D> {
+    driver: D,
+}
+
+impl<D> IdeKmResponder<D> {
+    /// Creates an IDE-KM responder over a platform driver.
+    pub const fn new(driver: D) -> Self {
+        Self { driver }
+    }
+
+    /// Returns the wrapped IDE driver.
+    pub const fn driver(&self) -> &D {
+        &self.driver
+    }
+}
+
+impl<D: IdeDriver> IdeKmResponder<D> {
+    /// Handles an IDE-KM request payload after the PCI-SIG protocol byte.
+    pub async fn handle_request(&self, req: &[u8], rsp: &mut [u8]) -> McuResult<usize> {
+        let mut reader = WireReader::new(req);
+        let hdr = *reader
+            .read::<IdeKmHdr>()
+            .map_err(|_| SPDM_INVALID_REQUEST)?;
+        let command = IdeKmCommand::from_u8(hdr.object_id).ok_or(SPDM_INVALID_REQUEST)?;
+        if reader.remaining() != command.payload_len() || command.response().is_none() {
+            return Err(SPDM_INVALID_REQUEST);
+        }
+
+        let mut writer = WireWriter::new(rsp);
+        match command {
+            IdeKmCommand::Query => self.handle_query(&mut reader, &mut writer),
+            IdeKmCommand::KeyProg => self.handle_key_prog(&mut reader, &mut writer).await,
+            IdeKmCommand::KeySetGo => {
+                self.handle_key_set_go_stop(true, &mut reader, &mut writer)
+                    .await
+            }
+            IdeKmCommand::KeySetStop => {
+                self.handle_key_set_go_stop(false, &mut reader, &mut writer)
+                    .await
+            }
+            _ => Err(SPDM_INVALID_REQUEST),
+        }
+    }
+
+    fn handle_query(
+        &self,
+        reader: &mut WireReader<'_>,
+        writer: &mut WireWriter<'_>,
+    ) -> McuResult<usize> {
+        let query = *reader.read::<Query>().map_err(|_| SPDM_INVALID_REQUEST)?;
+        writer
+            .write(&IdeKmHdr {
+                object_id: IdeKmCommand::QueryResp as u8,
+            })
+            .map_err(|_| SPDM_INVALID_REQUEST)?;
+        writer
+            .write(&Query {
+                reserved: 0,
+                port_index: query.port_index,
+            })
+            .map_err(|_| SPDM_INVALID_REQUEST)?;
+
+        let port_config = self
+            .driver
+            .port_config(query.port_index)
+            .map_err(map_ide_error)?;
+        writer
+            .write(&port_config)
+            .map_err(|_| SPDM_INVALID_REQUEST)?;
+
+        let ide_reg_block = self
+            .driver
+            .ide_reg_block(query.port_index)
+            .map_err(map_ide_error)?;
+        writer
+            .write(&ide_reg_block)
+            .map_err(|_| SPDM_INVALID_REQUEST)?;
+
+        let ide_cap_reg = ide_reg_block.ide_cap_reg;
+        if ide_cap_reg.link_ide_stream_supported() == 1 {
+            for block_index in 0..ide_cap_reg.num_tcs_supported_for_link_ide() {
+                let block = self
+                    .driver
+                    .link_ide_reg_block(query.port_index, block_index)
+                    .map_err(map_ide_error)?;
+                writer.write(&block).map_err(|_| SPDM_INVALID_REQUEST)?;
+            }
+        }
+
+        if ide_cap_reg.selective_ide_stream_supported() == 1 {
+            for block_index in 0..ide_cap_reg.num_selective_ide_streams_supported() {
+                let block = self
+                    .driver
+                    .selective_ide_reg_block(query.port_index, block_index)
+                    .map_err(map_ide_error)?;
+                block.encode(writer).map_err(|_| SPDM_INVALID_REQUEST)?;
+            }
+        }
+
+        Ok(writer.position())
+    }
+
+    async fn handle_key_prog(
+        &self,
+        reader: &mut WireReader<'_>,
+        writer: &mut WireWriter<'_>,
+    ) -> McuResult<usize> {
+        let mut key_prog = *reader
+            .read::<mcu_spdm_lite_codec::KeyProg>()
+            .map_err(|_| SPDM_INVALID_REQUEST)?;
+        let key_data = reader
+            .read::<mcu_spdm_lite_codec::KeyData>()
+            .map_err(|_| SPDM_INVALID_REQUEST)?;
+        let status = self
+            .driver
+            .key_prog(
+                key_prog.stream_id,
+                key_prog.key_info,
+                key_prog.port_index,
+                &key_data.key,
+                &key_data.iv,
+            )
+            .await
+            .map_err(map_ide_error)?;
+
+        key_prog.status = status;
+        writer
+            .write(&IdeKmHdr {
+                object_id: IdeKmCommand::KeyProgAck as u8,
+            })
+            .map_err(|_| SPDM_INVALID_REQUEST)?;
+        writer.write(&key_prog).map_err(|_| SPDM_INVALID_REQUEST)?;
+        Ok(writer.position())
+    }
+
+    async fn handle_key_set_go_stop(
+        &self,
+        key_set_go: bool,
+        reader: &mut WireReader<'_>,
+        writer: &mut WireWriter<'_>,
+    ) -> McuResult<usize> {
+        let key_set_go_stop = *reader
+            .read::<mcu_spdm_lite_codec::KeySetGoStop>()
+            .map_err(|_| SPDM_INVALID_REQUEST)?;
+        if key_set_go {
+            self.driver
+                .key_set_go(
+                    key_set_go_stop.stream_id,
+                    key_set_go_stop.key_info,
+                    key_set_go_stop.port_index,
+                )
+                .await
+                .map_err(map_ide_error)?;
+        } else {
+            self.driver
+                .key_set_stop(
+                    key_set_go_stop.stream_id,
+                    key_set_go_stop.key_info,
+                    key_set_go_stop.port_index,
+                )
+                .await
+                .map_err(map_ide_error)?;
+        }
+
+        writer
+            .write(&IdeKmHdr {
+                object_id: IdeKmCommand::KeyGoStopAck as u8,
+            })
+            .map_err(|_| SPDM_INVALID_REQUEST)?;
+        writer
+            .write(&mcu_spdm_lite_codec::KeySetGoStop {
+                reserved1: 0.into(),
+                stream_id: key_set_go_stop.stream_id,
+                reserved2: 0,
+                key_info: key_set_go_stop.key_info,
+                port_index: key_set_go_stop.port_index,
+            })
+            .map_err(|_| SPDM_INVALID_REQUEST)?;
+        Ok(writer.position())
+    }
+}
+
+/// PCI-SIG VDM backend with the IDE-KM protocol enabled.
+pub struct PciSigIdeKmVdm<D> {
+    vendor_id: u16,
+    ide_km: IdeKmResponder<D>,
+}
+
+impl<D> PciSigIdeKmVdm<D> {
+    /// Creates a PCI-SIG VDM backend for a PCI-SIG vendor ID and IDE-KM driver.
+    pub const fn new(vendor_id: u16, driver: D) -> Self {
+        Self {
+            vendor_id,
+            ide_km: IdeKmResponder::new(driver),
+        }
+    }
+
+    /// Returns the PCI-SIG vendor ID matched by this backend.
+    pub const fn vendor_id(&self) -> u16 {
+        self.vendor_id
+    }
+
+    /// Returns the IDE-KM responder.
+    pub const fn ide_km(&self) -> &IdeKmResponder<D> {
+        &self.ide_km
+    }
+}
+
+impl<D: IdeDriver> PciSigIdeKmVdm<D> {
+    async fn handle_ide_km_protocol_payload(
+        &self,
+        protocol_id: u8,
+        req: &[u8],
+        out: &mut [u8],
+    ) -> McuResult<usize> {
+        let Some((protocol_out, ide_out)) = out.split_first_mut() else {
+            return Err(SPDM_UNSPECIFIED);
+        };
+        *protocol_out = protocol_id;
+        let ide_len = self.ide_km.handle_request(req, ide_out).await?;
+        Ok(PciSigProtocolHdr::SIZE + ide_len)
+    }
+
+    fn query_response_size(&self, ide_km_payload: &[u8]) -> McuResult<Option<usize>> {
+        if !is_query_request(ide_km_payload) {
+            return Ok(None);
+        }
+
+        let mut reader = WireReader::new(ide_km_payload);
+        let _hdr = reader
+            .read::<IdeKmHdr>()
+            .map_err(|_| SPDM_INVALID_REQUEST)?;
+        if reader.remaining() != IdeKmCommand::Query.payload_len() {
+            return Err(SPDM_INVALID_REQUEST);
+        }
+        let query = *reader.read::<Query>().map_err(|_| SPDM_INVALID_REQUEST)?;
+
+        let ide_reg_block = self
+            .ide_km
+            .driver
+            .ide_reg_block(query.port_index)
+            .map_err(map_ide_error)?;
+        let ide_cap_reg = ide_reg_block.ide_cap_reg;
+        let mut len = PciSigProtocolHdr::SIZE
+            + IdeKmHdr::SIZE
+            + Query::SIZE
+            + PortConfig::SIZE
+            + IdeRegBlock::SIZE;
+
+        if ide_cap_reg.link_ide_stream_supported() == 1 {
+            len = len
+                .checked_add(
+                    ide_cap_reg.num_tcs_supported_for_link_ide() as usize
+                        * LinkIdeStreamRegBlock::SIZE,
+                )
+                .ok_or(SPDM_UNSPECIFIED)?;
+        }
+
+        if ide_cap_reg.selective_ide_stream_supported() == 1 {
+            for block_index in 0..ide_cap_reg.num_selective_ide_streams_supported() {
+                let block = self
+                    .ide_km
+                    .driver
+                    .selective_ide_reg_block(query.port_index, block_index)
+                    .map_err(map_ide_error)?;
+                let count = block.capability_reg.num_addr_association_reg_blocks() as usize;
+                if count > MAX_SELECTIVE_IDE_ADDR_ASSOC_BLOCK_COUNT {
+                    return Err(SPDM_UNSPECIFIED);
+                }
+                len = len
+                    .checked_add(
+                        SelectiveIdeStreamRegBlock::FIXED_SIZE
+                            + count * AddrAssociationRegBlock::SIZE,
+                    )
+                    .ok_or(SPDM_UNSPECIFIED)?;
+            }
+        }
+
+        Ok(Some(len))
+    }
+}
+
+impl<D: IdeDriver> SpdmVdmBackend for PciSigIdeKmVdm<D> {
+    const USES_LARGE_RESPONSE: bool = true;
+    const LARGE_RESPONSE_CAPACITY: usize = MAX_IDE_KM_QUERY_RESPONSE_SIZE;
+
+    fn large_response_capacity(&self, req: &[u8]) -> usize {
+        let mut reader = WireReader::new(req);
+        let Ok(pci_sig_hdr) = reader.read::<PciSigProtocolHdr>() else {
+            return 0;
+        };
+        if pci_sig_hdr.protocol_id != IDE_KM_PROTOCOL_ID {
+            return 0;
+        }
+        self.query_response_size(reader.rest())
+            .ok()
+            .flatten()
+            .unwrap_or(0)
+    }
+
+    fn match_id(&self, registry: &VdmRegistry<'_>) -> bool {
+        registry.standard_id == StandardsBodyId::PciSig.as_u16()
+            && registry.vendor_id == self.vendor_id.to_le_bytes()
+            && registry.secure_session
+    }
+
+    async fn handle_request<Alloc, Io>(
+        &self,
+        req: &[u8],
+        rsp: VdmResponseBuffer<'_, Alloc, Io>,
+    ) -> McuResult<VdmResponse>
+    where
+        Alloc: SpdmPalAlloc,
+        Io: SpdmPalIo,
+    {
+        let mut reader = WireReader::new(req);
+        let pci_sig_hdr = *reader
+            .read::<PciSigProtocolHdr>()
+            .map_err(|_| SPDM_INVALID_REQUEST)?;
+        if pci_sig_hdr.protocol_id != IDE_KM_PROTOCOL_ID {
+            return Err(SPDM_UNSUPPORTED_REQUEST);
+        }
+
+        let ide_km_payload = reader.rest();
+        if let Some(query_rsp_len) = self.query_response_size(ide_km_payload)? {
+            if query_rsp_len > rsp.inline.len() {
+                if query_rsp_len <= rsp.large.len() {
+                    let len = self
+                        .handle_ide_km_protocol_payload(
+                            pci_sig_hdr.protocol_id,
+                            ide_km_payload,
+                            rsp.large,
+                        )
+                        .await?;
+                    return Ok(VdmResponse::Large(len));
+                }
+                return Err(SPDM_UNSPECIFIED);
+            }
+        }
+
+        let len = self
+            .handle_ide_km_protocol_payload(pci_sig_hdr.protocol_id, ide_km_payload, rsp.inline)
+            .await?;
+        Ok(VdmResponse::Inline(len))
+    }
+}
+
+/// Simple no-allocation IDE-KM emulator driver used by validator tests.
+#[cfg(any(test, feature = "emulated-ide-km"))]
+#[derive(Debug, Clone, Copy)]
+pub struct EmulatedIdeDriver {
+    pub port_index: u8,
+    pub function_num: u8,
+    pub bus_num: u8,
+    pub segment: u8,
+    pub num_link_ide_streams: u8,
+    pub num_selective_ide_streams: u8,
+    pub num_addr_association_reg_blocks: u8,
+}
+
+#[cfg(any(test, feature = "emulated-ide-km"))]
+impl Default for EmulatedIdeDriver {
+    fn default() -> Self {
+        Self {
+            port_index: 0,
+            function_num: 0,
+            bus_num: 0,
+            segment: 0,
+            num_link_ide_streams: 1,
+            num_selective_ide_streams: 1,
+            num_addr_association_reg_blocks: 1,
+        }
+    }
+}
+
+#[cfg(any(test, feature = "emulated-ide-km"))]
+impl IdeDriver for EmulatedIdeDriver {
+    fn port_config(&self, port_index: u8) -> IdeDriverResult<PortConfig> {
+        self.check_port(port_index)?;
+        Ok(PortConfig {
+            function_num: self.function_num,
+            bus_num: self.bus_num,
+            segment: self.segment,
+            max_port_index: self.port_index,
+        })
+    }
+
+    fn ide_reg_block(&self, port_index: u8) -> IdeDriverResult<IdeRegBlock> {
+        self.check_port(port_index)?;
+        let mut ide_cap_reg = IdeCapabilityReg::default();
+        ide_cap_reg.set_link_ide_stream_supported(1);
+        ide_cap_reg.set_selective_ide_stream_supported(1);
+        ide_cap_reg.set_ide_km_protocol_supported(1);
+        ide_cap_reg.set_num_tcs_supported_for_link_ide(self.num_link_ide_streams);
+        ide_cap_reg.set_num_selective_ide_streams_supported(self.num_selective_ide_streams);
+
+        let mut ide_ctrl_reg = IdeControlReg::default();
+        ide_ctrl_reg.set_flow_through_ide_stream_enabled(1);
+        Ok(IdeRegBlock {
+            ide_cap_reg,
+            ide_ctrl_reg,
+        })
+    }
+
+    fn link_ide_reg_block(
+        &self,
+        port_index: u8,
+        block_index: u8,
+    ) -> IdeDriverResult<LinkIdeStreamRegBlock> {
+        self.check_port(port_index)?;
+        if block_index >= self.num_link_ide_streams {
+            return Err(IdeDriverError::InvalidStreamId);
+        }
+        let mut ctrl_reg = LinkIdeStreamControlReg::default();
+        ctrl_reg.set_link_ide_stream_enable(1);
+        ctrl_reg.set_pcrc_enable(1);
+        ctrl_reg.set_selected_algorithm(5);
+        ctrl_reg.set_tc(block_index & 0x7);
+        ctrl_reg.set_stream_id(block_index);
+
+        let mut status_reg = LinkIdeStreamStatusReg::default();
+        status_reg.set_link_ide_stream_state(7);
+        Ok(LinkIdeStreamRegBlock {
+            ctrl_reg,
+            status_reg,
+        })
+    }
+
+    fn selective_ide_reg_block(
+        &self,
+        port_index: u8,
+        block_index: u8,
+    ) -> IdeDriverResult<SelectiveIdeStreamRegBlock> {
+        self.check_port(port_index)?;
+        if block_index >= self.num_selective_ide_streams {
+            return Err(IdeDriverError::InvalidStreamId);
+        }
+
+        let mut capability_reg = SelectiveIdeStreamCapabilityReg::default();
+        capability_reg.set_num_addr_association_reg_blocks(
+            self.num_addr_association_reg_blocks
+                .min(MAX_SELECTIVE_IDE_ADDR_ASSOC_BLOCK_COUNT as u8),
+        );
+
+        let mut ctrl_reg = SelectiveIdeStreamControlReg::default();
+        ctrl_reg.set_selective_ide_stream_enable(1);
+        ctrl_reg.set_pcrc_enable(1);
+        ctrl_reg.set_selective_ide_for_config_req_enable(1);
+        ctrl_reg.set_selected_algorithm(4);
+        ctrl_reg.set_tc(block_index & 0x7);
+        ctrl_reg.set_default_stream(1);
+        ctrl_reg.set_stream_id(block_index);
+
+        let mut status_reg = SelectiveIdeStreamStatusReg::default();
+        status_reg.set_selective_ide_stream_state(5);
+
+        let mut rid_association_reg_1 = SelectiveIdeRidAssociationReg1::default();
+        rid_association_reg_1.set_rid_limit(0x1234);
+        let mut rid_association_reg_2 = SelectiveIdeRidAssociationReg2::default();
+        rid_association_reg_2.set_valid(1);
+        rid_association_reg_2.set_rid_base(0x5678);
+
+        let mut addr_association_reg_block =
+            [AddrAssociationRegBlock::default(); MAX_SELECTIVE_IDE_ADDR_ASSOC_BLOCK_COUNT];
+        for reg in addr_association_reg_block
+            .iter_mut()
+            .take(capability_reg.num_addr_association_reg_blocks() as usize)
+        {
+            reg.reg1.set_valid(1);
+            reg.reg1.set_memory_base_lower(0x12);
+            reg.reg1.set_memory_limit_lower(0x34);
+            reg.reg2.memory_limit_upper = U32::new(0x1234_5678);
+            reg.reg3.memory_base_upper = U32::new(0x8765_4321);
+        }
+
+        Ok(SelectiveIdeStreamRegBlock {
+            capability_reg,
+            ctrl_reg,
+            status_reg,
+            rid_association_reg_1,
+            rid_association_reg_2,
+            addr_association_reg_block,
+        })
+    }
+
+    async fn key_prog(
+        &self,
+        _stream_id: u8,
+        _key_info: KeyInfo,
+        port_index: u8,
+        _key: &[U32; IDE_STREAM_KEY_SIZE_DW],
+        _iv: &[U32; IDE_STREAM_IV_SIZE_DW],
+    ) -> IdeDriverResult<u8> {
+        self.check_port(port_index)?;
+        Ok(0)
+    }
+
+    async fn key_set_go(
+        &self,
+        _stream_id: u8,
+        key_info: KeyInfo,
+        port_index: u8,
+    ) -> IdeDriverResult<()> {
+        self.check_port(port_index)?;
+        let _ = key_info;
+        Ok(())
+    }
+
+    async fn key_set_stop(
+        &self,
+        _stream_id: u8,
+        key_info: KeyInfo,
+        port_index: u8,
+    ) -> IdeDriverResult<()> {
+        self.check_port(port_index)?;
+        let _ = key_info;
+        Ok(())
+    }
+}
+
+#[cfg(any(test, feature = "emulated-ide-km"))]
+impl EmulatedIdeDriver {
+    fn check_port(&self, port_index: u8) -> IdeDriverResult<()> {
+        if port_index == self.port_index {
+            Ok(())
+        } else {
+            Err(IdeDriverError::InvalidPortIndex)
+        }
+    }
+}
+
+fn is_query_request(ide_km_payload: &[u8]) -> bool {
+    ide_km_payload.first().copied() == Some(IdeKmCommand::Query as u8)
+}
+
+fn map_ide_error(_: IdeDriverError) -> McuErrorCode {
+    SPDM_UNSPECIFIED
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+
+    use core::marker::PhantomData;
+    use core::ops::{Deref, DerefMut};
+
+    use futures::executor::block_on;
+    use mcu_spdm_lite_codec::IDE_KM_PROTOCOL_ID;
+    use std::boxed::Box;
+    use std::vec;
+    use std::vec::Vec;
+
+    use super::*;
+
+    const VENDOR_ID_BYTES: [u8; 2] = 0x1234u16.to_le_bytes();
+
+    #[derive(Clone, Copy)]
+    struct StatusDriver {
+        key_prog_status: u8,
+    }
+
+    impl IdeDriver for StatusDriver {
+        fn port_config(&self, port_index: u8) -> IdeDriverResult<PortConfig> {
+            EmulatedIdeDriver::default().port_config(port_index)
+        }
+
+        fn ide_reg_block(&self, port_index: u8) -> IdeDriverResult<IdeRegBlock> {
+            EmulatedIdeDriver::default().ide_reg_block(port_index)
+        }
+
+        fn link_ide_reg_block(
+            &self,
+            port_index: u8,
+            block_index: u8,
+        ) -> IdeDriverResult<LinkIdeStreamRegBlock> {
+            EmulatedIdeDriver::default().link_ide_reg_block(port_index, block_index)
+        }
+
+        fn selective_ide_reg_block(
+            &self,
+            port_index: u8,
+            block_index: u8,
+        ) -> IdeDriverResult<SelectiveIdeStreamRegBlock> {
+            EmulatedIdeDriver::default().selective_ide_reg_block(port_index, block_index)
+        }
+
+        async fn key_prog(
+            &self,
+            _stream_id: u8,
+            _key_info: KeyInfo,
+            _port_index: u8,
+            _key: &[U32; IDE_STREAM_KEY_SIZE_DW],
+            _iv: &[U32; IDE_STREAM_IV_SIZE_DW],
+        ) -> IdeDriverResult<u8> {
+            Ok(self.key_prog_status)
+        }
+
+        async fn key_set_go(
+            &self,
+            _stream_id: u8,
+            _key_info: KeyInfo,
+            _port_index: u8,
+        ) -> IdeDriverResult<()> {
+            Ok(())
+        }
+
+        async fn key_set_stop(
+            &self,
+            _stream_id: u8,
+            _key_info: KeyInfo,
+            _port_index: u8,
+        ) -> IdeDriverResult<()> {
+            Ok(())
+        }
+    }
+
+    #[derive(Clone, Copy)]
+    struct StopOnlyDriver;
+
+    impl IdeDriver for StopOnlyDriver {
+        fn port_config(&self, port_index: u8) -> IdeDriverResult<PortConfig> {
+            EmulatedIdeDriver::default().port_config(port_index)
+        }
+
+        fn ide_reg_block(&self, port_index: u8) -> IdeDriverResult<IdeRegBlock> {
+            EmulatedIdeDriver::default().ide_reg_block(port_index)
+        }
+
+        fn link_ide_reg_block(
+            &self,
+            port_index: u8,
+            block_index: u8,
+        ) -> IdeDriverResult<LinkIdeStreamRegBlock> {
+            EmulatedIdeDriver::default().link_ide_reg_block(port_index, block_index)
+        }
+
+        fn selective_ide_reg_block(
+            &self,
+            port_index: u8,
+            block_index: u8,
+        ) -> IdeDriverResult<SelectiveIdeStreamRegBlock> {
+            EmulatedIdeDriver::default().selective_ide_reg_block(port_index, block_index)
+        }
+
+        async fn key_prog(
+            &self,
+            _stream_id: u8,
+            _key_info: KeyInfo,
+            _port_index: u8,
+            _key: &[U32; IDE_STREAM_KEY_SIZE_DW],
+            _iv: &[U32; IDE_STREAM_IV_SIZE_DW],
+        ) -> IdeDriverResult<u8> {
+            Err(IdeDriverError::KeyProgFail)
+        }
+
+        async fn key_set_go(
+            &self,
+            _stream_id: u8,
+            _key_info: KeyInfo,
+            _port_index: u8,
+        ) -> IdeDriverResult<()> {
+            Err(IdeDriverError::KeySetGoFail)
+        }
+
+        async fn key_set_stop(
+            &self,
+            _stream_id: u8,
+            _key_info: KeyInfo,
+            _port_index: u8,
+        ) -> IdeDriverResult<()> {
+            Ok(())
+        }
+    }
+
+    #[derive(Clone, Copy)]
+    struct VerifyingKeyProgDriver {
+        expected_stream_id: u8,
+        expected_key_info: KeyInfo,
+        expected_port_index: u8,
+        expected_key: [u32; IDE_STREAM_KEY_SIZE_DW],
+        expected_iv: [u32; IDE_STREAM_IV_SIZE_DW],
+        status: u8,
+    }
+
+    impl IdeDriver for VerifyingKeyProgDriver {
+        fn port_config(&self, port_index: u8) -> IdeDriverResult<PortConfig> {
+            EmulatedIdeDriver::default().port_config(port_index)
+        }
+
+        fn ide_reg_block(&self, port_index: u8) -> IdeDriverResult<IdeRegBlock> {
+            EmulatedIdeDriver::default().ide_reg_block(port_index)
+        }
+
+        fn link_ide_reg_block(
+            &self,
+            port_index: u8,
+            block_index: u8,
+        ) -> IdeDriverResult<LinkIdeStreamRegBlock> {
+            EmulatedIdeDriver::default().link_ide_reg_block(port_index, block_index)
+        }
+
+        fn selective_ide_reg_block(
+            &self,
+            port_index: u8,
+            block_index: u8,
+        ) -> IdeDriverResult<SelectiveIdeStreamRegBlock> {
+            EmulatedIdeDriver::default().selective_ide_reg_block(port_index, block_index)
+        }
+
+        async fn key_prog(
+            &self,
+            stream_id: u8,
+            key_info: KeyInfo,
+            port_index: u8,
+            key: &[U32; IDE_STREAM_KEY_SIZE_DW],
+            iv: &[U32; IDE_STREAM_IV_SIZE_DW],
+        ) -> IdeDriverResult<u8> {
+            assert_eq!(stream_id, self.expected_stream_id);
+            assert_eq!(key_info, self.expected_key_info);
+            assert_eq!(port_index, self.expected_port_index);
+            for (actual, expected) in key.iter().zip(self.expected_key.iter()) {
+                assert_eq!(actual.get(), *expected);
+            }
+            for (actual, expected) in iv.iter().zip(self.expected_iv.iter()) {
+                assert_eq!(actual.get(), *expected);
+            }
+            Ok(self.status)
+        }
+
+        async fn key_set_go(
+            &self,
+            _stream_id: u8,
+            _key_info: KeyInfo,
+            _port_index: u8,
+        ) -> IdeDriverResult<()> {
+            Err(IdeDriverError::KeySetGoFail)
+        }
+
+        async fn key_set_stop(
+            &self,
+            _stream_id: u8,
+            _key_info: KeyInfo,
+            _port_index: u8,
+        ) -> IdeDriverResult<()> {
+            Err(IdeDriverError::KeySetStopFail)
+        }
+    }
+
+    fn pci_sig_registry(secure_session: bool) -> VdmRegistry<'static> {
+        VdmRegistry {
+            standard_id: StandardsBodyId::PciSig.as_u16(),
+            vendor_id: &VENDOR_ID_BYTES,
+            secure_session,
+        }
+    }
+
+    struct TestBox<'a, T: 'a> {
+        value: Box<T>,
+        _lifetime: PhantomData<&'a ()>,
+    }
+
+    impl<T> Deref for TestBox<'_, T> {
+        type Target = T;
+
+        fn deref(&self) -> &Self::Target {
+            &self.value
+        }
+    }
+
+    impl<T> DerefMut for TestBox<'_, T> {
+        fn deref_mut(&mut self) -> &mut Self::Target {
+            &mut self.value
+        }
+    }
+
+    struct TestAlloc;
+
+    impl mcu_caliptra_api_lite::ApiAlloc for TestAlloc {
+        type Buf<'a>
+            = Vec<u8>
+        where
+            Self: 'a;
+
+        fn alloc(&self, len: usize) -> McuResult<Self::Buf<'_>> {
+            Ok(vec![0; len])
+        }
+    }
+
+    impl SpdmPalAlloc for TestAlloc {
+        type Box<'a, T>
+            = TestBox<'a, T>
+        where
+            Self: 'a,
+            T: 'a;
+        type Bytes<'a>
+            = Vec<u8>
+        where
+            Self: 'a;
+        type LargeBuf<'a>
+            = Vec<u8>
+        where
+            Self: 'a;
+
+        fn alloc<T: Sized>(&self, _io: &impl SpdmPalIo, value: T) -> McuResult<Self::Box<'_, T>> {
+            Ok(TestBox {
+                value: Box::new(value),
+                _lifetime: PhantomData,
+            })
+        }
+
+        fn alloc_bytes(&self, _io: &impl SpdmPalIo, len: usize) -> McuResult<Self::Bytes<'_>> {
+            Ok(vec![0; len])
+        }
+
+        fn large_capacity(&self) -> usize {
+            0
+        }
+        fn large_begin(&self, _len: usize) -> McuResult<()> {
+            Ok(())
+        }
+        fn large_write(&self, _offset: usize, _data: &[u8]) -> McuResult<()> {
+            Ok(())
+        }
+        fn large_read(&self, _offset: usize, _out: &mut [u8]) -> McuResult<()> {
+            Ok(())
+        }
+        fn large_end(&self) {}
+        fn large_take(&self, len: usize) -> McuResult<Self::LargeBuf<'_>> {
+            Ok(vec![0; len])
+        }
+    }
+
+    struct TestIo;
+    impl SpdmPalIo for TestIo {
+        fn kind(&self) -> mcu_spdm_lite_traits::SpdmPalIoKind {
+            mcu_spdm_lite_traits::SpdmPalIoKind::SecuredMessage
+        }
+
+        fn request(&self) -> &[u8] {
+            &[]
+        }
+    }
+
+    fn response_buffer<'a>(
+        inline: &'a mut [u8],
+        large: &'a mut [u8],
+    ) -> VdmResponseBuffer<'a, TestAlloc, TestIo> {
+        static ALLOC: TestAlloc = TestAlloc;
+        static IO: TestIo = TestIo;
+        VdmResponseBuffer {
+            inline,
+            large,
+            alloc: &ALLOC,
+            io: &IO,
+        }
+    }
+
+    #[test]
+    fn pci_sig_ide_km_matches_only_secure_session() {
+        let backend = PciSigIdeKmVdm::new(0x1234, EmulatedIdeDriver::default());
+        assert!(backend.match_id(&pci_sig_registry(true)));
+        assert!(!backend.match_id(&pci_sig_registry(false)));
+    }
+
+    #[test]
+    fn large_response_capacity_is_only_requested_for_query() {
+        let backend = PciSigIdeKmVdm::new(0x1234, EmulatedIdeDriver::default());
+        let query = [IDE_KM_PROTOCOL_ID, IdeKmCommand::Query as u8, 0, 0];
+        assert!(backend.large_response_capacity(&query) > 0);
+
+        let mut key_prog = [0u8; PciSigProtocolHdr::SIZE
+            + IdeKmHdr::SIZE
+            + mcu_spdm_lite_codec::KeyProg::SIZE
+            + mcu_spdm_lite_codec::KeyData::SIZE];
+        key_prog[0] = IDE_KM_PROTOCOL_ID;
+        key_prog[1] = IdeKmCommand::KeyProg as u8;
+        assert_eq!(backend.large_response_capacity(&key_prog), 0);
+    }
+
+    #[test]
+    fn query_response_prefers_inline_when_it_fits_even_with_large_buffer() {
+        let backend = PciSigIdeKmVdm::new(0x1234, EmulatedIdeDriver::default());
+        let payload = [IDE_KM_PROTOCOL_ID, IdeKmCommand::Query as u8, 0, 0];
+        let mut inline = [0u8; 256];
+        let mut large = [0u8; 512];
+        let response =
+            block_on(backend.handle_request(&payload, response_buffer(&mut inline, &mut large)))
+                .unwrap();
+
+        let VdmResponse::Inline(len) = response else {
+            panic!("IDE-KM query should be inline");
+        };
+        assert!(len > 1 + IdeKmHdr::SIZE + Query::SIZE);
+        assert_eq!(inline[0], IDE_KM_PROTOCOL_ID);
+        assert_eq!(inline[1], IdeKmCommand::QueryResp as u8);
+        assert_eq!(inline[2], 0);
+        assert_eq!(inline[3], 0);
+        assert_eq!(large[0], 0);
+    }
+
+    #[test]
+    fn query_response_uses_large_buffer_only_when_inline_is_too_small() {
+        let backend = PciSigIdeKmVdm::new(0x1234, EmulatedIdeDriver::default());
+        let payload = [IDE_KM_PROTOCOL_ID, IdeKmCommand::Query as u8, 0, 0];
+        let mut inline = [0u8; 1];
+        let mut large = [0u8; 256];
+        let response =
+            block_on(backend.handle_request(&payload, response_buffer(&mut inline, &mut large)))
+                .unwrap();
+
+        let VdmResponse::Large(len) = response else {
+            panic!("IDE-KM query should use available large storage");
+        };
+        assert!(len > 1 + IdeKmHdr::SIZE + Query::SIZE);
+        assert_eq!(large[0], IDE_KM_PROTOCOL_ID);
+        assert_eq!(large[1], IdeKmCommand::QueryResp as u8);
+    }
+
+    #[test]
+    fn key_prog_ack_stays_inline_when_large_buffer_is_available() {
+        let driver = StatusDriver {
+            key_prog_status: 0x5a,
+        };
+        let backend = PciSigIdeKmVdm::new(0x1234, driver);
+        let mut payload = [0u8; PciSigProtocolHdr::SIZE
+            + IdeKmHdr::SIZE
+            + mcu_spdm_lite_codec::KeyProg::SIZE
+            + mcu_spdm_lite_codec::KeyData::SIZE];
+        payload[0] = IDE_KM_PROTOCOL_ID;
+        payload[1] = IdeKmCommand::KeyProg as u8;
+        let mut inline = [0u8; 16];
+        let mut large = [0u8; 256];
+        let response =
+            block_on(backend.handle_request(&payload, response_buffer(&mut inline, &mut large)))
+                .unwrap();
+
+        let VdmResponse::Inline(len) = response else {
+            panic!("IDE-KM KEY_PROG ACK should stay inline");
+        };
+        assert_eq!(
+            len,
+            PciSigProtocolHdr::SIZE + IdeKmHdr::SIZE + mcu_spdm_lite_codec::KeyProg::SIZE
+        );
+        assert_eq!(inline[0], IDE_KM_PROTOCOL_ID);
+        assert_eq!(inline[1], IdeKmCommand::KeyProgAck as u8);
+        assert_eq!(inline[5], driver.key_prog_status);
+        assert_eq!(large[0], 0);
+    }
+
+    #[test]
+    fn key_set_ack_echoes_request_key_info_after_driver_success() {
+        let driver = StatusDriver { key_prog_status: 0 };
+        let responder = IdeKmResponder::new(driver);
+        let request_key_info = KeyInfo::new(false, false, 0x01);
+        let req = [
+            IdeKmCommand::KeySetGo as u8,
+            0,
+            0,
+            0x22,
+            0,
+            request_key_info.raw(),
+            0,
+        ];
+        let mut rsp = [0u8; 16];
+        let len = block_on(responder.handle_request(&req, &mut rsp)).unwrap();
+
+        assert_eq!(
+            len,
+            IdeKmHdr::SIZE + mcu_spdm_lite_codec::KeySetGoStop::SIZE
+        );
+        assert_eq!(rsp[0], IdeKmCommand::KeyGoStopAck as u8);
+        assert_eq!(rsp[5], request_key_info.raw());
+    }
+
+    #[test]
+    fn key_set_stop_ack_echoes_request_key_info_after_driver_success() {
+        let driver = StopOnlyDriver;
+        let responder = IdeKmResponder::new(driver);
+        let request_key_info = KeyInfo::new(false, true, 0x02);
+        let req = [
+            IdeKmCommand::KeySetStop as u8,
+            0,
+            0,
+            0x44,
+            0,
+            request_key_info.raw(),
+            0,
+        ];
+        let mut rsp = [0u8; 16];
+        let len = block_on(responder.handle_request(&req, &mut rsp)).unwrap();
+
+        assert_eq!(
+            len,
+            IdeKmHdr::SIZE + mcu_spdm_lite_codec::KeySetGoStop::SIZE
+        );
+        assert_eq!(rsp[0], IdeKmCommand::KeyGoStopAck as u8);
+        assert_eq!(rsp[5], request_key_info.raw());
+    }
+
+    #[test]
+    fn key_prog_success_path_forwards_fields_and_key_material() {
+        let expected_key = [
+            0x0302_0100,
+            0x0706_0504,
+            0x0b0a_0908,
+            0x0f0e_0d0c,
+            0x1312_1110,
+            0x1716_1514,
+            0x1b1a_1918,
+            0x1f1e_1d1c,
+        ];
+        let expected_iv = [0x2322_2120, 0x2726_2524];
+        let expected_key_info = KeyInfo::new(true, false, 0x02);
+        let driver = VerifyingKeyProgDriver {
+            expected_stream_id: 0x33,
+            expected_key_info,
+            expected_port_index: 0,
+            expected_key,
+            expected_iv,
+            status: 0xaa,
+        };
+        let responder = IdeKmResponder::new(driver);
+        let mut req = [0u8; IdeKmHdr::SIZE
+            + mcu_spdm_lite_codec::KeyProg::SIZE
+            + mcu_spdm_lite_codec::KeyData::SIZE];
+        req[0] = IdeKmCommand::KeyProg as u8;
+        req[3] = driver.expected_stream_id;
+        req[5] = expected_key_info.raw();
+        let mut offset = IdeKmHdr::SIZE + mcu_spdm_lite_codec::KeyProg::SIZE;
+        for value in expected_key {
+            req[offset..offset + core::mem::size_of::<u32>()].copy_from_slice(&value.to_le_bytes());
+            offset += core::mem::size_of::<u32>();
+        }
+        for value in expected_iv {
+            req[offset..offset + core::mem::size_of::<u32>()].copy_from_slice(&value.to_le_bytes());
+            offset += core::mem::size_of::<u32>();
+        }
+
+        let mut rsp = [0u8; 16];
+        let len = block_on(responder.handle_request(&req, &mut rsp)).unwrap();
+
+        assert_eq!(len, IdeKmHdr::SIZE + mcu_spdm_lite_codec::KeyProg::SIZE);
+        assert_eq!(rsp[0], IdeKmCommand::KeyProgAck as u8);
+        assert_eq!(rsp[4], driver.status);
+    }
+
+    #[test]
+    fn unsupported_pci_sig_protocol_is_rejected() {
+        let backend = PciSigIdeKmVdm::new(0x1234, EmulatedIdeDriver::default());
+        let mut rsp = [0u8; 16];
+        let result = block_on(backend.handle_request(&[0x7f], response_buffer(&mut rsp, &mut [])));
+
+        let Err(err) = result else {
+            panic!("unsupported PCI-SIG protocol should fail");
+        };
+        assert_eq!(err, SPDM_UNSUPPORTED_REQUEST);
+    }
+
+    #[test]
+    fn invalid_and_response_only_ide_km_object_ids_are_rejected() {
+        let responder = IdeKmResponder::new(EmulatedIdeDriver::default());
+        let mut rsp = [0u8; 16];
+
+        assert_eq!(
+            block_on(responder.handle_request(&[0xff], &mut rsp)).unwrap_err(),
+            SPDM_INVALID_REQUEST
+        );
+        assert_eq!(
+            block_on(responder.handle_request(&[IdeKmCommand::QueryResp as u8], &mut rsp))
+                .unwrap_err(),
+            SPDM_INVALID_REQUEST
+        );
+    }
+
+    #[test]
+    fn malformed_payload_lengths_are_rejected() {
+        let responder = IdeKmResponder::new(EmulatedIdeDriver::default());
+        let mut rsp = [0u8; 16];
+
+        assert_eq!(
+            block_on(responder.handle_request(&[IdeKmCommand::Query as u8, 0], &mut rsp))
+                .unwrap_err(),
+            SPDM_INVALID_REQUEST
+        );
+        assert_eq!(
+            block_on(responder.handle_request(&[IdeKmCommand::Query as u8, 0, 0, 0], &mut rsp))
+                .unwrap_err(),
+            SPDM_INVALID_REQUEST
+        );
+    }
+
+    #[test]
+    fn short_output_buffer_is_rejected() {
+        let responder = IdeKmResponder::new(EmulatedIdeDriver::default());
+        let req = [IdeKmCommand::Query as u8, 0, 0];
+        let mut rsp = [0u8; 1];
+
+        assert_eq!(
+            block_on(responder.handle_request(&req, &mut rsp)).unwrap_err(),
+            SPDM_INVALID_REQUEST
+        );
+    }
+}

--- a/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/mod.rs
+++ b/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/mod.rs
@@ -2,8 +2,12 @@
 
 //! PCI-SIG VENDOR_DEFINED protocols (Standards Body ID `PciSig`, 0x03).
 //!
-//! Reserved for the PCI-SIG VDM handlers — IDE_KM and TDISP — which are always
-//! delivered inside a secure session on the DOE transport. Not yet implemented.
-//!
-//! TODO: add `ide_km` and `tdisp` submodules implementing
-//! [`mcu_spdm_lite_traits::SpdmVdmBackend`].
+//! PCI-SIG VDMs are delivered inside a secure SPDM session. This module
+//! currently implements IDE-KM and keeps the protocol selected by the PCI-SIG
+//! protocol-id byte that prefixes the vendor-defined payload.
+
+pub mod ide_km;
+
+#[cfg(feature = "emulated-ide-km")]
+pub use ide_km::EmulatedIdeDriver;
+pub use ide_km::{IdeDriver, IdeDriverError, IdeDriverResult, IdeKmResponder, PciSigIdeKmVdm};


### PR DESCRIPTION
## Summary
- add PCI-SIG IDE-KM wire codec and VDM responder support on top of SPDM-Lite
- wire DOE to the PCI-SIG IDE-KM VDM backend for the validator feature
- fix large-response handshake sizing for secured VDM/measurements paths
- gate the emulated IDE-KM driver behind a validator-only feature

## SPDM validator
- MCTP: pass (spdm_responder_conformance_test: pass 607, fail 0)
- DOE: pass (spdm_responder_conformance_test: pass 894, fail 0)

## Memory report — profile: devel

Kernel (mcu-runtime-emulator)
| Section | Size (B) |
| --- | ---: |
| .text | 142,296 |
| .data | 36 |
| .bss | 24,536 |

User-app
| Section | Size (B) |
| --- | ---: |
| .text | 98,562 |
| .rodata | 20,908 |
| .data | 12 |
| .bss | 61,384 |
| FLASH | 119,482 |
| RAM | 61,396 |

SPDM task (symbol attribution from user-app)
| Section | Size (B) |
| --- | ---: |
| .text | 84,690 |
| .rodata | 732 |
| .data | 0 |
| .bss | 36,569 |
| FLASH | 85,422 |
| RAM | 36,569 |

| Bundle | Size (B) |
| --- | ---: |
| Runtime bundle | 263,168 |
