### PR TITLE
flash-image: remove magic number from FlashHeader, bump version to 2

### DIFF
--- a/builder/src/flash_image.rs
+++ b/builder/src/flash_image.rs
@@ -5,8 +5,8 @@ use caliptra_mcu_config_emulator::flash::{
     PartitionTable, StandAloneChecksumCalculator, IMAGE_A_PARTITION, IMAGE_B_PARTITION,
 };
 use caliptra_mcu_flash_image::{
-    FlashHeader, ImageHeader, CALIPTRA_FMC_RT_IDENTIFIER, FLASH_IMAGE_MAGIC_NUMBER, HEADER_VERSION,
-    MCU_RT_IDENTIFIER, SOC_IMAGES_BASE_IDENTIFIER, SOC_MANIFEST_IDENTIFIER,
+    FlashHeader, ImageHeader, CALIPTRA_FMC_RT_IDENTIFIER, HEADER_VERSION, MCU_RT_IDENTIFIER,
+    SOC_IMAGES_BASE_IDENTIFIER, SOC_MANIFEST_IDENTIFIER,
 };
 use std::fs::{File, OpenOptions};
 use std::io::{self, Error, ErrorKind, Read, Seek, Write};
@@ -43,7 +43,6 @@ impl<'a> FirmwareImage<'a> {
 impl<'a> FlashImage<'a> {
     pub fn new(images: &'a [FirmwareImage<'a>], image_info: &'a [ImageHeader]) -> Self {
         let mut header = FlashHeader {
-            magic: FLASH_IMAGE_MAGIC_NUMBER.into(),
             version: HEADER_VERSION,
             image_count: image_info.len() as u16,
             image_headers_offset: core::mem::size_of::<FlashHeader>() as u32,
@@ -119,9 +118,6 @@ impl<'a> FlashImage<'a> {
         }
         let header = FlashHeader::read_from_bytes(&image[..HEADER_SIZE])
             .map_err(|_| anyhow!("Failed to parse header: invalid format or size"))?;
-        if header.magic != FLASH_IMAGE_MAGIC_NUMBER {
-            bail!("Invalid header: incorrect magic number or header version.");
-        }
 
         if header.version != HEADER_VERSION {
             bail!("Unsupported header version");
@@ -450,7 +446,6 @@ mod tests {
         let header = FlashHeader::read_from_bytes(&data[..HEADER_SIZE])
             .expect("Failed to parse flash header");
 
-        assert_eq!(header.magic, FLASH_IMAGE_MAGIC_NUMBER);
         assert_eq!(header.version, HEADER_VERSION);
         assert_eq!(header.image_count, 5); // 3 main images + 2 SoC images
 

--- a/common/flash-image/src/lib.rs
+++ b/common/flash-image/src/lib.rs
@@ -3,20 +3,18 @@
 
 use core::mem::offset_of;
 
-use zerocopy::{byteorder::U32, FromBytes, Immutable, IntoBytes, KnownLayout};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 pub const CALIPTRA_FMC_RT_IDENTIFIER: u32 = 0x00000000;
 pub const SOC_MANIFEST_IDENTIFIER: u32 = 0x00000001;
 pub const MCU_RT_IDENTIFIER: u32 = 0x00000002;
 pub const SOC_IMAGES_BASE_IDENTIFIER: u32 = 0x00001000;
 
-pub const FLASH_IMAGE_MAGIC_NUMBER: u32 = u32::from_be_bytes(*b"FLSH");
-pub const HEADER_VERSION: u16 = 0x0001;
+pub const HEADER_VERSION: u16 = 0x0002;
 
 #[repr(C)]
 #[derive(Debug, FromBytes, IntoBytes, Immutable, KnownLayout)]
 pub struct FlashHeader {
-    pub magic: U32<zerocopy::byteorder::BigEndian>,
     pub version: u16,
     pub image_count: u16,
     pub image_headers_offset: u32,
@@ -25,9 +23,6 @@ pub struct FlashHeader {
 
 impl FlashHeader {
     pub fn verify(&self) -> bool {
-        if self.magic.get() != FLASH_IMAGE_MAGIC_NUMBER {
-            return false;
-        }
         if self.version != HEADER_VERSION {
             return false;
         }

--- a/docs/src/flash_layout.md
+++ b/docs/src/flash_layout.md
@@ -43,7 +43,6 @@ The Header section contains the metadata for the images.
 
 | Field          | Size (bytes) | Description                                                                                                                                |
 | -------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| Magic Number   | 4            | A unique identifier to mark the start of the header.<br />The value must be `0x464C5348` (`"FLSH"` in ASCII) for flash or `0x54465450` (`"TFTP"` in ASCII) for Network Boot                              |
 | Header Version | 2            | The header version format, allowing for backward compatibility if the package format changes over time.<br />(Current version is `0x0002`) |
 | Image Count    | 2            | The number of images contained in the `Payload`.<br />Each image will have its own image information section.                                      |
 | Payload Offset | 4            | Offset in bytes of the header to where the first byte of the Payload is located.  |


### PR DESCRIPTION
The `magic` field (`U32<BigEndian>`) has been removed from `FlashHeader` along with the `FLASH_IMAGE_MAGIC_NUMBER` constant and its associated validation in `FlashHeader::verify()`. The header version is bumped from `0x0001` to `0x0002` to reflect the structural change.

### Changes
- `common/flash-image/src/lib.rs`: remove `magic` field, `FLASH_IMAGE_MAGIC_NUMBER` constant, and magic check in `verify()`; bump `HEADER_VERSION` to `0x0002`
- `builder/src/flash_image.rs`: drop magic field from header construction, remove magic-number guard in `verify_flash_image()`, remove corresponding test assertion
- `docs/src/flash_layout.md`: remove Magic Number row from Header table