### PR TITLE
spdm-lite: add PCI-SIG IDE-KM VDM support

### DIFF
--- a/.github/workflows/spdm-validator.yml
+++ b/.github/workflows/spdm-validator.yml
@@ -181,50 +181,48 @@ jobs:
             exit 1
           fi
 
-      # TDISP/IDE validator temporarily disabled while SPDM-Lite work focuses on
-      # responder conformance coverage.
-      # - name: Checkout CCC spdm-rs repository
-      #   uses: actions/checkout@v4
-      #   with:
-      #     repository: chipsalliance/caliptra-spdm-rs
-      #     ref: caliptra-0.5.2
-      #     path: spdm-rs
-      #     submodules: recursive
+      - name: Checkout CCC spdm-rs repository
+        uses: actions/checkout@v4
+        with:
+          repository: chipsalliance/caliptra-spdm-rs
+          ref: caliptra-0.5.2
+          path: spdm-rs
+          submodules: recursive
 
-      # - name: Prepare, build spdm-rs, and copy test keys
-      #   working-directory: spdm-rs
-      #   run: |
-      #     git submodule update --init --recursive
-      #     sh_script/pre-build.sh
-      #     cargo build --no-default-features --features="spdm-ring,hashed-transcript-data,async-executor,chunk-cap"
-      #     cp -r test_key target/debug/
-      #     ls -l target/debug/test_key/ecp384/
+      - name: Prepare, build spdm-rs, and copy test keys
+        working-directory: spdm-rs
+        run: |
+          git submodule update --init --recursive
+          sh_script/pre-build.sh
+          cargo build --no-default-features --features="spdm-ring,hashed-transcript-data,async-executor,chunk-cap"
+          cp -r test_key target/debug/
+          ls -l target/debug/test_key/ecp384/
 
-      # - name: Copy caliptra root CA cert into spdm-rs test_key
-      #   run: |
-      #     cp ${{ github.workspace }}/ocp-eat-verifier/ocptoken/test-data/ta-store/roots/slot0_ecc_test_root_ca.der \
-      #        ${{ github.workspace }}/spdm-rs/target/debug/test_key/ecp384/ca.cert.der
+      - name: Copy caliptra root CA cert into spdm-rs test_key
+        run: |
+          cp ${{ github.workspace }}/ocp-eat-verifier/ocptoken/test-data/ta-store/roots/slot0_ecc_test_root_ca.der \
+             ${{ github.workspace }}/spdm-rs/target/debug/test_key/ecp384/ca.cert.der
 
-      # - name: Run CCC spdm-requester-emu tests for TDISP+IDE
-      #   env:
-      #     SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-rs/target/debug
-      #   run: |
-      #     cargo xtask all-build
-      #     cargo t -p caliptra-mcu-tests-integration -- --test test_doe_spdm_tdisp_ide_validator --nocapture --include-ignored
-      #     sccache --show-stats
+      - name: Run CCC spdm-requester-emu tests for TDISP+IDE
+        env:
+          SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-rs/target/debug
+        run: |
+          cargo xtask all-build
+          cargo t -p caliptra-mcu-tests-integration -- --test test_doe_spdm_tdisp_ide_validator --nocapture --include-ignored
+          sccache --show-stats
 
-      # - name: Display CCC spdm-requester-emu test results for TDISP+IDE
-      #   env:
-      #     SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-rs/target/debug
-      #   run: |
-      #     cat $SPDM_VALIDATOR_DIR/tdisp_ide_validator_output.txt
+      - name: Display CCC spdm-requester-emu test results for TDISP+IDE
+        env:
+          SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-rs/target/debug
+        run: |
+          cat $SPDM_VALIDATOR_DIR/tdisp_ide_validator_output.txt
 
