### PR TITLE
spdm-lite: unified task scratch buffer and large message handling

### DIFF
--- a/platforms/emulator/runtime/userspace/apps/user/src/spdm/device_measurements/ocp_eat/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/spdm/device_measurements/ocp_eat/mod.rs
@@ -18,6 +18,7 @@ pub mod claims;
 use mcu_caliptra_api_lite::signed_eat::SignedEatLite;
 use mcu_caliptra_api_lite::{
     dpe_certify_key_pubkey, sha_finish, sha_init, sha_update, HashAlgo, DPE_LABEL_LEN,
+    SHA_CONTEXT_SIZE,
 };
 use mcu_error::McuResult;
 use mcu_spdm_lite_pal::measurements::MeasurementProvider;
@@ -111,7 +112,8 @@ async fn compute_kid(
 
     dpe_certify_key_pubkey(alloc, key_label, &mut pubkey_x, &mut pubkey_y).await?;
 
-    let mut state = sha_init(alloc, HashAlgo::Sha384, &pubkey_x).await?;
+    let sha_buf = alloc.alloc_bytes(SHA_CONTEXT_SIZE)?;
+    let mut state = sha_init(alloc, sha_buf, HashAlgo::Sha384, &pubkey_x).await?;
     sha_update(alloc, &mut state, &pubkey_y).await?;
     sha_finish(alloc, &mut state, kid).await?;
 

--- a/platforms/emulator/runtime/userspace/apps/user/src/spdm/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/spdm/mod.rs
@@ -27,7 +27,7 @@ use embassy_executor::Spawner;
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_sync::signal::Signal;
 use mcu_spdm_lite_pal::cert::store::SharedCertStore;
-use mcu_spdm_lite_pal::{McuSpdmPal, BITMAP_SLOT_SIZE};
+use mcu_spdm_lite_pal::{BitmapAllocator, McuSpdmPal, StaticBitmapAllocatorCell, BITMAP_SLOT_SIZE};
 use mcu_spdm_lite_stack::SpdmStack;
 use mcu_spdm_lite_transports::{McuSpdmDoeTransport, McuSpdmMctpTransport};
 use mcu_spdm_lite_vdm_handler::iana::ocp::caliptra_vdm::CaliptraVdm;
@@ -42,12 +42,7 @@ use mcu_spdm_lite_vdm_handler::pci_sig::{
 /// Must hold `MEAS_RECORD_BUF_SIZE + MeasurementProvider::SCRATCH_SIZE`
 /// plus transient DPE/SHA mailbox buffers (peak ~2.4 KB during
 /// certify_key for kid computation).
-const SPDM_LITE_SCRATCH_SIZE: usize = 8 * 1024;
-/// Size of the dedicated static buffer holding one in-flight large SPDM message
-/// (a `CHUNK_GET` response or `CHUNK_SEND` reassembly). Separate from the
-/// scratch pool so it survives the per-request allocator reset; its length caps
-/// `MaxSPDMmsgSize`.
-const SPDM_LITE_LARGE_MSG_SIZE: usize = 8 * 1024;
+const SPDM_LITE_SCRATCH_SIZE: usize = 12 * 1024;
 
 #[cfg(feature = "test-doe-spdm-tdisp-ide-validator")]
 const TEST_PCI_SIG_VENDOR_ID: u16 = 0x0001;
@@ -128,18 +123,18 @@ async fn spdm_mctp_responder() {
     #[repr(C, align(64))]
     struct ScratchBuf([u8; SPDM_LITE_SCRATCH_SIZE]);
     static mut MCTP_SCRATCH: ScratchBuf = ScratchBuf([0u8; SPDM_LITE_SCRATCH_SIZE]);
-    struct LargeMsgBuf([u8; SPDM_LITE_LARGE_MSG_SIZE]);
-    static mut MCTP_LARGE_MSG: LargeMsgBuf = LargeMsgBuf([0u8; SPDM_LITE_LARGE_MSG_SIZE]);
     // SAFETY: this task is the sole owner of `MCTP_SCRATCH`.
     let scratch_ptr: NonNull<u8> = unsafe { NonNull::new_unchecked(MCTP_SCRATCH.0.as_mut_ptr()) };
-    // SAFETY: this task is the sole owner of `MCTP_LARGE_MSG`.
-    let large_msg: &'static mut [u8] = unsafe { &mut (*core::ptr::addr_of_mut!(MCTP_LARGE_MSG)).0 };
     debug_assert_eq!(scratch_ptr.as_ptr() as usize % BITMAP_SLOT_SIZE, 0);
 
+    // SAFETY: `init_once` is called once per task lifetime; this is the
+    // MCTP responder task. Backing memory (`MCTP_SCRATCH`) is `'static`.
+    static MCTP_ALLOC_CELL: StaticBitmapAllocatorCell = StaticBitmapAllocatorCell::new();
+    let allocator: &'static BitmapAllocator =
+        unsafe { MCTP_ALLOC_CELL.init_once(scratch_ptr, SPDM_LITE_SCRATCH_SIZE) };
+
     {
-        let init_alloc =
-            unsafe { mcu_spdm_lite_pal::BitmapAllocator::new(scratch_ptr, SPDM_LITE_SCRATCH_SIZE) };
-        if let Err(e) = ensure_cert_store_init(&init_alloc).await {
+        if let Err(e) = ensure_cert_store_init(allocator).await {
             crate::console_writeln!(cw, "SPDM_MCTP: cert store init failed: 0x{:08x}", e);
             return;
         }
@@ -153,19 +148,9 @@ async fn spdm_mctp_responder() {
         .expect("MCTP_SPDM driver with MCTP_MSG_TYPE_SPDM is a valid pairing"),
     );
 
-    // SAFETY: `MCTP_SCRATCH` and `MCTP_LARGE_MSG` are statically allocated and
-    // exclusively owned by this task; `MCTP_SCRATCH` is aligned for the bitmap
-    // allocator by `#[repr(align(64))]`.
-    let pal = unsafe {
-        McuSpdmPal::new(
-            transport,
-            scratch_ptr,
-            SPDM_LITE_SCRATCH_SIZE,
-            &CERT_STORE,
-            Some(large_msg),
-            measurement_provider(),
-        )
-    };
+    // SAFETY: `allocator` is the `&'static` handle obtained above and is
+    // exclusive to this task.
+    let pal = unsafe { McuSpdmPal::new(transport, allocator, &CERT_STORE, measurement_provider()) };
     // MCTP hosts the IANA / Caliptra VDM backend (plaintext today). DOE uses
     // the default NoVdmBackend unless the TDISP validator feature wires PCI-SIG.
     static MCTP_VDM_HOOK: caliptra_vdm::CaliptraVdmHook = caliptra_vdm::CaliptraVdmHook;
@@ -191,37 +176,27 @@ async fn spdm_doe_responder() {
     #[repr(C, align(64))]
     struct ScratchBuf([u8; SPDM_LITE_SCRATCH_SIZE]);
     static mut DOE_SCRATCH: ScratchBuf = ScratchBuf([0u8; SPDM_LITE_SCRATCH_SIZE]);
-    struct LargeMsgBuf([u8; SPDM_LITE_LARGE_MSG_SIZE]);
-    static mut DOE_LARGE_MSG: LargeMsgBuf = LargeMsgBuf([0u8; SPDM_LITE_LARGE_MSG_SIZE]);
     // SAFETY: this task is the sole owner of `DOE_SCRATCH`.
     let scratch_ptr: NonNull<u8> = unsafe { NonNull::new_unchecked(DOE_SCRATCH.0.as_mut_ptr()) };
-    // SAFETY: this task is the sole owner of `DOE_LARGE_MSG`.
-    let large_msg: &'static mut [u8] = unsafe { &mut (*core::ptr::addr_of_mut!(DOE_LARGE_MSG)).0 };
     debug_assert_eq!(scratch_ptr.as_ptr() as usize % BITMAP_SLOT_SIZE, 0);
 
+    // SAFETY: `init_once` is called once per task lifetime; this is the
+    // DOE responder task. Backing memory (`DOE_SCRATCH`) is `'static`.
+    static DOE_ALLOC_CELL: StaticBitmapAllocatorCell = StaticBitmapAllocatorCell::new();
+    let allocator: &'static BitmapAllocator =
+        unsafe { DOE_ALLOC_CELL.init_once(scratch_ptr, SPDM_LITE_SCRATCH_SIZE) };
+
     {
-        let init_alloc =
-            unsafe { mcu_spdm_lite_pal::BitmapAllocator::new(scratch_ptr, SPDM_LITE_SCRATCH_SIZE) };
-        if let Err(e) = ensure_cert_store_init(&init_alloc).await {
+        if let Err(e) = ensure_cert_store_init(allocator).await {
             crate::console_writeln!(cw, "SPDM_DOE: cert store init failed: 0x{:08x}", e);
             return;
         }
     }
 
     let transport = alloc::boxed::Box::new(doe_transport);
-    // SAFETY: `DOE_SCRATCH` and `DOE_LARGE_MSG` are statically allocated and
-    // exclusively owned by this task; `DOE_SCRATCH` is aligned for the bitmap
-    // allocator by `#[repr(align(64))]`.
-    let pal = unsafe {
-        McuSpdmPal::new(
-            transport,
-            scratch_ptr,
-            SPDM_LITE_SCRATCH_SIZE,
-            &CERT_STORE,
-            Some(large_msg),
-            measurement_provider(),
-        )
-    };
+    // SAFETY: `allocator` is the `&'static` handle obtained above and is
+    // exclusive to this task.
+    let pal = unsafe { McuSpdmPal::new(transport, allocator, &CERT_STORE, measurement_provider()) };
     #[cfg(feature = "test-doe-spdm-tdisp-ide-validator")]
     let mut stack = SpdmStack::<_, 1, _>::with_vdm_backend(
         pal,

--- a/runtime/userspace/api/caliptra-api-lite/src/lib.rs
+++ b/runtime/userspace/api/caliptra-api-lite/src/lib.rs
@@ -58,7 +58,9 @@ pub use fe_prog::fe_prog;
 pub use hmac::{cm_hmac, hkdf_expand, hkdf_extract, HkdfSalt, CMB_HMAC_MAX_SIZE};
 pub use import::{cm_delete, cm_import};
 pub use rng::rng_generate;
-pub use sha::{sha_finish, sha_init, sha_update, HashAlgo, HashState, SHA_CHUNK_SIZE};
+pub use sha::{
+    sha_finish, sha_init, sha_update, HashAlgo, HashState, SHA_CHUNK_SIZE, SHA_CONTEXT_SIZE,
+};
 pub use types::{CmKeyUsage, Cmk, CMK_SIZE};
 
 pub use mcu_error::{McuErrorCode, McuResult};

--- a/runtime/userspace/api/caliptra-api-lite/src/sha.rs
+++ b/runtime/userspace/api/caliptra-api-lite/src/sha.rs
@@ -7,18 +7,14 @@
 //! never inflates the task future with multi-kilobyte mailbox-request
 //! structs.
 //!
-//! The 200-byte SHA running-context is held in a fallibly allocated
-//! [`Box`] so [`HashState`] stays pointer-sized in async futures and
-//! other holders. That keeps the per-handler future state slim while
-//! the actual SHA context lives on the system heap and is freed
-//! automatically on drop.
+//! The 200-byte SHA running-context is held in a caller-supplied buffer
+//! (`B: DerefMut<Target = [u8]>`) so [`HashState`] stays pointer-sized
+//! in async futures. The buffer is typically allocated from a per-task
+//! bitmap pool (spdm-lite) or a heap `Vec` (test environments).
 
-extern crate alloc;
-
-use alloc::alloc::{alloc_zeroed, Layout};
-use alloc::boxed::Box;
 use core::mem::size_of;
-use mcu_error::codes::{INTERNAL_BUG, INVARIANT, OUT_OF_MEMORY};
+use core::ops::{Deref, DerefMut};
+use mcu_error::codes::{INTERNAL_BUG, INVARIANT};
 use mcu_error::McuResult;
 use zerocopy::{little_endian::U32, FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
@@ -38,62 +34,49 @@ use crate::ApiAlloc;
 pub const SHA_CHUNK_SIZE: usize = 512;
 const _: () = assert!(SHA_CHUNK_SIZE <= MAX_CMB_DATA_SIZE);
 
+/// Size (in bytes) of the opaque SHA running-context buffer that
+/// callers must allocate for each [`HashState`].
+pub const SHA_CONTEXT_SIZE: usize = CMB_SHA_CONTEXT_SIZE;
+
 /// Caliptra-mailbox SHA running-context.
 ///
-/// The 200-byte opaque context blob is stored on the heap behind a
-/// pointer, so `HashState` stays small inline. This is critical for
-/// SPDM transcript-tracking where multiple [`HashState`]s live across
-/// many async `.await` points — keeping each holder slim avoids
-/// ballooning the task future.
+/// The 200-byte opaque context blob is stored in a caller-supplied
+/// buffer `B`, so `HashState` stays small inline. This is critical
+/// for SPDM transcript-tracking where multiple [`HashState`]s live
+/// across many async `.await` points — keeping each holder slim
+/// avoids ballooning the task future.
 ///
-/// # Heap allocation
-///
-/// Each `HashState` allocates [`CMB_SHA_CONTEXT_SIZE`] (200) bytes
-/// from the **global heap** via a fallible allocation. spdm-lite may
-/// hold up to `3 + N` live instances (3 main transcripts + 1 TH per
-/// session), so the peak heap cost is `(3 + N) × 200` bytes (800 B
-/// for N = 1). Callers sizing the runtime heap budget must account
-/// for this.
-pub struct HashState {
-    inner: Box<[u8; CMB_SHA_CONTEXT_SIZE]>,
+/// `B` is typically a bitmap-pool guard (`BitmapBytes<'static>` in
+/// production) or a `Vec<u8>` in tests.
+pub struct HashState<B> {
+    inner: B,
 }
 
-impl HashState {
-    /// Allocate a fresh, all-zero `HashState`. Not a valid running
-    /// hash — must be initialized via [`sha_init`] before use.
-    pub fn try_new() -> McuResult<Self> {
-        // SAFETY: `layout()` is non-zero and matches the boxed array
-        // type below. A null return is handled as OUT_OF_MEMORY.
-        let ptr = unsafe { alloc_zeroed(Self::layout()) }.cast::<[u8; CMB_SHA_CONTEXT_SIZE]>();
-        if ptr.is_null() {
-            return Err(OUT_OF_MEMORY);
-        }
-        // SAFETY: `ptr` came from the global allocator with the exact
-        // layout for `[u8; CMB_SHA_CONTEXT_SIZE]`; Box now owns and
-        // deallocates it.
-        let inner = unsafe { Box::from_raw(ptr) };
-        Ok(Self { inner })
+impl<B: Deref<Target = [u8]> + DerefMut> HashState<B> {
+    /// Wrap an existing zeroed buffer as a HashState.
+    ///
+    /// Buffer must be at least [`CMB_SHA_CONTEXT_SIZE`] bytes.
+    /// Caller is responsible for zeroing before first use with
+    /// [`sha_init`].
+    #[inline]
+    pub fn from_buf(buf: B) -> Self {
+        Self { inner: buf }
     }
 
-    /// Fallibly deep-copy this running hash state.
-    pub fn try_clone(&self) -> McuResult<Self> {
-        let mut new = Self::try_new()?;
-        new.ctx_mut().copy_from_slice(self.ctx());
-        Ok(new)
+    /// Deep-copy this running hash state into a new buffer.
+    pub fn clone_into<B2: Deref<Target = [u8]> + DerefMut>(&self, mut buf: B2) -> HashState<B2> {
+        buf[..CMB_SHA_CONTEXT_SIZE].copy_from_slice(&self.inner[..CMB_SHA_CONTEXT_SIZE]);
+        HashState { inner: buf }
     }
 
     #[inline]
-    fn ctx(&self) -> &[u8; CMB_SHA_CONTEXT_SIZE] {
-        self.inner.as_ref()
+    fn ctx(&self) -> &[u8] {
+        &self.inner[..CMB_SHA_CONTEXT_SIZE]
     }
 
     #[inline]
-    fn ctx_mut(&mut self) -> &mut [u8; CMB_SHA_CONTEXT_SIZE] {
-        self.inner.as_mut()
-    }
-
-    const fn layout() -> Layout {
-        Layout::new::<[u8; CMB_SHA_CONTEXT_SIZE]>()
+    fn ctx_mut(&mut self) -> &mut [u8] {
+        &mut self.inner[..CMB_SHA_CONTEXT_SIZE]
     }
 }
 
@@ -163,14 +146,25 @@ const FINAL_RSP_MAX_LEN: usize = size_of::<ShaFinalRespPrefix>() + 64;
 // Public API
 // ---------------------------------------------------------------------------
 
-/// Begin a new running hash and return the resulting state.
+/// Begin a new running hash over a caller-supplied buffer.
+///
+/// `buf` must be at least [`CMB_SHA_CONTEXT_SIZE`] bytes. The caller
+/// allocates the buffer (from bitmap pool, heap, or stack) and passes
+/// ownership here.
 ///
 /// `seed` may be any length; data beyond [`SHA_CHUNK_SIZE`] is fed through
 /// chunked [`sha_update`] calls after the initial `CM_SHA_INIT`, mirroring
 /// how `sha_update` chunks internally.
 #[inline(never)]
-pub async fn sha_init<A: ApiAlloc>(alloc: &A, algo: HashAlgo, seed: &[u8]) -> McuResult<HashState> {
-    let mut state = HashState::try_new()?;
+pub async fn sha_init<A: ApiAlloc, B: Deref<Target = [u8]> + DerefMut>(
+    alloc: &A,
+    mut buf: B,
+    algo: HashAlgo,
+    seed: &[u8],
+) -> McuResult<HashState<B>> {
+    // Zero the context region before first use.
+    buf[..CMB_SHA_CONTEXT_SIZE].fill(0);
+    let mut state = HashState::from_buf(buf);
     let first_len = seed.len().min(SHA_CHUNK_SIZE);
     let (first, rest) = seed.split_at(first_len);
     sha_call(
@@ -191,9 +185,9 @@ pub async fn sha_init<A: ApiAlloc>(alloc: &A, algo: HashAlgo, seed: &[u8]) -> Mc
 /// Append `data` to a running hash. `data` may be any length; this
 /// function chunks internally as needed.
 #[inline(never)]
-pub async fn sha_update<A: ApiAlloc>(
+pub async fn sha_update<A: ApiAlloc, B: Deref<Target = [u8]> + DerefMut>(
     alloc: &A,
-    state: &mut HashState,
+    state: &mut HashState<B>,
     data: &[u8],
 ) -> McuResult<()> {
     if data.is_empty() {
@@ -209,9 +203,9 @@ pub async fn sha_update<A: ApiAlloc>(
 /// `out`. After this call, `state` is no longer a valid running
 /// hash.
 #[inline(never)]
-pub async fn sha_finish<A: ApiAlloc>(
+pub async fn sha_finish<A: ApiAlloc, B: Deref<Target = [u8]> + DerefMut>(
     alloc: &A,
-    state: &mut HashState,
+    state: &mut HashState<B>,
     out: &mut [u8],
 ) -> McuResult<()> {
     sha_call(alloc, CMD_CM_SHA_FINAL, None, &[], state, Some(out)).await
@@ -221,12 +215,12 @@ pub async fn sha_finish<A: ApiAlloc>(
 // Shared private workhorse — one async state machine for all 3 ops.
 // ---------------------------------------------------------------------------
 
-async fn sha_call<A: ApiAlloc>(
+async fn sha_call<A: ApiAlloc, B: Deref<Target = [u8]> + DerefMut>(
     alloc: &A,
     cmd: u32,
     algo: Option<u32>,
     data: &[u8],
-    state: &mut HashState,
+    state: &mut HashState<B>,
     out: Option<&mut [u8]>,
 ) -> McuResult<()> {
     let chunk_len = data.len();
@@ -250,7 +244,7 @@ async fn sha_call<A: ApiAlloc>(
     } else {
         let prefix =
             ShaUpdatePrefix::mut_from_bytes(&mut req[..prefix_len]).map_err(|_| INVARIANT)?;
-        prefix.context = *state.ctx();
+        prefix.context.copy_from_slice(state.ctx());
         prefix.input_size = U32::new(chunk_len as u32);
     }
     req[prefix_len..prefix_len + chunk_len].copy_from_slice(data);
@@ -280,7 +274,7 @@ async fn sha_call<A: ApiAlloc>(
     } else {
         let parsed = ShaCtxResp::ref_from_bytes(&rsp[..size_of::<ShaCtxResp>()])
             .map_err(|_| INTERNAL_BUG)?;
-        *state.ctx_mut() = parsed.context;
+        state.ctx_mut().copy_from_slice(&parsed.context);
     }
     Ok(())
 }

--- a/runtime/userspace/api/caliptra-api-lite/src/signed_eat.rs
+++ b/runtime/userspace/api/caliptra-api-lite/src/signed_eat.rs
@@ -4,7 +4,7 @@
 
 use crate::dpe::{dpe_sign_ecc_p384, DPE_LABEL_LEN, DPE_P384_SIGNATURE_SIZE};
 use crate::eat::cbor_bstr_len;
-use crate::sha::{sha_finish, sha_init, sha_update, HashAlgo};
+use crate::sha::{sha_finish, sha_init, sha_update, HashAlgo, SHA_CONTEXT_SIZE};
 use crate::ApiAlloc;
 use mcu_error::codes::INVARIANT;
 use mcu_error::McuResult;
@@ -130,7 +130,8 @@ impl<'a> SignedEatLite<'a> {
         alloc: &A,
         payload: &[u8],
     ) -> McuResult<[u8; DPE_P384_SIGNATURE_SIZE]> {
-        let mut state = sha_init(alloc, HashAlgo::Sha384, &SIG_PREAMBLE).await?;
+        let sha_buf = alloc.alloc(SHA_CONTEXT_SIZE)?;
+        let mut state = sha_init(alloc, sha_buf, HashAlgo::Sha384, &SIG_PREAMBLE).await?;
         let mut payload_header = [0u8; 9];
         let payload_header_len =
             write_cose_payload_bstr_len(&mut payload_header, payload.len()).ok_or(INVARIANT)?;

--- a/runtime/userspace/api/spdm-lite/pal/src/alloc.rs
+++ b/runtime/userspace/api/spdm-lite/pal/src/alloc.rs
@@ -13,9 +13,8 @@
 //!   (used by receive paths that allocate `mtu()` and trim to the real
 //!   message length).
 //!
-//! The allocator is reset by [`McuSpdmPal`] at the start of every
-//! `recv_request`, so allocations are logically scoped to a single SPDM
-//! exchange even though the allocator object itself outlives every box.
+//! The allocator serves both per-request scratch allocations and any
+//! connection-scoped large-message buffer parked on `ConnectionState`.
 //!
 //! # Soundness
 //!
@@ -26,45 +25,6 @@
 use super::measurements::MeasurementProvider;
 use super::*;
 use core::cell::Cell;
-use core::ops::{Deref, DerefMut};
-
-/// RAII guard handed out by [`SpdmPalAlloc::large_take`]. While alive, owns
-/// the static large-message slice and derefs to `&mut [u8]` of exactly the
-/// requested length. On drop, returns the slice to the PAL's [`Cell`] without
-/// wiping — the bytes survive for `CHUNK_GET` to serve via `large_read`.
-pub struct BitmapLargeBuf<'a> {
-    slice: Option<&'static mut [u8]>,
-    len: usize,
-    cell: &'a Cell<Option<&'static mut [u8]>>,
-}
-
-impl Deref for BitmapLargeBuf<'_> {
-    type Target = [u8];
-    fn deref(&self) -> &[u8] {
-        let buf = self.slice.as_deref().expect("BitmapLargeBuf slice missing");
-        &buf[..self.len]
-    }
-}
-
-impl DerefMut for BitmapLargeBuf<'_> {
-    fn deref_mut(&mut self) -> &mut [u8] {
-        let buf = self
-            .slice
-            .as_deref_mut()
-            .expect("BitmapLargeBuf slice missing");
-        &mut buf[..self.len]
-    }
-}
-
-impl Drop for BitmapLargeBuf<'_> {
-    fn drop(&mut self) {
-        // Park the slice back in the PAL. Do NOT wipe — the bytes need to
-        // survive across the rest of this request and the subsequent
-        // CHUNK_GET cycles. `pal.large_end()` (called by the chunking layer
-        // after the final chunk ships) is responsible for the wipe.
-        self.cell.set(self.slice.take());
-    }
-}
 
 impl<M: MeasurementProvider> SpdmPalAlloc for McuSpdmPal<M> {
     type Box<'a, T>
@@ -118,83 +78,19 @@ impl<M: MeasurementProvider> SpdmPalAlloc for McuSpdmPal<M> {
     }
 
     fn large_capacity(&self) -> usize {
-        let large_buf = self.large_buf.take();
-        let capacity = large_buf.as_deref().map_or(0, <[u8]>::len);
-        self.large_buf.set(large_buf);
-        capacity
+        self.allocator.largest_free_run() * crate::BITMAP_SLOT_SIZE
     }
 
-    fn large_begin(&self, len: usize) -> McuResult<()> {
-        // Static buffer: nothing to allocate — just bound-check against capacity.
-        if len > self.large_capacity() {
-            return Err(ERR_OUT_OF_MEMORY);
-        }
-        Ok(())
+    type LargeBuf = BitmapBytes<'static>;
+
+    fn alloc_large_buf(&self, len: usize) -> McuResult<Self::LargeBuf> {
+        self.allocator.alloc_bytes(len)
     }
 
-    fn large_write(&self, offset: usize, data: &[u8]) -> McuResult<()> {
-        let mut held = self.large_buf.take();
-        let result = (|| {
-            let buf = held.as_deref_mut().ok_or(INVARIANT)?;
-            let end = offset.checked_add(data.len()).ok_or(INVARIANT)?;
-            buf.get_mut(offset..end)
-                .ok_or(INVARIANT)?
-                .copy_from_slice(data);
-            Ok(())
-        })();
-        self.large_buf.set(held);
-        result
-    }
+    type PersistentBox<T: Sized + 'static> = McuSpdmBox<'static, T>;
 
-    fn large_read(&self, offset: usize, out: &mut [u8]) -> McuResult<()> {
-        let held = self.large_buf.take();
-        let result = (|| {
-            let buf = held.as_deref().ok_or(INVARIANT)?;
-            let end = offset.checked_add(out.len()).ok_or(INVARIANT)?;
-            out.copy_from_slice(buf.get(offset..end).ok_or(INVARIANT)?);
-            Ok(())
-        })();
-        self.large_buf.set(held);
-        result
-    }
-
-    fn large_end(&self) {
-        // Wipe the message bytes but keep the static slice parked in the Cell
-        // for reuse by the next large message.
-        let mut held = self.large_buf.take();
-        if let Some(buf) = held.as_deref_mut() {
-            buf.fill(0);
-        }
-        self.large_buf.set(held);
-    }
-
-    type LargeBuf<'a>
-        = BitmapLargeBuf<'a>
-    where
-        Self: 'a;
-
-    /// Takes the static large-message slice into an RAII handle of exactly
-    /// `len` bytes. While the handle is alive the slice is detached from the
-    /// PAL Cell, so callers must drop the handle before invoking any other
-    /// `large_*` method (capacity / write / read / end) on this PAL.
-    fn large_take(&self, len: usize) -> McuResult<Self::LargeBuf<'_>> {
-        let held = self.large_buf.take();
-        let Some(slice) = held else {
-            // Either no static buffer was provisioned at PAL construction, or
-            // a prior `large_take` handle is still alive. Either way, there is
-            // nothing to hand out.
-            self.large_buf.set(None);
-            return Err(INVARIANT);
-        };
-        if len > slice.len() {
-            self.large_buf.set(Some(slice));
-            return Err(ERR_OUT_OF_MEMORY);
-        }
-        Ok(BitmapLargeBuf {
-            slice: Some(slice),
-            len,
-            cell: &self.large_buf,
-        })
+    fn alloc_persistent<T: Sized + 'static>(&self, value: T) -> McuResult<Self::PersistentBox<T>> {
+        self.allocator.alloc(value)
     }
 }
 
@@ -219,7 +115,7 @@ impl<M: MeasurementProvider> SpdmPalAlloc for McuSpdmPal<M> {
 
 use core::cell::UnsafeCell;
 use core::marker::PhantomData;
-use core::mem::{align_of, size_of};
+use core::mem::{align_of, size_of, MaybeUninit};
 use core::ptr::NonNull;
 
 /// Slot granularity in bytes. Each bit in the occupancy bitmap tracks one
@@ -231,9 +127,7 @@ use core::ptr::NonNull;
 /// bitmap small (1 bit per 64 bytes ≈ 0.2 % overhead).
 pub const BITMAP_SLOT_SIZE: usize = 64;
 
-use mcu_error::codes::{
-    BAD_ALIGNMENT as ERR_BAD_ALIGNMENT, INVARIANT, OUT_OF_MEMORY as ERR_OUT_OF_MEMORY,
-};
+use mcu_error::codes::{BAD_ALIGNMENT as ERR_BAD_ALIGNMENT, OUT_OF_MEMORY as ERR_OUT_OF_MEMORY};
 
 /// Single-threaded bitmap allocator over a caller-supplied buffer.
 ///
@@ -249,6 +143,13 @@ pub struct BitmapAllocator {
     data: NonNull<u8>,
     /// Number of slots managed by the bitmap.
     num_slots: usize,
+    /// Running count of slots currently marked live (incremented by
+    /// `alloc_run`, decremented by `free_run`). Maintained for cheap
+    /// `live_slots()` and as the running input to `max_live_slots`.
+    live_count: Cell<u32>,
+    /// High-water mark of `live_count` over the allocator's lifetime.
+    /// Updated on every `alloc_run`. Read via `max_live_slots()`.
+    max_live: Cell<u32>,
     /// Interior mutability marker; the actual bitmap storage lives in the buffer.
     _state: UnsafeCell<()>,
     /// `!Send` + `!Sync` marker.
@@ -315,6 +216,8 @@ impl BitmapAllocator {
             base: ptr,
             data,
             num_slots,
+            live_count: Cell::new(0),
+            max_live: Cell::new(0),
             _state: UnsafeCell::new(()),
             _not_send: PhantomData,
         }
@@ -328,6 +231,51 @@ impl BitmapAllocator {
     /// number of single-slot allocations that can be live at once.
     pub fn num_slots(&self) -> usize {
         self.num_slots
+    }
+
+    /// Returns the number of slots currently marked live (the running
+    /// count maintained by [`Self::alloc_run`] and [`Self::free_run`]).
+    ///
+    /// A correctly-functioning steady-state responder returns to a known
+    /// baseline (zero, or the count of slots held by persistent allocations
+    /// owned by `ConnectionState`) between SPDM requests. A drift above the
+    /// baseline points at a leaked [`BitmapBytes`] / [`McuSpdmBox`] handle.
+    pub fn live_slots(&self) -> usize {
+        self.live_count.get() as usize
+    }
+
+    /// Returns the highest value [`Self::live_slots`] has reached since
+    /// allocator construction. Updated on every [`Self::alloc_run`].
+    ///
+    /// Useful for sizing the scratch region against observed peaks.
+    pub fn max_live_slots(&self) -> usize {
+        self.max_live.get() as usize
+    }
+
+    /// Returns the largest contiguous run of currently-free slots, in
+    /// slot units. O(num_slots) scan — intended for diagnostics, not
+    /// the hot path.
+    ///
+    /// Useful for spotting fragmentation: `live_slots() + largest_free_run()`
+    /// can be less than `num_slots()` when free space is split across the
+    /// bitmap.
+    pub fn largest_free_run(&self) -> usize {
+        let mut best = 0usize;
+        let mut run = 0usize;
+        for i in 0..self.num_slots {
+            if self.bit(i) {
+                if run > best {
+                    best = run;
+                }
+                run = 0;
+            } else {
+                run += 1;
+            }
+        }
+        if run > best {
+            best = run;
+        }
+        best
     }
 
     /// Resets the allocator by clearing every bit in the occupancy bitmap.
@@ -345,6 +293,7 @@ impl BitmapAllocator {
     pub unsafe fn reset(&self) {
         let bm_bytes = self.num_slots.div_ceil(8);
         core::ptr::write_bytes(self.base.as_ptr(), 0, bm_bytes);
+        self.live_count.set(0);
     }
 
     /// Allocates a byte buffer of `len` bytes from the pool.
@@ -412,7 +361,7 @@ impl BitmapAllocator {
         if n > u16::MAX as usize {
             return Err(ERR_OUT_OF_MEMORY);
         }
-        let start = self.alloc_run(n).ok_or(ERR_OUT_OF_MEMORY)?;
+        let start = self.alloc_run_backwards(n).ok_or(ERR_OUT_OF_MEMORY)?;
 
         // SAFETY: `start..start+n` slots are now marked used (exclusive
         // ownership), within bounds, and properly aligned for `T`.
@@ -476,6 +425,35 @@ impl BitmapAllocator {
                     for j in start..start + n {
                         self.set_bit(j, true);
                     }
+                    let new_live = self.live_count.get().saturating_add(n as u32);
+                    self.live_count.set(new_live);
+                    if new_live > self.max_live.get() {
+                        self.max_live.set(new_live);
+                    }
+                    return Some(start);
+                }
+            } else {
+                run = 0;
+            }
+        }
+        None
+    }
+
+    fn alloc_run_backwards(&self, n: usize) -> Option<usize> {
+        let mut run = 0usize;
+        for i in (0..self.num_slots).rev() {
+            if !self.bit(i) {
+                run += 1;
+                if run == n {
+                    let start = i;
+                    for j in start..start + n {
+                        self.set_bit(j, true);
+                    }
+                    let new_live = self.live_count.get().saturating_add(n as u32);
+                    self.live_count.set(new_live);
+                    if new_live > self.max_live.get() {
+                        self.max_live.set(new_live);
+                    }
                     return Some(start);
                 }
             } else {
@@ -497,6 +475,8 @@ impl BitmapAllocator {
         for j in start..start + n {
             self.set_bit(j, false);
         }
+        self.live_count
+            .set(self.live_count.get().saturating_sub(n as u32));
     }
 
     /// Reads bit `i` of the occupancy bitmap.
@@ -526,6 +506,7 @@ impl BitmapAllocator {
 /// Sized to be cheap to embed in async state machines: `&BitmapAllocator` +
 /// `(u16 start, u16 count)` = 8 bytes on a 32-bit target (12 bytes on
 /// 64-bit). The data pointer is recomputed from the allocator base.
+#[must_use = "dropping a McuSpdmBox without holding it would immediately free the underlying slots"]
 pub struct McuSpdmBox<'a, T> {
     /// Borrow of the backing allocator; used to free slots on drop.
     alloc: &'a BitmapAllocator,
@@ -596,6 +577,7 @@ impl<T> core::ops::DerefMut for McuSpdmBox<'_, T> {
 /// `unused` is the number of trailing bytes in the last slot that are
 /// *not* part of the logical buffer; valid range 0..63. Logical length
 /// is therefore `num_slots * SLOT_SIZE - unused`.
+#[must_use = "dropping a BitmapBytes without holding it would immediately free the underlying slots"]
 pub struct BitmapBytes<'a> {
     /// Borrow of the backing allocator; used to free slots on drop or
     /// shrink.
@@ -802,3 +784,293 @@ impl core::ops::DerefMut for BitmapBytes<'_> {
 /// machines, so growth here is felt across the firmware.
 #[cfg(target_pointer_width = "32")]
 const _: () = assert!(core::mem::size_of::<BitmapBytes<'_>>() == 8);
+
+// ---------------------------------------------------------------------------
+// Static allocator cell
+// ---------------------------------------------------------------------------
+
+/// One-shot cell that holds a [`BitmapAllocator`] as a `static`, returning a
+/// `&'static BitmapAllocator` after the single call to [`Self::init_once`].
+///
+/// `BitmapAllocator` is deliberately `!Sync` because its interior mutability
+/// is single-task by construction. We cannot wrap it in `OnceLock` /
+/// `OnceCell::sync` (those require `Sync`). Instead we hand-roll the minimal
+/// pattern: an `UnsafeCell<MaybeUninit<…>>` accessible via a `Sync` outer
+/// wrapper whose contract requires the caller to enforce the single-task
+/// invariant.
+///
+/// # Safety contract
+///
+/// * [`Self::init_once`] must be called at most once for the lifetime of the
+///   program. A second call invokes UB. Caller may enforce this with their
+///   own "this task ran" flag or by structural single-task ownership (the
+///   common pattern: one cell per `#[embassy_executor::task]`).
+/// * After `init_once`, the returned `&'static BitmapAllocator` is the
+///   canonical handle for that allocator and may be freely shared within the
+///   owning task. Sharing across tasks is undefined behavior.
+/// * The byte region passed to `init_once` must outlive every allocation
+///   produced from the returned allocator. In practice this means the region
+///   is itself `static`.
+pub struct StaticBitmapAllocatorCell {
+    inner: UnsafeCell<MaybeUninit<BitmapAllocator>>,
+}
+
+// SAFETY: The cell is `Sync` so it can appear in `static`. Actual access to
+// `inner` is `unsafe` and the contract requires single-task usage.
+unsafe impl Sync for StaticBitmapAllocatorCell {}
+
+impl StaticBitmapAllocatorCell {
+    /// Constructs an empty cell. The contained allocator is uninitialized
+    /// until [`Self::init_once`] is called.
+    pub const fn new() -> Self {
+        Self {
+            inner: UnsafeCell::new(MaybeUninit::uninit()),
+        }
+    }
+
+    /// Initializes the contained `BitmapAllocator` in place over
+    /// `[ptr, ptr + capacity)` and returns a `&'static` handle to it.
+    ///
+    /// # Safety
+    ///
+    /// All of the safety conditions on [`BitmapAllocator::new`] apply, plus:
+    ///
+    /// * MUST be called at most once for this cell.
+    /// * Must not be called concurrently with any access to the cell.
+    pub unsafe fn init_once(
+        &'static self,
+        ptr: NonNull<u8>,
+        capacity: usize,
+    ) -> &'static BitmapAllocator {
+        let slot = self.inner.get();
+        let alloc = BitmapAllocator::new(ptr, capacity);
+        (*slot).write(alloc);
+        (*slot).assume_init_ref()
+    }
+}
+
+impl Default for StaticBitmapAllocatorCell {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    extern crate alloc;
+    use alloc::vec;
+
+    /// Construct a fresh allocator over a heap-backed buffer for tests.
+    fn make_alloc(capacity: usize) -> (BitmapAllocator, alloc::vec::Vec<u8>) {
+        // Heap-backed buffer keeps the test target-independent. The Vec is
+        // returned alongside so the caller can keep it alive for the
+        // allocator's borrow.
+        let mut buf = vec![0u8; capacity + BITMAP_SLOT_SIZE];
+        // Round the base up to BITMAP_SLOT_SIZE alignment.
+        let raw = buf.as_mut_ptr();
+        let off = (raw as usize).wrapping_neg() & (BITMAP_SLOT_SIZE - 1);
+        let ptr = unsafe { NonNull::new_unchecked(raw.add(off)) };
+        let alloc = unsafe { BitmapAllocator::new(ptr, capacity) };
+        (alloc, buf)
+    }
+
+    #[test]
+    fn live_slots_balance_alloc_drop() {
+        let (alloc, _buf) = make_alloc(4 * 1024);
+        assert_eq!(alloc.live_slots(), 0);
+
+        let a = alloc.alloc_bytes(100).unwrap();
+        assert_eq!(alloc.live_slots(), 2); // 100 B over 64 B slots = 2 slots
+
+        let b = alloc.alloc_bytes(64).unwrap();
+        assert_eq!(alloc.live_slots(), 3);
+
+        drop(a);
+        assert_eq!(alloc.live_slots(), 1);
+        drop(b);
+        assert_eq!(alloc.live_slots(), 0);
+    }
+
+    #[test]
+    fn max_live_tracks_peak() {
+        let (alloc, _buf) = make_alloc(4 * 1024);
+        assert_eq!(alloc.max_live_slots(), 0);
+
+        let a = alloc.alloc_bytes(64).unwrap();
+        let b = alloc.alloc_bytes(64).unwrap();
+        let c = alloc.alloc_bytes(64).unwrap();
+        assert_eq!(alloc.max_live_slots(), 3);
+
+        drop(c);
+        // max stays at 3 even after free
+        assert_eq!(alloc.max_live_slots(), 3);
+
+        let _d = alloc.alloc_bytes(64).unwrap();
+        // back at 3 live; max unchanged
+        assert_eq!(alloc.live_slots(), 3);
+        assert_eq!(alloc.max_live_slots(), 3);
+
+        let _e = alloc.alloc_bytes(64).unwrap();
+        // now 4 live → new peak
+        assert_eq!(alloc.live_slots(), 4);
+        assert_eq!(alloc.max_live_slots(), 4);
+
+        drop(a);
+        drop(b);
+    }
+
+    #[test]
+    fn largest_free_run_finds_holes() {
+        let (alloc, _buf) = make_alloc(8 * 1024);
+        let total = alloc.num_slots();
+        assert_eq!(alloc.largest_free_run(), total);
+
+        let a = alloc.alloc_bytes(64).unwrap();
+        let b = alloc.alloc_bytes(64).unwrap();
+        let c = alloc.alloc_bytes(64).unwrap();
+        // 3 slots taken at the bottom; rest free.
+        assert_eq!(alloc.largest_free_run(), total - 3);
+
+        drop(b); // hole in the middle
+                 // Free regions: [bit 1..2] (1 slot) + [bit 3..total] (total-3 slots).
+                 // Largest = total - 3.
+        assert_eq!(alloc.largest_free_run(), total - 3);
+        drop(a);
+        drop(c);
+        assert_eq!(alloc.largest_free_run(), total);
+    }
+
+    #[test]
+    fn bidirectional_split_allocation() {
+        let (alloc, _buf) = make_alloc(8 * 1024);
+        let total = alloc.num_slots();
+
+        let low = alloc.alloc_bytes(2 * BITMAP_SLOT_SIZE).unwrap();
+        let high = alloc.alloc(0u64).unwrap();
+
+        assert_eq!(low.start_slot, 0);
+        assert_eq!(high.start_slot as usize, total - 1);
+        assert_eq!(alloc.live_slots(), 3);
+
+        drop(low);
+        drop(high);
+        assert_eq!(alloc.live_slots(), 0);
+    }
+
+    #[test]
+    fn oom_does_not_leak_slots() {
+        let (alloc, _buf) = make_alloc(4 * 1024);
+        let total = alloc.num_slots();
+
+        // Allocate up to (just under) capacity; one of these will be at the
+        // limit. Then attempt an oversized request and verify nothing leaked.
+        let huge = (total * BITMAP_SLOT_SIZE) + 1;
+        assert!(alloc.alloc_bytes(huge).is_err());
+        assert_eq!(alloc.live_slots(), 0);
+    }
+
+    #[test]
+    fn drop_alloc_box_releases_slots() {
+        let (alloc, _buf) = make_alloc(4 * 1024);
+        assert_eq!(alloc.live_slots(), 0);
+        {
+            let _b = alloc.alloc(0u64).unwrap();
+            assert_eq!(alloc.live_slots(), 1); // u64 fits in one slot
+        }
+        assert_eq!(alloc.live_slots(), 0);
+    }
+
+    /// Deterministic fragmentation soak — emulates the steady-state SPDM
+    /// responder allocation mix and verifies that an 8 KiB large-message
+    /// allocation can still succeed after many request cycles under
+    /// realistic interleaving of long-lived (transcript / session) and
+    /// transient (request / response framing) allocations.
+    ///
+    /// This test gates Phase 6 (delete static large buffer). If first-fit
+    /// fragments the bitmap enough that the 8 KiB contiguous run cannot
+    /// be allocated after the simulated workload, we must add directional
+    /// allocation (low for persistent, high for large) before deleting the
+    /// static buffer.
+    ///
+    /// Allocation mix per request cycle:
+    ///   * recv-buffer (~1.5 KiB) — transient
+    ///   * response-buffer (~1.5 KiB) — transient
+    ///   * 1-2 small scratch allocations (~256 B each) — transient
+    ///
+    /// Long-lived (allocated once at "session start", held for whole soak):
+    ///   * SessionInfo placeholder (~1 KiB)
+    ///   * Transcript hashes — VCA, M1, L1, TH (4 × 256 B)
+    ///
+    /// Cycles: 50 request cycles, all transients drop at end of each cycle.
+    ///
+    /// At the end of the soak, attempt an 8 KiB allocation for a hypothetical
+    /// CHUNK_GET large response. Pass means the bitmap allocator (with simple
+    /// first-fit) can sustain the realistic workload without fragmenting too
+    /// badly. Fail means we need directional allocation.
+    #[test]
+    fn fragmentation_soak_8k_alloc_after_realistic_workload() {
+        // 16 KiB pool — close to the realistic per-task budget for our
+        // platform after deleting the static large buffer.
+        let (alloc, _buf) = make_alloc(16 * 1024);
+
+        // Phase A — bring up the "session": one big object + four transcript
+        // hashes. These hold their slots for the whole soak.
+        let _session = alloc.alloc_bytes(1024).expect("session alloc");
+        let _vca = alloc.alloc_bytes(256).expect("vca alloc");
+        let _m1 = alloc.alloc_bytes(256).expect("m1 alloc");
+        let _l1 = alloc.alloc_bytes(256).expect("l1 alloc");
+        let _th = alloc.alloc_bytes(256).expect("th alloc");
+
+        let baseline_live = alloc.live_slots();
+        assert!(baseline_live > 0);
+
+        // Phase B — run 50 request cycles of transient churn.
+        for cycle in 0..50 {
+            {
+                let _recv = alloc
+                    .alloc_bytes(1536)
+                    .unwrap_or_else(|_| panic!("recv alloc failed at cycle {}", cycle));
+                let _resp = alloc
+                    .alloc_bytes(1536)
+                    .unwrap_or_else(|_| panic!("resp alloc failed at cycle {}", cycle));
+                let _scratch1 = alloc
+                    .alloc_bytes(256)
+                    .unwrap_or_else(|_| panic!("scratch1 alloc failed at cycle {}", cycle));
+                let _scratch2 = alloc
+                    .alloc_bytes(256)
+                    .unwrap_or_else(|_| panic!("scratch2 alloc failed at cycle {}", cycle));
+                // all transients drop here
+            }
+            // After cycle, live count must be back to baseline.
+            assert_eq!(
+                alloc.live_slots(),
+                baseline_live,
+                "transient leak at cycle {}",
+                cycle
+            );
+        }
+
+        // Phase C — record fragmentation state, then attempt the 8 KiB large
+        // allocation. This is the GATE: if it fails, Phase 6 needs directional
+        // allocation before deleting the static buffer.
+        let largest_run_slots = alloc.largest_free_run();
+        let largest_run_bytes = largest_run_slots * BITMAP_SLOT_SIZE;
+        let large = alloc.alloc_bytes(8 * 1024);
+
+        match large {
+            Ok(buf) => {
+                assert_eq!(buf.len(), 8 * 1024);
+                // Soak passes — first-fit holds up.
+            }
+            Err(_) => {
+                panic!(
+                    "FRAGMENTATION SOAK FAILED: 8 KiB allocation failed after 50 cycles. \
+                     baseline_live={}, largest_free_run={} slots ({} bytes). \
+                     Phase 6 (delete static large buffer) needs directional allocation.",
+                    baseline_live, largest_run_slots, largest_run_bytes
+                );
+            }
+        }
+    }
+}

--- a/runtime/userspace/api/spdm-lite/pal/src/alloc.rs
+++ b/runtime/userspace/api/spdm-lite/pal/src/alloc.rs
@@ -527,10 +527,18 @@ impl<T> McuSpdmBox<'_, T> {
 }
 
 impl<T> Drop for McuSpdmBox<'_, T> {
-    /// Drops the owned value in place, then releases the underlying
+    /// Drops the owned value in place, securely zero-wipes the memory slot, then releases the underlying
     /// slots back to the allocator's bitmap.
     fn drop(&mut self) {
         unsafe { core::ptr::drop_in_place(self.ptr().as_ptr()) };
+        // Securely zero-wipe the underlying memory slots to prevent information leaks of stateful data.
+        unsafe {
+            core::ptr::write_bytes(
+                self.ptr().as_ptr() as *mut u8,
+                0,
+                self.num_slots as usize * BITMAP_SLOT_SIZE,
+            );
+        }
         self.alloc
             .free_run(self.start_slot as usize, self.num_slots as usize);
     }

--- a/runtime/userspace/api/spdm-lite/pal/src/cert/endorsement.rs
+++ b/runtime/userspace/api/spdm-lite/pal/src/cert/endorsement.rs
@@ -164,7 +164,7 @@ impl SlotEndorsement {
     pub fn is_writable(&self) -> bool {
         #[cfg(feature = "set-certificate")]
         {
-            return matches!(self, Self::Managed(_));
+            matches!(self, Self::Managed(_))
         }
         #[cfg(not(feature = "set-certificate"))]
         {
@@ -175,7 +175,7 @@ impl SlotEndorsement {
     pub fn stores_complete_chain(&self) -> bool {
         #[cfg(feature = "set-certificate")]
         {
-            return matches!(self, Self::Managed(_));
+            matches!(self, Self::Managed(_))
         }
         #[cfg(not(feature = "set-certificate"))]
         {

--- a/runtime/userspace/api/spdm-lite/pal/src/cert/mod.rs
+++ b/runtime/userspace/api/spdm-lite/pal/src/cert/mod.rs
@@ -108,10 +108,10 @@ impl<M: MeasurementProvider> SpdmPalCertStore for McuSpdmPal<M> {
     ) -> bool {
         #[cfg(feature = "set-certificate")]
         {
-            return slot_index(slot)
+            slot_index(slot)
                 .and_then(|idx| self.cert_store.cert_slots().get(idx))
                 .map(|slot| slot.is_writable())
-                .unwrap_or(false);
+                .unwrap_or(false)
         }
         #[cfg(not(feature = "set-certificate"))]
         {

--- a/runtime/userspace/api/spdm-lite/pal/src/cert/store.rs
+++ b/runtime/userspace/api/spdm-lite/pal/src/cert/store.rs
@@ -8,7 +8,9 @@
 
 use core::cell::UnsafeCell;
 
-use mcu_caliptra_api_lite::{sha_finish, sha_init, sha_update, ApiAlloc, HashAlgo};
+use mcu_caliptra_api_lite::{
+    sha_finish, sha_init, sha_update, ApiAlloc, HashAlgo, SHA_CONTEXT_SIZE,
+};
 use mcu_error::McuResult;
 use mcu_spdm_lite_traits::MAX_SLOTS;
 
@@ -139,7 +141,8 @@ impl SharedCertStore {
             return Err(mcu_error::codes::INVARIANT);
         }
         let root_cert = chain[0];
-        let mut state = sha_init(alloc, HashAlgo::Sha384, &[]).await?;
+        let sha_buf = alloc.alloc(SHA_CONTEXT_SIZE)?;
+        let mut state = sha_init(alloc, sha_buf, HashAlgo::Sha384, &[]).await?;
         sha_update(alloc, &mut state, root_cert).await?;
         let mut hash = [0u8; 48];
         sha_finish(alloc, &mut state, &mut hash).await?;

--- a/runtime/userspace/api/spdm-lite/pal/src/hash.rs
+++ b/runtime/userspace/api/spdm-lite/pal/src/hash.rs
@@ -2,16 +2,16 @@
 
 //! [`SpdmPalHash`] + [`ApiAlloc`] implementations on [`McuSpdmPal`].
 //!
-//! The file is named `hash.rs` mirroring
-//! [`mcu_spdm_lite_traits::SpdmPalHash`] in
-//! [`traits/src/hash.rs`](../../traits/src/hash.rs). The
-//! [`ApiAlloc`] binding lives here as well because it shares the
-//! same dependency on the pool allocator that backs every hash
-//! request.
+//! Hash state buffers are allocated from the per-task bitmap pool via
+//! `alloc_bytes(SHA_CONTEXT_SIZE)`, making them deterministic and
+//! independent of the global heap. Each `HashState<BitmapBytes<'static>>`
+//! is 8 bytes on 32-bit targets.
 
 use super::measurements::MeasurementProvider;
 use super::*;
-use mcu_caliptra_api_lite::{sha_finish, sha_init, sha_update, ApiAlloc, HashAlgo, HashState};
+use mcu_caliptra_api_lite::{
+    sha_finish, sha_init, sha_update, ApiAlloc, HashAlgo, HashState, SHA_CONTEXT_SIZE,
+};
 use mcu_spdm_lite_traits::{SpdmPalHash, SpdmPalHashAlgo, SpdmPalIo};
 
 impl<M: MeasurementProvider> ApiAlloc for McuSpdmPal<M> {
@@ -39,7 +39,7 @@ impl ApiAlloc for BitmapAllocator {
 }
 
 impl<M: MeasurementProvider> SpdmPalHash for McuSpdmPal<M> {
-    type State = HashState;
+    type State = HashState<BitmapBytes<'static>>;
 
     #[inline]
     async fn hash_init(
@@ -47,30 +47,32 @@ impl<M: MeasurementProvider> SpdmPalHash for McuSpdmPal<M> {
         _io: &impl SpdmPalIo,
         algo: SpdmPalHashAlgo,
         seed: &[u8],
-    ) -> McuResult<HashState> {
-        sha_init(self, to_api_algo(algo), seed).await
+    ) -> McuResult<Self::State> {
+        let buf = self.allocator.alloc_bytes(SHA_CONTEXT_SIZE)?;
+        sha_init(self, buf, to_api_algo(algo), seed).await
     }
 
     #[inline]
     async fn hash_update(
         &self,
         _io: &impl SpdmPalIo,
-        state: &mut HashState,
+        state: &mut Self::State,
         data: &[u8],
     ) -> McuResult<()> {
         sha_update(self, state, data).await
     }
 
     #[inline]
-    fn hash_clone(&self, _io: &impl SpdmPalIo, state: &HashState) -> McuResult<HashState> {
-        state.try_clone()
+    fn hash_clone(&self, _io: &impl SpdmPalIo, state: &Self::State) -> McuResult<Self::State> {
+        let buf = self.allocator.alloc_bytes(SHA_CONTEXT_SIZE)?;
+        Ok(state.clone_into(buf))
     }
 
     #[inline]
     async fn hash_finish(
         &self,
         _io: &impl SpdmPalIo,
-        state: &mut HashState,
+        state: &mut Self::State,
         out: &mut [u8],
     ) -> McuResult<()> {
         sha_finish(self, state, out).await

--- a/runtime/userspace/api/spdm-lite/pal/src/hash.rs
+++ b/runtime/userspace/api/spdm-lite/pal/src/hash.rs
@@ -49,7 +49,7 @@ impl<M: MeasurementProvider> SpdmPalHash for McuSpdmPal<M> {
         seed: &[u8],
     ) -> McuResult<Self::State> {
         let buf = self.allocator.alloc_bytes(SHA_CONTEXT_SIZE)?;
-        sha_init(self, buf, to_api_algo(algo), seed).await
+        sha_init(self.allocator, buf, to_api_algo(algo), seed).await
     }
 
     #[inline]
@@ -59,7 +59,7 @@ impl<M: MeasurementProvider> SpdmPalHash for McuSpdmPal<M> {
         state: &mut Self::State,
         data: &[u8],
     ) -> McuResult<()> {
-        sha_update(self, state, data).await
+        sha_update(self.allocator, state, data).await
     }
 
     #[inline]
@@ -75,7 +75,7 @@ impl<M: MeasurementProvider> SpdmPalHash for McuSpdmPal<M> {
         state: &mut Self::State,
         out: &mut [u8],
     ) -> McuResult<()> {
-        sha_finish(self, state, out).await
+        sha_finish(self.allocator, state, out).await
     }
 }
 

--- a/runtime/userspace/api/spdm-lite/pal/src/io.rs
+++ b/runtime/userspace/api/spdm-lite/pal/src/io.rs
@@ -13,15 +13,13 @@
 //!
 //! On every `recv_request`:
 //!
-//! 1. The [`BitmapAllocator`] is reset — every previous allocation
-//!    has been dropped by now, so this just zeroes the bitmap.
-//! 2. A single `header_size + mtu` buffer is allocated; the
-//!    transport writes both its framing header *and* the SPDM
-//!    payload into it (no shift / copy is performed afterwards).
-//! 3. The buffer is shrunk to the actual frame length, releasing
-//!    the trailing slots back to the pool.
-//! 4. The resulting [`McuSpdmIo`] is returned to the stack and
-//!    keeps the frame alive until it is dropped.
+//! 1. A single `header_size + mtu` buffer is allocated; the transport
+//!    writes both its framing header *and* the SPDM payload into it
+//!    (no shift / copy is performed afterwards).
+//! 2. The buffer is shrunk to the actual frame length, releasing the
+//!    trailing slots back to the pool.
+//! 3. The resulting [`McuSpdmIo`] is returned to the stack and keeps
+//!    the frame alive until it is dropped.
 //!
 //! On `send_response`, the caller-provided `msg` already has the
 //! SPDM payload at offset `header_size()`; the transport fills
@@ -147,11 +145,8 @@ impl<M: MeasurementProvider> SpdmPalIoTransport for McuSpdmPal<M> {
     /// * Any [`McuErrorCode`] surfaced by the underlying
     ///   [`SpdmPalTransport::recv_request`].
     async fn recv_request(&self) -> McuResult<Self::Io<'_>> {
-        // SAFETY: `&self` + single-task responder ⇒ no live `McuSpdmIo` exists
-        // when this returns. Reset clears the bitmap for the new exchange. The
-        // large-message buffer is a separate static (not part of this pool), so
-        // it survives across requests for chunked transfers.
-        unsafe { self.allocator.reset() };
+        // Transient allocations are released by RAII. The persistent large-message
+        // buffer (if any) lives on ConnectionState and survives across cycles.
 
         // Need room for header + MTU; the transport writes both into the
         // same buffer (no shifting).

--- a/runtime/userspace/api/spdm-lite/pal/src/measurements.rs
+++ b/runtime/userspace/api/spdm-lite/pal/src/measurements.rs
@@ -67,11 +67,11 @@ impl<M: MeasurementProvider> SpdmPalMeasurements for McuSpdmPal<M> {
                 .map_err(|_| mcu_error::codes::INTERNAL_BUG)?;
             scratch.fill(0);
             self.meas_provider
-                .get_measurement_value(index, nonce, out, &mut scratch, &self.allocator)
+                .get_measurement_value(index, nonce, out, &mut scratch, self.allocator)
                 .await
         } else {
             self.meas_provider
-                .get_measurement_value(index, nonce, out, &mut [], &self.allocator)
+                .get_measurement_value(index, nonce, out, &mut [], self.allocator)
                 .await
         }
     }

--- a/runtime/userspace/api/spdm-lite/pal/src/pal.rs
+++ b/runtime/userspace/api/spdm-lite/pal/src/pal.rs
@@ -20,8 +20,7 @@ use super::*;
 extern crate alloc;
 
 use alloc::boxed::Box;
-use core::cell::{Cell, UnsafeCell};
-use core::ptr::NonNull;
+use core::cell::UnsafeCell;
 
 use super::cert::store::SharedCertStore;
 use super::measurements::MeasurementProvider;
@@ -35,61 +34,49 @@ use super::measurements::MeasurementProvider;
 /// [`UnsafeCell`] for interior mutability — the SPDM responder is
 /// strictly single-task, so we never observe concurrent access) plus a
 /// single [`BitmapAllocator`](super::alloc::BitmapAllocator) backed by
-/// a caller-supplied scratch region. The allocator is reset at the
-/// start of every `recv_request`, so allocations are scoped to a
-/// single SPDM exchange even though the allocator object itself lives
-/// on the PAL.
+/// a caller-supplied scratch region. The allocator serves both
+/// per-request scratch allocations and any large-message buffer
+/// retained on connection state across exchanges.
 pub struct McuSpdmPal<M: MeasurementProvider> {
     /// The wrapped byte-oriented PAL transport.
     pub(crate) transport: UnsafeCell<Box<dyn SpdmPalTransport>>,
 
-    /// Per-IO scratch allocator, reset by every `recv_request`.
-    pub(crate) allocator: BitmapAllocator,
+    /// Per-task scratch allocator. Lifted to `'static` so its lifetime is
+    /// independent of the PAL — long-lived allocations (the in-flight large
+    /// SPDM message owned by `LargeTransfer` state) can outlive any single
+    /// SPDM request cycle without needing a `'pal` lifetime parameter
+    /// threaded through the stack.
+    pub(crate) allocator: &'static BitmapAllocator,
 
     /// Shared cert store — same instance for all transports.
     pub(crate) cert_store: &'static SharedCertStore,
-
-    /// Persistent static buffer holding one in-flight large SPDM message
-    /// (`CHUNK_GET` response or `CHUNK_SEND` reassembly). Lent out for reads /
-    /// writes via [`Cell::take`]/[`Cell::set`] (the empty slice marks it
-    /// "checked out"), so a chunked transfer survives the per-request allocator
-    /// `reset`. No `unsafe` is needed to hand out the writable slice.
-    pub(crate) large_buf: Cell<Option<&'static mut [u8]>>,
 
     /// Measurement data provider (monomorphized).
     pub(crate) meas_provider: M,
 }
 
 impl<M: MeasurementProvider> McuSpdmPal<M> {
-    /// Creates a new `McuSpdmPal` with persistent chunk storage and a
-    /// measurement provider.
+    /// Creates a new `McuSpdmPal` with a measurement provider.
     ///
     /// # Safety
     ///
-    /// * `io_buf_ptr` must be aligned to
-    ///   [`BITMAP_SLOT_SIZE`](super::alloc::BITMAP_SLOT_SIZE) and point
-    ///   to `io_buf_capacity` bytes of writable memory exclusively
-    ///   owned by this `McuSpdmPal` for its entire lifetime.
-    /// * `large_buf` — When present, a dedicated static buffer holding one
-    ///   in-flight large SPDM message (`CHUNK_GET` response / `CHUNK_SEND`
-    ///   reassembly). Must be exclusively owned by this `McuSpdmPal` for its
-    ///   entire lifetime; its length caps `MaxSPDMmsgSize`.
+    /// * `allocator` — A `&'static BitmapAllocator` obtained from
+    ///   [`StaticBitmapAllocatorCell::init_once`]. Must be exclusively used
+    ///   by the task owning this `McuSpdmPal` (the underlying allocator is
+    ///   `!Sync`; using it from multiple tasks is undefined behavior).
     /// * The constructed `McuSpdmPal` must only be driven from a single
     ///   task; calling `recv_request` / `send_response` concurrently is
     ///   undefined behavior (interior mutability is not synchronized).
     pub unsafe fn new(
         transport: Box<dyn SpdmPalTransport>,
-        io_buf_ptr: NonNull<u8>,
-        io_buf_capacity: usize,
+        allocator: &'static BitmapAllocator,
         cert_store: &'static SharedCertStore,
-        large_buf: Option<&'static mut [u8]>,
         meas_provider: M,
     ) -> Self {
         Self {
             transport: UnsafeCell::new(transport),
-            allocator: BitmapAllocator::new(io_buf_ptr, io_buf_capacity),
+            allocator,
             cert_store,
-            large_buf: Cell::new(large_buf),
             meas_provider,
         }
     }

--- a/runtime/userspace/api/spdm-lite/stack/src/algorithms.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/algorithms.rs
@@ -26,7 +26,7 @@ use mcu_spdm_lite_codec::{
     alg_type, AeadAlgos, AlgStructEntry, AlgorithmsRsp, CapFlags, DheAlgos, KeyScheduleAlgos,
     NegotiateAlgorithmsReqBodyFixed, OtherParamSupport, ResponseBody, SpdmMsgHdrPdu, SpdmVersion,
 };
-use mcu_spdm_lite_traits::{PalBytes, SpdmPal, SpdmPalIo, SpdmPalIoTransport};
+use mcu_spdm_lite_traits::{PalBytes, SpdmPal, SpdmPalAlloc, SpdmPalIo, SpdmPalIoTransport};
 use zerocopy::FromBytes;
 
 use crate::build::build_response;
@@ -65,7 +65,7 @@ struct PeerAlgs {
 ///   the corresponding table (see [`locate_alg_structs`] / [`parse_peer_algs`]
 ///   for the exact rules).
 pub(crate) async fn handle_negotiate_algorithms<'a, Pal: SpdmPal>(
-    state: &mut ConnectionState<Pal::State>,
+    state: &mut ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
     pal: &'a Pal,
     io: &<Pal as SpdmPalIoTransport>::Io<'_>,
 ) -> SpdmResult<PalBytes<'a, Pal>> {
@@ -238,8 +238,8 @@ fn parse_peer_algs(slice: &[u8]) -> SpdmResult<PeerAlgs> {
 ///
 /// An [`AlgorithmsRsp`] ready to hand to [`build_response`]. Families
 /// with no overlap are omitted from `alg_structs` (encoded as `None`).
-fn build_response_body<S>(
-    state: &ConnectionState<S>,
+fn build_response_body<S, L>(
+    state: &ConnectionState<S, L>,
     fixed: &NegotiateAlgorithmsReqBodyFixed,
     peer: &PeerAlgs,
     secure_message_supported: bool,

--- a/runtime/userspace/api/spdm-lite/stack/src/capabilities.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/capabilities.rs
@@ -17,7 +17,7 @@
 use mcu_spdm_lite_codec::{
     CapFlags, CapabilitiesBody, CapabilitiesRsp, ResponseBody, SpdmMsgHdrPdu, SpdmVersion,
 };
-use mcu_spdm_lite_traits::{PalBytes, SpdmPal, SpdmPalIo, SpdmPalIoTransport};
+use mcu_spdm_lite_traits::{PalBytes, SpdmPal, SpdmPalAlloc, SpdmPalIo, SpdmPalIoTransport};
 use zerocopy::FromBytes;
 
 use crate::build::build_response;
@@ -54,7 +54,7 @@ use crate::version::SUPPORTED_VERSIONS;
 /// * [`SPDM_VERSION_MISMATCH`] — requested version is not in
 ///   [`SUPPORTED_VERSIONS`].
 pub(crate) async fn handle_get_capabilities<'a, Pal: SpdmPal>(
-    state: &mut ConnectionState<Pal::State>,
+    state: &mut ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
     pal: &'a Pal,
     io: &<Pal as SpdmPalIoTransport>::Io<'_>,
 ) -> SpdmResult<PalBytes<'a, Pal>> {
@@ -172,7 +172,10 @@ fn validate_capabilities_body(body: &CapabilitiesBody) -> SpdmResult<(u32, u32)>
 ///
 /// * [`SPDM_VERSION_MISMATCH`] — byte is not a recognised version or
 ///   not in [`SUPPORTED_VERSIONS`].
-fn select_version<S>(state: &mut ConnectionState<S>, requested: u8) -> SpdmResult<SpdmVersion> {
+fn select_version<S, L>(
+    state: &mut ConnectionState<S, L>,
+    requested: u8,
+) -> SpdmResult<SpdmVersion> {
     let v = SpdmVersion::from_u8(requested).ok_or(SPDM_VERSION_MISMATCH)?;
     if !SUPPORTED_VERSIONS.contains(&v) {
         return Err(SPDM_VERSION_MISMATCH);

--- a/runtime/userspace/api/spdm-lite/stack/src/certificate.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/certificate.rs
@@ -15,7 +15,7 @@ use mcu_spdm_lite_codec::{
     SpdmMsgHdrPdu, SpdmVersion, WireWriter, ATTR_SLOT_SIZE_REQUESTED,
 };
 use mcu_spdm_lite_traits::{
-    PalBytes, SpdmPal, SpdmPalAsymAlgo, SpdmPalIo, SpdmPalIoTransport, MAX_SLOTS,
+    PalBytes, SpdmPal, SpdmPalAlloc, SpdmPalAsymAlgo, SpdmPalIo, SpdmPalIoTransport, MAX_SLOTS,
 };
 use zerocopy::{little_endian::U16, FromBytes};
 
@@ -129,7 +129,7 @@ impl CertificateLargeResponse {
 }
 
 pub(crate) async fn handle_get_certificate<'a, Pal: SpdmPal>(
-    state: &mut ConnectionState<Pal::State>,
+    state: &mut ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
     pal: &'a Pal,
     io: &<Pal as SpdmPalIoTransport>::Io<'_>,
 ) -> SpdmResult<PalBytes<'a, Pal>> {

--- a/runtime/userspace/api/spdm-lite/stack/src/certificate.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/certificate.rs
@@ -219,7 +219,7 @@ pub(crate) async fn handle_get_certificate<'a, Pal: SpdmPal>(
             portion_len,
             remainder_len,
         );
-        let handle = state.large_response.next_handle();
+        let handle = state.large_msg_ctx.next_handle();
         let resp = build_error_response(
             pal,
             io,
@@ -230,10 +230,11 @@ pub(crate) async fn handle_get_certificate<'a, Pal: SpdmPal>(
         )?;
 
         state.transcript.append_m1(pal, io, io.request()).await?;
-        state.large_response.start(
+        state.large_msg_ctx.start_response(
             LargeResponse::Certificate(cert_rsp),
             cert_rsp.response_size(),
-        );
+            None,
+        )?;
         state.phase = Phase::AfterCertificate;
         return Ok(resp);
     }

--- a/runtime/userspace/api/spdm-lite/stack/src/challenge.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/challenge.rs
@@ -7,6 +7,7 @@ use mcu_spdm_lite_codec::{
     ECC_P384_SIGNATURE_SIZE, REQUESTER_CONTEXT_LEN, SHA384_HASH_SIZE, SPDM_CONTEXT_LEN,
     SPDM_PREFIX_LEN, SPDM_SIGNING_CONTEXT_LEN,
 };
+use mcu_spdm_lite_traits::SpdmPalAlloc;
 use mcu_spdm_lite_traits::*;
 use zerocopy::FromBytes;
 
@@ -15,7 +16,7 @@ use crate::error::{SpdmResult, SPDM_INVALID_REQUEST, SPDM_UNEXPECTED_REQUEST, SP
 use crate::stack::{ConnectionState, Phase};
 
 pub(crate) async fn handle_challenge<'a, Pal: SpdmPal>(
-    state: &mut ConnectionState<Pal::State>,
+    state: &mut ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
     pal: &'a Pal,
     io: &<Pal as SpdmPalIoTransport>::Io<'_>,
 ) -> SpdmResult<PalBytes<'a, Pal>> {

--- a/runtime/userspace/api/spdm-lite/stack/src/chunk/get.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/chunk/get.rs
@@ -6,7 +6,7 @@ use mcu_spdm_lite_codec::{
     ChunkGetReqBody, ChunkResponseBody, ReqRespCode, SpdmMsgHdrPdu, WireWriter,
     CHUNK_ATTR_LAST_CHUNK, CHUNK_RESPONSE_FIXED_BODY_SIZE, LARGE_RESPONSE_SIZE_FIELD_SIZE,
 };
-use mcu_spdm_lite_traits::{PalBytes, SpdmPal, SpdmPalIo, SpdmPalIoTransport};
+use mcu_spdm_lite_traits::{PalBytes, SpdmPal, SpdmPalAlloc, SpdmPalIo, SpdmPalIoTransport};
 use zerocopy::{little_endian::U16, little_endian::U32, FromBytes};
 
 use crate::build::alloc_padded;
@@ -18,7 +18,7 @@ use crate::stack::{ConnectionState, Phase};
 use super::LargeResponse;
 
 pub(crate) async fn handle_chunk_get<'a, Pal: SpdmPal>(
-    state: &mut ConnectionState<Pal::State>,
+    state: &mut ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
     pal: &'a Pal,
     io: &<Pal as SpdmPalIoTransport>::Io<'_>,
 ) -> SpdmResult<PalBytes<'a, Pal>> {
@@ -101,7 +101,11 @@ pub(crate) async fn handle_chunk_get<'a, Pal: SpdmPal>(
                 state.transcript.append_m1(pal, io, chunk).await?;
             }
             LargeResponse::Buffered => {
-                pal.large_read(bytes_sent, chunk)?;
+                let large = state
+                    .large_buf
+                    .as_deref()
+                    .ok_or(crate::error::SPDM_UNSPECIFIED)?;
+                chunk.copy_from_slice(&large[bytes_sent..bytes_sent + chunk_size]);
             }
         }
     }
@@ -110,7 +114,7 @@ pub(crate) async fn handle_chunk_get<'a, Pal: SpdmPal>(
     // Once the final chunk of a buffered response ships, release the pinned
     // large buffer (RAII free + zero) back to the pool.
     if last_chunk && is_buffered {
-        pal.large_end();
+        state.large_buf = None;
     }
     Ok(rsp)
 }

--- a/runtime/userspace/api/spdm-lite/stack/src/chunk/get.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/chunk/get.rs
@@ -6,7 +6,7 @@ use mcu_spdm_lite_codec::{
     ChunkGetReqBody, ChunkResponseBody, ReqRespCode, SpdmMsgHdrPdu, WireWriter,
     CHUNK_ATTR_LAST_CHUNK, CHUNK_RESPONSE_FIXED_BODY_SIZE, LARGE_RESPONSE_SIZE_FIELD_SIZE,
 };
-use mcu_spdm_lite_traits::{PalBytes, SpdmPal, SpdmPalAlloc, SpdmPalIo, SpdmPalIoTransport};
+use mcu_spdm_lite_traits::{PalBytes, SpdmPal, SpdmPalAlloc, SpdmPalIoTransport};
 use zerocopy::{little_endian::U16, little_endian::U32, FromBytes};
 
 use crate::build::alloc_padded;
@@ -21,12 +21,12 @@ pub(crate) async fn handle_chunk_get<'a, Pal: SpdmPal>(
     state: &mut ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
     pal: &'a Pal,
     io: &<Pal as SpdmPalIoTransport>::Io<'_>,
+    req: &[u8],
 ) -> SpdmResult<PalBytes<'a, Pal>> {
     if (state.phase as u8) < (Phase::AfterCapabilities as u8) || !state.chunking_enabled() {
         return Err(SPDM_UNEXPECTED_REQUEST);
     }
 
-    let req = io.request();
     if req.len() > pal.mtu() {
         return Err(SPDM_INVALID_REQUEST);
     }
@@ -42,7 +42,7 @@ pub(crate) async fn handle_chunk_get<'a, Pal: SpdmPal>(
         return Err(SPDM_INVALID_REQUEST);
     }
 
-    let Some(active_rsp) = state.large_response.response() else {
+    let Some(active_rsp) = state.large_msg_ctx.response() else {
         return Err(SPDM_UNEXPECTED_REQUEST);
     };
 
@@ -53,9 +53,6 @@ pub(crate) async fn handle_chunk_get<'a, Pal: SpdmPal>(
     }
 
     let large_response_size = active_rsp.response_size;
-    // Whether this large response is served from the pinned large buffer (vs a
-    // Certificate response, which regenerates each chunk and holds no pin).
-    let is_buffered = matches!(active_rsp.kind, LargeResponse::Buffered);
     let extra = if seq_num == 0 {
         LARGE_RESPONSE_SIZE_FIELD_SIZE
     } else {
@@ -102,19 +99,21 @@ pub(crate) async fn handle_chunk_get<'a, Pal: SpdmPal>(
             }
             LargeResponse::Buffered => {
                 let large = state
-                    .large_buf
+                    .large_msg_ctx
+                    .buf
                     .as_deref()
                     .ok_or(crate::error::SPDM_UNSPECIFIED)?;
-                chunk.copy_from_slice(&large[bytes_sent..bytes_sent + chunk_size]);
+                let end = bytes_sent
+                    .checked_add(chunk_size)
+                    .ok_or(crate::error::SPDM_UNSPECIFIED)?;
+                let src = large
+                    .get(bytes_sent..end)
+                    .ok_or(crate::error::SPDM_UNSPECIFIED)?;
+                chunk.copy_from_slice(src);
             }
         }
     }
 
-    state.large_response.chunk_sent(chunk_size);
-    // Once the final chunk of a buffered response ships, release the pinned
-    // large buffer (RAII free + zero) back to the pool.
-    if last_chunk && is_buffered {
-        state.large_buf = None;
-    }
+    state.large_msg_ctx.chunk_sent(chunk_size);
     Ok(rsp)
 }

--- a/runtime/userspace/api/spdm-lite/stack/src/chunk/mod.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/chunk/mod.rs
@@ -8,7 +8,7 @@ mod send;
 pub(crate) use get::handle_chunk_get;
 pub(crate) use send::handle_chunk_send;
 
-use mcu_spdm_lite_traits::{PalBytes, SpdmPal, SpdmPalIoTransport};
+use mcu_spdm_lite_traits::{PalBytes, SpdmPal, SpdmPalAlloc, SpdmPalIoTransport};
 
 use crate::build::build_error_response;
 use crate::certificate::CertificateLargeResponse;
@@ -134,7 +134,7 @@ impl ChunkState {
 }
 
 pub(crate) fn validate_buffered_large_response<Pal: SpdmPal>(
-    state: &ConnectionState<Pal::State>,
+    state: &ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
     pal: &Pal,
     large_resp_len: usize,
 ) -> SpdmResult<()> {
@@ -150,7 +150,7 @@ pub(crate) fn validate_buffered_large_response<Pal: SpdmPal>(
 }
 
 pub(crate) fn start_buffered_large_response<'a, Pal: SpdmPal>(
-    state: &mut ConnectionState<Pal::State>,
+    state: &mut ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
     pal: &'a Pal,
     io: &<Pal as SpdmPalIoTransport>::Io<'_>,
     large_resp_len: usize,

--- a/runtime/userspace/api/spdm-lite/stack/src/chunk/mod.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/chunk/mod.rs
@@ -12,78 +12,22 @@ use mcu_spdm_lite_traits::{PalBytes, SpdmPal, SpdmPalAlloc, SpdmPalIoTransport};
 
 use crate::build::build_error_response;
 use crate::certificate::CertificateLargeResponse;
-use crate::error::{SpdmResult, SPDM_LARGE_RESPONSE, SPDM_UNSPECIFIED};
+use crate::error::{
+    SpdmError, SpdmResult, SPDM_INVALID_REQUEST, SPDM_LARGE_RESPONSE, SPDM_UNEXPECTED_REQUEST,
+    SPDM_UNSPECIFIED,
+};
 use crate::stack::ConnectionState;
 
-#[derive(Copy, Clone)]
-pub(crate) struct LargeResponseState {
-    next_handle: u8,
-    active: Option<ActiveLargeResponse>,
+/// RAII guard that automatically zero-fills its contained buffer on Drop.
+/// Used to securely erase sensitive reassembled request or response payload data from RAM.
+pub(crate) struct WipeOnDrop<L: core::ops::DerefMut<Target = [u8]>> {
+    pub(crate) buf: Option<L>,
 }
 
-impl Default for LargeResponseState {
-    fn default() -> Self {
-        Self {
-            next_handle: 1,
-            active: None,
-        }
-    }
-}
-
-impl LargeResponseState {
-    #[inline]
-    pub(crate) fn reset(&mut self) {
-        self.active = None;
-    }
-
-    #[inline]
-    pub(crate) fn in_progress(&self) -> bool {
-        self.active.is_some()
-    }
-
-    #[inline]
-    pub(crate) fn next_handle(&self) -> u8 {
-        self.next_handle
-    }
-
-    #[inline]
-    pub(crate) fn start(&mut self, kind: LargeResponse, response_size: usize) {
-        let handle = self.next_handle;
-        self.active = Some(ActiveLargeResponse {
-            handle,
-            next_seq_num: 0,
-            bytes_sent: 0,
-            response_size,
-            kind,
-        });
-    }
-
-    #[inline]
-    fn response(&self) -> Option<&ActiveLargeResponse> {
-        self.active.as_ref()
-    }
-
-    fn chunk_sent(&mut self, n: usize) {
-        let complete = match self.active.as_mut() {
-            Some(rsp) => rsp.chunk_sent(n),
-            None => return,
-        };
-        if complete {
-            self.complete();
-        }
-    }
-
-    #[inline]
-    fn complete(&mut self) {
-        self.advance_handle();
-        self.reset();
-    }
-
-    #[inline]
-    fn advance_handle(&mut self) {
-        self.next_handle = self.next_handle.wrapping_add(1);
-        if self.next_handle == 0 {
-            self.next_handle = 1;
+impl<L: core::ops::DerefMut<Target = [u8]>> Drop for WipeOnDrop<L> {
+    fn drop(&mut self) {
+        if let Some(mut buf) = self.buf.take() {
+            buf.fill(0);
         }
     }
 }
@@ -95,17 +39,17 @@ pub(crate) enum LargeResponse {
 }
 
 #[derive(Copy, Clone)]
-struct ActiveLargeResponse {
-    handle: u8,
-    next_seq_num: u16,
-    bytes_sent: usize,
-    response_size: usize,
-    kind: LargeResponse,
+pub(crate) struct ActiveLargeResponse {
+    pub(crate) handle: u8,
+    pub(crate) next_seq_num: u16,
+    pub(crate) bytes_sent: usize,
+    pub(crate) response_size: usize,
+    pub(crate) kind: LargeResponse,
 }
 
 impl ActiveLargeResponse {
     #[inline]
-    fn chunk_sent(&mut self, n: usize) -> bool {
+    pub(crate) fn chunk_sent(&mut self, n: usize) -> bool {
         self.bytes_sent += n;
         self.next_seq_num = self.next_seq_num.wrapping_add(1);
         self.bytes_sent == self.response_size
@@ -114,7 +58,7 @@ impl ActiveLargeResponse {
 
 #[derive(Copy, Clone, Default)]
 pub(crate) struct ChunkState {
-    pub(super) in_use: bool,
+    pub(crate) in_use: bool,
     pub(super) handle: u8,
     pub(super) seq_num: u16,
     pub(super) bytes_received: u32,
@@ -128,8 +72,219 @@ impl ChunkState {
     }
 
     #[inline]
+    #[allow(dead_code)]
     pub(crate) fn in_progress(&self) -> bool {
         self.in_use
+    }
+}
+
+#[derive(Copy, Clone)]
+pub(crate) enum LargeMessageMode {
+    Idle,
+    Request,
+    Response(ActiveLargeResponse),
+}
+
+pub(crate) struct LargeMessageCtx<L> {
+    pub(crate) state: ChunkState,
+    pub(crate) mode: LargeMessageMode,
+    buf: Option<L>,
+    pub(crate) next_handle: u8,
+}
+
+impl<L> LargeMessageCtx<L> {
+    pub fn new() -> Self {
+        Self {
+            state: ChunkState::default(),
+            mode: LargeMessageMode::Idle,
+            buf: None,
+            next_handle: 1,
+        }
+    }
+}
+
+impl<L: core::ops::DerefMut<Target = [u8]>> LargeMessageCtx<L> {
+    pub fn reset(&mut self) {
+        self.state.reset();
+        self.mode = LargeMessageMode::Idle;
+        if let Some(mut backing) = self.buf.take() {
+            backing.fill(0);
+        }
+    }
+
+    /// Securely replaces the held buffer with `buf`, ensuring any previous buffer is securely zero-wiped first.
+    pub fn set_buffer(&mut self, buf: L) {
+        self.reset();
+        self.buf = Some(buf);
+    }
+
+    /// Securely takes the held buffer, returning it if present.
+    pub fn take_buffer(&mut self) -> Option<L> {
+        self.buf.take()
+    }
+
+    /// Access the underlying buffer to read or inspect.
+    pub fn get_buffer(&self) -> Option<&L> {
+        self.buf.as_ref()
+    }
+
+    /// Access the underlying buffer to mutably modify.
+    #[allow(dead_code)]
+    pub fn get_buffer_mut(&mut self) -> Option<&mut L> {
+        self.buf.as_mut()
+    }
+
+    pub fn request_in_progress(&self) -> bool {
+        matches!(self.mode, LargeMessageMode::Request) && self.state.in_use
+    }
+
+    pub fn response_in_progress(&self) -> bool {
+        matches!(self.mode, LargeMessageMode::Response(_))
+    }
+
+    pub fn is_idle(&self) -> bool {
+        matches!(self.mode, LargeMessageMode::Idle)
+    }
+
+    pub fn init_request(
+        &mut self,
+        handle: u8,
+        total_size: usize,
+        initial_chunk: &[u8],
+        mut rent_buf: L,
+    ) -> Result<(), SpdmError> {
+        if !self.is_idle() {
+            return Err(SPDM_UNEXPECTED_REQUEST);
+        }
+
+        self.mode = LargeMessageMode::Request;
+        self.state = ChunkState {
+            in_use: true,
+            handle,
+            seq_num: 0,
+            bytes_received: initial_chunk.len() as u32,
+            large_msg_size: total_size as u32,
+        };
+        let dest = rent_buf
+            .get_mut(..initial_chunk.len())
+            .ok_or(SPDM_INVALID_REQUEST)?;
+        dest.copy_from_slice(initial_chunk);
+        self.buf = Some(rent_buf);
+        Ok(())
+    }
+
+    pub fn append_request(
+        &mut self,
+        handle: u8,
+        seq_num: u16,
+        chunk: &[u8],
+    ) -> Result<(), SpdmError> {
+        if !self.request_in_progress()
+            || self.state.handle != handle
+            || self.state.seq_num.wrapping_add(1) != seq_num
+        {
+            return Err(SPDM_INVALID_REQUEST);
+        }
+        let start = self.state.bytes_received as usize;
+        let end = start.checked_add(chunk.len()).ok_or(SPDM_UNSPECIFIED)?;
+
+        if end > self.state.large_msg_size as usize {
+            return Err(SPDM_INVALID_REQUEST);
+        }
+
+        let buf = self.buf.as_deref_mut().ok_or(SPDM_UNSPECIFIED)?;
+        let destination = buf.get_mut(start..end).ok_or(SPDM_UNSPECIFIED)?;
+        destination.copy_from_slice(chunk);
+
+        self.state.bytes_received = end as u32;
+        self.state.seq_num = seq_num;
+        Ok(())
+    }
+
+    /// Securely processes the fully assembled request via a scoped loan closure hook,
+    /// guaranteeing zero-wipe and clean reset regardless of success or early error pathways.
+    ///
+    /// # Example (e.g., `SET_CERTIFICATE` reassembly dispatch):
+    /// ```ignore
+    /// state.large_msg_ctx.with_request_buf(len, |assembled_req| {
+    ///     set_certificate::handle_set_certificate_request(state, pal, io, assembled_req).await
+    /// })
+    /// ```
+    ///
+    /// Evaluates the reassembled payload bytes within the scoped closure. On exit (success or error),
+    /// the context unconditionally zero-fills the underlying memory and resets the chunk state.
+    #[allow(dead_code)]
+    pub fn with_request_buf<F, R>(&mut self, len: usize, op: F) -> Result<R, SpdmError>
+    where
+        F: FnOnce(&[u8]) -> Result<R, SpdmError>,
+    {
+        if !self.state.in_use
+            || self.state.bytes_received as usize != self.state.large_msg_size as usize
+        {
+            return Err(SPDM_INVALID_REQUEST);
+        }
+
+        let buf = self.buf.as_deref_mut().ok_or(SPDM_UNSPECIFIED)?;
+        let request_slice = buf.get(..len).ok_or(SPDM_INVALID_REQUEST)?;
+
+        let result = op(request_slice);
+
+        buf.fill(0);
+        self.reset();
+
+        result
+    }
+
+    pub(crate) fn next_handle(&self) -> u8 {
+        self.next_handle
+    }
+
+    pub(crate) fn start_response(
+        &mut self,
+        kind: LargeResponse,
+        response_size: usize,
+        response_buf: Option<L>,
+    ) -> Result<(), SpdmError> {
+        if !self.is_idle() {
+            return Err(SPDM_UNEXPECTED_REQUEST);
+        }
+        let handle = self.next_handle;
+        self.mode = LargeMessageMode::Response(ActiveLargeResponse {
+            handle,
+            next_seq_num: 0,
+            bytes_sent: 0,
+            response_size,
+            kind,
+        });
+        self.buf = response_buf;
+
+        self.advance_handle();
+        Ok(())
+    }
+
+    #[inline]
+    pub(crate) fn response(&self) -> Option<&ActiveLargeResponse> {
+        match &self.mode {
+            LargeMessageMode::Response(active) => Some(active),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn chunk_sent(&mut self, n: usize) {
+        let complete = match &mut self.mode {
+            LargeMessageMode::Response(active) => active.chunk_sent(n),
+            _ => return,
+        };
+        if complete {
+            self.reset();
+        }
+    }
+
+    fn advance_handle(&mut self) {
+        self.next_handle = self.next_handle.wrapping_add(1);
+        if self.next_handle == 0 {
+            self.next_handle = 1;
+        }
     }
 }
 
@@ -138,12 +293,22 @@ pub(crate) fn validate_buffered_large_response<Pal: SpdmPal>(
     pal: &Pal,
     large_resp_len: usize,
 ) -> SpdmResult<()> {
-    if state.chunk.in_progress() || !state.chunking_enabled() {
+    if state.large_msg_ctx.request_in_progress()
+        || state.large_msg_ctx.response_in_progress()
+        || !state.chunking_enabled()
+    {
         return Err(SPDM_UNSPECIFIED);
     }
-    if large_resp_len > pal.large_capacity()
-        || large_resp_len > state.effective_max_spdm_msg_size(pal)
-    {
+
+    // Check against allocated buffer capacity if already active, else check remaining PAL capacity.
+    // We don't double-revalidate against remaining free pool once rented.
+    let capacity = if let Some(buf) = state.large_msg_ctx.get_buffer() {
+        buf.len()
+    } else {
+        pal.large_capacity()
+    };
+
+    if large_resp_len > capacity || large_resp_len > state.effective_max_spdm_msg_size(pal) {
         return Err(SPDM_UNSPECIFIED);
     }
     Ok(())
@@ -154,9 +319,9 @@ pub(crate) fn start_buffered_large_response<'a, Pal: SpdmPal>(
     pal: &'a Pal,
     io: &<Pal as SpdmPalIoTransport>::Io<'_>,
     large_resp_len: usize,
-) -> SpdmResult<PalBytes<'a, Pal>> {
+) -> SpdmResult<(PalBytes<'a, Pal>, usize)> {
     validate_buffered_large_response(state, pal, large_resp_len)?;
-    let handle = state.large_response.next_handle();
+    let handle = state.large_msg_ctx.next_handle();
     let resp = build_error_response(
         pal,
         io,
@@ -165,8 +330,10 @@ pub(crate) fn start_buffered_large_response<'a, Pal: SpdmPal>(
         0,
         &[handle],
     )?;
+    let spdm_len = resp.len() - pal.header_size();
+    let rent_buf = state.large_msg_ctx.take_buffer();
     state
-        .large_response
-        .start(LargeResponse::Buffered, large_resp_len);
-    Ok(resp)
+        .large_msg_ctx
+        .start_response(LargeResponse::Buffered, large_resp_len, rent_buf)?;
+    Ok((resp, spdm_len))
 }

--- a/runtime/userspace/api/spdm-lite/stack/src/chunk/send.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/chunk/send.rs
@@ -6,7 +6,7 @@ use mcu_spdm_lite_codec::{
     CapabilitiesBody, ChunkSendAckBody, ChunkSendReqBody, ReqRespCode, SpdmMsgHdrPdu, SpdmVersion,
     WireWriter, CHUNK_ACK_ATTR_EARLY_ERROR, CHUNK_ATTR_LAST_CHUNK,
 };
-use mcu_spdm_lite_traits::{PalBytes, SpdmPal, SpdmPalIo, SpdmPalIoTransport};
+use mcu_spdm_lite_traits::{PalBytes, SpdmPal, SpdmPalAlloc, SpdmPalIo, SpdmPalIoTransport};
 use zerocopy::{little_endian::U16, FromBytes};
 
 use crate::build::alloc_padded;
@@ -25,7 +25,7 @@ struct ChunkInfo {
 }
 
 pub(crate) async fn handle_chunk_send<'a, Pal: SpdmPal>(
-    state: &mut ConnectionState<Pal::State>,
+    state: &mut ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
     pal: &'a Pal,
     io: &<Pal as SpdmPalIoTransport>::Io<'_>,
 ) -> SpdmResult<PalBytes<'a, Pal>> {
@@ -37,8 +37,7 @@ pub(crate) async fn handle_chunk_send<'a, Pal: SpdmPal>(
                 build_response_to_large_request(state, pal, io, &mut response_to_large_request)
                     .await;
                 state.chunk.reset();
-                // Reassembly consumed: release the pinned buffer (free + zero).
-                pal.large_end();
+                state.large_buf = None;
                 &response_to_large_request[..]
             } else {
                 &[]
@@ -61,8 +60,7 @@ pub(crate) async fn handle_chunk_send<'a, Pal: SpdmPal>(
             let mut error = [0u8; 4];
             encode_error_pdu(state.version, SPDM_INVALID_REQUEST, &mut error);
             state.chunk.reset();
-            // Release any pinned reassembly buffer reserved before the error.
-            pal.large_end();
+            state.large_buf = None;
             build_chunk_send_ack(pal, io, state.version, true, handle, chunk_seq_num, &error)
         }
     }
@@ -102,7 +100,7 @@ enum ChunkProcessError {
 }
 
 fn process_chunk_send<Pal: SpdmPal>(
-    state: &mut ConnectionState<Pal::State>,
+    state: &mut ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
     pal: &Pal,
     io: &impl SpdmPalIo,
 ) -> Result<ChunkInfo, ChunkProcessError> {
@@ -168,7 +166,7 @@ fn process_chunk_send<Pal: SpdmPal>(
 }
 
 fn process_first_chunk<Pal: SpdmPal>(
-    state: &mut ConnectionState<Pal::State>,
+    state: &mut ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
     pal: &Pal,
     handle: u8,
     chunk_seq_num: u16,
@@ -209,12 +207,17 @@ fn process_first_chunk<Pal: SpdmPal>(
             chunk_seq_num,
         });
     }
-    // Reserve the pinned reassembly buffer, then store the first chunk into it.
-    if pal.large_begin(large_msg_size).is_err() || pal.large_write(0, chunk).is_err() {
-        return Err(ChunkProcessError::Early {
-            handle,
-            chunk_seq_num,
-        });
+    match pal.alloc_large_buf(large_msg_size) {
+        Ok(mut buf) => {
+            buf[..chunk_size].copy_from_slice(chunk);
+            state.large_buf = Some(buf);
+        }
+        Err(_) => {
+            return Err(ChunkProcessError::Early {
+                handle,
+                chunk_seq_num,
+            })
+        }
     }
 
     state.chunk = super::ChunkState {
@@ -228,8 +231,8 @@ fn process_first_chunk<Pal: SpdmPal>(
 }
 
 fn process_next_chunk<Pal: SpdmPal>(
-    state: &mut ConnectionState<Pal::State>,
-    pal: &Pal,
+    state: &mut ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
+    _pal: &Pal,
     handle: u8,
     chunk_seq_num: u16,
     chunk_size: usize,
@@ -254,11 +257,20 @@ fn process_next_chunk<Pal: SpdmPal>(
         || end > large_msg_size
         || (last_chunk && end != large_msg_size)
         || (!last_chunk && (end >= large_msg_size || chunk_size < min_chunk_size));
-    if invalid || pal.large_write(bytes_received, chunk).is_err() {
+    if invalid {
         return Err(ChunkProcessError::Early {
             handle,
             chunk_seq_num,
         });
+    }
+    match state.large_buf.as_deref_mut() {
+        Some(buf) => buf[bytes_received..end].copy_from_slice(chunk),
+        None => {
+            return Err(ChunkProcessError::Early {
+                handle,
+                chunk_seq_num,
+            })
+        }
     }
 
     state.chunk.seq_num = chunk_seq_num;
@@ -267,7 +279,7 @@ fn process_next_chunk<Pal: SpdmPal>(
 }
 
 async fn build_response_to_large_request<Pal: SpdmPal>(
-    state: &mut ConnectionState<Pal::State>,
+    state: &mut ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
     pal: &Pal,
     io: &<Pal as SpdmPalIoTransport>::Io<'_>,
     out: &mut [u8; 4],
@@ -285,29 +297,35 @@ async fn build_response_to_large_request<Pal: SpdmPal>(
 }
 
 async fn dispatch_large_request<Pal: SpdmPal>(
-    state: &mut ConnectionState<Pal::State>,
+    state: &mut ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
     pal: &Pal,
     io: &<Pal as SpdmPalIoTransport>::Io<'_>,
     len: usize,
     out: &mut [u8; 4],
 ) -> Result<(), SpdmError> {
     #[cfg(not(feature = "set-certificate"))]
-    let _ = (io, out);
+    let _ = (pal, io, out);
 
-    let large_req = pal.large_take(len).map_err(|_| SPDM_INVALID_REQUEST)?;
-    let (hdr, _) = SpdmMsgHdrPdu::ref_from_prefix(&large_req).map_err(|_| SPDM_INVALID_REQUEST)?;
+    // Take the large buffer out of state so we can pass state mutably to
+    // the handler while still reading from the reassembled request.
+    let mut large_buf = state.large_buf.take().ok_or(SPDM_INVALID_REQUEST)?;
+    let buf = large_buf.as_mut();
+    let large_req = buf.get(..len).ok_or(SPDM_INVALID_REQUEST)?;
+    let (hdr, _) = SpdmMsgHdrPdu::ref_from_prefix(large_req).map_err(|_| SPDM_INVALID_REQUEST)?;
     if hdr.version != state.version.to_u8()
         || hdr.code == ReqRespCode::CHUNK_SEND
         || hdr.code == ReqRespCode::CHUNK_GET
     {
         return Err(SPDM_INVALID_REQUEST);
     }
+    let code = hdr.code;
 
-    match hdr.code {
+    match code {
         #[cfg(feature = "set-certificate")]
         ReqRespCode::SET_CERTIFICATE => {
             let slot_id =
-                set_certificate::handle_set_certificate_request(state, pal, io, &large_req).await?;
+                set_certificate::handle_set_certificate_request(state, pal, io, &buf[..len])
+                    .await?;
             out[0] = state.version.to_u8();
             out[1] = ReqRespCode::SET_CERTIFICATE_RSP.0;
             out[2] = slot_id;

--- a/runtime/userspace/api/spdm-lite/stack/src/chunk/send.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/chunk/send.rs
@@ -6,17 +6,19 @@ use mcu_spdm_lite_codec::{
     CapabilitiesBody, ChunkSendAckBody, ChunkSendReqBody, ReqRespCode, SpdmMsgHdrPdu, SpdmVersion,
     WireWriter, CHUNK_ACK_ATTR_EARLY_ERROR, CHUNK_ATTR_LAST_CHUNK,
 };
-use mcu_spdm_lite_traits::{PalBytes, SpdmPal, SpdmPalAlloc, SpdmPalIo, SpdmPalIoTransport};
+use mcu_spdm_lite_traits::{PalBytes, SpdmPal, SpdmPalAlloc, SpdmPalIoTransport, SpdmVdmBackend};
 use zerocopy::{little_endian::U16, FromBytes};
 
+use super::WipeOnDrop;
 use crate::build::alloc_padded;
 use crate::error::{
-    SpdmError, SpdmResult, SPDM_INVALID_REQUEST, SPDM_UNEXPECTED_REQUEST, SPDM_UNSUPPORTED_REQUEST,
-    SPDM_VERSION_MISMATCH,
+    SpdmError, SpdmResult, SPDM_INVALID_REQUEST, SPDM_LARGE_RESPONSE, SPDM_UNEXPECTED_REQUEST,
+    SPDM_UNSPECIFIED, SPDM_UNSUPPORTED_REQUEST, SPDM_VERSION_MISMATCH,
 };
 #[cfg(feature = "set-certificate")]
 use crate::set_certificate;
 use crate::stack::{ConnectionState, Phase};
+use crate::vendor_defined;
 
 struct ChunkInfo {
     handle: u8,
@@ -24,33 +26,43 @@ struct ChunkInfo {
     complete: bool,
 }
 
-pub(crate) async fn handle_chunk_send<'a, Pal: SpdmPal>(
+pub(crate) async fn handle_chunk_send<'a, Pal: SpdmPal, Vdm: SpdmVdmBackend>(
     state: &mut ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
     pal: &'a Pal,
     io: &<Pal as SpdmPalIoTransport>::Io<'_>,
+    vdm: &Vdm,
+    req: &[u8],
+    secure_session: bool,
 ) -> SpdmResult<PalBytes<'a, Pal>> {
-    let result = process_chunk_send(state, pal, io);
+    let result = process_chunk_send(state, pal, req);
     match result {
         Ok(info) => {
-            let mut response_to_large_request = [0u8; 4];
-            let response = if info.complete {
-                build_response_to_large_request(state, pal, io, &mut response_to_large_request)
-                    .await;
-                state.chunk.reset();
-                state.large_buf = None;
-                &response_to_large_request[..]
+            if info.complete {
+                let rsp = build_final_chunk_send_ack(
+                    state,
+                    pal,
+                    io,
+                    vdm,
+                    secure_session,
+                    info.handle,
+                    info.chunk_seq_num,
+                )
+                .await;
+                if state.large_msg_ctx.request_in_progress() {
+                    state.reset_chunk_assembly();
+                }
+                rsp
             } else {
-                &[]
-            };
-            build_chunk_send_ack(
-                pal,
-                io,
-                state.version,
-                false,
-                info.handle,
-                info.chunk_seq_num,
-                response,
-            )
+                build_chunk_send_ack(
+                    pal,
+                    io,
+                    state.version,
+                    false,
+                    info.handle,
+                    info.chunk_seq_num,
+                    &[],
+                )
+            }
         }
         Err(ChunkProcessError::Spdm(e)) => Err(e),
         Err(ChunkProcessError::Early {
@@ -59,8 +71,7 @@ pub(crate) async fn handle_chunk_send<'a, Pal: SpdmPal>(
         }) => {
             let mut error = [0u8; 4];
             encode_error_pdu(state.version, SPDM_INVALID_REQUEST, &mut error);
-            state.chunk.reset();
-            state.large_buf = None;
+            state.reset_chunk_assembly();
             build_chunk_send_ack(pal, io, state.version, true, handle, chunk_seq_num, &error)
         }
     }
@@ -102,17 +113,17 @@ enum ChunkProcessError {
 fn process_chunk_send<Pal: SpdmPal>(
     state: &mut ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
     pal: &Pal,
-    io: &impl SpdmPalIo,
+    req: &[u8],
 ) -> Result<ChunkInfo, ChunkProcessError> {
-    if state.large_response.in_progress()
+    if state.large_msg_ctx.response_in_progress()
         || (state.phase as u8) < (Phase::AfterCapabilities as u8)
         || !state.chunking_enabled()
     {
         return Err(ChunkProcessError::Spdm(SPDM_UNEXPECTED_REQUEST));
     }
 
-    let req = io.request();
-    if req.len() > pal.mtu() {
+    // Ensure the incoming request message fits our standard effective bounds, not raw MTU.
+    if req.len() > state.effective_data_transfer_size(pal) {
         return Err(ChunkProcessError::Spdm(SPDM_INVALID_REQUEST));
     }
 
@@ -136,7 +147,7 @@ fn process_chunk_send<Pal: SpdmPal>(
         });
     }
 
-    if !state.chunk.in_use {
+    if !state.large_msg_ctx.request_in_progress() {
         process_first_chunk(
             state,
             pal,
@@ -161,7 +172,8 @@ fn process_chunk_send<Pal: SpdmPal>(
     Ok(ChunkInfo {
         handle,
         chunk_seq_num,
-        complete: state.chunk.in_use && state.chunk.bytes_received == state.chunk.large_msg_size,
+        complete: state.large_msg_ctx.request_in_progress()
+            && state.large_msg_ctx.state.bytes_received == state.large_msg_ctx.state.large_msg_size,
     })
 }
 
@@ -184,6 +196,14 @@ fn process_first_chunk<Pal: SpdmPal>(
     large_msg_size.copy_from_slice(size_bytes);
     let large_msg_size = u32::from_le_bytes(large_msg_size) as usize;
     let chunk_data = &rest[4..];
+
+    // Require exact chunk body length match inside rest payload (no trailing junk bytes).
+    if chunk_data.len() != chunk_size {
+        return Err(ChunkProcessError::Early {
+            handle,
+            chunk_seq_num,
+        });
+    }
     let Some(chunk) = chunk_data.get(..chunk_size) else {
         return Err(ChunkProcessError::Early {
             handle,
@@ -207,26 +227,25 @@ fn process_first_chunk<Pal: SpdmPal>(
             chunk_seq_num,
         });
     }
-    match pal.alloc_large_buf(large_msg_size) {
-        Ok(mut buf) => {
-            buf[..chunk_size].copy_from_slice(chunk);
-            state.large_buf = Some(buf);
-        }
+    let rent_buf = match pal.alloc_large_buf(large_msg_size) {
+        Ok(buf) => buf,
         Err(_) => {
             return Err(ChunkProcessError::Early {
                 handle,
                 chunk_seq_num,
             })
         }
-    }
-
-    state.chunk = super::ChunkState {
-        in_use: true,
-        handle,
-        seq_num: 0,
-        bytes_received: chunk_size as u32,
-        large_msg_size: large_msg_size as u32,
     };
+    if state
+        .large_msg_ctx
+        .init_request(handle, large_msg_size, chunk, rent_buf)
+        .is_err()
+    {
+        return Err(ChunkProcessError::Early {
+            handle,
+            chunk_seq_num,
+        });
+    }
     Ok(())
 }
 
@@ -239,9 +258,17 @@ fn process_next_chunk<Pal: SpdmPal>(
     last_chunk: bool,
     rest: &[u8],
 ) -> Result<(), ChunkProcessError> {
-    let bytes_received = state.chunk.bytes_received as usize;
-    let large_msg_size = state.chunk.large_msg_size as usize;
+    let bytes_received = state.large_msg_ctx.state.bytes_received as usize;
+    let large_msg_size = state.large_msg_ctx.state.large_msg_size as usize;
     let end = bytes_received.saturating_add(chunk_size);
+
+    // Require exact chunk body length match inside rest payload (no trailing junk bytes).
+    if rest.len() != chunk_size {
+        return Err(ChunkProcessError::Early {
+            handle,
+            chunk_seq_num,
+        });
+    }
     let Some(chunk) = rest.get(..chunk_size) else {
         return Err(ChunkProcessError::Early {
             handle,
@@ -252,8 +279,8 @@ fn process_next_chunk<Pal: SpdmPal>(
         - SpdmMsgHdrPdu::SIZE
         - ChunkSendReqBody::SIZE;
     let invalid = chunk_seq_num == 0
-        || state.chunk.handle != handle
-        || state.chunk.seq_num.wrapping_add(1) != chunk_seq_num
+        || state.large_msg_ctx.state.handle != handle
+        || state.large_msg_ctx.state.seq_num.wrapping_add(1) != chunk_seq_num
         || end > large_msg_size
         || (last_chunk && end != large_msg_size)
         || (!last_chunk && (end >= large_msg_size || chunk_size < min_chunk_size));
@@ -263,52 +290,105 @@ fn process_next_chunk<Pal: SpdmPal>(
             chunk_seq_num,
         });
     }
-    match state.large_buf.as_deref_mut() {
-        Some(buf) => buf[bytes_received..end].copy_from_slice(chunk),
-        None => {
-            return Err(ChunkProcessError::Early {
-                handle,
-                chunk_seq_num,
-            })
-        }
+    if state
+        .large_msg_ctx
+        .append_request(handle, chunk_seq_num, chunk)
+        .is_err()
+    {
+        return Err(ChunkProcessError::Early {
+            handle,
+            chunk_seq_num,
+        });
     }
 
-    state.chunk.seq_num = chunk_seq_num;
-    state.chunk.bytes_received = end as u32;
     Ok(())
 }
 
-async fn build_response_to_large_request<Pal: SpdmPal>(
-    state: &mut ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
-    pal: &Pal,
-    io: &<Pal as SpdmPalIoTransport>::Io<'_>,
-    out: &mut [u8; 4],
-) {
-    let len = state.chunk.large_msg_size as usize;
-    let err = if len < SpdmMsgHdrPdu::SIZE {
-        SPDM_INVALID_REQUEST
-    } else {
-        match dispatch_large_request(state, pal, io, len, out).await {
-            Ok(()) => return,
-            Err(err) => err,
-        }
-    };
-    encode_error_pdu(state.version, err, out);
+enum ResponseToLargeRequest<'a, Pal: SpdmPal + 'a> {
+    Fixed([u8; 4]),
+    Allocated {
+        buf: PalBytes<'a, Pal>,
+        spdm_len: usize,
+    },
 }
 
-async fn dispatch_large_request<Pal: SpdmPal>(
+async fn build_final_chunk_send_ack<'a, Pal: SpdmPal, Vdm: SpdmVdmBackend>(
     state: &mut ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
-    pal: &Pal,
+    pal: &'a Pal,
     io: &<Pal as SpdmPalIoTransport>::Io<'_>,
-    len: usize,
-    out: &mut [u8; 4],
-) -> Result<(), SpdmError> {
-    #[cfg(not(feature = "set-certificate"))]
-    let _ = (pal, io, out);
+    vdm: &Vdm,
+    secure_session: bool,
+    handle: u8,
+    chunk_seq_num: u16,
+) -> SpdmResult<PalBytes<'a, Pal>> {
+    let len = state.large_msg_ctx.state.large_msg_size as usize;
+    let response = if len < SpdmMsgHdrPdu::SIZE {
+        ResponseToLargeRequest::Fixed(encode_error_response_to_large_request(
+            state.version,
+            SPDM_INVALID_REQUEST,
+        ))
+    } else {
+        match dispatch_large_request(state, pal, io, vdm, len, secure_session).await {
+            Ok(response) => response,
+            Err(err) => ResponseToLargeRequest::Fixed(encode_error_response_to_large_request(
+                state.version,
+                err,
+            )),
+        }
+    };
 
-    // Take the large buffer out of state so we can pass state mutably to
-    // the handler while still reading from the reassembled request.
-    let mut large_buf = state.large_buf.take().ok_or(SPDM_INVALID_REQUEST)?;
+    match response {
+        ResponseToLargeRequest::Fixed(bytes) => {
+            build_chunk_send_ack(pal, io, state.version, false, handle, chunk_seq_num, &bytes)
+        }
+        ResponseToLargeRequest::Allocated { buf, spdm_len } => {
+            let max_response_len = state
+                .effective_data_transfer_size(pal)
+                .saturating_sub(SpdmMsgHdrPdu::SIZE + ChunkSendAckBody::SIZE);
+            if spdm_len > max_response_len {
+                let bytes =
+                    encode_error_response_to_large_request(state.version, SPDM_LARGE_RESPONSE);
+                return build_chunk_send_ack(
+                    pal,
+                    io,
+                    state.version,
+                    false,
+                    handle,
+                    chunk_seq_num,
+                    &bytes,
+                );
+            }
+
+            let head = pal.header_size();
+            let end = head.checked_add(spdm_len).ok_or(SPDM_UNSPECIFIED)?;
+            let response = buf.get(head..end).ok_or(SPDM_UNSPECIFIED)?;
+            build_chunk_send_ack(
+                pal,
+                io,
+                state.version,
+                false,
+                handle,
+                chunk_seq_num,
+                response,
+            )
+        }
+    }
+}
+
+async fn dispatch_large_request<'a, Pal: SpdmPal, Vdm: SpdmVdmBackend>(
+    state: &mut ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
+    pal: &'a Pal,
+    io: &<Pal as SpdmPalIoTransport>::Io<'_>,
+    vdm: &Vdm,
+    len: usize,
+    secure_session: bool,
+) -> Result<ResponseToLargeRequest<'a, Pal>, SpdmError> {
+    // Detach the buffer, but immediately place it in an auto-wiping RAII guard.
+    // This addresses Issue 2 & 3: zeroization is guaranteed across all handler exit pathways!
+    let mut guard = WipeOnDrop {
+        buf: state.large_msg_ctx.take_buffer(),
+    };
+    let large_buf = guard.buf.as_mut().ok_or(SPDM_INVALID_REQUEST)?;
     let buf = large_buf.as_mut();
     let large_req = buf.get(..len).ok_or(SPDM_INVALID_REQUEST)?;
     let (hdr, _) = SpdmMsgHdrPdu::ref_from_prefix(large_req).map_err(|_| SPDM_INVALID_REQUEST)?;
@@ -326,14 +406,39 @@ async fn dispatch_large_request<Pal: SpdmPal>(
             let slot_id =
                 set_certificate::handle_set_certificate_request(state, pal, io, &buf[..len])
                     .await?;
-            out[0] = state.version.to_u8();
-            out[1] = ReqRespCode::SET_CERTIFICATE_RSP.0;
-            out[2] = slot_id;
-            out[3] = 0;
-            Ok(())
+            Ok(ResponseToLargeRequest::Fixed([
+                state.version.to_u8(),
+                ReqRespCode::SET_CERTIFICATE_RSP.0,
+                slot_id,
+                0,
+            ]))
+        }
+        ReqRespCode::VENDOR_DEFINED_REQUEST => {
+            let (v_rsp, spdm_len) = vendor_defined::handle_vendor_defined_request(
+                vdm,
+                state,
+                pal,
+                io,
+                &buf[..len],
+                secure_session,
+            )
+            .await?;
+            if spdm_len == 0 || v_rsp.len() < pal.header_size().saturating_add(spdm_len) {
+                return Err(SPDM_UNSPECIFIED);
+            }
+            Ok(ResponseToLargeRequest::Allocated {
+                buf: v_rsp,
+                spdm_len,
+            })
         }
         _ => Err(SPDM_UNSUPPORTED_REQUEST),
     }
+}
+
+fn encode_error_response_to_large_request(version: SpdmVersion, err: SpdmError) -> [u8; 4] {
+    let mut out = [0u8; 4];
+    encode_error_pdu(version, err, &mut out);
+    out
 }
 
 fn encode_error_pdu(version: SpdmVersion, err: SpdmError, out: &mut [u8; 4]) {

--- a/runtime/userspace/api/spdm-lite/stack/src/digests.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/digests.rs
@@ -9,7 +9,8 @@
 
 use mcu_spdm_lite_codec::{DigestsRsp, ResponseBody, SpdmMsgHdrPdu};
 use mcu_spdm_lite_traits::{
-    PalBytes, SpdmPal, SpdmPalAsymAlgo, SpdmPalHashAlgo, SpdmPalIo, SpdmPalIoTransport, MAX_SLOTS,
+    PalBytes, SpdmPal, SpdmPalAlloc, SpdmPalAsymAlgo, SpdmPalHashAlgo, SpdmPalIo,
+    SpdmPalIoTransport, MAX_SLOTS,
 };
 use zerocopy::FromBytes;
 
@@ -22,7 +23,7 @@ use crate::stack::{multi_key_conn_rsp, ConnectionState, Phase};
 const CERT_CHUNK_SIZE: usize = 1024;
 
 pub(crate) async fn handle_get_digests<'a, Pal: SpdmPal>(
-    state: &mut ConnectionState<Pal::State>,
+    state: &mut ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
     pal: &'a Pal,
     io: &<Pal as SpdmPalIoTransport>::Io<'_>,
 ) -> SpdmResult<PalBytes<'a, Pal>> {

--- a/runtime/userspace/api/spdm-lite/stack/src/key_exchange.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/key_exchange.rs
@@ -19,7 +19,6 @@ use mcu_spdm_lite_codec::{
     ECDH_P384_EXCHANGE_DATA_SIZE, KEY_EXCHANGE_RANDOM_DATA_LEN, OPAQUE_VERSION_SELECTION_SIZE,
     SHA384_HASH_SIZE, SPDM_PREFIX_LEN, SPDM_SIGNING_CONTEXT_LEN,
 };
-use mcu_spdm_lite_traits::SpdmPalAlloc;
 use mcu_spdm_lite_traits::*;
 use zerocopy::FromBytes;
 
@@ -28,8 +27,7 @@ use crate::error::{
     SpdmError, SpdmResult, SPDM_INVALID_REQUEST, SPDM_UNEXPECTED_REQUEST, SPDM_UNSPECIFIED,
 };
 use crate::key_schedule::SessionKeyType;
-use crate::session::{SessionInfo, SessionManager};
-use crate::stack::{ConnectionState, Phase};
+use crate::stack::{ConnState, Phase, Sessions};
 
 const ECDH_P384_ENCRYPTED_CONTEXT_SIZE: usize = 76;
 const KEY_EXCHANGE_WORKSPACE_SIZE: usize = SHA384_HASH_SIZE
@@ -51,15 +49,8 @@ const KEY_EXCHANGE_SIGNING_PREFIX_V13: &[u8; KEY_EXCHANGE_SIGNING_PREFIX_CHUNK_L
 const KEY_EXCHANGE_SIGNING_OP: &[u8; 34] = b"responder-key_exchange_rsp signing";
 
 pub(crate) async fn handle_key_exchange<'a, Pal: SpdmPal, const N: usize>(
-    state: &mut ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
-    sessions: &mut SessionManager<
-        <Pal as SpdmPalSessionCrypto>::Key,
-        Pal::State,
-        <Pal as SpdmPalAlloc>::PersistentBox<
-            SessionInfo<<Pal as SpdmPalSessionCrypto>::Key, Pal::State>,
-        >,
-        N,
-    >,
+    state: &mut ConnState<'_, Pal>,
+    sessions: &mut Sessions<Pal, N>,
     pal: &'a Pal,
     io: &<Pal as SpdmPalIoTransport>::Io<'_>,
 ) -> SpdmResult<PalBytes<'a, Pal>> {
@@ -167,15 +158,8 @@ pub(crate) async fn handle_key_exchange<'a, Pal: SpdmPal, const N: usize>(
 #[allow(clippy::too_many_arguments)]
 #[inline(never)]
 async fn key_exchange_inner<'a, Pal: SpdmPal, const N: usize>(
-    state: &mut ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
-    sessions: &mut SessionManager<
-        <Pal as SpdmPalSessionCrypto>::Key,
-        Pal::State,
-        <Pal as SpdmPalAlloc>::PersistentBox<
-            SessionInfo<<Pal as SpdmPalSessionCrypto>::Key, Pal::State>,
-        >,
-        N,
-    >,
+    state: &mut ConnState<'_, Pal>,
+    sessions: &mut Sessions<Pal, N>,
     pal: &'a Pal,
     io: &<Pal as SpdmPalIoTransport>::Io<'_>,
     req: &[u8],

--- a/runtime/userspace/api/spdm-lite/stack/src/key_exchange.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/key_exchange.rs
@@ -19,6 +19,7 @@ use mcu_spdm_lite_codec::{
     ECDH_P384_EXCHANGE_DATA_SIZE, KEY_EXCHANGE_RANDOM_DATA_LEN, OPAQUE_VERSION_SELECTION_SIZE,
     SHA384_HASH_SIZE, SPDM_PREFIX_LEN, SPDM_SIGNING_CONTEXT_LEN,
 };
+use mcu_spdm_lite_traits::SpdmPalAlloc;
 use mcu_spdm_lite_traits::*;
 use zerocopy::FromBytes;
 
@@ -27,7 +28,7 @@ use crate::error::{
     SpdmError, SpdmResult, SPDM_INVALID_REQUEST, SPDM_UNEXPECTED_REQUEST, SPDM_UNSPECIFIED,
 };
 use crate::key_schedule::SessionKeyType;
-use crate::session::SessionManager;
+use crate::session::{SessionInfo, SessionManager};
 use crate::stack::{ConnectionState, Phase};
 
 const ECDH_P384_ENCRYPTED_CONTEXT_SIZE: usize = 76;
@@ -50,8 +51,15 @@ const KEY_EXCHANGE_SIGNING_PREFIX_V13: &[u8; KEY_EXCHANGE_SIGNING_PREFIX_CHUNK_L
 const KEY_EXCHANGE_SIGNING_OP: &[u8; 34] = b"responder-key_exchange_rsp signing";
 
 pub(crate) async fn handle_key_exchange<'a, Pal: SpdmPal, const N: usize>(
-    state: &mut ConnectionState<Pal::State>,
-    sessions: &mut SessionManager<<Pal as SpdmPalSessionCrypto>::Key, Pal::State, N>,
+    state: &mut ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
+    sessions: &mut SessionManager<
+        <Pal as SpdmPalSessionCrypto>::Key,
+        Pal::State,
+        <Pal as SpdmPalAlloc>::PersistentBox<
+            SessionInfo<<Pal as SpdmPalSessionCrypto>::Key, Pal::State>,
+        >,
+        N,
+    >,
     pal: &'a Pal,
     io: &<Pal as SpdmPalIoTransport>::Io<'_>,
 ) -> SpdmResult<PalBytes<'a, Pal>> {
@@ -118,7 +126,9 @@ pub(crate) async fn handle_key_exchange<'a, Pal: SpdmPal, const N: usize>(
         .map_err(|_| SPDM_UNSPECIFIED)?;
 
     // ── Create session ──────────────────────────────────────────────
-    let session_id = match sessions.create_session(req_session_id, state.version) {
+    let session_id = match sessions.create_session(req_session_id, state.version, |info| {
+        pal.alloc_persistent(info)
+    }) {
         Ok(id) => id,
         Err(e) => {
             let err = SpdmError::from(e);
@@ -157,8 +167,15 @@ pub(crate) async fn handle_key_exchange<'a, Pal: SpdmPal, const N: usize>(
 #[allow(clippy::too_many_arguments)]
 #[inline(never)]
 async fn key_exchange_inner<'a, Pal: SpdmPal, const N: usize>(
-    state: &mut ConnectionState<Pal::State>,
-    sessions: &mut SessionManager<<Pal as SpdmPalSessionCrypto>::Key, Pal::State, N>,
+    state: &mut ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
+    sessions: &mut SessionManager<
+        <Pal as SpdmPalSessionCrypto>::Key,
+        Pal::State,
+        <Pal as SpdmPalAlloc>::PersistentBox<
+            SessionInfo<<Pal as SpdmPalSessionCrypto>::Key, Pal::State>,
+        >,
+        N,
+    >,
     pal: &'a Pal,
     io: &<Pal as SpdmPalIoTransport>::Io<'_>,
     req: &[u8],

--- a/runtime/userspace/api/spdm-lite/stack/src/measurements.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/measurements.rs
@@ -7,6 +7,7 @@ use mcu_spdm_lite_codec::{
     WireWriter, ECC_P384_SIGNATURE_SIZE, MEAS_BLOCK_METADATA_SIZE, REQUESTER_CONTEXT_LEN,
     SHA384_HASH_SIZE, SPDM_CONTEXT_LEN, SPDM_PREFIX_LEN, SPDM_SIGNING_CONTEXT_LEN,
 };
+use mcu_spdm_lite_traits::SpdmPalAlloc;
 use mcu_spdm_lite_traits::*;
 use zerocopy::{FromBytes, IntoBytes};
 
@@ -35,7 +36,7 @@ struct MeasurementsResponseCtx<'a> {
 }
 
 pub(crate) async fn handle_get_measurements_req<'a, Pal: SpdmPal>(
-    state: &mut ConnectionState<Pal::State>,
+    state: &mut ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
     pal: &'a Pal,
     io: &<Pal as SpdmPalIoTransport>::Io<'_>,
     req: &[u8],
@@ -238,33 +239,32 @@ pub(crate) async fn handle_get_measurements_req<'a, Pal: SpdmPal>(
 }
 
 async fn handle_large_measurements_response<'a, Pal: SpdmPal>(
-    state: &mut ConnectionState<Pal::State>,
+    state: &mut ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
     pal: &'a Pal,
     io: &<Pal as SpdmPalIoTransport>::Io<'_>,
     plan: &MeasurementsResponseCtx<'_>,
 ) -> SpdmResult<(PalBytes<'a, Pal>, usize)> {
     chunk::validate_buffered_large_response(state, pal, plan.large_resp_len)?;
-    // Reserve the pinned large buffer before writing the response into it; it is
-    // freed (RAII) once CHUNK_GET ships the final chunk.
-    pal.large_begin(plan.large_resp_len)?;
+    let mut buf = pal.alloc_large_buf(plan.large_resp_len)?;
 
     let mut offset = 0usize;
     let hdr = SpdmMsgHdrPdu::new(state.version, ReqRespCode::MEASUREMENTS);
-    offset = write_large_measurement_bytes(pal, offset, hdr.as_bytes())?;
+    offset = write_into_slice(&mut buf, offset, hdr.as_bytes())?;
 
     let mut fixed = [0u8; MEASUREMENTS_FIXED_BODY_SIZE];
     fixed[0] = plan.total_number_of_measurement;
     fixed[1] = (plan.slot_id & 0x0F) | ((plan.content_changed & 0x03) << 4);
     fixed[2] = plan.number_of_blocks;
     fixed[3..6].copy_from_slice(&u24_le(plan.measurement_record_len)?);
-    offset = write_large_measurement_bytes(pal, offset, &fixed)?;
+    offset = write_into_slice(&mut buf, offset, &fixed)?;
 
-    let (next_offset, written_blocks) = write_measurement_record_large(
+    let (next_offset, written_blocks) = write_measurement_record_into_slice(
         pal,
         io,
         plan.meas_info,
         plan.meas_op,
         plan.meas_nonce,
+        &mut buf,
         offset,
     )
     .await?;
@@ -273,15 +273,18 @@ async fn handle_large_measurements_response<'a, Pal: SpdmPal>(
     }
     offset = next_offset;
 
-    offset = write_large_measurement_bytes(pal, offset, plan.nonce)?;
-    offset = write_large_measurement_bytes(pal, offset, &0u16.to_le_bytes())?;
+    offset = write_into_slice(&mut buf, offset, plan.nonce)?;
+    offset = write_into_slice(&mut buf, offset, &0u16.to_le_bytes())?;
     if let Some(ctx) = plan.requester_context {
-        offset = write_large_measurement_bytes(pal, offset, ctx)?;
+        offset = write_into_slice(&mut buf, offset, ctx)?;
     }
 
     let signature_offset = offset;
     if plan.signature_requested {
-        append_buffered_l1(state, pal, io, signature_offset).await?;
+        state
+            .transcript
+            .append_l1(pal, io, &buf[..signature_offset])
+            .await?;
 
         let mut hash = [0u8; SHA384_HASH_SIZE];
         state.transcript.finalize_l1(pal, io, &mut hash).await?;
@@ -300,8 +303,7 @@ async fn handle_large_measurements_response<'a, Pal: SpdmPal>(
         if sig_len != ECC_P384_SIGNATURE_SIZE {
             return Err(SPDM_UNSPECIFIED);
         }
-        pal.large_write(signature_offset, &signature)
-            .map_err(|_| SPDM_UNSPECIFIED)?;
+        write_into_slice(&mut buf, signature_offset, &signature)?;
         offset += ECC_P384_SIGNATURE_SIZE;
     }
 
@@ -309,6 +311,7 @@ async fn handle_large_measurements_response<'a, Pal: SpdmPal>(
         return Err(SPDM_UNSPECIFIED);
     }
 
+    state.large_buf = Some(buf);
     let resp = chunk::start_buffered_large_response(state, pal, io, plan.large_resp_len)?;
     Ok((resp, 0))
 }
@@ -428,12 +431,13 @@ async fn write_measurement_record<Pal: SpdmPal>(
     Ok(blocks)
 }
 
-async fn write_measurement_record_large<Pal: SpdmPal>(
+async fn write_measurement_record_into_slice<Pal: SpdmPal>(
     pal: &Pal,
     io: &<Pal as SpdmPalIoTransport>::Io<'_>,
     info: &[MeasurementInfo],
     meas_op: u8,
     nonce: Option<&[u8; SPDM_NONCE_LEN]>,
+    out: &mut [u8],
     mut offset: usize,
 ) -> SpdmResult<(usize, u8)> {
     let mut blocks = 0u8;
@@ -441,7 +445,9 @@ async fn write_measurement_record_large<Pal: SpdmPal>(
         0x00 => {}
         0xFF => {
             for entry in info {
-                offset = write_measurement_block_large(pal, io, entry, nonce, offset).await?;
+                offset =
+                    write_measurement_record_block_into_slice(pal, io, entry, nonce, out, offset)
+                        .await?;
                 blocks = blocks.checked_add(1).ok_or(SPDM_UNSPECIFIED)?;
             }
         }
@@ -450,23 +456,25 @@ async fn write_measurement_record_large<Pal: SpdmPal>(
                 .iter()
                 .find(|m| m.index == idx)
                 .ok_or(SPDM_INVALID_REQUEST)?;
-            offset = write_measurement_block_large(pal, io, entry, nonce, offset).await?;
+            offset = write_measurement_record_block_into_slice(pal, io, entry, nonce, out, offset)
+                .await?;
             blocks = 1;
         }
     }
     Ok((offset, blocks))
 }
 
-async fn write_measurement_block_large<Pal: SpdmPal>(
+async fn write_measurement_record_block_into_slice<Pal: SpdmPal>(
     pal: &Pal,
     io: &<Pal as SpdmPalIoTransport>::Io<'_>,
     info: &MeasurementInfo,
     nonce: Option<&[u8; SPDM_NONCE_LEN]>,
+    out: &mut [u8],
     mut offset: usize,
 ) -> SpdmResult<usize> {
     let block_hdr =
         DmtfMeasurementBlockHeader::new(info.index, info.is_raw, info.value_type, info.value_size);
-    offset = write_large_measurement_bytes(pal, offset, block_hdr.as_bytes())?;
+    offset = write_into_slice(out, offset, block_hdr.as_bytes())?;
 
     let value_size = info.value_size as usize;
     if value_size == 0 {
@@ -482,7 +490,7 @@ async fn write_measurement_block_large<Pal: SpdmPal>(
         return Err(SPDM_UNSPECIFIED);
     }
 
-    write_large_measurement_bytes(pal, offset, &value)
+    write_into_slice(out, offset, &value)
 }
 
 /// Write a single DMTF measurement block (header + value) into `out`.
@@ -534,33 +542,12 @@ fn u24_le(len: usize) -> SpdmResult<[u8; 3]> {
     ])
 }
 
-fn write_large_measurement_bytes<Pal: SpdmPal>(
-    pal: &Pal,
-    offset: usize,
-    bytes: &[u8],
-) -> SpdmResult<usize> {
+fn write_into_slice(out: &mut [u8], offset: usize, bytes: &[u8]) -> SpdmResult<usize> {
     let next = offset.checked_add(bytes.len()).ok_or(SPDM_UNSPECIFIED)?;
-    pal.large_write(offset, bytes)
-        .map_err(|_| SPDM_UNSPECIFIED)?;
+    out.get_mut(offset..next)
+        .ok_or(SPDM_UNSPECIFIED)?
+        .copy_from_slice(bytes);
     Ok(next)
-}
-
-async fn append_buffered_l1<Pal: SpdmPal>(
-    state: &mut ConnectionState<Pal::State>,
-    pal: &Pal,
-    io: &<Pal as SpdmPalIoTransport>::Io<'_>,
-    len: usize,
-) -> SpdmResult<()> {
-    let mut offset = 0usize;
-    let mut buf = [0u8; 128];
-    while offset < len {
-        let n = (len - offset).min(buf.len());
-        pal.large_read(offset, &mut buf[..n])
-            .map_err(|_| SPDM_UNSPECIFIED)?;
-        state.transcript.append_l1(pal, io, &buf[..n]).await?;
-        offset += n;
-    }
-    Ok(())
 }
 
 /// Build the 100-byte SPDM signing context for MEASUREMENTS.

--- a/runtime/userspace/api/spdm-lite/stack/src/measurements.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/measurements.rs
@@ -245,18 +245,23 @@ async fn handle_large_measurements_response<'a, Pal: SpdmPal>(
     plan: &MeasurementsResponseCtx<'_>,
 ) -> SpdmResult<(PalBytes<'a, Pal>, usize)> {
     chunk::validate_buffered_large_response(state, pal, plan.large_resp_len)?;
-    let mut buf = pal.alloc_large_buf(plan.large_resp_len)?;
+
+    // We replace the local AutoWipeGuard struct definition with standard WipeOnDrop from chunk!
+    let mut guard = chunk::WipeOnDrop {
+        buf: Some(pal.alloc_large_buf(plan.large_resp_len)?),
+    };
+    let buf = guard.buf.as_mut().ok_or(SPDM_UNSPECIFIED)?;
 
     let mut offset = 0usize;
     let hdr = SpdmMsgHdrPdu::new(state.version, ReqRespCode::MEASUREMENTS);
-    offset = write_into_slice(&mut buf, offset, hdr.as_bytes())?;
+    offset = write_into_slice(buf, offset, hdr.as_bytes())?;
 
     let mut fixed = [0u8; MEASUREMENTS_FIXED_BODY_SIZE];
     fixed[0] = plan.total_number_of_measurement;
     fixed[1] = (plan.slot_id & 0x0F) | ((plan.content_changed & 0x03) << 4);
     fixed[2] = plan.number_of_blocks;
     fixed[3..6].copy_from_slice(&u24_le(plan.measurement_record_len)?);
-    offset = write_into_slice(&mut buf, offset, &fixed)?;
+    offset = write_into_slice(buf, offset, &fixed)?;
 
     let (next_offset, written_blocks) = write_measurement_record_into_slice(
         pal,
@@ -264,7 +269,7 @@ async fn handle_large_measurements_response<'a, Pal: SpdmPal>(
         plan.meas_info,
         plan.meas_op,
         plan.meas_nonce,
-        &mut buf,
+        buf,
         offset,
     )
     .await?;
@@ -273,10 +278,10 @@ async fn handle_large_measurements_response<'a, Pal: SpdmPal>(
     }
     offset = next_offset;
 
-    offset = write_into_slice(&mut buf, offset, plan.nonce)?;
-    offset = write_into_slice(&mut buf, offset, &0u16.to_le_bytes())?;
+    offset = write_into_slice(buf, offset, plan.nonce)?;
+    offset = write_into_slice(buf, offset, &0u16.to_le_bytes())?;
     if let Some(ctx) = plan.requester_context {
-        offset = write_into_slice(&mut buf, offset, ctx)?;
+        offset = write_into_slice(buf, offset, ctx)?;
     }
 
     let signature_offset = offset;
@@ -303,7 +308,7 @@ async fn handle_large_measurements_response<'a, Pal: SpdmPal>(
         if sig_len != ECC_P384_SIGNATURE_SIZE {
             return Err(SPDM_UNSPECIFIED);
         }
-        write_into_slice(&mut buf, signature_offset, &signature)?;
+        write_into_slice(buf, signature_offset, &signature)?;
         offset += ECC_P384_SIGNATURE_SIZE;
     }
 
@@ -311,9 +316,17 @@ async fn handle_large_measurements_response<'a, Pal: SpdmPal>(
         return Err(SPDM_UNSPECIFIED);
     }
 
-    state.large_buf = Some(buf);
-    let resp = chunk::start_buffered_large_response(state, pal, io, plan.large_resp_len)?;
-    Ok((resp, 0))
+    let final_buf = guard.buf.take().ok_or(SPDM_UNSPECIFIED)?;
+    state.large_msg_ctx.set_buffer(final_buf);
+    let (resp, spdm_len) =
+        match chunk::start_buffered_large_response(state, pal, io, plan.large_resp_len) {
+            Ok(res) => res,
+            Err(err) => {
+                state.large_msg_ctx.reset();
+                return Err(err);
+            }
+        };
+    Ok((resp, spdm_len))
 }
 
 fn measurement_record_shape(info: &[MeasurementInfo], meas_op: u8) -> SpdmResult<(usize, u8)> {

--- a/runtime/userspace/api/spdm-lite/stack/src/session.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/session.rs
@@ -11,9 +11,7 @@
 //! 3. Session used for secured message framing
 //! 4. GET_VERSION or error → [`SessionManager::remove_all_and_destroy`]
 
-use alloc::alloc::{alloc, Layout};
-use alloc::boxed::Box;
-use mcu_error::codes::OUT_OF_MEMORY;
+use core::ops::{Deref, DerefMut};
 use mcu_spdm_lite_codec::{errors::SPDM_SESSION_LIMIT_EXCEEDED, SpdmVersion};
 use mcu_spdm_lite_traits::{McuResult, SpdmPalHash, SpdmPalIo};
 
@@ -150,25 +148,14 @@ pub struct SessionInfo<K: Clone, S> {
 }
 
 impl<K: Clone, S> SessionInfo<K, S> {
-    fn try_new(session_id: u32, version: SpdmVersion) -> McuResult<Box<Self>> {
-        let layout = Layout::new::<Self>();
-        // SAFETY: `layout` is for `SessionInfo<K, S>`. A null return is
-        // converted to OUT_OF_MEMORY; otherwise the allocation is
-        // initialized exactly once below and then owned by Box.
-        let ptr = unsafe { alloc(layout) }.cast::<Self>();
-        if ptr.is_null() {
-            return Err(OUT_OF_MEMORY);
-        }
-        // SAFETY: `ptr` is non-null and properly aligned for `Self`,
-        // and no references exist before we initialize it.
-        unsafe {
-            ptr.write(Self {
-                session_id,
-                state: SessionState::HandshakeInProgress,
-                key_schedule: KeySchedule::new(spdm_version_str(version)),
-                transcript: SessionTranscript::new(),
-            });
-            Ok(Box::from_raw(ptr))
+    /// Construct a new `SessionInfo` value. Caller is responsible for
+    /// wrapping it in the appropriate box type via the PAL allocator.
+    pub fn new(session_id: u32, version: SpdmVersion) -> Self {
+        Self {
+            session_id,
+            state: SessionState::HandshakeInProgress,
+            key_schedule: KeySchedule::new(spdm_version_str(version)),
+            transcript: SessionTranscript::new(),
         }
     }
 }
@@ -177,31 +164,46 @@ impl<K: Clone, S> SessionInfo<K, S> {
 
 /// Fixed-size session table.
 ///
-/// `K` = key handle, `S` = hash state, `N` = max concurrent sessions.
-pub struct SessionManager<K: Clone, S, const N: usize> {
-    sessions: [Option<Box<SessionInfo<K, S>>>; N],
+/// `K` = key handle, `S` = hash state, `B` = box type wrapping
+/// `SessionInfo<K, S>`, `N` = max concurrent sessions.
+pub struct SessionManager<K: Clone, S, B, const N: usize> {
+    sessions: [Option<B>; N],
     next_rsp_session_id: u16,
+    _phantom: core::marker::PhantomData<(K, S)>,
 }
 
-impl<K: Clone, S, const N: usize> Default for SessionManager<K, S, N> {
+impl<K: Clone, S, B, const N: usize> Default for SessionManager<K, S, B, N> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<K: Clone, S, const N: usize> SessionManager<K, S, N> {
+impl<K: Clone, S, B, const N: usize> SessionManager<K, S, B, N> {
     pub fn new() -> Self {
         Self {
             sessions: core::array::from_fn(|_| None),
             next_rsp_session_id: 1,
+            _phantom: core::marker::PhantomData,
         }
     }
+}
 
+impl<K: Clone, S, B: Deref<Target = SessionInfo<K, S>> + DerefMut, const N: usize>
+    SessionManager<K, S, B, N>
+{
     /// Allocate a new session slot.
+    ///
+    /// `alloc_fn` is called to wrap the constructed `SessionInfo` in the
+    /// platform box type (e.g., `McuSpdmBox` from bitmap, or `Box` in tests).
     ///
     /// Returns the combined session ID on success. The session starts
     /// in [`SessionState::HandshakeInProgress`].
-    pub fn create_session(&mut self, req_session_id: u16, version: SpdmVersion) -> McuResult<u32> {
+    pub fn create_session(
+        &mut self,
+        req_session_id: u16,
+        version: SpdmVersion,
+        alloc_fn: impl FnOnce(SessionInfo<K, S>) -> McuResult<B>,
+    ) -> McuResult<u32> {
         let slot = self
             .sessions
             .iter()
@@ -212,7 +214,8 @@ impl<K: Clone, S, const N: usize> SessionManager<K, S, N> {
         let rsp_id = self.alloc_rsp_session_id(req_session_id)?;
         let session_id = ((rsp_id as u32) << 16) | (req_session_id as u32);
 
-        self.sessions[slot] = Some(SessionInfo::try_new(session_id, version)?);
+        let info = SessionInfo::new(session_id, version);
+        self.sessions[slot] = Some(alloc_fn(info)?);
 
         Ok(session_id)
     }
@@ -223,7 +226,7 @@ impl<K: Clone, S, const N: usize> SessionManager<K, S, N> {
             .iter()
             .flatten()
             .find(|s| s.session_id == session_id)
-            .map(Box::as_ref)
+            .map(|b| &**b)
     }
 
     /// Look up a session by combined ID (mutable).
@@ -232,7 +235,7 @@ impl<K: Clone, S, const N: usize> SessionManager<K, S, N> {
             .iter_mut()
             .flatten()
             .find(|s| s.session_id == session_id)
-            .map(Box::as_mut)
+            .map(|b| &mut **b)
     }
 
     /// Remove a session and clear all local key blobs.

--- a/runtime/userspace/api/spdm-lite/stack/src/session.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/session.rs
@@ -147,6 +147,14 @@ pub struct SessionInfo<K: Clone, S> {
     pub transcript: SessionTranscript<S>,
 }
 
+impl<K: Clone, S> Drop for SessionInfo<K, S> {
+    fn drop(&mut self) {
+        self.key_schedule.destroy_all();
+        // NOTE: The physical backing memory slot of this SessionInfo structure in the coordinator pool
+        // is guaranteed to be securely zeroized/wiped inside `McuSpdmBox::drop()` upon slot reclamation.
+    }
+}
+
 impl<K: Clone, S> SessionInfo<K, S> {
     /// Construct a new `SessionInfo` value. Caller is responsible for
     /// wrapping it in the appropriate box type via the PAL allocator.

--- a/runtime/userspace/api/spdm-lite/stack/src/set_certificate.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/set_certificate.rs
@@ -14,7 +14,7 @@ use mcu_spdm_lite_codec::{
 };
 use mcu_spdm_lite_errors::as_spdm_wire;
 use mcu_spdm_lite_traits::{
-    PalBytes, SpdmPal, SpdmPalHashAlgo, SpdmPalIo, SpdmPalIoTransport, MAX_SLOTS,
+    PalBytes, SpdmPal, SpdmPalAlloc, SpdmPalHashAlgo, SpdmPalIo, SpdmPalIoTransport, MAX_SLOTS,
 };
 use zerocopy::FromBytes;
 
@@ -32,7 +32,7 @@ const CERT_MODEL_ALIAS_CERT: u8 = 2;
 const CERT_MODEL_GENERIC_CERT: u8 = 3;
 
 pub(crate) async fn handle_set_certificate<'a, Pal: SpdmPal>(
-    state: &mut ConnectionState<Pal::State>,
+    state: &mut ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
     pal: &'a Pal,
     io: &<Pal as SpdmPalIoTransport>::Io<'_>,
 ) -> SpdmResult<PalBytes<'a, Pal>> {
@@ -45,7 +45,7 @@ pub(crate) async fn handle_set_certificate<'a, Pal: SpdmPal>(
 }
 
 pub(crate) async fn handle_set_certificate_request<Pal: SpdmPal>(
-    state: &mut ConnectionState<Pal::State>,
+    state: &mut ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
     pal: &Pal,
     io: &<Pal as SpdmPalIoTransport>::Io<'_>,
     req: &[u8],
@@ -138,8 +138,8 @@ fn validate_request_slot(slot_id: u8, supported_slots: u8) -> SpdmResult<()> {
     Ok(())
 }
 
-fn validate_request_attributes<S>(
-    state: &ConnectionState<S>,
+fn validate_request_attributes<S, L>(
+    state: &ConnectionState<S, L>,
     req: &SetCertificateReqBody,
 ) -> SpdmResult<()> {
     if state.version < SpdmVersion::V13 {
@@ -165,8 +165,8 @@ fn validate_request_attributes<S>(
     Ok(())
 }
 
-fn effective_cert_model<S>(
-    state: &ConnectionState<S>,
+fn effective_cert_model<S, L>(
+    state: &ConnectionState<S, L>,
     req: &SetCertificateReqBody,
 ) -> SpdmResult<u8> {
     if multi_key_conn_rsp(state)? && req.cert_model() != 0 {
@@ -184,7 +184,9 @@ fn cert_model_from_capabilities(cap_flags: CapFlags) -> u8 {
     }
 }
 
-fn validate_negotiated_set_certificate_algorithms<S>(state: &ConnectionState<S>) -> SpdmResult<()> {
+fn validate_negotiated_set_certificate_algorithms<S, L>(
+    state: &ConnectionState<S, L>,
+) -> SpdmResult<()> {
     if state.negotiated_base_hash_sel != HashAlgos::SHA_384 {
         return Err(SPDM_UNSPECIFIED);
     }
@@ -409,10 +411,7 @@ mod tests {
             = Vec<u8>
         where
             Self: 'a;
-        type LargeBuf<'a>
-            = Vec<u8>
-        where
-            Self: 'a;
+        type LargeBuf = Vec<u8>;
 
         fn alloc<T: Sized>(&self, _io: &impl SpdmPalIo, value: T) -> McuResult<Self::Box<'_, T>> {
             Ok(TestBox {
@@ -429,23 +428,17 @@ mod tests {
             self.mtu
         }
 
-        fn large_begin(&self, _len: usize) -> McuResult<()> {
-            Ok(())
-        }
-
-        fn large_write(&self, _offset: usize, _data: &[u8]) -> McuResult<()> {
-            Ok(())
-        }
-
-        fn large_read(&self, _offset: usize, out: &mut [u8]) -> McuResult<()> {
-            out.fill(0);
-            Ok(())
-        }
-
-        fn large_end(&self) {}
-
-        fn large_take(&self, len: usize) -> McuResult<Self::LargeBuf<'_>> {
+        fn alloc_large_buf(&self, len: usize) -> McuResult<Self::LargeBuf> {
             Ok(vec![0u8; len])
+        }
+
+        type PersistentBox<T: Sized + 'static> = Box<T>;
+
+        fn alloc_persistent<T: Sized + 'static>(
+            &self,
+            value: T,
+        ) -> McuResult<Self::PersistentBox<T>> {
+            Ok(Box::new(value))
         }
     }
 
@@ -658,7 +651,7 @@ mod tests {
         digest
     }
 
-    fn state(version: SpdmVersion) -> ConnectionState<TestHashState> {
+    fn state(version: SpdmVersion) -> ConnectionState<TestHashState, Vec<u8>> {
         let mut state = ConnectionState::default();
         state.phase = Phase::AfterAlgorithms;
         state.version = version;
@@ -668,7 +661,7 @@ mod tests {
         state
     }
 
-    fn state_v13_multi_key() -> ConnectionState<TestHashState> {
+    fn state_v13_multi_key() -> ConnectionState<TestHashState, Vec<u8>> {
         let mut state = state(SpdmVersion::V13);
         state.other_param_sel = OtherParamSupport::MULTI_KEY_CONN;
         state.peer_cap_flags = CapFlags::MULTI_KEY_CONN_RSP;

--- a/runtime/userspace/api/spdm-lite/stack/src/stack.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/stack.rs
@@ -19,6 +19,7 @@ use mcu_spdm_lite_codec::{
     MeasHashAlgos, MeasSpec, OtherParamSupport, ReqRespCode, SecuredMessageHeader, SpdmMsgHdrPdu,
     SpdmVersion, AES_256_GCM_TAG_SIZE, SECURED_MSG_HDR_SIZE,
 };
+use mcu_spdm_lite_traits::SpdmPalAlloc;
 use mcu_spdm_lite_traits::*;
 use zerocopy::FromBytes;
 
@@ -28,7 +29,7 @@ use crate::error::{
     SPDM_UNEXPECTED_REQUEST, SPDM_UNSPECIFIED, SPDM_UNSUPPORTED_REQUEST, SPDM_VERSION_MISMATCH,
 };
 use crate::key_schedule::SessionKeyType;
-use crate::session::{SessionManager, SessionState};
+use crate::session::{SessionInfo, SessionManager, SessionState};
 use crate::{
     algorithms, capabilities, certificate, challenge, chunk, digests, end_session, finish,
     key_exchange, measurements, vendor_defined, version,
@@ -72,7 +73,7 @@ pub enum Phase {
 ///    `GET_VERSION` → `GET_CAPABILITIES` → `NEGOTIATE_ALGORITHMS`
 ///    handshake and reset on every `GET_VERSION` via
 ///    [`Self::reset_negotiation`].
-pub struct ConnectionState<S> {
+pub struct ConnectionState<S, L> {
     // ---- Local responder policy (fixed at startup) -----------------------
     /// Responder `CT` time exponent.
     /// Maximum response time is `2^ct_exponent` µs.
@@ -125,9 +126,10 @@ pub struct ConnectionState<S> {
     pub(crate) chunk: chunk::ChunkState,
     /// Pending large response served by CHUNK_GET.
     pub(crate) large_response: chunk::LargeResponseState,
+    pub(crate) large_buf: Option<L>,
 }
 
-impl<S> ConnectionState<S> {
+impl<S, L> ConnectionState<S, L> {
     /// Builds the Caliptra responder's fixed local-policy advertisement.
     ///
     /// # Returns
@@ -183,6 +185,7 @@ impl<S> ConnectionState<S> {
             transcript: crate::transcript::Transcript::new(),
             chunk: chunk::ChunkState::default(),
             large_response: chunk::LargeResponseState::default(),
+            large_buf: None,
         }
     }
 
@@ -203,6 +206,7 @@ impl<S> ConnectionState<S> {
         self.transcript.reset();
         self.chunk.reset();
         self.large_response.reset();
+        self.large_buf = None;
     }
 
     /// Returns true when both peers negotiated CHUNK support.
@@ -237,13 +241,13 @@ impl<S> ConnectionState<S> {
     }
 }
 
-impl<S> Default for ConnectionState<S> {
+impl<S, L> Default for ConnectionState<S, L> {
     fn default() -> Self {
         Self::caliptra()
     }
 }
 
-pub(crate) fn multi_key_conn_rsp<S>(state: &ConnectionState<S>) -> SpdmResult<bool> {
+pub(crate) fn multi_key_conn_rsp<S, L>(state: &ConnectionState<S, L>) -> SpdmResult<bool> {
     let selected = state
         .other_param_sel
         .contains(OtherParamSupport::MULTI_KEY_CONN);
@@ -298,9 +302,9 @@ pub struct SpdmStack<
     Vdm: SpdmVdmBackend = NoVdmBackend,
 > {
     pub(crate) pal: Pal,
-    pub(crate) state: ConnectionState<Pal::State>,
-    pub(crate) sessions:
-        SessionManager<<Pal as SpdmPalSessionCrypto>::Key, Pal::State, MAX_SESSIONS>,
+    pub(crate) state: ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
+    #[allow(clippy::type_complexity)]
+    pub(crate) sessions: Sessions<Pal, MAX_SESSIONS>,
     vdm_backend: Vdm,
 }
 
@@ -331,7 +335,7 @@ impl<Pal: SpdmPal, const MAX_SESSIONS: usize, Vdm: SpdmVdmBackend>
     /// If the PAL cannot hold at least one transport-sized large message,
     /// `CHUNK` is removed from the advertised capabilities.
     pub fn with_vdm_backend(pal: Pal, vdm_backend: Vdm) -> Self {
-        let mut state = ConnectionState::<Pal::State>::default();
+        let mut state = ConnectionState::<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>::default();
         if pal.large_capacity() < pal.mtu() {
             state.cap_flags =
                 CapFlags::from_bits(state.cap_flags.into_bits() & !CapFlags::CHUNK.into_bits());
@@ -521,6 +525,16 @@ impl<Pal: SpdmPal, const MAX_SESSIONS: usize, Vdm: SpdmVdmBackend>
     }
 }
 
+/// Type alias for the SessionManager with full PAL type resolution.
+type Sessions<Pal, const N: usize> = SessionManager<
+    <Pal as SpdmPalSessionCrypto>::Key,
+    <Pal as SpdmPalHash>::State,
+    <Pal as SpdmPalAlloc>::PersistentBox<
+        SessionInfo<<Pal as SpdmPalSessionCrypto>::Key, <Pal as SpdmPalHash>::State>,
+    >,
+    N,
+>;
+
 /// Routes a decoded request code to the matching handler.
 ///
 /// Free-standing (rather than a method on [`SpdmStack`]) so the
@@ -547,8 +561,8 @@ impl<Pal: SpdmPal, const MAX_SESSIONS: usize, Vdm: SpdmVdmBackend>
 /// * Whatever the specific handler returns.
 #[inline(never)]
 async fn dispatch<'a, Pal: SpdmPal, Vdm: SpdmVdmBackend, const MAX_SESSIONS: usize>(
-    state: &mut ConnectionState<Pal::State>,
-    sessions: &mut SessionManager<<Pal as SpdmPalSessionCrypto>::Key, Pal::State, MAX_SESSIONS>,
+    state: &mut ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
+    sessions: &mut Sessions<Pal, MAX_SESSIONS>,
     pal: &'a Pal,
     io: &<Pal as SpdmPalIoTransport>::Io<'_>,
     code: ReqRespCode,
@@ -562,6 +576,7 @@ async fn dispatch<'a, Pal: SpdmPal, Vdm: SpdmVdmBackend, const MAX_SESSIONS: usi
         && state.large_response.in_progress()
     {
         state.large_response.reset();
+        state.large_buf = None;
     }
     match code {
         ReqRespCode::GET_VERSION => {
@@ -625,8 +640,8 @@ async fn handle_secured_request<
     Vdm: SpdmVdmBackend,
     const MAX_SESSIONS: usize,
 >(
-    state: &mut ConnectionState<Pal::State>,
-    sessions: &mut SessionManager<<Pal as SpdmPalSessionCrypto>::Key, Pal::State, MAX_SESSIONS>,
+    state: &mut ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
+    sessions: &mut Sessions<Pal, MAX_SESSIONS>,
     pal: &'a Pal,
     io: &<Pal as SpdmPalIoTransport>::Io<'_>,
     vdm: &Vdm,
@@ -678,8 +693,8 @@ async fn handle_secured_request<
 /// Inner secured message handler: decrypt → dispatch → encrypt.
 #[inline(never)]
 async fn handle_secured_inner<'a, Pal: SpdmPal, Vdm: SpdmVdmBackend, const MAX_SESSIONS: usize>(
-    state: &mut ConnectionState<Pal::State>,
-    sessions: &mut SessionManager<<Pal as SpdmPalSessionCrypto>::Key, Pal::State, MAX_SESSIONS>,
+    state: &mut ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
+    sessions: &mut Sessions<Pal, MAX_SESSIONS>,
     pal: &'a Pal,
     io: &<Pal as SpdmPalIoTransport>::Io<'_>,
     session_id: u32,

--- a/runtime/userspace/api/spdm-lite/stack/src/stack.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/stack.rs
@@ -35,6 +35,20 @@ use crate::{
     key_exchange, measurements, vendor_defined, version,
 };
 
+/// Type alias for the SessionManager with full PAL type resolution.
+pub(crate) type Sessions<Pal, const N: usize> = SessionManager<
+    <Pal as SpdmPalSessionCrypto>::Key,
+    <Pal as SpdmPalHash>::State,
+    <Pal as SpdmPalAlloc>::PersistentBox<
+        SessionInfo<<Pal as SpdmPalSessionCrypto>::Key, <Pal as SpdmPalHash>::State>,
+    >,
+    N,
+>;
+
+/// Type alias for ConnectionState with full PAL type resolution.
+pub(crate) type ConnState<'a, Pal> =
+    ConnectionState<<Pal as SpdmPalHash>::State, <Pal as SpdmPalAlloc>::LargeBuf>;
+
 /// Connection phase tracked on the responder so the dispatcher can
 /// enforce the SPDM ordering
 /// `GET_VERSION → GET_CAPABILITIES → NEGOTIATE_ALGORITHMS`.
@@ -122,11 +136,8 @@ pub struct ConnectionState<S, L> {
     pub negotiated_base_hash_sel: HashAlgos,
     /// Transcript state (running VCA/M1/L1 hashes per SPDM).
     pub transcript: crate::transcript::Transcript<S>,
-    /// In-progress CHUNK_SEND large-request reassembly state.
-    pub(crate) chunk: chunk::ChunkState,
-    /// Pending large response served by CHUNK_GET.
-    pub(crate) large_response: chunk::LargeResponseState,
-    pub(crate) large_buf: Option<L>,
+    /// Consolidated context managing large-payload request reassembly and response chunking.
+    pub(crate) large_msg_ctx: chunk::LargeMessageCtx<L>,
 }
 
 impl<S, L> ConnectionState<S, L> {
@@ -183,30 +194,8 @@ impl<S, L> ConnectionState<S, L> {
             negotiated_base_asym_sel: AsymAlgos::EMPTY,
             negotiated_base_hash_sel: HashAlgos::EMPTY,
             transcript: crate::transcript::Transcript::new(),
-            chunk: chunk::ChunkState::default(),
-            large_response: chunk::LargeResponseState::default(),
-            large_buf: None,
+            large_msg_ctx: chunk::LargeMessageCtx::new(),
         }
-    }
-
-    /// Drops every connection-scoped negotiation result.
-    ///
-    /// Called by the dispatcher on every `GET_VERSION` per SPDM
-    /// Local-policy fields (the upper block) are not modified.
-    pub(crate) fn reset_negotiation(&mut self) {
-        self.phase = Phase::Start;
-        self.version = SpdmVersion::V12;
-        self.peer_data_transfer_size = 0;
-        self.peer_max_spdm_msg_size = 0;
-        self.advertised_cap_flags = CapFlags::EMPTY;
-        self.peer_cap_flags = CapFlags::EMPTY;
-        self.other_param_sel = OtherParamSupport::EMPTY;
-        self.negotiated_base_asym_sel = AsymAlgos::EMPTY;
-        self.negotiated_base_hash_sel = HashAlgos::EMPTY;
-        self.transcript.reset();
-        self.chunk.reset();
-        self.large_response.reset();
-        self.large_buf = None;
     }
 
     /// Returns true when both peers negotiated CHUNK support.
@@ -238,6 +227,35 @@ impl<S, L> ConnectionState<S, L> {
     pub(crate) fn asym_algo(&self) -> SpdmPalAsymAlgo {
         // TODO: add MLDSA-87 mapping once codec and DPE support it.
         SpdmPalAsymAlgo::EccP384
+    }
+}
+
+impl<S, L: core::ops::DerefMut<Target = [u8]>> ConnectionState<S, L> {
+    /// Resets the connection-level large message context, securely wiping any buffered bytes.
+    pub(crate) fn reset_negotiation(&mut self) {
+        self.phase = Phase::Start;
+        self.version = SpdmVersion::V12;
+        self.peer_data_transfer_size = 0;
+        self.peer_max_spdm_msg_size = 0;
+        self.advertised_cap_flags = CapFlags::EMPTY;
+        self.peer_cap_flags = CapFlags::EMPTY;
+        self.other_param_sel = OtherParamSupport::EMPTY;
+        self.negotiated_base_asym_sel = AsymAlgos::EMPTY;
+        self.negotiated_base_hash_sel = HashAlgos::EMPTY;
+        self.transcript.reset();
+        self.large_msg_ctx.reset();
+    }
+
+    /// Resets the incoming chunk reassembly state, securely wiping any buffered reassembly bytes.
+    #[allow(dead_code)]
+    pub(crate) fn reset_chunk_assembly(&mut self) {
+        self.large_msg_ctx.reset();
+    }
+
+    /// Resets the outgoing large response state, securely wiping any buffered response bytes.
+    #[allow(dead_code)]
+    pub(crate) fn reset_large_response(&mut self) {
+        self.large_msg_ctx.reset();
     }
 }
 
@@ -525,16 +543,6 @@ impl<Pal: SpdmPal, const MAX_SESSIONS: usize, Vdm: SpdmVdmBackend>
     }
 }
 
-/// Type alias for the SessionManager with full PAL type resolution.
-type Sessions<Pal, const N: usize> = SessionManager<
-    <Pal as SpdmPalSessionCrypto>::Key,
-    <Pal as SpdmPalHash>::State,
-    <Pal as SpdmPalAlloc>::PersistentBox<
-        SessionInfo<<Pal as SpdmPalSessionCrypto>::Key, <Pal as SpdmPalHash>::State>,
-    >,
-    N,
->;
-
 /// Routes a decoded request code to the matching handler.
 ///
 /// Free-standing (rather than a method on [`SpdmStack`]) so the
@@ -568,15 +576,14 @@ async fn dispatch<'a, Pal: SpdmPal, Vdm: SpdmVdmBackend, const MAX_SESSIONS: usi
     code: ReqRespCode,
     vdm: &Vdm,
 ) -> SpdmResult<PalBytes<'a, Pal>> {
-    if code != ReqRespCode::CHUNK_SEND && state.chunk.in_progress() {
-        state.chunk.reset();
+    if code != ReqRespCode::CHUNK_SEND && state.large_msg_ctx.request_in_progress() {
+        state.large_msg_ctx.reset();
     }
     if code != ReqRespCode::CHUNK_GET
         && code != ReqRespCode::CHUNK_SEND
-        && state.large_response.in_progress()
+        && state.large_msg_ctx.response_in_progress()
     {
-        state.large_response.reset();
-        state.large_buf = None;
+        state.large_msg_ctx.reset();
     }
     match code {
         ReqRespCode::GET_VERSION => {
@@ -593,8 +600,10 @@ async fn dispatch<'a, Pal: SpdmPal, Vdm: SpdmVdmBackend, const MAX_SESSIONS: usi
         ReqRespCode::GET_DIGESTS => digests::handle_get_digests(state, pal, io).await,
         ReqRespCode::GET_CERTIFICATE => certificate::handle_get_certificate(state, pal, io).await,
         ReqRespCode::CHALLENGE => challenge::handle_challenge(state, pal, io).await,
-        ReqRespCode::CHUNK_SEND => chunk::handle_chunk_send(state, pal, io).await,
-        ReqRespCode::CHUNK_GET => chunk::handle_chunk_get(state, pal, io).await,
+        ReqRespCode::CHUNK_SEND => {
+            chunk::handle_chunk_send(state, pal, io, vdm, io.request(), false).await
+        }
+        ReqRespCode::CHUNK_GET => chunk::handle_chunk_get(state, pal, io, io.request()).await,
         #[cfg(feature = "set-certificate")]
         ReqRespCode::SET_CERTIFICATE => {
             crate::set_certificate::handle_set_certificate(state, pal, io).await
@@ -767,6 +776,18 @@ async fn handle_secured_inner<'a, Pal: SpdmPal, Vdm: SpdmVdmBackend, const MAX_S
     let session_state = sessions.find(session_id).ok_or(SPDM_UNSPECIFIED)?.state;
     let response_key_type = validate_message_allowed_phase(spdm_hdr.code, session_state)?;
 
+    // After decoding secure inner SPDM code, ensure stale large-message reassembly/response state is cleared.
+    let code = spdm_hdr.code;
+    if code != ReqRespCode::CHUNK_SEND && state.large_msg_ctx.request_in_progress() {
+        state.large_msg_ctx.reset();
+    }
+    if code != ReqRespCode::CHUNK_GET
+        && code != ReqRespCode::CHUNK_SEND
+        && state.large_msg_ctx.response_in_progress()
+    {
+        state.large_msg_ctx.reset();
+    }
+
     match spdm_hdr.code {
         ReqRespCode::FINISH => {
             let session = sessions.find_mut(session_id).ok_or(SPDM_UNSPECIFIED)?;
@@ -837,6 +858,39 @@ async fn handle_secured_inner<'a, Pal: SpdmPal, Vdm: SpdmVdmBackend, const MAX_S
             )
             .await
         }
+        ReqRespCode::CHUNK_GET => {
+            let chunk_rsp = chunk::handle_chunk_get(state, pal, io, spdm_msg).await?;
+            let head = pal.header_size();
+            let spdm_rsp = &chunk_rsp[head..];
+            let session = sessions.find_mut(session_id).ok_or(SPDM_UNSPECIFIED)?;
+            encrypt_secured_spdm_response(
+                pal,
+                io,
+                session,
+                session_id,
+                version,
+                response_key_type,
+                spdm_rsp,
+            )
+            .await
+        }
+        ReqRespCode::CHUNK_SEND => {
+            let chunk_send_ack =
+                chunk::handle_chunk_send(state, pal, io, vdm, spdm_msg, true).await?;
+            let head = pal.header_size();
+            let spdm_rsp = &chunk_send_ack[head..];
+            let session = sessions.find_mut(session_id).ok_or(SPDM_UNSPECIFIED)?;
+            encrypt_secured_spdm_response(
+                pal,
+                io,
+                session,
+                session_id,
+                version,
+                response_key_type,
+                spdm_rsp,
+            )
+            .await
+        }
         _ => Err(SPDM_UNSUPPORTED_REQUEST.with_data(spdm_hdr.code.0)),
     }
 }
@@ -876,7 +930,9 @@ fn validate_message_allowed_phase(
                 Err(SPDM_UNEXPECTED_REQUEST)
             }
         }
-        ReqRespCode::VENDOR_DEFINED_REQUEST => current_key(),
+        ReqRespCode::VENDOR_DEFINED_REQUEST | ReqRespCode::CHUNK_GET | ReqRespCode::CHUNK_SEND => {
+            current_key()
+        }
         _ => Err(SPDM_UNSUPPORTED_REQUEST.with_data(code.0)),
     }
 }

--- a/runtime/userspace/api/spdm-lite/stack/src/vendor_defined.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/vendor_defined.rs
@@ -13,7 +13,7 @@ use mcu_spdm_lite_codec::{
     VendorDefinedRspBody,
 };
 use mcu_spdm_lite_traits::{
-    PalBytes, SpdmPal, SpdmPalIoTransport, SpdmVdmBackend, VdmRegistry, VdmResponse,
+    PalBytes, SpdmPal, SpdmPalAlloc, SpdmPalIoTransport, SpdmVdmBackend, VdmRegistry, VdmResponse,
     VdmResponseBuffer,
 };
 use zerocopy::{FromBytes, IntoBytes};
@@ -32,7 +32,7 @@ use crate::stack::ConnectionState;
 /// Returns the framed response buffer and its SPDM-payload length.
 pub(crate) async fn handle_vendor_defined_request<'a, Pal: SpdmPal, V: SpdmVdmBackend>(
     vdm: &V,
-    state: &mut ConnectionState<Pal::State>,
+    state: &mut ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
     pal: &'a Pal,
     io: &<Pal as SpdmPalIoTransport>::Io<'_>,
     spdm_msg: &[u8],
@@ -85,7 +85,7 @@ pub(crate) async fn handle_vendor_defined_request<'a, Pal: SpdmPal, V: SpdmVdmBa
     // The guard must be dropped before invoking any other `large_*` PAL method
     // (e.g. `chunk::start_buffered_large_response` calls `large_capacity`).
     let mut large_guard = if large_cap > 0 {
-        Some(pal.large_take(envelope + large_cap)?)
+        Some(pal.alloc_large_buf(envelope + large_cap)?)
     } else {
         None
     };
@@ -137,10 +137,8 @@ pub(crate) async fn handle_vendor_defined_request<'a, Pal: SpdmPal, V: SpdmVdmBa
                 &mut guard[..envelope],
             )?;
             let full_len = envelope + n;
-            // Release the static slice back to the PAL so the chunking layer's
-            // `large_capacity` / `large_read` calls observe it again.
-            drop(guard);
-            chunk::validate_buffered_large_response(state, pal, full_len)?;
+            state.large_buf = Some(guard);
+            chunk::validate_buffered_large_response::<Pal>(state, pal, full_len)?;
             let resp = chunk::start_buffered_large_response(state, pal, io, full_len)?;
             Ok((resp, 0))
         }

--- a/runtime/userspace/api/spdm-lite/stack/src/vendor_defined.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/vendor_defined.rs
@@ -78,21 +78,19 @@ pub(crate) async fn handle_vendor_defined_request<'a, Pal: SpdmPal, V: SpdmVdmBa
         0
     };
 
-    // Take the persistent large-message buffer directly (no scratch hop): the
-    // backend writes its payload at offsets [envelope..envelope+large_cap] in
-    // the same static slice that `CHUNK_GET` will later serve from. The envelope
-    // is written into [0..envelope] only after the backend reports `Large(n)`.
-    // The guard must be dropped before invoking any other `large_*` PAL method
-    // (e.g. `chunk::start_buffered_large_response` calls `large_capacity`).
+    // WipeOnDrop ensures that the allocated large buffer gets zero-wiped
+    // and freed under any exit path.
     let mut large_guard = if large_cap > 0 {
-        Some(pal.alloc_large_buf(envelope + large_cap)?)
+        Some(chunk::WipeOnDrop {
+            buf: Some(pal.alloc_large_buf(envelope + large_cap)?),
+        })
     } else {
         None
     };
 
     let outcome = {
-        let large_slice: &mut [u8] = match large_guard.as_deref_mut() {
-            Some(buf) => &mut buf[envelope..envelope + large_cap],
+        let large_slice: &mut [u8] = match large_guard.as_mut() {
+            Some(guard) => &mut guard.buf.as_deref_mut().unwrap()[envelope..envelope + large_cap],
             None => &mut [],
         };
         let rsp = VdmResponseBuffer {
@@ -106,7 +104,7 @@ pub(crate) async fn handle_vendor_defined_request<'a, Pal: SpdmPal, V: SpdmVdmBa
 
     match outcome {
         VdmResponse::Inline(n) => {
-            // Drop the static-buffer guard early; not needed for inline.
+            // Drop large_guard here; its Drop impl auto-zeroizes!
             drop(large_guard);
             if n > inline_buf.len() {
                 return Err(SPDM_UNSPECIFIED);
@@ -127,6 +125,7 @@ pub(crate) async fn handle_vendor_defined_request<'a, Pal: SpdmPal, V: SpdmVdmBa
             if n > large_cap {
                 return Err(SPDM_UNSPECIFIED);
             }
+            let mut buf = guard.buf.take().ok_or(SPDM_UNSPECIFIED)?;
             // Backend has written its payload at static_buf[envelope..envelope+n].
             // Frame the VENDOR_DEFINED envelope in-place at offset 0.
             write_vendor_defined_envelope(
@@ -134,13 +133,19 @@ pub(crate) async fn handle_vendor_defined_request<'a, Pal: SpdmPal, V: SpdmVdmBa
                 decoded.standard_id,
                 decoded.vendor_id,
                 n,
-                &mut guard[..envelope],
+                &mut buf[..envelope],
             )?;
             let full_len = envelope + n;
-            state.large_buf = Some(guard);
-            chunk::validate_buffered_large_response::<Pal>(state, pal, full_len)?;
-            let resp = chunk::start_buffered_large_response(state, pal, io, full_len)?;
-            Ok((resp, 0))
+            state.large_msg_ctx.set_buffer(buf);
+            let (resp, spdm_len) =
+                match chunk::start_buffered_large_response(state, pal, io, full_len) {
+                    Ok(res) => res,
+                    Err(err) => {
+                        state.large_msg_ctx.reset();
+                        return Err(err);
+                    }
+                };
+            Ok((resp, spdm_len))
         }
     }
 }

--- a/runtime/userspace/api/spdm-lite/stack/src/version.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/version.rs
@@ -9,7 +9,7 @@
 //! GET_VERSION always resets the connection.
 
 use mcu_spdm_lite_codec::{ResponseBody, SpdmMsgHdrPdu, SpdmVersion, VersionRsp};
-use mcu_spdm_lite_traits::{PalBytes, SpdmPal, SpdmPalIo};
+use mcu_spdm_lite_traits::{PalBytes, SpdmPal, SpdmPalAlloc, SpdmPalIo};
 use zerocopy::FromBytes;
 
 use crate::build::build_response;
@@ -53,7 +53,7 @@ pub(crate) const SUPPORTED_VERSIONS: &[SpdmVersion] = &[SpdmVersion::V13, SpdmVe
 ///   `?` and end up as [`SPDM_BUSY`](crate::error::SPDM_BUSY) /
 ///   [`SPDM_INVALID_REQUEST`] respectively.
 pub(crate) async fn handle_get_version<'a, Pal: SpdmPal>(
-    state: &mut ConnectionState<Pal::State>,
+    state: &mut ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
     pal: &'a Pal,
     io: &Pal::Io<'_>,
 ) -> SpdmResult<PalBytes<'a, Pal>> {

--- a/runtime/userspace/api/spdm-lite/traits/src/alloc.rs
+++ b/runtime/userspace/api/spdm-lite/traits/src/alloc.rs
@@ -11,9 +11,9 @@
 //!   are returned as RAII guards implementing [`core::ops::DerefMut`],
 //!   which release the underlying memory back to the pool on drop.
 //!
-//! Allocations are scoped to a single SPDM I/O exchange ([`SpdmPalIo`])
-//! so the platform can correlate allocator lifetime with the in-flight
-//! request and reclaim memory between exchanges.
+//! Most allocations are scoped to a single SPDM I/O exchange ([`SpdmPalIo`]).
+//! One persistent large-message buffer may outlive an exchange while it is
+//! parked on `ConnectionState::large_buf`.
 
 use self::super::*;
 use core::ops::DerefMut;
@@ -61,54 +61,32 @@ pub trait SpdmPalAlloc: mcu_caliptra_api_lite::ApiAlloc {
     // ---- Persistent large-message buffer ------------------------------------
     //
     // One in-flight large SPDM message (a `CHUNK_GET` response or a `CHUNK_SEND`
-    // reassembly buffer) is held in a single persistent buffer that outlives the
-    // request that produces it and is served/consumed over later exchanges.
-    // Backed by the same pool as the per-request scratch (allocated on demand,
-    // reusable as scratch when idle) rather than a dedicated static region.
+    // reassembly buffer) may be allocated from the same pool as scratch memory,
+    // then parked on `ConnectionState::large_buf` so it can survive across later
+    // exchanges until chunking completes.
 
     /// Maximum size, in bytes, of a single in-flight large SPDM message this
     /// responder can hold. Drives the `CHUNK` capability advertisement
     /// (`MaxSPDMmsgSize`) and buffered large-response/request validation.
     fn large_capacity(&self) -> usize;
 
-    /// Reserves the persistent large-message buffer (`len` bytes) from the pool,
-    /// replacing (freeing) any previously-held one. Must be called before
-    /// [`Self::large_write`] / [`Self::large_read`]. The buffer persists across
-    /// requests until [`Self::large_end`] releases it (or the next `large_begin`
-    /// replaces it).
-    fn large_begin(&self, len: usize) -> McuResult<()>;
+    /// RAII guard type returned by [`Self::alloc_large_buf`].
+    type LargeBuf: DerefMut<Target = [u8]>;
 
-    /// Copies `data` into the held large-message buffer at `offset`.
-    fn large_write(&self, offset: usize, data: &[u8]) -> McuResult<()>;
+    /// Allocates a persistent large-message buffer of exactly `len` bytes.
+    /// Callers move the returned guard onto `ConnectionState::large_buf` when the
+    /// message must survive across later exchanges.
+    fn alloc_large_buf(&self, len: usize) -> McuResult<Self::LargeBuf>;
 
-    /// Copies bytes from the held large-message buffer at `offset` into `out`.
-    fn large_read(&self, offset: usize, out: &mut [u8]) -> McuResult<()>;
+    // ---- Persistent typed allocations ----------------------------------------
+    //
+    // Long-lived objects (session state, hash contexts) that must survive across
+    // SPDM exchanges but should NOT compete on the global heap.
 
-    /// Releases the large-message buffer back to the pool (freed and zeroed).
-    /// Idempotent: a no-op when no large buffer is currently held.
-    fn large_end(&self);
+    /// RAII owner for a typed persistent allocation. Stored in
+    /// `SessionManager` across exchanges; released on session teardown.
+    type PersistentBox<T: Sized + 'static>: DerefMut<Target = T>;
 
-    /// RAII guard type returned by [`Self::large_take`].
-    ///
-    /// Implementors return any owning handle that derefs to a `[u8]` slice of
-    /// exactly the requested length over the persistent large-message buffer.
-    /// Dropping the guard must return the underlying slice to the PAL so that
-    /// subsequent [`Self::large_read`] / [`Self::large_capacity`] calls see it
-    /// again. The drop **must not** wipe the slice — the bytes need to survive
-    /// for chunked delivery.
-    type LargeBuf<'a>: DerefMut<Target = [u8]>
-    where
-        Self: 'a;
-
-    /// Reserves the persistent large-message buffer and hands out a mutable
-    /// view of exactly `len` bytes to the caller. The bytes survive after the
-    /// guard drops (so `CHUNK_GET` can serve them via [`Self::large_read`]).
-    ///
-    /// While the returned guard is alive, the underlying slice is not parked
-    /// in the PAL, so calls to [`Self::large_capacity`], [`Self::large_begin`],
-    /// [`Self::large_write`], or [`Self::large_read`] from another code path
-    /// will observe an empty buffer. A single-task SPDM responder runs requests
-    /// sequentially, so this is safe — but callers must drop the guard before
-    /// invoking those methods.
-    fn large_take(&self, len: usize) -> McuResult<Self::LargeBuf<'_>>;
+    /// Allocate a persistent typed object from the per-task pool.
+    fn alloc_persistent<T: Sized + 'static>(&self, value: T) -> McuResult<Self::PersistentBox<T>>;
 }

--- a/runtime/userspace/api/spdm-lite/traits/src/hash.rs
+++ b/runtime/userspace/api/spdm-lite/traits/src/hash.rs
@@ -61,7 +61,7 @@ impl SpdmPalHashAlgo {
 /// digest written by `finish` is observable externally.
 pub trait SpdmPalHash {
     /// Backend-defined running-hash state.
-    type State;
+    type State: 'static;
 
     /// Begins a new running hash and returns the initial state.
     ///

--- a/runtime/userspace/api/spdm-lite/traits/src/session_crypto.rs
+++ b/runtime/userspace/api/spdm-lite/traits/src/session_crypto.rs
@@ -20,7 +20,7 @@ pub trait SpdmPalSessionCrypto {
     /// Opaque key handle (e.g. `Cmk` on Caliptra).
     ///
     /// `Clone` is required so containers can hold `Option<Key>`.
-    type Key: Clone;
+    type Key: Clone + 'static;
 
     /// Generate an ephemeral ECDH key pair.
     ///

--- a/runtime/userspace/api/spdm-lite/vdm-handler/src/iana/ocp/caliptra_vdm/mod.rs
+++ b/runtime/userspace/api/spdm-lite/vdm-handler/src/iana/ocp/caliptra_vdm/mod.rs
@@ -286,10 +286,7 @@ mod tests {
             = Vec<u8>
         where
             Self: 'a;
-        type LargeBuf<'a>
-            = Vec<u8>
-        where
-            Self: 'a;
+        type LargeBuf = Vec<u8>;
 
         fn alloc<T: Sized>(&self, _io: &impl SpdmPalIo, value: T) -> McuResult<Self::Box<'_, T>> {
             Ok(TestBox {
@@ -306,22 +303,17 @@ mod tests {
             4096
         }
 
-        fn large_begin(&self, _len: usize) -> McuResult<()> {
-            Ok(())
-        }
-
-        fn large_write(&self, _offset: usize, _data: &[u8]) -> McuResult<()> {
-            Ok(())
-        }
-
-        fn large_read(&self, _offset: usize, _out: &mut [u8]) -> McuResult<()> {
-            Ok(())
-        }
-
-        fn large_end(&self) {}
-
-        fn large_take(&self, len: usize) -> McuResult<Self::LargeBuf<'_>> {
+        fn alloc_large_buf(&self, len: usize) -> McuResult<Self::LargeBuf> {
             Ok(vec![0; len])
+        }
+
+        type PersistentBox<T: Sized + 'static> = Box<T>;
+
+        fn alloc_persistent<T: Sized + 'static>(
+            &self,
+            value: T,
+        ) -> McuResult<Self::PersistentBox<T>> {
+            Ok(Box::new(value))
         }
     }
 

--- a/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/mod.rs
+++ b/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/mod.rs
@@ -172,10 +172,8 @@ mod tests {
             = Vec<u8>
         where
             Self: 'a;
-        type LargeBuf<'a>
-            = Vec<u8>
-        where
-            Self: 'a;
+        type LargeBuf = Vec<u8>;
+        type PersistentBox<T: Sized + 'static> = Box<T>;
 
         fn alloc<T: Sized>(&self, _io: &impl SpdmPalIo, value: T) -> McuResult<Self::Box<'_, T>> {
             Ok(TestBox {
@@ -192,22 +190,15 @@ mod tests {
             0
         }
 
-        fn large_begin(&self, _len: usize) -> McuResult<()> {
-            Ok(())
-        }
-
-        fn large_write(&self, _offset: usize, _data: &[u8]) -> McuResult<()> {
-            Ok(())
-        }
-
-        fn large_read(&self, _offset: usize, _out: &mut [u8]) -> McuResult<()> {
-            Ok(())
-        }
-
-        fn large_end(&self) {}
-
-        fn large_take(&self, len: usize) -> McuResult<Self::LargeBuf<'_>> {
+        fn alloc_large_buf(&self, len: usize) -> McuResult<Self::LargeBuf> {
             Ok(vec![0; len])
+        }
+
+        fn alloc_persistent<T: Sized + 'static>(
+            &self,
+            value: T,
+        ) -> McuResult<Self::PersistentBox<T>> {
+            Ok(Box::new(value))
         }
     }
 


### PR DESCRIPTION
 1.  allocate SHA contexts and sessions from per-task bitmap pool 
 • Moves the large-message buffer to the per-task bitmap scratch allocator.
 • Moves SHA running contexts to scratch-backed  BitmapBytes .
 • Adds `PersistentBox<T>` to `SpdmPalAlloc` for long-lived typed allocations from the per-task bitmap pool. This is used for `SessionInfo`, which must survive across SPDM messages but should not use the global heap.
 • Removes the separate static large-message buffers and keeps global heap usage limited to existing async/transport costs which are fixed size allocations.
 2. unify large message handling into a state-driven context 
    • Replaces separate large-message state (`chunk` ,  `large_response` ,  `large_buf` ) with unified  `LargeMessageCtx` .
    • Uses the per-task scratch/bitmap allocator for large-message buffers.
    • Supports buffered large request assembly via `CHUNK_SEND` .
    • Dispatches completed large requests for both `SET_CERTIFICATE` and  `VENDOR_DEFINED_REQUEST` .
    • Returns the assembled request’s response in final  `CHUNK_SEND_ACK.ResponseToLargeRequest` .
    • Fixes VDM final `CHUNK_SEND` responses so inline VDM responses are not limited to 4 bytes.
    • Cleans up SHA scratch allocation paths to reduce extra generated code.

 Net result: ~8 KiB RAM saved for SPDM/user-app, with ~3.7 KiB user-app flash increase.

| Area | Section | Current | Baseline (`spdm-lite`) | Delta |
 |---|---:|---:|---:|---:|
 | User-app | `.text` | **102,122 B** | 98,556 B | +3,566 B |
 | User-app | `.rodata` | **25,248 B** | 25,132 B | +116 B |
 | User-app | `.data` | **12 B** | 12 B | — |
 | User-app | `.bss` | **53,344 B** | 61,384 B | -8,040 B |
 | User-app | **FLASH** | **127,382 B** | 123,700 B | **+3,682 B** |
 | User-app | **RAM** | **53,356 B** | 61,396 B | **-8,040 B** |
 | SPDM-attributed | `.text` | 88,596 B | 84,680 B | +3,916 B |
 | SPDM-attributed | `.rodata` | 696 B | 696 B | — |
 | SPDM-attributed | `.data` | 0 B | 0 B | — |
 | SPDM-attributed | `.bss` | 28,545 B | 36,569 B | -8,024 B |
 | SPDM-attributed | **FLASH** | **89,292 B** | **85,376 B** | **+3,916 B** |
 | SPDM-attributed | **RAM** | **28,545 B** | **36,569 B** | **-8,024 B** |
 | Runtime bundle | Total | 275,200 B | 271,360 B | +3,840 B |
