### PR TITLE
docs: add debug unlock transport flows

### DIFF
--- a/docs/src/caliptra_common_commands.md
+++ b/docs/src/caliptra_common_commands.md
@@ -269,6 +269,35 @@ Authorizes the debug unlock token.
 |---------|-----------------|------|----------------------------|
 | 0:3     | completion_code | u32  | Command completion status  |
 
+#### SPDM VDM Flow
+
+Over SPDM VDM, production debug unlock uses the same two-step semantic flow as the MCU mailbox path, but the transport command IDs are `0x0A` and `0x0B`:
+
+1. The requester sends `Request Debug Unlock` (`0x0A`) with the requested `unlock_level`.
+2. The device returns `unique_device_identifier` and a 48-byte `challenge`.
+3. The requester builds the message `unique_device_identifier || unlock_level || reserved || challenge`.
+4. The requester signs that message twice:
+   - ECDSA P-384 over the SHA-384 digest
+   - ML-DSA over the SHA-512 digest
+5. The requester sends `Authorize Debug Unlock Token` (`0x0B`) with the original challenge data, both public keys, and both signatures.
+6. The device verifies the token and enables the requested debug level if validation succeeds.
+
+```mermaid
+sequenceDiagram
+    participant Requester
+    participant Device
+
+    Requester->>Device: SPDM VDM 0x0A Request Debug Unlock(unlock_level)
+    Device-->>Requester: completion_code + UDI + challenge
+    Note over Requester: Build message = UDI || unlock_level || reserved || challenge
+    Note over Requester: Sign with ECDSA P-384 and ML-DSA
+    Requester->>Device: SPDM VDM 0x0B Authorize Debug Unlock Token(token)
+    Note over Device: Verify challenge, UDI, public keys, and signatures
+    Device-->>Requester: completion_code
+```
+
+The token payload is transport-agnostic: the fields and signing inputs are the same as the MCU mailbox path. Only the framing changes between SPDM VDM and mailbox.
+
 ### Export Attested CSR
 
 Exports an attested Certificate Signing Request (CSR) for a specified device key.

--- a/docs/src/external_mailbox_cmds.md
+++ b/docs/src/external_mailbox_cmds.md
@@ -484,6 +484,56 @@ Command Code: `0x4D44_5554` ("MDUT")
 | chksum                   | u32            |                                                                                 |
 | fips_status              | u32            | FIPS approved or an error                                                      |
 
+#### MCU Mailbox Flow
+
+Production debug unlock over the MCU mailbox is a two-command flow:
+
+1. The host sends `MC_PRODUCTION_DEBUG_UNLOCK_REQ` with the requested `unlock_level`.
+2. The MCU returns `unique_device_identifier` and a 48-byte `challenge`.
+3. The host constructs the signed token over `unique_device_identifier || unlock_level || reserved || challenge`.
+4. The host signs that message twice:
+   - ECDSA P-384 over the SHA-384 digest
+   - ML-DSA over the SHA-512 digest
+5. The host sends `MC_PRODUCTION_DEBUG_UNLOCK_TOKEN` with the original challenge data, both public keys, and both signatures.
+6. The MCU verifies the token and unlocks the requested debug level if all checks succeed.
+
+```mermaid
+sequenceDiagram
+    participant Host
+    participant MCU
+
+    Host->>MCU: MC_PRODUCTION_DEBUG_UNLOCK_REQ(unlock_level)
+    MCU-->>Host: UDI + challenge
+    Note over Host: Build message = UDI || unlock_level || reserved || challenge
+    Note over Host: Sign with ECDSA P-384 and ML-DSA
+    Host->>MCU: MC_PRODUCTION_DEBUG_UNLOCK_TOKEN(token)
+    Note over MCU: Verify challenge, UDI, public keys, and signatures
+    MCU-->>Host: fips_status
+```
+
+#### Host-Side Token Construction
+
+The host constructs the token fields as follows:
+
+| **Field** | **Source** |
+|-----------|------------|
+| `unique_device_identifier` | Copied from `MC_PRODUCTION_DEBUG_UNLOCK_REQ` response |
+| `unlock_level` | Same value used in the request |
+| `reserved` | Zero-filled |
+| `challenge` | Copied from `MC_PRODUCTION_DEBUG_UNLOCK_REQ` response |
+| `ecc_public_key` | Public key paired with the ECDSA signing key |
+| `mldsa_public_key` | Public key paired with the ML-DSA signing key |
+| `ecc_signature` | Signature over the mailbox message using ECDSA P-384 |
+| `mldsa_signature` | Signature over the mailbox message using ML-DSA |
+
+The reference host implementation is in `caliptra-util-host/apps/mailbox/client/src/validator.rs`, where the validator:
+
+1. Calls the mailbox request command to fetch the challenge.
+2. Uses the debug unlock signer to build the token.
+3. Sends the mailbox token command to complete the unlock flow.
+
+The signing abstraction is implemented in `common/debug-unlock-signer/src/lib.rs` and the local software signer is in `common/debug-unlock-signer/src/local.rs`.
+
 {{#include fuse_api_cmd.md}}
 
 ### Cryptographic Command Format


### PR DESCRIPTION
## Summary
- add the MCU mailbox production debug unlock flow to the external mailbox commands doc
- add the SPDM VDM production debug unlock flow to the common commands doc
- keep the flow documentation in the main command specs instead of a separate debug unlock doc

## Testing
- verified both edited markdown files for doc-local errors
