### PR TITLE
spdm-lite: allocate large-message buffer from per-task bitmap pool

### DIFF
--- a/platforms/emulator/runtime/userspace/apps/user/src/spdm/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/spdm/mod.rs
@@ -23,7 +23,7 @@ use embassy_executor::Spawner;
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_sync::signal::Signal;
 use mcu_spdm_lite_pal::cert::store::SharedCertStore;
-use mcu_spdm_lite_pal::{McuSpdmPal, BITMAP_SLOT_SIZE};
+use mcu_spdm_lite_pal::{BitmapAllocator, McuSpdmPal, StaticBitmapAllocatorCell, BITMAP_SLOT_SIZE};
 use mcu_spdm_lite_stack::SpdmStack;
 use mcu_spdm_lite_transports::{McuSpdmDoeTransport, McuSpdmMctpTransport};
 use mcu_spdm_lite_vdm_handler::iana::ocp::caliptra_vdm::CaliptraVdm;
@@ -33,12 +33,7 @@ use mcu_spdm_lite_vdm_handler::iana::ocp::caliptra_vdm::CaliptraVdm;
 /// Must hold `MEAS_RECORD_BUF_SIZE + MeasurementProvider::SCRATCH_SIZE`
 /// plus transient DPE/SHA mailbox buffers (peak ~2.4 KB during
 /// certify_key for kid computation).
-const SPDM_LITE_SCRATCH_SIZE: usize = 8 * 1024;
-/// Size of the dedicated static buffer holding one in-flight large SPDM message
-/// (a `CHUNK_GET` response or `CHUNK_SEND` reassembly). Separate from the
-/// scratch pool so it survives the per-request allocator reset; its length caps
-/// `MaxSPDMmsgSize`.
-const SPDM_LITE_LARGE_MSG_SIZE: usize = 8 * 1024;
+const SPDM_LITE_SCRATCH_SIZE: usize = 12 * 1024;
 
 /// Single cert store shared by all SPDM responder tasks.
 static CERT_STORE: SharedCertStore = SharedCertStore::new();
