### PR TITLE
Fix cherry-picker workflow permissions for fork PRs

### DIFF
--- a/.github/workflows/cherry-picker.yml
+++ b/.github/workflows/cherry-picker.yml
@@ -3,7 +3,7 @@
 name: Backport Cherry-Pick with AI Assist
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/cherry-picker.yml
+++ b/.github/workflows/cherry-picker.yml
@@ -2,6 +2,16 @@
 
 name: Backport Cherry-Pick with AI Assist
 
+# NOTE: We use 'pull_request_target' instead of 'pull_request' to ensure the workflow
+# has write permissions to push the backport branch and create the PR, even when
+# triggered by a PR originating from a fork (which are otherwise read-only).
+#
+# SECURITY: 'pull_request_target' runs with write access and secrets.
+# This is SAFE here because:
+# 1. The 'backport' job has a strict guard ('pull_request.merged == true') and only
+#    runs after a maintainer has reviewed and merged the PR.
+# 2. We checkout the trusted base branch (main) by default, not the untrusted PR branch.
+# 3. We only perform git cherry-pick operations and do not run untrusted code/tests.
 on:
   pull_request_target:
     types: [closed]


### PR DESCRIPTION
Use `pull_request_target` instead of `pull_request` to grant `GITHUB_TOKEN` write permissions when the workflow is triggered by a merged PR from a fork.

This fixes the 403 error:
`remote: Permission to chipsalliance/caliptra-mcu-sw.git denied to github-actions[bot].`
which occurs because workflows triggered by `pull_request` from forks are always read-only.