### PR TITLE
Fix MCTP multi-packet TX hang on FPGA

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -62,7 +62,8 @@ default-filter = """
 (package(caliptra-mcu-tests-integration) and test(jtag::test_manuf_debug_unlock)) |
 (package(caliptra-mcu-tests-integration) and test(test_sw_digest_lock)) |
 (package(caliptra-mcu-tests-integration) and test(test_otp_blank_check)) |
-(package(caliptra-mcu-tests-integration) and test(test_otp_scramble_check))
+(package(caliptra-mcu-tests-integration) and test(test_otp_scramble_check)) |
+(package(caliptra-mcu-tests-integration) and test(test_mctp_capsule_loopback))
 """
 # Disabled because they hang the FPGA at boot (LifecycleControllerState::Dev):
 #   test_sw_digest_lock,

--- a/platforms/emulator/runtime/src/board.rs
+++ b/platforms/emulator/runtime/src/board.rs
@@ -914,6 +914,7 @@ pub unsafe fn main() {
         }
     );
 
+    #[cfg(not(feature = "test-mctp-capsule-loopback"))]
     kernel::process::load_processes(
         board_kernel,
         chip,

--- a/platforms/fpga/runtime/src/board.rs
+++ b/platforms/fpga/runtime/src/board.rs
@@ -883,6 +883,7 @@ pub unsafe fn main() {
         }
     );
 
+    #[cfg(not(feature = "test-mctp-capsule-loopback"))]
     kernel::process::load_processes(
         board_kernel,
         chip,


### PR DESCRIPTION
Skip loading user-app processes when the test-mctp-capsule-loopback feature is
enabled. The user-app SPDM task interferes with the MCTP capsule loopback test
by preventing Tock's kernel loop from processing deferred calls set during I3C
interrupt context, causing multi-packet TX to stall.