@@ -114,18 +109,18 @@ async fn spdm_mctp_responder() {
     #[repr(C, align(64))]
     struct ScratchBuf([u8; SPDM_LITE_SCRATCH_SIZE]);
     static mut MCTP_SCRATCH: ScratchBuf = ScratchBuf([0u8; SPDM_LITE_SCRATCH_SIZE]);
-    struct LargeMsgBuf([u8; SPDM_LITE_LARGE_MSG_SIZE]);
-    static mut MCTP_LARGE_MSG: LargeMsgBuf = LargeMsgBuf([0u8; SPDM_LITE_LARGE_MSG_SIZE]);
     // SAFETY: this task is the sole owner of `MCTP_SCRATCH`.
     let scratch_ptr: NonNull<u8> = unsafe { NonNull::new_unchecked(MCTP_SCRATCH.0.as_mut_ptr()) };
-    // SAFETY: this task is the sole owner of `MCTP_LARGE_MSG`.
-    let large_msg: &'static mut [u8] = unsafe { &mut (*core::ptr::addr_of_mut!(MCTP_LARGE_MSG)).0 };
     debug_assert_eq!(scratch_ptr.as_ptr() as usize % BITMAP_SLOT_SIZE, 0);
 
+    // SAFETY: `init_once` is called once per task lifetime; this is the
+    // MCTP responder task. Backing memory (`MCTP_SCRATCH`) is `'static`.
+    static MCTP_ALLOC_CELL: StaticBitmapAllocatorCell = StaticBitmapAllocatorCell::new();
+    let allocator: &'static BitmapAllocator =
+        unsafe { MCTP_ALLOC_CELL.init_once(scratch_ptr, SPDM_LITE_SCRATCH_SIZE) };
+
     {
-        let init_alloc =
-            unsafe { mcu_spdm_lite_pal::BitmapAllocator::new(scratch_ptr, SPDM_LITE_SCRATCH_SIZE) };
-        if let Err(e) = ensure_cert_store_init(&init_alloc).await {
+        if let Err(e) = ensure_cert_store_init(allocator).await {
             crate::console_writeln!(cw, "SPDM_MCTP: cert store init failed: 0x{:08x}", e);
             return;
         }
@@ -139,19 +134,9 @@ async fn spdm_mctp_responder() {
         .expect("MCTP_SPDM driver with MCTP_MSG_TYPE_SPDM is a valid pairing"),
     );
 
-    // SAFETY: `MCTP_SCRATCH` and `MCTP_LARGE_MSG` are statically allocated and
-    // exclusively owned by this task; `MCTP_SCRATCH` is aligned for the bitmap
-    // allocator by `#[repr(align(64))]`.
-    let pal = unsafe {
-        McuSpdmPal::new(
-            transport,
-            scratch_ptr,
-            SPDM_LITE_SCRATCH_SIZE,
-            &CERT_STORE,
-            Some(large_msg),
-            measurement_provider(),
-        )
-    };
+    // SAFETY: `allocator` is the `&'static` handle obtained above and is
+    // exclusive to this task.
+    let pal = unsafe { McuSpdmPal::new(transport, allocator, &CERT_STORE, measurement_provider()) };
     // MCTP hosts the IANA / Caliptra VDM backend (plaintext today). DOE hosts
     // PCI-SIG and stays on the default NoVdmBackend.
     static MCTP_VDM_HOOK: caliptra_vdm::CaliptraVdmHook = caliptra_vdm::CaliptraVdmHook;
@@ -177,37 +162,27 @@ async fn spdm_doe_responder() {
     #[repr(C, align(64))]
     struct ScratchBuf([u8; SPDM_LITE_SCRATCH_SIZE]);
     static mut DOE_SCRATCH: ScratchBuf = ScratchBuf([0u8; SPDM_LITE_SCRATCH_SIZE]);
-    struct LargeMsgBuf([u8; SPDM_LITE_LARGE_MSG_SIZE]);
-    static mut DOE_LARGE_MSG: LargeMsgBuf = LargeMsgBuf([0u8; SPDM_LITE_LARGE_MSG_SIZE]);
     // SAFETY: this task is the sole owner of `DOE_SCRATCH`.
     let scratch_ptr: NonNull<u8> = unsafe { NonNull::new_unchecked(DOE_SCRATCH.0.as_mut_ptr()) };
-    // SAFETY: this task is the sole owner of `DOE_LARGE_MSG`.
-    let large_msg: &'static mut [u8] = unsafe { &mut (*core::ptr::addr_of_mut!(DOE_LARGE_MSG)).0 };
     debug_assert_eq!(scratch_ptr.as_ptr() as usize % BITMAP_SLOT_SIZE, 0);
 
+    // SAFETY: `init_once` is called once per task lifetime; this is the
+    // DOE responder task. Backing memory (`DOE_SCRATCH`) is `'static`.
+    static DOE_ALLOC_CELL: StaticBitmapAllocatorCell = StaticBitmapAllocatorCell::new();
+    let allocator: &'static BitmapAllocator =
+        unsafe { DOE_ALLOC_CELL.init_once(scratch_ptr, SPDM_LITE_SCRATCH_SIZE) };
+
     {
-        let init_alloc =
-            unsafe { mcu_spdm_lite_pal::BitmapAllocator::new(scratch_ptr, SPDM_LITE_SCRATCH_SIZE) };
-        if let Err(e) = ensure_cert_store_init(&init_alloc).await {
+        if let Err(e) = ensure_cert_store_init(allocator).await {
             crate::console_writeln!(cw, "SPDM_DOE: cert store init failed: 0x{:08x}", e);
             return;
         }
     }
 
     let transport = alloc::boxed::Box::new(doe_transport);
-    // SAFETY: `DOE_SCRATCH` and `DOE_LARGE_MSG` are statically allocated and
-    // exclusively owned by this task; `DOE_SCRATCH` is aligned for the bitmap
-    // allocator by `#[repr(align(64))]`.
-    let pal = unsafe {
-        McuSpdmPal::new(
-            transport,
-            scratch_ptr,
-            SPDM_LITE_SCRATCH_SIZE,
-            &CERT_STORE,
-            Some(large_msg),
-            measurement_provider(),
-        )
-    };
+    // SAFETY: `allocator` is the `&'static` handle obtained above and is
+    // exclusive to this task.
+    let pal = unsafe { McuSpdmPal::new(transport, allocator, &CERT_STORE, measurement_provider()) };
     let mut stack: SpdmStack<_, 1> = SpdmStack::new(pal);
 
     crate::console_writeln!(cw, "SPDM_DOE: starting spdm-lite DOE run loop");

--- a/runtime/userspace/api/spdm-lite/pal/src/alloc.rs
+++ b/runtime/userspace/api/spdm-lite/pal/src/alloc.rs
@@ -13,9 +13,8 @@
 //!   (used by receive paths that allocate `mtu()` and trim to the real
 //!   message length).
 //!
-//! The allocator is reset by [`McuSpdmPal`] at the start of every
-//! `recv_request`, so allocations are logically scoped to a single SPDM
-//! exchange even though the allocator object itself outlives every box.
+//! The allocator serves both per-request scratch allocations and any
+//! connection-scoped large-message buffer parked on `ConnectionState`.
 //!
 //! # Soundness
 //!
@@ -26,45 +25,6 @@
 use super::measurements::MeasurementProvider;
 use super::*;
 use core::cell::Cell;
-use core::ops::{Deref, DerefMut};
-
-/// RAII guard handed out by [`SpdmPalAlloc::large_take`]. While alive, owns
-/// the static large-message slice and derefs to `&mut [u8]` of exactly the
-/// requested length. On drop, returns the slice to the PAL's [`Cell`] without
-/// wiping — the bytes survive for `CHUNK_GET` to serve via `large_read`.
-pub struct BitmapLargeBuf<'a> {
-    slice: Option<&'static mut [u8]>,
-    len: usize,
-    cell: &'a Cell<Option<&'static mut [u8]>>,
-}
-
-impl Deref for BitmapLargeBuf<'_> {
-    type Target = [u8];
-    fn deref(&self) -> &[u8] {
-        let buf = self.slice.as_deref().expect("BitmapLargeBuf slice missing");
-        &buf[..self.len]
-    }
-}
-
-impl DerefMut for BitmapLargeBuf<'_> {
-    fn deref_mut(&mut self) -> &mut [u8] {
-        let buf = self
-            .slice
-            .as_deref_mut()
-            .expect("BitmapLargeBuf slice missing");
-        &mut buf[..self.len]
-    }
-}
-
-impl Drop for BitmapLargeBuf<'_> {
-    fn drop(&mut self) {
-        // Park the slice back in the PAL. Do NOT wipe — the bytes need to
-        // survive across the rest of this request and the subsequent
-        // CHUNK_GET cycles. `pal.large_end()` (called by the chunking layer
-        // after the final chunk ships) is responsible for the wipe.
-        self.cell.set(self.slice.take());
-    }
-}
 
 impl<M: MeasurementProvider> SpdmPalAlloc for McuSpdmPal<M> {
     type Box<'a, T>
@@ -118,83 +78,13 @@ impl<M: MeasurementProvider> SpdmPalAlloc for McuSpdmPal<M> {
     }
 
     fn large_capacity(&self) -> usize {
-        let large_buf = self.large_buf.take();
-        let capacity = large_buf.as_deref().map_or(0, <[u8]>::len);
-        self.large_buf.set(large_buf);
-        capacity
+        self.allocator.largest_free_run() * crate::BITMAP_SLOT_SIZE
     }
 
-    fn large_begin(&self, len: usize) -> McuResult<()> {
-        // Static buffer: nothing to allocate — just bound-check against capacity.
-        if len > self.large_capacity() {
-            return Err(ERR_OUT_OF_MEMORY);
-        }
-        Ok(())
-    }
+    type LargeBuf = BitmapBytes<'static>;
 
-    fn large_write(&self, offset: usize, data: &[u8]) -> McuResult<()> {
-        let mut held = self.large_buf.take();
-        let result = (|| {
-            let buf = held.as_deref_mut().ok_or(INVARIANT)?;
-            let end = offset.checked_add(data.len()).ok_or(INVARIANT)?;
-            buf.get_mut(offset..end)
-                .ok_or(INVARIANT)?
-                .copy_from_slice(data);
-            Ok(())
-        })();
-        self.large_buf.set(held);
-        result
-    }
-
-    fn large_read(&self, offset: usize, out: &mut [u8]) -> McuResult<()> {
-        let held = self.large_buf.take();
-        let result = (|| {
-            let buf = held.as_deref().ok_or(INVARIANT)?;
-            let end = offset.checked_add(out.len()).ok_or(INVARIANT)?;
-            out.copy_from_slice(buf.get(offset..end).ok_or(INVARIANT)?);
-            Ok(())
-        })();
-        self.large_buf.set(held);
-        result
-    }
-
-    fn large_end(&self) {
-        // Wipe the message bytes but keep the static slice parked in the Cell
-        // for reuse by the next large message.
-        let mut held = self.large_buf.take();
-        if let Some(buf) = held.as_deref_mut() {
-            buf.fill(0);
-        }
-        self.large_buf.set(held);
-    }
-
-    type LargeBuf<'a>
-        = BitmapLargeBuf<'a>
-    where
-        Self: 'a;
-
-    /// Takes the static large-message slice into an RAII handle of exactly
-    /// `len` bytes. While the handle is alive the slice is detached from the
-    /// PAL Cell, so callers must drop the handle before invoking any other
-    /// `large_*` method (capacity / write / read / end) on this PAL.
-    fn large_take(&self, len: usize) -> McuResult<Self::LargeBuf<'_>> {
-        let held = self.large_buf.take();
-        let Some(slice) = held else {
-            // Either no static buffer was provisioned at PAL construction, or
-            // a prior `large_take` handle is still alive. Either way, there is
-            // nothing to hand out.
-            self.large_buf.set(None);
-            return Err(INVARIANT);
-        };
-        if len > slice.len() {
-            self.large_buf.set(Some(slice));
-            return Err(ERR_OUT_OF_MEMORY);
-        }
-        Ok(BitmapLargeBuf {
-            slice: Some(slice),
-            len,
-            cell: &self.large_buf,
-        })
+    fn alloc_large_buf(&self, len: usize) -> McuResult<Self::LargeBuf> {
+        self.allocator.alloc_bytes(len)
     }
 }
 
@@ -219,7 +109,7 @@ impl<M: MeasurementProvider> SpdmPalAlloc for McuSpdmPal<M> {
 
 use core::cell::UnsafeCell;
 use core::marker::PhantomData;
-use core::mem::{align_of, size_of};
+use core::mem::{align_of, size_of, MaybeUninit};
 use core::ptr::NonNull;
 
 /// Slot granularity in bytes. Each bit in the occupancy bitmap tracks one
@@ -231,9 +121,7 @@ use core::ptr::NonNull;
 /// bitmap small (1 bit per 64 bytes ≈ 0.2 % overhead).
 pub const BITMAP_SLOT_SIZE: usize = 64;
 
-use mcu_error::codes::{
-    BAD_ALIGNMENT as ERR_BAD_ALIGNMENT, INVARIANT, OUT_OF_MEMORY as ERR_OUT_OF_MEMORY,
-};
+use mcu_error::codes::{BAD_ALIGNMENT as ERR_BAD_ALIGNMENT, OUT_OF_MEMORY as ERR_OUT_OF_MEMORY};
 
 /// Single-threaded bitmap allocator over a caller-supplied buffer.
 ///
@@ -249,6 +137,13 @@ pub struct BitmapAllocator {
     data: NonNull<u8>,
     /// Number of slots managed by the bitmap.
     num_slots: usize,
+    /// Running count of slots currently marked live (incremented by
+    /// `alloc_run`, decremented by `free_run`). Maintained for cheap
+    /// `live_slots()` and as the running input to `max_live_slots`.
+    live_count: Cell<u32>,
+    /// High-water mark of `live_count` over the allocator's lifetime.
+    /// Updated on every `alloc_run`. Read via `max_live_slots()`.
+    max_live: Cell<u32>,
     /// Interior mutability marker; the actual bitmap storage lives in the buffer.
     _state: UnsafeCell<()>,
     /// `!Send` + `!Sync` marker.
@@ -315,6 +210,8 @@ impl BitmapAllocator {
             base: ptr,
             data,
             num_slots,
+            live_count: Cell::new(0),
+            max_live: Cell::new(0),
             _state: UnsafeCell::new(()),
             _not_send: PhantomData,
         }
@@ -328,6 +225,51 @@ impl BitmapAllocator {
     /// number of single-slot allocations that can be live at once.
     pub fn num_slots(&self) -> usize {
         self.num_slots
+    }
+
+    /// Returns the number of slots currently marked live (the running
+    /// count maintained by [`Self::alloc_run`] and [`Self::free_run`]).
+    ///
+    /// A correctly-functioning steady-state responder returns to a known
+    /// baseline (zero, or the count of slots held by persistent allocations
+    /// owned by `ConnectionState`) between SPDM requests. A drift above the
+    /// baseline points at a leaked [`BitmapBytes`] / [`McuSpdmBox`] handle.
+    pub fn live_slots(&self) -> usize {
+        self.live_count.get() as usize
+    }
+
+    /// Returns the highest value [`Self::live_slots`] has reached since
+    /// allocator construction. Updated on every [`Self::alloc_run`].
+    ///
+    /// Useful for sizing the scratch region against observed peaks.
+    pub fn max_live_slots(&self) -> usize {
+        self.max_live.get() as usize
+    }
+
+    /// Returns the largest contiguous run of currently-free slots, in
+    /// slot units. O(num_slots) scan — intended for diagnostics, not
+    /// the hot path.
+    ///
+    /// Useful for spotting fragmentation: `live_slots() + largest_free_run()`
+    /// can be less than `num_slots()` when free space is split across the
+    /// bitmap.
+    pub fn largest_free_run(&self) -> usize {
+        let mut best = 0usize;
+        let mut run = 0usize;
+        for i in 0..self.num_slots {
+            if self.bit(i) {
+                if run > best {
+                    best = run;
+                }
+                run = 0;
+            } else {
+                run += 1;
+            }
+        }
+        if run > best {
+            best = run;
+        }
+        best
     }
 
     /// Resets the allocator by clearing every bit in the occupancy bitmap.
@@ -345,6 +287,7 @@ impl BitmapAllocator {
     pub unsafe fn reset(&self) {
         let bm_bytes = self.num_slots.div_ceil(8);
         core::ptr::write_bytes(self.base.as_ptr(), 0, bm_bytes);
+        self.live_count.set(0);
     }
 
     /// Allocates a byte buffer of `len` bytes from the pool.
@@ -412,7 +355,7 @@ impl BitmapAllocator {
         if n > u16::MAX as usize {
             return Err(ERR_OUT_OF_MEMORY);
         }
-        let start = self.alloc_run(n).ok_or(ERR_OUT_OF_MEMORY)?;
+        let start = self.alloc_run_backwards(n).ok_or(ERR_OUT_OF_MEMORY)?;
 
         // SAFETY: `start..start+n` slots are now marked used (exclusive
         // ownership), within bounds, and properly aligned for `T`.
@@ -476,6 +419,35 @@ impl BitmapAllocator {
                     for j in start..start + n {
                         self.set_bit(j, true);
                     }
+                    let new_live = self.live_count.get().saturating_add(n as u32);
+                    self.live_count.set(new_live);
+                    if new_live > self.max_live.get() {
+                        self.max_live.set(new_live);
+                    }
+                    return Some(start);
+                }
+            } else {
+                run = 0;
+            }
+        }
+        None
+    }
+
+    fn alloc_run_backwards(&self, n: usize) -> Option<usize> {
+        let mut run = 0usize;
+        for i in (0..self.num_slots).rev() {
+            if !self.bit(i) {
+                run += 1;
+                if run == n {
+                    let start = i;
+                    for j in start..start + n {
+                        self.set_bit(j, true);
+                    }
+                    let new_live = self.live_count.get().saturating_add(n as u32);
+                    self.live_count.set(new_live);
+                    if new_live > self.max_live.get() {
+                        self.max_live.set(new_live);
+                    }
                     return Some(start);
                 }
             } else {
@@ -497,6 +469,8 @@ impl BitmapAllocator {
         for j in start..start + n {
             self.set_bit(j, false);
         }
+        self.live_count
+            .set(self.live_count.get().saturating_sub(n as u32));
     }
 
     /// Reads bit `i` of the occupancy bitmap.
@@ -526,6 +500,7 @@ impl BitmapAllocator {
 /// Sized to be cheap to embed in async state machines: `&BitmapAllocator` +
 /// `(u16 start, u16 count)` = 8 bytes on a 32-bit target (12 bytes on
 /// 64-bit). The data pointer is recomputed from the allocator base.
+#[must_use = "dropping a McuSpdmBox without holding it would immediately free the underlying slots"]
 pub struct McuSpdmBox<'a, T> {
     /// Borrow of the backing allocator; used to free slots on drop.
     alloc: &'a BitmapAllocator,
@@ -596,6 +571,7 @@ impl<T> core::ops::DerefMut for McuSpdmBox<'_, T> {
 /// `unused` is the number of trailing bytes in the last slot that are
 /// *not* part of the logical buffer; valid range 0..63. Logical length
 /// is therefore `num_slots * SLOT_SIZE - unused`.
+#[must_use = "dropping a BitmapBytes without holding it would immediately free the underlying slots"]
 pub struct BitmapBytes<'a> {
     /// Borrow of the backing allocator; used to free slots on drop or
     /// shrink.
@@ -802,3 +778,293 @@ impl core::ops::DerefMut for BitmapBytes<'_> {
 /// machines, so growth here is felt across the firmware.
 #[cfg(target_pointer_width = "32")]
 const _: () = assert!(core::mem::size_of::<BitmapBytes<'_>>() == 8);
+
+// ---------------------------------------------------------------------------
+// Static allocator cell
+// ---------------------------------------------------------------------------
+
+/// One-shot cell that holds a [`BitmapAllocator`] as a `static`, returning a
+/// `&'static BitmapAllocator` after the single call to [`Self::init_once`].
+///
+/// `BitmapAllocator` is deliberately `!Sync` because its interior mutability
+/// is single-task by construction. We cannot wrap it in `OnceLock` /
+/// `OnceCell::sync` (those require `Sync`). Instead we hand-roll the minimal
+/// pattern: an `UnsafeCell<MaybeUninit<…>>` accessible via a `Sync` outer
+/// wrapper whose contract requires the caller to enforce the single-task
+/// invariant.
+///
+/// # Safety contract
+///
+/// * [`Self::init_once`] must be called at most once for the lifetime of the
+///   program. A second call invokes UB. Caller may enforce this with their
+///   own "this task ran" flag or by structural single-task ownership (the
+///   common pattern: one cell per `#[embassy_executor::task]`).
+/// * After `init_once`, the returned `&'static BitmapAllocator` is the
+///   canonical handle for that allocator and may be freely shared within the
+///   owning task. Sharing across tasks is undefined behavior.
+/// * The byte region passed to `init_once` must outlive every allocation
+///   produced from the returned allocator. In practice this means the region
+///   is itself `static`.
+pub struct StaticBitmapAllocatorCell {
+    inner: UnsafeCell<MaybeUninit<BitmapAllocator>>,
+}
+
+// SAFETY: The cell is `Sync` so it can appear in `static`. Actual access to
+// `inner` is `unsafe` and the contract requires single-task usage.
+unsafe impl Sync for StaticBitmapAllocatorCell {}
+
+impl StaticBitmapAllocatorCell {
+    /// Constructs an empty cell. The contained allocator is uninitialized
+    /// until [`Self::init_once`] is called.
+    pub const fn new() -> Self {
+        Self {
+            inner: UnsafeCell::new(MaybeUninit::uninit()),
+        }
+    }
+
+    /// Initializes the contained `BitmapAllocator` in place over
+    /// `[ptr, ptr + capacity)` and returns a `&'static` handle to it.
+    ///
+    /// # Safety
+    ///
+    /// All of the safety conditions on [`BitmapAllocator::new`] apply, plus:
+    ///
+    /// * MUST be called at most once for this cell.
+    /// * Must not be called concurrently with any access to the cell.
+    pub unsafe fn init_once(
+        &'static self,
+        ptr: NonNull<u8>,
+        capacity: usize,
+    ) -> &'static BitmapAllocator {
+        let slot = self.inner.get();
+        let alloc = BitmapAllocator::new(ptr, capacity);
+        (*slot).write(alloc);
+        (*slot).assume_init_ref()
+    }
+}
+
+impl Default for StaticBitmapAllocatorCell {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    extern crate alloc;
+    use alloc::vec;
+
+    /// Construct a fresh allocator over a heap-backed buffer for tests.
+    fn make_alloc(capacity: usize) -> (BitmapAllocator, alloc::vec::Vec<u8>) {
+        // Heap-backed buffer keeps the test target-independent. The Vec is
+        // returned alongside so the caller can keep it alive for the
+        // allocator's borrow.
+        let mut buf = vec![0u8; capacity + BITMAP_SLOT_SIZE];
+        // Round the base up to BITMAP_SLOT_SIZE alignment.
+        let raw = buf.as_mut_ptr();
+        let off = (raw as usize).wrapping_neg() & (BITMAP_SLOT_SIZE - 1);
+        let ptr = unsafe { NonNull::new_unchecked(raw.add(off)) };
+        let alloc = unsafe { BitmapAllocator::new(ptr, capacity) };
+        (alloc, buf)
+    }
+
+    #[test]
+    fn live_slots_balance_alloc_drop() {
+        let (alloc, _buf) = make_alloc(4 * 1024);
+        assert_eq!(alloc.live_slots(), 0);
+
+        let a = alloc.alloc_bytes(100).unwrap();
+        assert_eq!(alloc.live_slots(), 2); // 100 B over 64 B slots = 2 slots
+
+        let b = alloc.alloc_bytes(64).unwrap();
+        assert_eq!(alloc.live_slots(), 3);
+
+        drop(a);
+        assert_eq!(alloc.live_slots(), 1);
+        drop(b);
+        assert_eq!(alloc.live_slots(), 0);
+    }
+
+    #[test]
+    fn max_live_tracks_peak() {
+        let (alloc, _buf) = make_alloc(4 * 1024);
+        assert_eq!(alloc.max_live_slots(), 0);
+
+        let a = alloc.alloc_bytes(64).unwrap();
+        let b = alloc.alloc_bytes(64).unwrap();
+        let c = alloc.alloc_bytes(64).unwrap();
+        assert_eq!(alloc.max_live_slots(), 3);
+
+        drop(c);
+        // max stays at 3 even after free
+        assert_eq!(alloc.max_live_slots(), 3);
+
+        let _d = alloc.alloc_bytes(64).unwrap();
+        // back at 3 live; max unchanged
+        assert_eq!(alloc.live_slots(), 3);
+        assert_eq!(alloc.max_live_slots(), 3);
+
+        let _e = alloc.alloc_bytes(64).unwrap();
+        // now 4 live → new peak
+        assert_eq!(alloc.live_slots(), 4);
+        assert_eq!(alloc.max_live_slots(), 4);
+
+        drop(a);
+        drop(b);
+    }
+
+    #[test]
+    fn largest_free_run_finds_holes() {
+        let (alloc, _buf) = make_alloc(8 * 1024);
+        let total = alloc.num_slots();
+        assert_eq!(alloc.largest_free_run(), total);
+
+        let a = alloc.alloc_bytes(64).unwrap();
+        let b = alloc.alloc_bytes(64).unwrap();
+        let c = alloc.alloc_bytes(64).unwrap();
+        // 3 slots taken at the bottom; rest free.
+        assert_eq!(alloc.largest_free_run(), total - 3);
+
+        drop(b); // hole in the middle
+                 // Free regions: [bit 1..2] (1 slot) + [bit 3..total] (total-3 slots).
+                 // Largest = total - 3.
+        assert_eq!(alloc.largest_free_run(), total - 3);
+        drop(a);
+        drop(c);
+        assert_eq!(alloc.largest_free_run(), total);
+    }
+
+    #[test]
+    fn bidirectional_split_allocation() {
+        let (alloc, _buf) = make_alloc(8 * 1024);
+        let total = alloc.num_slots();
+
+        let low = alloc.alloc_bytes(2 * BITMAP_SLOT_SIZE).unwrap();
+        let high = alloc.alloc(0u64).unwrap();
+
+        assert_eq!(low.start_slot, 0);
+        assert_eq!(high.start_slot as usize, total - 1);
+        assert_eq!(alloc.live_slots(), 3);
+
+        drop(low);
+        drop(high);
+        assert_eq!(alloc.live_slots(), 0);
+    }
+
+    #[test]
+    fn oom_does_not_leak_slots() {
+        let (alloc, _buf) = make_alloc(4 * 1024);
+        let total = alloc.num_slots();
+
+        // Allocate up to (just under) capacity; one of these will be at the
+        // limit. Then attempt an oversized request and verify nothing leaked.
+        let huge = (total * BITMAP_SLOT_SIZE) + 1;
+        assert!(alloc.alloc_bytes(huge).is_err());
+        assert_eq!(alloc.live_slots(), 0);
+    }
+
+    #[test]
+    fn drop_alloc_box_releases_slots() {
+        let (alloc, _buf) = make_alloc(4 * 1024);
+        assert_eq!(alloc.live_slots(), 0);
+        {
+            let _b = alloc.alloc(0u64).unwrap();
+            assert_eq!(alloc.live_slots(), 1); // u64 fits in one slot
+        }
+        assert_eq!(alloc.live_slots(), 0);
+    }
+
+    /// Deterministic fragmentation soak — emulates the steady-state SPDM
+    /// responder allocation mix and verifies that an 8 KiB large-message
+    /// allocation can still succeed after many request cycles under
+    /// realistic interleaving of long-lived (transcript / session) and
+    /// transient (request / response framing) allocations.
+    ///
+    /// This test gates Phase 6 (delete static large buffer). If first-fit
+    /// fragments the bitmap enough that the 8 KiB contiguous run cannot
+    /// be allocated after the simulated workload, we must add directional
+    /// allocation (low for persistent, high for large) before deleting the
+    /// static buffer.
+    ///
+    /// Allocation mix per request cycle:
+    ///   * recv-buffer (~1.5 KiB) — transient
+    ///   * response-buffer (~1.5 KiB) — transient
+    ///   * 1-2 small scratch allocations (~256 B each) — transient
+    ///
+    /// Long-lived (allocated once at "session start", held for whole soak):
+    ///   * SessionInfo placeholder (~1 KiB)
+    ///   * Transcript hashes — VCA, M1, L1, TH (4 × 256 B)
+    ///
+    /// Cycles: 50 request cycles, all transients drop at end of each cycle.
+    ///
+    /// At the end of the soak, attempt an 8 KiB allocation for a hypothetical
+    /// CHUNK_GET large response. Pass means the bitmap allocator (with simple
+    /// first-fit) can sustain the realistic workload without fragmenting too
+    /// badly. Fail means we need directional allocation.
+    #[test]
+    fn fragmentation_soak_8k_alloc_after_realistic_workload() {
+        // 16 KiB pool — close to the realistic per-task budget for our
+        // platform after deleting the static large buffer.
+        let (alloc, _buf) = make_alloc(16 * 1024);
+
+        // Phase A — bring up the "session": one big object + four transcript
+        // hashes. These hold their slots for the whole soak.
+        let _session = alloc.alloc_bytes(1024).expect("session alloc");
+        let _vca = alloc.alloc_bytes(256).expect("vca alloc");
+        let _m1 = alloc.alloc_bytes(256).expect("m1 alloc");
+        let _l1 = alloc.alloc_bytes(256).expect("l1 alloc");
+        let _th = alloc.alloc_bytes(256).expect("th alloc");
+
+        let baseline_live = alloc.live_slots();
+        assert!(baseline_live > 0);
+
+        // Phase B — run 50 request cycles of transient churn.
+        for cycle in 0..50 {
+            {
+                let _recv = alloc
+                    .alloc_bytes(1536)
+                    .unwrap_or_else(|_| panic!("recv alloc failed at cycle {}", cycle));
+                let _resp = alloc
+                    .alloc_bytes(1536)
+                    .unwrap_or_else(|_| panic!("resp alloc failed at cycle {}", cycle));
+                let _scratch1 = alloc
+                    .alloc_bytes(256)
+                    .unwrap_or_else(|_| panic!("scratch1 alloc failed at cycle {}", cycle));
+                let _scratch2 = alloc
+                    .alloc_bytes(256)
+                    .unwrap_or_else(|_| panic!("scratch2 alloc failed at cycle {}", cycle));
+                // all transients drop here
+            }
+            // After cycle, live count must be back to baseline.
+            assert_eq!(
+                alloc.live_slots(),
+                baseline_live,
+                "transient leak at cycle {}",
+                cycle
+            );
+        }
+
+        // Phase C — record fragmentation state, then attempt the 8 KiB large
+        // allocation. This is the GATE: if it fails, Phase 6 needs directional
+        // allocation before deleting the static buffer.
+        let largest_run_slots = alloc.largest_free_run();
+        let largest_run_bytes = largest_run_slots * BITMAP_SLOT_SIZE;
+        let large = alloc.alloc_bytes(8 * 1024);
+
+        match large {
+            Ok(buf) => {
+                assert_eq!(buf.len(), 8 * 1024);
+                // Soak passes — first-fit holds up.
+            }
+            Err(_) => {
+                panic!(
+                    "FRAGMENTATION SOAK FAILED: 8 KiB allocation failed after 50 cycles. \
+                     baseline_live={}, largest_free_run={} slots ({} bytes). \
+                     Phase 6 (delete static large buffer) needs directional allocation.",
+                    baseline_live, largest_run_slots, largest_run_bytes
+                );
+            }
+        }
+    }
+}

--- a/runtime/userspace/api/spdm-lite/pal/src/io.rs
+++ b/runtime/userspace/api/spdm-lite/pal/src/io.rs
@@ -13,15 +13,13 @@
 //!
 //! On every `recv_request`:
 //!
-//! 1. The [`BitmapAllocator`] is reset — every previous allocation
-//!    has been dropped by now, so this just zeroes the bitmap.
-//! 2. A single `header_size + mtu` buffer is allocated; the
-//!    transport writes both its framing header *and* the SPDM
-//!    payload into it (no shift / copy is performed afterwards).
-//! 3. The buffer is shrunk to the actual frame length, releasing
-//!    the trailing slots back to the pool.
-//! 4. The resulting [`McuSpdmIo`] is returned to the stack and
-//!    keeps the frame alive until it is dropped.
+//! 1. A single `header_size + mtu` buffer is allocated; the transport
+//!    writes both its framing header *and* the SPDM payload into it
+//!    (no shift / copy is performed afterwards).
+//! 2. The buffer is shrunk to the actual frame length, releasing the
+//!    trailing slots back to the pool.
+//! 3. The resulting [`McuSpdmIo`] is returned to the stack and keeps
+//!    the frame alive until it is dropped.
 //!
 //! On `send_response`, the caller-provided `msg` already has the
 //! SPDM payload at offset `header_size()`; the transport fills
@@ -147,11 +145,8 @@ impl<M: MeasurementProvider> SpdmPalIoTransport for McuSpdmPal<M> {
     /// * Any [`McuErrorCode`] surfaced by the underlying
     ///   [`SpdmPalTransport::recv_request`].
     async fn recv_request(&self) -> McuResult<Self::Io<'_>> {
-        // SAFETY: `&self` + single-task responder ⇒ no live `McuSpdmIo` exists
-        // when this returns. Reset clears the bitmap for the new exchange. The
-        // large-message buffer is a separate static (not part of this pool), so
-        // it survives across requests for chunked transfers.
-        unsafe { self.allocator.reset() };
+        // Transient allocations are released by RAII. The persistent large-message
+        // buffer (if any) lives on ConnectionState and survives across cycles.
 
         // Need room for header + MTU; the transport writes both into the
         // same buffer (no shifting).

--- a/runtime/userspace/api/spdm-lite/pal/src/pal.rs
+++ b/runtime/userspace/api/spdm-lite/pal/src/pal.rs
@@ -20,8 +20,7 @@ use super::*;
 extern crate alloc;
 
 use alloc::boxed::Box;
-use core::cell::{Cell, UnsafeCell};
-use core::ptr::NonNull;
+use core::cell::UnsafeCell;
 
 use super::cert::store::SharedCertStore;
 use super::measurements::MeasurementProvider;
@@ -35,61 +34,49 @@ use super::measurements::MeasurementProvider;
 /// [`UnsafeCell`] for interior mutability — the SPDM responder is
 /// strictly single-task, so we never observe concurrent access) plus a
 /// single [`BitmapAllocator`](super::alloc::BitmapAllocator) backed by
-/// a caller-supplied scratch region. The allocator is reset at the
-/// start of every `recv_request`, so allocations are scoped to a
-/// single SPDM exchange even though the allocator object itself lives
-/// on the PAL.
+/// a caller-supplied scratch region. The allocator serves both
+/// per-request scratch allocations and any large-message buffer
+/// retained on connection state across exchanges.
 pub struct McuSpdmPal<M: MeasurementProvider> {
     /// The wrapped byte-oriented PAL transport.
     pub(crate) transport: UnsafeCell<Box<dyn SpdmPalTransport>>,
 
-    /// Per-IO scratch allocator, reset by every `recv_request`.
-    pub(crate) allocator: BitmapAllocator,
+    /// Per-task scratch allocator. Lifted to `'static` so its lifetime is
+    /// independent of the PAL — long-lived allocations (the in-flight large
+    /// SPDM message owned by `LargeTransfer` state) can outlive any single
+    /// SPDM request cycle without needing a `'pal` lifetime parameter
+    /// threaded through the stack.
+    pub(crate) allocator: &'static BitmapAllocator,
 
     /// Shared cert store — same instance for all transports.
     pub(crate) cert_store: &'static SharedCertStore,
-
-    /// Persistent static buffer holding one in-flight large SPDM message
-    /// (`CHUNK_GET` response or `CHUNK_SEND` reassembly). Lent out for reads /
-    /// writes via [`Cell::take`]/[`Cell::set`] (the empty slice marks it
-    /// "checked out"), so a chunked transfer survives the per-request allocator
-    /// `reset`. No `unsafe` is needed to hand out the writable slice.
-    pub(crate) large_buf: Cell<Option<&'static mut [u8]>>,
 
     /// Measurement data provider (monomorphized).
     pub(crate) meas_provider: M,
 }
 
 impl<M: MeasurementProvider> McuSpdmPal<M> {
-    /// Creates a new `McuSpdmPal` with persistent chunk storage and a
-    /// measurement provider.
+    /// Creates a new `McuSpdmPal` with a measurement provider.
     ///
     /// # Safety
     ///
-    /// * `io_buf_ptr` must be aligned to
-    ///   [`BITMAP_SLOT_SIZE`](super::alloc::BITMAP_SLOT_SIZE) and point
-    ///   to `io_buf_capacity` bytes of writable memory exclusively
-    ///   owned by this `McuSpdmPal` for its entire lifetime.
-    /// * `large_buf` — When present, a dedicated static buffer holding one
-    ///   in-flight large SPDM message (`CHUNK_GET` response / `CHUNK_SEND`
-    ///   reassembly). Must be exclusively owned by this `McuSpdmPal` for its
-    ///   entire lifetime; its length caps `MaxSPDMmsgSize`.
+    /// * `allocator` — A `&'static BitmapAllocator` obtained from
+    ///   [`StaticBitmapAllocatorCell::init_once`]. Must be exclusively used
+    ///   by the task owning this `McuSpdmPal` (the underlying allocator is
+    ///   `!Sync`; using it from multiple tasks is undefined behavior).
     /// * The constructed `McuSpdmPal` must only be driven from a single
     ///   task; calling `recv_request` / `send_response` concurrently is
     ///   undefined behavior (interior mutability is not synchronized).
     pub unsafe fn new(
         transport: Box<dyn SpdmPalTransport>,
-        io_buf_ptr: NonNull<u8>,
-        io_buf_capacity: usize,
+        allocator: &'static BitmapAllocator,
         cert_store: &'static SharedCertStore,
-        large_buf: Option<&'static mut [u8]>,
         meas_provider: M,
     ) -> Self {
         Self {
             transport: UnsafeCell::new(transport),
-            allocator: BitmapAllocator::new(io_buf_ptr, io_buf_capacity),
+            allocator,
             cert_store,
-            large_buf: Cell::new(large_buf),
             meas_provider,
         }
     }

--- a/runtime/userspace/api/spdm-lite/stack/src/algorithms.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/algorithms.rs
@@ -26,7 +26,7 @@ use mcu_spdm_lite_codec::{
     alg_type, AeadAlgos, AlgStructEntry, AlgorithmsRsp, CapFlags, DheAlgos, KeyScheduleAlgos,
     NegotiateAlgorithmsReqBodyFixed, OtherParamSupport, ResponseBody, SpdmMsgHdrPdu, SpdmVersion,
 };
-use mcu_spdm_lite_traits::{PalBytes, SpdmPal, SpdmPalIo, SpdmPalIoTransport};
+use mcu_spdm_lite_traits::{PalBytes, SpdmPal, SpdmPalAlloc, SpdmPalIo, SpdmPalIoTransport};
 use zerocopy::FromBytes;
 
 use crate::build::build_response;
@@ -65,7 +65,7 @@ struct PeerAlgs {
 ///   the corresponding table (see [`locate_alg_structs`] / [`parse_peer_algs`]
 ///   for the exact rules).
 pub(crate) async fn handle_negotiate_algorithms<'a, Pal: SpdmPal>(
-    state: &mut ConnectionState<Pal::State>,
+    state: &mut ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
     pal: &'a Pal,
     io: &<Pal as SpdmPalIoTransport>::Io<'_>,
 ) -> SpdmResult<PalBytes<'a, Pal>> {
@@ -238,8 +238,8 @@ fn parse_peer_algs(slice: &[u8]) -> SpdmResult<PeerAlgs> {
 ///
 /// An [`AlgorithmsRsp`] ready to hand to [`build_response`]. Families
 /// with no overlap are omitted from `alg_structs` (encoded as `None`).
-fn build_response_body<S>(
-    state: &ConnectionState<S>,
+fn build_response_body<S, L>(
+    state: &ConnectionState<S, L>,
     fixed: &NegotiateAlgorithmsReqBodyFixed,
     peer: &PeerAlgs,
     secure_message_supported: bool,

--- a/runtime/userspace/api/spdm-lite/stack/src/capabilities.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/capabilities.rs
@@ -17,7 +17,7 @@
 use mcu_spdm_lite_codec::{
     CapFlags, CapabilitiesBody, CapabilitiesRsp, ResponseBody, SpdmMsgHdrPdu, SpdmVersion,
 };
-use mcu_spdm_lite_traits::{PalBytes, SpdmPal, SpdmPalIo, SpdmPalIoTransport};
+use mcu_spdm_lite_traits::{PalBytes, SpdmPal, SpdmPalAlloc, SpdmPalIo, SpdmPalIoTransport};
 use zerocopy::FromBytes;
 
 use crate::build::build_response;
@@ -54,7 +54,7 @@ use crate::version::SUPPORTED_VERSIONS;
 /// * [`SPDM_VERSION_MISMATCH`] — requested version is not in
 ///   [`SUPPORTED_VERSIONS`].
 pub(crate) async fn handle_get_capabilities<'a, Pal: SpdmPal>(
-    state: &mut ConnectionState<Pal::State>,
+    state: &mut ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
     pal: &'a Pal,
     io: &<Pal as SpdmPalIoTransport>::Io<'_>,
 ) -> SpdmResult<PalBytes<'a, Pal>> {
@@ -172,7 +172,10 @@ fn validate_capabilities_body(body: &CapabilitiesBody) -> SpdmResult<(u32, u32)>
 ///
 /// * [`SPDM_VERSION_MISMATCH`] — byte is not a recognised version or
 ///   not in [`SUPPORTED_VERSIONS`].
-fn select_version<S>(state: &mut ConnectionState<S>, requested: u8) -> SpdmResult<SpdmVersion> {
+fn select_version<S, L>(
+    state: &mut ConnectionState<S, L>,
+    requested: u8,
+) -> SpdmResult<SpdmVersion> {
     let v = SpdmVersion::from_u8(requested).ok_or(SPDM_VERSION_MISMATCH)?;
     if !SUPPORTED_VERSIONS.contains(&v) {
         return Err(SPDM_VERSION_MISMATCH);

--- a/runtime/userspace/api/spdm-lite/stack/src/certificate.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/certificate.rs
@@ -15,7 +15,7 @@ use mcu_spdm_lite_codec::{
     SpdmMsgHdrPdu, SpdmVersion, WireWriter, ATTR_SLOT_SIZE_REQUESTED,
 };
 use mcu_spdm_lite_traits::{
-    PalBytes, SpdmPal, SpdmPalAsymAlgo, SpdmPalIo, SpdmPalIoTransport, MAX_SLOTS,
+    PalBytes, SpdmPal, SpdmPalAlloc, SpdmPalAsymAlgo, SpdmPalIo, SpdmPalIoTransport, MAX_SLOTS,
 };
 use zerocopy::{little_endian::U16, FromBytes};
 
@@ -129,7 +129,7 @@ impl CertificateLargeResponse {
 }
 
 pub(crate) async fn handle_get_certificate<'a, Pal: SpdmPal>(
-    state: &mut ConnectionState<Pal::State>,
+    state: &mut ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
     pal: &'a Pal,
     io: &<Pal as SpdmPalIoTransport>::Io<'_>,
 ) -> SpdmResult<PalBytes<'a, Pal>> {

--- a/runtime/userspace/api/spdm-lite/stack/src/challenge.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/challenge.rs
@@ -7,6 +7,7 @@ use mcu_spdm_lite_codec::{
     ECC_P384_SIGNATURE_SIZE, REQUESTER_CONTEXT_LEN, SHA384_HASH_SIZE, SPDM_CONTEXT_LEN,
     SPDM_PREFIX_LEN, SPDM_SIGNING_CONTEXT_LEN,
 };
+use mcu_spdm_lite_traits::SpdmPalAlloc;
 use mcu_spdm_lite_traits::*;
 use zerocopy::FromBytes;
 
@@ -15,7 +16,7 @@ use crate::error::{SpdmResult, SPDM_INVALID_REQUEST, SPDM_UNEXPECTED_REQUEST, SP
 use crate::stack::{ConnectionState, Phase};
 
 pub(crate) async fn handle_challenge<'a, Pal: SpdmPal>(
-    state: &mut ConnectionState<Pal::State>,
+    state: &mut ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
     pal: &'a Pal,
     io: &<Pal as SpdmPalIoTransport>::Io<'_>,
 ) -> SpdmResult<PalBytes<'a, Pal>> {

--- a/runtime/userspace/api/spdm-lite/stack/src/chunk/get.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/chunk/get.rs
@@ -6,7 +6,7 @@ use mcu_spdm_lite_codec::{
     ChunkGetReqBody, ChunkResponseBody, ReqRespCode, SpdmMsgHdrPdu, WireWriter,
     CHUNK_ATTR_LAST_CHUNK, CHUNK_RESPONSE_FIXED_BODY_SIZE, LARGE_RESPONSE_SIZE_FIELD_SIZE,
 };
-use mcu_spdm_lite_traits::{PalBytes, SpdmPal, SpdmPalIo, SpdmPalIoTransport};
+use mcu_spdm_lite_traits::{PalBytes, SpdmPal, SpdmPalAlloc, SpdmPalIo, SpdmPalIoTransport};
 use zerocopy::{little_endian::U16, little_endian::U32, FromBytes};
 
 use crate::build::alloc_padded;
@@ -18,7 +18,7 @@ use crate::stack::{ConnectionState, Phase};
 use super::LargeResponse;
 
 pub(crate) async fn handle_chunk_get<'a, Pal: SpdmPal>(
-    state: &mut ConnectionState<Pal::State>,
+    state: &mut ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
     pal: &'a Pal,
     io: &<Pal as SpdmPalIoTransport>::Io<'_>,
 ) -> SpdmResult<PalBytes<'a, Pal>> {
@@ -101,7 +101,11 @@ pub(crate) async fn handle_chunk_get<'a, Pal: SpdmPal>(
                 state.transcript.append_m1(pal, io, chunk).await?;
             }
             LargeResponse::Buffered => {
-                pal.large_read(bytes_sent, chunk)?;
+                let large = state
+                    .large_buf
+                    .as_deref()
+                    .ok_or(crate::error::SPDM_UNSPECIFIED)?;
+                chunk.copy_from_slice(&large[bytes_sent..bytes_sent + chunk_size]);
             }
         }
     }
@@ -110,7 +114,7 @@ pub(crate) async fn handle_chunk_get<'a, Pal: SpdmPal>(
     // Once the final chunk of a buffered response ships, release the pinned
     // large buffer (RAII free + zero) back to the pool.
     if last_chunk && is_buffered {
-        pal.large_end();
+        state.large_buf = None;
     }
     Ok(rsp)
 }

--- a/runtime/userspace/api/spdm-lite/stack/src/chunk/mod.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/chunk/mod.rs
@@ -8,7 +8,7 @@ mod send;
 pub(crate) use get::handle_chunk_get;
 pub(crate) use send::handle_chunk_send;
 
-use mcu_spdm_lite_traits::{PalBytes, SpdmPal, SpdmPalIoTransport};
+use mcu_spdm_lite_traits::{PalBytes, SpdmPal, SpdmPalAlloc, SpdmPalIoTransport};
 
 use crate::build::build_error_response;
 use crate::certificate::CertificateLargeResponse;
@@ -134,7 +134,7 @@ impl ChunkState {
 }
 
 pub(crate) fn validate_buffered_large_response<Pal: SpdmPal>(
-    state: &ConnectionState<Pal::State>,
+    state: &ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
     pal: &Pal,
     large_resp_len: usize,
 ) -> SpdmResult<()> {
@@ -150,7 +150,7 @@ pub(crate) fn validate_buffered_large_response<Pal: SpdmPal>(
 }
 
 pub(crate) fn start_buffered_large_response<'a, Pal: SpdmPal>(
-    state: &mut ConnectionState<Pal::State>,
+    state: &mut ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
     pal: &'a Pal,
     io: &<Pal as SpdmPalIoTransport>::Io<'_>,
     large_resp_len: usize,

--- a/runtime/userspace/api/spdm-lite/stack/src/chunk/send.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/chunk/send.rs
@@ -6,7 +6,7 @@ use mcu_spdm_lite_codec::{
     CapabilitiesBody, ChunkSendAckBody, ChunkSendReqBody, ReqRespCode, SpdmMsgHdrPdu, SpdmVersion,
     WireWriter, CHUNK_ACK_ATTR_EARLY_ERROR, CHUNK_ATTR_LAST_CHUNK,
 };
-use mcu_spdm_lite_traits::{PalBytes, SpdmPal, SpdmPalIo, SpdmPalIoTransport};
+use mcu_spdm_lite_traits::{PalBytes, SpdmPal, SpdmPalAlloc, SpdmPalIo, SpdmPalIoTransport};
 use zerocopy::{little_endian::U16, FromBytes};
 
 use crate::build::alloc_padded;
@@ -25,7 +25,7 @@ struct ChunkInfo {
 }
 
 pub(crate) async fn handle_chunk_send<'a, Pal: SpdmPal>(
-    state: &mut ConnectionState<Pal::State>,
+    state: &mut ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
     pal: &'a Pal,
     io: &<Pal as SpdmPalIoTransport>::Io<'_>,
 ) -> SpdmResult<PalBytes<'a, Pal>> {
@@ -37,8 +37,7 @@ pub(crate) async fn handle_chunk_send<'a, Pal: SpdmPal>(
                 build_response_to_large_request(state, pal, io, &mut response_to_large_request)
                     .await;
                 state.chunk.reset();
-                // Reassembly consumed: release the pinned buffer (free + zero).
-                pal.large_end();
+                state.large_buf = None;
                 &response_to_large_request[..]
             } else {
                 &[]
@@ -61,8 +60,7 @@ pub(crate) async fn handle_chunk_send<'a, Pal: SpdmPal>(
             let mut error = [0u8; 4];
             encode_error_pdu(state.version, SPDM_INVALID_REQUEST, &mut error);
             state.chunk.reset();
-            // Release any pinned reassembly buffer reserved before the error.
-            pal.large_end();
+            state.large_buf = None;
             build_chunk_send_ack(pal, io, state.version, true, handle, chunk_seq_num, &error)
         }
     }
@@ -102,7 +100,7 @@ enum ChunkProcessError {
 }
 
 fn process_chunk_send<Pal: SpdmPal>(
-    state: &mut ConnectionState<Pal::State>,
+    state: &mut ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
     pal: &Pal,
     io: &impl SpdmPalIo,
 ) -> Result<ChunkInfo, ChunkProcessError> {
@@ -168,7 +166,7 @@ fn process_chunk_send<Pal: SpdmPal>(
 }
 
 fn process_first_chunk<Pal: SpdmPal>(
-    state: &mut ConnectionState<Pal::State>,
+    state: &mut ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
     pal: &Pal,
     handle: u8,
     chunk_seq_num: u16,
@@ -209,12 +207,17 @@ fn process_first_chunk<Pal: SpdmPal>(
             chunk_seq_num,
         });
     }
-    // Reserve the pinned reassembly buffer, then store the first chunk into it.
-    if pal.large_begin(large_msg_size).is_err() || pal.large_write(0, chunk).is_err() {
-        return Err(ChunkProcessError::Early {
-            handle,
-            chunk_seq_num,
-        });
+    match pal.alloc_large_buf(large_msg_size) {
+        Ok(mut buf) => {
+            buf[..chunk_size].copy_from_slice(chunk);
+            state.large_buf = Some(buf);
+        }
+        Err(_) => {
+            return Err(ChunkProcessError::Early {
+                handle,
+                chunk_seq_num,
+            })
+        }
     }
 
     state.chunk = super::ChunkState {
@@ -228,8 +231,8 @@ fn process_first_chunk<Pal: SpdmPal>(
 }
 
 fn process_next_chunk<Pal: SpdmPal>(
-    state: &mut ConnectionState<Pal::State>,
-    pal: &Pal,
+    state: &mut ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
+    _pal: &Pal,
     handle: u8,
     chunk_seq_num: u16,
     chunk_size: usize,
@@ -254,11 +257,20 @@ fn process_next_chunk<Pal: SpdmPal>(
         || end > large_msg_size
         || (last_chunk && end != large_msg_size)
         || (!last_chunk && (end >= large_msg_size || chunk_size < min_chunk_size));
-    if invalid || pal.large_write(bytes_received, chunk).is_err() {
+    if invalid {
         return Err(ChunkProcessError::Early {
             handle,
             chunk_seq_num,
         });
+    }
+    match state.large_buf.as_deref_mut() {
+        Some(buf) => buf[bytes_received..end].copy_from_slice(chunk),
+        None => {
+            return Err(ChunkProcessError::Early {
+                handle,
+                chunk_seq_num,
+            })
+        }
     }
 
     state.chunk.seq_num = chunk_seq_num;
@@ -267,7 +279,7 @@ fn process_next_chunk<Pal: SpdmPal>(
 }
 
 async fn build_response_to_large_request<Pal: SpdmPal>(
-    state: &mut ConnectionState<Pal::State>,
+    state: &mut ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
     pal: &Pal,
     io: &<Pal as SpdmPalIoTransport>::Io<'_>,
     out: &mut [u8; 4],
@@ -285,17 +297,18 @@ async fn build_response_to_large_request<Pal: SpdmPal>(
 }
 
 async fn dispatch_large_request<Pal: SpdmPal>(
-    state: &mut ConnectionState<Pal::State>,
+    state: &mut ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
     pal: &Pal,
     io: &<Pal as SpdmPalIoTransport>::Io<'_>,
     len: usize,
     out: &mut [u8; 4],
 ) -> Result<(), SpdmError> {
     #[cfg(not(feature = "set-certificate"))]
-    let _ = (io, out);
+    let _ = (pal, io, out);
 
-    let large_req = pal.large_take(len).map_err(|_| SPDM_INVALID_REQUEST)?;
-    let (hdr, _) = SpdmMsgHdrPdu::ref_from_prefix(&large_req).map_err(|_| SPDM_INVALID_REQUEST)?;
+    let buf = state.large_buf.as_deref().ok_or(SPDM_INVALID_REQUEST)?;
+    let large_req = buf.get(..len).ok_or(SPDM_INVALID_REQUEST)?;
+    let (hdr, _) = SpdmMsgHdrPdu::ref_from_prefix(large_req).map_err(|_| SPDM_INVALID_REQUEST)?;
     if hdr.version != state.version.to_u8()
         || hdr.code == ReqRespCode::CHUNK_SEND
         || hdr.code == ReqRespCode::CHUNK_GET
@@ -307,7 +320,7 @@ async fn dispatch_large_request<Pal: SpdmPal>(
         #[cfg(feature = "set-certificate")]
         ReqRespCode::SET_CERTIFICATE => {
             let slot_id =
-                set_certificate::handle_set_certificate_request(state, pal, io, &large_req).await?;
+                set_certificate::handle_set_certificate_request(state, pal, io, large_req).await?;
             out[0] = state.version.to_u8();
             out[1] = ReqRespCode::SET_CERTIFICATE_RSP.0;
             out[2] = slot_id;

--- a/runtime/userspace/api/spdm-lite/stack/src/digests.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/digests.rs
@@ -9,7 +9,8 @@
 
 use mcu_spdm_lite_codec::{DigestsRsp, ResponseBody, SpdmMsgHdrPdu};
 use mcu_spdm_lite_traits::{
-    PalBytes, SpdmPal, SpdmPalAsymAlgo, SpdmPalHashAlgo, SpdmPalIo, SpdmPalIoTransport, MAX_SLOTS,
+    PalBytes, SpdmPal, SpdmPalAlloc, SpdmPalAsymAlgo, SpdmPalHashAlgo, SpdmPalIo,
+    SpdmPalIoTransport, MAX_SLOTS,
 };
 use zerocopy::FromBytes;
 
@@ -22,7 +23,7 @@ use crate::stack::{multi_key_conn_rsp, ConnectionState, Phase};
 const CERT_CHUNK_SIZE: usize = 1024;
 
 pub(crate) async fn handle_get_digests<'a, Pal: SpdmPal>(
-    state: &mut ConnectionState<Pal::State>,
+    state: &mut ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
     pal: &'a Pal,
     io: &<Pal as SpdmPalIoTransport>::Io<'_>,
 ) -> SpdmResult<PalBytes<'a, Pal>> {

--- a/runtime/userspace/api/spdm-lite/stack/src/key_exchange.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/key_exchange.rs
@@ -19,6 +19,7 @@ use mcu_spdm_lite_codec::{
     ECDH_P384_EXCHANGE_DATA_SIZE, KEY_EXCHANGE_RANDOM_DATA_LEN, OPAQUE_VERSION_SELECTION_SIZE,
     SHA384_HASH_SIZE, SPDM_PREFIX_LEN, SPDM_SIGNING_CONTEXT_LEN,
 };
+use mcu_spdm_lite_traits::SpdmPalAlloc;
 use mcu_spdm_lite_traits::*;
 use zerocopy::FromBytes;
 
@@ -50,7 +51,7 @@ const KEY_EXCHANGE_SIGNING_PREFIX_V13: &[u8; KEY_EXCHANGE_SIGNING_PREFIX_CHUNK_L
 const KEY_EXCHANGE_SIGNING_OP: &[u8; 34] = b"responder-key_exchange_rsp signing";
 
 pub(crate) async fn handle_key_exchange<'a, Pal: SpdmPal, const N: usize>(
-    state: &mut ConnectionState<Pal::State>,
+    state: &mut ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
     sessions: &mut SessionManager<<Pal as SpdmPalSessionCrypto>::Key, Pal::State, N>,
     pal: &'a Pal,
     io: &<Pal as SpdmPalIoTransport>::Io<'_>,
@@ -157,7 +158,7 @@ pub(crate) async fn handle_key_exchange<'a, Pal: SpdmPal, const N: usize>(
 #[allow(clippy::too_many_arguments)]
 #[inline(never)]
 async fn key_exchange_inner<'a, Pal: SpdmPal, const N: usize>(
-    state: &mut ConnectionState<Pal::State>,
+    state: &mut ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
     sessions: &mut SessionManager<<Pal as SpdmPalSessionCrypto>::Key, Pal::State, N>,
     pal: &'a Pal,
     io: &<Pal as SpdmPalIoTransport>::Io<'_>,

--- a/runtime/userspace/api/spdm-lite/stack/src/measurements.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/measurements.rs
@@ -7,6 +7,7 @@ use mcu_spdm_lite_codec::{
     WireWriter, ECC_P384_SIGNATURE_SIZE, MEAS_BLOCK_METADATA_SIZE, REQUESTER_CONTEXT_LEN,
     SHA384_HASH_SIZE, SPDM_CONTEXT_LEN, SPDM_PREFIX_LEN, SPDM_SIGNING_CONTEXT_LEN,
 };
+use mcu_spdm_lite_traits::SpdmPalAlloc;
 use mcu_spdm_lite_traits::*;
 use zerocopy::{FromBytes, IntoBytes};
 
@@ -35,7 +36,7 @@ struct MeasurementsResponseCtx<'a> {
 }
 
 pub(crate) async fn handle_get_measurements_req<'a, Pal: SpdmPal>(
-    state: &mut ConnectionState<Pal::State>,
+    state: &mut ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
     pal: &'a Pal,
     io: &<Pal as SpdmPalIoTransport>::Io<'_>,
     req: &[u8],
@@ -238,33 +239,32 @@ pub(crate) async fn handle_get_measurements_req<'a, Pal: SpdmPal>(
 }
 
 async fn handle_large_measurements_response<'a, Pal: SpdmPal>(
-    state: &mut ConnectionState<Pal::State>,
+    state: &mut ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
     pal: &'a Pal,
     io: &<Pal as SpdmPalIoTransport>::Io<'_>,
     plan: &MeasurementsResponseCtx<'_>,
 ) -> SpdmResult<(PalBytes<'a, Pal>, usize)> {
     chunk::validate_buffered_large_response(state, pal, plan.large_resp_len)?;
-    // Reserve the pinned large buffer before writing the response into it; it is
-    // freed (RAII) once CHUNK_GET ships the final chunk.
-    pal.large_begin(plan.large_resp_len)?;
+    let mut buf = pal.alloc_large_buf(plan.large_resp_len)?;
 
     let mut offset = 0usize;
     let hdr = SpdmMsgHdrPdu::new(state.version, ReqRespCode::MEASUREMENTS);
-    offset = write_large_measurement_bytes(pal, offset, hdr.as_bytes())?;
+    offset = write_into_slice(&mut buf, offset, hdr.as_bytes())?;
 
     let mut fixed = [0u8; MEASUREMENTS_FIXED_BODY_SIZE];
     fixed[0] = plan.total_number_of_measurement;
     fixed[1] = (plan.slot_id & 0x0F) | ((plan.content_changed & 0x03) << 4);
     fixed[2] = plan.number_of_blocks;
     fixed[3..6].copy_from_slice(&u24_le(plan.measurement_record_len)?);
-    offset = write_large_measurement_bytes(pal, offset, &fixed)?;
+    offset = write_into_slice(&mut buf, offset, &fixed)?;
 
-    let (next_offset, written_blocks) = write_measurement_record_large(
+    let (next_offset, written_blocks) = write_measurement_record_into_slice(
         pal,
         io,
         plan.meas_info,
         plan.meas_op,
         plan.meas_nonce,
+        &mut buf,
         offset,
     )
     .await?;
@@ -273,15 +273,18 @@ async fn handle_large_measurements_response<'a, Pal: SpdmPal>(
     }
     offset = next_offset;
 
-    offset = write_large_measurement_bytes(pal, offset, plan.nonce)?;
-    offset = write_large_measurement_bytes(pal, offset, &0u16.to_le_bytes())?;
+    offset = write_into_slice(&mut buf, offset, plan.nonce)?;
+    offset = write_into_slice(&mut buf, offset, &0u16.to_le_bytes())?;
     if let Some(ctx) = plan.requester_context {
-        offset = write_large_measurement_bytes(pal, offset, ctx)?;
+        offset = write_into_slice(&mut buf, offset, ctx)?;
     }
 
     let signature_offset = offset;
     if plan.signature_requested {
-        append_buffered_l1(state, pal, io, signature_offset).await?;
+        state
+            .transcript
+            .append_l1(pal, io, &buf[..signature_offset])
+            .await?;
 
         let mut hash = [0u8; SHA384_HASH_SIZE];
         state.transcript.finalize_l1(pal, io, &mut hash).await?;
@@ -300,8 +303,7 @@ async fn handle_large_measurements_response<'a, Pal: SpdmPal>(
         if sig_len != ECC_P384_SIGNATURE_SIZE {
             return Err(SPDM_UNSPECIFIED);
         }
-        pal.large_write(signature_offset, &signature)
-            .map_err(|_| SPDM_UNSPECIFIED)?;
+        write_into_slice(&mut buf, signature_offset, &signature)?;
         offset += ECC_P384_SIGNATURE_SIZE;
     }
 
@@ -309,6 +311,7 @@ async fn handle_large_measurements_response<'a, Pal: SpdmPal>(
         return Err(SPDM_UNSPECIFIED);
     }
 
+    state.large_buf = Some(buf);
     let resp = chunk::start_buffered_large_response(state, pal, io, plan.large_resp_len)?;
     Ok((resp, 0))
 }
@@ -428,12 +431,13 @@ async fn write_measurement_record<Pal: SpdmPal>(
     Ok(blocks)
 }
 
-async fn write_measurement_record_large<Pal: SpdmPal>(
+async fn write_measurement_record_into_slice<Pal: SpdmPal>(
     pal: &Pal,
     io: &<Pal as SpdmPalIoTransport>::Io<'_>,
     info: &[MeasurementInfo],
     meas_op: u8,
     nonce: Option<&[u8; SPDM_NONCE_LEN]>,
+    out: &mut [u8],
     mut offset: usize,
 ) -> SpdmResult<(usize, u8)> {
     let mut blocks = 0u8;
@@ -441,7 +445,9 @@ async fn write_measurement_record_large<Pal: SpdmPal>(
         0x00 => {}
         0xFF => {
             for entry in info {
-                offset = write_measurement_block_large(pal, io, entry, nonce, offset).await?;
+                offset =
+                    write_measurement_record_block_into_slice(pal, io, entry, nonce, out, offset)
+                        .await?;
                 blocks = blocks.checked_add(1).ok_or(SPDM_UNSPECIFIED)?;
             }
         }
@@ -450,23 +456,25 @@ async fn write_measurement_record_large<Pal: SpdmPal>(
                 .iter()
                 .find(|m| m.index == idx)
                 .ok_or(SPDM_INVALID_REQUEST)?;
-            offset = write_measurement_block_large(pal, io, entry, nonce, offset).await?;
+            offset = write_measurement_record_block_into_slice(pal, io, entry, nonce, out, offset)
+                .await?;
             blocks = 1;
         }
     }
     Ok((offset, blocks))
 }
 
-async fn write_measurement_block_large<Pal: SpdmPal>(
+async fn write_measurement_record_block_into_slice<Pal: SpdmPal>(
     pal: &Pal,
     io: &<Pal as SpdmPalIoTransport>::Io<'_>,
     info: &MeasurementInfo,
     nonce: Option<&[u8; SPDM_NONCE_LEN]>,
+    out: &mut [u8],
     mut offset: usize,
 ) -> SpdmResult<usize> {
     let block_hdr =
         DmtfMeasurementBlockHeader::new(info.index, info.is_raw, info.value_type, info.value_size);
-    offset = write_large_measurement_bytes(pal, offset, block_hdr.as_bytes())?;
+    offset = write_into_slice(out, offset, block_hdr.as_bytes())?;
 
     let value_size = info.value_size as usize;
     if value_size == 0 {
@@ -482,7 +490,7 @@ async fn write_measurement_block_large<Pal: SpdmPal>(
         return Err(SPDM_UNSPECIFIED);
     }
 
-    write_large_measurement_bytes(pal, offset, &value)
+    write_into_slice(out, offset, &value)
 }
 
 /// Write a single DMTF measurement block (header + value) into `out`.
@@ -534,33 +542,12 @@ fn u24_le(len: usize) -> SpdmResult<[u8; 3]> {
     ])
 }
 
-fn write_large_measurement_bytes<Pal: SpdmPal>(
-    pal: &Pal,
-    offset: usize,
-    bytes: &[u8],
-) -> SpdmResult<usize> {
+fn write_into_slice(out: &mut [u8], offset: usize, bytes: &[u8]) -> SpdmResult<usize> {
     let next = offset.checked_add(bytes.len()).ok_or(SPDM_UNSPECIFIED)?;
-    pal.large_write(offset, bytes)
-        .map_err(|_| SPDM_UNSPECIFIED)?;
+    out.get_mut(offset..next)
+        .ok_or(SPDM_UNSPECIFIED)?
+        .copy_from_slice(bytes);
     Ok(next)
-}
-
-async fn append_buffered_l1<Pal: SpdmPal>(
-    state: &mut ConnectionState<Pal::State>,
-    pal: &Pal,
-    io: &<Pal as SpdmPalIoTransport>::Io<'_>,
-    len: usize,
-) -> SpdmResult<()> {
-    let mut offset = 0usize;
-    let mut buf = [0u8; 128];
-    while offset < len {
-        let n = (len - offset).min(buf.len());
-        pal.large_read(offset, &mut buf[..n])
-            .map_err(|_| SPDM_UNSPECIFIED)?;
-        state.transcript.append_l1(pal, io, &buf[..n]).await?;
-        offset += n;
-    }
-    Ok(())
 }
 
 /// Build the 100-byte SPDM signing context for MEASUREMENTS.

--- a/runtime/userspace/api/spdm-lite/stack/src/set_certificate.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/set_certificate.rs
@@ -32,7 +32,7 @@ const CERT_MODEL_ALIAS_CERT: u8 = 2;
 const CERT_MODEL_GENERIC_CERT: u8 = 3;
 
 pub(crate) async fn handle_set_certificate<'a, Pal: SpdmPal>(
-    state: &mut ConnectionState<Pal::State>,
+    state: &mut ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
     pal: &'a Pal,
     io: &<Pal as SpdmPalIoTransport>::Io<'_>,
 ) -> SpdmResult<PalBytes<'a, Pal>> {
@@ -45,7 +45,7 @@ pub(crate) async fn handle_set_certificate<'a, Pal: SpdmPal>(
 }
 
 pub(crate) async fn handle_set_certificate_request<Pal: SpdmPal>(
-    state: &mut ConnectionState<Pal::State>,
+    state: &mut ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
     pal: &Pal,
     io: &<Pal as SpdmPalIoTransport>::Io<'_>,
     req: &[u8],
@@ -138,8 +138,8 @@ fn validate_request_slot(slot_id: u8, supported_slots: u8) -> SpdmResult<()> {
     Ok(())
 }
 
-fn validate_request_attributes<S>(
-    state: &ConnectionState<S>,
+fn validate_request_attributes<S, L>(
+    state: &ConnectionState<S, L>,
     req: &SetCertificateReqBody,
 ) -> SpdmResult<()> {
     if state.version < SpdmVersion::V13 {
@@ -165,8 +165,8 @@ fn validate_request_attributes<S>(
     Ok(())
 }
 
-fn effective_cert_model<S>(
-    state: &ConnectionState<S>,
+fn effective_cert_model<S, L>(
+    state: &ConnectionState<S, L>,
     req: &SetCertificateReqBody,
 ) -> SpdmResult<u8> {
     if multi_key_conn_rsp(state)? && req.cert_model() != 0 {
@@ -184,7 +184,9 @@ fn cert_model_from_capabilities(cap_flags: CapFlags) -> u8 {
     }
 }
 
-fn validate_negotiated_set_certificate_algorithms<S>(state: &ConnectionState<S>) -> SpdmResult<()> {
+fn validate_negotiated_set_certificate_algorithms<S, L>(
+    state: &ConnectionState<S, L>,
+) -> SpdmResult<()> {
     if state.negotiated_base_hash_sel != HashAlgos::SHA_384 {
         return Err(SPDM_UNSPECIFIED);
     }
@@ -409,10 +411,7 @@ mod tests {
             = Vec<u8>
         where
             Self: 'a;
-        type LargeBuf<'a>
-            = Vec<u8>
-        where
-            Self: 'a;
+        type LargeBuf = Vec<u8>;
 
         fn alloc<T: Sized>(&self, _io: &impl SpdmPalIo, value: T) -> McuResult<Self::Box<'_, T>> {
             Ok(TestBox {
@@ -429,22 +428,7 @@ mod tests {
             self.mtu
         }
 
-        fn large_begin(&self, _len: usize) -> McuResult<()> {
-            Ok(())
-        }
-
-        fn large_write(&self, _offset: usize, _data: &[u8]) -> McuResult<()> {
-            Ok(())
-        }
-
-        fn large_read(&self, _offset: usize, out: &mut [u8]) -> McuResult<()> {
-            out.fill(0);
-            Ok(())
-        }
-
-        fn large_end(&self) {}
-
-        fn large_take(&self, len: usize) -> McuResult<Self::LargeBuf<'_>> {
+        fn alloc_large_buf(&self, len: usize) -> McuResult<Self::LargeBuf> {
             Ok(vec![0u8; len])
         }
     }
@@ -658,7 +642,7 @@ mod tests {
         digest
     }
 
-    fn state(version: SpdmVersion) -> ConnectionState<TestHashState> {
+    fn state(version: SpdmVersion) -> ConnectionState<TestHashState, Vec<u8>> {
         let mut state = ConnectionState::default();
         state.phase = Phase::AfterAlgorithms;
         state.version = version;
@@ -668,7 +652,7 @@ mod tests {
         state
     }
 
-    fn state_v13_multi_key() -> ConnectionState<TestHashState> {
+    fn state_v13_multi_key() -> ConnectionState<TestHashState, Vec<u8>> {
         let mut state = state(SpdmVersion::V13);
         state.other_param_sel = OtherParamSupport::MULTI_KEY_CONN;
         state.peer_cap_flags = CapFlags::MULTI_KEY_CONN_RSP;

--- a/runtime/userspace/api/spdm-lite/stack/src/stack.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/stack.rs
@@ -19,6 +19,7 @@ use mcu_spdm_lite_codec::{
     MeasHashAlgos, MeasSpec, OtherParamSupport, ReqRespCode, SecuredMessageHeader, SpdmMsgHdrPdu,
     SpdmVersion, AES_256_GCM_TAG_SIZE, SECURED_MSG_HDR_SIZE,
 };
+use mcu_spdm_lite_traits::SpdmPalAlloc;
 use mcu_spdm_lite_traits::*;
 use zerocopy::FromBytes;
 
@@ -72,7 +73,7 @@ pub enum Phase {
 ///    `GET_VERSION` → `GET_CAPABILITIES` → `NEGOTIATE_ALGORITHMS`
 ///    handshake and reset on every `GET_VERSION` via
 ///    [`Self::reset_negotiation`].
-pub struct ConnectionState<S> {
+pub struct ConnectionState<S, L> {
     // ---- Local responder policy (fixed at startup) -----------------------
     /// Responder `CT` time exponent.
     /// Maximum response time is `2^ct_exponent` µs.
@@ -125,9 +126,10 @@ pub struct ConnectionState<S> {
     pub(crate) chunk: chunk::ChunkState,
     /// Pending large response served by CHUNK_GET.
     pub(crate) large_response: chunk::LargeResponseState,
+    pub(crate) large_buf: Option<L>,
 }
 
-impl<S> ConnectionState<S> {
+impl<S, L> ConnectionState<S, L> {
     /// Builds the Caliptra responder's fixed local-policy advertisement.
     ///
     /// # Returns
@@ -183,6 +185,7 @@ impl<S> ConnectionState<S> {
             transcript: crate::transcript::Transcript::new(),
             chunk: chunk::ChunkState::default(),
             large_response: chunk::LargeResponseState::default(),
+            large_buf: None,
         }
     }
 
@@ -203,6 +206,7 @@ impl<S> ConnectionState<S> {
         self.transcript.reset();
         self.chunk.reset();
         self.large_response.reset();
+        self.large_buf = None;
     }
 
     /// Returns true when both peers negotiated CHUNK support.
@@ -237,13 +241,13 @@ impl<S> ConnectionState<S> {
     }
 }
 
-impl<S> Default for ConnectionState<S> {
+impl<S, L> Default for ConnectionState<S, L> {
     fn default() -> Self {
         Self::caliptra()
     }
 }
 
-pub(crate) fn multi_key_conn_rsp<S>(state: &ConnectionState<S>) -> SpdmResult<bool> {
+pub(crate) fn multi_key_conn_rsp<S, L>(state: &ConnectionState<S, L>) -> SpdmResult<bool> {
     let selected = state
         .other_param_sel
         .contains(OtherParamSupport::MULTI_KEY_CONN);
@@ -298,7 +302,7 @@ pub struct SpdmStack<
     Vdm: SpdmVdmBackend = NoVdmBackend,
 > {
     pub(crate) pal: Pal,
-    pub(crate) state: ConnectionState<Pal::State>,
+    pub(crate) state: ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
     pub(crate) sessions:
         SessionManager<<Pal as SpdmPalSessionCrypto>::Key, Pal::State, MAX_SESSIONS>,
     vdm_backend: Vdm,
@@ -331,7 +335,7 @@ impl<Pal: SpdmPal, const MAX_SESSIONS: usize, Vdm: SpdmVdmBackend>
     /// If the PAL cannot hold at least one transport-sized large message,
     /// `CHUNK` is removed from the advertised capabilities.
     pub fn with_vdm_backend(pal: Pal, vdm_backend: Vdm) -> Self {
-        let mut state = ConnectionState::<Pal::State>::default();
+        let mut state = ConnectionState::<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>::default();
         if pal.large_capacity() < pal.mtu() {
             state.cap_flags =
                 CapFlags::from_bits(state.cap_flags.into_bits() & !CapFlags::CHUNK.into_bits());
@@ -547,7 +551,7 @@ impl<Pal: SpdmPal, const MAX_SESSIONS: usize, Vdm: SpdmVdmBackend>
 /// * Whatever the specific handler returns.
 #[inline(never)]
 async fn dispatch<'a, Pal: SpdmPal, Vdm: SpdmVdmBackend, const MAX_SESSIONS: usize>(
-    state: &mut ConnectionState<Pal::State>,
+    state: &mut ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
     sessions: &mut SessionManager<<Pal as SpdmPalSessionCrypto>::Key, Pal::State, MAX_SESSIONS>,
     pal: &'a Pal,
     io: &<Pal as SpdmPalIoTransport>::Io<'_>,
@@ -562,6 +566,7 @@ async fn dispatch<'a, Pal: SpdmPal, Vdm: SpdmVdmBackend, const MAX_SESSIONS: usi
         && state.large_response.in_progress()
     {
         state.large_response.reset();
+        state.large_buf = None;
     }
     match code {
         ReqRespCode::GET_VERSION => {
@@ -625,7 +630,7 @@ async fn handle_secured_request<
     Vdm: SpdmVdmBackend,
     const MAX_SESSIONS: usize,
 >(
-    state: &mut ConnectionState<Pal::State>,
+    state: &mut ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
     sessions: &mut SessionManager<<Pal as SpdmPalSessionCrypto>::Key, Pal::State, MAX_SESSIONS>,
     pal: &'a Pal,
     io: &<Pal as SpdmPalIoTransport>::Io<'_>,
@@ -678,7 +683,7 @@ async fn handle_secured_request<
 /// Inner secured message handler: decrypt → dispatch → encrypt.
 #[inline(never)]
 async fn handle_secured_inner<'a, Pal: SpdmPal, Vdm: SpdmVdmBackend, const MAX_SESSIONS: usize>(
-    state: &mut ConnectionState<Pal::State>,
+    state: &mut ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
     sessions: &mut SessionManager<<Pal as SpdmPalSessionCrypto>::Key, Pal::State, MAX_SESSIONS>,
     pal: &'a Pal,
     io: &<Pal as SpdmPalIoTransport>::Io<'_>,

--- a/runtime/userspace/api/spdm-lite/stack/src/vendor_defined.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/vendor_defined.rs
@@ -13,7 +13,7 @@ use mcu_spdm_lite_codec::{
     VendorDefinedRspBody,
 };
 use mcu_spdm_lite_traits::{
-    PalBytes, SpdmPal, SpdmPalIoTransport, SpdmVdmBackend, VdmRegistry, VdmResponse,
+    PalBytes, SpdmPal, SpdmPalAlloc, SpdmPalIoTransport, SpdmVdmBackend, VdmRegistry, VdmResponse,
     VdmResponseBuffer,
 };
 use zerocopy::{FromBytes, IntoBytes};
@@ -32,7 +32,7 @@ use crate::stack::ConnectionState;
 /// Returns the framed response buffer and its SPDM-payload length.
 pub(crate) async fn handle_vendor_defined_request<'a, Pal: SpdmPal, V: SpdmVdmBackend>(
     vdm: &V,
-    state: &mut ConnectionState<Pal::State>,
+    state: &mut ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
     pal: &'a Pal,
     io: &<Pal as SpdmPalIoTransport>::Io<'_>,
     spdm_msg: &[u8],
@@ -85,7 +85,7 @@ pub(crate) async fn handle_vendor_defined_request<'a, Pal: SpdmPal, V: SpdmVdmBa
     // The guard must be dropped before invoking any other `large_*` PAL method
     // (e.g. `chunk::start_buffered_large_response` calls `large_capacity`).
     let mut large_guard = if large_cap > 0 {
-        Some(pal.large_take(envelope + large_cap)?)
+        Some(pal.alloc_large_buf(envelope + large_cap)?)
     } else {
         None
     };
@@ -137,10 +137,8 @@ pub(crate) async fn handle_vendor_defined_request<'a, Pal: SpdmPal, V: SpdmVdmBa
                 &mut guard[..envelope],
             )?;
             let full_len = envelope + n;
-            // Release the static slice back to the PAL so the chunking layer's
-            // `large_capacity` / `large_read` calls observe it again.
-            drop(guard);
-            chunk::validate_buffered_large_response(state, pal, full_len)?;
+            state.large_buf = Some(guard);
+            chunk::validate_buffered_large_response::<Pal>(state, pal, full_len)?;
             let resp = chunk::start_buffered_large_response(state, pal, io, full_len)?;
             Ok((resp, 0))
         }

--- a/runtime/userspace/api/spdm-lite/stack/src/version.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/version.rs
@@ -9,7 +9,7 @@
 //! GET_VERSION always resets the connection.
 
 use mcu_spdm_lite_codec::{ResponseBody, SpdmMsgHdrPdu, SpdmVersion, VersionRsp};
-use mcu_spdm_lite_traits::{PalBytes, SpdmPal, SpdmPalIo};
+use mcu_spdm_lite_traits::{PalBytes, SpdmPal, SpdmPalAlloc, SpdmPalIo};
 use zerocopy::FromBytes;
 
 use crate::build::build_response;
@@ -53,7 +53,7 @@ pub(crate) const SUPPORTED_VERSIONS: &[SpdmVersion] = &[SpdmVersion::V13, SpdmVe
 ///   `?` and end up as [`SPDM_BUSY`](crate::error::SPDM_BUSY) /
 ///   [`SPDM_INVALID_REQUEST`] respectively.
 pub(crate) async fn handle_get_version<'a, Pal: SpdmPal>(
-    state: &mut ConnectionState<Pal::State>,
+    state: &mut ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
     pal: &'a Pal,
     io: &Pal::Io<'_>,
 ) -> SpdmResult<PalBytes<'a, Pal>> {

--- a/runtime/userspace/api/spdm-lite/traits/src/alloc.rs
+++ b/runtime/userspace/api/spdm-lite/traits/src/alloc.rs
@@ -11,9 +11,9 @@
 //!   are returned as RAII guards implementing [`core::ops::DerefMut`],
 //!   which release the underlying memory back to the pool on drop.
 //!
-//! Allocations are scoped to a single SPDM I/O exchange ([`SpdmPalIo`])
-//! so the platform can correlate allocator lifetime with the in-flight
-//! request and reclaim memory between exchanges.
+//! Most allocations are scoped to a single SPDM I/O exchange ([`SpdmPalIo`]).
+//! One persistent large-message buffer may outlive an exchange while it is
+//! parked on `ConnectionState::large_buf`.
 
 use self::super::*;
 use core::ops::DerefMut;
@@ -61,54 +61,20 @@ pub trait SpdmPalAlloc: mcu_caliptra_api_lite::ApiAlloc {
     // ---- Persistent large-message buffer ------------------------------------
     //
     // One in-flight large SPDM message (a `CHUNK_GET` response or a `CHUNK_SEND`
-    // reassembly buffer) is held in a single persistent buffer that outlives the
-    // request that produces it and is served/consumed over later exchanges.
-    // Backed by the same pool as the per-request scratch (allocated on demand,
-    // reusable as scratch when idle) rather than a dedicated static region.
+    // reassembly buffer) may be allocated from the same pool as scratch memory,
+    // then parked on `ConnectionState::large_buf` so it can survive across later
+    // exchanges until chunking completes.
 
     /// Maximum size, in bytes, of a single in-flight large SPDM message this
     /// responder can hold. Drives the `CHUNK` capability advertisement
     /// (`MaxSPDMmsgSize`) and buffered large-response/request validation.
     fn large_capacity(&self) -> usize;
 
-    /// Reserves the persistent large-message buffer (`len` bytes) from the pool,
-    /// replacing (freeing) any previously-held one. Must be called before
-    /// [`Self::large_write`] / [`Self::large_read`]. The buffer persists across
-    /// requests until [`Self::large_end`] releases it (or the next `large_begin`
-    /// replaces it).
-    fn large_begin(&self, len: usize) -> McuResult<()>;
+    /// RAII guard type returned by [`Self::alloc_large_buf`].
+    type LargeBuf: DerefMut<Target = [u8]>;
 
-    /// Copies `data` into the held large-message buffer at `offset`.
-    fn large_write(&self, offset: usize, data: &[u8]) -> McuResult<()>;
-
-    /// Copies bytes from the held large-message buffer at `offset` into `out`.
-    fn large_read(&self, offset: usize, out: &mut [u8]) -> McuResult<()>;
-
-    /// Releases the large-message buffer back to the pool (freed and zeroed).
-    /// Idempotent: a no-op when no large buffer is currently held.
-    fn large_end(&self);
-
-    /// RAII guard type returned by [`Self::large_take`].
-    ///
-    /// Implementors return any owning handle that derefs to a `[u8]` slice of
-    /// exactly the requested length over the persistent large-message buffer.
-    /// Dropping the guard must return the underlying slice to the PAL so that
-    /// subsequent [`Self::large_read`] / [`Self::large_capacity`] calls see it
-    /// again. The drop **must not** wipe the slice — the bytes need to survive
-    /// for chunked delivery.
-    type LargeBuf<'a>: DerefMut<Target = [u8]>
-    where
-        Self: 'a;
-
-    /// Reserves the persistent large-message buffer and hands out a mutable
-    /// view of exactly `len` bytes to the caller. The bytes survive after the
-    /// guard drops (so `CHUNK_GET` can serve them via [`Self::large_read`]).
-    ///
-    /// While the returned guard is alive, the underlying slice is not parked
-    /// in the PAL, so calls to [`Self::large_capacity`], [`Self::large_begin`],
-    /// [`Self::large_write`], or [`Self::large_read`] from another code path
-    /// will observe an empty buffer. A single-task SPDM responder runs requests
-    /// sequentially, so this is safe — but callers must drop the guard before
-    /// invoking those methods.
-    fn large_take(&self, len: usize) -> McuResult<Self::LargeBuf<'_>>;
+    /// Allocates a persistent large-message buffer of exactly `len` bytes.
+    /// Callers move the returned guard onto `ConnectionState::large_buf` when the
+    /// message must survive across later exchanges.
+    fn alloc_large_buf(&self, len: usize) -> McuResult<Self::LargeBuf>;
 }

--- a/runtime/userspace/api/spdm-lite/vdm-handler/src/iana/ocp/caliptra_vdm/mod.rs
+++ b/runtime/userspace/api/spdm-lite/vdm-handler/src/iana/ocp/caliptra_vdm/mod.rs
@@ -286,10 +286,7 @@ mod tests {
             = Vec<u8>
         where
             Self: 'a;
-        type LargeBuf<'a>
-            = Vec<u8>
-        where
-            Self: 'a;
+        type LargeBuf = Vec<u8>;
 
         fn alloc<T: Sized>(&self, _io: &impl SpdmPalIo, value: T) -> McuResult<Self::Box<'_, T>> {
             Ok(TestBox {
@@ -306,21 +303,7 @@ mod tests {
             4096
         }
 
-        fn large_begin(&self, _len: usize) -> McuResult<()> {
-            Ok(())
-        }
-
-        fn large_write(&self, _offset: usize, _data: &[u8]) -> McuResult<()> {
-            Ok(())
-        }
-
-        fn large_read(&self, _offset: usize, _out: &mut [u8]) -> McuResult<()> {
-            Ok(())
-        }
-
-        fn large_end(&self) {}
-
-        fn large_take(&self, len: usize) -> McuResult<Self::LargeBuf<'_>> {
+        fn alloc_large_buf(&self, len: usize) -> McuResult<Self::LargeBuf> {
             Ok(vec![0; len])
         }
     }


### PR DESCRIPTION
Move the CHUNK_GET/CHUNK_SEND large-message buffer from a dedicated static region into the existing per-task BitmapAllocator pool. The
buffer is stored as ConnectionState::large_buf: Option<Pal::LargeBuf>
alongside the existing LargeResponseState and ChunkState structs.

Key changes:
- BitmapAllocator lifted to 'static via StaticBitmapAllocatorCell (one-shot init per task; guards carry &'static BitmapAllocator)
- Bidirectional allocation: alloc_bytes (transient) scans left-to-right; alloc<T> (stateful) scans right-to-left to reduce fragmentation
- New SpdmPalAlloc::alloc_large_buf returns an owned LargeBuf (no lifetime parameter) storable on ConnectionState across SPDM cycles
- Old PAL large_begin/write/read/end/take methods deleted
- CHUNK_GET/SEND handlers read/write state.large_buf directly
- Measurements + VDM handlers write directly into the allocated slice
- Per-request bulk allocator reset removed (pure RAII)
- MCTP_LARGE_MSG and DOE_LARGE_MSG static buffers deleted
- SPDM_LITE_SCRATCH_SIZE: 8K -> 12K (holds transient + large message)
- Allocator instrumentation: live_slots, max_live_slots, largest_free_run
- Fragmentation soak test + bidirectional allocation test

Memory delta vs spdm-lite (fded89cd):
  SPDM .text +668 B    SPDM .bss -8,136 B    RAM -8,136 B