-      # - name: Upload CCC spdm-requester-emu test results for TDISP+IDE
-      #   if: always()
-      #   uses: actions/upload-artifact@v4
-      #   env:
-      #     SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-rs/target/debug
-      #   with:
-      #     name: spdm-tdisp-ide-validator-test-results
-      #     path: |
-      #       ${{ env.SPDM_VALIDATOR_DIR }}/tdisp_ide_validator_output.txt
+      - name: Upload CCC spdm-requester-emu test results for TDISP+IDE
+        if: always()
+        uses: actions/upload-artifact@v4
+        env:
+          SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-rs/target/debug
+        with:
+          name: spdm-tdisp-ide-validator-test-results
+          path: |
+            ${{ env.SPDM_VALIDATOR_DIR }}/tdisp_ide_validator_output.txt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4074,10 +4074,13 @@ dependencies = [
 name = "mcu-spdm-lite-vdm-handler"
 version = "0.1.0"
 dependencies = [
+ "futures",
  "mcu-caliptra-api-lite",
  "mcu-error",
  "mcu-spdm-lite-codec",
+ "mcu-spdm-lite-errors",
  "mcu-spdm-lite-traits",
+ "zerocopy",
 ]
 
 [[package]]
@@ -5979,6 +5982,7 @@ dependencies = [
  "embedded-alloc",
  "mcu-caliptra-api-lite",
  "mcu-error",
+ "mcu-spdm-lite-codec",
  "mcu-spdm-lite-pal",
  "mcu-spdm-lite-stack",
  "mcu-spdm-lite-traits",

--- a/docs/src/ide_km.md
+++ b/docs/src/ide_km.md
@@ -64,7 +64,6 @@ pub enum IdeDriverError {
 
 pub type IdeDriverResult<T> = Result<T, IdeDriverError>;
 
-
 /// KeyInfo structure contains information about the key set, direction, and sub-stream.
 bitfield! {
     #[derive(Clone, Copy, PartialEq, Eq)]
@@ -80,7 +79,7 @@ bitfield! {
 ///
 /// Provides an interface for Integrity and Data Encryption (IDE) key management operations.
 /// This trait abstracts hardware-specific implementations for different platforms.
-#[async_trait]
+#[allow(async_fn_in_trait)]
 pub trait IdeDriver {
     /// Get the port configuration for a given port index.
     ///
@@ -90,7 +89,13 @@ pub trait IdeDriver {
     /// # Returns
     /// A result containing the `PortConfig` for the specified port index, or an error
     /// if the port index is invalid or unsupported.
-    fn port_config(&self, port_index: u8) -> IdeDriverResult<PortConfig>;
+    fn port_config<Alloc>(
+        &self,
+        port_index: u8,
+        scratch: &Alloc,
+    ) -> IdeDriverResult<PortConfig>
+    where
+        Alloc: SpdmPalAlloc;
 
     /// Get the IDE register block.
     ///
@@ -99,7 +104,13 @@ pub trait IdeDriver {
     ///
     /// # Returns
     /// A result containing the `IdeRegBlock` for the specified port, or an error
-    fn ide_register_block(&self, port_index: u8) -> IdeDriverResult<IdeRegBlock>;
+    fn ide_reg_block<Alloc>(
+        &self,
+        port_index: u8,
+        scratch: &Alloc,
+    ) -> IdeDriverResult<IdeRegBlock>
+    where
+        Alloc: SpdmPalAlloc;
 
     /// Get the link IDE register block for a specific port and block index.
     ///
@@ -109,11 +120,14 @@ pub trait IdeDriver {
     ///
     /// # Returns
     /// A result containing the `LinkIdeStreamRegBlock` for the specified port and block
-    fn link_ide_reg_block(
+    fn link_ide_reg_block<Alloc>(
         &self,
         port_index: u8,
         block_index: u8,
-    ) -> IdeDriverResult<LinkIdeStreamRegBlock>;
+        scratch: &Alloc,
+    ) -> IdeDriverResult<LinkIdeStreamRegBlock>
+    where
+        Alloc: SpdmPalAlloc;
 
     /// Get the selective IDE register block for a specific port and block index.
     ///
@@ -123,11 +137,14 @@ pub trait IdeDriver {
     ///
     /// # Returns
     /// A result containing the `SelectiveIdeStreamRegBlock` for the specified port and block
-    fn selective_ide_reg_block(
+    fn selective_ide_reg_block<Alloc>(
         &self,
         port_index: u8,
         block_index: u8,
-    ) -> IdeDriverResult<SelectiveIdeStreamRegBlock>;
+        scratch: &Alloc,
+    ) -> IdeDriverResult<SelectiveIdeStreamRegBlock>
+    where
+        Alloc: SpdmPalAlloc;
 
     /// Key programming for a specific port and stream.
     ///
@@ -145,14 +162,17 @@ pub trait IdeDriver {
     /// - `02h`: Unsupported Port Index value
     /// - `03h`: Unsupported value in other fields
     /// - `04h`: Unspecified Failure
-    async fn key_prog(
+    async fn key_prog<Alloc>(
         &self,
         stream_id: u8,
         key_info: KeyInfo,
         port_index: u8,
-        key: &[u32; IDE_STREAM_KEY_SIZE_DW],
-        iv: &[u32; IDE_STREAM_IV_SIZE_DW],
-    ) -> IdeDriverResult<u8>;
+        key: &[U32; IDE_STREAM_KEY_SIZE_DW],
+        iv: &[U32; IDE_STREAM_IV_SIZE_DW],
+        scratch: &Alloc,
+    ) -> IdeDriverResult<u8>
+    where
+        Alloc: SpdmPalAlloc;
 
     /// Start using the key set for a specific port and stream.
     ///
@@ -162,14 +182,17 @@ pub trait IdeDriver {
     /// * `port_index` - Port to which the key set is to be started.
     ///
     /// # Returns
-    /// A result containing the updated `KeyInfo` after starting the key set, or an
-    /// error if the operation fails.
-    async fn key_set_go(
+    /// `Ok(())` when the operation succeeds, or an error if the operation fails.
+    /// The KEY_GO_STOP_ACK response echoes the request `KeyInfo`.
+    async fn key_set_go<Alloc>(
         &self,
         stream_id: u8,
         key_info: KeyInfo,
         port_index: u8,
-    ) -> IdeDriverResult<KeyInfo>;
+        scratch: &Alloc,
+    ) -> IdeDriverResult<()>
+    where
+        Alloc: SpdmPalAlloc;
 
     /// Stop the key set for a specific port and stream.
     ///
@@ -179,13 +202,16 @@ pub trait IdeDriver {
     /// * `port_index` - Port to which the key set is to be stopped
     ///
     /// # Returns
-    /// A result containing the updated `KeyInfo` after stopping the key set, or an error
-    /// if the operation fails.
-    async fn key_set_stop(
+    /// `Ok(())` when the operation succeeds, or an error if the operation fails.
+    /// The KEY_GO_STOP_ACK response echoes the request `KeyInfo`.
+    async fn key_set_stop<Alloc>(
         &self,
         stream_id: u8,
         key_info: KeyInfo,
         port_index: u8,
-    ) -> IdeDriverResult<KeyInfo>;
+        scratch: &Alloc,
+    ) -> IdeDriverResult<()>
+    where
+        Alloc: SpdmPalAlloc;
 }
 ```

--- a/docs/src/tdisp.md
+++ b/docs/src/tdisp.md
@@ -68,98 +68,82 @@ pub enum TdiStatus {
 #[allow(async_fn_in_trait)]
 pub trait TdispDriver {
     /// Fills `out` with a START_INTERFACE nonce.
-    async fn generate_start_interface_nonce<Alloc, Io>(
+    async fn generate_start_interface_nonce<Alloc>(
         &self,
         scratch: &Alloc,
-        io: &Io,
         out: &mut [u8; START_INTERFACE_NONCE_SIZE],
     ) -> TdispDriverResult<()>
     where
-        Alloc: SpdmPalAlloc,
-        Io: SpdmPalIo;
+        Alloc: SpdmPalAlloc;
 
     /// Gets responder capabilities.
-    async fn get_capabilities<Alloc, Io>(
+    async fn get_capabilities<Alloc>(
         &self,
         req_caps: TdispReqCapabilities,
         scratch: &Alloc,
-        io: &Io,
         resp_caps: &mut TdispRespCapabilities,
     ) -> TdispDriverResult<u32>
     where
-        Alloc: SpdmPalAlloc,
-        Io: SpdmPalIo;
+        Alloc: SpdmPalAlloc;
 
     /// Locks an interface.
-    async fn lock_interface<Alloc, Io>(
+    async fn lock_interface<Alloc>(
         &self,
         function_id: FunctionId,
         param: TdispLockInterfaceParam,
         scratch: &Alloc,
-        io: &Io,
     ) -> TdispDriverResult<u32>
     where
-        Alloc: SpdmPalAlloc,
-        Io: SpdmPalIo;
+        Alloc: SpdmPalAlloc;
 
     /// Returns the total device interface report length.
-    async fn get_device_interface_report_len<Alloc, Io>(
+    async fn get_device_interface_report_len<Alloc>(
         &self,
         function_id: FunctionId,
         scratch: &Alloc,
-        io: &Io,
         intf_report_len: &mut u16,
     ) -> TdispDriverResult<u32>
     where
-        Alloc: SpdmPalAlloc,
-        Io: SpdmPalIo;
+        Alloc: SpdmPalAlloc;
 
     /// Copies a device interface report portion.
-    async fn get_device_interface_report<Alloc, Io>(
+    async fn get_device_interface_report<Alloc>(
         &self,
         function_id: FunctionId,
         offset: u16,
         scratch: &Alloc,
-        io: &Io,
         report: &mut [u8],
         copied: &mut usize,
     ) -> TdispDriverResult<u32>
     where
-        Alloc: SpdmPalAlloc,
-        Io: SpdmPalIo;
+        Alloc: SpdmPalAlloc;
 
     /// Gets the current device interface state.
-    async fn get_device_interface_state<Alloc, Io>(
+    async fn get_device_interface_state<Alloc>(
         &self,
         function_id: FunctionId,
         scratch: &Alloc,
-        io: &Io,
         tdi_state: &mut TdiStatus,
     ) -> TdispDriverResult<u32>
     where
-        Alloc: SpdmPalAlloc,
-        Io: SpdmPalIo;
+        Alloc: SpdmPalAlloc;
 
     /// Starts an interface.
-    async fn start_interface<Alloc, Io>(
+    async fn start_interface<Alloc>(
         &self,
         function_id: FunctionId,
         scratch: &Alloc,
-        io: &Io,
     ) -> TdispDriverResult<u32>
     where
-        Alloc: SpdmPalAlloc,
-        Io: SpdmPalIo;
+        Alloc: SpdmPalAlloc;
 
     /// Stops an interface.
-    async fn stop_interface<Alloc, Io>(
+    async fn stop_interface<Alloc>(
         &self,
         function_id: FunctionId,
         scratch: &Alloc,
-        io: &Io,
     ) -> TdispDriverResult<u32>
     where
-        Alloc: SpdmPalAlloc,
-        Io: SpdmPalIo;
+        Alloc: SpdmPalAlloc;
 }
 ```

--- a/platforms/emulator/runtime/userspace/apps/user/Cargo.toml
+++ b/platforms/emulator/runtime/userspace/apps/user/Cargo.toml
@@ -38,6 +38,7 @@ caliptra-mcu-romtime.workspace = true
 caliptra-mcu-spdm-lib.workspace = true
 mcu-caliptra-api-lite.workspace = true
 mcu-error.workspace = true
+mcu-spdm-lite-codec.workspace = true
 mcu-spdm-lite-pal.workspace = true
 mcu-spdm-lite-stack = { workspace = true }
 mcu-spdm-lite-transports.workspace = true

--- a/platforms/emulator/runtime/userspace/apps/user/src/spdm/caliptra_vdm.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/spdm/caliptra_vdm.rs
@@ -16,7 +16,7 @@ use mcu_caliptra_api_lite::{
     cm_hmac, cm_import, fe_prog, get_attested_csr_ecc384, get_attested_csr_mldsa87, rng_generate,
     ApiAlloc, CmKeyUsage, McuErrorCode,
 };
-use mcu_spdm_lite_traits::{SpdmPalAlloc, SpdmPalIo};
+use mcu_spdm_lite_traits::SpdmPalAlloc;
 use mcu_spdm_lite_vdm_handler::iana::ocp::caliptra_vdm::{
     CaliptraCompletionCode, CaliptraVdmCommands, CaliptraVdmLogResult, CaliptraVdmResult,
 };
@@ -41,11 +41,10 @@ static AUTH_CHALLENGE: Mutex<CriticalSectionRawMutex, Option<[u8; 32]>> = Mutex:
 pub struct CaliptraVdmHook;
 
 impl CaliptraVdmCommands for CaliptraVdmHook {
-    async fn get_log<A: SpdmPalAlloc, I: SpdmPalIo>(
+    async fn get_log<A: SpdmPalAlloc>(
         &self,
         log_type: u32,
         _scratch: &A,
-        _io: &I,
         out: &mut [u8],
     ) -> CaliptraVdmResult<CaliptraVdmLogResult> {
         let result = match log_type {
@@ -65,11 +64,10 @@ impl CaliptraVdmCommands for CaliptraVdmHook {
         })
     }
 
-    async fn clear_log<A: SpdmPalAlloc, I: SpdmPalIo>(
+    async fn clear_log<A: SpdmPalAlloc>(
         &self,
         log_type: u32,
         _scratch: &A,
-        _io: &I,
     ) -> CaliptraVdmResult<()> {
         match log_type {
             0 => crate::caliptra_cmd_handler::debug_log::clear()
@@ -80,13 +78,12 @@ impl CaliptraVdmCommands for CaliptraVdmHook {
         }
     }
 
-    async fn export_attested_csr<A: SpdmPalAlloc, I: SpdmPalIo>(
+    async fn export_attested_csr<A: SpdmPalAlloc>(
         &self,
         device_key_id: u32,
         algorithm: u32,
         nonce: &[u8; 32],
         _scratch: &A,
-        _io: &I,
         out: &mut [u8],
     ) -> CaliptraVdmResult<usize> {
         let result = match algorithm {
@@ -97,10 +94,9 @@ impl CaliptraVdmCommands for CaliptraVdmHook {
         result.map_err(map_mcu_err)
     }
 
-    async fn get_auth_challenge<A: SpdmPalAlloc, I: SpdmPalIo>(
+    async fn get_auth_challenge<A: SpdmPalAlloc>(
         &self,
         scratch: &A,
-        _io: &I,
         out: &mut [u8],
     ) -> CaliptraVdmResult<usize> {
         let mut challenge = [0u8; 32];
@@ -111,12 +107,11 @@ impl CaliptraVdmCommands for CaliptraVdmHook {
         copy_bytes(&challenge, out)
     }
 
-    async fn program_field_entropy<A: SpdmPalAlloc, I: SpdmPalIo>(
+    async fn program_field_entropy<A: SpdmPalAlloc>(
         &self,
         partition: u32,
         mac: &[u8; 48],
         scratch: &A,
-        _io: &I,
     ) -> CaliptraVdmResult<()> {
         verify_fe_prog_mac(scratch, partition, mac).await?;
         fe_prog(scratch, partition).await.map_err(map_mcu_err)

--- a/platforms/emulator/runtime/userspace/apps/user/src/spdm/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/spdm/mod.rs
@@ -12,10 +12,10 @@ mod caliptra_vdm;
 mod cert_store;
 mod device_measurements;
 #[cfg(feature = "test-doe-spdm-tdisp-ide-validator")]
-mod emulated_tdisp;
+mod pci_sig_vdm;
 
 #[cfg(feature = "test-doe-spdm-tdisp-ide-validator")]
-use self::emulated_tdisp::EmulatedTdispDriver;
+use self::pci_sig_vdm::{emulated_ide_km::EmulatedIdeDriver, emulated_tdisp::EmulatedTdispDriver};
 use caliptra_mcu_libsyscall_caliptra::doe;
 use caliptra_mcu_libsyscall_caliptra::mctp;
 use caliptra_mcu_libsyscall_caliptra::DefaultSyscalls;
@@ -33,8 +33,8 @@ use mcu_spdm_lite_transports::{McuSpdmDoeTransport, McuSpdmMctpTransport};
 use mcu_spdm_lite_vdm_handler::iana::ocp::caliptra_vdm::CaliptraVdm;
 #[cfg(feature = "test-doe-spdm-tdisp-ide-validator")]
 use mcu_spdm_lite_vdm_handler::pci_sig::{
+    ide_km::PciSigIdeKmTdispVdm,
     tdisp::{TdispResponder, TdispVersion},
-    PciSigTdispVdm,
 };
 
 /// Bitmap allocator pool size per responder task.
@@ -152,7 +152,7 @@ async fn spdm_mctp_responder() {
     // exclusive to this task.
     let pal = unsafe { McuSpdmPal::new(transport, allocator, &CERT_STORE, measurement_provider()) };
     // MCTP hosts the IANA / Caliptra VDM backend (plaintext today). DOE uses
-    // the default NoVdmBackend unless the TDISP validator feature wires PCI-SIG.
+    // the default NoVdmBackend unless the TDISP/IDE validator feature wires PCI-SIG.
     static MCTP_VDM_HOOK: caliptra_vdm::CaliptraVdmHook = caliptra_vdm::CaliptraVdmHook;
     let vdm = CaliptraVdm::new(&MCTP_VDM_HOOK);
     let mut stack = SpdmStack::<_, 1, _>::with_vdm_backend(pal, vdm);
@@ -200,8 +200,9 @@ async fn spdm_doe_responder() {
     #[cfg(feature = "test-doe-spdm-tdisp-ide-validator")]
     let mut stack = SpdmStack::<_, 1, _>::with_vdm_backend(
         pal,
-        PciSigTdispVdm::new(
+        PciSigIdeKmTdispVdm::new(
             TEST_PCI_SIG_VENDOR_ID,
+            EmulatedIdeDriver::default(),
             TdispResponder::new(SUPPORTED_TDISP_VERSIONS, EmulatedTdispDriver::new())
                 .expect("TDISP validator versions are non-empty"),
         ),

--- a/platforms/emulator/runtime/userspace/apps/user/src/spdm/pci_sig_vdm/emulated_ide_km.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/spdm/pci_sig_vdm/emulated_ide_km.rs
@@ -1,0 +1,224 @@
+// Licensed under the Apache-2.0 license
+
+//! Emulator IDE-KM driver used by the DOE/SPDM TDISP+IDE validator test.
+
+use mcu_spdm_lite_codec::{
+    AddrAssociationRegBlock, IdeCapabilityReg, IdeControlReg, KeyInfo, LinkIdeStreamControlReg,
+    LinkIdeStreamRegBlock, LinkIdeStreamStatusReg, PortConfig, SelectiveIdeRidAssociationReg1,
+    SelectiveIdeRidAssociationReg2, SelectiveIdeStreamCapabilityReg, SelectiveIdeStreamControlReg,
+    SelectiveIdeStreamRegBlock, SelectiveIdeStreamStatusReg, IDE_STREAM_IV_SIZE_DW,
+    IDE_STREAM_KEY_SIZE_DW, MAX_SELECTIVE_IDE_ADDR_ASSOC_BLOCK_COUNT,
+};
+use mcu_spdm_lite_traits::SpdmPalAlloc;
+use mcu_spdm_lite_vdm_handler::pci_sig::ide_km::{IdeDriver, IdeDriverError, IdeDriverResult};
+use zerocopy::little_endian::U32;
+
+/// Minimal emulator implementation for DOE/SPDM IDE-KM validation.
+#[derive(Debug, Clone, Copy)]
+pub struct EmulatedIdeDriver {
+    pub port_index: u8,
+    pub function_num: u8,
+    pub bus_num: u8,
+    pub segment: u8,
+    pub num_link_ide_streams: u8,
+    pub num_selective_ide_streams: u8,
+    pub num_addr_association_reg_blocks: u8,
+}
+
+impl Default for EmulatedIdeDriver {
+    fn default() -> Self {
+        Self {
+            port_index: 0,
+            function_num: 0,
+            bus_num: 0,
+            segment: 0,
+            num_link_ide_streams: 1,
+            num_selective_ide_streams: 1,
+            num_addr_association_reg_blocks: 1,
+        }
+    }
+}
+
+impl IdeDriver for EmulatedIdeDriver {
+    fn port_config<Alloc>(&self, port_index: u8, _scratch: &Alloc) -> IdeDriverResult<PortConfig>
+    where
+        Alloc: SpdmPalAlloc,
+    {
+        self.check_port(port_index)?;
+        Ok(PortConfig {
+            function_num: self.function_num,
+            bus_num: self.bus_num,
+            segment: self.segment,
+            max_port_index: self.port_index,
+        })
+    }
+
+    fn ide_reg_block<Alloc>(
+        &self,
+        port_index: u8,
+        _scratch: &Alloc,
+    ) -> IdeDriverResult<mcu_spdm_lite_codec::IdeRegBlock>
+    where
+        Alloc: SpdmPalAlloc,
+    {
+        self.check_port(port_index)?;
+        let mut ide_cap_reg = IdeCapabilityReg::default();
+        ide_cap_reg.set_link_ide_stream_supported(1);
+        ide_cap_reg.set_selective_ide_stream_supported(1);
+        ide_cap_reg.set_ide_km_protocol_supported(1);
+        ide_cap_reg.set_num_tcs_supported_for_link_ide(self.num_link_ide_streams);
+        ide_cap_reg.set_num_selective_ide_streams_supported(self.num_selective_ide_streams);
+
+        let mut ide_ctrl_reg = IdeControlReg::default();
+        ide_ctrl_reg.set_flow_through_ide_stream_enabled(1);
+        Ok(mcu_spdm_lite_codec::IdeRegBlock {
+            ide_cap_reg,
+            ide_ctrl_reg,
+        })
+    }
+
+    fn link_ide_reg_block<Alloc>(
+        &self,
+        port_index: u8,
+        block_index: u8,
+        _scratch: &Alloc,
+    ) -> IdeDriverResult<LinkIdeStreamRegBlock>
+    where
+        Alloc: SpdmPalAlloc,
+    {
+        self.check_port(port_index)?;
+        if block_index >= self.num_link_ide_streams {
+            return Err(IdeDriverError::InvalidStreamId);
+        }
+        let mut ctrl_reg = LinkIdeStreamControlReg::default();
+        ctrl_reg.set_link_ide_stream_enable(1);
+        ctrl_reg.set_pcrc_enable(1);
+        ctrl_reg.set_selected_algorithm(5);
+        ctrl_reg.set_tc(block_index & 0x7);
+        ctrl_reg.set_stream_id(block_index);
+
+        let mut status_reg = LinkIdeStreamStatusReg::default();
+        status_reg.set_link_ide_stream_state(7);
+        Ok(LinkIdeStreamRegBlock {
+            ctrl_reg,
+            status_reg,
+        })
+    }
+
+    fn selective_ide_reg_block<Alloc>(
+        &self,
+        port_index: u8,
+        block_index: u8,
+        _scratch: &Alloc,
+    ) -> IdeDriverResult<SelectiveIdeStreamRegBlock>
+    where
+        Alloc: SpdmPalAlloc,
+    {
+        self.check_port(port_index)?;
+        if block_index >= self.num_selective_ide_streams {
+            return Err(IdeDriverError::InvalidStreamId);
+        }
+
+        let mut capability_reg = SelectiveIdeStreamCapabilityReg::default();
+        capability_reg.set_num_addr_association_reg_blocks(
+            self.num_addr_association_reg_blocks
+                .min(MAX_SELECTIVE_IDE_ADDR_ASSOC_BLOCK_COUNT as u8),
+        );
+
+        let mut ctrl_reg = SelectiveIdeStreamControlReg::default();
+        ctrl_reg.set_selective_ide_stream_enable(1);
+        ctrl_reg.set_pcrc_enable(1);
+        ctrl_reg.set_selective_ide_for_config_req_enable(1);
+        ctrl_reg.set_selected_algorithm(4);
+        ctrl_reg.set_tc(block_index & 0x7);
+        ctrl_reg.set_default_stream(1);
+        ctrl_reg.set_stream_id(block_index);
+
+        let mut status_reg = SelectiveIdeStreamStatusReg::default();
+        status_reg.set_selective_ide_stream_state(5);
+
+        let mut rid_association_reg_1 = SelectiveIdeRidAssociationReg1::default();
+        rid_association_reg_1.set_rid_limit(0x1234);
+        let mut rid_association_reg_2 = SelectiveIdeRidAssociationReg2::default();
+        rid_association_reg_2.set_valid(1);
+        rid_association_reg_2.set_rid_base(0x5678);
+
+        let mut addr_association_reg_block =
+            [AddrAssociationRegBlock::default(); MAX_SELECTIVE_IDE_ADDR_ASSOC_BLOCK_COUNT];
+        for reg in addr_association_reg_block
+            .iter_mut()
+            .take(capability_reg.num_addr_association_reg_blocks() as usize)
+        {
+            reg.reg1.set_valid(1);
+            reg.reg1.set_memory_base_lower(0x12);
+            reg.reg1.set_memory_limit_lower(0x34);
+            reg.reg2.memory_limit_upper = U32::new(0x1234_5678);
+            reg.reg3.memory_base_upper = U32::new(0x8765_4321);
+        }
+
+        Ok(SelectiveIdeStreamRegBlock {
+            capability_reg,
+            ctrl_reg,
+            status_reg,
+            rid_association_reg_1,
+            rid_association_reg_2,
+            addr_association_reg_block,
+        })
+    }
+
+    async fn key_prog<Alloc>(
+        &self,
+        _stream_id: u8,
+        _key_info: KeyInfo,
+        port_index: u8,
+        _key: &[U32; IDE_STREAM_KEY_SIZE_DW],
+        _iv: &[U32; IDE_STREAM_IV_SIZE_DW],
+        _scratch: &Alloc,
+    ) -> IdeDriverResult<u8>
+    where
+        Alloc: SpdmPalAlloc,
+    {
+        self.check_port(port_index)?;
+        Ok(0)
+    }
+
+    async fn key_set_go<Alloc>(
+        &self,
+        _stream_id: u8,
+        key_info: KeyInfo,
+        port_index: u8,
+        _scratch: &Alloc,
+    ) -> IdeDriverResult<()>
+    where
+        Alloc: SpdmPalAlloc,
+    {
+        self.check_port(port_index)?;
+        let _ = key_info;
+        Ok(())
+    }
+
+    async fn key_set_stop<Alloc>(
+        &self,
+        _stream_id: u8,
+        key_info: KeyInfo,
+        port_index: u8,
+        _scratch: &Alloc,
+    ) -> IdeDriverResult<()>
+    where
+        Alloc: SpdmPalAlloc,
+    {
+        self.check_port(port_index)?;
+        let _ = key_info;
+        Ok(())
+    }
+}
+
+impl EmulatedIdeDriver {
+    fn check_port(&self, port_index: u8) -> IdeDriverResult<()> {
+        if port_index == self.port_index {
+            Ok(())
+        } else {
+            Err(IdeDriverError::InvalidPortIndex)
+        }
+    }
+}

--- a/platforms/emulator/runtime/userspace/apps/user/src/spdm/pci_sig_vdm/emulated_tdisp.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/spdm/pci_sig_vdm/emulated_tdisp.rs
@@ -4,7 +4,7 @@
 
 use core::cell::Cell;
 
-use mcu_spdm_lite_traits::{SpdmPalAlloc, SpdmPalIo};
+use mcu_spdm_lite_traits::SpdmPalAlloc;
 use mcu_spdm_lite_vdm_handler::pci_sig::tdisp::{
     FunctionId, TdiStatus, TdispDriver, TdispDriverResult, TdispLockInterfaceParam,
     TdispReqCapabilities, TdispRespCapabilities, START_INTERFACE_NONCE_SIZE,
@@ -39,15 +39,13 @@ impl Default for EmulatedTdispDriver {
 }
 
 impl TdispDriver for EmulatedTdispDriver {
-    async fn generate_start_interface_nonce<Alloc, Io>(
+    async fn generate_start_interface_nonce<Alloc>(
         &self,
         _scratch: &Alloc,
-        _io: &Io,
         out: &mut [u8; START_INTERFACE_NONCE_SIZE],
     ) -> TdispDriverResult<()>
     where
         Alloc: SpdmPalAlloc,
-        Io: SpdmPalIo,
     {
         let start = self.nonce_counter.get().wrapping_add(1);
         self.nonce_counter.set(start);
@@ -57,31 +55,27 @@ impl TdispDriver for EmulatedTdispDriver {
         Ok(())
     }
 
-    async fn get_capabilities<Alloc, Io>(
+    async fn get_capabilities<Alloc>(
         &self,
         _req_caps: TdispReqCapabilities,
         _scratch: &Alloc,
-        _io: &Io,
         resp_caps: &mut TdispRespCapabilities,
     ) -> TdispDriverResult<u32>
     where
         Alloc: SpdmPalAlloc,
-        Io: SpdmPalIo,
     {
         *resp_caps = TdispRespCapabilities::new(0, EMULATED_REQ_MSGS_SUPPORTED, 0x07, 48, 0, 0);
         Ok(0)
     }
 
-    async fn lock_interface<Alloc, Io>(
+    async fn lock_interface<Alloc>(
         &self,
         _function_id: FunctionId,
         _param: TdispLockInterfaceParam,
         _scratch: &Alloc,
-        _io: &Io,
     ) -> TdispDriverResult<u32>
     where
         Alloc: SpdmPalAlloc,
-        Io: SpdmPalIo,
     {
         if self.state.get() != TdiStatus::ConfigUnlocked {
             return Ok(TDISP_ERROR_INVALID_INTERFACE_STATE);
@@ -90,16 +84,14 @@ impl TdispDriver for EmulatedTdispDriver {
         Ok(0)
     }
 
-    async fn get_device_interface_report_len<Alloc, Io>(
+    async fn get_device_interface_report_len<Alloc>(
         &self,
         _function_id: FunctionId,
         _scratch: &Alloc,
-        _io: &Io,
         intf_report_len: &mut u16,
     ) -> TdispDriverResult<u32>
     where
         Alloc: SpdmPalAlloc,
-        Io: SpdmPalIo,
     {
         *intf_report_len = if self.state.get() == TdiStatus::ConfigUnlocked {
             0
@@ -109,18 +101,16 @@ impl TdispDriver for EmulatedTdispDriver {
         Ok(0)
     }
 
-    async fn get_device_interface_report<Alloc, Io>(
+    async fn get_device_interface_report<Alloc>(
         &self,
         _function_id: FunctionId,
         offset: u16,
         _scratch: &Alloc,
-        _io: &Io,
         report: &mut [u8],
         copied: &mut usize,
     ) -> TdispDriverResult<u32>
     where
         Alloc: SpdmPalAlloc,
-        Io: SpdmPalIo,
     {
         let offset = offset as usize;
         if self.state.get() == TdiStatus::ConfigUnlocked
@@ -135,30 +125,26 @@ impl TdispDriver for EmulatedTdispDriver {
         Ok(0)
     }
 
-    async fn get_device_interface_state<Alloc, Io>(
+    async fn get_device_interface_state<Alloc>(
         &self,
         _function_id: FunctionId,
         _scratch: &Alloc,
-        _io: &Io,
         tdi_state: &mut TdiStatus,
     ) -> TdispDriverResult<u32>
     where
         Alloc: SpdmPalAlloc,
-        Io: SpdmPalIo,
     {
         *tdi_state = self.state.get();
         Ok(0)
     }
 
-    async fn start_interface<Alloc, Io>(
+    async fn start_interface<Alloc>(
         &self,
         _function_id: FunctionId,
         _scratch: &Alloc,
-        _io: &Io,
     ) -> TdispDriverResult<u32>
     where
         Alloc: SpdmPalAlloc,
-        Io: SpdmPalIo,
     {
         if self.state.get() != TdiStatus::ConfigLocked {
             return Ok(TDISP_ERROR_INVALID_INTERFACE_STATE);
@@ -167,15 +153,13 @@ impl TdispDriver for EmulatedTdispDriver {
         Ok(0)
     }
 
-    async fn stop_interface<Alloc, Io>(
+    async fn stop_interface<Alloc>(
         &self,
         _function_id: FunctionId,
         _scratch: &Alloc,
-        _io: &Io,
     ) -> TdispDriverResult<u32>
     where
         Alloc: SpdmPalAlloc,
-        Io: SpdmPalIo,
     {
         if self.state.get() == TdiStatus::ConfigUnlocked {
             return Ok(TDISP_ERROR_INVALID_INTERFACE_STATE);

--- a/platforms/emulator/runtime/userspace/apps/user/src/spdm/pci_sig_vdm/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/spdm/pci_sig_vdm/mod.rs
@@ -1,0 +1,4 @@
+// Licensed under the Apache-2.0 license
+
+pub mod emulated_ide_km;
+pub mod emulated_tdisp;

--- a/runtime/userspace/api/spdm-lite/codec/src/lib.rs
+++ b/runtime/userspace/api/spdm-lite/codec/src/lib.rs
@@ -22,7 +22,7 @@ mod measurements;
 mod opaque;
 mod secured_message;
 mod set_certificate;
-mod vendor_defined;
+pub mod vendor_defined;
 mod version;
 mod wire;
 
@@ -57,6 +57,19 @@ pub use measurements::{
     SPDM_MAX_MEASUREMENT_RECORD_SIZE,
 };
 pub use set_certificate::{SetCertificateReqBody, SetCertificateRsp, SetCertificateRspBody};
+pub use vendor_defined::pci_sig::ide_km::{
+    AddrAssociationRegBlock, IdeAddrAssociationReg1, IdeAddrAssociationReg2,
+    IdeAddrAssociationReg3, IdeCapabilityReg, IdeControlReg, IdeKmCommand, IdeKmHdr, IdeRegBlock,
+    KeyData, KeyInfo, KeyProg, KeySetGoStop, LinkIdeStreamControlReg, LinkIdeStreamRegBlock,
+    LinkIdeStreamStatusReg, PortConfig, Query, SelectiveIdeRidAssociationReg1,
+    SelectiveIdeRidAssociationReg2, SelectiveIdeStreamCapabilityReg, SelectiveIdeStreamControlReg,
+    SelectiveIdeStreamRegBlock, SelectiveIdeStreamStatusReg, IDE_KM_OBJECT_ID_KEY_GO_STOP_ACK,
+    IDE_KM_OBJECT_ID_KEY_PROG, IDE_KM_OBJECT_ID_KEY_PROG_ACK, IDE_KM_OBJECT_ID_KEY_SET_GO,
+    IDE_KM_OBJECT_ID_KEY_SET_STOP, IDE_KM_OBJECT_ID_QUERY, IDE_KM_OBJECT_ID_QUERY_RESP,
+    IDE_KM_PROTOCOL_ID, IDE_STREAM_IV_SIZE_DW, IDE_STREAM_KEY_SIZE_DW,
+    MAX_SELECTIVE_IDE_ADDR_ASSOC_BLOCK_COUNT,
+};
+pub use vendor_defined::pci_sig::PciSigProtocolHdr;
 pub use vendor_defined::{
     decode_vendor_defined_req, StandardsBodyId, VendorDefinedReq, VendorDefinedReqPdu,
     VendorDefinedRspBody, VendorDefinedRspPdu,

--- a/runtime/userspace/api/spdm-lite/codec/src/vendor_defined/iana/ocp/caliptra.rs
+++ b/runtime/userspace/api/spdm-lite/codec/src/vendor_defined/iana/ocp/caliptra.rs
@@ -85,8 +85,7 @@ pub enum CaliptraCompletionCode {
     CaliptraBufferTooSmall = 0xC1,
 }
 
-/// Device-operation result from a [`CaliptraVdmCommands`](super::CaliptraVdmCommands)
-/// PAL hook: bytes written on success, or a completion code on failure.
+/// Device-operation result: bytes written on success, or a completion code on failure.
 pub type CaliptraVdmResult<T> = Result<T, CaliptraCompletionCode>;
 
 /// Outcome of dispatching a single Caliptra VDM command.

--- a/runtime/userspace/api/spdm-lite/codec/src/vendor_defined/mod.rs
+++ b/runtime/userspace/api/spdm-lite/codec/src/vendor_defined/mod.rs
@@ -2,6 +2,13 @@
 
 //! VENDOR_DEFINED request / response wire types.
 
+pub mod iana {
+    pub mod ocp {
+        pub mod caliptra;
+    }
+}
+pub mod pci_sig;
+
 use zerocopy::{little_endian::U16, FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 use crate::{ReqRespCode, ResponseBody, WireError, WireReader, WireWriter};

--- a/runtime/userspace/api/spdm-lite/codec/src/vendor_defined/pci_sig/ide_km.rs
+++ b/runtime/userspace/api/spdm-lite/codec/src/vendor_defined/pci_sig/ide_km.rs
@@ -1,0 +1,875 @@
+// Licensed under the Apache-2.0 license
+
+//! PCI-SIG IDE-KM protocol wire types.
+
+use core::mem::size_of;
+
+use zerocopy::{
+    little_endian::U16, little_endian::U32, FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned,
+};
+
+use crate::{WireError, WireWriter};
+
+/// IDE stream key size in DWORDs.
+pub const IDE_STREAM_KEY_SIZE_DW: usize = 8;
+/// IDE stream IV size in DWORDs.
+pub const IDE_STREAM_IV_SIZE_DW: usize = 2;
+/// Maximum selective IDE address-association register blocks.
+pub const MAX_SELECTIVE_IDE_ADDR_ASSOC_BLOCK_COUNT: usize = 15;
+
+/// PCI-SIG IDE-KM protocol ID within PCI-SIG VDMs.
+pub const IDE_KM_PROTOCOL_ID: u8 = 0x00;
+
+/// IDE-KM QUERY object ID.
+pub const IDE_KM_OBJECT_ID_QUERY: u8 = 0x00;
+/// IDE-KM QUERY_RESP object ID.
+pub const IDE_KM_OBJECT_ID_QUERY_RESP: u8 = 0x01;
+/// IDE-KM KEY_PROG object ID.
+pub const IDE_KM_OBJECT_ID_KEY_PROG: u8 = 0x02;
+/// IDE-KM KEY_PROG_ACK object ID.
+pub const IDE_KM_OBJECT_ID_KEY_PROG_ACK: u8 = 0x03;
+/// IDE-KM KEY_SET_GO object ID.
+pub const IDE_KM_OBJECT_ID_KEY_SET_GO: u8 = 0x04;
+/// IDE-KM KEY_SET_STOP object ID.
+pub const IDE_KM_OBJECT_ID_KEY_SET_STOP: u8 = 0x05;
+/// IDE-KM KEY_GO_STOP_ACK object ID.
+pub const IDE_KM_OBJECT_ID_KEY_GO_STOP_ACK: u8 = 0x06;
+
+/// IDE-KM object IDs used as command and response codes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum IdeKmCommand {
+    Query = 0x00,
+    QueryResp = 0x01,
+    KeyProg = 0x02,
+    KeyProgAck = 0x03,
+    KeySetGo = 0x04,
+    KeySetStop = 0x05,
+    KeyGoStopAck = 0x06,
+}
+
+impl IdeKmCommand {
+    /// Returns the IDE-KM response object ID for a request object ID.
+    pub const fn response(self) -> Option<Self> {
+        match self {
+            Self::Query => Some(Self::QueryResp),
+            Self::KeyProg => Some(Self::KeyProgAck),
+            Self::KeySetGo | Self::KeySetStop => Some(Self::KeyGoStopAck),
+            _ => None,
+        }
+    }
+
+    /// Returns the expected request payload size after [`IdeKmHdr`].
+    pub const fn payload_len(self) -> usize {
+        match self {
+            Self::Query => Query::SIZE,
+            Self::KeyProg => KeyProg::SIZE + KeyData::SIZE,
+            Self::KeySetGo | Self::KeySetStop => KeySetGoStop::SIZE,
+            _ => 0,
+        }
+    }
+
+    /// Decodes an IDE-KM object ID.
+    pub const fn from_u8(value: u8) -> Option<Self> {
+        match value {
+            0x00 => Some(Self::Query),
+            0x01 => Some(Self::QueryResp),
+            0x02 => Some(Self::KeyProg),
+            0x03 => Some(Self::KeyProgAck),
+            0x04 => Some(Self::KeySetGo),
+            0x05 => Some(Self::KeySetStop),
+            0x06 => Some(Self::KeyGoStopAck),
+            _ => None,
+        }
+    }
+}
+
+/// IDE-KM command header.
+#[derive(FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned, Copy, Clone, Debug)]
+#[repr(C)]
+pub struct IdeKmHdr {
+    /// IDE-KM object ID.
+    pub object_id: u8,
+}
+
+impl IdeKmHdr {
+    /// Size of the IDE-KM header on the wire.
+    pub const SIZE: usize = 1;
+}
+
+const _: () = assert!(size_of::<IdeKmHdr>() == IdeKmHdr::SIZE);
+
+/// Key Information field: Key Sub-stream | Reserved | RxTxB | Key Set.
+#[derive(
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+)]
+#[repr(transparent)]
+pub struct KeyInfo(pub u8);
+
+impl KeyInfo {
+    /// Creates a KeyInfo field from key-set, direction, and sub-stream values.
+    pub fn new(key_set_bit: bool, key_direction: bool, key_sub_stream: u8) -> Self {
+        let mut info = Self(0);
+        info.set_key_set_bit(key_set_bit as u8);
+        info.set_key_direction(key_direction as u8);
+        info.set_key_sub_stream(key_sub_stream);
+        info
+    }
+
+    /// Returns the Key Set bit.
+    pub const fn key_set_bit(self) -> u8 {
+        self.0 & 0x1
+    }
+
+    /// Sets the Key Set bit.
+    pub fn set_key_set_bit(&mut self, value: u8) {
+        self.0 = set_field_u8(self.0, 0, 1, value);
+    }
+
+    /// Returns the RxTxB key direction bit.
+    pub const fn key_direction(self) -> u8 {
+        (self.0 >> 1) & 0x1
+    }
+
+    /// Sets the RxTxB key direction bit.
+    pub fn set_key_direction(&mut self, value: u8) {
+        self.0 = set_field_u8(self.0, 1, 1, value);
+    }
+
+    /// Returns the key sub-stream nibble.
+    pub const fn key_sub_stream(self) -> u8 {
+        (self.0 >> 4) & 0x0f
+    }
+
+    /// Sets the key sub-stream nibble.
+    pub fn set_key_sub_stream(&mut self, value: u8) {
+        self.0 = set_field_u8(self.0, 4, 4, value);
+    }
+
+    /// Returns the raw wire byte.
+    pub const fn raw(self) -> u8 {
+        self.0
+    }
+}
+
+/// IDE Capability Register.
+#[derive(
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+)]
+#[repr(transparent)]
+pub struct IdeCapabilityReg(pub U32);
+
+impl IdeCapabilityReg {
+    /// Creates a register from raw bits.
+    pub const fn new(bits: u32) -> Self {
+        Self(U32::new(bits))
+    }
+
+    /// Returns raw register bits.
+    pub fn raw(self) -> u32 {
+        self.0.get()
+    }
+
+    pub fn link_ide_stream_supported(self) -> u8 {
+        get_bit(self.raw(), 0)
+    }
+    pub fn set_link_ide_stream_supported(&mut self, value: u8) {
+        self.set_bits(set_field(self.raw(), 0, 1, value as u32));
+    }
+    pub fn selective_ide_stream_supported(self) -> u8 {
+        get_bit(self.raw(), 1)
+    }
+    pub fn set_selective_ide_stream_supported(&mut self, value: u8) {
+        self.set_bits(set_field(self.raw(), 1, 1, value as u32));
+    }
+    pub fn flow_through_ide_stream_supported(self) -> u8 {
+        get_field(self.raw(), 2, 2) as u8
+    }
+    pub fn set_flow_through_ide_stream_supported(&mut self, value: u8) {
+        self.set_bits(set_field(self.raw(), 2, 2, value as u32));
+    }
+    pub fn aggregation_supported(self) -> u8 {
+        get_bit(self.raw(), 4)
+    }
+    pub fn set_aggregation_supported(&mut self, value: u8) {
+        self.set_bits(set_field(self.raw(), 4, 1, value as u32));
+    }
+    pub fn pcrc_supported(self) -> u8 {
+        get_bit(self.raw(), 5)
+    }
+    pub fn set_pcrc_supported(&mut self, value: u8) {
+        self.set_bits(set_field(self.raw(), 5, 1, value as u32));
+    }
+    pub fn ide_km_protocol_supported(self) -> u8 {
+        get_bit(self.raw(), 6)
+    }
+    pub fn set_ide_km_protocol_supported(&mut self, value: u8) {
+        self.set_bits(set_field(self.raw(), 6, 1, value as u32));
+    }
+    pub fn selective_ide_for_config_req_supported(self) -> u8 {
+        get_bit(self.raw(), 7)
+    }
+    pub fn set_selective_ide_for_config_req_supported(&mut self, value: u8) {
+        self.set_bits(set_field(self.raw(), 7, 1, value as u32));
+    }
+    pub fn supported_algorithms(self) -> u8 {
+        get_field(self.raw(), 8, 5) as u8
+    }
+    pub fn set_supported_algorithms(&mut self, value: u8) {
+        self.set_bits(set_field(self.raw(), 8, 5, value as u32));
+    }
+    pub fn num_tcs_supported_for_link_ide(self) -> u8 {
+        get_field(self.raw(), 13, 3) as u8
+    }
+    pub fn set_num_tcs_supported_for_link_ide(&mut self, value: u8) {
+        self.set_bits(set_field(self.raw(), 13, 3, value as u32));
+    }
+    pub fn num_selective_ide_streams_supported(self) -> u8 {
+        get_field(self.raw(), 16, 8) as u8
+    }
+    pub fn set_num_selective_ide_streams_supported(&mut self, value: u8) {
+        self.set_bits(set_field(self.raw(), 16, 8, value as u32));
+    }
+
+    fn set_bits(&mut self, bits: u32) {
+        self.0 = U32::new(bits);
+    }
+}
+
+/// IDE Control Register.
+#[derive(
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+)]
+#[repr(transparent)]
+pub struct IdeControlReg(pub U32);
+
+impl IdeControlReg {
+    pub const fn new(bits: u32) -> Self {
+        Self(U32::new(bits))
+    }
+    pub fn raw(self) -> u32 {
+        self.0.get()
+    }
+    pub fn flow_through_ide_stream_enabled(self) -> u8 {
+        get_bit(self.raw(), 2)
+    }
+    pub fn set_flow_through_ide_stream_enabled(&mut self, value: u8) {
+        self.0 = U32::new(set_field(self.raw(), 2, 1, value as u32));
+    }
+}
+
+/// Link IDE Stream Control Register.
+#[derive(
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+)]
+#[repr(transparent)]
+pub struct LinkIdeStreamControlReg(pub U32);
+
+impl LinkIdeStreamControlReg {
+    pub const fn new(bits: u32) -> Self {
+        Self(U32::new(bits))
+    }
+    pub fn raw(self) -> u32 {
+        self.0.get()
+    }
+    pub fn link_ide_stream_enable(self) -> u8 {
+        get_bit(self.raw(), 0)
+    }
+    pub fn set_link_ide_stream_enable(&mut self, value: u8) {
+        self.set_bits(set_field(self.raw(), 0, 1, value as u32));
+    }
+    pub fn tx_aggregation_mode_npr(self) -> u8 {
+        get_field(self.raw(), 2, 2) as u8
+    }
+    pub fn set_tx_aggregation_mode_npr(&mut self, value: u8) {
+        self.set_bits(set_field(self.raw(), 2, 2, value as u32));
+    }
+    pub fn tx_aggregation_mode_pr(self) -> u8 {
+        get_field(self.raw(), 4, 2) as u8
+    }
+    pub fn set_tx_aggregation_mode_pr(&mut self, value: u8) {
+        self.set_bits(set_field(self.raw(), 4, 2, value as u32));
+    }
+    pub fn tx_aggregation_mode_cpl(self) -> u8 {
+        get_field(self.raw(), 6, 2) as u8
+    }
+    pub fn set_tx_aggregation_mode_cpl(&mut self, value: u8) {
+        self.set_bits(set_field(self.raw(), 6, 2, value as u32));
+    }
+    pub fn pcrc_enable(self) -> u8 {
+        get_bit(self.raw(), 8)
+    }
+    pub fn set_pcrc_enable(&mut self, value: u8) {
+        self.set_bits(set_field(self.raw(), 8, 1, value as u32));
+    }
+    pub fn selected_algorithm(self) -> u8 {
+        get_field(self.raw(), 14, 5) as u8
+    }
+    pub fn set_selected_algorithm(&mut self, value: u8) {
+        self.set_bits(set_field(self.raw(), 14, 5, value as u32));
+    }
+    pub fn tc(self) -> u8 {
+        get_field(self.raw(), 19, 3) as u8
+    }
+    pub fn set_tc(&mut self, value: u8) {
+        self.set_bits(set_field(self.raw(), 19, 3, value as u32));
+    }
+    pub fn stream_id(self) -> u8 {
+        get_field(self.raw(), 24, 8) as u8
+    }
+    pub fn set_stream_id(&mut self, value: u8) {
+        self.set_bits(set_field(self.raw(), 24, 8, value as u32));
+    }
+    fn set_bits(&mut self, bits: u32) {
+        self.0 = U32::new(bits);
+    }
+}
+
+/// Link IDE Stream Status Register.
+#[derive(
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+)]
+#[repr(transparent)]
+pub struct LinkIdeStreamStatusReg(pub U32);
+
+impl LinkIdeStreamStatusReg {
+    pub const fn new(bits: u32) -> Self {
+        Self(U32::new(bits))
+    }
+    pub fn raw(self) -> u32 {
+        self.0.get()
+    }
+    pub fn link_ide_stream_state(self) -> u8 {
+        get_field(self.raw(), 0, 4) as u8
+    }
+    pub fn set_link_ide_stream_state(&mut self, value: u8) {
+        self.0 = U32::new(set_field(self.raw(), 0, 4, value as u32));
+    }
+}
+
+/// Selective IDE Stream Capability Register.
+#[derive(
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+)]
+#[repr(transparent)]
+pub struct SelectiveIdeStreamCapabilityReg(pub U32);
+
+impl SelectiveIdeStreamCapabilityReg {
+    pub const fn new(bits: u32) -> Self {
+        Self(U32::new(bits))
+    }
+    pub fn raw(self) -> u32 {
+        self.0.get()
+    }
+    pub fn num_addr_association_reg_blocks(self) -> u8 {
+        get_field(self.raw(), 0, 4) as u8
+    }
+    pub fn set_num_addr_association_reg_blocks(&mut self, value: u8) {
+        self.0 = U32::new(set_field(self.raw(), 0, 4, value as u32));
+    }
+}
+
+/// Selective IDE Stream Control Register.
+#[derive(
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+)]
+#[repr(transparent)]
+pub struct SelectiveIdeStreamControlReg(pub U32);
+
+impl SelectiveIdeStreamControlReg {
+    pub const fn new(bits: u32) -> Self {
+        Self(U32::new(bits))
+    }
+    pub fn raw(self) -> u32 {
+        self.0.get()
+    }
+    pub fn selective_ide_stream_enable(self) -> u8 {
+        get_bit(self.raw(), 0)
+    }
+    pub fn set_selective_ide_stream_enable(&mut self, value: u8) {
+        self.set_bits(set_field(self.raw(), 0, 1, value as u32));
+    }
+    pub fn tx_aggregation_mode_npr(self) -> u8 {
+        get_field(self.raw(), 2, 2) as u8
+    }
+    pub fn set_tx_aggregation_mode_npr(&mut self, value: u8) {
+        self.set_bits(set_field(self.raw(), 2, 2, value as u32));
+    }
+    pub fn tx_aggregation_mode_pr(self) -> u8 {
+        get_field(self.raw(), 4, 2) as u8
+    }
+    pub fn set_tx_aggregation_mode_pr(&mut self, value: u8) {
+        self.set_bits(set_field(self.raw(), 4, 2, value as u32));
+    }
+    pub fn tx_aggregation_mode_cpl(self) -> u8 {
+        get_field(self.raw(), 6, 2) as u8
+    }
+    pub fn set_tx_aggregation_mode_cpl(&mut self, value: u8) {
+        self.set_bits(set_field(self.raw(), 6, 2, value as u32));
+    }
+    pub fn pcrc_enable(self) -> u8 {
+        get_bit(self.raw(), 8)
+    }
+    pub fn set_pcrc_enable(&mut self, value: u8) {
+        self.set_bits(set_field(self.raw(), 8, 1, value as u32));
+    }
+    pub fn selective_ide_for_config_req_enable(self) -> u8 {
+        get_bit(self.raw(), 9)
+    }
+    pub fn set_selective_ide_for_config_req_enable(&mut self, value: u8) {
+        self.set_bits(set_field(self.raw(), 9, 1, value as u32));
+    }
+    pub fn selected_algorithm(self) -> u8 {
+        get_field(self.raw(), 14, 5) as u8
+    }
+    pub fn set_selected_algorithm(&mut self, value: u8) {
+        self.set_bits(set_field(self.raw(), 14, 5, value as u32));
+    }
+    pub fn tc(self) -> u8 {
+        get_field(self.raw(), 19, 3) as u8
+    }
+    pub fn set_tc(&mut self, value: u8) {
+        self.set_bits(set_field(self.raw(), 19, 3, value as u32));
+    }
+    pub fn default_stream(self) -> u8 {
+        get_bit(self.raw(), 22)
+    }
+    pub fn set_default_stream(&mut self, value: u8) {
+        self.set_bits(set_field(self.raw(), 22, 1, value as u32));
+    }
+    pub fn stream_id(self) -> u8 {
+        get_field(self.raw(), 24, 8) as u8
+    }
+    pub fn set_stream_id(&mut self, value: u8) {
+        self.set_bits(set_field(self.raw(), 24, 8, value as u32));
+    }
+    fn set_bits(&mut self, bits: u32) {
+        self.0 = U32::new(bits);
+    }
+}
+
+/// Selective IDE Stream Status Register.
+#[derive(
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+)]
+#[repr(transparent)]
+pub struct SelectiveIdeStreamStatusReg(pub U32);
+
+impl SelectiveIdeStreamStatusReg {
+    pub const fn new(bits: u32) -> Self {
+        Self(U32::new(bits))
+    }
+    pub fn raw(self) -> u32 {
+        self.0.get()
+    }
+    pub fn selective_ide_stream_state(self) -> u8 {
+        get_field(self.raw(), 0, 4) as u8
+    }
+    pub fn set_selective_ide_stream_state(&mut self, value: u8) {
+        self.set_bits(set_field(self.raw(), 0, 4, value as u32));
+    }
+    pub fn received_integrity_check_fail_msg(self) -> u32 {
+        get_field(self.raw(), 4, 28)
+    }
+    pub fn set_received_integrity_check_fail_msg(&mut self, value: u32) {
+        self.set_bits(set_field(self.raw(), 4, 28, value));
+    }
+    fn set_bits(&mut self, bits: u32) {
+        self.0 = U32::new(bits);
+    }
+}
+
+/// Selective IDE RID Association Register 1.
+#[derive(
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+)]
+#[repr(transparent)]
+pub struct SelectiveIdeRidAssociationReg1(pub U32);
+
+impl SelectiveIdeRidAssociationReg1 {
+    pub const fn new(bits: u32) -> Self {
+        Self(U32::new(bits))
+    }
+    pub fn raw(self) -> u32 {
+        self.0.get()
+    }
+    pub fn rid_limit(self) -> u16 {
+        get_field(self.raw(), 8, 16) as u16
+    }
+    pub fn set_rid_limit(&mut self, value: u16) {
+        self.0 = U32::new(set_field(self.raw(), 8, 16, value as u32));
+    }
+}
+
+/// Selective IDE RID Association Register 2.
+#[derive(
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+)]
+#[repr(transparent)]
+pub struct SelectiveIdeRidAssociationReg2(pub U32);
+
+impl SelectiveIdeRidAssociationReg2 {
+    pub const fn new(bits: u32) -> Self {
+        Self(U32::new(bits))
+    }
+    pub fn raw(self) -> u32 {
+        self.0.get()
+    }
+    pub fn valid(self) -> u8 {
+        get_bit(self.raw(), 0)
+    }
+    pub fn set_valid(&mut self, value: u8) {
+        self.set_bits(set_field(self.raw(), 0, 1, value as u32));
+    }
+    pub fn rid_base(self) -> u16 {
+        get_field(self.raw(), 8, 16) as u16
+    }
+    pub fn set_rid_base(&mut self, value: u16) {
+        self.set_bits(set_field(self.raw(), 8, 16, value as u32));
+    }
+    fn set_bits(&mut self, bits: u32) {
+        self.0 = U32::new(bits);
+    }
+}
+
+/// Selective IDE Address Association Register 1.
+#[derive(
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+)]
+#[repr(transparent)]
+pub struct IdeAddrAssociationReg1(pub U32);
+
+impl IdeAddrAssociationReg1 {
+    pub const fn new(bits: u32) -> Self {
+        Self(U32::new(bits))
+    }
+    pub fn raw(self) -> u32 {
+        self.0.get()
+    }
+    pub fn valid(self) -> u8 {
+        get_bit(self.raw(), 0)
+    }
+    pub fn set_valid(&mut self, value: u8) {
+        self.set_bits(set_field(self.raw(), 0, 1, value as u32));
+    }
+    pub fn memory_base_lower(self) -> u16 {
+        get_field(self.raw(), 8, 12) as u16
+    }
+    pub fn set_memory_base_lower(&mut self, value: u16) {
+        self.set_bits(set_field(self.raw(), 8, 12, value as u32));
+    }
+    pub fn memory_limit_lower(self) -> u16 {
+        get_field(self.raw(), 20, 12) as u16
+    }
+    pub fn set_memory_limit_lower(&mut self, value: u16) {
+        self.set_bits(set_field(self.raw(), 20, 12, value as u32));
+    }
+    fn set_bits(&mut self, bits: u32) {
+        self.0 = U32::new(bits);
+    }
+}
+
+/// Selective IDE Address Association Register 2.
+#[derive(FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned, Copy, Clone, Debug, Default)]
+#[repr(C)]
+pub struct IdeAddrAssociationReg2 {
+    pub memory_limit_upper: U32,
+}
+
+/// Selective IDE Address Association Register 3.
+#[derive(FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned, Copy, Clone, Debug, Default)]
+#[repr(C)]
+pub struct IdeAddrAssociationReg3 {
+    pub memory_base_upper: U32,
+}
+
+/// IDE Port configuration.
+#[derive(FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned, Copy, Clone, Debug, Default)]
+#[repr(C)]
+pub struct PortConfig {
+    pub function_num: u8,
+    pub bus_num: u8,
+    pub segment: u8,
+    pub max_port_index: u8,
+}
+
+impl PortConfig {
+    pub const SIZE: usize = 4;
+}
+
+/// IDE Capability and Control register block.
+#[derive(FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned, Copy, Clone, Debug, Default)]
+#[repr(C)]
+pub struct IdeRegBlock {
+    pub ide_cap_reg: IdeCapabilityReg,
+    pub ide_ctrl_reg: IdeControlReg,
+}
+
+impl IdeRegBlock {
+    pub const SIZE: usize = 8;
+}
+
+/// Link IDE Stream register block.
+#[derive(FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned, Copy, Clone, Debug, Default)]
+#[repr(C)]
+pub struct LinkIdeStreamRegBlock {
+    pub ctrl_reg: LinkIdeStreamControlReg,
+    pub status_reg: LinkIdeStreamStatusReg,
+}
+
+impl LinkIdeStreamRegBlock {
+    pub const SIZE: usize = 8;
+}
+
+/// Selective IDE Stream register block.
+#[derive(FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned, Copy, Clone, Debug)]
+#[repr(C)]
+pub struct SelectiveIdeStreamRegBlock {
+    pub capability_reg: SelectiveIdeStreamCapabilityReg,
+    pub ctrl_reg: SelectiveIdeStreamControlReg,
+    pub status_reg: SelectiveIdeStreamStatusReg,
+    pub rid_association_reg_1: SelectiveIdeRidAssociationReg1,
+    pub rid_association_reg_2: SelectiveIdeRidAssociationReg2,
+    pub addr_association_reg_block:
+        [AddrAssociationRegBlock; MAX_SELECTIVE_IDE_ADDR_ASSOC_BLOCK_COUNT],
+}
+
+impl SelectiveIdeStreamRegBlock {
+    /// Size of the fixed fields before variable address-association blocks.
+    pub const FIXED_SIZE: usize = 20;
+
+    /// Encodes this block with the variable address-association count from capability_reg.
+    pub fn encode(&self, writer: &mut WireWriter<'_>) -> Result<(), WireError> {
+        let count = self.capability_reg.num_addr_association_reg_blocks() as usize;
+        if count > MAX_SELECTIVE_IDE_ADDR_ASSOC_BLOCK_COUNT {
+            return Err(WireError);
+        }
+        writer.write(&self.capability_reg)?;
+        writer.write(&self.ctrl_reg)?;
+        writer.write(&self.status_reg)?;
+        writer.write(&self.rid_association_reg_1)?;
+        writer.write(&self.rid_association_reg_2)?;
+        for reg in self.addr_association_reg_block.iter().take(count) {
+            writer.write(reg)?;
+        }
+        Ok(())
+    }
+}
+
+impl Default for SelectiveIdeStreamRegBlock {
+    fn default() -> Self {
+        Self {
+            capability_reg: SelectiveIdeStreamCapabilityReg::default(),
+            ctrl_reg: SelectiveIdeStreamControlReg::default(),
+            status_reg: SelectiveIdeStreamStatusReg::default(),
+            rid_association_reg_1: SelectiveIdeRidAssociationReg1::default(),
+            rid_association_reg_2: SelectiveIdeRidAssociationReg2::default(),
+            addr_association_reg_block: [AddrAssociationRegBlock::default();
+                MAX_SELECTIVE_IDE_ADDR_ASSOC_BLOCK_COUNT],
+        }
+    }
+}
+
+/// Selective IDE Address Association register block.
+#[derive(FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned, Copy, Clone, Debug, Default)]
+#[repr(C)]
+pub struct AddrAssociationRegBlock {
+    pub reg1: IdeAddrAssociationReg1,
+    pub reg2: IdeAddrAssociationReg2,
+    pub reg3: IdeAddrAssociationReg3,
+}
+
+impl AddrAssociationRegBlock {
+    pub const SIZE: usize = 12;
+}
+
+/// IDE-KM QUERY request payload.
+#[derive(FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned, Copy, Clone, Debug, Default)]
+#[repr(C)]
+pub struct Query {
+    pub reserved: u8,
+    pub port_index: u8,
+}
+
+impl Query {
+    pub const SIZE: usize = 2;
+}
+
+/// IDE-KM KEY_PROG request/ack payload before key material.
+#[derive(FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned, Copy, Clone, Debug, Default)]
+#[repr(C)]
+pub struct KeyProg {
+    pub reserved: U16,
+    pub stream_id: u8,
+    pub status: u8,
+    pub key_info: KeyInfo,
+    pub port_index: u8,
+}
+
+impl KeyProg {
+    pub const SIZE: usize = 6;
+}
+
+/// IDE-KM key material payload.
+#[derive(FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned, Copy, Clone)]
+#[repr(C)]
+pub struct KeyData {
+    pub key: [U32; IDE_STREAM_KEY_SIZE_DW],
+    pub iv: [U32; IDE_STREAM_IV_SIZE_DW],
+}
+
+impl KeyData {
+    pub const SIZE: usize = 40;
+}
+
+/// IDE-KM KEY_SET_GO / KEY_SET_STOP request and ACK payload.
+#[derive(FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned, Copy, Clone, Debug, Default)]
+#[repr(C)]
+pub struct KeySetGoStop {
+    pub reserved1: U16,
+    pub stream_id: u8,
+    pub reserved2: u8,
+    pub key_info: KeyInfo,
+    pub port_index: u8,
+}
+
+impl KeySetGoStop {
+    pub const SIZE: usize = 6;
+}
+
+const _: () = assert!(size_of::<PortConfig>() == PortConfig::SIZE);
+const _: () = assert!(size_of::<IdeRegBlock>() == IdeRegBlock::SIZE);
+const _: () = assert!(size_of::<LinkIdeStreamRegBlock>() == LinkIdeStreamRegBlock::SIZE);
+const _: () = assert!(size_of::<AddrAssociationRegBlock>() == AddrAssociationRegBlock::SIZE);
+const _: () = assert!(size_of::<Query>() == Query::SIZE);
+const _: () = assert!(size_of::<KeyProg>() == KeyProg::SIZE);
+const _: () = assert!(size_of::<KeyData>() == KeyData::SIZE);
+const _: () = assert!(size_of::<KeySetGoStop>() == KeySetGoStop::SIZE);
+
+const fn set_field_u8(bits: u8, shift: u8, width: u8, value: u8) -> u8 {
+    let mask = ((1u16 << width) - 1) as u8;
+    (bits & !(mask << shift)) | ((value & mask) << shift)
+}
+
+fn get_bit(bits: u32, shift: u8) -> u8 {
+    ((bits >> shift) & 1) as u8
+}
+
+fn get_field(bits: u32, shift: u8, width: u8) -> u32 {
+    (bits >> shift) & ((1u32 << width) - 1)
+}
+
+fn set_field(bits: u32, shift: u8, width: u8, value: u32) -> u32 {
+    let mask = (1u32 << width) - 1;
+    (bits & !(mask << shift)) | ((value & mask) << shift)
+}

--- a/runtime/userspace/api/spdm-lite/codec/src/vendor_defined/pci_sig/mod.rs
+++ b/runtime/userspace/api/spdm-lite/codec/src/vendor_defined/pci_sig/mod.rs
@@ -1,0 +1,23 @@
+// Licensed under the Apache-2.0 license
+
+//! PCI-SIG VDM protocol wire types.
+
+pub mod ide_km;
+pub mod tdisp;
+
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
+
+/// PCI-SIG protocol selector byte that prefixes PCI-SIG VDM payloads.
+#[derive(FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned, Copy, Clone, Debug)]
+#[repr(C)]
+pub struct PciSigProtocolHdr {
+    /// PCI-SIG protocol ID (0 = IDE-KM).
+    pub protocol_id: u8,
+}
+
+impl PciSigProtocolHdr {
+    /// Size of the PCI-SIG protocol header on the wire.
+    pub const SIZE: usize = 1;
+}
+
+const _: () = assert!(core::mem::size_of::<PciSigProtocolHdr>() == PciSigProtocolHdr::SIZE);

--- a/runtime/userspace/api/spdm-lite/codec/src/vendor_defined/pci_sig/tdisp.rs
+++ b/runtime/userspace/api/spdm-lite/codec/src/vendor_defined/pci_sig/tdisp.rs
@@ -2,8 +2,9 @@
 
 //! Shared TDISP wire protocol types.
 
-use mcu_spdm_lite_codec::errors::{SPDM_INVALID_REQUEST, SPDM_UNSPECIFIED};
 use mcu_spdm_lite_traits::McuResult;
+
+use crate::errors::{SPDM_INVALID_REQUEST, SPDM_UNSPECIFIED};
 
 /// TDISP version 1.0 wire value.
 pub const TDISP_VERSION_1_0: u8 = 0x10;
@@ -125,7 +126,7 @@ pub enum TdispCommand {
 
 impl TdispCommand {
     /// Returns the matching response command for a request command.
-    pub(crate) const fn response(self) -> Option<Self> {
+    pub const fn response(self) -> Option<Self> {
         match self {
             Self::GetTdispVersion => Some(Self::TdispVersion),
             Self::GetTdispCapabilities => Some(Self::TdispCapabilities),
@@ -143,7 +144,7 @@ impl TdispCommand {
     }
 
     /// Returns the exact request payload length for this command.
-    pub(crate) const fn payload_len(self) -> usize {
+    pub const fn payload_len(self) -> usize {
         match self {
             Self::GetTdispVersion => 0,
             Self::GetTdispCapabilities => TDISP_CAPS_REQ_LEN,
@@ -247,7 +248,7 @@ impl TdispMessageHeader {
         }
     }
 
-    pub(crate) fn decode(input: &[u8]) -> McuResult<(Self, &[u8])> {
+    pub fn decode(input: &[u8]) -> McuResult<(Self, &[u8])> {
         let hdr = input.get(..TDISP_HEADER_LEN).ok_or(SPDM_INVALID_REQUEST)?;
         Ok((
             Self {
@@ -263,7 +264,7 @@ impl TdispMessageHeader {
         ))
     }
 
-    pub(crate) fn encode(self, out: &mut [u8]) -> McuResult<()> {
+    pub fn encode(self, out: &mut [u8]) -> McuResult<()> {
         let out = out.get_mut(..TDISP_HEADER_LEN).ok_or(SPDM_UNSPECIFIED)?;
         out[0] = self.version;
         out[1] = self.message_type;
@@ -282,7 +283,7 @@ pub struct TdispReqCapabilities {
 }
 
 impl TdispReqCapabilities {
-    pub(crate) fn decode(input: &[u8]) -> McuResult<Self> {
+    pub fn decode(input: &[u8]) -> McuResult<Self> {
         if input.len() != TDISP_CAPS_REQ_LEN {
             return Err(SPDM_INVALID_REQUEST);
         }
@@ -329,7 +330,7 @@ impl TdispRespCapabilities {
         }
     }
 
-    pub(crate) fn encode(self, out: &mut [u8]) -> McuResult<()> {
+    pub fn encode(self, out: &mut [u8]) -> McuResult<()> {
         let out = out.get_mut(..TDISP_CAPS_RSP_LEN).ok_or(SPDM_UNSPECIFIED)?;
         out[0..4].copy_from_slice(&self.dsm_capabilities.to_le_bytes());
         out[4..20].copy_from_slice(&self.req_msgs_supported);
@@ -362,7 +363,7 @@ pub struct TdispLockInterfaceParam {
 }
 
 impl TdispLockInterfaceParam {
-    pub(crate) fn decode(input: &[u8]) -> McuResult<Self> {
+    pub fn decode(input: &[u8]) -> McuResult<Self> {
         if input.len() != LOCK_INTERFACE_PARAM_LEN {
             return Err(SPDM_INVALID_REQUEST);
         }
@@ -382,13 +383,13 @@ impl TdispLockInterfaceParam {
 
 /// GET_DEVICE_INTERFACE_REPORT request payload.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) struct DeviceInterfaceReportReq {
-    pub(crate) offset: u16,
-    pub(crate) length: u16,
+pub struct DeviceInterfaceReportReq {
+    pub offset: u16,
+    pub length: u16,
 }
 
 impl DeviceInterfaceReportReq {
-    pub(crate) fn decode(input: &[u8]) -> McuResult<Self> {
+    pub fn decode(input: &[u8]) -> McuResult<Self> {
         if input.len() != DEVICE_INTERFACE_REPORT_REQ_LEN {
             return Err(SPDM_INVALID_REQUEST);
         }
@@ -434,7 +435,7 @@ fn read_u64(input: &[u8]) -> u64 {
     u64::from_le_bytes(bytes)
 }
 
-pub(crate) fn ct_eq(a: &[u8; START_INTERFACE_NONCE_SIZE], b: &[u8]) -> bool {
+pub fn ct_eq(a: &[u8; START_INTERFACE_NONCE_SIZE], b: &[u8]) -> bool {
     if b.len() != START_INTERFACE_NONCE_SIZE {
         return false;
     }

--- a/runtime/userspace/api/spdm-lite/errors/src/lib.rs
+++ b/runtime/userspace/api/spdm-lite/errors/src/lib.rs
@@ -50,6 +50,23 @@ pub const SUBDOMAIN_MCTP: u8 = 0x10;
 /// PCIe DOE transport (used by SPDM) — reserved for future use.
 pub const SUBDOMAIN_DOE: u8 = 0x11;
 
+/// VDM handler control errors that affect responder framing rather than the
+/// vendor-defined wire payload.
+pub const SUBDOMAIN_VDM: u8 = 0x20;
+
+/// A matched VDM backend failed in the vendor protocol handler and the request
+/// should be dropped without generating an SPDM ERROR response.
+///
+/// Use this when a backend owns the VDM request but cannot form a valid
+/// vendor-defined response payload.
+pub const VDM_NO_RESPONSE: McuErrorCode = McuErrorCode::new(domain::SPDM, SUBDOMAIN_VDM, 0x0001);
+
+/// Returns true when `e` requests silent VDM failure handling.
+#[inline]
+pub const fn is_vdm_no_response(e: McuErrorCode) -> bool {
+    e.domain() == domain::SPDM && e.subdomain() == SUBDOMAIN_VDM && e.code() == 0x0001
+}
+
 // ----- Wire-byte convention --------------------------------------------------
 
 /// Builds an [`McuErrorCode`] from a DSP0274 §10.10.2 SPDM error byte.

--- a/runtime/userspace/api/spdm-lite/stack/src/certificate.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/certificate.rs
@@ -133,6 +133,16 @@ pub(crate) async fn handle_get_certificate<'a, Pal: SpdmPal>(
     pal: &'a Pal,
     io: &<Pal as SpdmPalIoTransport>::Io<'_>,
 ) -> SpdmResult<PalBytes<'a, Pal>> {
+    let (resp, _) = handle_get_certificate_req(state, pal, io, io.request()).await?;
+    Ok(resp)
+}
+
+pub(crate) async fn handle_get_certificate_req<'a, Pal: SpdmPal>(
+    state: &mut ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
+    pal: &'a Pal,
+    io: &<Pal as SpdmPalIoTransport>::Io<'_>,
+    spdm_msg: &[u8],
+) -> SpdmResult<(PalBytes<'a, Pal>, usize)> {
     // GET_CERTIFICATE is legal once algorithms are negotiated, and
     // any number of times after (pagination, re-requests).
     if (state.phase as u8) < (Phase::AfterAlgorithms as u8) {
@@ -140,8 +150,7 @@ pub(crate) async fn handle_get_certificate<'a, Pal: SpdmPal>(
     }
 
     // Decode the 6-byte request body.
-    let req = io.request();
-    let (hdr, body) = SpdmMsgHdrPdu::ref_from_prefix(req).map_err(|_| SPDM_INVALID_REQUEST)?;
+    let (hdr, body) = SpdmMsgHdrPdu::ref_from_prefix(spdm_msg).map_err(|_| SPDM_INVALID_REQUEST)?;
     if hdr.version != state.version.to_u8() {
         return Err(crate::error::SPDM_VERSION_MISMATCH);
     }
@@ -229,14 +238,14 @@ pub(crate) async fn handle_get_certificate<'a, Pal: SpdmPal>(
             &[handle],
         )?;
 
-        state.transcript.append_m1(pal, io, io.request()).await?;
+        state.transcript.append_m1(pal, io, spdm_msg).await?;
         state.large_msg_ctx.start_response(
             LargeResponse::Certificate(cert_rsp),
             cert_rsp.response_size(),
             None,
         )?;
         state.phase = Phase::AfterCertificate;
-        return Ok(resp);
+        return Ok((resp, SpdmMsgHdrPdu::SIZE + 2 + 1));
     }
 
     if portion_len == 0 {
@@ -253,12 +262,23 @@ pub(crate) async fn handle_get_certificate<'a, Pal: SpdmPal>(
             },
         )?;
 
+        let spdm_len = CertificateRsp {
+            slot_id,
+            param2: cert_info,
+            portion_length: 0,
+            remainder_length: remainder_len,
+            chain_portion: &[],
+        }
+        .encoded_size();
         let head = pal.header_size();
-        state.transcript.append_m1(pal, io, io.request()).await?;
-        state.transcript.append_m1(pal, io, &resp[head..]).await?;
+        state.transcript.append_m1(pal, io, spdm_msg).await?;
+        state
+            .transcript
+            .append_m1(pal, io, &resp[head..head + spdm_len])
+            .await?;
 
         state.phase = Phase::AfterCertificate;
-        return Ok(resp);
+        return Ok((resp, spdm_len));
     }
 
     // Allocate the portion buffer from the per-IO pool. Bytes
@@ -279,14 +299,14 @@ pub(crate) async fn handle_get_certificate<'a, Pal: SpdmPal>(
     let resp = build_response(pal, io, state.version, &cert_body)?;
 
     let head = pal.header_size();
-    state.transcript.append_m1(pal, io, io.request()).await?;
+    state.transcript.append_m1(pal, io, spdm_msg).await?;
     state
         .transcript
         .append_m1(pal, io, &resp[head..head + spdm_len])
         .await?;
 
     state.phase = Phase::AfterCertificate;
-    Ok(resp)
+    Ok((resp, spdm_len))
 }
 
 /// Splice the SPDM cert-chain header (first 52 bytes) with raw DER

--- a/runtime/userspace/api/spdm-lite/stack/src/digests.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/digests.rs
@@ -27,14 +27,23 @@ pub(crate) async fn handle_get_digests<'a, Pal: SpdmPal>(
     pal: &'a Pal,
     io: &<Pal as SpdmPalIoTransport>::Io<'_>,
 ) -> SpdmResult<PalBytes<'a, Pal>> {
-    if state.phase != Phase::AfterAlgorithms && state.phase != Phase::AfterDigests {
+    let (resp, _) = handle_get_digests_req(state, pal, io, io.request()).await?;
+    Ok(resp)
+}
+
+pub(crate) async fn handle_get_digests_req<'a, Pal: SpdmPal>(
+    state: &mut ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
+    pal: &'a Pal,
+    io: &<Pal as SpdmPalIoTransport>::Io<'_>,
+    spdm_msg: &[u8],
+) -> SpdmResult<(PalBytes<'a, Pal>, usize)> {
+    if (state.phase as u8) < (Phase::AfterAlgorithms as u8) {
         return Err(SPDM_UNEXPECTED_REQUEST);
     }
 
     // DSP0274 §10.5 Table 24: GET_DIGESTS header version shall match
     // the negotiated VCA version.
-    let req = io.request();
-    let (hdr, rest) = SpdmMsgHdrPdu::ref_from_prefix(req).map_err(|_| SPDM_INVALID_REQUEST)?;
+    let (hdr, rest) = SpdmMsgHdrPdu::ref_from_prefix(spdm_msg).map_err(|_| SPDM_INVALID_REQUEST)?;
     if hdr.version != state.version.to_u8() {
         return Err(crate::error::SPDM_VERSION_MISMATCH);
     }
@@ -92,14 +101,14 @@ pub(crate) async fn handle_get_digests<'a, Pal: SpdmPal>(
     let resp = build_response(pal, io, state.version, &digests_body)?;
 
     let head = pal.header_size();
-    state.transcript.append_m1(pal, io, io.request()).await?;
+    state.transcript.append_m1(pal, io, spdm_msg).await?;
     state
         .transcript
         .append_m1(pal, io, &resp[head..head + spdm_len])
         .await?;
 
     state.phase = Phase::AfterDigests;
-    Ok(resp)
+    Ok((resp, spdm_len))
 }
 
 fn fill_multi_key_conn_rsp_data<Pal: SpdmPal>(pal: &Pal, provisioned: u8, dst: &mut [u8]) {

--- a/runtime/userspace/api/spdm-lite/stack/src/error.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/error.rs
@@ -15,7 +15,7 @@
 //! every layer boundary, no `.map_err(...)` ever needed.
 
 use mcu_error::{domain, McuErrorCode};
-use mcu_spdm_lite_errors::{as_spdm_wire, is_mctp_error};
+use mcu_spdm_lite_errors::{as_spdm_wire, is_mctp_error, is_vdm_no_response};
 
 /// SPDM-level error suitable for emission as an `ERROR` PDU.
 ///
@@ -31,6 +31,21 @@ pub struct SpdmError {
 pub type SpdmResult<T> = core::result::Result<T, SpdmError>;
 
 impl SpdmError {
+    /// Constructs a sentinel error that suppresses any SPDM response.
+    #[inline]
+    pub const fn no_response() -> Self {
+        Self {
+            spec_byte: 0,
+            error_data: 0,
+        }
+    }
+
+    /// Returns true when this error should be dropped instead of serialized.
+    #[inline]
+    pub const fn is_no_response(&self) -> bool {
+        self.spec_byte == 0
+    }
+
     /// Constructs an [`SpdmError`] from an SPDM `ERROR` spec byte.
     ///
     /// # Parameters
@@ -80,6 +95,9 @@ impl SpdmError {
 /// just use `?` and the conversion happens automatically.
 impl From<McuErrorCode> for SpdmError {
     fn from(e: McuErrorCode) -> Self {
+        if is_vdm_no_response(e) {
+            return Self::no_response();
+        }
         // Already a wire-encoded SPDM error: extract the byte.
         if let Some(byte) = as_spdm_wire(e) {
             return Self::new(byte);

--- a/runtime/userspace/api/spdm-lite/stack/src/lib.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/lib.rs
@@ -8,7 +8,9 @@
 //!
 //! * A [`SpdmStack`] — the main `run()` loop that receives an SPDM
 //!   request, dispatches it to a handler, and sends back either the
-//!   handler's response or a SPDM `ERROR` PDU.
+//!   handler's response or a SPDM `ERROR` PDU. A matched VDM backend may
+//!   request that a vendor-protocol failure be dropped without a response
+//!   when that is the source stack's wire behavior.
 //! * A [`ConnectionState`] — the per-connection negotiation state
 //!   (current phase, negotiated version, peer capabilities, …) plus
 //!   the responder's fixed local-policy advertisement.

--- a/runtime/userspace/api/spdm-lite/stack/src/stack.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/stack.rs
@@ -833,6 +833,40 @@ async fn handle_secured_inner<'a, Pal: SpdmPal, Vdm: SpdmVdmBackend, const MAX_S
             sessions.remove_and_destroy(session_id);
             Ok(rsp)
         }
+        ReqRespCode::GET_DIGESTS => {
+            let (digests_rsp, spdm_len) =
+                digests::handle_get_digests_req(state, pal, io, spdm_msg).await?;
+            let head = pal.header_size();
+            let spdm_rsp = &digests_rsp[head..head + spdm_len];
+            let session = sessions.find_mut(session_id).ok_or(SPDM_UNSPECIFIED)?;
+            encrypt_secured_spdm_response(
+                pal,
+                io,
+                session,
+                session_id,
+                version,
+                response_key_type,
+                spdm_rsp,
+            )
+            .await
+        }
+        ReqRespCode::GET_CERTIFICATE => {
+            let (certificate_rsp, spdm_len) =
+                certificate::handle_get_certificate_req(state, pal, io, spdm_msg).await?;
+            let head = pal.header_size();
+            let spdm_rsp = &certificate_rsp[head..head + spdm_len];
+            let session = sessions.find_mut(session_id).ok_or(SPDM_UNSPECIFIED)?;
+            encrypt_secured_spdm_response(
+                pal,
+                io,
+                session,
+                session_id,
+                version,
+                response_key_type,
+                spdm_rsp,
+            )
+            .await
+        }
         ReqRespCode::GET_MEASUREMENTS => {
             let (measurements_rsp, spdm_len) =
                 measurements::handle_get_measurements_req(state, pal, io, spdm_msg).await?;

--- a/runtime/userspace/api/spdm-lite/stack/src/stack.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/stack.rs
@@ -369,8 +369,9 @@ impl<Pal: SpdmPal, const MAX_SESSIONS: usize, Vdm: SpdmVdmBackend>
     /// Main responder run loop. On each iteration: receive one request, dispatch
     /// it to the matching handler (routing `VENDOR_DEFINED_REQUEST` to the
     /// registered VDM backend), and send back either the handler's response or a
-    /// SPDM `ERROR` PDU. Returns only on a fatal transport error (`recv_request`
-    /// / `send_response` failure).
+    /// SPDM `ERROR` PDU. A matched VDM backend can request no response for
+    /// vendor-protocol failures that should be dropped. Returns only on a fatal
+    /// transport error (`recv_request` / `send_response` failure).
     ///
     /// # Returns
     ///
@@ -426,6 +427,9 @@ impl<Pal: SpdmPal, const MAX_SESSIONS: usize, Vdm: SpdmVdmBackend>
                                 .await?
                         }
                         Err(e) => {
+                            if e.is_no_response() {
+                                continue;
+                            }
                             #[cfg(feature = "debug-trace")]
                             {
                                 let _ = writeln!(
@@ -460,6 +464,9 @@ impl<Pal: SpdmPal, const MAX_SESSIONS: usize, Vdm: SpdmVdmBackend>
                         }
                         Ok(None) => {}
                         Err(e) => {
+                            if e.is_no_response() {
+                                continue;
+                            }
                             #[cfg(feature = "debug-trace")]
                             {
                                 let _ = writeln!(
@@ -667,6 +674,9 @@ async fn handle_secured_request<
     match handle_secured_inner(state, sessions, pal, io, session_id, vdm).await {
         Ok(rsp) => Ok(Some(rsp)),
         Err(e) => {
+            if e.is_no_response() {
+                return Ok(None);
+            }
             let Some(session) = sessions.find_mut(session_id) else {
                 return Ok(None);
             };

--- a/runtime/userspace/api/spdm-lite/stack/src/vendor_defined.rs
+++ b/runtime/userspace/api/spdm-lite/stack/src/vendor_defined.rs
@@ -64,16 +64,20 @@ pub(crate) async fn handle_vendor_defined_request<'a, Pal: SpdmPal, V: SpdmVdmBa
     let inline_cap = frame.saturating_sub(envelope);
     let mut inline_buf = pal.alloc_bytes(io, inline_cap)?;
 
-    // Large staging buffer: provisioned only when the backend can emit responses
-    // that overflow a single frame AND chunking is available. Sized so the full
-    // buffered message (envelope + payload) fits both the large-response store and
-    // the negotiated max SPDM message size; empty otherwise (forcing inline).
+    // Large staging buffer: provisioned only when chunking is available and the
+    // matched backend says this request can emit a response that overflows one
+    // frame. This keeps inline-only VDMs from consuming scarce scratch space.
     let large_cap = if V::USES_LARGE_RESPONSE && state.chunking_enabled() {
-        state
-            .effective_max_spdm_msg_size(pal)
-            .min(pal.large_capacity())
-            .saturating_sub(envelope)
-            .min(V::LARGE_RESPONSE_CAPACITY)
+        let requested = vdm.large_response_capacity(decoded.payload);
+        if requested > inline_cap {
+            state
+                .effective_max_spdm_msg_size(pal)
+                .min(pal.large_capacity())
+                .saturating_sub(envelope)
+                .min(requested)
+        } else {
+            0
+        }
     } else {
         0
     };

--- a/runtime/userspace/api/spdm-lite/traits/src/vendor_defined.rs
+++ b/runtime/userspace/api/spdm-lite/traits/src/vendor_defined.rs
@@ -26,11 +26,14 @@ pub enum VdmResponse {
 pub struct VdmResponseBuffer<'a, Alloc: SpdmPalAlloc, Io: SpdmPalIo> {
     /// Per-request payload buffer sized to fit a single transport frame.
     pub inline: &'a mut [u8],
-    /// Buffer for responses that do not fit `inline`; the stack transmits it via
-    /// chunking. Non-empty only when [`SpdmVdmBackend::USES_LARGE_RESPONSE`] is set (and
-    /// chunking is available). Its backing memory is owned by the stack (today a
-    /// persistent large-message store; planned: the per-task scratch allocator) and is
-    /// not the handler's concern.
+    /// Buffer for responses that do not fit `inline`; when the handler returns
+    /// [`VdmResponse::Large`], the stack transmits these bytes via chunking.
+    /// Empty when chunking is unavailable or the backend indicates this request
+    /// cannot produce a large response.
+    ///
+    /// The backing storage is chosen by the stack and may be the persistent
+    /// large-message store directly, so handlers must only write the returned
+    /// byte count and must not assume this is disposable scratch.
     pub large: &'a mut [u8],
     /// Allocator for per-request VDM working scratch (e.g. staging a mailbox call).
     pub alloc: &'a Alloc,
@@ -38,22 +41,43 @@ pub struct VdmResponseBuffer<'a, Alloc: SpdmPalAlloc, Io: SpdmPalIo> {
     pub io: &'a Io,
 }
 
+impl<'a, Alloc: SpdmPalAlloc, Io: SpdmPalIo> VdmResponseBuffer<'a, Alloc, Io> {
+    /// Returns the request-scoped scratch allocator for platform hooks.
+    pub fn scratch(&self) -> &'a Alloc {
+        self.alloc
+    }
+}
+
 /// Static-dispatch VDM backend used by the spdm-lite dispatcher.
 #[allow(async_fn_in_trait)]
 pub trait SpdmVdmBackend {
     /// True when this backend can emit a response that does not fit the inline
-    /// transport frame and must use [`VdmResponseBuffer::large`]. PCI-SIG IDE_KM/TDISP
-    /// set this `false` (they chunk large reports at the protocol level); OCP sets it
-    /// `true`.
+    /// transport frame and must use [`VdmResponseBuffer::large`]. Backends should
+    /// keep this `false` unless at least one response can overflow one SPDM frame
+    /// and should still choose [`VdmResponse::Inline`] whenever the actual
+    /// response fits inline.
     const USES_LARGE_RESPONSE: bool = false;
 
-    /// Maximum VDM payload bytes this backend needs for a large response.
+    /// Maximum VDM payload bytes this backend needs for any large response.
     ///
     /// The stack still caps this by the negotiated maximum SPDM message size and
     /// PAL large-message capacity, but this backend-specific bound avoids
     /// reserving a worst-case SPDM-sized scratch buffer for small vendor command
     /// sets.
     const LARGE_RESPONSE_CAPACITY: usize = usize::MAX;
+
+    /// Returns the large-response capacity needed for this request.
+    ///
+    /// Backends that can cheaply identify only some large-capable requests should
+    /// override this to avoid reserving the persistent large-message buffer for
+    /// requests that will stay inline.
+    fn large_response_capacity(&self, _req: &[u8]) -> usize {
+        if Self::USES_LARGE_RESPONSE {
+            Self::LARGE_RESPONSE_CAPACITY
+        } else {
+            0
+        }
+    }
 
     /// Returns true when this backend owns the decoded VDM registry ID.
     fn match_id(&self, registry: &VdmRegistry<'_>) -> bool;

--- a/runtime/userspace/api/spdm-lite/vdm-handler/Cargo.toml
+++ b/runtime/userspace/api/spdm-lite/vdm-handler/Cargo.toml
@@ -12,7 +12,10 @@ default = []
 [dependencies]
 mcu-spdm-lite-traits = { workspace = true }
 mcu-spdm-lite-codec = { workspace = true }
+mcu-spdm-lite-errors = { workspace = true }
 mcu-error = { workspace = true }
+zerocopy = { workspace = true }
 
 [dev-dependencies]
+futures = { workspace = true }
 mcu-caliptra-api-lite = { workspace = true }

--- a/runtime/userspace/api/spdm-lite/vdm-handler/src/iana/ocp/caliptra_vdm/commands/authorized_command.rs
+++ b/runtime/userspace/api/spdm-lite/vdm-handler/src/iana/ocp/caliptra_vdm/commands/authorized_command.rs
@@ -2,10 +2,12 @@
 
 //! AUTHORIZED_COMMAND (0x12): dispatches authorization subcommands.
 
-use mcu_spdm_lite_traits::{SpdmPalAlloc, SpdmPalIo};
+use mcu_spdm_lite_traits::SpdmPalAlloc;
 
-use crate::iana::ocp::caliptra_vdm::protocol::{CaliptraCompletionCode, CaliptraVdmCmdResult};
 use crate::iana::ocp::caliptra_vdm::CaliptraVdmCommands;
+use mcu_spdm_lite_codec::vendor_defined::iana::ocp::caliptra::{
+    CaliptraCompletionCode, CaliptraVdmCmdResult,
+};
 
 /// MC_GET_AUTH_CMD_CHALLENGE sub-command (`MACC`).
 pub const GET_AUTH_CHALLENGE_CMD_ID: u32 = 0x4D41_4343;
@@ -13,17 +15,15 @@ pub const GET_AUTH_CHALLENGE_CMD_ID: u32 = 0x4D41_4343;
 pub const FE_PROG_CMD_ID: u32 = 0x4D43_4650;
 const MAC_LEN: usize = 48;
 
-pub(crate) async fn handle<H, A, I>(
+pub(crate) async fn handle<H, A>(
     cmds: &H,
     req: &[u8],
     scratch: &A,
-    io: &I,
     out: &mut [u8],
 ) -> CaliptraVdmCmdResult
 where
     H: CaliptraVdmCommands,
     A: SpdmPalAlloc,
-    I: SpdmPalIo,
 {
     let Some(sub_cmd_bytes) = req.get(..4) else {
         return CaliptraVdmCmdResult::Error(CaliptraCompletionCode::InvalidPayloadSize);
@@ -36,25 +36,21 @@ where
     ]);
     let payload = &req[4..];
     match sub_cmd {
-        GET_AUTH_CHALLENGE_CMD_ID => {
-            handle_get_auth_challenge(cmds, payload, scratch, io, out).await
-        }
-        FE_PROG_CMD_ID => handle_fe_prog(cmds, payload, scratch, io, out).await,
+        GET_AUTH_CHALLENGE_CMD_ID => handle_get_auth_challenge(cmds, payload, scratch, out).await,
+        FE_PROG_CMD_ID => handle_fe_prog(cmds, payload, scratch, out).await,
         _ => CaliptraVdmCmdResult::Error(CaliptraCompletionCode::InvalidParameter),
     }
 }
 
-async fn handle_get_auth_challenge<H, A, I>(
+async fn handle_get_auth_challenge<H, A>(
     cmds: &H,
     req: &[u8],
     scratch: &A,
-    io: &I,
     out: &mut [u8],
 ) -> CaliptraVdmCmdResult
 where
     H: CaliptraVdmCommands,
     A: SpdmPalAlloc,
-    I: SpdmPalIo,
 {
     if let Err(code) = super::require_empty(req) {
         return CaliptraVdmCmdResult::Error(code);
@@ -63,23 +59,21 @@ where
         Ok(data) => data,
         Err(code) => return CaliptraVdmCmdResult::Error(code),
     };
-    match cmds.get_auth_challenge(scratch, io, data).await {
+    match cmds.get_auth_challenge(scratch, data).await {
         Ok(n) => CaliptraVdmCmdResult::Response(1 + n),
         Err(code) => CaliptraVdmCmdResult::Error(code),
     }
 }
 
-async fn handle_fe_prog<H, A, I>(
+async fn handle_fe_prog<H, A>(
     cmds: &H,
     req: &[u8],
     scratch: &A,
-    io: &I,
     out: &mut [u8],
 ) -> CaliptraVdmCmdResult
 where
     H: CaliptraVdmCommands,
     A: SpdmPalAlloc,
-    I: SpdmPalIo,
 {
     if req.len() != 4 + MAC_LEN {
         return CaliptraVdmCmdResult::Error(CaliptraCompletionCode::InvalidPayloadSize);
@@ -87,10 +81,7 @@ where
     let partition = u32::from_le_bytes([req[0], req[1], req[2], req[3]]);
     let mut mac = [0u8; MAC_LEN];
     mac.copy_from_slice(&req[4..4 + MAC_LEN]);
-    match cmds
-        .program_field_entropy(partition, &mac, scratch, io)
-        .await
-    {
+    match cmds.program_field_entropy(partition, &mac, scratch).await {
         Ok(()) => match super::write_success(out) {
             Ok(_) => CaliptraVdmCmdResult::Response(1),
             Err(code) => CaliptraVdmCmdResult::Error(code),

--- a/runtime/userspace/api/spdm-lite/vdm-handler/src/iana/ocp/caliptra_vdm/commands/clear_attestation_log.rs
+++ b/runtime/userspace/api/spdm-lite/vdm-handler/src/iana/ocp/caliptra_vdm/commands/clear_attestation_log.rs
@@ -2,30 +2,25 @@
 
 //! CLEAR_ATTESTATION_LOG (0x08): clears the attestation log.
 
-use mcu_spdm_lite_traits::{SpdmPalAlloc, SpdmPalIo};
+use mcu_spdm_lite_traits::SpdmPalAlloc;
 
-use crate::iana::ocp::caliptra_vdm::protocol::CaliptraVdmCmdResult;
 use crate::iana::ocp::caliptra_vdm::CaliptraVdmCommands;
+use mcu_spdm_lite_codec::vendor_defined::iana::ocp::caliptra::CaliptraVdmCmdResult;
 
-pub(crate) async fn handle<H, A, I>(
+pub(crate) async fn handle<H, A>(
     cmds: &H,
     req: &[u8],
     scratch: &A,
-    io: &I,
     out: &mut [u8],
 ) -> CaliptraVdmCmdResult
 where
     H: CaliptraVdmCommands,
     A: SpdmPalAlloc,
-    I: SpdmPalIo,
 {
     if let Err(code) = super::require_empty(req) {
         return CaliptraVdmCmdResult::Error(code);
     }
-    match cmds
-        .clear_log(super::LOG_TYPE_ATTESTATION, scratch, io)
-        .await
-    {
+    match cmds.clear_log(super::LOG_TYPE_ATTESTATION, scratch).await {
         Ok(()) => match super::write_success(out) {
             Ok(_) => CaliptraVdmCmdResult::Response(1),
             Err(code) => CaliptraVdmCmdResult::Error(code),

--- a/runtime/userspace/api/spdm-lite/vdm-handler/src/iana/ocp/caliptra_vdm/commands/clear_debug_log.rs
+++ b/runtime/userspace/api/spdm-lite/vdm-handler/src/iana/ocp/caliptra_vdm/commands/clear_debug_log.rs
@@ -2,27 +2,25 @@
 
 //! CLEAR_DEBUG_LOG (0x06): clears the debug log.
 
-use mcu_spdm_lite_traits::{SpdmPalAlloc, SpdmPalIo};
+use mcu_spdm_lite_traits::SpdmPalAlloc;
 
-use crate::iana::ocp::caliptra_vdm::protocol::CaliptraVdmCmdResult;
 use crate::iana::ocp::caliptra_vdm::CaliptraVdmCommands;
+use mcu_spdm_lite_codec::vendor_defined::iana::ocp::caliptra::CaliptraVdmCmdResult;
 
-pub(crate) async fn handle<H, A, I>(
+pub(crate) async fn handle<H, A>(
     cmds: &H,
     req: &[u8],
     scratch: &A,
-    io: &I,
     out: &mut [u8],
 ) -> CaliptraVdmCmdResult
 where
     H: CaliptraVdmCommands,
     A: SpdmPalAlloc,
-    I: SpdmPalIo,
 {
     if let Err(code) = super::require_empty(req) {
         return CaliptraVdmCmdResult::Error(code);
     }
-    match cmds.clear_log(super::LOG_TYPE_DEBUG, scratch, io).await {
+    match cmds.clear_log(super::LOG_TYPE_DEBUG, scratch).await {
         Ok(()) => match super::write_success(out) {
             Ok(_) => CaliptraVdmCmdResult::Response(1),
             Err(code) => CaliptraVdmCmdResult::Error(code),

--- a/runtime/userspace/api/spdm-lite/vdm-handler/src/iana/ocp/caliptra_vdm/commands/export_attested_csr.rs
+++ b/runtime/userspace/api/spdm-lite/vdm-handler/src/iana/ocp/caliptra_vdm/commands/export_attested_csr.rs
@@ -7,12 +7,12 @@
 //! `large` staging buffer's tail, then framed inline when the whole response
 //! fits one transport frame, otherwise as a chunked large response.
 
-use mcu_spdm_lite_traits::{SpdmPalAlloc, SpdmPalIo};
+use mcu_spdm_lite_traits::SpdmPalAlloc;
 
-use crate::iana::ocp::caliptra_vdm::protocol::{
+use crate::iana::ocp::caliptra_vdm::CaliptraVdmCommands;
+use mcu_spdm_lite_codec::vendor_defined::iana::ocp::caliptra::{
     CaliptraCompletionCode, CaliptraVdmCmdResult, CALIPTRA_VDM_COMMAND_VERSION,
 };
-use crate::iana::ocp::caliptra_vdm::CaliptraVdmCommands;
 
 /// Request payload: `device_key_id` (u32 LE) | `algorithm` (u32 LE) | `nonce` (32 bytes).
 const REQ_LEN: usize = 4 + 4 + 32;
@@ -36,19 +36,17 @@ const INLINE_PREFIX_LEN: usize = 1 + CSR_LEN_FIELD;
 /// copied back inline (if it fits one frame) or framed in place as a large
 /// response.
 #[allow(clippy::too_many_arguments)]
-pub(crate) async fn handle<H, A, I>(
+pub(crate) async fn handle<H, A>(
     cmds: &H,
     req: &[u8],
     command_code: u8,
     inline_payload: &mut [u8],
     large: &mut [u8],
     scratch: &A,
-    io: &I,
 ) -> CaliptraVdmCmdResult
 where
     H: CaliptraVdmCommands,
     A: SpdmPalAlloc,
-    I: SpdmPalIo,
 {
     if req.len() != REQ_LEN {
         return CaliptraVdmCmdResult::Error(CaliptraCompletionCode::InvalidPayloadSize);
@@ -67,7 +65,6 @@ where
                 algorithm,
                 &nonce,
                 scratch,
-                io,
                 &mut large[CSR_PAYLOAD_HEADER_LEN..],
             )
             .await
@@ -103,7 +100,6 @@ where
                 algorithm,
                 &nonce,
                 scratch,
-                io,
                 &mut inline_payload[INLINE_PREFIX_LEN..],
             )
             .await

--- a/runtime/userspace/api/spdm-lite/vdm-handler/src/iana/ocp/caliptra_vdm/commands/get_attestation_log.rs
+++ b/runtime/userspace/api/spdm-lite/vdm-handler/src/iana/ocp/caliptra_vdm/commands/get_attestation_log.rs
@@ -2,22 +2,20 @@
 
 //! GET_ATTESTATION_LOG (0x07): drains attestation-log bytes.
 
-use mcu_spdm_lite_traits::{SpdmPalAlloc, SpdmPalIo};
+use mcu_spdm_lite_traits::SpdmPalAlloc;
 
-use crate::iana::ocp::caliptra_vdm::protocol::CaliptraVdmCmdResult;
 use crate::iana::ocp::caliptra_vdm::CaliptraVdmCommands;
+use mcu_spdm_lite_codec::vendor_defined::iana::ocp::caliptra::CaliptraVdmCmdResult;
 
-pub(crate) async fn handle<H, A, I>(
+pub(crate) async fn handle<H, A>(
     cmds: &H,
     req: &[u8],
     scratch: &A,
-    io: &I,
     out: &mut [u8],
 ) -> CaliptraVdmCmdResult
 where
     H: CaliptraVdmCommands,
     A: SpdmPalAlloc,
-    I: SpdmPalIo,
 {
-    super::get_debug_log::handle_log(cmds, super::LOG_TYPE_ATTESTATION, req, scratch, io, out).await
+    super::get_debug_log::handle_log(cmds, super::LOG_TYPE_ATTESTATION, req, scratch, out).await
 }

--- a/runtime/userspace/api/spdm-lite/vdm-handler/src/iana/ocp/caliptra_vdm/commands/get_debug_log.rs
+++ b/runtime/userspace/api/spdm-lite/vdm-handler/src/iana/ocp/caliptra_vdm/commands/get_debug_log.rs
@@ -2,38 +2,34 @@
 
 //! GET_DEBUG_LOG (0x05): drains debug-log bytes.
 
-use mcu_spdm_lite_traits::{SpdmPalAlloc, SpdmPalIo};
+use mcu_spdm_lite_traits::SpdmPalAlloc;
 
-use crate::iana::ocp::caliptra_vdm::protocol::CaliptraVdmCmdResult;
 use crate::iana::ocp::caliptra_vdm::CaliptraVdmCommands;
+use mcu_spdm_lite_codec::vendor_defined::iana::ocp::caliptra::CaliptraVdmCmdResult;
 
-pub(crate) async fn handle<H, A, I>(
+pub(crate) async fn handle<H, A>(
     cmds: &H,
     req: &[u8],
     scratch: &A,
-    io: &I,
     out: &mut [u8],
 ) -> CaliptraVdmCmdResult
 where
     H: CaliptraVdmCommands,
     A: SpdmPalAlloc,
-    I: SpdmPalIo,
 {
-    handle_log(cmds, super::LOG_TYPE_DEBUG, req, scratch, io, out).await
+    handle_log(cmds, super::LOG_TYPE_DEBUG, req, scratch, out).await
 }
 
-pub(crate) async fn handle_log<H, A, I>(
+pub(crate) async fn handle_log<H, A>(
     cmds: &H,
     log_type: u32,
     req: &[u8],
     scratch: &A,
-    io: &I,
     out: &mut [u8],
 ) -> CaliptraVdmCmdResult
 where
     H: CaliptraVdmCommands,
     A: SpdmPalAlloc,
-    I: SpdmPalIo,
 {
     use crate::iana::ocp::caliptra_vdm::CaliptraCompletionCode;
 
@@ -64,7 +60,7 @@ where
         }
     };
 
-    match cmds.get_log(log_type, scratch, io, log_buf).await {
+    match cmds.get_log(log_type, scratch, log_buf).await {
         Ok(result) => {
             if result.bytes_written > log_buf.len() {
                 return CaliptraVdmCmdResult::Error(CaliptraCompletionCode::InsufficientResources);

--- a/runtime/userspace/api/spdm-lite/vdm-handler/src/iana/ocp/caliptra_vdm/commands/mod.rs
+++ b/runtime/userspace/api/spdm-lite/vdm-handler/src/iana/ocp/caliptra_vdm/commands/mod.rs
@@ -6,7 +6,7 @@
 //! [`CaliptraVdmCommands`](super::CaliptraVdmCommands) PAL hook, and writes the
 //! VDM response payload `[completion_code, command_data..]`.
 
-use crate::iana::ocp::caliptra_vdm::protocol::CaliptraCompletionCode;
+use mcu_spdm_lite_codec::vendor_defined::iana::ocp::caliptra::CaliptraCompletionCode;
 
 pub(crate) mod authorized_command;
 pub(crate) mod clear_attestation_log;

--- a/runtime/userspace/api/spdm-lite/vdm-handler/src/iana/ocp/caliptra_vdm/mod.rs
+++ b/runtime/userspace/api/spdm-lite/vdm-handler/src/iana/ocp/caliptra_vdm/mod.rs
@@ -3,14 +3,13 @@
 //! Caliptra VENDOR_DEFINED Message (VDM) backend.
 //!
 //! Implements [`SpdmVdmBackend`] for the Caliptra VDM protocol (IANA standards
-//! body, vendor id [`protocol::CALIPTRA_VENDOR_ID`]). The backend decodes the
+//! body, vendor id [`CALIPTRA_VENDOR_ID`]). The backend decodes the
 //! Caliptra VDM message header, dispatches the command, and frames the response.
 //! Per-command device operations are provided by the platform through the
 //! [`CaliptraVdmCommands`] PAL hook — the protocol/dispatch stays in this lib,
 //! only the device work crosses to the platform.
 
 mod commands;
-pub mod protocol;
 
 use mcu_error::codes::INVARIANT;
 use mcu_spdm_lite_codec::StandardsBodyId;
@@ -18,7 +17,7 @@ use mcu_spdm_lite_traits::{
     McuResult, SpdmPalAlloc, SpdmPalIo, SpdmVdmBackend, VdmRegistry, VdmResponse, VdmResponseBuffer,
 };
 
-pub use protocol::{
+pub use mcu_spdm_lite_codec::vendor_defined::iana::ocp::caliptra::{
     CaliptraCompletionCode, CaliptraVdmCmdResult, CaliptraVdmCommand, CaliptraVdmResult,
     CALIPTRA_VDM_COMMAND_VERSION, CALIPTRA_VENDOR_ID,
 };
@@ -39,55 +38,45 @@ const MAX_LARGE_VDM_PAYLOAD_LEN: usize = VDM_HEADER_LEN + 1 + 4 + MAX_LARGE_COMM
 /// the number of bytes written, or a [`CaliptraCompletionCode`] on failure
 /// (surfaced as a VDM error completion, not an SPDM error).
 ///
-/// `scratch`/`io` give each device op the request-scoped scratch allocator (and
-/// the I/O handle that scopes it) so it can stage device interactions — e.g.
-/// building a Caliptra mailbox request and receiving its response — without
-/// owning persistent buffers.
+/// `scratch` gives each device op the request-scoped scratch allocator so it can
+/// stage device interactions without owning persistent buffers.
 pub trait CaliptraVdmCommands {
     /// Drains log bytes of `log_type` into `out`.
-    async fn get_log<A: SpdmPalAlloc, I: SpdmPalIo>(
+    async fn get_log<A: SpdmPalAlloc>(
         &self,
         log_type: u32,
         scratch: &A,
-        io: &I,
         out: &mut [u8],
     ) -> CaliptraVdmResult<CaliptraVdmLogResult>;
 
     /// Clears the log identified by `log_type`.
-    async fn clear_log<A: SpdmPalAlloc, I: SpdmPalIo>(
-        &self,
-        log_type: u32,
-        scratch: &A,
-        io: &I,
-    ) -> CaliptraVdmResult<()>;
+    async fn clear_log<A: SpdmPalAlloc>(&self, log_type: u32, scratch: &A)
+        -> CaliptraVdmResult<()>;
 
     /// Exports an attested CSR for `device_key_id` using `algorithm` and `nonce`,
     /// writing the raw CSR bytes into `out` and returning their length.
-    async fn export_attested_csr<A: SpdmPalAlloc, I: SpdmPalIo>(
+    async fn export_attested_csr<A: SpdmPalAlloc>(
         &self,
         device_key_id: u32,
         algorithm: u32,
         nonce: &[u8; 32],
         scratch: &A,
-        io: &I,
         out: &mut [u8],
     ) -> CaliptraVdmResult<usize>;
 
     /// Generates an authorization challenge nonce into `out`.
-    async fn get_auth_challenge<A: SpdmPalAlloc, I: SpdmPalIo>(
+    async fn get_auth_challenge<A: SpdmPalAlloc>(
         &self,
         scratch: &A,
-        io: &I,
         out: &mut [u8],
     ) -> CaliptraVdmResult<usize>;
 
     /// Verifies `mac` for FE_PROG and programs field entropy for `partition`.
-    async fn program_field_entropy<A: SpdmPalAlloc, I: SpdmPalIo>(
+    async fn program_field_entropy<A: SpdmPalAlloc>(
         &self,
         partition: u32,
         mac: &[u8; 48],
         scratch: &A,
-        io: &I,
     ) -> CaliptraVdmResult<()>;
 }
 
@@ -146,8 +135,9 @@ impl<H: CaliptraVdmCommands> SpdmVdmBackend for CaliptraVdm<'_, H> {
             inline: out,
             large,
             alloc,
-            io,
+            io: _,
         } = rsp;
+        let scratch = alloc;
         // No room for even the response header + completion code → no
         // vendor-defined response can be formed; surfaced as an SPDM error by
         // the stack.
@@ -168,17 +158,16 @@ impl<H: CaliptraVdmCommands> SpdmVdmBackend for CaliptraVdm<'_, H> {
 
         let result = match CaliptraVdmCommand::try_from(command_code) {
             Ok(CaliptraVdmCommand::GetDebugLog) => {
-                commands::get_debug_log::handle(self.cmds, cmd_req, alloc, io, payload).await
+                commands::get_debug_log::handle(self.cmds, cmd_req, scratch, payload).await
             }
             Ok(CaliptraVdmCommand::ClearDebugLog) => {
-                commands::clear_debug_log::handle(self.cmds, cmd_req, alloc, io, payload).await
+                commands::clear_debug_log::handle(self.cmds, cmd_req, scratch, payload).await
             }
             Ok(CaliptraVdmCommand::GetAttestationLog) => {
-                commands::get_attestation_log::handle(self.cmds, cmd_req, alloc, io, payload).await
+                commands::get_attestation_log::handle(self.cmds, cmd_req, scratch, payload).await
             }
             Ok(CaliptraVdmCommand::ClearAttestationLog) => {
-                commands::clear_attestation_log::handle(self.cmds, cmd_req, alloc, io, payload)
-                    .await
+                commands::clear_attestation_log::handle(self.cmds, cmd_req, scratch, payload).await
             }
             Ok(CaliptraVdmCommand::ExportAttestedCsr) => {
                 commands::export_attested_csr::handle(
@@ -187,13 +176,12 @@ impl<H: CaliptraVdmCommands> SpdmVdmBackend for CaliptraVdm<'_, H> {
                     command_code,
                     payload,
                     large,
-                    alloc,
-                    io,
+                    scratch,
                 )
                 .await
             }
             Ok(CaliptraVdmCommand::AuthorizedCommand) => {
-                commands::authorized_command::handle(self.cmds, cmd_req, alloc, io, payload).await
+                commands::authorized_command::handle(self.cmds, cmd_req, scratch, payload).await
             }
             // Recognized-but-unimplemented and unknown command codes both map to
             // an UnsupportedOperation completion.
@@ -334,41 +322,37 @@ mod tests {
     }
 
     impl CaliptraVdmCommands for TestCommands {
-        async fn get_log<A: SpdmPalAlloc, I: SpdmPalIo>(
+        async fn get_log<A: SpdmPalAlloc>(
             &self,
             _log_type: u32,
             _scratch: &A,
-            _io: &I,
             _out: &mut [u8],
         ) -> CaliptraVdmResult<CaliptraVdmLogResult> {
             Err(CaliptraCompletionCode::UnsupportedOperation)
         }
 
-        async fn clear_log<A: SpdmPalAlloc, I: SpdmPalIo>(
+        async fn clear_log<A: SpdmPalAlloc>(
             &self,
             _log_type: u32,
             _scratch: &A,
-            _io: &I,
         ) -> CaliptraVdmResult<()> {
             Err(CaliptraCompletionCode::UnsupportedOperation)
         }
 
-        async fn export_attested_csr<A: SpdmPalAlloc, I: SpdmPalIo>(
+        async fn export_attested_csr<A: SpdmPalAlloc>(
             &self,
             _device_key_id: u32,
             _algorithm: u32,
             _nonce: &[u8; 32],
             _scratch: &A,
-            _io: &I,
             out: &mut [u8],
         ) -> CaliptraVdmResult<usize> {
             self.write_csr(out)
         }
 
-        async fn get_auth_challenge<A: SpdmPalAlloc, I: SpdmPalIo>(
+        async fn get_auth_challenge<A: SpdmPalAlloc>(
             &self,
             _scratch: &A,
-            _io: &I,
             out: &mut [u8],
         ) -> CaliptraVdmResult<usize> {
             if out.len() < 32 {
@@ -378,12 +362,11 @@ mod tests {
             Ok(32)
         }
 
-        async fn program_field_entropy<A: SpdmPalAlloc, I: SpdmPalIo>(
+        async fn program_field_entropy<A: SpdmPalAlloc>(
             &self,
             _partition: u32,
             _mac: &[u8; 48],
             _scratch: &A,
-            _io: &I,
         ) -> CaliptraVdmResult<()> {
             Ok(())
         }

--- a/runtime/userspace/api/spdm-lite/vdm-handler/src/iana/ocp/mod.rs
+++ b/runtime/userspace/api/spdm-lite/vdm-handler/src/iana/ocp/mod.rs
@@ -1,6 +1,6 @@
 // Licensed under the Apache-2.0 license
 
 //! OCP / Caliptra Working Group VENDOR_DEFINED protocols
-//! (IANA vendor id [`caliptra_vdm::protocol::CALIPTRA_VENDOR_ID`], 0xA67F).
+//! (IANA vendor id [`caliptra_vdm::CALIPTRA_VENDOR_ID`], 0xA67F).
 
 pub mod caliptra_vdm;

--- a/runtime/userspace/api/spdm-lite/vdm-handler/src/lib.rs
+++ b/runtime/userspace/api/spdm-lite/vdm-handler/src/lib.rs
@@ -11,9 +11,16 @@
 //! Handling is organized by SPDM Standards Body ID:
 //!
 //! * [`iana`] — IANA-registered vendors (OCP / Caliptra VDM).
-//! * [`pci_sig`] — PCI-SIG protocols (TDISP; IDE-KM reserved for future support).
+//! * [`pci_sig`] — PCI-SIG protocols (IDE-KM and TDISP).
 #![no_std]
 #![allow(async_fn_in_trait)]
 
 pub mod iana;
 pub mod pci_sig;
+
+/// Integrator-facing platform hook traits for supported VDM protocols.
+pub mod drivers {
+    pub use crate::iana::ocp::caliptra_vdm::CaliptraVdmCommands;
+    pub use crate::pci_sig::ide_km::{IdeDriver, IdeDriverError, IdeDriverResult};
+    pub use crate::pci_sig::tdisp::{TdispDriver, TdispDriverError, TdispDriverResult};
+}

--- a/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/ide_km/commands/key_go_stop_ack.rs
+++ b/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/ide_km/commands/key_go_stop_ack.rs
@@ -1,0 +1,26 @@
+// Licensed under the Apache-2.0 license
+
+use mcu_spdm_lite_codec::errors::SPDM_INVALID_REQUEST;
+use mcu_spdm_lite_codec::{IdeKmHdr, KeySetGoStop, WireWriter};
+use mcu_spdm_lite_traits::McuResult;
+
+pub(crate) fn write_key_go_stop_ack(
+    req: KeySetGoStop,
+    writer: &mut WireWriter<'_>,
+) -> McuResult<usize> {
+    writer
+        .write(&IdeKmHdr {
+            object_id: mcu_spdm_lite_codec::IDE_KM_OBJECT_ID_KEY_GO_STOP_ACK,
+        })
+        .map_err(|_| SPDM_INVALID_REQUEST)?;
+    writer
+        .write(&KeySetGoStop {
+            reserved1: 0.into(),
+            stream_id: req.stream_id,
+            reserved2: 0,
+            key_info: req.key_info,
+            port_index: req.port_index,
+        })
+        .map_err(|_| SPDM_INVALID_REQUEST)?;
+    Ok(writer.position())
+}

--- a/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/ide_km/commands/key_prog.rs
+++ b/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/ide_km/commands/key_prog.rs
@@ -1,0 +1,41 @@
+// Licensed under the Apache-2.0 license
+
+use mcu_spdm_lite_codec::errors::SPDM_INVALID_REQUEST;
+use mcu_spdm_lite_codec::{IdeKmHdr, KeyData, KeyProg, WireReader, WireWriter};
+use mcu_spdm_lite_traits::{McuResult, SpdmPalAlloc};
+
+use crate::pci_sig::ide_km::{map_ide_error, IdeDriver};
+
+pub(crate) async fn handle_key_prog<D, Alloc>(
+    driver: &D,
+    scratch: &Alloc,
+    reader: &mut WireReader<'_>,
+    writer: &mut WireWriter<'_>,
+) -> McuResult<usize>
+where
+    D: IdeDriver,
+    Alloc: SpdmPalAlloc,
+{
+    let mut key_prog = *reader.read::<KeyProg>().map_err(|_| SPDM_INVALID_REQUEST)?;
+    let key_data = reader.read::<KeyData>().map_err(|_| SPDM_INVALID_REQUEST)?;
+    let status = driver
+        .key_prog(
+            key_prog.stream_id,
+            key_prog.key_info,
+            key_prog.port_index,
+            &key_data.key,
+            &key_data.iv,
+            scratch,
+        )
+        .await
+        .map_err(map_ide_error)?;
+
+    key_prog.status = status;
+    writer
+        .write(&IdeKmHdr {
+            object_id: mcu_spdm_lite_codec::IDE_KM_OBJECT_ID_KEY_PROG_ACK,
+        })
+        .map_err(|_| SPDM_INVALID_REQUEST)?;
+    writer.write(&key_prog).map_err(|_| SPDM_INVALID_REQUEST)?;
+    Ok(writer.position())
+}

--- a/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/ide_km/commands/key_set_go.rs
+++ b/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/ide_km/commands/key_set_go.rs
@@ -1,0 +1,35 @@
+// Licensed under the Apache-2.0 license
+
+use mcu_spdm_lite_codec::errors::SPDM_INVALID_REQUEST;
+use mcu_spdm_lite_codec::{KeySetGoStop, WireReader, WireWriter};
+use mcu_spdm_lite_traits::{McuResult, SpdmPalAlloc};
+
+use crate::pci_sig::ide_km::{map_ide_error, IdeDriver};
+
+use super::key_go_stop_ack::write_key_go_stop_ack;
+
+pub(crate) async fn handle_key_set_go<D, Alloc>(
+    driver: &D,
+    scratch: &Alloc,
+    reader: &mut WireReader<'_>,
+    writer: &mut WireWriter<'_>,
+) -> McuResult<usize>
+where
+    D: IdeDriver,
+    Alloc: SpdmPalAlloc,
+{
+    let key_set_go = *reader
+        .read::<KeySetGoStop>()
+        .map_err(|_| SPDM_INVALID_REQUEST)?;
+    driver
+        .key_set_go(
+            key_set_go.stream_id,
+            key_set_go.key_info,
+            key_set_go.port_index,
+            scratch,
+        )
+        .await
+        .map_err(map_ide_error)?;
+
+    write_key_go_stop_ack(key_set_go, writer)
+}

--- a/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/ide_km/commands/key_set_stop.rs
+++ b/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/ide_km/commands/key_set_stop.rs
@@ -1,0 +1,35 @@
+// Licensed under the Apache-2.0 license
+
+use mcu_spdm_lite_codec::errors::SPDM_INVALID_REQUEST;
+use mcu_spdm_lite_codec::{KeySetGoStop, WireReader, WireWriter};
+use mcu_spdm_lite_traits::{McuResult, SpdmPalAlloc};
+
+use crate::pci_sig::ide_km::{map_ide_error, IdeDriver};
+
+use super::key_go_stop_ack::write_key_go_stop_ack;
+
+pub(crate) async fn handle_key_set_stop<D, Alloc>(
+    driver: &D,
+    scratch: &Alloc,
+    reader: &mut WireReader<'_>,
+    writer: &mut WireWriter<'_>,
+) -> McuResult<usize>
+where
+    D: IdeDriver,
+    Alloc: SpdmPalAlloc,
+{
+    let key_set_stop = *reader
+        .read::<KeySetGoStop>()
+        .map_err(|_| SPDM_INVALID_REQUEST)?;
+    driver
+        .key_set_stop(
+            key_set_stop.stream_id,
+            key_set_stop.key_info,
+            key_set_stop.port_index,
+            scratch,
+        )
+        .await
+        .map_err(map_ide_error)?;
+
+    write_key_go_stop_ack(key_set_stop, writer)
+}

--- a/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/ide_km/commands/mod.rs
+++ b/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/ide_km/commands/mod.rs
@@ -1,0 +1,14 @@
+// Licensed under the Apache-2.0 license
+
+//! IDE-KM command handlers.
+
+mod key_go_stop_ack;
+mod key_prog;
+mod key_set_go;
+mod key_set_stop;
+mod query;
+
+pub(crate) use key_prog::handle_key_prog;
+pub(crate) use key_set_go::handle_key_set_go;
+pub(crate) use key_set_stop::handle_key_set_stop;
+pub(crate) use query::handle_query;

--- a/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/ide_km/commands/query.rs
+++ b/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/ide_km/commands/query.rs
@@ -1,0 +1,139 @@
+// Licensed under the Apache-2.0 license
+
+use mcu_spdm_lite_codec::errors::SPDM_INVALID_REQUEST;
+use mcu_spdm_lite_codec::{
+    IdeKmHdr, IdeRegBlock, LinkIdeStreamRegBlock, PortConfig, Query, SelectiveIdeStreamRegBlock,
+    WireReader, WireWriter,
+};
+use mcu_spdm_lite_traits::{McuResult, SpdmPalAlloc};
+use zerocopy::{Immutable, IntoBytes};
+
+use crate::pci_sig::ide_km::{map_ide_error, IdeDriver};
+
+pub(crate) trait QueryResponseWriter {
+    fn position(&self) -> usize;
+    fn write_bytes(&mut self, bytes: &[u8]) -> Result<(), ()>;
+
+    fn write<T: IntoBytes + Immutable + ?Sized>(&mut self, value: &T) -> Result<(), ()> {
+        self.write_bytes(value.as_bytes())
+    }
+}
+
+impl QueryResponseWriter for WireWriter<'_> {
+    fn position(&self) -> usize {
+        self.position()
+    }
+
+    fn write_bytes(&mut self, bytes: &[u8]) -> Result<(), ()> {
+        self.write_bytes(bytes).map_err(|_| ())
+    }
+}
+
+pub(crate) fn handle_query<D, W, Alloc>(
+    driver: &D,
+    scratch: &Alloc,
+    reader: &mut WireReader<'_>,
+    writer: &mut W,
+) -> McuResult<usize>
+where
+    D: IdeDriver,
+    W: QueryResponseWriter,
+    Alloc: SpdmPalAlloc,
+{
+    let query = *reader.read::<Query>().map_err(|_| SPDM_INVALID_REQUEST)?;
+    generate_query_resp(query.port_index, driver, scratch, writer)
+}
+
+fn generate_query_resp<D, W, Alloc>(
+    port_index: u8,
+    driver: &D,
+    scratch: &Alloc,
+    writer: &mut W,
+) -> McuResult<usize>
+where
+    D: IdeDriver,
+    W: QueryResponseWriter,
+    Alloc: SpdmPalAlloc,
+{
+    writer
+        .write(&IdeKmHdr {
+            object_id: mcu_spdm_lite_codec::IDE_KM_OBJECT_ID_QUERY_RESP,
+        })
+        .map_err(|_| SPDM_INVALID_REQUEST)?;
+
+    writer
+        .write(&Query {
+            reserved: 0,
+            port_index,
+        })
+        .map_err(|_| SPDM_INVALID_REQUEST)?;
+
+    let port_config: PortConfig = driver
+        .port_config(port_index, scratch)
+        .map_err(map_ide_error)?;
+    writer
+        .write(&port_config)
+        .map_err(|_| SPDM_INVALID_REQUEST)?;
+
+    let ide_reg_block: IdeRegBlock = driver
+        .ide_reg_block(port_index, scratch)
+        .map_err(map_ide_error)?;
+    writer
+        .write(&ide_reg_block)
+        .map_err(|_| SPDM_INVALID_REQUEST)?;
+
+    let ide_cap_reg = ide_reg_block.ide_cap_reg;
+    if ide_cap_reg.link_ide_stream_supported() == 1 {
+        for block_index in 0..ide_cap_reg.num_tcs_supported_for_link_ide() {
+            let block: LinkIdeStreamRegBlock = driver
+                .link_ide_reg_block(port_index, block_index, scratch)
+                .map_err(map_ide_error)?;
+            writer.write(&block).map_err(|_| SPDM_INVALID_REQUEST)?;
+        }
+    }
+
+    if ide_cap_reg.selective_ide_stream_supported() == 1 {
+        for block_index in 0..ide_cap_reg.num_selective_ide_streams_supported() {
+            let block: SelectiveIdeStreamRegBlock = driver
+                .selective_ide_reg_block(port_index, block_index, scratch)
+                .map_err(map_ide_error)?;
+            write_selective_ide_stream_reg_block(&block, writer)?;
+        }
+    }
+
+    Ok(writer.position())
+}
+
+fn write_selective_ide_stream_reg_block<W>(
+    block: &SelectiveIdeStreamRegBlock,
+    writer: &mut W,
+) -> McuResult<()>
+where
+    W: QueryResponseWriter,
+{
+    let count = block.capability_reg.num_addr_association_reg_blocks() as usize;
+    if count > mcu_spdm_lite_codec::MAX_SELECTIVE_IDE_ADDR_ASSOC_BLOCK_COUNT {
+        return Err(SPDM_INVALID_REQUEST);
+    }
+
+    writer
+        .write(&block.capability_reg)
+        .map_err(|_| SPDM_INVALID_REQUEST)?;
+    writer
+        .write(&block.ctrl_reg)
+        .map_err(|_| SPDM_INVALID_REQUEST)?;
+    writer
+        .write(&block.status_reg)
+        .map_err(|_| SPDM_INVALID_REQUEST)?;
+    writer
+        .write(&block.rid_association_reg_1)
+        .map_err(|_| SPDM_INVALID_REQUEST)?;
+    writer
+        .write(&block.rid_association_reg_2)
+        .map_err(|_| SPDM_INVALID_REQUEST)?;
+    for reg in block.addr_association_reg_block.iter().take(count) {
+        writer.write(reg).map_err(|_| SPDM_INVALID_REQUEST)?;
+    }
+
+    Ok(())
+}

--- a/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/ide_km/driver.rs
+++ b/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/ide_km/driver.rs
@@ -1,0 +1,199 @@
+// Licensed under the Apache-2.0 license
+
+//! IDE-KM platform driver abstraction.
+
+use mcu_spdm_lite_codec::{
+    IdeRegBlock, KeyInfo, LinkIdeStreamRegBlock, PortConfig, SelectiveIdeStreamRegBlock,
+    IDE_STREAM_IV_SIZE_DW, IDE_STREAM_KEY_SIZE_DW,
+};
+use mcu_spdm_lite_errors::VDM_NO_RESPONSE;
+use mcu_spdm_lite_traits::{McuErrorCode, SpdmPalAlloc};
+use zerocopy::little_endian::U32;
+
+/// IDE-KM driver-level failures.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum IdeDriverError {
+    InvalidPortIndex = 0x01,
+    UnsupportedPortIndex = 0x02,
+    InvalidStreamId = 0x03,
+    InvalidArgument = 0x04,
+    GetPortConfigFail = 0x05,
+    KeyProgFail = 0x06,
+    KeySetGoFail = 0x07,
+    KeySetStopFail = 0x08,
+    NoMemory = 0x09,
+}
+
+/// IDE-KM driver result alias.
+pub type IdeDriverResult<T> = core::result::Result<T, IdeDriverError>;
+
+/// Platform abstraction for PCIe IDE key-management hardware.
+///
+/// The trait uses static dispatch and borrowed little-endian key arrays so
+/// spdm-lite does not allocate or copy the KEY_PROG key material before handing
+/// it to the platform.
+#[allow(async_fn_in_trait)]
+pub trait IdeDriver {
+    /// Gets the port configuration for a given port index.
+    fn port_config<Alloc>(&self, port_index: u8, scratch: &Alloc) -> IdeDriverResult<PortConfig>
+    where
+        Alloc: SpdmPalAlloc;
+
+    /// Gets the IDE capability/control register block.
+    fn ide_reg_block<Alloc>(&self, port_index: u8, scratch: &Alloc) -> IdeDriverResult<IdeRegBlock>
+    where
+        Alloc: SpdmPalAlloc;
+
+    /// Gets one Link IDE stream register block.
+    fn link_ide_reg_block<Alloc>(
+        &self,
+        port_index: u8,
+        block_index: u8,
+        scratch: &Alloc,
+    ) -> IdeDriverResult<LinkIdeStreamRegBlock>
+    where
+        Alloc: SpdmPalAlloc;
+
+    /// Gets one Selective IDE stream register block.
+    fn selective_ide_reg_block<Alloc>(
+        &self,
+        port_index: u8,
+        block_index: u8,
+        scratch: &Alloc,
+    ) -> IdeDriverResult<SelectiveIdeStreamRegBlock>
+    where
+        Alloc: SpdmPalAlloc;
+
+    /// Programs a stream key and IV.
+    async fn key_prog<Alloc>(
+        &self,
+        stream_id: u8,
+        key_info: KeyInfo,
+        port_index: u8,
+        key: &[U32; IDE_STREAM_KEY_SIZE_DW],
+        iv: &[U32; IDE_STREAM_IV_SIZE_DW],
+        scratch: &Alloc,
+    ) -> IdeDriverResult<u8>
+    where
+        Alloc: SpdmPalAlloc;
+
+    /// Starts using a key set for a stream.
+    ///
+    /// The IDE-KM `KEY_GO_STOP_ACK` response echoes the request `KeyInfo` for
+    /// the wire response, so this hook reports only operation success or failure.
+    async fn key_set_go<Alloc>(
+        &self,
+        stream_id: u8,
+        key_info: KeyInfo,
+        port_index: u8,
+        scratch: &Alloc,
+    ) -> IdeDriverResult<()>
+    where
+        Alloc: SpdmPalAlloc;
+
+    /// Stops using a key set for a stream.
+    ///
+    /// The IDE-KM `KEY_GO_STOP_ACK` response echoes the request `KeyInfo` for
+    /// the wire response, so this hook reports only operation success or failure.
+    async fn key_set_stop<Alloc>(
+        &self,
+        stream_id: u8,
+        key_info: KeyInfo,
+        port_index: u8,
+        scratch: &Alloc,
+    ) -> IdeDriverResult<()>
+    where
+        Alloc: SpdmPalAlloc;
+}
+
+impl<T: IdeDriver> IdeDriver for &T {
+    fn port_config<Alloc>(&self, port_index: u8, scratch: &Alloc) -> IdeDriverResult<PortConfig>
+    where
+        Alloc: SpdmPalAlloc,
+    {
+        (**self).port_config(port_index, scratch)
+    }
+
+    fn ide_reg_block<Alloc>(&self, port_index: u8, scratch: &Alloc) -> IdeDriverResult<IdeRegBlock>
+    where
+        Alloc: SpdmPalAlloc,
+    {
+        (**self).ide_reg_block(port_index, scratch)
+    }
+
+    fn link_ide_reg_block<Alloc>(
+        &self,
+        port_index: u8,
+        block_index: u8,
+        scratch: &Alloc,
+    ) -> IdeDriverResult<LinkIdeStreamRegBlock>
+    where
+        Alloc: SpdmPalAlloc,
+    {
+        (**self).link_ide_reg_block(port_index, block_index, scratch)
+    }
+
+    fn selective_ide_reg_block<Alloc>(
+        &self,
+        port_index: u8,
+        block_index: u8,
+        scratch: &Alloc,
+    ) -> IdeDriverResult<SelectiveIdeStreamRegBlock>
+    where
+        Alloc: SpdmPalAlloc,
+    {
+        (**self).selective_ide_reg_block(port_index, block_index, scratch)
+    }
+
+    async fn key_prog<Alloc>(
+        &self,
+        stream_id: u8,
+        key_info: KeyInfo,
+        port_index: u8,
+        key: &[U32; IDE_STREAM_KEY_SIZE_DW],
+        iv: &[U32; IDE_STREAM_IV_SIZE_DW],
+        scratch: &Alloc,
+    ) -> IdeDriverResult<u8>
+    where
+        Alloc: SpdmPalAlloc,
+    {
+        (**self)
+            .key_prog(stream_id, key_info, port_index, key, iv, scratch)
+            .await
+    }
+
+    async fn key_set_go<Alloc>(
+        &self,
+        stream_id: u8,
+        key_info: KeyInfo,
+        port_index: u8,
+        scratch: &Alloc,
+    ) -> IdeDriverResult<()>
+    where
+        Alloc: SpdmPalAlloc,
+    {
+        (**self)
+            .key_set_go(stream_id, key_info, port_index, scratch)
+            .await
+    }
+
+    async fn key_set_stop<Alloc>(
+        &self,
+        stream_id: u8,
+        key_info: KeyInfo,
+        port_index: u8,
+        scratch: &Alloc,
+    ) -> IdeDriverResult<()>
+    where
+        Alloc: SpdmPalAlloc,
+    {
+        (**self)
+            .key_set_stop(stream_id, key_info, port_index, scratch)
+            .await
+    }
+}
+
+pub(crate) fn map_ide_error(_err: IdeDriverError) -> McuErrorCode {
+    VDM_NO_RESPONSE
+}

--- a/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/ide_km/mod.rs
+++ b/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/ide_km/mod.rs
@@ -1,0 +1,1146 @@
+// Licensed under the Apache-2.0 license
+
+//! PCI-SIG IDE-KM VDM responder for SPDM-Lite.
+
+use mcu_spdm_lite_codec::{
+    IdeKmCommand, IdeKmHdr, PciSigProtocolHdr, StandardsBodyId, WireReader, WireWriter,
+    IDE_KM_PROTOCOL_ID,
+};
+
+use mcu_spdm_lite_codec::errors::{
+    SPDM_INVALID_REQUEST, SPDM_UNSPECIFIED, SPDM_UNSUPPORTED_REQUEST,
+};
+use mcu_spdm_lite_errors::VDM_NO_RESPONSE;
+use mcu_spdm_lite_traits::{
+    McuResult, SpdmPalAlloc, SpdmPalIo, SpdmVdmBackend, VdmRegistry, VdmResponse, VdmResponseBuffer,
+};
+
+use super::{handle_tdisp_protocol_payload, pci_sig_envelope_matches, tdisp, TDISP_PROTOCOL_ID};
+
+mod commands;
+mod driver;
+
+pub(crate) use driver::map_ide_error;
+pub use driver::{IdeDriver, IdeDriverError, IdeDriverResult};
+
+/// IDE-KM protocol responder.
+pub struct IdeKmResponder<D> {
+    driver: D,
+}
+
+impl<D> IdeKmResponder<D> {
+    /// Creates an IDE-KM responder over a platform driver.
+    pub const fn new(driver: D) -> Self {
+        Self { driver }
+    }
+
+    /// Returns the wrapped IDE driver.
+    pub const fn driver(&self) -> &D {
+        &self.driver
+    }
+}
+
+impl<D: IdeDriver> IdeKmResponder<D> {
+    /// Handles an IDE-KM request payload after the PCI-SIG protocol byte.
+    pub async fn handle_request<Alloc>(
+        &self,
+        req: &[u8],
+        rsp: &mut [u8],
+        scratch: &Alloc,
+    ) -> McuResult<usize>
+    where
+        Alloc: SpdmPalAlloc,
+    {
+        let mut reader = WireReader::new(req);
+        let hdr = *reader
+            .read::<IdeKmHdr>()
+            .map_err(|_| SPDM_INVALID_REQUEST)?;
+        let command = IdeKmCommand::from_u8(hdr.object_id).ok_or(SPDM_INVALID_REQUEST)?;
+
+        // Decode object ID, check the command payload length, then reject
+        // response-only object IDs.
+        if reader.remaining() != command.payload_len() {
+            return Err(SPDM_INVALID_REQUEST);
+        }
+
+        let mut writer = WireWriter::new(rsp);
+        match command {
+            IdeKmCommand::Query => {
+                commands::handle_query(&self.driver, scratch, &mut reader, &mut writer)
+            }
+            IdeKmCommand::KeyProg => {
+                commands::handle_key_prog(&self.driver, scratch, &mut reader, &mut writer).await
+            }
+            IdeKmCommand::KeySetGo => {
+                commands::handle_key_set_go(&self.driver, scratch, &mut reader, &mut writer).await
+            }
+            IdeKmCommand::KeySetStop => {
+                commands::handle_key_set_stop(&self.driver, scratch, &mut reader, &mut writer).await
+            }
+            _ => Err(SPDM_INVALID_REQUEST),
+        }
+    }
+}
+
+/// PCI-SIG VDM backend with the IDE-KM protocol enabled.
+pub struct PciSigIdeKmVdm<D> {
+    vendor_id: u16,
+    ide_km: IdeKmResponder<D>,
+}
+
+impl<D> PciSigIdeKmVdm<D> {
+    /// Creates a PCI-SIG VDM backend for a PCI-SIG vendor ID and IDE-KM driver.
+    pub const fn new(vendor_id: u16, driver: D) -> Self {
+        Self {
+            vendor_id,
+            ide_km: IdeKmResponder::new(driver),
+        }
+    }
+
+    /// Returns the PCI-SIG vendor ID matched by this backend.
+    pub const fn vendor_id(&self) -> u16 {
+        self.vendor_id
+    }
+
+    /// Returns the IDE-KM responder.
+    pub const fn ide_km(&self) -> &IdeKmResponder<D> {
+        &self.ide_km
+    }
+}
+
+impl<D: IdeDriver> PciSigIdeKmVdm<D> {
+    async fn handle_ide_km_protocol_payload<Alloc>(
+        &self,
+        protocol_id: u8,
+        req: &[u8],
+        out: &mut [u8],
+        scratch: &Alloc,
+    ) -> McuResult<usize>
+    where
+        Alloc: SpdmPalAlloc,
+    {
+        let Some((protocol_out, ide_out)) = out.split_first_mut() else {
+            return Err(SPDM_UNSPECIFIED);
+        };
+        *protocol_out = protocol_id;
+        let ide_len = self.ide_km.handle_request(req, ide_out, scratch).await?;
+        Ok(PciSigProtocolHdr::SIZE + ide_len)
+    }
+}
+
+impl<D: IdeDriver> SpdmVdmBackend for PciSigIdeKmVdm<D> {
+    fn match_id(&self, registry: &VdmRegistry<'_>) -> bool {
+        registry.standard_id == StandardsBodyId::PciSig.as_u16()
+            && registry.vendor_id == self.vendor_id.to_le_bytes()
+            && registry.secure_session
+    }
+
+    async fn handle_request<Alloc, Io>(
+        &self,
+        req: &[u8],
+        rsp: VdmResponseBuffer<'_, Alloc, Io>,
+    ) -> McuResult<VdmResponse>
+    where
+        Alloc: SpdmPalAlloc,
+        Io: SpdmPalIo,
+    {
+        let mut reader = WireReader::new(req);
+        let pci_sig_hdr = *reader
+            .read::<PciSigProtocolHdr>()
+            .map_err(|_| VDM_NO_RESPONSE)?;
+        if pci_sig_hdr.protocol_id != IDE_KM_PROTOCOL_ID {
+            return Err(VDM_NO_RESPONSE);
+        }
+
+        let ide_km_payload = reader.rest();
+        let scratch = rsp.scratch();
+        let len = self
+            .handle_ide_km_protocol_payload(
+                pci_sig_hdr.protocol_id,
+                ide_km_payload,
+                rsp.inline,
+                scratch,
+            )
+            .await
+            .map_err(|_| VDM_NO_RESPONSE)?;
+        Ok(VdmResponse::Inline(len))
+    }
+}
+
+/// PCI-SIG VDM backend with IDE-KM and TDISP enabled for the same vendor ID.
+pub struct PciSigIdeKmTdispVdm<Ide, Tdisp> {
+    vendor_id: u16,
+    ide_km: PciSigIdeKmVdm<Ide>,
+    tdisp: tdisp::TdispResponder<Tdisp>,
+}
+
+impl<Ide, Tdisp> PciSigIdeKmTdispVdm<Ide, Tdisp> {
+    /// Creates a PCI-SIG VDM backend that routes by PCI-SIG protocol id.
+    pub const fn new(vendor_id: u16, ide_driver: Ide, tdisp: tdisp::TdispResponder<Tdisp>) -> Self {
+        Self {
+            vendor_id,
+            ide_km: PciSigIdeKmVdm::new(vendor_id, ide_driver),
+            tdisp,
+        }
+    }
+
+    /// Returns the PCI-SIG vendor ID matched by this backend.
+    pub const fn vendor_id(&self) -> u16 {
+        self.vendor_id
+    }
+}
+
+impl<Ide, Tdisp> SpdmVdmBackend for PciSigIdeKmTdispVdm<Ide, Tdisp>
+where
+    Ide: IdeDriver,
+    Tdisp: tdisp::TdispDriver,
+{
+    fn match_id(&self, registry: &VdmRegistry<'_>) -> bool {
+        pci_sig_envelope_matches(registry, self.vendor_id)
+    }
+
+    async fn handle_request<Alloc, Io>(
+        &self,
+        req: &[u8],
+        rsp: VdmResponseBuffer<'_, Alloc, Io>,
+    ) -> McuResult<VdmResponse>
+    where
+        Alloc: SpdmPalAlloc,
+        Io: SpdmPalIo,
+    {
+        let Some((&protocol_id, payload)) = req.split_first() else {
+            return Err(SPDM_INVALID_REQUEST);
+        };
+        match protocol_id {
+            IDE_KM_PROTOCOL_ID => self.ide_km.handle_request(req, rsp).await,
+            TDISP_PROTOCOL_ID => {
+                let VdmResponseBuffer { inline, alloc, .. } = rsp;
+                handle_tdisp_protocol_payload(&self.tdisp, protocol_id, payload, inline, alloc)
+                    .await
+            }
+            _ => Err(SPDM_UNSUPPORTED_REQUEST),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+
+    use core::marker::PhantomData;
+    use core::ops::{Deref, DerefMut};
+
+    use futures::executor::block_on;
+    use mcu_spdm_lite_codec::{
+        AddrAssociationRegBlock, IdeCapabilityReg, IdeControlReg, IdeRegBlock, KeyInfo,
+        LinkIdeStreamControlReg, LinkIdeStreamRegBlock, LinkIdeStreamStatusReg, PortConfig, Query,
+        SelectiveIdeRidAssociationReg1, SelectiveIdeRidAssociationReg2,
+        SelectiveIdeStreamCapabilityReg, SelectiveIdeStreamControlReg, SelectiveIdeStreamRegBlock,
+        SelectiveIdeStreamStatusReg, IDE_KM_PROTOCOL_ID, IDE_STREAM_IV_SIZE_DW,
+        IDE_STREAM_KEY_SIZE_DW, MAX_SELECTIVE_IDE_ADDR_ASSOC_BLOCK_COUNT,
+    };
+
+    use std::boxed::Box;
+    use std::vec;
+    use std::vec::Vec;
+    use zerocopy::little_endian::U32;
+
+    use super::*;
+
+    const VENDOR_ID_BYTES: [u8; 2] = 0x1234u16.to_le_bytes();
+
+    #[derive(Debug, Clone, Copy)]
+    struct TestIdeDriver {
+        port_index: u8,
+        function_num: u8,
+        bus_num: u8,
+        segment: u8,
+        num_link_ide_streams: u8,
+        num_selective_ide_streams: u8,
+        num_addr_association_reg_blocks: u8,
+    }
+
+    impl Default for TestIdeDriver {
+        fn default() -> Self {
+            Self {
+                port_index: 0,
+                function_num: 0,
+                bus_num: 0,
+                segment: 0,
+                num_link_ide_streams: 1,
+                num_selective_ide_streams: 1,
+                num_addr_association_reg_blocks: 1,
+            }
+        }
+    }
+
+    impl IdeDriver for TestIdeDriver {
+        fn port_config<Alloc>(
+            &self,
+            port_index: u8,
+            _scratch: &Alloc,
+        ) -> IdeDriverResult<PortConfig>
+        where
+            Alloc: SpdmPalAlloc,
+        {
+            self.check_port(port_index)?;
+            Ok(PortConfig {
+                function_num: self.function_num,
+                bus_num: self.bus_num,
+                segment: self.segment,
+                max_port_index: self.port_index,
+            })
+        }
+
+        fn ide_reg_block<Alloc>(
+            &self,
+            port_index: u8,
+            _scratch: &Alloc,
+        ) -> IdeDriverResult<IdeRegBlock>
+        where
+            Alloc: SpdmPalAlloc,
+        {
+            self.check_port(port_index)?;
+            let mut ide_cap_reg = IdeCapabilityReg::default();
+            ide_cap_reg.set_link_ide_stream_supported(1);
+            ide_cap_reg.set_selective_ide_stream_supported(1);
+            ide_cap_reg.set_ide_km_protocol_supported(1);
+            ide_cap_reg.set_num_tcs_supported_for_link_ide(self.num_link_ide_streams);
+            ide_cap_reg.set_num_selective_ide_streams_supported(self.num_selective_ide_streams);
+
+            let mut ide_ctrl_reg = IdeControlReg::default();
+            ide_ctrl_reg.set_flow_through_ide_stream_enabled(1);
+            Ok(IdeRegBlock {
+                ide_cap_reg,
+                ide_ctrl_reg,
+            })
+        }
+
+        fn link_ide_reg_block<Alloc>(
+            &self,
+            port_index: u8,
+            block_index: u8,
+            _scratch: &Alloc,
+        ) -> IdeDriverResult<LinkIdeStreamRegBlock>
+        where
+            Alloc: SpdmPalAlloc,
+        {
+            self.check_port(port_index)?;
+            if block_index >= self.num_link_ide_streams {
+                return Err(IdeDriverError::InvalidStreamId);
+            }
+            let mut ctrl_reg = LinkIdeStreamControlReg::default();
+            ctrl_reg.set_link_ide_stream_enable(1);
+            ctrl_reg.set_pcrc_enable(1);
+            ctrl_reg.set_selected_algorithm(5);
+            ctrl_reg.set_tc(block_index & 0x7);
+            ctrl_reg.set_stream_id(block_index);
+
+            let mut status_reg = LinkIdeStreamStatusReg::default();
+            status_reg.set_link_ide_stream_state(7);
+            Ok(LinkIdeStreamRegBlock {
+                ctrl_reg,
+                status_reg,
+            })
+        }
+
+        fn selective_ide_reg_block<Alloc>(
+            &self,
+            port_index: u8,
+            block_index: u8,
+            _scratch: &Alloc,
+        ) -> IdeDriverResult<SelectiveIdeStreamRegBlock>
+        where
+            Alloc: SpdmPalAlloc,
+        {
+            self.check_port(port_index)?;
+            if block_index >= self.num_selective_ide_streams {
+                return Err(IdeDriverError::InvalidStreamId);
+            }
+
+            let mut capability_reg = SelectiveIdeStreamCapabilityReg::default();
+            capability_reg.set_num_addr_association_reg_blocks(
+                self.num_addr_association_reg_blocks
+                    .min(MAX_SELECTIVE_IDE_ADDR_ASSOC_BLOCK_COUNT as u8),
+            );
+
+            let mut ctrl_reg = SelectiveIdeStreamControlReg::default();
+            ctrl_reg.set_selective_ide_stream_enable(1);
+            ctrl_reg.set_pcrc_enable(1);
+            ctrl_reg.set_selective_ide_for_config_req_enable(1);
+            ctrl_reg.set_selected_algorithm(4);
+            ctrl_reg.set_tc(block_index & 0x7);
+            ctrl_reg.set_default_stream(1);
+            ctrl_reg.set_stream_id(block_index);
+
+            let mut status_reg = SelectiveIdeStreamStatusReg::default();
+            status_reg.set_selective_ide_stream_state(5);
+
+            let mut rid_association_reg_1 = SelectiveIdeRidAssociationReg1::default();
+            rid_association_reg_1.set_rid_limit(0x1234);
+            let mut rid_association_reg_2 = SelectiveIdeRidAssociationReg2::default();
+            rid_association_reg_2.set_valid(1);
+            rid_association_reg_2.set_rid_base(0x5678);
+
+            let mut addr_association_reg_block =
+                [AddrAssociationRegBlock::default(); MAX_SELECTIVE_IDE_ADDR_ASSOC_BLOCK_COUNT];
+            for reg in addr_association_reg_block
+                .iter_mut()
+                .take(capability_reg.num_addr_association_reg_blocks() as usize)
+            {
+                reg.reg1.set_valid(1);
+                reg.reg1.set_memory_base_lower(0x12);
+                reg.reg1.set_memory_limit_lower(0x34);
+                reg.reg2.memory_limit_upper = U32::new(0x1234_5678);
+                reg.reg3.memory_base_upper = U32::new(0x8765_4321);
+            }
+
+            Ok(SelectiveIdeStreamRegBlock {
+                capability_reg,
+                ctrl_reg,
+                status_reg,
+                rid_association_reg_1,
+                rid_association_reg_2,
+                addr_association_reg_block,
+            })
+        }
+
+        async fn key_prog<Alloc>(
+            &self,
+            _stream_id: u8,
+            _key_info: KeyInfo,
+            port_index: u8,
+            _key: &[U32; IDE_STREAM_KEY_SIZE_DW],
+            _iv: &[U32; IDE_STREAM_IV_SIZE_DW],
+            _scratch: &Alloc,
+        ) -> IdeDriverResult<u8>
+        where
+            Alloc: SpdmPalAlloc,
+        {
+            self.check_port(port_index)?;
+            Ok(0)
+        }
+
+        async fn key_set_go<Alloc>(
+            &self,
+            _stream_id: u8,
+            key_info: KeyInfo,
+            port_index: u8,
+            _scratch: &Alloc,
+        ) -> IdeDriverResult<()>
+        where
+            Alloc: SpdmPalAlloc,
+        {
+            self.check_port(port_index)?;
+            let _ = key_info;
+            Ok(())
+        }
+
+        async fn key_set_stop<Alloc>(
+            &self,
+            _stream_id: u8,
+            key_info: KeyInfo,
+            port_index: u8,
+            _scratch: &Alloc,
+        ) -> IdeDriverResult<()>
+        where
+            Alloc: SpdmPalAlloc,
+        {
+            self.check_port(port_index)?;
+            let _ = key_info;
+            Ok(())
+        }
+    }
+
+    impl TestIdeDriver {
+        fn check_port(&self, port_index: u8) -> IdeDriverResult<()> {
+            if port_index == self.port_index {
+                Ok(())
+            } else {
+                Err(IdeDriverError::InvalidPortIndex)
+            }
+        }
+    }
+
+    #[derive(Clone, Copy)]
+    struct StatusDriver {
+        key_prog_status: u8,
+    }
+
+    impl IdeDriver for StatusDriver {
+        fn port_config<Alloc>(&self, port_index: u8, scratch: &Alloc) -> IdeDriverResult<PortConfig>
+        where
+            Alloc: SpdmPalAlloc,
+        {
+            TestIdeDriver::default().port_config(port_index, scratch)
+        }
+
+        fn ide_reg_block<Alloc>(
+            &self,
+            port_index: u8,
+            scratch: &Alloc,
+        ) -> IdeDriverResult<IdeRegBlock>
+        where
+            Alloc: SpdmPalAlloc,
+        {
+            TestIdeDriver::default().ide_reg_block(port_index, scratch)
+        }
+
+        fn link_ide_reg_block<Alloc>(
+            &self,
+            port_index: u8,
+            block_index: u8,
+            scratch: &Alloc,
+        ) -> IdeDriverResult<LinkIdeStreamRegBlock>
+        where
+            Alloc: SpdmPalAlloc,
+        {
+            TestIdeDriver::default().link_ide_reg_block(port_index, block_index, scratch)
+        }
+
+        fn selective_ide_reg_block<Alloc>(
+            &self,
+            port_index: u8,
+            block_index: u8,
+            scratch: &Alloc,
+        ) -> IdeDriverResult<SelectiveIdeStreamRegBlock>
+        where
+            Alloc: SpdmPalAlloc,
+        {
+            TestIdeDriver::default().selective_ide_reg_block(port_index, block_index, scratch)
+        }
+
+        async fn key_prog<Alloc>(
+            &self,
+            _stream_id: u8,
+            _key_info: KeyInfo,
+            _port_index: u8,
+            _key: &[U32; IDE_STREAM_KEY_SIZE_DW],
+            _iv: &[U32; IDE_STREAM_IV_SIZE_DW],
+            _scratch: &Alloc,
+        ) -> IdeDriverResult<u8>
+        where
+            Alloc: SpdmPalAlloc,
+        {
+            Ok(self.key_prog_status)
+        }
+
+        async fn key_set_go<Alloc>(
+            &self,
+            _stream_id: u8,
+            _key_info: KeyInfo,
+            _port_index: u8,
+            _scratch: &Alloc,
+        ) -> IdeDriverResult<()>
+        where
+            Alloc: SpdmPalAlloc,
+        {
+            Ok(())
+        }
+
+        async fn key_set_stop<Alloc>(
+            &self,
+            _stream_id: u8,
+            _key_info: KeyInfo,
+            _port_index: u8,
+            _scratch: &Alloc,
+        ) -> IdeDriverResult<()>
+        where
+            Alloc: SpdmPalAlloc,
+        {
+            Ok(())
+        }
+    }
+
+    #[derive(Clone, Copy)]
+    struct StopOnlyDriver;
+
+    impl IdeDriver for StopOnlyDriver {
+        fn port_config<Alloc>(&self, port_index: u8, scratch: &Alloc) -> IdeDriverResult<PortConfig>
+        where
+            Alloc: SpdmPalAlloc,
+        {
+            TestIdeDriver::default().port_config(port_index, scratch)
+        }
+
+        fn ide_reg_block<Alloc>(
+            &self,
+            port_index: u8,
+            scratch: &Alloc,
+        ) -> IdeDriverResult<IdeRegBlock>
+        where
+            Alloc: SpdmPalAlloc,
+        {
+            TestIdeDriver::default().ide_reg_block(port_index, scratch)
+        }
+
+        fn link_ide_reg_block<Alloc>(
+            &self,
+            port_index: u8,
+            block_index: u8,
+            scratch: &Alloc,
+        ) -> IdeDriverResult<LinkIdeStreamRegBlock>
+        where
+            Alloc: SpdmPalAlloc,
+        {
+            TestIdeDriver::default().link_ide_reg_block(port_index, block_index, scratch)
+        }
+
+        fn selective_ide_reg_block<Alloc>(
+            &self,
+            port_index: u8,
+            block_index: u8,
+            scratch: &Alloc,
+        ) -> IdeDriverResult<SelectiveIdeStreamRegBlock>
+        where
+            Alloc: SpdmPalAlloc,
+        {
+            TestIdeDriver::default().selective_ide_reg_block(port_index, block_index, scratch)
+        }
+
+        async fn key_prog<Alloc>(
+            &self,
+            _stream_id: u8,
+            _key_info: KeyInfo,
+            _port_index: u8,
+            _key: &[U32; IDE_STREAM_KEY_SIZE_DW],
+            _iv: &[U32; IDE_STREAM_IV_SIZE_DW],
+            _scratch: &Alloc,
+        ) -> IdeDriverResult<u8>
+        where
+            Alloc: SpdmPalAlloc,
+        {
+            Err(IdeDriverError::KeyProgFail)
+        }
+
+        async fn key_set_go<Alloc>(
+            &self,
+            _stream_id: u8,
+            _key_info: KeyInfo,
+            _port_index: u8,
+            _scratch: &Alloc,
+        ) -> IdeDriverResult<()>
+        where
+            Alloc: SpdmPalAlloc,
+        {
+            Err(IdeDriverError::KeySetGoFail)
+        }
+
+        async fn key_set_stop<Alloc>(
+            &self,
+            _stream_id: u8,
+            _key_info: KeyInfo,
+            _port_index: u8,
+            _scratch: &Alloc,
+        ) -> IdeDriverResult<()>
+        where
+            Alloc: SpdmPalAlloc,
+        {
+            Ok(())
+        }
+    }
+
+    #[derive(Clone, Copy)]
+    struct VerifyingKeyProgDriver {
+        expected_stream_id: u8,
+        expected_key_info: KeyInfo,
+        expected_port_index: u8,
+        expected_key: [u32; IDE_STREAM_KEY_SIZE_DW],
+        expected_iv: [u32; IDE_STREAM_IV_SIZE_DW],
+        status: u8,
+    }
+
+    impl IdeDriver for VerifyingKeyProgDriver {
+        fn port_config<Alloc>(&self, port_index: u8, scratch: &Alloc) -> IdeDriverResult<PortConfig>
+        where
+            Alloc: SpdmPalAlloc,
+        {
+            TestIdeDriver::default().port_config(port_index, scratch)
+        }
+
+        fn ide_reg_block<Alloc>(
+            &self,
+            port_index: u8,
+            scratch: &Alloc,
+        ) -> IdeDriverResult<IdeRegBlock>
+        where
+            Alloc: SpdmPalAlloc,
+        {
+            TestIdeDriver::default().ide_reg_block(port_index, scratch)
+        }
+
+        fn link_ide_reg_block<Alloc>(
+            &self,
+            port_index: u8,
+            block_index: u8,
+            scratch: &Alloc,
+        ) -> IdeDriverResult<LinkIdeStreamRegBlock>
+        where
+            Alloc: SpdmPalAlloc,
+        {
+            TestIdeDriver::default().link_ide_reg_block(port_index, block_index, scratch)
+        }
+
+        fn selective_ide_reg_block<Alloc>(
+            &self,
+            port_index: u8,
+            block_index: u8,
+            scratch: &Alloc,
+        ) -> IdeDriverResult<SelectiveIdeStreamRegBlock>
+        where
+            Alloc: SpdmPalAlloc,
+        {
+            TestIdeDriver::default().selective_ide_reg_block(port_index, block_index, scratch)
+        }
+
+        async fn key_prog<Alloc>(
+            &self,
+            stream_id: u8,
+            key_info: KeyInfo,
+            port_index: u8,
+            key: &[U32; IDE_STREAM_KEY_SIZE_DW],
+            iv: &[U32; IDE_STREAM_IV_SIZE_DW],
+            _scratch: &Alloc,
+        ) -> IdeDriverResult<u8>
+        where
+            Alloc: SpdmPalAlloc,
+        {
+            assert_eq!(stream_id, self.expected_stream_id);
+            assert_eq!(key_info, self.expected_key_info);
+            assert_eq!(port_index, self.expected_port_index);
+            for (actual, expected) in key.iter().zip(self.expected_key.iter()) {
+                assert_eq!(actual.get(), *expected);
+            }
+            for (actual, expected) in iv.iter().zip(self.expected_iv.iter()) {
+                assert_eq!(actual.get(), *expected);
+            }
+            Ok(self.status)
+        }
+
+        async fn key_set_go<Alloc>(
+            &self,
+            _stream_id: u8,
+            _key_info: KeyInfo,
+            _port_index: u8,
+            _scratch: &Alloc,
+        ) -> IdeDriverResult<()>
+        where
+            Alloc: SpdmPalAlloc,
+        {
+            Err(IdeDriverError::KeySetGoFail)
+        }
+
+        async fn key_set_stop<Alloc>(
+            &self,
+            _stream_id: u8,
+            _key_info: KeyInfo,
+            _port_index: u8,
+            _scratch: &Alloc,
+        ) -> IdeDriverResult<()>
+        where
+            Alloc: SpdmPalAlloc,
+        {
+            Err(IdeDriverError::KeySetStopFail)
+        }
+    }
+
+    fn pci_sig_registry(secure_session: bool) -> VdmRegistry<'static> {
+        VdmRegistry {
+            standard_id: StandardsBodyId::PciSig.as_u16(),
+            vendor_id: &VENDOR_ID_BYTES,
+            secure_session,
+        }
+    }
+
+    struct TestBox<'a, T: 'a> {
+        value: Box<T>,
+        _lifetime: PhantomData<&'a ()>,
+    }
+
+    impl<T> Deref for TestBox<'_, T> {
+        type Target = T;
+
+        fn deref(&self) -> &Self::Target {
+            &self.value
+        }
+    }
+
+    impl<T> DerefMut for TestBox<'_, T> {
+        fn deref_mut(&mut self) -> &mut Self::Target {
+            &mut self.value
+        }
+    }
+
+    struct TestAlloc;
+
+    impl mcu_caliptra_api_lite::ApiAlloc for TestAlloc {
+        type Buf<'a>
+            = Vec<u8>
+        where
+            Self: 'a;
+
+        fn alloc(&self, len: usize) -> McuResult<Self::Buf<'_>> {
+            Ok(vec![0; len])
+        }
+    }
+
+    impl SpdmPalAlloc for TestAlloc {
+        type Box<'a, T>
+            = TestBox<'a, T>
+        where
+            Self: 'a,
+            T: 'a;
+        type Bytes<'a>
+            = Vec<u8>
+        where
+            Self: 'a;
+        type LargeBuf = Vec<u8>;
+        type PersistentBox<T: Sized + 'static> = Box<T>;
+
+        fn alloc<T: Sized>(&self, _io: &impl SpdmPalIo, value: T) -> McuResult<Self::Box<'_, T>> {
+            Ok(TestBox {
+                value: Box::new(value),
+                _lifetime: PhantomData,
+            })
+        }
+
+        fn alloc_bytes(&self, _io: &impl SpdmPalIo, len: usize) -> McuResult<Self::Bytes<'_>> {
+            Ok(vec![0; len])
+        }
+
+        fn large_capacity(&self) -> usize {
+            0
+        }
+
+        fn alloc_large_buf(&self, len: usize) -> McuResult<Self::LargeBuf> {
+            Ok(vec![0; len])
+        }
+
+        fn alloc_persistent<T: Sized + 'static>(
+            &self,
+            value: T,
+        ) -> McuResult<Self::PersistentBox<T>> {
+            Ok(Box::new(value))
+        }
+    }
+
+    struct TestIo;
+    impl SpdmPalIo for TestIo {
+        fn kind(&self) -> mcu_spdm_lite_traits::SpdmPalIoKind {
+            mcu_spdm_lite_traits::SpdmPalIoKind::SecuredMessage
+        }
+
+        fn request(&self) -> &[u8] {
+            &[]
+        }
+    }
+
+    static TEST_ALLOC: TestAlloc = TestAlloc;
+    static TEST_IO: TestIo = TestIo;
+
+    fn scratch() -> &'static TestAlloc {
+        &TEST_ALLOC
+    }
+
+    fn response_buffer<'a>(
+        inline: &'a mut [u8],
+        large: &'a mut [u8],
+    ) -> VdmResponseBuffer<'a, TestAlloc, TestIo> {
+        VdmResponseBuffer {
+            inline,
+            large,
+            alloc: &TEST_ALLOC,
+            io: &TEST_IO,
+        }
+    }
+
+    #[test]
+    fn pci_sig_ide_km_matches_only_secure_session() {
+        let backend = PciSigIdeKmVdm::new(0x1234, TestIdeDriver::default());
+        assert!(backend.match_id(&pci_sig_registry(true)));
+        assert!(!backend.match_id(&pci_sig_registry(false)));
+    }
+
+    #[test]
+    fn large_response_capacity_is_not_requested_for_ide_km() {
+        let backend = PciSigIdeKmVdm::new(0x1234, TestIdeDriver::default());
+        let query = [IDE_KM_PROTOCOL_ID, IdeKmCommand::Query as u8, 0, 0];
+        assert_eq!(backend.large_response_capacity(&query), 0);
+
+        let mut key_prog = [0u8; PciSigProtocolHdr::SIZE
+            + IdeKmHdr::SIZE
+            + mcu_spdm_lite_codec::KeyProg::SIZE
+            + mcu_spdm_lite_codec::KeyData::SIZE];
+        key_prog[0] = IDE_KM_PROTOCOL_ID;
+        key_prog[1] = IdeKmCommand::KeyProg as u8;
+        assert_eq!(backend.large_response_capacity(&key_prog), 0);
+    }
+
+    #[test]
+    fn query_response_prefers_inline_when_it_fits_even_with_large_buffer() {
+        let backend = PciSigIdeKmVdm::new(0x1234, TestIdeDriver::default());
+        let payload = [IDE_KM_PROTOCOL_ID, IdeKmCommand::Query as u8, 0, 0];
+        let mut inline = [0u8; 256];
+        let mut large = [0u8; 512];
+        let response =
+            block_on(backend.handle_request(&payload, response_buffer(&mut inline, &mut large)))
+                .unwrap();
+
+        let VdmResponse::Inline(len) = response else {
+            panic!("IDE-KM query should be inline");
+        };
+        assert!(len > 1 + IdeKmHdr::SIZE + Query::SIZE);
+        assert_eq!(inline[0], IDE_KM_PROTOCOL_ID);
+        assert_eq!(inline[1], IdeKmCommand::QueryResp as u8);
+        assert_eq!(inline[2], 0);
+        assert_eq!(inline[3], 0);
+        assert_eq!(large[0], 0);
+    }
+
+    #[test]
+    fn query_response_does_not_use_large_buffer_when_inline_is_too_small() {
+        let backend = PciSigIdeKmVdm::new(0x1234, TestIdeDriver::default());
+        let payload = [IDE_KM_PROTOCOL_ID, IdeKmCommand::Query as u8, 0, 0];
+        let mut inline = [0u8; 1];
+        let mut large = [0u8; 256];
+        let err = match block_on(
+            backend.handle_request(&payload, response_buffer(&mut inline, &mut large)),
+        ) {
+            Ok(_) => panic!("IDE-KM query should fail when inline storage is too small"),
+            Err(err) => err,
+        };
+
+        assert_eq!(err, VDM_NO_RESPONSE);
+        assert_eq!(large[0], 0);
+    }
+
+    #[test]
+    fn key_prog_ack_stays_inline_when_large_buffer_is_available() {
+        let driver = StatusDriver {
+            key_prog_status: 0x5a,
+        };
+        let backend = PciSigIdeKmVdm::new(0x1234, driver);
+        let mut payload = [0u8; PciSigProtocolHdr::SIZE
+            + IdeKmHdr::SIZE
+            + mcu_spdm_lite_codec::KeyProg::SIZE
+            + mcu_spdm_lite_codec::KeyData::SIZE];
+        payload[0] = IDE_KM_PROTOCOL_ID;
+        payload[1] = IdeKmCommand::KeyProg as u8;
+        let mut inline = [0u8; 16];
+        let mut large = [0u8; 256];
+        let response =
+            block_on(backend.handle_request(&payload, response_buffer(&mut inline, &mut large)))
+                .unwrap();
+
+        let VdmResponse::Inline(len) = response else {
+            panic!("IDE-KM KEY_PROG ACK should stay inline");
+        };
+        assert_eq!(
+            len,
+            PciSigProtocolHdr::SIZE + IdeKmHdr::SIZE + mcu_spdm_lite_codec::KeyProg::SIZE
+        );
+        assert_eq!(inline[0], IDE_KM_PROTOCOL_ID);
+        assert_eq!(inline[1], IdeKmCommand::KeyProgAck as u8);
+        assert_eq!(inline[5], driver.key_prog_status);
+        assert_eq!(large[0], 0);
+    }
+
+    #[test]
+    fn key_set_ack_echoes_request_key_info_after_driver_success() {
+        let driver = StatusDriver { key_prog_status: 0 };
+        let responder = IdeKmResponder::new(driver);
+        let request_key_info = KeyInfo::new(false, false, 0x01);
+        let req = [
+            IdeKmCommand::KeySetGo as u8,
+            0,
+            0,
+            0x22,
+            0,
+            request_key_info.raw(),
+            0,
+        ];
+        let mut rsp = [0u8; 16];
+        let len = block_on(responder.handle_request(&req, &mut rsp, scratch())).unwrap();
+
+        assert_eq!(
+            len,
+            IdeKmHdr::SIZE + mcu_spdm_lite_codec::KeySetGoStop::SIZE
+        );
+        assert_eq!(rsp[0], IdeKmCommand::KeyGoStopAck as u8);
+        assert_eq!(rsp[5], request_key_info.raw());
+    }
+
+    #[test]
+    fn key_set_stop_ack_echoes_request_key_info_after_driver_success() {
+        let driver = StopOnlyDriver;
+        let responder = IdeKmResponder::new(driver);
+        let request_key_info = KeyInfo::new(false, true, 0x02);
+        let req = [
+            IdeKmCommand::KeySetStop as u8,
+            0,
+            0,
+            0x44,
+            0,
+            request_key_info.raw(),
+            0,
+        ];
+        let mut rsp = [0u8; 16];
+        let len = block_on(responder.handle_request(&req, &mut rsp, scratch())).unwrap();
+
+        assert_eq!(
+            len,
+            IdeKmHdr::SIZE + mcu_spdm_lite_codec::KeySetGoStop::SIZE
+        );
+        assert_eq!(rsp[0], IdeKmCommand::KeyGoStopAck as u8);
+        assert_eq!(rsp[5], request_key_info.raw());
+    }
+
+    #[test]
+    fn key_prog_success_path_forwards_fields_and_key_material() {
+        let expected_key = [
+            0x0302_0100,
+            0x0706_0504,
+            0x0b0a_0908,
+            0x0f0e_0d0c,
+            0x1312_1110,
+            0x1716_1514,
+            0x1b1a_1918,
+            0x1f1e_1d1c,
+        ];
+        let expected_iv = [0x2322_2120, 0x2726_2524];
+        let expected_key_info = KeyInfo::new(true, false, 0x02);
+        let driver = VerifyingKeyProgDriver {
+            expected_stream_id: 0x33,
+            expected_key_info,
+            expected_port_index: 0,
+            expected_key,
+            expected_iv,
+            status: 0xaa,
+        };
+        let responder = IdeKmResponder::new(driver);
+        let mut req = [0u8; IdeKmHdr::SIZE
+            + mcu_spdm_lite_codec::KeyProg::SIZE
+            + mcu_spdm_lite_codec::KeyData::SIZE];
+        req[0] = IdeKmCommand::KeyProg as u8;
+        req[3] = driver.expected_stream_id;
+        req[5] = expected_key_info.raw();
+        let mut offset = IdeKmHdr::SIZE + mcu_spdm_lite_codec::KeyProg::SIZE;
+        for value in expected_key {
+            req[offset..offset + core::mem::size_of::<u32>()].copy_from_slice(&value.to_le_bytes());
+            offset += core::mem::size_of::<u32>();
+        }
+        for value in expected_iv {
+            req[offset..offset + core::mem::size_of::<u32>()].copy_from_slice(&value.to_le_bytes());
+            offset += core::mem::size_of::<u32>();
+        }
+
+        let mut rsp = [0u8; 16];
+        let len = block_on(responder.handle_request(&req, &mut rsp, scratch())).unwrap();
+
+        assert_eq!(len, IdeKmHdr::SIZE + mcu_spdm_lite_codec::KeyProg::SIZE);
+        assert_eq!(rsp[0], IdeKmCommand::KeyProgAck as u8);
+        assert_eq!(rsp[4], driver.status);
+    }
+
+    #[test]
+    fn ide_driver_errors_drop_vdm_response() {
+        let responder = IdeKmResponder::new(StopOnlyDriver);
+        let mut req = [0u8; IdeKmHdr::SIZE
+            + mcu_spdm_lite_codec::KeyProg::SIZE
+            + mcu_spdm_lite_codec::KeyData::SIZE];
+        req[0] = IdeKmCommand::KeyProg as u8;
+        let mut rsp = [0u8; 16];
+
+        assert_eq!(
+            block_on(responder.handle_request(&req, &mut rsp, scratch())).unwrap_err(),
+            VDM_NO_RESPONSE
+        );
+    }
+
+    #[test]
+    fn unsupported_pci_sig_protocol_is_rejected() {
+        let backend = PciSigIdeKmVdm::new(0x1234, TestIdeDriver::default());
+        let mut rsp = [0u8; 16];
+        let result = block_on(backend.handle_request(&[0x7f], response_buffer(&mut rsp, &mut [])));
+
+        let Err(err) = result else {
+            panic!("unsupported PCI-SIG protocol should fail");
+        };
+        assert_eq!(err, VDM_NO_RESPONSE);
+    }
+
+    #[test]
+    fn invalid_and_response_only_ide_km_object_ids_are_rejected() {
+        let responder = IdeKmResponder::new(TestIdeDriver::default());
+        let mut rsp = [0u8; 16];
+
+        assert_eq!(
+            block_on(responder.handle_request(&[0xff], &mut rsp, scratch())).unwrap_err(),
+            SPDM_INVALID_REQUEST
+        );
+        assert_eq!(
+            block_on(responder.handle_request(
+                &[IdeKmCommand::QueryResp as u8],
+                &mut rsp,
+                scratch()
+            ))
+            .unwrap_err(),
+            SPDM_INVALID_REQUEST
+        );
+    }
+
+    #[test]
+    fn backend_drops_invalid_and_response_only_ide_km_object_ids() {
+        let backend = PciSigIdeKmVdm::new(0x1234, TestIdeDriver::default());
+        let mut rsp = [0u8; 16];
+
+        for payload in [
+            [IDE_KM_PROTOCOL_ID, 0xff],
+            [IDE_KM_PROTOCOL_ID, IdeKmCommand::QueryResp as u8],
+        ] {
+            let result =
+                block_on(backend.handle_request(&payload, response_buffer(&mut rsp, &mut [])));
+            let Err(err) = result else {
+                panic!("invalid IDE-KM object should fail without response");
+            };
+            assert_eq!(err, VDM_NO_RESPONSE);
+        }
+    }
+
+    #[test]
+    fn malformed_payload_lengths_are_rejected() {
+        let responder = IdeKmResponder::new(TestIdeDriver::default());
+        let mut rsp = [0u8; 16];
+
+        assert_eq!(
+            block_on(responder.handle_request(
+                &[IdeKmCommand::Query as u8, 0],
+                &mut rsp,
+                scratch()
+            ))
+            .unwrap_err(),
+            SPDM_INVALID_REQUEST
+        );
+        assert_eq!(
+            block_on(responder.handle_request(
+                &[IdeKmCommand::Query as u8, 0, 0, 0],
+                &mut rsp,
+                scratch()
+            ))
+            .unwrap_err(),
+            SPDM_INVALID_REQUEST
+        );
+    }
+
+    #[test]
+    fn short_output_buffer_is_rejected() {
+        let responder = IdeKmResponder::new(TestIdeDriver::default());
+        let req = [IdeKmCommand::Query as u8, 0, 0];
+        let mut rsp = [0u8; 1];
+
+        assert_eq!(
+            block_on(responder.handle_request(&req, &mut rsp, scratch())).unwrap_err(),
+            SPDM_INVALID_REQUEST
+        );
+    }
+}

--- a/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/mod.rs
+++ b/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/mod.rs
@@ -3,9 +3,10 @@
 //! PCI-SIG VENDOR_DEFINED protocols (Standards Body ID `PciSig`, 0x03).
 //!
 //! PCI-SIG protocols such as IDE-KM and TDISP are carried as SPDM
-//! VENDOR_DEFINED messages and, for TDISP, are expected inside a secured
-//! session on DOE.
+//! VENDOR_DEFINED messages inside a secured session on DOE. The first byte of
+//! the PCI-SIG VDM payload selects the PCI-SIG protocol.
 
+pub mod ide_km;
 pub mod tdisp;
 
 use mcu_spdm_lite_codec::errors::{
@@ -16,16 +17,10 @@ use mcu_spdm_lite_traits::{
     McuResult, SpdmPalAlloc, SpdmPalIo, SpdmVdmBackend, VdmRegistry, VdmResponse, VdmResponseBuffer,
 };
 
-/// PCI-SIG protocol identifier for IDE-KM.
-pub const IDE_KM_PROTOCOL_ID: u8 = 0x00;
 /// PCI-SIG protocol identifier for TDISP.
 pub const TDISP_PROTOCOL_ID: u8 = 0x01;
 
 /// PCI-SIG VDM backend that dispatches protocol-id `0x01` to TDISP.
-///
-/// The first byte of the PCI-SIG VDM payload is the PCI-SIG protocol id. This
-/// backend preserves that top-level byte and delegates the remaining payload to
-/// the size-conscious TDISP responder.
 pub struct PciSigTdispVdm<D> {
     vendor_id: u16,
     tdisp: tdisp::TdispResponder<D>,
@@ -39,9 +34,7 @@ impl<D> PciSigTdispVdm<D> {
 
     #[inline]
     fn matches_envelope(&self, registry: &VdmRegistry<'_>) -> bool {
-        registry.standard_id == StandardsBodyId::PciSig.as_u16()
-            && registry.vendor_id == self.vendor_id.to_le_bytes()
-            && registry.secure_session
+        pci_sig_envelope_matches(registry, self.vendor_id)
     }
 }
 
@@ -62,29 +55,47 @@ where
         Alloc: SpdmPalAlloc,
         Io: SpdmPalIo,
     {
-        let VdmResponseBuffer {
-            inline, alloc, io, ..
-        } = rsp;
+        let VdmResponseBuffer { inline, alloc, .. } = rsp;
         let Some((&protocol_id, payload)) = req.split_first() else {
             return Err(SPDM_INVALID_REQUEST);
         };
         if protocol_id != TDISP_PROTOCOL_ID {
             return Err(SPDM_UNSUPPORTED_REQUEST);
         }
-        let Some(tdisp_inline) = inline.get_mut(1..) else {
-            return Err(SPDM_UNSPECIFIED);
-        };
-        let response = self
-            .tdisp
-            .handle_tdisp_payload(payload, alloc, io, tdisp_inline)
-            .await?;
-        match response {
-            VdmResponse::Inline(len) => {
-                inline[0] = protocol_id;
-                Ok(VdmResponse::Inline(len + 1))
-            }
-            VdmResponse::Large(_) => Err(SPDM_UNSPECIFIED),
+        handle_tdisp_protocol_payload(&self.tdisp, protocol_id, payload, inline, alloc).await
+    }
+}
+
+#[inline]
+fn pci_sig_envelope_matches(registry: &VdmRegistry<'_>, vendor_id: u16) -> bool {
+    registry.standard_id == StandardsBodyId::PciSig.as_u16()
+        && registry.vendor_id == vendor_id.to_le_bytes()
+        && registry.secure_session
+}
+
+async fn handle_tdisp_protocol_payload<D, Alloc>(
+    tdisp: &tdisp::TdispResponder<D>,
+    protocol_id: u8,
+    payload: &[u8],
+    inline: &mut [u8],
+    alloc: &Alloc,
+) -> McuResult<VdmResponse>
+where
+    D: tdisp::TdispDriver,
+    Alloc: SpdmPalAlloc,
+{
+    let Some(tdisp_inline) = inline.get_mut(1..) else {
+        return Err(SPDM_UNSPECIFIED);
+    };
+    let response = tdisp
+        .handle_tdisp_payload(payload, alloc, tdisp_inline)
+        .await?;
+    match response {
+        VdmResponse::Inline(len) => {
+            inline[0] = protocol_id;
+            Ok(VdmResponse::Inline(len + 1))
         }
+        VdmResponse::Large(_) => Err(SPDM_UNSPECIFIED),
     }
 }
 
@@ -99,7 +110,7 @@ mod tests {
     use core::pin::Pin;
     use core::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
 
-    use mcu_spdm_lite_codec::errors::SPDM_VERSION_MISMATCH;
+    use mcu_spdm_lite_codec::{errors::SPDM_VERSION_MISMATCH, IDE_KM_PROTOCOL_ID};
     use mcu_spdm_lite_traits::{SpdmPalIoKind, VdmResponse};
     use std::boxed::Box;
     use std::vec;
@@ -250,15 +261,13 @@ mod tests {
     }
 
     impl TdispDriver for TestTdispDriver {
-        async fn generate_start_interface_nonce<Alloc, Io>(
+        async fn generate_start_interface_nonce<Alloc>(
             &self,
             _scratch: &Alloc,
-            _io: &Io,
             out: &mut [u8; START_INTERFACE_NONCE_SIZE],
         ) -> TdispDriverResult<()>
         where
             Alloc: SpdmPalAlloc,
-            Io: SpdmPalIo,
         {
             let start = self.nonce_counter.get().wrapping_add(1);
             self.nonce_counter.set(start);
@@ -268,31 +277,27 @@ mod tests {
             Ok(())
         }
 
-        async fn get_capabilities<Alloc, Io>(
+        async fn get_capabilities<Alloc>(
             &self,
             _req_caps: TdispReqCapabilities,
             _scratch: &Alloc,
-            _io: &Io,
             resp_caps: &mut TdispRespCapabilities,
         ) -> TdispDriverResult<u32>
         where
             Alloc: SpdmPalAlloc,
-            Io: SpdmPalIo,
         {
             *resp_caps = TdispRespCapabilities::new(0, TEST_REQ_MSGS_SUPPORTED, 0x07, 48, 0, 0);
             Ok(0)
         }
 
-        async fn lock_interface<Alloc, Io>(
+        async fn lock_interface<Alloc>(
             &self,
             _function_id: FunctionId,
             _param: TdispLockInterfaceParam,
             _scratch: &Alloc,
-            _io: &Io,
         ) -> TdispDriverResult<u32>
         where
             Alloc: SpdmPalAlloc,
-            Io: SpdmPalIo,
         {
             if self.state.get() != TdiStatus::ConfigUnlocked {
                 return Ok(TDISP_ERROR_INVALID_INTERFACE_STATE);
@@ -301,16 +306,14 @@ mod tests {
             Ok(0)
         }
 
-        async fn get_device_interface_report_len<Alloc, Io>(
+        async fn get_device_interface_report_len<Alloc>(
             &self,
             _function_id: FunctionId,
             _scratch: &Alloc,
-            _io: &Io,
             intf_report_len: &mut u16,
         ) -> TdispDriverResult<u32>
         where
             Alloc: SpdmPalAlloc,
-            Io: SpdmPalIo,
         {
             *intf_report_len = if self.state.get() == TdiStatus::ConfigUnlocked {
                 0
@@ -320,18 +323,16 @@ mod tests {
             Ok(0)
         }
 
-        async fn get_device_interface_report<Alloc, Io>(
+        async fn get_device_interface_report<Alloc>(
             &self,
             _function_id: FunctionId,
             offset: u16,
             _scratch: &Alloc,
-            _io: &Io,
             report: &mut [u8],
             copied: &mut usize,
         ) -> TdispDriverResult<u32>
         where
             Alloc: SpdmPalAlloc,
-            Io: SpdmPalIo,
         {
             let offset = offset as usize;
             if self.state.get() == TdiStatus::ConfigUnlocked
@@ -346,30 +347,26 @@ mod tests {
             Ok(0)
         }
 
-        async fn get_device_interface_state<Alloc, Io>(
+        async fn get_device_interface_state<Alloc>(
             &self,
             _function_id: FunctionId,
             _scratch: &Alloc,
-            _io: &Io,
             tdi_state: &mut TdiStatus,
         ) -> TdispDriverResult<u32>
         where
             Alloc: SpdmPalAlloc,
-            Io: SpdmPalIo,
         {
             *tdi_state = self.state.get();
             Ok(0)
         }
 
-        async fn start_interface<Alloc, Io>(
+        async fn start_interface<Alloc>(
             &self,
             _function_id: FunctionId,
             _scratch: &Alloc,
-            _io: &Io,
         ) -> TdispDriverResult<u32>
         where
             Alloc: SpdmPalAlloc,
-            Io: SpdmPalIo,
         {
             if self.state.get() != TdiStatus::ConfigLocked {
                 return Ok(TDISP_ERROR_INVALID_INTERFACE_STATE);
@@ -378,15 +375,13 @@ mod tests {
             Ok(0)
         }
 
-        async fn stop_interface<Alloc, Io>(
+        async fn stop_interface<Alloc>(
             &self,
             _function_id: FunctionId,
             _scratch: &Alloc,
-            _io: &Io,
         ) -> TdispDriverResult<u32>
         where
             Alloc: SpdmPalAlloc,
-            Io: SpdmPalIo,
         {
             if self.state.get() == TdiStatus::ConfigUnlocked {
                 return Ok(TDISP_ERROR_INVALID_INTERFACE_STATE);
@@ -490,7 +485,7 @@ mod tests {
     }
 
     #[test]
-    fn get_capabilities_matches_libspdm_sample_after_get_version() {
+    fn get_capabilities_matches_expected_sample_after_get_version() {
         let backend = backend();
         let get_version = request(TdispCommand::GetTdispVersion as u8, &[]);
         dispatch(&backend, &get_version, 64).expect("interface initialized");

--- a/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/tdisp/commands/device_interface_report.rs
+++ b/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/tdisp/commands/device_interface_report.rs
@@ -3,27 +3,25 @@
 //! GET_DEVICE_INTERFACE_REPORT command handler.
 
 use mcu_spdm_lite_codec::errors::SPDM_UNSPECIFIED;
-use mcu_spdm_lite_traits::{McuResult, SpdmPalAlloc, SpdmPalIo};
+use mcu_spdm_lite_traits::{McuResult, SpdmPalAlloc};
 
-use crate::pci_sig::tdisp::protocol::{
+use crate::pci_sig::tdisp::{TdispDriver, TdispHandlerResult, TdispResponder};
+use mcu_spdm_lite_codec::vendor_defined::pci_sig::tdisp::{
     tdisp_error_code, DeviceInterfaceReportReq, TdispMessageHeader,
     DEVICE_INTERFACE_REPORT_RSP_HDR_LEN, TDISP_ERROR_INVALID_INTERFACE,
     TDISP_ERROR_INVALID_REQUEST, TDISP_ERROR_UNSPECIFIED, TDISP_HEADER_LEN,
 };
-use crate::pci_sig::tdisp::{TdispDriver, TdispHandlerResult, TdispResponder};
 
-pub(crate) async fn handle<D, Alloc, Io>(
+pub(crate) async fn handle<D, Alloc>(
     tdisp: &TdispResponder<D>,
     req_hdr: TdispMessageHeader,
     req_payload: &[u8],
     scratch: &Alloc,
-    io: &Io,
     out: &mut [u8],
 ) -> McuResult<TdispHandlerResult>
 where
     D: TdispDriver,
     Alloc: SpdmPalAlloc,
-    Io: SpdmPalIo,
 {
     if tdisp.state.interface_state(req_hdr.interface_id).is_none() {
         return Ok(TdispHandlerResult::Error(TDISP_ERROR_INVALID_INTERFACE, 0));
@@ -33,12 +31,7 @@ where
     let mut report_len = 0u16;
     match tdisp
         .driver
-        .get_device_interface_report_len(
-            req_hdr.interface_id.function_id,
-            scratch,
-            io,
-            &mut report_len,
-        )
+        .get_device_interface_report_len(req_hdr.interface_id.function_id, scratch, &mut report_len)
         .await
     {
         Ok(0) if req.offset as usize >= report_len as usize => {
@@ -75,7 +68,6 @@ where
             req_hdr.interface_id.function_id,
             req.offset,
             scratch,
-            io,
             report_portion,
             &mut copied,
         )

--- a/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/tdisp/commands/device_interface_state.rs
+++ b/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/tdisp/commands/device_interface_state.rs
@@ -3,35 +3,28 @@
 //! GET_DEVICE_INTERFACE_STATE command handler.
 
 use mcu_spdm_lite_codec::errors::SPDM_UNSPECIFIED;
-use mcu_spdm_lite_traits::{McuResult, SpdmPalAlloc, SpdmPalIo};
+use mcu_spdm_lite_traits::{McuResult, SpdmPalAlloc};
 
-use crate::pci_sig::tdisp::protocol::{
+use crate::pci_sig::tdisp::{TdispDriver, TdispHandlerResult, TdispResponder};
+use mcu_spdm_lite_codec::vendor_defined::pci_sig::tdisp::{
     tdisp_error_code, TdiStatus, TdispMessageHeader, TDISP_ERROR_INVALID_INTERFACE_STATE,
     TDISP_ERROR_UNSPECIFIED, TDISP_HEADER_LEN,
 };
-use crate::pci_sig::tdisp::{TdispDriver, TdispHandlerResult, TdispResponder};
 
-pub(crate) async fn handle<D, Alloc, Io>(
+pub(crate) async fn handle<D, Alloc>(
     tdisp: &TdispResponder<D>,
     req_hdr: TdispMessageHeader,
     scratch: &Alloc,
-    io: &Io,
     out: &mut [u8],
 ) -> McuResult<TdispHandlerResult>
 where
     D: TdispDriver,
     Alloc: SpdmPalAlloc,
-    Io: SpdmPalIo,
 {
     let mut tdi_status = TdiStatus::Reserved;
     match tdisp
         .driver
-        .get_device_interface_state(
-            req_hdr.interface_id.function_id,
-            scratch,
-            io,
-            &mut tdi_status,
-        )
+        .get_device_interface_state(req_hdr.interface_id.function_id, scratch, &mut tdi_status)
         .await
     {
         Ok(0) if tdi_status != TdiStatus::Reserved => {

--- a/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/tdisp/commands/error_rsp.rs
+++ b/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/tdisp/commands/error_rsp.rs
@@ -5,7 +5,7 @@
 use mcu_spdm_lite_codec::errors::SPDM_UNSPECIFIED;
 use mcu_spdm_lite_traits::{McuResult, VdmResponse};
 
-use crate::pci_sig::tdisp::protocol::{
+use mcu_spdm_lite_codec::vendor_defined::pci_sig::tdisp::{
     InterfaceId, TdispCommand, TdispErrorCode, TdispMessageHeader, ERROR_RSP_LEN, TDISP_HEADER_LEN,
 };
 

--- a/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/tdisp/commands/get_tdisp_capabilities.rs
+++ b/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/tdisp/commands/get_tdisp_capabilities.rs
@@ -3,32 +3,30 @@
 //! GET_TDISP_CAPABILITIES command handler.
 
 use mcu_spdm_lite_codec::errors::SPDM_UNSPECIFIED;
-use mcu_spdm_lite_traits::{McuResult, SpdmPalAlloc, SpdmPalIo};
+use mcu_spdm_lite_traits::{McuResult, SpdmPalAlloc};
 
-use crate::pci_sig::tdisp::protocol::{
+use crate::pci_sig::tdisp::{TdispDriver, TdispHandlerResult, TdispResponder};
+use mcu_spdm_lite_codec::vendor_defined::pci_sig::tdisp::{
     tdisp_error_code, TdispMessageHeader, TdispReqCapabilities, TdispRespCapabilities,
     TDISP_CAPS_RSP_LEN, TDISP_ERROR_UNSPECIFIED, TDISP_HEADER_LEN,
 };
-use crate::pci_sig::tdisp::{TdispDriver, TdispHandlerResult, TdispResponder};
 
-pub(crate) async fn handle<D, Alloc, Io>(
+pub(crate) async fn handle<D, Alloc>(
     tdisp: &TdispResponder<D>,
     _req_hdr: TdispMessageHeader,
     req_payload: &[u8],
     scratch: &Alloc,
-    io: &Io,
     out: &mut [u8],
 ) -> McuResult<TdispHandlerResult>
 where
     D: TdispDriver,
     Alloc: SpdmPalAlloc,
-    Io: SpdmPalIo,
 {
     let req_caps = TdispReqCapabilities::decode(req_payload)?;
     let mut rsp_caps = TdispRespCapabilities::default();
     match tdisp
         .driver
-        .get_capabilities(req_caps, scratch, io, &mut rsp_caps)
+        .get_capabilities(req_caps, scratch, &mut rsp_caps)
         .await
     {
         Ok(0) => {

--- a/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/tdisp/commands/get_tdisp_version.rs
+++ b/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/tdisp/commands/get_tdisp_version.rs
@@ -5,10 +5,10 @@
 use mcu_spdm_lite_codec::errors::SPDM_UNSPECIFIED;
 use mcu_spdm_lite_traits::McuResult;
 
-use crate::pci_sig::tdisp::protocol::{
+use crate::pci_sig::tdisp::{TdispHandlerResult, TdispResponder};
+use mcu_spdm_lite_codec::vendor_defined::pci_sig::tdisp::{
     TdispMessageHeader, TDISP_ERROR_INVALID_INTERFACE, TDISP_HEADER_LEN,
 };
-use crate::pci_sig::tdisp::{TdispHandlerResult, TdispResponder};
 
 pub(crate) fn handle<D>(
     tdisp: &TdispResponder<D>,

--- a/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/tdisp/commands/lock_interface.rs
+++ b/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/tdisp/commands/lock_interface.rs
@@ -3,27 +3,25 @@
 //! LOCK_INTERFACE command handler.
 
 use mcu_spdm_lite_codec::errors::SPDM_UNSPECIFIED;
-use mcu_spdm_lite_traits::{McuResult, SpdmPalAlloc, SpdmPalIo};
+use mcu_spdm_lite_traits::{McuResult, SpdmPalAlloc};
 
-use crate::pci_sig::tdisp::protocol::{
+use crate::pci_sig::tdisp::{TdispDriver, TdispHandlerResult, TdispResponder};
+use mcu_spdm_lite_codec::vendor_defined::pci_sig::tdisp::{
     tdisp_error_code, TdispLockInterfaceParam, TdispMessageHeader, START_INTERFACE_NONCE_SIZE,
     TDISP_ERROR_INSUFFICIENT_ENTROPY, TDISP_ERROR_INVALID_INTERFACE, TDISP_ERROR_UNSPECIFIED,
     TDISP_HEADER_LEN,
 };
-use crate::pci_sig::tdisp::{TdispDriver, TdispHandlerResult, TdispResponder};
 
-pub(crate) async fn handle<D, Alloc, Io>(
+pub(crate) async fn handle<D, Alloc>(
     tdisp: &TdispResponder<D>,
     req_hdr: TdispMessageHeader,
     req_payload: &[u8],
     scratch: &Alloc,
-    io: &Io,
     out: &mut [u8],
 ) -> McuResult<TdispHandlerResult>
 where
     D: TdispDriver,
     Alloc: SpdmPalAlloc,
-    Io: SpdmPalIo,
 {
     if tdisp.state.interface_state(req_hdr.interface_id).is_none() {
         return Ok(TdispHandlerResult::Error(TDISP_ERROR_INVALID_INTERFACE, 0));
@@ -36,7 +34,7 @@ where
         nonce.try_into().map_err(|_| SPDM_UNSPECIFIED)?;
     if tdisp
         .driver
-        .generate_start_interface_nonce(scratch, io, nonce)
+        .generate_start_interface_nonce(scratch, nonce)
         .await
         .is_err()
     {
@@ -50,7 +48,7 @@ where
     let param = TdispLockInterfaceParam::decode(req_payload)?;
     match tdisp
         .driver
-        .lock_interface(req_hdr.interface_id.function_id, param, scratch, io)
+        .lock_interface(req_hdr.interface_id.function_id, param, scratch)
         .await
     {
         Ok(0) => Ok(TdispHandlerResult::Response(START_INTERFACE_NONCE_SIZE)),

--- a/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/tdisp/commands/start_interface.rs
+++ b/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/tdisp/commands/start_interface.rs
@@ -2,25 +2,23 @@
 
 //! START_INTERFACE command handler.
 
-use mcu_spdm_lite_traits::{McuResult, SpdmPalAlloc, SpdmPalIo};
+use mcu_spdm_lite_traits::{McuResult, SpdmPalAlloc};
 
-use crate::pci_sig::tdisp::protocol::{
+use crate::pci_sig::tdisp::{TdispDriver, TdispHandlerResult, TdispResponder};
+use mcu_spdm_lite_codec::vendor_defined::pci_sig::tdisp::{
     ct_eq, tdisp_error_code, TdispMessageHeader, TDISP_ERROR_INVALID_INTERFACE,
     TDISP_ERROR_INVALID_INTERFACE_STATE, TDISP_ERROR_UNSPECIFIED,
 };
-use crate::pci_sig::tdisp::{TdispDriver, TdispHandlerResult, TdispResponder};
 
-pub(crate) async fn handle<D, Alloc, Io>(
+pub(crate) async fn handle<D, Alloc>(
     tdisp: &TdispResponder<D>,
     req_hdr: TdispMessageHeader,
     req_payload: &[u8],
     scratch: &Alloc,
-    io: &Io,
 ) -> McuResult<TdispHandlerResult>
 where
     D: TdispDriver,
     Alloc: SpdmPalAlloc,
-    Io: SpdmPalIo,
 {
     let Some(interface_state) = tdisp.state.interface_state(req_hdr.interface_id) else {
         return Ok(TdispHandlerResult::Error(TDISP_ERROR_INVALID_INTERFACE, 0));
@@ -39,7 +37,7 @@ where
     }
     match tdisp
         .driver
-        .start_interface(req_hdr.interface_id.function_id, scratch, io)
+        .start_interface(req_hdr.interface_id.function_id, scratch)
         .await
     {
         Ok(0) => {

--- a/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/tdisp/commands/stop_interface.rs
+++ b/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/tdisp/commands/stop_interface.rs
@@ -2,27 +2,25 @@
 
 //! STOP_INTERFACE command handler.
 
-use mcu_spdm_lite_traits::{McuResult, SpdmPalAlloc, SpdmPalIo};
+use mcu_spdm_lite_traits::{McuResult, SpdmPalAlloc};
 
-use crate::pci_sig::tdisp::protocol::{
+use crate::pci_sig::tdisp::{TdispDriver, TdispHandlerResult, TdispResponder};
+use mcu_spdm_lite_codec::vendor_defined::pci_sig::tdisp::{
     tdisp_error_code, TdispMessageHeader, TDISP_ERROR_UNSPECIFIED,
 };
-use crate::pci_sig::tdisp::{TdispDriver, TdispHandlerResult, TdispResponder};
 
-pub(crate) async fn handle<D, Alloc, Io>(
+pub(crate) async fn handle<D, Alloc>(
     tdisp: &TdispResponder<D>,
     req_hdr: TdispMessageHeader,
     scratch: &Alloc,
-    io: &Io,
 ) -> McuResult<TdispHandlerResult>
 where
     D: TdispDriver,
     Alloc: SpdmPalAlloc,
-    Io: SpdmPalIo,
 {
     match tdisp
         .driver
-        .stop_interface(req_hdr.interface_id.function_id, scratch, io)
+        .stop_interface(req_hdr.interface_id.function_id, scratch)
         .await
     {
         Ok(0) => Ok(TdispHandlerResult::Response(0)),

--- a/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/tdisp/driver.rs
+++ b/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/tdisp/driver.rs
@@ -2,9 +2,9 @@
 
 //! TDISP platform driver abstraction.
 
-use mcu_spdm_lite_traits::{SpdmPalAlloc, SpdmPalIo};
+use mcu_spdm_lite_traits::SpdmPalAlloc;
 
-use super::protocol::{
+use mcu_spdm_lite_codec::vendor_defined::pci_sig::tdisp::{
     FunctionId, TdiStatus, TdispLockInterfaceParam, TdispReqCapabilities, TdispRespCapabilities,
     START_INTERFACE_NONCE_SIZE,
 };
@@ -41,97 +41,81 @@ pub type TdispDriverResult<T> = Result<T, TdispDriverError>;
 #[allow(async_fn_in_trait)]
 pub trait TdispDriver {
     /// Fills `out` with a START_INTERFACE nonce.
-    async fn generate_start_interface_nonce<Alloc, Io>(
+    async fn generate_start_interface_nonce<Alloc>(
         &self,
         scratch: &Alloc,
-        io: &Io,
         out: &mut [u8; START_INTERFACE_NONCE_SIZE],
     ) -> TdispDriverResult<()>
     where
-        Alloc: SpdmPalAlloc,
-        Io: SpdmPalIo;
+        Alloc: SpdmPalAlloc;
 
     /// Gets responder capabilities.
-    async fn get_capabilities<Alloc, Io>(
+    async fn get_capabilities<Alloc>(
         &self,
         req_caps: TdispReqCapabilities,
         scratch: &Alloc,
-        io: &Io,
         resp_caps: &mut TdispRespCapabilities,
     ) -> TdispDriverResult<u32>
     where
-        Alloc: SpdmPalAlloc,
-        Io: SpdmPalIo;
+        Alloc: SpdmPalAlloc;
 
     /// Locks an interface.
-    async fn lock_interface<Alloc, Io>(
+    async fn lock_interface<Alloc>(
         &self,
         function_id: FunctionId,
         param: TdispLockInterfaceParam,
         scratch: &Alloc,
-        io: &Io,
     ) -> TdispDriverResult<u32>
     where
-        Alloc: SpdmPalAlloc,
-        Io: SpdmPalIo;
+        Alloc: SpdmPalAlloc;
 
     /// Returns the total device interface report length.
-    async fn get_device_interface_report_len<Alloc, Io>(
+    async fn get_device_interface_report_len<Alloc>(
         &self,
         function_id: FunctionId,
         scratch: &Alloc,
-        io: &Io,
         intf_report_len: &mut u16,
     ) -> TdispDriverResult<u32>
     where
-        Alloc: SpdmPalAlloc,
-        Io: SpdmPalIo;
+        Alloc: SpdmPalAlloc;
 
     /// Copies a device interface report portion.
-    async fn get_device_interface_report<Alloc, Io>(
+    async fn get_device_interface_report<Alloc>(
         &self,
         function_id: FunctionId,
         offset: u16,
         scratch: &Alloc,
-        io: &Io,
         report: &mut [u8],
         copied: &mut usize,
     ) -> TdispDriverResult<u32>
     where
-        Alloc: SpdmPalAlloc,
-        Io: SpdmPalIo;
+        Alloc: SpdmPalAlloc;
 
     /// Gets the current device interface state.
-    async fn get_device_interface_state<Alloc, Io>(
+    async fn get_device_interface_state<Alloc>(
         &self,
         function_id: FunctionId,
         scratch: &Alloc,
-        io: &Io,
         tdi_state: &mut TdiStatus,
     ) -> TdispDriverResult<u32>
     where
-        Alloc: SpdmPalAlloc,
-        Io: SpdmPalIo;
+        Alloc: SpdmPalAlloc;
 
     /// Starts an interface.
-    async fn start_interface<Alloc, Io>(
+    async fn start_interface<Alloc>(
         &self,
         function_id: FunctionId,
         scratch: &Alloc,
-        io: &Io,
     ) -> TdispDriverResult<u32>
     where
-        Alloc: SpdmPalAlloc,
-        Io: SpdmPalIo;
+        Alloc: SpdmPalAlloc;
 
     /// Stops an interface.
-    async fn stop_interface<Alloc, Io>(
+    async fn stop_interface<Alloc>(
         &self,
         function_id: FunctionId,
         scratch: &Alloc,
-        io: &Io,
     ) -> TdispDriverResult<u32>
     where
-        Alloc: SpdmPalAlloc,
-        Io: SpdmPalIo;
+        Alloc: SpdmPalAlloc;
 }

--- a/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/tdisp/mod.rs
+++ b/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/tdisp/mod.rs
@@ -8,14 +8,14 @@
 
 mod commands;
 mod driver;
-mod protocol;
 mod state;
 
 use mcu_spdm_lite_codec::errors::{SPDM_INVALID_REQUEST, SPDM_VERSION_MISMATCH};
-use mcu_spdm_lite_traits::{McuResult, SpdmPalAlloc, SpdmPalIo, VdmResponse};
+use mcu_spdm_lite_codec::vendor_defined::pci_sig::tdisp::{TdispMessageHeader, TDISP_HEADER_LEN};
+use mcu_spdm_lite_traits::{McuResult, SpdmPalAlloc, VdmResponse};
 
 pub use driver::{TdispDriver, TdispDriverError, TdispDriverResult};
-pub use protocol::{
+pub use mcu_spdm_lite_codec::vendor_defined::pci_sig::tdisp::{
     FunctionId, InterfaceId, TdiStatus, TdispCommand, TdispErrorCode, TdispLockInterfaceFlags,
     TdispLockInterfaceParam, TdispReqCapabilities, TdispRespCapabilities, TdispVersion,
     START_INTERFACE_NONCE_SIZE, TDISP_ERROR_BUSY, TDISP_ERROR_INSUFFICIENT_ENTROPY,
@@ -26,7 +26,6 @@ pub use protocol::{
 };
 pub use state::MAX_TDISP_INTERFACES;
 
-use protocol::{TdispMessageHeader, TDISP_HEADER_LEN};
 use state::TdispState;
 
 /// TDISP responder with fixed-size state storage.
@@ -60,17 +59,16 @@ where
     D: TdispDriver,
 {
     /// Handles a TDISP payload excluding the PCI-SIG protocol id byte.
-    pub async fn handle_tdisp_payload<Alloc, Io>(
+    pub async fn handle_tdisp_payload<Alloc>(
         &self,
         payload: &[u8],
-        scratch: &Alloc,
-        io: &Io,
+        alloc: &Alloc,
         out: &mut [u8],
     ) -> McuResult<VdmResponse>
     where
         Alloc: SpdmPalAlloc,
-        Io: SpdmPalIo,
     {
+        let scratch = alloc;
         let (req_hdr, req_payload) = TdispMessageHeader::decode(payload)?;
 
         if TdispVersion::try_from(req_hdr.version).is_err() {
@@ -105,38 +103,24 @@ where
                 commands::get_tdisp_version::handle(self, req_hdr, out)
             }
             TdispCommand::GetTdispCapabilities => {
-                commands::get_tdisp_capabilities::handle(
-                    self,
-                    req_hdr,
-                    req_payload,
-                    scratch,
-                    io,
-                    out,
-                )
-                .await
+                commands::get_tdisp_capabilities::handle(self, req_hdr, req_payload, scratch, out)
+                    .await
             }
             TdispCommand::LockInterface => {
-                commands::lock_interface::handle(self, req_hdr, req_payload, scratch, io, out).await
+                commands::lock_interface::handle(self, req_hdr, req_payload, scratch, out).await
             }
             TdispCommand::GetDeviceInterfaceReport => {
-                commands::device_interface_report::handle(
-                    self,
-                    req_hdr,
-                    req_payload,
-                    scratch,
-                    io,
-                    out,
-                )
-                .await
+                commands::device_interface_report::handle(self, req_hdr, req_payload, scratch, out)
+                    .await
             }
             TdispCommand::GetDeviceInterfaceState => {
-                commands::device_interface_state::handle(self, req_hdr, scratch, io, out).await
+                commands::device_interface_state::handle(self, req_hdr, scratch, out).await
             }
             TdispCommand::StartInterfaceRequest => {
-                commands::start_interface::handle(self, req_hdr, req_payload, scratch, io).await
+                commands::start_interface::handle(self, req_hdr, req_payload, scratch).await
             }
             TdispCommand::StopInterfaceRequest => {
-                commands::stop_interface::handle(self, req_hdr, scratch, io).await
+                commands::stop_interface::handle(self, req_hdr, scratch).await
             }
             TdispCommand::BindP2PStreamRequest
             | TdispCommand::UnbindP2PStreamRequest

--- a/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/tdisp/state.rs
+++ b/runtime/userspace/api/spdm-lite/vdm-handler/src/pci_sig/tdisp/state.rs
@@ -4,7 +4,9 @@
 
 use core::cell::Cell;
 
-use super::protocol::{InterfaceId, START_INTERFACE_NONCE_SIZE};
+use mcu_spdm_lite_codec::vendor_defined::pci_sig::tdisp::{
+    InterfaceId, START_INTERFACE_NONCE_SIZE,
+};
 
 /// Maximum number of TDISP interfaces tracked by the responder.
 pub const MAX_TDISP_INTERFACES: usize = 64;


### PR DESCRIPTION
## Summary

 - Add PCI-SIG IDE-KM VDM support for SPDM-lite secure sessions.
 - Add static-dispatch IDE-KM driver hooks and emulator validator support.
 - Route PCI-SIG VDMs by protocol ID so IDE-KM and TDISP can share the same PCI-SIG VDM backend.
 - Keep PCI-SIG IDE-KM/TDISP inline-only while preserving generic large-response support for Caliptra/OCP VDMs.
 - Move VDM codec definitions under `codec/src/vendor_defined/...` for PCI-SIG IDE-KM, PCI-SIG TDISP, and IANA/OCP Caliptra.
 - Allow DIGESTS and CERTIFICATE requests to be handled inside established sessions.

 ## Validation

 - `cargo xtask precheckin`
 - DOE SPDM TDISP/IDE validator passed

 ## Memory delta

 | Section | `origin/spdm-lite` | This PR | Delta |
 |---|---:|---:|---:|
 | `.text` | 101,218 | 101,456 | **+238 B** |
 | `.rodata` | 20,768 | 20,896 | **+128 B** |
 | `.data` | 12 | 12 | 0 |
 | `.bss` | 53,008 | 53,008 | 0 |
 | **Flash (`.text + .rodata + .data`)** | **121,998** | **122,364** | **+366 B** |

 SPDM task attribution decreased by 670 B flash and 8 B RAM; kernel sections were unchanged.
