### PR TITLE
[fix] rom: program FIPS zeroization mask before config lock

### DIFF
--- a/docs/src/rom.md
+++ b/docs/src/rom.md
@@ -59,8 +59,8 @@ These are selected based on the MCI `RESET_REASON` register that is set by hardw
     * See [the ROM fuses](rom-fuses.md) documentation for details on how these are read and interpreted.
 1. Configure MCU mailbox AXI users (see [Security Configuration](#security-configuration) below).
 1. Set mailbox AXI user lock registers.
-1. [2.1] Set [FC_FIPS_ZEROZATION](https://chipsalliance.github.io/caliptra-ss/main/regs/?p=soc.mci_top.mci_reg.FC_FIPS_ZEROZATION) to the appropriate value.
 1. Configure the MCU SRAM execution region size by writing to the `FW_SRAM_EXEC_REGION_SIZE` register. If not specified in `RomParameters`, it defaults to reserving 32KB at the top of SRAM for the Protected Data Region.
+1. [2.1] Set [FC_FIPS_ZEROZATION](https://chipsalliance.github.io/caliptra-ss/main/regs/?p=soc.mci_top.mci_reg.FC_FIPS_ZEROZATION) to the value provided by `RomParameters::fips_zeroization_mask`. This must happen before `SS_CONFIG_DONE` is set because the register becomes read-only once configuration is locked. Platform integrators detect the FIPS PPD signal and supply the appropriate mask; if `None`, the register is left at its reset-default value.
 1. Set `SS_CONFIG_DONE_STICKY`, `SS_CONFIG_DONE` registers to lock MCI configuration.
 1. Verify PK hashes and MCU mailbox AXI users after locking (see [Security Configuration](#security-configuration) below).
 1. Poll on Caliptra `FLOW_STATUS` registers for Caliptra to deassert the Ready for Fuses state.

--- a/rom/src/cold_boot.rs
+++ b/rom/src/cold_boot.rs
@@ -581,6 +581,12 @@ impl BootFlow for ColdBoot {
         );
         mci.set_fw_sram_exec_region_size(size_value);
 
+        if let Some(mask) = params.fips_zeroization_mask {
+            caliptra_mcu_romtime::println!("[mcu-rom] Setting FIPS zeroization mask");
+            mci.set_fips_zeroization_mask(mask);
+            mci.set_flow_checkpoint(McuRomBootStatus::FipsZeroizationMaskSet.into());
+        }
+
         // Set SS_CONFIG_DONE_STICKY to lock MCI configuration registers
         caliptra_mcu_romtime::println!(
             "[mcu-rom] Setting SS_CONFIG_DONE_STICKY to lock configuration"

--- a/rom/src/rom.rs
+++ b/rom/src/rom.rs
@@ -767,6 +767,11 @@ pub struct RomParameters<'a> {
     pub recovery_status_open: bool,
     /// Size of the executable SRAM region to pass into FW_SRAM_EXEC_REGION_SIZE
     pub mcu_fw_sram_exec_region_size: Option<u32>,
+    /// Bitmask to write to FC_FIPS_ZEROZATION before MCI configuration locks.
+    ///
+    /// Platform integrators should provide this when the FIPS PPD signal is
+    /// asserted. When `None`, the register is left at its hardware reset value.
+    pub fips_zeroization_mask: Option<u32>,
     /// Valid AXI users for Caliptra mailbox. 0 values are ignored.
     pub cptra_mbox_axi_users: [u32; 5],
     /// Valid AXI user for Caliptra fuse registers. 0 = don't configure.

--- a/rom/src/warm_boot.rs
+++ b/rom/src/warm_boot.rs
@@ -101,6 +101,12 @@ impl BootFlow for WarmBoot {
         );
         mci.set_fw_sram_exec_region_size(size_value);
 
+        if let Some(mask) = params.fips_zeroization_mask {
+            caliptra_mcu_romtime::println!("[mcu-rom] Setting FIPS zeroization mask");
+            mci.set_fips_zeroization_mask(mask);
+            mci.set_flow_checkpoint(McuRomBootStatus::FipsZeroizationMaskSet.into());
+        }
+
         // Set SS_CONFIG_DONE_STICKY to lock MCI configuration registers
         caliptra_mcu_romtime::println!(
             "[mcu-rom] Setting SS_CONFIG_DONE_STICKY to lock configuration"

--- a/romtime/src/boot_status.rs
+++ b/romtime/src/boot_status.rs
@@ -70,6 +70,7 @@ pub enum McuRomBootStatus {
     I3cServicesStarted = CALIPTRA_SETUP_BASE + 18,
     I3cServicesReady = CALIPTRA_SETUP_BASE + 19,
     I3cServicesComplete = CALIPTRA_SETUP_BASE + 20,
+    FipsZeroizationMaskSet = CALIPTRA_SETUP_BASE + 21,
 
     // Firmware Loading Statuses
     RiDownloadFirmwareCommandSent = FIRMWARE_LOADING_BASE,

--- a/romtime/src/mci.rs
+++ b/romtime/src/mci.rs
@@ -204,6 +204,14 @@ impl Mci {
         self.registers.mci_reg_fw_sram_exec_region_size.set(size);
     }
 
+    /// Sets the FC_FIPS_ZEROZATION register mask.
+    ///
+    /// This must be called before `set_ss_config_done()` or
+    /// `set_ss_config_done_sticky()` because those calls lock the register.
+    pub fn set_fips_zeroization_mask(&self, mask: u32) {
+        self.registers.mci_reg_fc_fips_zerozation.set(mask);
+    }
+
     pub fn trigger_warm_reset(&self) {
         self.registers.mci_reg_reset_request.set(1);
     }


### PR DESCRIPTION
Add an optional fips_zeroization_mask ROM parameter and write it to FC_FIPS_ZEROZATION before SS_CONFIG_DONE/SS_CONFIG_DONE_STICKY lock MCI configuration registers.

When the parameter is None, the register is left at its reset value to preserve existing platform behavior.