### PR TITLE
fix(rom): add mailbox status acknowledgment after DOT override

### DIFF
--- a/rom/src/device_ownership_transfer.rs
+++ b/rom/src/device_ownership_transfer.rs
@@ -628,6 +628,14 @@ pub trait RecoveryTransport {
 
     /// Receive the signed challenge response from the BMC.
     fn receive_override_response(&self) -> McuResult<OverrideChallengeResponse<'_>>;
+
+    /// Notify the BMC of the final override result.
+    ///
+    /// Must be called after `receive_override_response` returns `Ok` to
+    /// acknowledge the DOT_OVERRIDE command back to the sender.  Pass `true`
+    /// when the override completed successfully, or `false` if signature
+    /// verification or fuse/flash operations failed.
+    fn notify_override_result(&self, success: bool);
 }
 
 // ---------------------------------------------------------------------------
@@ -1153,6 +1161,7 @@ pub fn dot_override_challenge_flow(
     };
 
     verify_override_response(&mut env.soc_manager, recovery_pk_hash, &auth).inspect_err(|_e| {
+        transport.notify_override_result(false);
         env.mci
             .set_flow_checkpoint(McuRomBootStatus::DotOverrideFailed.into());
     })?;
@@ -1169,6 +1178,7 @@ pub fn dot_override_challenge_flow(
         stable_key_type,
     )
     .inspect_err(|_e| {
+        transport.notify_override_result(false);
         env.mci
             .set_flow_checkpoint(McuRomBootStatus::DotOverrideFailed.into());
     })?;
@@ -1176,6 +1186,7 @@ pub fn dot_override_challenge_flow(
     env.mci
         .set_flow_checkpoint(McuRomBootStatus::DotOverrideBlobWritten.into());
 
+    transport.notify_override_result(true);
     caliptra_mcu_romtime::println!("[mcu-rom-dot] DOT override complete");
     env.mci
         .set_flow_checkpoint(McuRomBootStatus::DotOverrideComplete.into());

--- a/rom/src/dot_override.rs
+++ b/rom/src/dot_override.rs
@@ -147,6 +147,12 @@ impl Mbox0Helpers {
             .write(mci::bits::MboxCmdStatus::Status::CmdFailure);
     }
 
+    fn cmd_complete(&self) {
+        self.mci
+            .mcu_mbox0_csr_mbox_cmd_status
+            .write(mci::bits::MboxCmdStatus::Status::CmdComplete);
+    }
+
     fn dlen(&self) -> usize {
         self.mci.mcu_mbox0_csr_mbox_dlen.get() as usize
     }
@@ -265,5 +271,13 @@ impl RecoveryTransport for Mbox0RecoveryTransport {
             mldsa_signature,
             mldsa_pub_key,
         })
+    }
+
+    fn notify_override_result(&self, success: bool) {
+        if success {
+            self.helpers.cmd_complete();
+        } else {
+            self.helpers.cmd_failure();
+        }
     }
 }

--- a/tests/integration/src/test_dot.rs
+++ b/tests/integration/src/test_dot.rs
@@ -2021,9 +2021,9 @@ mod test {
         hw.start_mailbox_execute(CMD_DOT_OVERRIDE, &response_payload)
             .expect("Failed to send DOT_OVERRIDE");
 
-        // Step 5: Let the ROM verify signatures, burn fuse, write new blob, and complete.
-        let start = hw.cycle_count();
-        hw.step_until(|m| m.mci_fw_fatal_error().is_some() || m.cycle_count() - start > 20_000_000);
+        // Step 5: Wait for ROM to acknowledge the DOT_OVERRIDE command.
+        hw.finish_mailbox_execute()
+            .expect("DOT_OVERRIDE should complete with CmdComplete status");
 
         // Verify a new DOT blob was written to flash (non-empty, HMAC'd for EVEN state)
         let dot_flash = hw.read_dot_flash();


### PR DESCRIPTION
After receive_override_response() successfully validates the DOT_OVERRIDE command, no mailbox completion status was ever set. The BMC would wait indefinitely for an acknowledgment that never came.

Add notify_override_result() to the RecoveryTransport trait and call it from dot_override_challenge_flow():
- CmdComplete on success (after fuse burn and blob write)
- CmdFailure on post-receive errors (signature verification, apply_override)

Update test_dot_override_challenge_success to call finish_mailbox_execute() after DOT_OVERRIDE, which verifies the CmdComplete status is properly set.

Fixes #1512