### PR TITLE
[rom] Program Caliptra fatal-error wait strap from MCU config

### DIFF
--- a/common/config/src/lib.rs
+++ b/common/config/src/lib.rs
@@ -115,6 +115,10 @@ pub struct McuStraps {
     /// Selects which I3C core is used for MCTP transport.
     /// 0 = i3c0 (default), 1 = i3c1.
     pub active_i3c: u8,
+    /// Mirrors Caliptra ROM `SS_STRAP_GENERIC[3][1]` behavior.
+    /// When non-zero, Caliptra ROM waits for recovery `DEVICE_RESET` before
+    /// reporting fatal errors.
+    pub cptra_wait_for_device_reset_before_fatal_error: u8,
     pub cptra_wdt_cfg0: u32,
     pub cptra_wdt_cfg1: u32,
     pub mcu_wdt_cfg0: u32,
@@ -131,6 +135,7 @@ impl McuStraps {
             i3c_static_addr: 0x3a,
             i3c1_static_addr: 0x3c,
             active_i3c: 0,
+            cptra_wait_for_device_reset_before_fatal_error: 0,
             cptra_wdt_cfg0: 100_000_000,
             cptra_wdt_cfg1: 100_000_000,
             mcu_wdt_cfg0: 20_000_000,

--- a/platforms/emulator/rom/src/io.rs
+++ b/platforms/emulator/rom/src/io.rs
@@ -29,7 +29,7 @@ impl FatalErrorHandler for EmulatorFatalErrorHandler {
     fn fatal_error(&mut self, code: u32) -> ! {
         let _ = writeln!(EmulatorWriter {}, "MCU fatal error: {}", HexWord(code));
         let mut env = RomEnv::new();
-        env.report_i3c_recovery_fatal_error();
+        env.report_i3c_recovery_fatal_error(code);
         env.mci.set_fw_fatal_error(code);
         exit_emulator(code);
     }

--- a/platforms/emulator/rom/src/io.rs
+++ b/platforms/emulator/rom/src/io.rs
@@ -28,7 +28,9 @@ pub(crate) static mut FATAL_ERROR_HANDLER: EmulatorFatalErrorHandler = EmulatorF
 impl FatalErrorHandler for EmulatorFatalErrorHandler {
     fn fatal_error(&mut self, code: u32) -> ! {
         let _ = writeln!(EmulatorWriter {}, "MCU fatal error: {}", HexWord(code));
-        RomEnv::new().mci.set_fw_fatal_error(code);
+        let mut env = RomEnv::new();
+        env.report_i3c_recovery_fatal_error();
+        env.mci.set_fw_fatal_error(code);
         exit_emulator(code);
     }
 }

--- a/platforms/fpga/config/src/lib.rs
+++ b/platforms/fpga/config/src/lib.rs
@@ -56,6 +56,7 @@ pub const FPGA_MCU_STRAPS: McuStraps = McuStraps {
     i3c_static_addr: 0x3a,
     i3c1_static_addr: 0x3c,
     active_i3c: 0,
+    cptra_wait_for_device_reset_before_fatal_error: 0,
     cptra_wdt_cfg0: 200_000_000,
     cptra_wdt_cfg1: 200_000_000,
     mcu_wdt_cfg0: 800_000_000, // the FPGA is slower to boot

--- a/platforms/fpga/rom/src/io.rs
+++ b/platforms/fpga/rom/src/io.rs
@@ -32,7 +32,7 @@ impl FatalErrorHandler for FpgaFatalErrorHandler {
     fn fatal_error(&mut self, code: u32) -> ! {
         let _ = writeln!(FpgaWriter {}, "MCU fatal error: {}", HexWord(code));
         let mut env = RomEnv::new();
-        env.report_i3c_recovery_fatal_error();
+        env.report_i3c_recovery_fatal_error(code);
         env.mci.set_fw_fatal_error(code);
         exit_fpga(code);
     }

--- a/platforms/fpga/rom/src/io.rs
+++ b/platforms/fpga/rom/src/io.rs
@@ -31,7 +31,9 @@ pub(crate) static mut FATAL_ERROR_HANDLER: FpgaFatalErrorHandler = FpgaFatalErro
 impl FatalErrorHandler for FpgaFatalErrorHandler {
     fn fatal_error(&mut self, code: u32) -> ! {
         let _ = writeln!(FpgaWriter {}, "MCU fatal error: {}", HexWord(code));
-        RomEnv::new().mci.set_fw_fatal_error(code);
+        let mut env = RomEnv::new();
+        env.report_i3c_recovery_fatal_error();
+        env.mci.set_fw_fatal_error(code);
         exit_fpga(code);
     }
 }

--- a/rom/src/cold_boot.rs
+++ b/rom/src/cold_boot.rs
@@ -246,8 +246,7 @@ impl crate::device_ownership_transfer::DotLockedRecoveryHandler for I3cDotLocked
             self.services,
             self.i3c_target_addr,
             Some(dot_ctx),
-        );
-        Ok(())
+        )
     }
 }
 
@@ -261,7 +260,7 @@ fn enter_i3c_services(
     services: I3cServicesModes,
     target_addr: u8,
     dot_ctx: Option<crate::DotContext<'_>>,
-) {
+) -> caliptra_mcu_error::McuResult<()> {
     // Extend the watchdog timeout for I3C services since the loop may run
     // for an extended period waiting for commands from the BMC.
     mci.configure_wdt(u32::MAX as u64, 1);
@@ -322,16 +321,25 @@ fn enter_i3c_services(
 
     let mut handler =
         I3cMailboxHandler::new(i3c_base, services, target_addr, dot_ctx, reassembly_buf);
-    match handler.run(|| {
+    let result = match handler.run(|| {
         mci.set_flow_checkpoint(McuRomBootStatus::I3cServicesReady.into());
     }) {
         Ok(()) => {
             mci.set_flow_checkpoint(McuRomBootStatus::I3cServicesComplete.into());
+            Ok(())
         }
         Err(err) => {
             caliptra_mcu_romtime::println!("[mcu-rom] I3C services error: {}", HexWord(err.into()));
+            let mut i3c = crate::i3c::I3c::new(i3c_base);
+            let _ = i3c.try_configure(crate::I3cConfig {
+                static_addr: target_addr,
+                recovery_enabled: true,
+                timings: crate::I3cTimings::default(),
+            });
+            i3c.set_recovery_boot_failure();
+            Err(err)
         }
-    }
+    };
 
     // Release mailbox lock if we acquired it
     if lock_acquired {
@@ -339,6 +347,8 @@ fn enter_i3c_services(
             .mcu_mbox0_csr_mbox_execute
             .write(MboxExecute::Execute::CLEAR);
     }
+
+    result
 }
 
 impl BootFlow for ColdBoot {
@@ -763,7 +773,7 @@ impl BootFlow for ColdBoot {
                         key_type,
                     }
                 });
-                enter_i3c_services(&env.mci, i3c_base, services, i3c_target_addr, dot_ctx);
+                let _ = enter_i3c_services(&env.mci, i3c_base, services, i3c_target_addr, dot_ctx);
             }
         }
 

--- a/rom/src/i3c.rs
+++ b/rom/src/i3c.rs
@@ -16,6 +16,7 @@ const DEVICE_STATUS_BOOT_FAILURE: u32 = 0x0e;
 const DEVICE_STATUS_FATAL_ERROR: u32 = 0x0f;
 const RECOVERY_STATUS_FAILED: u32 = 0x0c;
 const RECOVERY_REASON_CORRUPTED_CRITICAL_DATA: u32 = 0x0004;
+const RECOVERY_REASON_DOT_BLOB_CORRUPT: u32 = 0x0084;
 
 /// I3C bus timing parameters, in clock units.
 ///
@@ -284,6 +285,19 @@ impl I3c {
     pub fn set_recovery_fatal_error(&self) {
         self.set_recovery_status(RECOVERY_STATUS_FAILED);
         self.set_device_status(DEVICE_STATUS_FATAL_ERROR);
+    }
+
+    pub fn set_recovery_fatal_error_with_reason(&self, recovery_reason: u32) {
+        self.set_recovery_status(RECOVERY_STATUS_FAILED);
+        self.set_device_status_with_recovery_reason(DEVICE_STATUS_FATAL_ERROR, recovery_reason);
+    }
+
+    pub fn recovery_reason_for_fatal_error(error_code: u32) -> Option<u32> {
+        if error_code == u32::from(caliptra_mcu_error::McuError::ROM_COLD_BOOT_DOT_BLOB_CORRUPT_ERROR) {
+            Some(RECOVERY_REASON_DOT_BLOB_CORRUPT)
+        } else {
+            None
+        }
     }
 
     pub fn disable_recovery(&mut self) {

--- a/rom/src/i3c.rs
+++ b/rom/src/i3c.rs
@@ -12,6 +12,11 @@ use tock_registers::interfaces::{ReadWriteable, Readable, Writeable};
 
 use crate::fatal_error;
 
+const DEVICE_STATUS_BOOT_FAILURE: u32 = 0x0e;
+const DEVICE_STATUS_FATAL_ERROR: u32 = 0x0f;
+const RECOVERY_STATUS_FAILED: u32 = 0x0c;
+const RECOVERY_REASON_CORRUPTED_CRITICAL_DATA: u32 = 0x0004;
+
 /// I3C bus timing parameters, in clock units.
 ///
 /// Each value is written to the corresponding `soc_mgmt_if_t_*_reg` timing
@@ -89,6 +94,15 @@ impl I3c {
 
     /// Run the initialization steps for the primary and secondary controller.
     pub fn configure(&mut self, config: I3cConfig) {
+        if let Err(err) = self.try_configure(config) {
+            fatal_error(err);
+        }
+    }
+
+    /// Run I3C initialization and report errors to the caller instead of
+    /// fataling. This is used by fatal-error reporting paths that must not
+    /// recursively enter `fatal_error` if I3C is unavailable.
+    pub fn try_configure(&mut self, config: I3cConfig) -> Result<(), McuError> {
         let I3cConfig {
             static_addr: addr,
             recovery_enabled,
@@ -117,7 +131,7 @@ impl I3c {
             .read(RingHeadersSectionOffset::SectionOffset);
         if rhso != 0 {
             caliptra_mcu_romtime::println!("[mcu-rom-i3c] RING_HEADERS_SECTION_OFFSET is not 0");
-            fatal_error(McuError::ROM_I3C_CONFIG_RING_HEADER_ERROR);
+            return Err(McuError::ROM_I3C_CONFIG_RING_HEADER_ERROR);
         }
 
         // initialize timing registers
@@ -191,7 +205,7 @@ impl I3c {
             caliptra_mcu_romtime::println!(
                 "[mcu-rom-i3c] I3C target transaction support is not enabled"
             );
-            fatal_error(McuError::ROM_I3C_CONFIG_STDBY_CTRL_MODE_ERROR)
+            return Err(McuError::ROM_I3C_CONFIG_STDBY_CTRL_MODE_ERROR);
         }
 
         // program a static address
@@ -237,6 +251,39 @@ impl I3c {
         // enable the PHY connection to the bus
         regs.i3c_base_hc_control
             .modify(HcControl::ModeSelector::SET + HcControl::BusEnable::SET);
+        Ok(())
+    }
+
+    fn set_recovery_status(&self, status: u32) {
+        self.registers
+            .sec_fw_recovery_if_recovery_status
+            .write(RecoveryStatus::DevRecStatus.val(status));
+    }
+
+    fn set_device_status(&self, status: u32) {
+        self.registers
+            .sec_fw_recovery_if_device_status_0
+            .write(DeviceStatus0::DevStatus.val(status));
+    }
+
+    fn set_device_status_with_recovery_reason(&self, status: u32, recovery_reason: u32) {
+        self.registers.sec_fw_recovery_if_device_status_0.write(
+            DeviceStatus0::DevStatus.val(status)
+                + DeviceStatus0::RecReasonCode.val(recovery_reason),
+        );
+    }
+
+    pub fn set_recovery_boot_failure(&self) {
+        self.set_recovery_status(RECOVERY_STATUS_FAILED);
+        self.set_device_status_with_recovery_reason(
+            DEVICE_STATUS_BOOT_FAILURE,
+            RECOVERY_REASON_CORRUPTED_CRITICAL_DATA,
+        );
+    }
+
+    pub fn set_recovery_fatal_error(&self) {
+        self.set_recovery_status(RECOVERY_STATUS_FAILED);
+        self.set_device_status(DEVICE_STATUS_FATAL_ERROR);
     }
 
     pub fn disable_recovery(&mut self) {

--- a/rom/src/lib.rs
+++ b/rom/src/lib.rs
@@ -138,7 +138,7 @@ fn fatal_error_raw(code: u32) -> ! {
     } else {
         // If no handler is set, just set the MCI fatal error code and loop forever
         let mut env = RomEnv::new();
-        env.report_i3c_recovery_fatal_error();
+        env.report_i3c_recovery_fatal_error(code);
         env.mci.set_fw_fatal_error(code);
         loop {}
     }

--- a/rom/src/lib.rs
+++ b/rom/src/lib.rs
@@ -137,7 +137,9 @@ fn fatal_error_raw(code: u32) -> ! {
         handler.fatal_error(code);
     } else {
         // If no handler is set, just set the MCI fatal error code and loop forever
-        RomEnv::new().mci.set_fw_fatal_error(code);
+        let mut env = RomEnv::new();
+        env.report_i3c_recovery_fatal_error();
+        env.mci.set_fw_fatal_error(code);
         loop {}
     }
 }

--- a/rom/src/rom.rs
+++ b/rom/src/rom.rs
@@ -46,6 +46,7 @@ const LMS_CALIPTRA_VALUE: u8 = 3;
 const OTP_DAI_IDLE_BIT_OFFSET: u32 = 22;
 const OTP_STATUS_REG_OFFSET: u32 = 0x10;
 const OTP_DIRECT_ACCESS_CMD_REG_OFFSET: u32 = 0x60;
+const SS_STRAP_GENERIC_3_WAIT_FOR_DEVICE_RESET_BEFORE_FATAL_ERROR: u32 = 1 << 1;
 
 pub const MCU_SRAM_DEFAULT_PROTECTED_REGION_BLOCKS: u32 = 8; // 32 kB / 4 kB chunks
 
@@ -188,6 +189,8 @@ impl Soc {
         mci: &caliptra_mcu_romtime::Mci,
         params: &RomParameters,
     ) -> usize {
+        let straps = unsafe { &MCU_STRAPS };
+
         // secret fuses are populated by a hardware state machine, so we can skip those
 
         // UDS partition base address. (FE offset is calculated automatically by Caliptra ROM.)
@@ -208,6 +211,16 @@ impl Soc {
         self.registers.ss_strap_generic[0]
             .set((OTP_DAI_IDLE_BIT_OFFSET << 16) | OTP_STATUS_REG_OFFSET);
         self.registers.ss_strap_generic[1].set(OTP_DIRECT_ACCESS_CMD_REG_OFFSET);
+
+        // Mirror platform config into Caliptra ROM gate bit
+        // `SS_STRAP_GENERIC[3][1]` (wait for DEVICE_RESET before fatal error).
+        let mut ss_strap_generic_3 = self.registers.ss_strap_generic[3].get();
+        if straps.cptra_wait_for_device_reset_before_fatal_error != 0 {
+            ss_strap_generic_3 |= SS_STRAP_GENERIC_3_WAIT_FOR_DEVICE_RESET_BEFORE_FATAL_ERROR;
+        } else {
+            ss_strap_generic_3 &= !SS_STRAP_GENERIC_3_WAIT_FOR_DEVICE_RESET_BEFORE_FATAL_ERROR;
+        }
+        self.registers.ss_strap_generic[3].set(ss_strap_generic_3);
 
         // Select the vendor public key slot to use.
         let default_policy = DefaultVendorKeyPolicy::new(

--- a/rom/src/rom_env.rs
+++ b/rom/src/rom_env.rs
@@ -15,6 +15,7 @@ Abstract:
 use crate::Soc;
 use caliptra_mcu_registers_generated::{i3c, lc_ctrl, mci, otp_ctrl, soc};
 use caliptra_mcu_romtime::{CaliptraSoC, Lifecycle, Mci, Otp, StaticRef};
+use core::ops::Deref;
 use core::ptr::addr_of;
 
 /// ROM Environment containing all peripherals and managers
@@ -80,6 +81,35 @@ impl RomEnv {
                 soc_manager,
                 straps,
             }
+        }
+    }
+
+    pub fn report_i3c_recovery_fatal_error(&mut self) {
+        let straps = self.straps.deref();
+        if straps.active_i3c == 1 {
+            if let Err(err) = self.i3c1.try_configure(crate::I3cConfig {
+                static_addr: straps.i3c1_static_addr,
+                recovery_enabled: true,
+                timings: crate::I3cTimings::default(),
+            }) {
+                caliptra_mcu_romtime::println!(
+                    "[mcu-rom] Failed to initialize I3C1 for fatal recovery status: {}",
+                    caliptra_mcu_romtime::HexWord(err.into())
+                );
+            }
+            self.i3c1.set_recovery_fatal_error();
+        } else {
+            if let Err(err) = self.i3c.try_configure(crate::I3cConfig {
+                static_addr: straps.i3c_static_addr,
+                recovery_enabled: true,
+                timings: crate::I3cTimings::default(),
+            }) {
+                caliptra_mcu_romtime::println!(
+                    "[mcu-rom] Failed to initialize I3C for fatal recovery status: {}",
+                    caliptra_mcu_romtime::HexWord(err.into())
+                );
+            }
+            self.i3c.set_recovery_fatal_error();
         }
     }
 }

--- a/rom/src/rom_env.rs
+++ b/rom/src/rom_env.rs
@@ -84,8 +84,9 @@ impl RomEnv {
         }
     }
 
-    pub fn report_i3c_recovery_fatal_error(&mut self) {
+    pub fn report_i3c_recovery_fatal_error(&mut self, fatal_error_code: u32) {
         let straps = self.straps.deref();
+        let recovery_reason = crate::i3c::I3c::recovery_reason_for_fatal_error(fatal_error_code);
         if straps.active_i3c == 1 {
             if let Err(err) = self.i3c1.try_configure(crate::I3cConfig {
                 static_addr: straps.i3c1_static_addr,
@@ -97,7 +98,11 @@ impl RomEnv {
                     caliptra_mcu_romtime::HexWord(err.into())
                 );
             }
-            self.i3c1.set_recovery_fatal_error();
+            if let Some(reason) = recovery_reason {
+                self.i3c1.set_recovery_fatal_error_with_reason(reason);
+            } else {
+                self.i3c1.set_recovery_fatal_error();
+            }
         } else {
             if let Err(err) = self.i3c.try_configure(crate::I3cConfig {
                 static_addr: straps.i3c_static_addr,
@@ -109,7 +114,11 @@ impl RomEnv {
                     caliptra_mcu_romtime::HexWord(err.into())
                 );
             }
-            self.i3c.set_recovery_fatal_error();
+            if let Some(reason) = recovery_reason {
+                self.i3c.set_recovery_fatal_error_with_reason(reason);
+            } else {
+                self.i3c.set_recovery_fatal_error();
+            }
         }
     }
 }


### PR DESCRIPTION
Plumb a new MCU strap configuration field into ROM fuse/strap programming so MCU ROM can control Caliptra ROM’s
`SS_STRAP_GENERIC[3][1]` (wait-for-DEVICE_RESET-before-fatal-error) bit.

Changes:
- Add `cptra_wait_for_device_reset_before_fatal_error` to `McuStraps` with default `0`
- Set FPGA platform strap value explicitly to `0`
- In MCU ROM `populate_fuses()`, read `MCU_STRAPS` and update `ss_strap_generic[3]` bit 1 via read-modify-write (preserve other bits)