### PR TITLE
Implement streaming DebugUnlock and SET_CERTIFICATE

### DIFF
--- a/caliptra-util-host/transport/src/transports/spdm_vdm/commands.rs
+++ b/caliptra-util-host/transport/src/transports/spdm_vdm/commands.rs
@@ -529,7 +529,7 @@ pub fn handle_prod_debug_unlock_req(
     let data = &resp_buf[VDM_RESPONSE_HEADER_SIZE..resp_len];
 
     // Response data: [unique_device_identifier(32), challenge(48)]
-    if data.len() < UNIQUE_DEVICE_ID_SIZE + DEBUG_UNLOCK_CHALLENGE_SIZE {
+    if data.len() != UNIQUE_DEVICE_ID_SIZE + DEBUG_UNLOCK_CHALLENGE_SIZE {
         return Err(TransportError::InvalidMessage);
     }
 
@@ -569,14 +569,15 @@ pub fn handle_prod_debug_unlock_token(
     let req = ProdDebugUnlockTokenRequest::from_bytes(payload)
         .map_err(|_| TransportError::InvalidMessage)?;
 
-    // Build VDM payload in Caliptra RT mailbox format:
-    // [MailboxReqHeader(chksum: u32) | token_struct_bytes...]
-    // The MCU streams this directly to the Caliptra mailbox FIFO.
+    // DebugUnlock is intentionally transported as Caliptra RT mailbox bytes so
+    // the MCU can stream the host-provided request directly into the Caliptra
+    // mailbox FIFO. The checksum must be the first mailbox word and covers the
+    // token body, so building it on the host avoids staging the whole token in
+    // MCU RAM before forwarding.
     let token_bytes = req.as_bytes();
     let hdr_size = core::mem::size_of::<u32>(); // MailboxReqHeader = chksum(u32)
     let total_len = hdr_size + token_bytes.len();
 
-    // Build the payload with zeroed checksum first, then compute
     let mut mbox_payload = vec![0u8; total_len];
     mbox_payload[hdr_size..].copy_from_slice(token_bytes);
     let chksum = calc_checksum(CALIPTRA_RT_CMD_PROD_DEBUG_UNLOCK_TOKEN, &mbox_payload);
@@ -763,6 +764,26 @@ mod tests {
             TransportError::BufferError(msg) => assert!(msg.contains("maximum CSR size")),
             other => panic!("unexpected error: {:?}", other),
         }
+    }
+
+    #[test]
+    fn debug_unlock_req_rejects_trailing_response_bytes() {
+        let req = ProdDebugUnlockReqRequest::new(1);
+        let mut data = vec![0xA5; UNIQUE_DEVICE_ID_SIZE + DEBUG_UNLOCK_CHALLENGE_SIZE + 1];
+        let mut driver = FakeDriver {
+            response: success_response(CaliptraVdmCommand::RequestDebugUnlock, &data),
+            last_request: Vec::new(),
+        };
+        let mut response_buffer = [0u8; core::mem::size_of::<ProdDebugUnlockReqResponse>()];
+
+        let err = handle_prod_debug_unlock_req(req.as_bytes(), &mut driver, &mut response_buffer)
+            .expect_err("DebugUnlock response with trailing bytes must be rejected");
+
+        assert!(matches!(err, TransportError::InvalidMessage));
+        data.truncate(UNIQUE_DEVICE_ID_SIZE + DEBUG_UNLOCK_CHALLENGE_SIZE);
+        driver.response = success_response(CaliptraVdmCommand::RequestDebugUnlock, &data);
+        handle_prod_debug_unlock_req(req.as_bytes(), &mut driver, &mut response_buffer)
+            .expect("exact-length DebugUnlock response should be accepted");
     }
 
     #[test]

--- a/docs/src/caliptra_common_commands.md
+++ b/docs/src/caliptra_common_commands.md
@@ -253,15 +253,16 @@ Authorizes the debug unlock token.
 
 | Byte(s)   | Name                     | Type         | Description                                                                 |
 |-----------|--------------------------|--------------|-----------------------------------------------------------------------------|
-| 0:3       | length                   | u32          | Length of the message in DWORDs                                             |
-| 4:35      | unique_device_identifier | u8[32]       | Device identifier of the Caliptra device                                    |
-| 36        | unlock_level             | u8           | Debug unlock level (1-8)                                                    |
-| 37:39     | reserved                 | u8[3]        | Reserved field                                                              |
-| 40:87     | challenge                | u8[48]       | Random number challenge                                                     |
-| 88:183    | ecc_public_key           | u32[24]      | ECC public key in hardware format (little endian)                           |
-| 184:2635  | mldsa_public_key         | u32[648]     | MLDSA public key in hardware format (little endian)                         |
-| 2636:2731 | ecc_signature            | u32[24]      | ECC P-384 signature of the message hashed using SHA2-384 (R and S coordinates) |
-| 2732:6195 | mldsa_signature          | u32[1157]    | MLDSA signature of the message hashed using SHA2-512 (4627 bytes + 1 reserved byte) |
+| 0:3       | checksum                 | u32          | Caliptra RT mailbox request checksum (`MailboxReqHeader.checksum`)          |
+| 4:7       | length                   | u32          | Length of the message in DWORDs                                             |
+| 8:39      | unique_device_identifier | u8[32]       | Device identifier of the Caliptra device                                    |
+| 40        | unlock_level             | u8           | Debug unlock level (1-8)                                                    |
+| 41:43     | reserved                 | u8[3]        | Reserved field                                                              |
+| 44:91     | challenge                | u8[48]       | Random number challenge                                                     |
+| 92:187    | ecc_public_key           | u32[24]      | ECC public key in hardware format (little endian)                           |
+| 188:2639  | mldsa_public_key         | u32[648]     | MLDSA public key in hardware format (little endian)                         |
+| 2640:2735 | ecc_signature            | u32[24]      | ECC P-384 signature of the message hashed using SHA2-384 (R and S coordinates) |
+| 2736:6199 | mldsa_signature          | u32[1157]    | MLDSA signature of the message hashed using SHA2-512 (4627 bytes + 1 reserved byte) |
 
 **Response Payload**:
 

--- a/docs/src/caliptra_common_commands.md
+++ b/docs/src/caliptra_common_commands.md
@@ -248,6 +248,8 @@ Requests debug unlock in production environment.
 ### Authorize Debug Unlock Token
 
 Authorizes the debug unlock token.
+The request body is identical for MCI mailbox and SPDM VDM transports; the
+leading `checksum` is part of the common command body, not transport framing.
 
 **Request Payload**:
 

--- a/docs/src/caliptra_spdm_vdm_cmds.md
+++ b/docs/src/caliptra_spdm_vdm_cmds.md
@@ -4,7 +4,7 @@
 
 This document describes how Caliptra external commands are transported over SPDM Vendor Defined Messages (VDM) via MCTP. This is the **out-of-band (OOB)** path for accessing Caliptra device management commands from an external agent such as a BMC.
 
-For command definitions (categories, payloads, and completion codes), see [Caliptra Common Commands](caliptra_common_commands.md).
+For command definitions (categories, payloads, and completion codes), see [Caliptra Common Commands](caliptra_common_commands.md). SPDM VDM payloads generally use those command payload definitions directly and do not include Caliptra RT mailbox `MailboxReqHeader` or checksum bytes. `Authorize Debug Unlock Token` is the exception: its VDM payload is a host-prebuilt Caliptra RT mailbox request, including `MailboxReqHeader.checksum`, so the MCU can stream the request bytes unchanged into the Caliptra mailbox FIFO.
 
 For the unified software architecture shared between OOB (SPDM VDM) and in-band (MCI Mailbox) paths, see [Unified Caliptra Command Handling](unified_caliptra_command_handling.md).
 

--- a/docs/src/caliptra_spdm_vdm_cmds.md
+++ b/docs/src/caliptra_spdm_vdm_cmds.md
@@ -92,3 +92,19 @@ The following table maps SPDM VDM command codes to Caliptra common commands. For
 | `0x12`       | Authorized Command           | O   | Execute an authorized sub-command via challenge-response MAC. Sub-commands: Get Auth Challenge (`0x01`), Program Field Entropy (`0x02`). |
 
 R = Required, O = Optional
+
+## Debug Unlock Payloads
+
+`Request Debug Unlock (0x0A)` uses a VDM-specific compact payload, not the
+MCI mailbox layout:
+
+- Request: `unlock_level` (`u8`).
+- Response: completion code (`u8`), unique device identifier (`u8[32]`),
+  then challenge (`u8[48]`).
+
+`Authorize Debug Unlock Token (0x0B)` carries a complete Caliptra RT mailbox
+request as its VDM payload. The first word is `MailboxReqHeader.checksum`,
+followed by the token request body described in
+[Caliptra Common Commands](caliptra_common_commands.md#authorize-debug-unlock-token).
+The MCU preserves these payload bytes exactly and forwards them to the Caliptra
+mailbox; the response is only the VDM completion code.

--- a/docs/src/caliptra_spdm_vdm_cmds.md
+++ b/docs/src/caliptra_spdm_vdm_cmds.md
@@ -4,7 +4,7 @@
 
 This document describes how Caliptra external commands are transported over SPDM Vendor Defined Messages (VDM) via MCTP. This is the **out-of-band (OOB)** path for accessing Caliptra device management commands from an external agent such as a BMC.
 
-For command definitions (categories, payloads, and completion codes), see [Caliptra Common Commands](caliptra_common_commands.md). SPDM VDM payloads generally use those command payload definitions directly and do not include Caliptra RT mailbox `MailboxReqHeader` or checksum bytes. `Authorize Debug Unlock Token` is the exception: its VDM payload is a host-prebuilt Caliptra RT mailbox request, including `MailboxReqHeader.checksum`, so the MCU can stream the request bytes unchanged into the Caliptra mailbox FIFO.
+For command definitions (categories, payloads, and completion codes), see [Caliptra Common Commands](caliptra_common_commands.md).
 
 For the unified software architecture shared between OOB (SPDM VDM) and in-band (MCI Mailbox) paths, see [Unified Caliptra Command Handling](unified_caliptra_command_handling.md).
 

--- a/docs/src/caliptra_spdm_vdm_cmds.md
+++ b/docs/src/caliptra_spdm_vdm_cmds.md
@@ -92,19 +92,3 @@ The following table maps SPDM VDM command codes to Caliptra common commands. For
 | `0x12`       | Authorized Command           | O   | Execute an authorized sub-command via challenge-response MAC. Sub-commands: Get Auth Challenge (`0x01`), Program Field Entropy (`0x02`). |
 
 R = Required, O = Optional
-
-## Debug Unlock Payloads
-
-`Request Debug Unlock (0x0A)` uses a VDM-specific compact payload, not the
-MCI mailbox layout:
-
-- Request: `unlock_level` (`u8`).
-- Response: completion code (`u8`), unique device identifier (`u8[32]`),
-  then challenge (`u8[48]`).
-
-`Authorize Debug Unlock Token (0x0B)` carries a complete Caliptra RT mailbox
-request as its VDM payload. The first word is `MailboxReqHeader.checksum`,
-followed by the token request body described in
-[Caliptra Common Commands](caliptra_common_commands.md#authorize-debug-unlock-token).
-The MCU preserves these payload bytes exactly and forwards them to the Caliptra
-mailbox; the response is only the VDM completion code.

--- a/platforms/emulator/runtime/userspace/apps/example/src/test_caliptra_mailbox.rs
+++ b/platforms/emulator/runtime/userspace/apps/example/src/test_caliptra_mailbox.rs
@@ -157,8 +157,8 @@ pub(crate) async fn test_caliptra_mailbox_chunked() {
         test_exit(1);
     }
 
-    // Step 2: Send data in 4-byte chunks
-    for chunk in req_data.chunks(4) {
+    // Step 2: Send data in 3-byte chunks
+    for chunk in req_data.chunks(3) {
         if let Err(err) = mailbox.send_chunk(chunk).await {
             println!("send_chunk failed with err {:?}", err);
             test_exit(1);

--- a/platforms/emulator/runtime/userspace/apps/user/src/caliptra_cmd_handler/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/caliptra_cmd_handler/mod.rs
@@ -184,7 +184,7 @@ impl CaliptraCmdHandler for CaliptraCmdBackend {
 
         let mut resp_buf = [0u8; core::mem::size_of::<ProductionAuthDebugUnlockChallenge>()];
 
-        let resp_len = execute_mailbox_cmd(
+        execute_mailbox_cmd(
             &mailbox,
             CommandId::PRODUCTION_AUTH_DEBUG_UNLOCK_REQ.0,
             req.as_mut_bytes(),
@@ -192,12 +192,9 @@ impl CaliptraCmdHandler for CaliptraCmdBackend {
         )
         .await
         .map_err(|_| CaliptraCompletionCode::OperationFailed)?;
-        if resp_len != core::mem::size_of::<ProductionAuthDebugUnlockChallenge>() {
-            return Err(CaliptraCompletionCode::OperationFailed);
-        }
 
         let resp = ProductionAuthDebugUnlockChallenge::ref_from_bytes(&resp_buf)
-            .map_err(|_| CaliptraCompletionCode::OperationFailed)?;
+            .map_err(|_| CaliptraCompletionCode::GeneralError)?;
 
         challenge
             .unique_device_identifier

--- a/platforms/emulator/runtime/userspace/apps/user/src/caliptra_cmd_handler/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/caliptra_cmd_handler/mod.rs
@@ -184,7 +184,7 @@ impl CaliptraCmdHandler for CaliptraCmdBackend {
 
         let mut resp_buf = [0u8; core::mem::size_of::<ProductionAuthDebugUnlockChallenge>()];
 
-        execute_mailbox_cmd(
+        let resp_len = execute_mailbox_cmd(
             &mailbox,
             CommandId::PRODUCTION_AUTH_DEBUG_UNLOCK_REQ.0,
             req.as_mut_bytes(),
@@ -192,9 +192,12 @@ impl CaliptraCmdHandler for CaliptraCmdBackend {
         )
         .await
         .map_err(|_| CaliptraCompletionCode::OperationFailed)?;
+        if resp_len != core::mem::size_of::<ProductionAuthDebugUnlockChallenge>() {
+            return Err(CaliptraCompletionCode::OperationFailed);
+        }
 
         let resp = ProductionAuthDebugUnlockChallenge::ref_from_bytes(&resp_buf)
-            .map_err(|_| CaliptraCompletionCode::GeneralError)?;
+            .map_err(|_| CaliptraCompletionCode::OperationFailed)?;
 
         challenge
             .unique_device_identifier

--- a/platforms/emulator/runtime/userspace/apps/user/src/spdm/caliptra_vdm.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/spdm/caliptra_vdm.rs
@@ -45,6 +45,8 @@ const TEST_AUTH_CMD_HMAC_KEY: [u8; 48] = [
 ];
 
 static AUTH_CHALLENGE: Mutex<CriticalSectionRawMutex, Option<[u8; 32]>> = Mutex::new(None);
+// Kernel chunked-mailbox state rejects other processes; this flag serializes this
+// app's DebugUnlock stream and lets abort clean up the in-flight mailbox request.
 static DEBUG_UNLOCK_TOKEN_STREAM: Mutex<CriticalSectionRawMutex, bool> = Mutex::new(false);
 
 /// Emulator Caliptra VDM device-operations backend.

--- a/platforms/emulator/runtime/userspace/apps/user/src/spdm/caliptra_vdm.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/spdm/caliptra_vdm.rs
@@ -14,7 +14,7 @@ use caliptra_mcu_common_commands::{
     CaliptraCompletionCode as CommonCompletionCode, GetLogResult, DEBUG_UNLOCK_CHALLENGE_SIZE,
     DEBUG_UNLOCK_UNIQUE_DEVICE_ID_SIZE,
 };
-use caliptra_mcu_libsyscall_caliptra::mailbox::{ChunkedMailboxRequest, Mailbox, MailboxError};
+use caliptra_mcu_libsyscall_caliptra::mailbox::{Mailbox, MailboxError};
 use caliptra_mcu_libsyscall_caliptra::DefaultSyscalls;
 use caliptra_mcu_libtock_platform::ErrorCode;
 use caliptra_mcu_spdm_traits::SpdmPalAlloc;
@@ -45,10 +45,7 @@ const TEST_AUTH_CMD_HMAC_KEY: [u8; 48] = [
 ];
 
 static AUTH_CHALLENGE: Mutex<CriticalSectionRawMutex, Option<[u8; 32]>> = Mutex::new(None);
-static DEBUG_UNLOCK_TOKEN_STREAM: Mutex<
-    CriticalSectionRawMutex,
-    Option<ChunkedMailboxRequest<DefaultSyscalls>>,
-> = Mutex::new(None);
+static DEBUG_UNLOCK_TOKEN_STREAM: Mutex<CriticalSectionRawMutex, bool> = Mutex::new(false);
 
 /// Emulator Caliptra VDM device-operations backend.
 pub struct CaliptraVdmHook;
@@ -132,22 +129,25 @@ impl CaliptraVdmCommands for CaliptraVdmHook {
         first: &[u8],
         _scratch: &A,
     ) -> CaliptraVdmResult<()> {
-        let mut stream_slot = DEBUG_UNLOCK_TOKEN_STREAM.lock().await;
-        if let Some(stream) = stream_slot.take() {
-            let _ = stream.abort().await;
+        let mut active = DEBUG_UNLOCK_TOKEN_STREAM.lock().await;
+        let mailbox = Mailbox::<DefaultSyscalls>::new();
+        if *active {
+            let _ = mailbox.abort_chunked_request().await;
+            *active = false;
         }
 
-        let stream = Mailbox::<DefaultSyscalls>::new()
-            .start_guarded_chunked_request(PRODUCTION_AUTH_DEBUG_UNLOCK_TOKEN_CMD, token_len)
+        mailbox
+            .start_chunked_request(PRODUCTION_AUTH_DEBUG_UNLOCK_TOKEN_CMD, token_len)
             .await
             .map_err(map_mailbox_error)?;
+        *active = true;
         if !first.is_empty() {
-            if let Err(err) = stream.send_chunk(first).await {
-                let _ = stream.abort().await;
+            if let Err(err) = mailbox.send_chunk(first).await {
+                let _ = mailbox.abort_chunked_request().await;
+                *active = false;
                 return Err(map_mailbox_error(err));
             }
         }
-        *stream_slot = Some(stream);
         Ok(())
     }
 
@@ -159,14 +159,14 @@ impl CaliptraVdmCommands for CaliptraVdmHook {
         if chunk.is_empty() {
             return Ok(());
         }
-        let mut stream_slot = DEBUG_UNLOCK_TOKEN_STREAM.lock().await;
-        let Some(stream) = stream_slot.as_ref() else {
+        let mut active = DEBUG_UNLOCK_TOKEN_STREAM.lock().await;
+        if !*active {
             return Err(CaliptraCompletionCode::InvalidState);
-        };
-        if let Err(err) = stream.send_chunk(chunk).await {
-            if let Some(stream) = stream_slot.take() {
-                let _ = stream.abort().await;
-            }
+        }
+        let mailbox = Mailbox::<DefaultSyscalls>::new();
+        if let Err(err) = mailbox.send_chunk(chunk).await {
+            let _ = mailbox.abort_chunked_request().await;
+            *active = false;
             return Err(map_mailbox_error(err));
         }
         Ok(())
@@ -176,29 +176,36 @@ impl CaliptraVdmCommands for CaliptraVdmHook {
         &self,
         scratch: &A,
     ) -> CaliptraVdmResult<()> {
-        let mut stream_slot = DEBUG_UNLOCK_TOKEN_STREAM.lock().await;
-        let Some(stream) = stream_slot.take() else {
+        let mut active = DEBUG_UNLOCK_TOKEN_STREAM.lock().await;
+        if !*active {
             return Err(CaliptraCompletionCode::InvalidState);
-        };
+        }
+        let mailbox = Mailbox::<DefaultSyscalls>::new();
         let mut resp_buf =
             match ApiAlloc::alloc(scratch, PRODUCTION_AUTH_DEBUG_UNLOCK_TOKEN_RSP_LEN) {
                 Ok(buf) => buf,
                 Err(err) => {
-                    let _ = stream.abort().await;
+                    let _ = mailbox.abort_chunked_request().await;
+                    *active = false;
                     return Err(map_mcu_err(err));
                 }
             };
-        stream
-            .execute(PRODUCTION_AUTH_DEBUG_UNLOCK_TOKEN_CMD, &mut resp_buf)
+        let result = mailbox
+            .execute_chunked_request(PRODUCTION_AUTH_DEBUG_UNLOCK_TOKEN_CMD, &mut resp_buf)
             .await
-            .map_err(map_mailbox_error)?;
+            .map_err(map_mailbox_error);
+        *active = false;
+        result?;
         Ok(())
     }
 
     async fn abort_authorize_debug_unlock_token_stream<A: SpdmPalAlloc>(&self, _scratch: &A) {
-        let mut stream_slot = DEBUG_UNLOCK_TOKEN_STREAM.lock().await;
-        if let Some(stream) = stream_slot.take() {
-            let _ = stream.abort().await;
+        let mut active = DEBUG_UNLOCK_TOKEN_STREAM.lock().await;
+        if *active {
+            let _ = Mailbox::<DefaultSyscalls>::new()
+                .abort_chunked_request()
+                .await;
+            *active = false;
         }
     }
 

--- a/platforms/emulator/runtime/userspace/apps/user/src/spdm/caliptra_vdm.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/spdm/caliptra_vdm.rs
@@ -9,13 +9,12 @@
 
 extern crate alloc;
 
-use alloc::boxed::Box;
 use arrayvec::ArrayVec;
 use caliptra_mcu_common_commands::{
     CaliptraCompletionCode as CommonCompletionCode, GetLogResult, DEBUG_UNLOCK_CHALLENGE_SIZE,
     DEBUG_UNLOCK_UNIQUE_DEVICE_ID_SIZE,
 };
-use caliptra_mcu_libsyscall_caliptra::mailbox::{Mailbox, MailboxError, PayloadStream};
+use caliptra_mcu_libsyscall_caliptra::mailbox::{ChunkedMailboxRequest, Mailbox, MailboxError};
 use caliptra_mcu_libsyscall_caliptra::DefaultSyscalls;
 use caliptra_mcu_libtock_platform::ErrorCode;
 use caliptra_mcu_spdm_traits::SpdmPalAlloc;
@@ -46,6 +45,10 @@ const TEST_AUTH_CMD_HMAC_KEY: [u8; 48] = [
 ];
 
 static AUTH_CHALLENGE: Mutex<CriticalSectionRawMutex, Option<[u8; 32]>> = Mutex::new(None);
+static DEBUG_UNLOCK_TOKEN_STREAM: Mutex<
+    CriticalSectionRawMutex,
+    Option<ChunkedMailboxRequest<DefaultSyscalls>>,
+> = Mutex::new(None);
 
 /// Emulator Caliptra VDM device-operations backend.
 pub struct CaliptraVdmHook;
@@ -110,20 +113,93 @@ impl CaliptraVdmCommands for CaliptraVdmHook {
         scratch: &A,
     ) -> CaliptraVdmResult<()> {
         let cmd = PRODUCTION_AUTH_DEBUG_UNLOCK_TOKEN_CMD;
-        // The host sends the production debug-unlock token payload in Caliptra RT
-        // mailbox format, including the MailboxReqHeader/checksum, and large
-        // requests are streamed directly to the mailbox. Do not synthesize
-        // another checksum header here or the mailbox would receive
-        // `[new_checksum || host_checksum || token]`.
-        let mut token_stream = SlicePayloadStream::new(token_data);
+        // The host sends AuthorizeDebugUnlockToken as a complete Caliptra RT
+        // mailbox request, including MailboxReqHeader.checksum. Preserve those
+        // payload bytes exactly; do not synthesize another mailbox header here.
         let mut resp_buf = ApiAlloc::alloc(scratch, PRODUCTION_AUTH_DEBUG_UNLOCK_TOKEN_RSP_LEN)
             .map_err(map_mcu_err)?;
 
         Mailbox::<DefaultSyscalls>::new()
-            .execute_with_payload_stream(cmd, None, &mut token_stream, &mut resp_buf)
+            .execute_with_payload_slice(cmd, None, token_data, &mut resp_buf)
             .await
             .map_err(map_mailbox_error)?;
         Ok(())
+    }
+
+    async fn start_authorize_debug_unlock_token_stream<A: SpdmPalAlloc>(
+        &self,
+        token_len: usize,
+        first: &[u8],
+        _scratch: &A,
+    ) -> CaliptraVdmResult<()> {
+        let mut stream_slot = DEBUG_UNLOCK_TOKEN_STREAM.lock().await;
+        if let Some(stream) = stream_slot.take() {
+            let _ = stream.abort().await;
+        }
+
+        let stream = Mailbox::<DefaultSyscalls>::new()
+            .start_guarded_chunked_request(PRODUCTION_AUTH_DEBUG_UNLOCK_TOKEN_CMD, token_len)
+            .await
+            .map_err(map_mailbox_error)?;
+        if !first.is_empty() {
+            if let Err(err) = stream.send_chunk(first).await {
+                let _ = stream.abort().await;
+                return Err(map_mailbox_error(err));
+            }
+        }
+        *stream_slot = Some(stream);
+        Ok(())
+    }
+
+    async fn continue_authorize_debug_unlock_token_stream<A: SpdmPalAlloc>(
+        &self,
+        chunk: &[u8],
+        _scratch: &A,
+    ) -> CaliptraVdmResult<()> {
+        if chunk.is_empty() {
+            return Ok(());
+        }
+        let mut stream_slot = DEBUG_UNLOCK_TOKEN_STREAM.lock().await;
+        let Some(stream) = stream_slot.as_ref() else {
+            return Err(CaliptraCompletionCode::InvalidState);
+        };
+        if let Err(err) = stream.send_chunk(chunk).await {
+            if let Some(stream) = stream_slot.take() {
+                let _ = stream.abort().await;
+            }
+            return Err(map_mailbox_error(err));
+        }
+        Ok(())
+    }
+
+    async fn finish_authorize_debug_unlock_token_stream<A: SpdmPalAlloc>(
+        &self,
+        scratch: &A,
+    ) -> CaliptraVdmResult<()> {
+        let mut stream_slot = DEBUG_UNLOCK_TOKEN_STREAM.lock().await;
+        let Some(stream) = stream_slot.take() else {
+            return Err(CaliptraCompletionCode::InvalidState);
+        };
+        let mut resp_buf =
+            match ApiAlloc::alloc(scratch, PRODUCTION_AUTH_DEBUG_UNLOCK_TOKEN_RSP_LEN) {
+                Ok(buf) => buf,
+                Err(err) => {
+                    let _ = stream.abort().await;
+                    return Err(map_mcu_err(err));
+                }
+            };
+        stream
+            .execute(PRODUCTION_AUTH_DEBUG_UNLOCK_TOKEN_CMD, &mut resp_buf)
+            .await
+            .map_err(map_mailbox_error)?;
+        Ok(())
+    }
+
+    async fn abort_authorize_debug_unlock_token_stream<A: SpdmPalAlloc>(&self, _scratch: &A) {
+        let mut stream_slot = DEBUG_UNLOCK_TOKEN_STREAM.lock().await;
+        if let Some(stream) = stream_slot.take() {
+            let _ = stream.abort().await;
+        }
     }
 
     async fn export_attested_csr<A: SpdmPalAlloc>(
@@ -166,40 +242,11 @@ impl CaliptraVdmCommands for CaliptraVdmHook {
     }
 }
 
-struct SlicePayloadStream<'a> {
-    data: &'a [u8],
-    offset: usize,
-}
-
-impl<'a> SlicePayloadStream<'a> {
-    fn new(data: &'a [u8]) -> Self {
-        Self { data, offset: 0 }
-    }
-}
-
-#[async_trait::async_trait(?Send)]
-impl PayloadStream for SlicePayloadStream<'_> {
-    fn size(&self) -> usize {
-        self.data.len()
-    }
-
-    async fn read(&mut self, buffer: &mut [u8]) -> Result<usize, ErrorCode> {
-        let remaining = self.data.len().saturating_sub(self.offset);
-        if remaining == 0 {
-            return Ok(0);
-        }
-        let n = remaining.min(buffer.len());
-        buffer[..n].copy_from_slice(&self.data[self.offset..self.offset + n]);
-        self.offset += n;
-        Ok(n)
-    }
-}
-
 fn map_mcu_err(e: McuErrorCode) -> CaliptraCompletionCode {
     use mcu_error::codes;
     if e == codes::MAILBOX_BUSY {
         CaliptraCompletionCode::CaliptraMailboxBusy
-    } else if e == codes::INVARIANT {
+    } else if e == codes::INVARIANT || e == codes::INTERNAL_BUG {
         CaliptraCompletionCode::OperationFailed
     } else if e.domain() == mcu_error::domain::MEMORY {
         CaliptraCompletionCode::InsufficientResources

--- a/runtime/kernel/capsules/src/mailbox.rs
+++ b/runtime/kernel/capsules/src/mailbox.rs
@@ -121,6 +121,9 @@ pub struct Mailbox<'a, A: Alarm<'a>> {
     current_app: OptionalCell<ProcessId>,
     // Current state of the mailbox state machine.
     state: Cell<MailboxState>,
+    // Trailing request bytes not yet forming a complete FIFO word.
+    pending_bytes: Cell<u8>,
+    pending_word: Cell<u32>,
     // Timeout ticks for the initiated state before auto-resetting to idle.
     // If None, no timeout is enforced.
     timeout_ticks: Option<u32>,
@@ -146,6 +149,8 @@ impl<'a, A: Alarm<'a>> Mailbox<'a, A> {
             apps: grant,
             current_app: OptionalCell::empty(),
             state: Cell::new(MailboxState::Idle),
+            pending_bytes: Cell::new(0),
+            pending_word: Cell::new(0),
             timeout_ticks,
             resp_min_size: Cell::new(0),
             resp_size: Cell::new(0),
@@ -197,7 +202,6 @@ impl<'a, A: Alarm<'a>> Mailbox<'a, A> {
         app_buffer: &ReadableProcessSlice,
     ) -> Result<(), ErrorCode> {
         self.current_app.set(processid);
-        self.state.set(MailboxState::Executing);
 
         // App buffer contains the full payload. The mailbox is 32-bit wide and
         // payload length is delimited by `dlen` (= `app_buffer.len()`), so the
@@ -214,13 +218,14 @@ impl<'a, A: Alarm<'a>> Mailbox<'a, A> {
             }),
         ) {
             Ok(_) => {
+                self.clear_pending();
+                self.state.set(MailboxState::Executing);
                 self.schedule_alarm();
                 Ok(())
             }
             Err(err) => {
                 log_caliptra_error(&err);
-                self.state.set(MailboxState::Idle);
-                self.current_app.take();
+                self.reset_to_idle();
                 Err(ErrorCode::FAIL)
             }
         }
@@ -236,22 +241,22 @@ impl<'a, A: Alarm<'a>> Mailbox<'a, A> {
         if self.state.get() != MailboxState::Idle {
             return Err(ErrorCode::BUSY);
         }
-        self.current_app.set(processid);
-        self.state.set(MailboxState::Initiated);
         self.driver
-            .map(
-                |driver| match driver.initiate_request(command, payload_size) {
+            .map(|driver| {
+                self.current_app.set(processid);
+                self.state.set(MailboxState::Initiated);
+                match driver.initiate_request(command, payload_size) {
                     Ok(()) => {
+                        self.clear_pending();
                         self.schedule_initiate_timeout();
                         Ok(())
                     }
                     Err(_) => {
-                        self.state.set(MailboxState::Idle);
-                        self.current_app.take();
+                        self.reset_to_idle();
                         Err(ErrorCode::FAIL)
                     }
-                },
-            )
+                }
+            })
             .ok_or(ErrorCode::RESERVE)?
     }
 
@@ -304,17 +309,42 @@ impl<'a, A: Alarm<'a>> Mailbox<'a, A> {
         driver: &mut CaliptraSoC,
         app_buffer: &ReadableProcessSlice,
     ) -> Result<(), ErrorCode> {
-        // The mailbox FIFO is 32-bit wide and the payload length is delimited
-        // by `dlen`, so a trailing partial word is zero-padded into a u32
-        // (matching the policy in `start_request`).
-        for chunk in app_buffer.chunks(4) {
-            let mut buf = [0u8; 4];
-            let n = chunk.len();
-            chunk.copy_to_slice(&mut buf[..n]);
-            let data = u32::from_le_bytes(buf);
-            driver.write_data(data).map_err(|_| ErrorCode::FAIL)?;
+        let mut pending_bytes = self.pending_bytes.get() as usize;
+        let mut pending_word = self.pending_word.get();
+
+        for i in 0..app_buffer.len() {
+            pending_word |= u32::from(app_buffer[i].get()) << (pending_bytes * 8);
+            pending_bytes += 1;
+            if pending_bytes == 4 {
+                if driver.write_data(pending_word).is_err() {
+                    self.abort_and_reset(driver);
+                    return Err(ErrorCode::FAIL);
+                }
+                pending_bytes = 0;
+                pending_word = 0;
+            }
         }
+
+        self.pending_bytes.set(pending_bytes as u8);
+        self.pending_word.set(pending_word);
         Ok(())
+    }
+
+    fn clear_pending(&self) {
+        self.pending_bytes.set(0);
+        self.pending_word.set(0);
+    }
+
+    fn reset_to_idle(&self) {
+        let _ = self.alarm.disarm();
+        self.clear_pending();
+        self.state.set(MailboxState::Idle);
+        self.current_app.take();
+    }
+
+    fn abort_and_reset(&self, driver: &mut CaliptraSoC) {
+        driver.abort_request();
+        self.reset_to_idle();
     }
 
     fn abort_initiated_request(&self, processid: ProcessId) -> Result<(), ErrorCode> {
@@ -327,12 +357,8 @@ impl<'a, A: Alarm<'a>> Mailbox<'a, A> {
             return Err(ErrorCode::INVAL);
         }
         self.driver
-            .map(|driver| driver.abort_request())
-            .ok_or(ErrorCode::FAIL)?;
-        let _ = self.alarm.disarm();
-        self.state.set(MailboxState::Idle);
-        self.current_app.take();
-        Ok(())
+            .map(|driver| self.abort_and_reset(driver))
+            .ok_or(ErrorCode::FAIL)
     }
 
     fn execute(&self, processid: ProcessId) -> Result<(), ErrorCode> {
@@ -344,18 +370,22 @@ impl<'a, A: Alarm<'a>> Mailbox<'a, A> {
         if self.current_app.get() != Some(processid) {
             return Err(ErrorCode::INVAL);
         }
-        self.state.set(MailboxState::Executing);
         self.driver
-            .map(|driver| match driver.execute_command() {
-                Ok(()) => {
-                    self.schedule_alarm();
-                    Ok(())
+            .map(|driver| {
+                if self.pending_bytes.get() != 0
+                    && driver.write_data(self.pending_word.get()).is_err()
+                {
+                    self.abort_and_reset(driver);
+                    return Err(ErrorCode::FAIL);
                 }
-                Err(_err) => {
-                    self.state.set(MailboxState::Idle);
-                    self.current_app.take();
-                    Err(ErrorCode::FAIL)
+                if driver.execute_command().is_err() {
+                    self.abort_and_reset(driver);
+                    return Err(ErrorCode::FAIL);
                 }
+                self.clear_pending();
+                self.state.set(MailboxState::Executing);
+                self.schedule_alarm();
+                Ok(())
             })
             .unwrap_or(Err(ErrorCode::FAIL))
     }
@@ -463,13 +493,11 @@ impl<'a, A: Alarm<'a>> AlarmClient for Mailbox<'a, A> {
             MailboxState::Initiated => {
                 // Timeout: user didn't complete the chunked send in time.
                 capsule_debug!("MBOX", "Mailbox initiate timeout: resetting to idle");
-                let _ = self.alarm.disarm();
                 // Release the HW mailbox lock by clearing the execute bit.
                 self.driver.map(|driver| {
                     driver.abort_request();
                 });
-                self.state.set(MailboxState::Idle);
-                self.current_app.take();
+                self.reset_to_idle();
             }
             MailboxState::Executing => {
                 let reschedule = self
@@ -487,9 +515,7 @@ impl<'a, A: Alarm<'a>> AlarmClient for Mailbox<'a, A> {
                 if reschedule {
                     self.schedule_alarm();
                 } else {
-                    let _ = self.alarm.disarm();
-                    self.state.set(MailboxState::Idle);
-                    self.current_app.take();
+                    self.reset_to_idle();
                 }
             }
             MailboxState::Idle => {

--- a/runtime/kernel/capsules/src/mailbox.rs
+++ b/runtime/kernel/capsules/src/mailbox.rs
@@ -326,10 +326,10 @@ impl<'a, A: Alarm<'a>> Mailbox<'a, A> {
         if self.current_app.get() != Some(processid) {
             return Err(ErrorCode::INVAL);
         }
+        self.driver
+            .map(|driver| driver.abort_request())
+            .ok_or(ErrorCode::FAIL)?;
         let _ = self.alarm.disarm();
-        self.driver.map(|driver| {
-            driver.abort_request();
-        });
         self.state.set(MailboxState::Idle);
         self.current_app.take();
         Ok(())

--- a/runtime/kernel/capsules/src/mailbox.rs
+++ b/runtime/kernel/capsules/src/mailbox.rs
@@ -317,6 +317,24 @@ impl<'a, A: Alarm<'a>> Mailbox<'a, A> {
         Ok(())
     }
 
+    fn abort_initiated_request(&self, processid: ProcessId) -> Result<(), ErrorCode> {
+        // Only allowed after initiate_request (command 2).
+        if self.state.get() != MailboxState::Initiated {
+            return Err(ErrorCode::INVAL);
+        }
+        // Verify that the caller is the app that initiated the request.
+        if self.current_app.get() != Some(processid) {
+            return Err(ErrorCode::INVAL);
+        }
+        let _ = self.alarm.disarm();
+        self.driver.map(|driver| {
+            driver.abort_request();
+        });
+        self.state.set(MailboxState::Idle);
+        self.current_app.take();
+        Ok(())
+    }
+
     fn execute(&self, processid: ProcessId) -> Result<(), ErrorCode> {
         // Only allowed after initiate_request (command 2).
         if self.state.get() != MailboxState::Initiated {
@@ -532,6 +550,15 @@ impl<'a, A: Alarm<'a>> SyscallDriver for Mailbox<'a, A> {
             4 => {
                 // Execute the command
                 let res = self.execute(processid);
+                match res {
+                    Ok(()) => CommandReturn::success(),
+                    Err(e) => CommandReturn::failure(e),
+                }
+            }
+
+            5 => {
+                // Abort an initiated chunked command
+                let res = self.abort_initiated_request(processid);
                 match res {
                     Ok(()) => CommandReturn::success(),
                     Err(e) => CommandReturn::failure(e),

--- a/runtime/userspace/api/caliptra-api-lite/src/debug_unlock.rs
+++ b/runtime/userspace/api/caliptra-api-lite/src/debug_unlock.rs
@@ -47,7 +47,7 @@ pub async fn request_debug_unlock_challenge<A: ApiAlloc>(
 
     let mut rsp = alloc.alloc(RSP_LEN)?;
     let rsp_len = mbox_execute(CMD_PRODUCTION_AUTH_DEBUG_UNLOCK_REQ, &req, &mut rsp).await?;
-    if rsp_len < RSP_LEN {
+    if rsp_len != RSP_LEN {
         return Err(INTERNAL_BUG);
     }
 

--- a/runtime/userspace/api/spdm-lib/pal/src/cert/endorsement.rs
+++ b/runtime/userspace/api/spdm-lib/pal/src/cert/endorsement.rs
@@ -438,11 +438,11 @@ impl ManagedEndorsement {
         cert_info: u8,
         root_hash: &[u8; 48],
         data_len: usize,
-        data_checksum: u32,
     ) -> McuResult<Self> {
         if algo != SpdmPalAsymAlgo::EccP384 || data_len > self.der_capacity() {
             return Err(mcu_error::codes::INVARIANT);
         }
+        let data_checksum = self.stored_checksum(data_len).await?;
         let record = ManagedRecord {
             version: MANAGED_FORMAT_VERSION,
             header_size: MANAGED_HEADER_SIZE as u16,

--- a/runtime/userspace/api/spdm-lib/pal/src/cert/endorsement.rs
+++ b/runtime/userspace/api/spdm-lib/pal/src/cert/endorsement.rs
@@ -47,15 +47,6 @@ pub const fn slot_index(slot_id: u8) -> Option<usize> {
     None
 }
 
-/// DPE key indices for device cert chain anchor points.
-/// IDevID (0) is the default.
-#[allow(dead_code)]
-pub const DEVICE_KEY_LDEVID: u8 = 1;
-#[allow(dead_code)]
-pub const DEVICE_KEY_FMC_ALIAS: u8 = 2;
-#[allow(dead_code)]
-pub const DEVICE_KEY_RT_ALIAS: u8 = 3;
-
 /// A single SPDM certificate slot.
 ///
 /// Slots store the endorsement/root portion. The PAL composes the full
@@ -102,7 +93,6 @@ impl CertSlot {
 }
 
 /// Per-slot endorsement cert chain — enum dispatch.
-#[allow(dead_code)]
 pub enum SlotEndorsement {
     /// Not provisioned and not exposed as a supported SPDM slot.
     Empty,
@@ -260,7 +250,6 @@ type CertStoreFlash = SpiFlash<DefaultSyscalls>;
 
 /// Managed flash-backed endorsement/root chain installed by SET_CERTIFICATE.
 #[cfg(feature = "set-certificate")]
-#[allow(dead_code)]
 #[derive(Clone, Copy)]
 pub struct ManagedEndorsement {
     slot: u8,
@@ -277,7 +266,6 @@ pub struct ManagedEndorsement {
 }
 
 #[cfg(feature = "set-certificate")]
-#[allow(dead_code)]
 impl ManagedEndorsement {
     pub const fn new(slot: u8, driver_num: u32, base: usize, capacity: usize) -> Self {
         Self {
@@ -393,6 +381,94 @@ impl ManagedEndorsement {
             .await
             .map_err(map_flash_error)?;
         Ok(n)
+    }
+
+    pub async fn begin_stream_update(
+        mut self,
+        algo: SpdmPalAsymAlgo,
+        data_len: usize,
+    ) -> McuResult<Self> {
+        if algo != SpdmPalAsymAlgo::EccP384 || data_len > self.der_capacity() {
+            return Err(mcu_error::codes::INVARIANT);
+        }
+        self.flash()
+            .erase(self.base, self.capacity)
+            .await
+            .map_err(map_flash_error)?;
+        self.initialized = false;
+        self.len = 0;
+        self.root_hash = [0; 48];
+        self.key_pair_id = 0;
+        self.cert_info = 0;
+        Ok(self)
+    }
+
+    pub async fn write_stream_chunk(&self, offset: usize, data: &[u8]) -> McuResult<()> {
+        let end = offset
+            .checked_add(data.len())
+            .ok_or(mcu_error::codes::INVARIANT)?;
+        if end > self.der_capacity() {
+            return Err(mcu_error::codes::INVARIANT);
+        }
+        if !data.is_empty() {
+            self.flash()
+                .write(self.data_base() + offset, data.len(), data)
+                .await
+                .map_err(map_flash_error)?;
+        }
+        Ok(())
+    }
+
+    pub async fn read_stream_chunk(&self, offset: usize, buf: &mut [u8]) -> McuResult<usize> {
+        if offset >= self.der_capacity() || buf.is_empty() {
+            return Ok(0);
+        }
+        let n = (self.der_capacity() - offset).min(buf.len());
+        self.flash()
+            .read(self.data_base() + offset, n, &mut buf[..n])
+            .await
+            .map_err(map_flash_error)?;
+        Ok(n)
+    }
+
+    pub async fn finish_stream_update(
+        mut self,
+        algo: SpdmPalAsymAlgo,
+        key_pair_id: u8,
+        cert_info: u8,
+        root_hash: &[u8; 48],
+        data_len: usize,
+        data_checksum: u32,
+    ) -> McuResult<Self> {
+        if algo != SpdmPalAsymAlgo::EccP384 || data_len > self.der_capacity() {
+            return Err(mcu_error::codes::INVARIANT);
+        }
+        let record = ManagedRecord {
+            version: MANAGED_FORMAT_VERSION,
+            header_size: MANAGED_HEADER_SIZE as u16,
+            slot: self.slot,
+            algo: MANAGED_ALGO_ECC_P384,
+            key_pair_id,
+            cert_info,
+            key_usage_mask: MANAGED_KEY_USAGE_MASK,
+            cert_len: data_len,
+            data_checksum,
+            root_hash: *root_hash,
+        };
+        let mut header = [MANAGED_ERASED_BYTE; MANAGED_HEADER_SIZE];
+        record.encode(&mut header);
+        self.flash()
+            .write(self.base, MANAGED_HEADER_SIZE, &header)
+            .await
+            .map_err(map_flash_error)?;
+        self.initialized = true;
+        self.algo = algo;
+        self.len = data_len;
+        self.root_hash = *root_hash;
+        self.key_pair_id = key_pair_id;
+        self.cert_info = cert_info;
+        self.key_usage_mask = MANAGED_KEY_USAGE_MASK;
+        Ok(self)
     }
 
     pub async fn write_updated(

--- a/runtime/userspace/api/spdm-lib/pal/src/cert/mod.rs
+++ b/runtime/userspace/api/spdm-lib/pal/src/cert/mod.rs
@@ -64,7 +64,8 @@ async fn validate_streamed_root_hash<M: MeasurementProvider>(
     data_len: usize,
 ) -> McuResult<()> {
     let first_cert_len = streamed_first_der_len(managed, data_len).await?;
-    let sha_buf = ApiAlloc::alloc(pal, mcu_caliptra_api_lite::SHA_CONTEXT_SIZE)?;
+    let sha_buf =
+        mcu_caliptra_api_lite::ApiAlloc::alloc(pal, mcu_caliptra_api_lite::SHA_CONTEXT_SIZE)?;
     let mut state =
         mcu_caliptra_api_lite::sha_init(pal, sha_buf, mcu_caliptra_api_lite::HashAlgo::Sha384, &[])
             .await?;
@@ -438,12 +439,15 @@ impl<M: MeasurementProvider> SpdmPalCertStore for McuSpdmPal<M> {
         slot: u8,
         algo: SpdmPalAsymAlgo,
         _key_pair_id: u8,
-        _cert_info: u8,
+        cert_info: u8,
         _root_hash: &[u8; 48],
         data_len: usize,
     ) -> McuResult<()> {
         #[cfg(feature = "set-certificate")]
         {
+            if cert_info != CERT_MODEL_ALIAS_CERT {
+                return Err(INVARIANT);
+            }
             let idx = slot_index(slot).ok_or(INVARIANT)?;
             self.cert_store.cert_slots()[idx]
                 .write_in_progress
@@ -472,7 +476,7 @@ impl<M: MeasurementProvider> SpdmPalCertStore for McuSpdmPal<M> {
         }
         #[cfg(not(feature = "set-certificate"))]
         {
-            let _ = (slot, algo, data_len);
+            let _ = (slot, algo, cert_info, data_len);
             Err(mcu_error::codes::NOT_IMPLEMENTED)
         }
     }
@@ -568,6 +572,29 @@ impl<M: MeasurementProvider> SpdmPalCertStore for McuSpdmPal<M> {
             Err(mcu_error::codes::NOT_IMPLEMENTED)
         }
     }
+
+    async fn abort_write_cert_chain_stream(
+        &self,
+        _io: &Self::Io<'_>,
+        slot: u8,
+        _algo: SpdmPalAsymAlgo,
+    ) -> McuResult<()> {
+        #[cfg(feature = "set-certificate")]
+        {
+            let idx = slot_index(slot).ok_or(INVARIANT)?;
+            self.cert_store.cert_slots()[idx]
+                .write_in_progress
+                .store(false, Ordering::Relaxed);
+            self.cert_store.invalidate_cert_caches(slot);
+            Ok(())
+        }
+        #[cfg(not(feature = "set-certificate"))]
+        {
+            let _ = slot;
+            Ok(())
+        }
+    }
+
     #[cfg(feature = "set-certificate")]
     async fn erase_cert_chain(
         &self,

--- a/runtime/userspace/api/spdm-lib/pal/src/cert/mod.rs
+++ b/runtime/userspace/api/spdm-lib/pal/src/cert/mod.rs
@@ -52,6 +52,27 @@ impl DpeChainSink for CountSink {
     }
 }
 
+#[cfg(feature = "set-certificate")]
+async fn validate_root_hash<M: MeasurementProvider>(
+    pal: &McuSpdmPal<M>,
+    root_hash: &[u8; 48],
+    cert_chain: &[u8],
+) -> McuResult<()> {
+    let root_cert_len = der_first_seq_len(cert_chain).ok_or(INVARIANT)?;
+    let sha_buf =
+        mcu_caliptra_api_lite::ApiAlloc::alloc(pal, mcu_caliptra_api_lite::SHA_CONTEXT_SIZE)?;
+    let mut state =
+        mcu_caliptra_api_lite::sha_init(pal, sha_buf, mcu_caliptra_api_lite::HashAlgo::Sha384, &[])
+            .await?;
+    mcu_caliptra_api_lite::sha_update(pal, &mut state, &cert_chain[..root_cert_len]).await?;
+    let mut digest = [0u8; 48];
+    mcu_caliptra_api_lite::sha_finish(pal, &mut state, &mut digest).await?;
+    if &digest != root_hash {
+        return Err(INVARIANT);
+    }
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // Streaming SET_CERTIFICATE validation helpers
 // ---------------------------------------------------------------------------
@@ -213,12 +234,13 @@ impl<M: MeasurementProvider> SpdmPalCertStore for McuSpdmPal<M> {
         _slot: u8,
         _key_pair_id: u8,
         cert_model: u8,
-        _root_hash: &[u8; 48],
-        _cert_chain: &[u8],
+        root_hash: &[u8; 48],
+        cert_chain: &[u8],
     ) -> McuResult<()> {
         if cert_model != CERT_MODEL_ALIAS_CERT {
             return Err(INVARIANT);
         }
+        validate_root_hash(self, root_hash, cert_chain).await?;
         Ok(())
     }
 
@@ -520,7 +542,6 @@ impl<M: MeasurementProvider> SpdmPalCertStore for McuSpdmPal<M> {
         cert_info: u8,
         root_hash: &[u8; 48],
         data_len: usize,
-        data_checksum: u32,
     ) -> McuResult<()> {
         #[cfg(feature = "set-certificate")]
         {
@@ -535,14 +556,7 @@ impl<M: MeasurementProvider> SpdmPalCertStore for McuSpdmPal<M> {
                 };
                 validate_streamed_root_hash(self, &managed, root_hash, data_len).await?;
                 let managed = managed
-                    .finish_stream_update(
-                        algo,
-                        key_pair_id,
-                        cert_info,
-                        root_hash,
-                        data_len,
-                        data_checksum,
-                    )
+                    .finish_stream_update(algo, key_pair_id, cert_info, root_hash, data_len)
                     .await?;
                 let cert_slot = self.cert_store.cert_slot_mut(idx).ok_or(INVARIANT)?;
                 cert_slot.endorsement = endorsement::SlotEndorsement::Managed(managed);
@@ -560,15 +574,7 @@ impl<M: MeasurementProvider> SpdmPalCertStore for McuSpdmPal<M> {
         }
         #[cfg(not(feature = "set-certificate"))]
         {
-            let _ = (
-                slot,
-                algo,
-                key_pair_id,
-                cert_info,
-                root_hash,
-                data_len,
-                data_checksum,
-            );
+            let _ = (slot, algo, key_pair_id, cert_info, root_hash, data_len);
             Err(mcu_error::codes::NOT_IMPLEMENTED)
         }
     }
@@ -685,4 +691,53 @@ impl<M: MeasurementProvider> SpdmPalCertStore for McuSpdmPal<M> {
 /// subsequent calls produce identical sizes.
 async fn probe_leaf_len<M: MeasurementProvider>(pal: &McuSpdmPal<M>) -> McuResult<usize> {
     dpe_certify_key_cert_size(pal, &DPE_LEAF_LABEL).await
+}
+
+/// Return the total encoded length of the first DER SEQUENCE in `buf`.
+#[cfg(any(test, feature = "set-certificate"))]
+fn der_first_seq_len(buf: &[u8]) -> Option<usize> {
+    if buf.len() < 2 || buf[0] != 0x30 {
+        return None;
+    }
+    let len_byte = buf[1];
+    let total = if len_byte & 0x80 == 0 {
+        let content = len_byte as usize;
+        if content == 0 {
+            return None;
+        }
+        2usize.checked_add(content)?
+    } else {
+        let n = (len_byte & 0x7f) as usize;
+        if n == 0 || n > 4 || buf.len() < 2 + n {
+            return None;
+        }
+        let mut content = 0usize;
+        for &byte in &buf[2..2 + n] {
+            content = content.checked_shl(8)?;
+            content = content.checked_add(byte as usize)?;
+        }
+        if content == 0 {
+            return None;
+        }
+        2usize.checked_add(n)?.checked_add(content)?
+    };
+    (total <= buf.len()).then_some(total)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::der_first_seq_len;
+
+    #[test]
+    fn der_first_sequence_length() {
+        assert_eq!(der_first_seq_len(&[0x30, 0x01, 0x05]), Some(3));
+
+        let mut long = [0u8; 262];
+        long[..4].copy_from_slice(&[0x30, 0x82, 0x01, 0x02]);
+        assert_eq!(der_first_seq_len(&long), Some(262));
+
+        assert_eq!(der_first_seq_len(&[]), None);
+        assert_eq!(der_first_seq_len(&[0x31, 0x01]), None);
+        assert_eq!(der_first_seq_len(&[0x30]), None);
+    }
 }

--- a/runtime/userspace/api/spdm-lib/pal/src/cert/mod.rs
+++ b/runtime/userspace/api/spdm-lib/pal/src/cert/mod.rs
@@ -23,8 +23,6 @@ use mcu_caliptra_api_lite::{
     dpe_certify_key_cert_size, dpe_certify_key_cert_slice, dpe_get_cert_chain_chunk,
     dpe_sign_ecc_p384, walk_dpe_chain, DpeChainSink, DPE_LABEL_LEN, DPE_MAX_CHUNK_SIZE,
 };
-#[cfg(feature = "set-certificate")]
-use mcu_caliptra_api_lite::{sha_finish, sha_init, sha_update, HashAlgo, SHA_CONTEXT_SIZE};
 use mcu_error::codes::{INTERNAL_BUG, INVARIANT};
 
 /// 48-byte label fed to DPE `CertifyKey`. Keep this stable so DPE
@@ -54,22 +52,83 @@ impl DpeChainSink for CountSink {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Streaming SET_CERTIFICATE validation helpers
+// ---------------------------------------------------------------------------
+
 #[cfg(feature = "set-certificate")]
-async fn validate_root_hash<M: MeasurementProvider>(
+async fn validate_streamed_root_hash<M: MeasurementProvider>(
     pal: &McuSpdmPal<M>,
+    managed: &endorsement::ManagedEndorsement,
     root_hash: &[u8; 48],
-    cert_chain: &[u8],
+    data_len: usize,
 ) -> McuResult<()> {
-    let root_cert_len = der_first_seq_len(cert_chain).ok_or(INVARIANT)?;
-    let sha_buf = pal.allocator.alloc_bytes(SHA_CONTEXT_SIZE)?;
-    let mut state = sha_init(pal.allocator, sha_buf, HashAlgo::Sha384, &[]).await?;
-    sha_update(pal.allocator, &mut state, &cert_chain[..root_cert_len]).await?;
+    let first_cert_len = streamed_first_der_len(managed, data_len).await?;
+    let sha_buf = ApiAlloc::alloc(pal, mcu_caliptra_api_lite::SHA_CONTEXT_SIZE)?;
+    let mut state =
+        mcu_caliptra_api_lite::sha_init(pal, sha_buf, mcu_caliptra_api_lite::HashAlgo::Sha384, &[])
+            .await?;
+    let mut offset = 0usize;
+    let mut buf = [0u8; 256];
+    while offset < first_cert_len {
+        let n = (first_cert_len - offset).min(buf.len());
+        let read = managed.read_stream_chunk(offset, &mut buf[..n]).await?;
+        if read != n {
+            return Err(INVARIANT);
+        }
+        mcu_caliptra_api_lite::sha_update(pal, &mut state, &buf[..n]).await?;
+        offset += n;
+    }
     let mut digest = [0u8; 48];
-    sha_finish(pal.allocator, &mut state, &mut digest).await?;
+    mcu_caliptra_api_lite::sha_finish(pal, &mut state, &mut digest).await?;
     if &digest != root_hash {
         return Err(INVARIANT);
     }
     Ok(())
+}
+
+#[cfg(feature = "set-certificate")]
+async fn streamed_first_der_len(
+    managed: &endorsement::ManagedEndorsement,
+    data_len: usize,
+) -> McuResult<usize> {
+    let mut header = [0u8; 6];
+    if data_len < 2 || managed.read_stream_chunk(0, &mut header[..2]).await? != 2 {
+        return Err(INVARIANT);
+    }
+    if header[0] != 0x30 {
+        return Err(INVARIANT);
+    }
+    let len_byte = header[1];
+    let (header_len, content_len) = if len_byte & 0x80 == 0 {
+        (2usize, len_byte as usize)
+    } else {
+        let len_len = (len_byte & 0x7f) as usize;
+        if len_len == 0 || len_len > 4 || data_len < 2 + len_len {
+            return Err(INVARIANT);
+        }
+        if managed
+            .read_stream_chunk(2, &mut header[2..2 + len_len])
+            .await?
+            != len_len
+        {
+            return Err(INVARIANT);
+        }
+        let mut content_len = 0usize;
+        for &byte in &header[2..2 + len_len] {
+            content_len = content_len.checked_shl(8).ok_or(INVARIANT)?;
+            content_len = content_len.checked_add(byte as usize).ok_or(INVARIANT)?;
+        }
+        (2 + len_len, content_len)
+    };
+    if content_len == 0 {
+        return Err(INVARIANT);
+    }
+    let cert_len = header_len.checked_add(content_len).ok_or(INVARIANT)?;
+    if cert_len > data_len {
+        return Err(INVARIANT);
+    }
+    Ok(cert_len)
 }
 
 // ---------------------------------------------------------------------------
@@ -153,13 +212,12 @@ impl<M: MeasurementProvider> SpdmPalCertStore for McuSpdmPal<M> {
         _slot: u8,
         _key_pair_id: u8,
         cert_model: u8,
-        root_hash: &[u8; 48],
-        cert_chain: &[u8],
+        _root_hash: &[u8; 48],
+        _cert_chain: &[u8],
     ) -> McuResult<()> {
         if cert_model != CERT_MODEL_ALIAS_CERT {
             return Err(INVARIANT);
         }
-        validate_root_hash(self, root_hash, cert_chain).await?;
         Ok(())
     }
 
@@ -374,6 +432,142 @@ impl<M: MeasurementProvider> SpdmPalCertStore for McuSpdmPal<M> {
         Ok(())
     }
 
+    async fn begin_write_cert_chain_stream(
+        &self,
+        _io: &Self::Io<'_>,
+        slot: u8,
+        algo: SpdmPalAsymAlgo,
+        _key_pair_id: u8,
+        _cert_info: u8,
+        _root_hash: &[u8; 48],
+        data_len: usize,
+    ) -> McuResult<()> {
+        #[cfg(feature = "set-certificate")]
+        {
+            let idx = slot_index(slot).ok_or(INVARIANT)?;
+            self.cert_store.cert_slots()[idx]
+                .write_in_progress
+                .store(true, Ordering::Relaxed);
+            let result = async {
+                let managed = match &self.cert_store.cert_slots()[idx].endorsement {
+                    endorsement::SlotEndorsement::Managed(e) => *e,
+                    endorsement::SlotEndorsement::ReadOnly(_) => {
+                        return Err(mcu_error::codes::NOT_IMPLEMENTED);
+                    }
+                    endorsement::SlotEndorsement::Empty => return Err(INVARIANT),
+                };
+                let managed = managed.begin_stream_update(algo, data_len).await?;
+                let cert_slot = self.cert_store.cert_slot_mut(idx).ok_or(INVARIANT)?;
+                cert_slot.endorsement = endorsement::SlotEndorsement::Managed(managed);
+                cert_slot.clear_metadata();
+                Ok(())
+            }
+            .await;
+            if result.is_err() {
+                self.cert_store.cert_slots()[idx]
+                    .write_in_progress
+                    .store(false, Ordering::Relaxed);
+            }
+            result
+        }
+        #[cfg(not(feature = "set-certificate"))]
+        {
+            let _ = (slot, algo, data_len);
+            Err(mcu_error::codes::NOT_IMPLEMENTED)
+        }
+    }
+
+    async fn write_cert_chain_stream_chunk(
+        &self,
+        _io: &Self::Io<'_>,
+        slot: u8,
+        algo: SpdmPalAsymAlgo,
+        offset: usize,
+        data: &[u8],
+    ) -> McuResult<()> {
+        #[cfg(feature = "set-certificate")]
+        {
+            let idx = slot_index(slot).ok_or(INVARIANT)?;
+            let managed = match &self.cert_store.cert_slots()[idx].endorsement {
+                endorsement::SlotEndorsement::Managed(e) => *e,
+                endorsement::SlotEndorsement::ReadOnly(_) => {
+                    return Err(mcu_error::codes::NOT_IMPLEMENTED);
+                }
+                endorsement::SlotEndorsement::Empty => return Err(INVARIANT),
+            };
+            if algo != SpdmPalAsymAlgo::EccP384 {
+                return Err(INVARIANT);
+            }
+            managed.write_stream_chunk(offset, data).await
+        }
+        #[cfg(not(feature = "set-certificate"))]
+        {
+            let _ = (slot, algo, offset, data);
+            Err(mcu_error::codes::NOT_IMPLEMENTED)
+        }
+    }
+
+    async fn finish_write_cert_chain_stream(
+        &self,
+        _io: &Self::Io<'_>,
+        slot: u8,
+        algo: SpdmPalAsymAlgo,
+        key_pair_id: u8,
+        cert_info: u8,
+        root_hash: &[u8; 48],
+        data_len: usize,
+        data_checksum: u32,
+    ) -> McuResult<()> {
+        #[cfg(feature = "set-certificate")]
+        {
+            let idx = slot_index(slot).ok_or(INVARIANT)?;
+            let result = async {
+                let managed = match &self.cert_store.cert_slots()[idx].endorsement {
+                    endorsement::SlotEndorsement::Managed(e) => *e,
+                    endorsement::SlotEndorsement::ReadOnly(_) => {
+                        return Err(mcu_error::codes::NOT_IMPLEMENTED);
+                    }
+                    endorsement::SlotEndorsement::Empty => return Err(INVARIANT),
+                };
+                validate_streamed_root_hash(self, &managed, root_hash, data_len).await?;
+                let managed = managed
+                    .finish_stream_update(
+                        algo,
+                        key_pair_id,
+                        cert_info,
+                        root_hash,
+                        data_len,
+                        data_checksum,
+                    )
+                    .await?;
+                let cert_slot = self.cert_store.cert_slot_mut(idx).ok_or(INVARIANT)?;
+                cert_slot.endorsement = endorsement::SlotEndorsement::Managed(managed);
+                cert_slot.key_pair_id = Some(key_pair_id);
+                cert_slot.cert_info = Some(cert_info);
+                Ok(())
+            }
+            .await;
+            self.cert_store.cert_slots()[idx]
+                .write_in_progress
+                .store(false, Ordering::Relaxed);
+            result?;
+            self.cert_store.invalidate_cert_caches(slot);
+            Ok(())
+        }
+        #[cfg(not(feature = "set-certificate"))]
+        {
+            let _ = (
+                slot,
+                algo,
+                key_pair_id,
+                cert_info,
+                root_hash,
+                data_len,
+                data_checksum,
+            );
+            Err(mcu_error::codes::NOT_IMPLEMENTED)
+        }
+    }
     #[cfg(feature = "set-certificate")]
     async fn erase_cert_chain(
         &self,
@@ -464,71 +658,4 @@ impl<M: MeasurementProvider> SpdmPalCertStore for McuSpdmPal<M> {
 /// subsequent calls produce identical sizes.
 async fn probe_leaf_len<M: MeasurementProvider>(pal: &McuSpdmPal<M>) -> McuResult<usize> {
     dpe_certify_key_cert_size(pal, &DPE_LEAF_LABEL).await
-}
-
-/// Parse `len(TLV)` for the leading X.509 `SEQUENCE` in `buf` and
-/// return `tag_and_length_bytes + content_bytes` — i.e. the total
-/// DER encoding size of the first certificate in the chain. Returns
-/// `None` on malformed input.
-#[allow(dead_code)]
-fn der_first_seq_len(buf: &[u8]) -> Option<usize> {
-    // Tag 0x30 = SEQUENCE.
-    if buf.len() < 2 || buf[0] != 0x30 {
-        return None;
-    }
-    let len_byte = buf[1];
-    let total = if len_byte & 0x80 == 0 {
-        // Short form: length fits in 7 bits.
-        let content = len_byte as usize;
-        if content == 0 {
-            return None;
-        }
-        2usize.checked_add(content)?
-    } else {
-        // Long form: low 7 bits = number of length bytes.
-        let n = (len_byte & 0x7f) as usize;
-        if n == 0 || n > 4 || buf.len() < 2 + n {
-            return None;
-        }
-        let mut content = 0usize;
-        for &b in &buf[2..2 + n] {
-            content = content.checked_shl(8)?;
-            content = content.checked_add(b as usize)?;
-        }
-        if content == 0 {
-            return None;
-        }
-        2usize.checked_add(n)?.checked_add(content)?
-    };
-    (total <= buf.len()).then_some(total)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::der_first_seq_len;
-
-    #[test]
-    fn der_short_form() {
-        // SEQUENCE { 0x05 } len-byte = 0x01 → total = 2 + 1 = 3
-        assert_eq!(der_first_seq_len(&[0x30, 0x01, 0x05]), Some(3));
-    }
-
-    #[test]
-    fn der_long_form_two_byte_len() {
-        // SEQUENCE, length-of-length = 2, content_len = 0x0102 = 258
-        // Total DER encoding = tag(1) + len-of-len(1) + len(2) + content(258) = 262
-        let mut buf = [0u8; 262];
-        buf[0] = 0x30;
-        buf[1] = 0x82;
-        buf[2] = 0x01;
-        buf[3] = 0x02;
-        assert_eq!(der_first_seq_len(&buf), Some(262));
-    }
-
-    #[test]
-    fn der_malformed_returns_none() {
-        assert_eq!(der_first_seq_len(&[]), None);
-        assert_eq!(der_first_seq_len(&[0x31, 0x01]), None); // wrong tag
-        assert_eq!(der_first_seq_len(&[0x30]), None); // truncated
-    }
 }

--- a/runtime/userspace/api/spdm-lib/stack/Cargo.toml
+++ b/runtime/userspace/api/spdm-lib/stack/Cargo.toml
@@ -24,6 +24,7 @@ futures.workspace = true
 [features]
 default = []
 set-certificate = ["caliptra-mcu-spdm-traits/set-certificate"]
+generic-large-request = []
 debug-trace = [
   "caliptra-mcu-libtock_console",
   "caliptra-mcu-libsyscall-caliptra",

--- a/runtime/userspace/api/spdm-lib/stack/src/chunk/mod.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/chunk/mod.rs
@@ -92,6 +92,7 @@ pub(crate) struct StreamPrefixState {
 
 #[derive(Copy, Clone)]
 pub(crate) enum ActiveLargeRequest {
+    #[cfg(any(test, feature = "generic-large-request"))]
     Buffered,
     #[cfg(feature = "set-certificate")]
     Prefix(StreamPrefixState),
@@ -178,6 +179,7 @@ impl<L: core::ops::DerefMut<Target = [u8]>> LargeMessageCtx<L> {
         matches!(self.mode, LargeMessageMode::Idle)
     }
 
+    #[cfg(any(test, feature = "generic-large-request"))]
     pub fn init_request(
         &mut self,
         handle: u8,
@@ -263,6 +265,7 @@ impl<L: core::ops::DerefMut<Target = [u8]>> LargeMessageCtx<L> {
         Ok(())
     }
 
+    #[cfg(any(test, feature = "generic-large-request"))]
     pub fn append_request(
         &mut self,
         handle: u8,

--- a/runtime/userspace/api/spdm-lib/stack/src/chunk/mod.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/chunk/mod.rs
@@ -6,7 +6,7 @@ mod get;
 mod send;
 
 pub(crate) use get::handle_chunk_get;
-pub(crate) use send::abort_streaming_request_if_needed;
+pub(crate) use send::abort_active_streaming_request;
 pub(crate) use send::handle_chunk_send;
 
 use caliptra_mcu_spdm_traits::{PalBytes, SpdmPal, SpdmPalAlloc, SpdmPalIoTransport};
@@ -98,8 +98,6 @@ pub(crate) enum ActiveLargeRequest {
     Prefix(StreamPrefixState),
     #[cfg(feature = "set-certificate")]
     SetCertificate(crate::set_certificate::SetCertificateStreamState),
-    #[cfg(feature = "set-certificate")]
-    Unsupported(SpdmError),
     VendorDefined(VendorDefinedStreamState),
 }
 

--- a/runtime/userspace/api/spdm-lib/stack/src/chunk/mod.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/chunk/mod.rs
@@ -6,6 +6,7 @@ mod get;
 mod send;
 
 pub(crate) use get::handle_chunk_get;
+pub(crate) use send::abort_streaming_request_if_needed;
 pub(crate) use send::handle_chunk_send;
 
 use caliptra_mcu_spdm_traits::{PalBytes, SpdmPal, SpdmPalAlloc, SpdmPalIoTransport};
@@ -70,18 +71,41 @@ impl ChunkState {
     pub(crate) fn reset(&mut self) {
         *self = Self::default();
     }
+}
 
-    #[inline]
-    #[allow(dead_code)]
-    pub(crate) fn in_progress(&self) -> bool {
-        self.in_use
-    }
+#[derive(Copy, Clone)]
+pub(crate) struct VendorDefinedStreamState {
+    pub(crate) standard_id: u16,
+    pub(crate) vendor_id: [u8; 4],
+    pub(crate) vendor_id_len: u8,
+}
+
+#[cfg(feature = "set-certificate")]
+pub(crate) const STREAM_PREFIX_CAPACITY: usize = 96;
+
+#[cfg(feature = "set-certificate")]
+#[derive(Copy, Clone)]
+pub(crate) struct StreamPrefixState {
+    pub(crate) data: [u8; STREAM_PREFIX_CAPACITY],
+    pub(crate) len: usize,
+}
+
+#[derive(Copy, Clone)]
+pub(crate) enum ActiveLargeRequest {
+    Buffered,
+    #[cfg(feature = "set-certificate")]
+    Prefix(StreamPrefixState),
+    #[cfg(feature = "set-certificate")]
+    SetCertificate(crate::set_certificate::SetCertificateStreamState),
+    #[cfg(feature = "set-certificate")]
+    Unsupported(SpdmError),
+    VendorDefined(VendorDefinedStreamState),
 }
 
 #[derive(Copy, Clone)]
 pub(crate) enum LargeMessageMode {
     Idle,
-    Request,
+    Request(ActiveLargeRequest),
     Response(ActiveLargeResponse),
 }
 
@@ -128,14 +152,22 @@ impl<L: core::ops::DerefMut<Target = [u8]>> LargeMessageCtx<L> {
         self.buf.as_ref()
     }
 
-    /// Access the underlying buffer to mutably modify.
-    #[allow(dead_code)]
-    pub fn get_buffer_mut(&mut self) -> Option<&mut L> {
-        self.buf.as_mut()
+    pub fn request_in_progress(&self) -> bool {
+        matches!(self.mode, LargeMessageMode::Request(_)) && self.state.in_use
     }
 
-    pub fn request_in_progress(&self) -> bool {
-        matches!(self.mode, LargeMessageMode::Request) && self.state.in_use
+    pub(crate) fn active_request(&self) -> Option<&ActiveLargeRequest> {
+        match &self.mode {
+            LargeMessageMode::Request(active) if self.state.in_use => Some(active),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn active_request_mut(&mut self) -> Option<&mut ActiveLargeRequest> {
+        match &mut self.mode {
+            LargeMessageMode::Request(active) if self.state.in_use => Some(active),
+            _ => None,
+        }
     }
 
     pub fn response_in_progress(&self) -> bool {
@@ -157,7 +189,7 @@ impl<L: core::ops::DerefMut<Target = [u8]>> LargeMessageCtx<L> {
             return Err(SPDM_UNEXPECTED_REQUEST);
         }
 
-        self.mode = LargeMessageMode::Request;
+        self.mode = LargeMessageMode::Request(ActiveLargeRequest::Buffered);
         self.state = ChunkState {
             in_use: true,
             handle,
@@ -172,6 +204,62 @@ impl<L: core::ops::DerefMut<Target = [u8]>> LargeMessageCtx<L> {
             *d = *s;
         }
         self.buf = Some(rent_buf);
+        Ok(())
+    }
+
+    pub(crate) fn init_streaming_request(
+        &mut self,
+        handle: u8,
+        total_size: usize,
+        initial_chunk_len: usize,
+        active: ActiveLargeRequest,
+    ) -> Result<(), SpdmError> {
+        if !self.is_idle() {
+            return Err(SPDM_UNEXPECTED_REQUEST);
+        }
+        self.mode = LargeMessageMode::Request(active);
+        self.state = ChunkState {
+            in_use: true,
+            handle,
+            seq_num: 0,
+            bytes_received: initial_chunk_len as u32,
+            large_msg_size: total_size as u32,
+        };
+        Ok(())
+    }
+
+    #[cfg(feature = "set-certificate")]
+    pub(crate) fn replace_active_request(
+        &mut self,
+        active: ActiveLargeRequest,
+    ) -> Result<(), SpdmError> {
+        if !self.request_in_progress() {
+            return Err(SPDM_INVALID_REQUEST);
+        }
+        self.mode = LargeMessageMode::Request(active);
+        Ok(())
+    }
+
+    pub(crate) fn append_streaming_request(
+        &mut self,
+        handle: u8,
+        seq_num: u16,
+        chunk_len: usize,
+    ) -> Result<(), SpdmError> {
+        if !self.request_in_progress()
+            || self.state.handle != handle
+            || self.state.seq_num.wrapping_add(1) != seq_num
+        {
+            return Err(SPDM_INVALID_REQUEST);
+        }
+        let end = (self.state.bytes_received as usize)
+            .checked_add(chunk_len)
+            .ok_or(SPDM_UNSPECIFIED)?;
+        if end > self.state.large_msg_size as usize {
+            return Err(SPDM_INVALID_REQUEST);
+        }
+        self.state.bytes_received = end as u32;
+        self.state.seq_num = seq_num;
         Ok(())
     }
 
@@ -203,40 +291,6 @@ impl<L: core::ops::DerefMut<Target = [u8]>> LargeMessageCtx<L> {
         self.state.bytes_received = end as u32;
         self.state.seq_num = seq_num;
         Ok(())
-    }
-
-    /// Securely processes the fully assembled request via a scoped loan closure hook,
-    /// guaranteeing zero-wipe and clean reset regardless of success or early error pathways.
-    ///
-    /// # Example (e.g., `SET_CERTIFICATE` reassembly dispatch):
-    /// ```ignore
-    /// state.large_msg_ctx.with_request_buf(len, |assembled_req| {
-    ///     set_certificate::handle_set_certificate_request(state, pal, io, assembled_req).await
-    /// })
-    /// ```
-    ///
-    /// Evaluates the reassembled payload bytes within the scoped closure. On exit (success or error),
-    /// the context unconditionally zero-fills the underlying memory and resets the chunk state.
-    #[allow(dead_code)]
-    pub fn with_request_buf<F, R>(&mut self, len: usize, op: F) -> Result<R, SpdmError>
-    where
-        F: FnOnce(&[u8]) -> Result<R, SpdmError>,
-    {
-        if !self.state.in_use
-            || self.state.bytes_received as usize != self.state.large_msg_size as usize
-        {
-            return Err(SPDM_INVALID_REQUEST);
-        }
-
-        let buf = self.buf.as_deref_mut().ok_or(SPDM_UNSPECIFIED)?;
-        let request_slice = buf.get(..len).ok_or(SPDM_INVALID_REQUEST)?;
-
-        let result = op(request_slice);
-
-        buf.fill(0);
-        self.reset();
-
-        result
     }
 
     pub(crate) fn next_handle(&self) -> u8 {

--- a/runtime/userspace/api/spdm-lib/stack/src/chunk/mod.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/chunk/mod.rs
@@ -64,6 +64,7 @@ pub(crate) struct ChunkState {
     pub(super) seq_num: u16,
     pub(super) bytes_received: u32,
     pub(super) large_msg_size: u32,
+    pub(super) session_id: Option<u32>,
 }
 
 impl ChunkState {
@@ -73,15 +74,8 @@ impl ChunkState {
     }
 }
 
-#[derive(Copy, Clone)]
-pub(crate) struct VendorDefinedStreamState {
-    pub(crate) standard_id: u16,
-    pub(crate) vendor_id: [u8; 4],
-    pub(crate) vendor_id_len: u8,
-}
-
 #[cfg(feature = "set-certificate")]
-pub(crate) const STREAM_PREFIX_CAPACITY: usize = 96;
+pub(crate) const STREAM_PREFIX_CAPACITY: usize = 56;
 
 #[cfg(feature = "set-certificate")]
 #[derive(Copy, Clone)]
@@ -98,7 +92,7 @@ pub(crate) enum ActiveLargeRequest {
     Prefix(StreamPrefixState),
     #[cfg(feature = "set-certificate")]
     SetCertificate(crate::set_certificate::SetCertificateStreamState),
-    VendorDefined(VendorDefinedStreamState),
+    AuthorizeDebugUnlockToken,
 }
 
 #[derive(Copy, Clone)]
@@ -184,6 +178,7 @@ impl<L: core::ops::DerefMut<Target = [u8]>> LargeMessageCtx<L> {
         total_size: usize,
         initial_chunk: &[u8],
         mut rent_buf: L,
+        session_id: Option<u32>,
     ) -> Result<(), SpdmError> {
         if !self.is_idle() {
             return Err(SPDM_UNEXPECTED_REQUEST);
@@ -196,6 +191,7 @@ impl<L: core::ops::DerefMut<Target = [u8]>> LargeMessageCtx<L> {
             seq_num: 0,
             bytes_received: initial_chunk.len() as u32,
             large_msg_size: total_size as u32,
+            session_id,
         };
         let dest = rent_buf
             .get_mut(..initial_chunk.len())
@@ -213,6 +209,7 @@ impl<L: core::ops::DerefMut<Target = [u8]>> LargeMessageCtx<L> {
         total_size: usize,
         initial_chunk_len: usize,
         active: ActiveLargeRequest,
+        session_id: Option<u32>,
     ) -> Result<(), SpdmError> {
         if !self.is_idle() {
             return Err(SPDM_UNEXPECTED_REQUEST);
@@ -224,6 +221,7 @@ impl<L: core::ops::DerefMut<Target = [u8]>> LargeMessageCtx<L> {
             seq_num: 0,
             bytes_received: initial_chunk_len as u32,
             large_msg_size: total_size as u32,
+            session_id,
         };
         Ok(())
     }

--- a/runtime/userspace/api/spdm-lib/stack/src/chunk/send.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/chunk/send.rs
@@ -37,8 +37,18 @@ pub(crate) async fn handle_chunk_send<'a, Pal: SpdmPal, Vdm: SpdmVdmBackend>(
     vdm: &Vdm,
     req: &[u8],
     secure_session: bool,
+    set_certificate_allowed: bool,
 ) -> SpdmResult<PalBytes<'a, Pal>> {
-    let result = process_chunk_send(state, pal, io, vdm, req, secure_session).await;
+    let result = process_chunk_send(
+        state,
+        pal,
+        io,
+        vdm,
+        req,
+        secure_session,
+        set_certificate_allowed,
+    )
+    .await;
     match result {
         Ok(info) => {
             if info.complete {
@@ -73,7 +83,7 @@ pub(crate) async fn handle_chunk_send<'a, Pal: SpdmPal, Vdm: SpdmVdmBackend>(
             handle,
             chunk_seq_num,
         }) => {
-            abort_streaming_request_if_needed(state, pal, io, vdm).await;
+            abort_active_streaming_request(state, pal, io, vdm).await;
             let mut error = [0u8; 4];
             encode_error_pdu(state.version, SPDM_INVALID_REQUEST, &mut error);
             state.reset_chunk_assembly();
@@ -125,6 +135,7 @@ async fn process_chunk_send<Pal: SpdmPal, Vdm: SpdmVdmBackend>(
     vdm: &Vdm,
     req: &[u8],
     secure_session: bool,
+    set_certificate_allowed: bool,
 ) -> Result<ChunkInfo, ChunkProcessError> {
     if state.large_msg_ctx.response_in_progress()
         || (state.phase as u8) < (Phase::AfterCapabilities as u8)
@@ -170,6 +181,7 @@ async fn process_chunk_send<Pal: SpdmPal, Vdm: SpdmVdmBackend>(
             last_chunk,
             rest,
             secure_session,
+            set_certificate_allowed,
         )
         .await?;
     } else {
@@ -207,6 +219,7 @@ async fn process_first_chunk<Pal: SpdmPal, Vdm: SpdmVdmBackend>(
     last_chunk: bool,
     rest: &[u8],
     secure_session: bool,
+    set_certificate_allowed: bool,
 ) -> Result<(), ChunkProcessError> {
     let Some(size_bytes) = rest.first_chunk::<4>() else {
         return Err(ChunkProcessError::Early {
@@ -249,7 +262,13 @@ async fn process_first_chunk<Pal: SpdmPal, Vdm: SpdmVdmBackend>(
     }
     #[cfg(feature = "set-certificate")]
     {
-        if let Some(required_len) = required_stream_prefix_len(chunk, secure_session) {
+        if let Some(required_len) = required_stream_prefix_len(chunk) {
+            if !set_certificate_allowed {
+                return Err(ChunkProcessError::Early {
+                    handle,
+                    chunk_seq_num,
+                });
+            }
             let mut prefix = StreamPrefixState {
                 data: [0; super::STREAM_PREFIX_CAPACITY],
                 len: chunk.len(),
@@ -285,6 +304,7 @@ async fn process_first_chunk<Pal: SpdmPal, Vdm: SpdmVdmBackend>(
         large_msg_size,
         chunk,
         secure_session,
+        set_certificate_allowed,
     )
     .await
     .map_err(|_| ChunkProcessError::Early {
@@ -447,16 +467,6 @@ async fn process_next_chunk<Pal: SpdmPal, Vdm: SpdmVdmBackend>(
                     chunk_seq_num,
                 })?;
         }
-        #[cfg(feature = "set-certificate")]
-        Some(ActiveLargeRequest::Unsupported(_)) => {
-            state
-                .large_msg_ctx
-                .append_streaming_request(handle, chunk_seq_num, chunk.len())
-                .map_err(|_| ChunkProcessError::Early {
-                    handle,
-                    chunk_seq_num,
-                })?;
-        }
         Some(ActiveLargeRequest::VendorDefined(_)) => {
             vdm.continue_streaming_request(chunk, pal, io)
                 .await
@@ -488,8 +498,8 @@ const SET_CERT_STREAM_PREFIX_LEN: usize =
     SpdmMsgHdrPdu::SIZE + caliptra_mcu_spdm_codec::SetCertificateReqBody::SIZE + 4 + 48;
 
 #[cfg(feature = "set-certificate")]
-fn required_stream_prefix_len(first: &[u8], secure_session: bool) -> Option<usize> {
-    if secure_session || first.len() >= SET_CERT_STREAM_PREFIX_LEN {
+fn required_stream_prefix_len(first: &[u8]) -> Option<usize> {
+    if first.len() >= SET_CERT_STREAM_PREFIX_LEN {
         return None;
     }
     let (hdr, _) = SpdmMsgHdrPdu::ref_from_prefix(first).ok()?;
@@ -543,7 +553,7 @@ async fn continue_setcert_prefix<Pal: SpdmPal>(
     Ok(consumed)
 }
 
-pub(crate) async fn abort_streaming_request_if_needed<Pal: SpdmPal, Vdm: SpdmVdmBackend>(
+pub(crate) async fn abort_active_streaming_request<Pal: SpdmPal, Vdm: SpdmVdmBackend>(
     state: &ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
     pal: &Pal,
     io: &<Pal as SpdmPalIoTransport>::Io<'_>,
@@ -571,6 +581,7 @@ async fn try_start_streaming_request<Pal: SpdmPal, Vdm: SpdmVdmBackend>(
     large_msg_size: usize,
     first: &[u8],
     secure_session: bool,
+    _set_certificate_allowed: bool,
 ) -> SpdmResult<bool> {
     let (hdr, body) = SpdmMsgHdrPdu::ref_from_prefix(first).map_err(|_| SPDM_INVALID_REQUEST)?;
     if hdr.version != state.version.to_u8() {
@@ -579,14 +590,8 @@ async fn try_start_streaming_request<Pal: SpdmPal, Vdm: SpdmVdmBackend>(
     match hdr.code {
         #[cfg(feature = "set-certificate")]
         ReqRespCode::SET_CERTIFICATE => {
-            if secure_session {
-                state.large_msg_ctx.init_streaming_request(
-                    handle,
-                    large_msg_size,
-                    first.len(),
-                    ActiveLargeRequest::Unsupported(SPDM_UNSUPPORTED_REQUEST),
-                )?;
-                return Ok(true);
+            if !_set_certificate_allowed {
+                return Err(SPDM_UNEXPECTED_REQUEST);
             }
             let stream = set_certificate::start_set_certificate_stream(
                 state,
@@ -712,15 +717,6 @@ async fn build_final_chunk_send_ack<'a, Pal: SpdmPal, Vdm: SpdmVdmBackend>(
                 ),
             }
         }
-        #[cfg(feature = "set-certificate")]
-        Some(ActiveLargeRequest::Unsupported(spdm)) => (
-            write_error_response_to_large_request(
-                &mut response_to_large_request,
-                state.version,
-                spdm,
-            ),
-            false,
-        ),
         Some(ActiveLargeRequest::VendorDefined(stream)) => {
             let vendor_id_len = stream.vendor_id_len as usize;
             let vendor_id = &stream.vendor_id[..vendor_id_len];
@@ -874,9 +870,6 @@ async fn dispatch_large_request<Pal: SpdmPal, Vdm: SpdmVdmBackend>(
     match hdr.code {
         #[cfg(feature = "set-certificate")]
         ReqRespCode::SET_CERTIFICATE => {
-            if secure_session {
-                return Err(SPDM_UNSUPPORTED_REQUEST.into());
-            }
             let slot_id =
                 set_certificate::handle_set_certificate_request(state, pal, io, large_req).await?;
             let bytes = [
@@ -1157,6 +1150,7 @@ mod tests {
             &vdm,
             &first_chunk,
             false,
+            true,
         ))
         .unwrap();
         assert_eq!(
@@ -1181,6 +1175,7 @@ mod tests {
             &vdm,
             &second_chunk,
             false,
+            true,
         ))
         .unwrap();
         assert_eq!(
@@ -1238,6 +1233,7 @@ mod tests {
             &vdm,
             &first_chunk,
             false,
+            true,
         ))
         .unwrap();
         assert_eq!(
@@ -1262,6 +1258,7 @@ mod tests {
             &vdm,
             &second_chunk,
             false,
+            true,
         ))
         .unwrap();
         assert_eq!(

--- a/runtime/userspace/api/spdm-lib/stack/src/chunk/send.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/chunk/send.rs
@@ -4,14 +4,17 @@
 
 use caliptra_mcu_spdm_codec::{
     CapabilitiesBody, ChunkSendAckBody, ChunkSendReqBody, ReqRespCode, SpdmMsgHdrPdu, SpdmVersion,
-    WireWriter, CHUNK_ACK_ATTR_EARLY_ERROR, CHUNK_ATTR_LAST_CHUNK,
+    VendorDefinedReqPdu, WireWriter, CHUNK_ACK_ATTR_EARLY_ERROR, CHUNK_ATTR_LAST_CHUNK,
 };
 use caliptra_mcu_spdm_traits::{
-    PalBytes, SpdmPal, SpdmPalAlloc, SpdmPalIoTransport, SpdmVdmBackend,
+    PalBytes, SpdmPal, SpdmPalAlloc, SpdmPalIoTransport, SpdmVdmBackend, VdmRegistry, VdmResponse,
+    VdmResponseBuffer,
 };
 use zerocopy::{little_endian::U16, FromBytes};
 
-use super::WipeOnDrop;
+#[cfg(feature = "set-certificate")]
+use super::StreamPrefixState;
+use super::{ActiveLargeRequest, VendorDefinedStreamState, WipeOnDrop};
 use crate::build::alloc_padded;
 use crate::error::*;
 #[cfg(feature = "set-certificate")]
@@ -33,7 +36,7 @@ pub(crate) async fn handle_chunk_send<'a, Pal: SpdmPal, Vdm: SpdmVdmBackend>(
     req: &[u8],
     secure_session: bool,
 ) -> SpdmResult<PalBytes<'a, Pal>> {
-    let result = process_chunk_send(state, pal, req);
+    let result = process_chunk_send(state, pal, io, vdm, req, secure_session).await;
     match result {
         Ok(info) => {
             if info.complete {
@@ -68,6 +71,7 @@ pub(crate) async fn handle_chunk_send<'a, Pal: SpdmPal, Vdm: SpdmVdmBackend>(
             handle,
             chunk_seq_num,
         }) => {
+            abort_streaming_request_if_needed(state, pal, io, vdm).await;
             let mut error = [0u8; 4];
             encode_error_pdu(state.version, SPDM_INVALID_REQUEST, &mut error);
             state.reset_chunk_assembly();
@@ -112,10 +116,13 @@ enum ChunkProcessError {
     Early { handle: u8, chunk_seq_num: u16 },
 }
 
-fn process_chunk_send<Pal: SpdmPal>(
+async fn process_chunk_send<Pal: SpdmPal, Vdm: SpdmVdmBackend>(
     state: &mut ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
     pal: &Pal,
+    io: &<Pal as SpdmPalIoTransport>::Io<'_>,
+    vdm: &Vdm,
     req: &[u8],
+    secure_session: bool,
 ) -> Result<ChunkInfo, ChunkProcessError> {
     if state.large_msg_ctx.response_in_progress()
         || (state.phase as u8) < (Phase::AfterCapabilities as u8)
@@ -153,22 +160,29 @@ fn process_chunk_send<Pal: SpdmPal>(
         process_first_chunk(
             state,
             pal,
+            io,
+            vdm,
             handle,
             chunk_seq_num,
             chunk_size,
             last_chunk,
             rest,
-        )?;
+            secure_session,
+        )
+        .await?;
     } else {
         process_next_chunk(
             state,
             pal,
+            io,
+            vdm,
             handle,
             chunk_seq_num,
             chunk_size,
             last_chunk,
             rest,
-        )?;
+        )
+        .await?;
     }
 
     Ok(ChunkInfo {
@@ -179,14 +193,18 @@ fn process_chunk_send<Pal: SpdmPal>(
     })
 }
 
-fn process_first_chunk<Pal: SpdmPal>(
+#[allow(clippy::too_many_arguments)]
+async fn process_first_chunk<Pal: SpdmPal, Vdm: SpdmVdmBackend>(
     state: &mut ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
     pal: &Pal,
+    io: &<Pal as SpdmPalIoTransport>::Io<'_>,
+    vdm: &Vdm,
     handle: u8,
     chunk_seq_num: u16,
     chunk_size: usize,
     last_chunk: bool,
     rest: &[u8],
+    secure_session: bool,
 ) -> Result<(), ChunkProcessError> {
     let Some(size_bytes) = rest.first_chunk::<4>() else {
         return Err(ChunkProcessError::Early {
@@ -227,6 +245,52 @@ fn process_first_chunk<Pal: SpdmPal>(
             chunk_seq_num,
         });
     }
+    #[cfg(feature = "set-certificate")]
+    {
+        if let Some(required_len) = required_stream_prefix_len(chunk, secure_session) {
+            let mut prefix = StreamPrefixState {
+                data: [0; super::STREAM_PREFIX_CAPACITY],
+                len: chunk.len(),
+            };
+            prefix.data[..chunk.len()].copy_from_slice(chunk);
+            if required_len > prefix.data.len() {
+                return Err(ChunkProcessError::Early {
+                    handle,
+                    chunk_seq_num,
+                });
+            }
+            state
+                .large_msg_ctx
+                .init_streaming_request(
+                    handle,
+                    large_msg_size,
+                    chunk.len(),
+                    ActiveLargeRequest::Prefix(prefix),
+                )
+                .map_err(|_| ChunkProcessError::Early {
+                    handle,
+                    chunk_seq_num,
+                })?;
+            return Ok(());
+        }
+    }
+    if try_start_streaming_request(
+        state,
+        pal,
+        io,
+        vdm,
+        handle,
+        large_msg_size,
+        chunk,
+        secure_session,
+    )
+    .await
+    .map_err(|_| ChunkProcessError::Early {
+        handle,
+        chunk_seq_num,
+    })? {
+        return Ok(());
+    }
     let rent_buf = match pal.alloc_large_buf(large_msg_size) {
         Ok(buf) => buf,
         Err(_) => {
@@ -249,9 +313,12 @@ fn process_first_chunk<Pal: SpdmPal>(
     Ok(())
 }
 
-fn process_next_chunk<Pal: SpdmPal>(
+#[allow(clippy::too_many_arguments)]
+async fn process_next_chunk<Pal: SpdmPal, Vdm: SpdmVdmBackend>(
     state: &mut ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
-    _pal: &Pal,
+    pal: &Pal,
+    io: &<Pal as SpdmPalIoTransport>::Io<'_>,
+    vdm: &Vdm,
     handle: u8,
     chunk_seq_num: u16,
     chunk_size: usize,
@@ -290,18 +357,294 @@ fn process_next_chunk<Pal: SpdmPal>(
             chunk_seq_num,
         });
     }
-    if state
-        .large_msg_ctx
-        .append_request(handle, chunk_seq_num, chunk)
-        .is_err()
-    {
-        return Err(ChunkProcessError::Early {
-            handle,
-            chunk_seq_num,
-        });
+    #[cfg(feature = "set-certificate")]
+    let algo = state.asym_algo();
+    match state.large_msg_ctx.active_request_mut() {
+        Some(ActiveLargeRequest::Buffered) => {
+            if state
+                .large_msg_ctx
+                .append_request(handle, chunk_seq_num, chunk)
+                .is_err()
+            {
+                return Err(ChunkProcessError::Early {
+                    handle,
+                    chunk_seq_num,
+                });
+            }
+        }
+        #[cfg(feature = "set-certificate")]
+        Some(ActiveLargeRequest::Prefix(_)) => {
+            let consumed = continue_setcert_prefix(state, pal, io, handle, chunk)
+                .await
+                .map_err(|_| ChunkProcessError::Early {
+                    handle,
+                    chunk_seq_num,
+                })?;
+            let remaining = &chunk[consumed..];
+            if !remaining.is_empty() {
+                let active =
+                    state
+                        .large_msg_ctx
+                        .active_request_mut()
+                        .ok_or(ChunkProcessError::Early {
+                            handle,
+                            chunk_seq_num,
+                        })?;
+                match active {
+                    #[cfg(feature = "set-certificate")]
+                    ActiveLargeRequest::SetCertificate(stream) => {
+                        set_certificate::continue_set_certificate_stream(
+                            pal, io, algo, stream, remaining,
+                        )
+                        .await
+                        .map_err(|_| ChunkProcessError::Early {
+                            handle,
+                            chunk_seq_num,
+                        })?;
+                    }
+                    _ => {
+                        return Err(ChunkProcessError::Early {
+                            handle,
+                            chunk_seq_num,
+                        })
+                    }
+                }
+            }
+            state
+                .large_msg_ctx
+                .append_streaming_request(handle, chunk_seq_num, chunk.len())
+                .map_err(|_| ChunkProcessError::Early {
+                    handle,
+                    chunk_seq_num,
+                })?;
+        }
+        #[cfg(feature = "set-certificate")]
+        Some(ActiveLargeRequest::SetCertificate(stream)) => {
+            set_certificate::continue_set_certificate_stream(pal, io, algo, stream, chunk)
+                .await
+                .map_err(|_| ChunkProcessError::Early {
+                    handle,
+                    chunk_seq_num,
+                })?;
+            state
+                .large_msg_ctx
+                .append_streaming_request(handle, chunk_seq_num, chunk.len())
+                .map_err(|_| ChunkProcessError::Early {
+                    handle,
+                    chunk_seq_num,
+                })?;
+        }
+        #[cfg(feature = "set-certificate")]
+        Some(ActiveLargeRequest::Unsupported(_)) => {
+            state
+                .large_msg_ctx
+                .append_streaming_request(handle, chunk_seq_num, chunk.len())
+                .map_err(|_| ChunkProcessError::Early {
+                    handle,
+                    chunk_seq_num,
+                })?;
+        }
+        Some(ActiveLargeRequest::VendorDefined(_)) => {
+            vdm.continue_streaming_request(chunk, pal, io)
+                .await
+                .map_err(|_| ChunkProcessError::Early {
+                    handle,
+                    chunk_seq_num,
+                })?;
+            state
+                .large_msg_ctx
+                .append_streaming_request(handle, chunk_seq_num, chunk.len())
+                .map_err(|_| ChunkProcessError::Early {
+                    handle,
+                    chunk_seq_num,
+                })?;
+        }
+        None => {
+            return Err(ChunkProcessError::Early {
+                handle,
+                chunk_seq_num,
+            })
+        }
     }
 
     Ok(())
+}
+
+#[cfg(feature = "set-certificate")]
+const SET_CERT_STREAM_PREFIX_LEN: usize =
+    SpdmMsgHdrPdu::SIZE + caliptra_mcu_spdm_codec::SetCertificateReqBody::SIZE + 4 + 48;
+
+#[cfg(feature = "set-certificate")]
+fn required_stream_prefix_len(first: &[u8], secure_session: bool) -> Option<usize> {
+    if secure_session || first.len() >= SET_CERT_STREAM_PREFIX_LEN {
+        return None;
+    }
+    let (hdr, _) = SpdmMsgHdrPdu::ref_from_prefix(first).ok()?;
+    (hdr.code == ReqRespCode::SET_CERTIFICATE).then_some(SET_CERT_STREAM_PREFIX_LEN)
+}
+
+#[cfg(feature = "set-certificate")]
+async fn continue_setcert_prefix<Pal: SpdmPal>(
+    state: &mut ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
+    pal: &Pal,
+    io: &<Pal as SpdmPalIoTransport>::Io<'_>,
+    _handle: u8,
+    chunk: &[u8],
+) -> SpdmResult<usize> {
+    let large_msg_size = state.large_msg_ctx.state.large_msg_size as usize;
+    let mut prefix_data = [0u8; super::STREAM_PREFIX_CAPACITY];
+    let (prefix_len, consumed, complete) = {
+        let Some(ActiveLargeRequest::Prefix(prefix)) = state.large_msg_ctx.active_request_mut()
+        else {
+            return Err(SPDM_INVALID_REQUEST);
+        };
+        let needed = SET_CERT_STREAM_PREFIX_LEN
+            .checked_sub(prefix.len)
+            .ok_or(SPDM_INVALID_REQUEST)?;
+        let consumed = needed.min(chunk.len());
+        if prefix.len + consumed > prefix.data.len() {
+            return Err(SPDM_INVALID_REQUEST);
+        }
+        prefix.data[prefix.len..prefix.len + consumed].copy_from_slice(&chunk[..consumed]);
+        prefix.len += consumed;
+        prefix_data[..prefix.len].copy_from_slice(&prefix.data[..prefix.len]);
+        (
+            prefix.len,
+            consumed,
+            prefix.len >= SET_CERT_STREAM_PREFIX_LEN,
+        )
+    };
+    if complete {
+        let stream = set_certificate::start_set_certificate_stream(
+            state,
+            pal,
+            io,
+            large_msg_size,
+            &prefix_data[..prefix_len],
+        )
+        .await?;
+        state
+            .large_msg_ctx
+            .replace_active_request(ActiveLargeRequest::SetCertificate(stream))?;
+    }
+    Ok(consumed)
+}
+
+pub(crate) async fn abort_streaming_request_if_needed<Pal: SpdmPal, Vdm: SpdmVdmBackend>(
+    state: &ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
+    pal: &Pal,
+    io: &<Pal as SpdmPalIoTransport>::Io<'_>,
+    vdm: &Vdm,
+) {
+    match state.large_msg_ctx.active_request() {
+        #[cfg(feature = "set-certificate")]
+        Some(ActiveLargeRequest::SetCertificate(stream)) => {
+            set_certificate::abort_set_certificate_stream(state, pal, io, stream).await;
+        }
+        Some(ActiveLargeRequest::VendorDefined(_)) => {
+            vdm.abort_streaming_request(pal, io).await;
+        }
+        _ => {}
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn try_start_streaming_request<Pal: SpdmPal, Vdm: SpdmVdmBackend>(
+    state: &mut ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
+    pal: &Pal,
+    io: &<Pal as SpdmPalIoTransport>::Io<'_>,
+    vdm: &Vdm,
+    handle: u8,
+    large_msg_size: usize,
+    first: &[u8],
+    secure_session: bool,
+) -> SpdmResult<bool> {
+    let (hdr, body) = SpdmMsgHdrPdu::ref_from_prefix(first).map_err(|_| SPDM_INVALID_REQUEST)?;
+    if hdr.version != state.version.to_u8() {
+        return Err(SPDM_INVALID_REQUEST);
+    }
+    match hdr.code {
+        #[cfg(feature = "set-certificate")]
+        ReqRespCode::SET_CERTIFICATE => {
+            if secure_session {
+                state.large_msg_ctx.init_streaming_request(
+                    handle,
+                    large_msg_size,
+                    first.len(),
+                    ActiveLargeRequest::Unsupported(SPDM_UNSUPPORTED_REQUEST),
+                )?;
+                return Ok(true);
+            }
+            let stream = set_certificate::start_set_certificate_stream(
+                state,
+                pal,
+                io,
+                large_msg_size,
+                first,
+            )
+            .await?;
+            state.large_msg_ctx.init_streaming_request(
+                handle,
+                large_msg_size,
+                first.len(),
+                ActiveLargeRequest::SetCertificate(stream),
+            )?;
+            Ok(true)
+        }
+        ReqRespCode::VENDOR_DEFINED_REQUEST => {
+            let (vdm_hdr, rest) =
+                VendorDefinedReqPdu::ref_from_prefix(body).map_err(|_| SPDM_INVALID_REQUEST)?;
+            let vendor_id_len = vdm_hdr.vendor_id_len as usize;
+            if vendor_id_len > 4 {
+                return Ok(false);
+            }
+            let vendor_id = rest.get(..vendor_id_len).ok_or(SPDM_INVALID_REQUEST)?;
+            let req_len_offset = vendor_id_len;
+            let req_len_bytes = rest
+                .get(req_len_offset..req_len_offset + 2)
+                .ok_or(SPDM_INVALID_REQUEST)?;
+            let req_len = u16::from_le_bytes([req_len_bytes[0], req_len_bytes[1]]) as usize;
+            let payload_start = req_len_offset + 2;
+            let payload = rest.get(payload_start..).ok_or(SPDM_INVALID_REQUEST)?;
+            let expected = SpdmMsgHdrPdu::SIZE
+                .checked_add(VendorDefinedReqPdu::SIZE)
+                .and_then(|n| n.checked_add(vendor_id_len))
+                .and_then(|n| n.checked_add(2))
+                .and_then(|n| n.checked_add(req_len))
+                .ok_or(SPDM_INVALID_REQUEST)?;
+            if expected != large_msg_size || payload.len() > req_len {
+                return Err(SPDM_INVALID_REQUEST);
+            }
+            let registry = VdmRegistry {
+                standard_id: vdm_hdr.standard_id.get(),
+                vendor_id,
+                secure_session,
+            };
+            if !vdm.match_id(&registry) {
+                return Ok(false);
+            }
+            if !vdm
+                .start_streaming_request(req_len, payload, pal, io)
+                .await?
+            {
+                return Ok(false);
+            }
+            let mut vendor_id_buf = [0u8; 4];
+            vendor_id_buf[..vendor_id_len].copy_from_slice(vendor_id);
+            state.large_msg_ctx.init_streaming_request(
+                handle,
+                large_msg_size,
+                first.len(),
+                ActiveLargeRequest::VendorDefined(VendorDefinedStreamState {
+                    standard_id: vdm_hdr.standard_id.get(),
+                    vendor_id: vendor_id_buf,
+                    vendor_id_len: vdm_hdr.vendor_id_len,
+                }),
+            )?;
+            Ok(true)
+        }
+        _ => Ok(false),
+    }
 }
 
 struct LargeRequestError {
@@ -329,17 +672,108 @@ async fn build_final_chunk_send_ack<'a, Pal: SpdmPal, Vdm: SpdmVdmBackend>(
 ) -> SpdmResult<PalBytes<'a, Pal>> {
     let len = state.large_msg_ctx.state.large_msg_size as usize;
     let mut response_to_large_request = [0u8; LARGE_REQUEST_RESPONSE_BUF_SIZE];
-    let (mut response_len, early_error) = if len < SpdmMsgHdrPdu::SIZE {
-        (
+    let active = state.large_msg_ctx.active_request().copied();
+    let (mut response_len, early_error) = match active {
+        #[cfg(feature = "set-certificate")]
+        Some(ActiveLargeRequest::SetCertificate(stream)) => {
+            match set_certificate::finish_set_certificate_stream(state, pal, io, &stream).await {
+                Ok(slot_id) => {
+                    let bytes = [
+                        state.version.to_u8(),
+                        ReqRespCode::SET_CERTIFICATE_RSP.0,
+                        slot_id,
+                        0,
+                    ];
+                    response_to_large_request[..bytes.len()].copy_from_slice(&bytes);
+                    (bytes.len(), false)
+                }
+                Err(spdm) => (
+                    write_error_response_to_large_request(
+                        &mut response_to_large_request,
+                        state.version,
+                        spdm,
+                    ),
+                    false,
+                ),
+            }
+        }
+        #[cfg(feature = "set-certificate")]
+        Some(ActiveLargeRequest::Unsupported(spdm)) => (
+            write_error_response_to_large_request(
+                &mut response_to_large_request,
+                state.version,
+                spdm,
+            ),
+            false,
+        ),
+        Some(ActiveLargeRequest::VendorDefined(stream)) => {
+            let vendor_id_len = stream.vendor_id_len as usize;
+            let vendor_id = &stream.vendor_id[..vendor_id_len];
+            let envelope_len = SpdmMsgHdrPdu::SIZE + 2 + 2 + 1 + vendor_id_len + 2;
+            if envelope_len > response_to_large_request.len() {
+                (
+                    write_error_response_to_large_request(
+                        &mut response_to_large_request,
+                        state.version,
+                        SPDM_UNSPECIFIED,
+                    ),
+                    false,
+                )
+            } else {
+                let mut empty_large = [];
+                let outcome = vdm
+                    .finish_streaming_request(VdmResponseBuffer {
+                        inline: &mut response_to_large_request[envelope_len..],
+                        large: &mut empty_large,
+                        alloc: pal,
+                        io,
+                    })
+                    .await;
+                match outcome {
+                    Ok(VdmResponse::Inline(payload_len)) => {
+                        let invalid_response = envelope_len + payload_len
+                            > response_to_large_request.len()
+                            || vendor_defined::write_vendor_defined_envelope(
+                                state.version,
+                                stream.standard_id,
+                                vendor_id,
+                                payload_len,
+                                &mut response_to_large_request[..envelope_len],
+                            )
+                            .is_err();
+                        if invalid_response {
+                            (
+                                write_error_response_to_large_request(
+                                    &mut response_to_large_request,
+                                    state.version,
+                                    SPDM_UNSPECIFIED,
+                                ),
+                                false,
+                            )
+                        } else {
+                            (envelope_len + payload_len, false)
+                        }
+                    }
+                    _ => (
+                        write_error_response_to_large_request(
+                            &mut response_to_large_request,
+                            state.version,
+                            SPDM_UNSPECIFIED,
+                        ),
+                        false,
+                    ),
+                }
+            }
+        }
+        _ if len < SpdmMsgHdrPdu::SIZE => (
             write_error_response_to_large_request(
                 &mut response_to_large_request,
                 state.version,
                 SPDM_INVALID_REQUEST,
             ),
             false,
-        )
-    } else {
-        match dispatch_large_request(
+        ),
+        _ => match dispatch_large_request(
             state,
             pal,
             io,
@@ -359,7 +793,7 @@ async fn build_final_chunk_send_ack<'a, Pal: SpdmPal, Vdm: SpdmVdmBackend>(
                 ),
                 err.early_error,
             ),
-        }
+        },
     };
 
     let max_response_len = state
@@ -517,6 +951,116 @@ mod tests {
             registry.standard_id == 0x0004 && registry.vendor_id == CALIPTRA_VENDOR_ID_BYTES
         }
 
+        async fn start_streaming_request<Alloc, Io>(
+            &self,
+            _req_len: usize,
+            first: &[u8],
+            _alloc: &Alloc,
+            _io: &Io,
+        ) -> McuResult<bool>
+        where
+            Alloc: SpdmPalAlloc,
+            Io: SpdmPalIo,
+        {
+            assert_eq!(first.first().copied(), Some(CALIPTRA_VDM_COMMAND_VERSION));
+            assert_eq!(
+                first.get(1).copied(),
+                Some(CaliptraVdmCommand::AuthorizeDebugUnlockToken as u8)
+            );
+            self.captured_token_payload
+                .replace(Some(first[2..].to_vec()));
+            Ok(true)
+        }
+
+        async fn continue_streaming_request<Alloc, Io>(
+            &self,
+            chunk: &[u8],
+            _alloc: &Alloc,
+            _io: &Io,
+        ) -> McuResult<()>
+        where
+            Alloc: SpdmPalAlloc,
+            Io: SpdmPalIo,
+        {
+            self.captured_token_payload
+                .borrow_mut()
+                .as_mut()
+                .expect("streaming request started")
+                .extend_from_slice(chunk);
+            Ok(())
+        }
+
+        async fn finish_streaming_request<Alloc, Io>(
+            &self,
+            rsp: VdmResponseBuffer<'_, Alloc, Io>,
+        ) -> McuResult<VdmResponse>
+        where
+            Alloc: SpdmPalAlloc,
+            Io: SpdmPalIo,
+        {
+            rsp.inline[..3].copy_from_slice(&[
+                CALIPTRA_VDM_COMMAND_VERSION,
+                CaliptraVdmCommand::AuthorizeDebugUnlockToken as u8,
+                0,
+            ]);
+            Ok(VdmResponse::Inline(3))
+        }
+
+        async fn handle_request<Alloc, Io>(
+            &self,
+            req: &[u8],
+            rsp: VdmResponseBuffer<'_, Alloc, Io>,
+        ) -> McuResult<VdmResponse>
+        where
+            Alloc: SpdmPalAlloc,
+            Io: SpdmPalIo,
+        {
+            assert_eq!(req.first().copied(), Some(CALIPTRA_VDM_COMMAND_VERSION));
+            assert_eq!(
+                req.get(1).copied(),
+                Some(CaliptraVdmCommand::AuthorizeDebugUnlockToken as u8)
+            );
+            self.captured_token_payload.replace(Some(req[2..].to_vec()));
+            rsp.inline[..3].copy_from_slice(&[
+                CALIPTRA_VDM_COMMAND_VERSION,
+                CaliptraVdmCommand::AuthorizeDebugUnlockToken as u8,
+                0,
+            ]);
+            Ok(VdmResponse::Inline(3))
+        }
+    }
+
+    struct BufferedOnlyVdmBackend {
+        captured_token_payload: RefCell<Option<Vec<u8>>>,
+    }
+
+    impl BufferedOnlyVdmBackend {
+        fn new() -> Self {
+            Self {
+                captured_token_payload: RefCell::new(None),
+            }
+        }
+    }
+
+    impl SpdmVdmBackend for BufferedOnlyVdmBackend {
+        fn match_id(&self, registry: &VdmRegistry<'_>) -> bool {
+            registry.standard_id == 0x0004 && registry.vendor_id == CALIPTRA_VENDOR_ID_BYTES
+        }
+
+        async fn start_streaming_request<Alloc, Io>(
+            &self,
+            _req_len: usize,
+            _first: &[u8],
+            _alloc: &Alloc,
+            _io: &Io,
+        ) -> McuResult<bool>
+        where
+            Alloc: SpdmPalAlloc,
+            Io: SpdmPalIo,
+        {
+            Ok(false)
+        }
+
         async fn handle_request<Alloc, Io>(
             &self,
             req: &[u8],
@@ -601,6 +1145,7 @@ mod tests {
             ]
         );
         assert!(state.large_msg_ctx.request_in_progress());
+        assert!(state.large_msg_ctx.get_buffer().is_none());
 
         let second_io = TestIo::message(second_chunk.clone());
         let rsp = block_on(handle_chunk_send(
@@ -645,5 +1190,59 @@ mod tests {
                 0,
             ]
         );
+    }
+
+    #[test]
+    fn chunked_vendor_defined_debug_unlock_falls_back_when_streaming_declines() {
+        let pal = TestPal::default();
+        let mut state = chunking_state();
+        let vdm = BufferedOnlyVdmBackend::new();
+
+        let host_mailbox_payload = vec![0x5au8; 4 + 96];
+        let large_req = vendor_defined_authorize_debug_unlock_request(&host_mailbox_payload);
+        let (first, second) = large_req.split_at(64);
+        let first_chunk = chunk_send_request(10, 0, false, Some(large_req.len()), first);
+        let second_chunk = chunk_send_request(10, 1, true, None, second);
+
+        let first_io = TestIo::message(first_chunk.clone());
+        let rsp = block_on(handle_chunk_send(
+            &mut state,
+            &pal,
+            &first_io,
+            &vdm,
+            &first_chunk,
+            false,
+        ))
+        .unwrap();
+        assert_eq!(
+            &rsp[..],
+            &[
+                SpdmVersion::V12.to_u8(),
+                ReqRespCode::CHUNK_SEND_ACK.0,
+                0,
+                10,
+                0,
+                0,
+            ]
+        );
+        assert!(state.large_msg_ctx.request_in_progress());
+        assert!(state.large_msg_ctx.get_buffer().is_some());
+
+        let second_io = TestIo::message(second_chunk.clone());
+        let rsp = block_on(handle_chunk_send(
+            &mut state,
+            &pal,
+            &second_io,
+            &vdm,
+            &second_chunk,
+            false,
+        ))
+        .unwrap();
+        assert_eq!(
+            vdm.captured_token_payload.take(),
+            Some(host_mailbox_payload)
+        );
+        assert!(!state.large_msg_ctx.request_in_progress());
+        assert_eq!(rsp[1], ReqRespCode::CHUNK_SEND_ACK.0);
     }
 }

--- a/runtime/userspace/api/spdm-lib/stack/src/chunk/send.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/chunk/send.rs
@@ -14,7 +14,9 @@ use zerocopy::{little_endian::U16, FromBytes};
 
 #[cfg(feature = "set-certificate")]
 use super::StreamPrefixState;
-use super::{ActiveLargeRequest, VendorDefinedStreamState, WipeOnDrop};
+#[cfg(any(test, feature = "generic-large-request"))]
+use super::WipeOnDrop;
+use super::{ActiveLargeRequest, VendorDefinedStreamState};
 use crate::build::alloc_padded;
 use crate::error::*;
 #[cfg(feature = "set-certificate")]
@@ -291,26 +293,36 @@ async fn process_first_chunk<Pal: SpdmPal, Vdm: SpdmVdmBackend>(
     })? {
         return Ok(());
     }
-    let rent_buf = match pal.alloc_large_buf(large_msg_size) {
-        Ok(buf) => buf,
-        Err(_) => {
+    #[cfg(any(test, feature = "generic-large-request"))]
+    {
+        let rent_buf = match pal.alloc_large_buf(large_msg_size) {
+            Ok(buf) => buf,
+            Err(_) => {
+                return Err(ChunkProcessError::Early {
+                    handle,
+                    chunk_seq_num,
+                })
+            }
+        };
+        if state
+            .large_msg_ctx
+            .init_request(handle, large_msg_size, chunk, rent_buf)
+            .is_err()
+        {
             return Err(ChunkProcessError::Early {
                 handle,
                 chunk_seq_num,
-            })
+            });
         }
-    };
-    if state
-        .large_msg_ctx
-        .init_request(handle, large_msg_size, chunk, rent_buf)
-        .is_err()
+        Ok(())
+    }
+    #[cfg(not(any(test, feature = "generic-large-request")))]
     {
-        return Err(ChunkProcessError::Early {
+        Err(ChunkProcessError::Early {
             handle,
             chunk_seq_num,
-        });
+        })
     }
-    Ok(())
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -360,6 +372,7 @@ async fn process_next_chunk<Pal: SpdmPal, Vdm: SpdmVdmBackend>(
     #[cfg(feature = "set-certificate")]
     let algo = state.asym_algo();
     match state.large_msg_ctx.active_request_mut() {
+        #[cfg(any(test, feature = "generic-large-request"))]
         Some(ActiveLargeRequest::Buffered) => {
             if state
                 .large_msg_ctx
@@ -647,11 +660,13 @@ async fn try_start_streaming_request<Pal: SpdmPal, Vdm: SpdmVdmBackend>(
     }
 }
 
+#[cfg(any(test, feature = "generic-large-request"))]
 struct LargeRequestError {
     spdm: SpdmError,
     early_error: bool,
 }
 
+#[cfg(any(test, feature = "generic-large-request"))]
 impl From<SpdmError> for LargeRequestError {
     fn from(spdm: SpdmError) -> Self {
         Self {
@@ -666,7 +681,7 @@ async fn build_final_chunk_send_ack<'a, Pal: SpdmPal, Vdm: SpdmVdmBackend>(
     pal: &'a Pal,
     io: &<Pal as SpdmPalIoTransport>::Io<'_>,
     vdm: &Vdm,
-    secure_session: bool,
+    _secure_session: bool,
     handle: u8,
     chunk_seq_num: u16,
 ) -> SpdmResult<PalBytes<'a, Pal>> {
@@ -773,13 +788,14 @@ async fn build_final_chunk_send_ack<'a, Pal: SpdmPal, Vdm: SpdmVdmBackend>(
             ),
             false,
         ),
+        #[cfg(any(test, feature = "generic-large-request"))]
         _ => match dispatch_large_request(
             state,
             pal,
             io,
             vdm,
             len,
-            secure_session,
+            _secure_session,
             &mut response_to_large_request,
         )
         .await
@@ -794,6 +810,15 @@ async fn build_final_chunk_send_ack<'a, Pal: SpdmPal, Vdm: SpdmVdmBackend>(
                 err.early_error,
             ),
         },
+        #[cfg(not(any(test, feature = "generic-large-request")))]
+        _ => (
+            write_error_response_to_large_request(
+                &mut response_to_large_request,
+                state.version,
+                SPDM_UNSUPPORTED_REQUEST,
+            ),
+            false,
+        ),
     };
 
     let max_response_len = state
@@ -818,6 +843,7 @@ async fn build_final_chunk_send_ack<'a, Pal: SpdmPal, Vdm: SpdmVdmBackend>(
     )
 }
 
+#[cfg(any(test, feature = "generic-large-request"))]
 async fn dispatch_large_request<Pal: SpdmPal, Vdm: SpdmVdmBackend>(
     state: &mut ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
     pal: &Pal,

--- a/runtime/userspace/api/spdm-lib/stack/src/chunk/send.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/chunk/send.rs
@@ -12,11 +12,11 @@ use caliptra_mcu_spdm_traits::{
 };
 use zerocopy::{little_endian::U16, FromBytes};
 
+use super::ActiveLargeRequest;
 #[cfg(feature = "set-certificate")]
 use super::StreamPrefixState;
 #[cfg(any(test, feature = "generic-large-request"))]
 use super::WipeOnDrop;
-use super::{ActiveLargeRequest, VendorDefinedStreamState};
 use crate::build::alloc_padded;
 use crate::error::*;
 #[cfg(feature = "set-certificate")]
@@ -36,7 +36,7 @@ pub(crate) async fn handle_chunk_send<'a, Pal: SpdmPal, Vdm: SpdmVdmBackend>(
     io: &<Pal as SpdmPalIoTransport>::Io<'_>,
     vdm: &Vdm,
     req: &[u8],
-    secure_session: bool,
+    session_id: Option<u32>,
     set_certificate_allowed: bool,
 ) -> SpdmResult<PalBytes<'a, Pal>> {
     let result = process_chunk_send(
@@ -45,7 +45,7 @@ pub(crate) async fn handle_chunk_send<'a, Pal: SpdmPal, Vdm: SpdmVdmBackend>(
         io,
         vdm,
         req,
-        secure_session,
+        session_id,
         set_certificate_allowed,
     )
     .await;
@@ -57,7 +57,6 @@ pub(crate) async fn handle_chunk_send<'a, Pal: SpdmPal, Vdm: SpdmVdmBackend>(
                     pal,
                     io,
                     vdm,
-                    secure_session,
                     info.handle,
                     info.chunk_seq_num,
                 )
@@ -122,6 +121,9 @@ fn build_chunk_send_ack<'a, Pal: SpdmPal>(
 
 /// Maximum bytes carried as `ResponseToLargeRequest` inside CHUNK_SEND_ACK.
 const LARGE_REQUEST_RESPONSE_BUF_SIZE: usize = 512;
+const DEBUG_UNLOCK_STANDARD_ID: u16 = 0x0004;
+const DEBUG_UNLOCK_VENDOR_ID: [u8; 4] =
+    caliptra_mcu_spdm_codec::vendor_defined::iana::ocp::caliptra::CALIPTRA_VENDOR_ID.to_le_bytes();
 
 enum ChunkProcessError {
     Spdm(SpdmError),
@@ -134,12 +136,18 @@ async fn process_chunk_send<Pal: SpdmPal, Vdm: SpdmVdmBackend>(
     io: &<Pal as SpdmPalIoTransport>::Io<'_>,
     vdm: &Vdm,
     req: &[u8],
-    secure_session: bool,
+    session_id: Option<u32>,
     set_certificate_allowed: bool,
 ) -> Result<ChunkInfo, ChunkProcessError> {
     if state.large_msg_ctx.response_in_progress()
         || (state.phase as u8) < (Phase::AfterCapabilities as u8)
         || !state.chunking_enabled()
+    {
+        return Err(ChunkProcessError::Spdm(SPDM_UNEXPECTED_REQUEST));
+    }
+
+    if state.large_msg_ctx.request_in_progress()
+        && state.large_msg_ctx.state.session_id != session_id
     {
         return Err(ChunkProcessError::Spdm(SPDM_UNEXPECTED_REQUEST));
     }
@@ -180,7 +188,7 @@ async fn process_chunk_send<Pal: SpdmPal, Vdm: SpdmVdmBackend>(
             chunk_size,
             last_chunk,
             rest,
-            secure_session,
+            session_id,
             set_certificate_allowed,
         )
         .await?;
@@ -218,7 +226,7 @@ async fn process_first_chunk<Pal: SpdmPal, Vdm: SpdmVdmBackend>(
     chunk_size: usize,
     last_chunk: bool,
     rest: &[u8],
-    secure_session: bool,
+    session_id: Option<u32>,
     set_certificate_allowed: bool,
 ) -> Result<(), ChunkProcessError> {
     let Some(size_bytes) = rest.first_chunk::<4>() else {
@@ -287,6 +295,7 @@ async fn process_first_chunk<Pal: SpdmPal, Vdm: SpdmVdmBackend>(
                     large_msg_size,
                     chunk.len(),
                     ActiveLargeRequest::Prefix(prefix),
+                    session_id,
                 )
                 .map_err(|_| ChunkProcessError::Early {
                     handle,
@@ -303,7 +312,7 @@ async fn process_first_chunk<Pal: SpdmPal, Vdm: SpdmVdmBackend>(
         handle,
         large_msg_size,
         chunk,
-        secure_session,
+        session_id,
         set_certificate_allowed,
     )
     .await
@@ -326,7 +335,7 @@ async fn process_first_chunk<Pal: SpdmPal, Vdm: SpdmVdmBackend>(
         };
         if state
             .large_msg_ctx
-            .init_request(handle, large_msg_size, chunk, rent_buf)
+            .init_request(handle, large_msg_size, chunk, rent_buf, session_id)
             .is_err()
         {
             return Err(ChunkProcessError::Early {
@@ -467,8 +476,8 @@ async fn process_next_chunk<Pal: SpdmPal, Vdm: SpdmVdmBackend>(
                     chunk_seq_num,
                 })?;
         }
-        Some(ActiveLargeRequest::VendorDefined(_)) => {
-            vdm.continue_streaming_request(chunk, pal, io)
+        Some(ActiveLargeRequest::AuthorizeDebugUnlockToken) => {
+            vdm.continue_authorize_debug_unlock_token_stream(chunk, pal, io)
                 .await
                 .map_err(|_| ChunkProcessError::Early {
                     handle,
@@ -564,8 +573,8 @@ pub(crate) async fn abort_active_streaming_request<Pal: SpdmPal, Vdm: SpdmVdmBac
         Some(ActiveLargeRequest::SetCertificate(stream)) => {
             set_certificate::abort_set_certificate_stream(state, pal, io, stream).await;
         }
-        Some(ActiveLargeRequest::VendorDefined(_)) => {
-            vdm.abort_streaming_request(pal, io).await;
+        Some(ActiveLargeRequest::AuthorizeDebugUnlockToken) => {
+            vdm.abort_authorize_debug_unlock_token_stream(pal, io).await;
         }
         _ => {}
     }
@@ -580,7 +589,7 @@ async fn try_start_streaming_request<Pal: SpdmPal, Vdm: SpdmVdmBackend>(
     handle: u8,
     large_msg_size: usize,
     first: &[u8],
-    secure_session: bool,
+    session_id: Option<u32>,
     _set_certificate_allowed: bool,
 ) -> SpdmResult<bool> {
     let (hdr, body) = SpdmMsgHdrPdu::ref_from_prefix(first).map_err(|_| SPDM_INVALID_REQUEST)?;
@@ -606,6 +615,7 @@ async fn try_start_streaming_request<Pal: SpdmPal, Vdm: SpdmVdmBackend>(
                 large_msg_size,
                 first.len(),
                 ActiveLargeRequest::SetCertificate(stream),
+                session_id,
             )?;
             Ok(true)
         }
@@ -636,28 +646,23 @@ async fn try_start_streaming_request<Pal: SpdmPal, Vdm: SpdmVdmBackend>(
             let registry = VdmRegistry {
                 standard_id: vdm_hdr.standard_id.get(),
                 vendor_id,
-                secure_session,
+                secure_session: session_id.is_some(),
             };
             if !vdm.match_id(&registry) {
                 return Ok(false);
             }
             if !vdm
-                .start_streaming_request(req_len, payload, pal, io)
+                .start_authorize_debug_unlock_token_stream(req_len, payload, pal, io)
                 .await?
             {
                 return Ok(false);
             }
-            let mut vendor_id_buf = [0u8; 4];
-            vendor_id_buf[..vendor_id_len].copy_from_slice(vendor_id);
             state.large_msg_ctx.init_streaming_request(
                 handle,
                 large_msg_size,
                 first.len(),
-                ActiveLargeRequest::VendorDefined(VendorDefinedStreamState {
-                    standard_id: vdm_hdr.standard_id.get(),
-                    vendor_id: vendor_id_buf,
-                    vendor_id_len: vdm_hdr.vendor_id_len,
-                }),
+                ActiveLargeRequest::AuthorizeDebugUnlockToken,
+                session_id,
             )?;
             Ok(true)
         }
@@ -686,7 +691,6 @@ async fn build_final_chunk_send_ack<'a, Pal: SpdmPal, Vdm: SpdmVdmBackend>(
     pal: &'a Pal,
     io: &<Pal as SpdmPalIoTransport>::Io<'_>,
     vdm: &Vdm,
-    _secure_session: bool,
     handle: u8,
     chunk_seq_num: u16,
 ) -> SpdmResult<PalBytes<'a, Pal>> {
@@ -707,20 +711,22 @@ async fn build_final_chunk_send_ack<'a, Pal: SpdmPal, Vdm: SpdmVdmBackend>(
                     response_to_large_request[..bytes.len()].copy_from_slice(&bytes);
                     (bytes.len(), false)
                 }
-                Err(spdm) => (
-                    write_error_response_to_large_request(
-                        &mut response_to_large_request,
-                        state.version,
-                        spdm,
-                    ),
-                    false,
-                ),
+                Err(spdm) => {
+                    set_certificate::abort_set_certificate_stream(state, pal, io, &stream).await;
+                    (
+                        write_error_response_to_large_request(
+                            &mut response_to_large_request,
+                            state.version,
+                            spdm,
+                        ),
+                        false,
+                    )
+                }
             }
         }
-        Some(ActiveLargeRequest::VendorDefined(stream)) => {
-            let vendor_id_len = stream.vendor_id_len as usize;
-            let vendor_id = &stream.vendor_id[..vendor_id_len];
-            let envelope_len = SpdmMsgHdrPdu::SIZE + 2 + 2 + 1 + vendor_id_len + 2;
+        Some(ActiveLargeRequest::AuthorizeDebugUnlockToken) => {
+            let vendor_id = &DEBUG_UNLOCK_VENDOR_ID;
+            let envelope_len = SpdmMsgHdrPdu::SIZE + 2 + 2 + 1 + vendor_id.len() + 2;
             if envelope_len > response_to_large_request.len() {
                 (
                     write_error_response_to_large_request(
@@ -733,7 +739,7 @@ async fn build_final_chunk_send_ack<'a, Pal: SpdmPal, Vdm: SpdmVdmBackend>(
             } else {
                 let mut empty_large = [];
                 let outcome = vdm
-                    .finish_streaming_request(VdmResponseBuffer {
+                    .finish_authorize_debug_unlock_token_stream(VdmResponseBuffer {
                         inline: &mut response_to_large_request[envelope_len..],
                         large: &mut empty_large,
                         alloc: pal,
@@ -746,7 +752,7 @@ async fn build_final_chunk_send_ack<'a, Pal: SpdmPal, Vdm: SpdmVdmBackend>(
                             > response_to_large_request.len()
                             || vendor_defined::write_vendor_defined_envelope(
                                 state.version,
-                                stream.standard_id,
+                                DEBUG_UNLOCK_STANDARD_ID,
                                 vendor_id,
                                 payload_len,
                                 &mut response_to_large_request[..envelope_len],
@@ -791,7 +797,7 @@ async fn build_final_chunk_send_ack<'a, Pal: SpdmPal, Vdm: SpdmVdmBackend>(
             io,
             vdm,
             len,
-            _secure_session,
+            state.large_msg_ctx.state.session_id.is_some(),
             &mut response_to_large_request,
         )
         .await
@@ -970,7 +976,7 @@ mod tests {
             registry.standard_id == 0x0004 && registry.vendor_id == CALIPTRA_VENDOR_ID_BYTES
         }
 
-        async fn start_streaming_request<Alloc, Io>(
+        async fn start_authorize_debug_unlock_token_stream<Alloc, Io>(
             &self,
             _req_len: usize,
             first: &[u8],
@@ -991,7 +997,7 @@ mod tests {
             Ok(true)
         }
 
-        async fn continue_streaming_request<Alloc, Io>(
+        async fn continue_authorize_debug_unlock_token_stream<Alloc, Io>(
             &self,
             chunk: &[u8],
             _alloc: &Alloc,
@@ -1009,7 +1015,7 @@ mod tests {
             Ok(())
         }
 
-        async fn finish_streaming_request<Alloc, Io>(
+        async fn finish_authorize_debug_unlock_token_stream<Alloc, Io>(
             &self,
             rsp: VdmResponseBuffer<'_, Alloc, Io>,
         ) -> McuResult<VdmResponse>
@@ -1066,7 +1072,7 @@ mod tests {
             registry.standard_id == 0x0004 && registry.vendor_id == CALIPTRA_VENDOR_ID_BYTES
         }
 
-        async fn start_streaming_request<Alloc, Io>(
+        async fn start_authorize_debug_unlock_token_stream<Alloc, Io>(
             &self,
             _req_len: usize,
             _first: &[u8],
@@ -1149,7 +1155,7 @@ mod tests {
             &first_io,
             &vdm,
             &first_chunk,
-            false,
+            None,
             true,
         ))
         .unwrap();
@@ -1174,7 +1180,7 @@ mod tests {
             &second_io,
             &vdm,
             &second_chunk,
-            false,
+            None,
             true,
         ))
         .unwrap();
@@ -1232,7 +1238,7 @@ mod tests {
             &first_io,
             &vdm,
             &first_chunk,
-            false,
+            None,
             true,
         ))
         .unwrap();
@@ -1257,7 +1263,7 @@ mod tests {
             &second_io,
             &vdm,
             &second_chunk,
-            false,
+            None,
             true,
         ))
         .unwrap();

--- a/runtime/userspace/api/spdm-lib/stack/src/set_certificate.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/set_certificate.rs
@@ -122,6 +122,265 @@ pub(crate) async fn handle_set_certificate_request<Pal: SpdmPal>(
     Ok(slot_id)
 }
 
+#[derive(Copy, Clone)]
+pub(crate) struct SetCertificateStreamState {
+    slot_id: u8,
+    key_pair_id: u8,
+    cert_model: u8,
+    root_hash: [u8; SHA384_DIGEST_SIZE],
+    der_len: usize,
+    der_received: usize,
+    data_checksum: u32,
+    cert_remaining: usize,
+    header: [u8; 6],
+    header_len: usize,
+    cert_count: usize,
+}
+
+pub(crate) async fn start_set_certificate_stream<Pal: SpdmPal>(
+    state: &ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
+    pal: &Pal,
+    io: &<Pal as SpdmPalIoTransport>::Io<'_>,
+    large_msg_size: usize,
+    first: &[u8],
+) -> SpdmResult<SetCertificateStreamState> {
+    if (state.phase as u8) < (Phase::AfterAlgorithms as u8) {
+        return Err(SPDM_UNEXPECTED_REQUEST);
+    }
+    if !state.advertised_cap_flags.contains(CapFlags::SET_CERT) {
+        return Err(unsupported_set_certificate());
+    }
+    let (hdr, body) = SpdmMsgHdrPdu::ref_from_prefix(first).map_err(|_| SPDM_INVALID_REQUEST)?;
+    if hdr.version != state.version.to_u8() {
+        return Err(SPDM_VERSION_MISMATCH);
+    }
+    if state.version < SpdmVersion::V12 {
+        return Err(unsupported_set_certificate());
+    }
+    let req_body = SetCertificateReqBody::ref_from_bytes(
+        body.get(..SetCertificateReqBody::SIZE)
+            .ok_or(SPDM_INVALID_REQUEST)?,
+    )
+    .map_err(|_| SPDM_INVALID_REQUEST)?;
+    if req_body.erase() {
+        return Err(SPDM_INVALID_REQUEST);
+    }
+    let slot_id = req_body.slot_id();
+    validate_request_slot(slot_id, pal.supported_slots())?;
+    let cert_model = effective_cert_model(state, req_body)?;
+    if !pal.set_certificate_authorized(io, slot_id, req_body.key_pair_id, cert_model, false) {
+        return Err(SPDM_SESSION_REQUIRED);
+    }
+    validate_request_attributes(state, req_body)?;
+    validate_negotiated_set_certificate_algorithms(state)?;
+
+    let payload_len = large_msg_size
+        .checked_sub(SpdmMsgHdrPdu::SIZE + SetCertificateReqBody::SIZE)
+        .ok_or(SPDM_INVALID_REQUEST)?;
+    if payload_len < SPDM_CERT_CHAIN_HDR_LEN || payload_len > u16::MAX as usize {
+        return Err(SPDM_INVALID_REQUEST);
+    }
+    let payload = body
+        .get(SetCertificateReqBody::SIZE..)
+        .ok_or(SPDM_INVALID_REQUEST)?;
+    if payload.len() < SPDM_CERT_CHAIN_HDR_LEN {
+        return Err(SPDM_INVALID_REQUEST);
+    }
+    let length = u16::from_le_bytes([payload[0], payload[1]]) as usize;
+    let reserved = u16::from_le_bytes([payload[2], payload[3]]);
+    if reserved != 0 || length != payload_len || length < SPDM_CERT_CHAIN_HDR_LEN {
+        return Err(SPDM_INVALID_REQUEST);
+    }
+    let root_hash: [u8; SHA384_DIGEST_SIZE] = payload
+        .get(4..SPDM_CERT_CHAIN_HDR_LEN)
+        .and_then(|s| s.try_into().ok())
+        .ok_or(SPDM_INVALID_REQUEST)?;
+    let der_len = payload_len - SPDM_CERT_CHAIN_HDR_LEN;
+    if der_len == 0 {
+        return Err(SPDM_INVALID_REQUEST);
+    }
+
+    pal.begin_write_cert_chain_stream(
+        io,
+        slot_id,
+        state.asym_algo(),
+        req_body.key_pair_id,
+        cert_model,
+        &root_hash,
+        der_len,
+    )
+    .await?;
+
+    let mut stream = SetCertificateStreamState {
+        slot_id,
+        key_pair_id: req_body.key_pair_id,
+        cert_model,
+        root_hash,
+        der_len,
+        der_received: 0,
+        data_checksum: 0,
+        cert_remaining: 0,
+        header: [0; 6],
+        header_len: 0,
+        cert_count: 0,
+    };
+    let der = &payload[SPDM_CERT_CHAIN_HDR_LEN..];
+    if let Err(err) =
+        continue_set_certificate_stream(pal, io, state.asym_algo(), &mut stream, der).await
+    {
+        abort_set_certificate_stream(state, pal, io, &stream).await;
+        return Err(err);
+    }
+    Ok(stream)
+}
+
+pub(crate) async fn continue_set_certificate_stream<Pal: SpdmPal>(
+    pal: &Pal,
+    io: &<Pal as SpdmPalIoTransport>::Io<'_>,
+    algo: caliptra_mcu_spdm_traits::SpdmPalAsymAlgo,
+    stream: &mut SetCertificateStreamState,
+    der: &[u8],
+) -> SpdmResult<()> {
+    if der.is_empty() {
+        return Ok(());
+    }
+    let end = stream
+        .der_received
+        .checked_add(der.len())
+        .ok_or(SPDM_INVALID_REQUEST)?;
+    if end > stream.der_len {
+        return Err(SPDM_INVALID_REQUEST);
+    }
+    validate_der_stream_chunk(stream, der)?;
+    pal.write_cert_chain_stream_chunk(io, stream.slot_id, algo, stream.der_received, der)
+        .await?;
+    stream.data_checksum = stream.data_checksum.wrapping_add(
+        der.iter()
+            .fold(0u32, |acc, &byte| acc.wrapping_add(byte as u32)),
+    );
+    stream.der_received = end;
+    Ok(())
+}
+
+pub(crate) async fn finish_set_certificate_stream<Pal: SpdmPal>(
+    state: &ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
+    pal: &Pal,
+    io: &<Pal as SpdmPalIoTransport>::Io<'_>,
+    stream: &SetCertificateStreamState,
+) -> SpdmResult<u8> {
+    if stream.der_received != stream.der_len
+        || stream.cert_remaining != 0
+        || stream.header_len != 0
+        || stream.cert_count == 0
+    {
+        return Err(SPDM_INVALID_REQUEST);
+    }
+    pal.finish_write_cert_chain_stream(
+        io,
+        stream.slot_id,
+        state.asym_algo(),
+        stream.key_pair_id,
+        stream.cert_model,
+        &stream.root_hash,
+        stream.der_len,
+        stream.data_checksum,
+    )
+    .await?;
+    Ok(stream.slot_id)
+}
+
+pub(crate) async fn abort_set_certificate_stream<Pal: SpdmPal>(
+    state: &ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
+    pal: &Pal,
+    io: &<Pal as SpdmPalIoTransport>::Io<'_>,
+    stream: &SetCertificateStreamState,
+) {
+    let _ = pal
+        .abort_write_cert_chain_stream(io, stream.slot_id, state.asym_algo())
+        .await;
+}
+
+fn validate_der_stream_chunk(
+    stream: &mut SetCertificateStreamState,
+    mut data: &[u8],
+) -> SpdmResult<()> {
+    while !data.is_empty() {
+        if stream.cert_remaining == 0 {
+            while !data.is_empty() {
+                if stream.header_len >= stream.header.len() {
+                    return Err(SPDM_INVALID_REQUEST);
+                }
+                stream.header[stream.header_len] = data[0];
+                stream.header_len += 1;
+                data = &data[1..];
+                if let Some(cert_len) =
+                    der_sequence_len_prefix(&stream.header[..stream.header_len])?
+                {
+                    if cert_len < stream.header_len {
+                        return Err(SPDM_INVALID_REQUEST);
+                    }
+                    stream.cert_count = stream.cert_count.saturating_add(1);
+                    stream.cert_remaining = cert_len - stream.header_len;
+                    if stream.cert_remaining == 0 {
+                        stream.header_len = 0;
+                    }
+                    break;
+                }
+            }
+        }
+
+        if stream.cert_remaining != 0 {
+            let n = stream.cert_remaining.min(data.len());
+            stream.cert_remaining -= n;
+            data = &data[n..];
+            if stream.cert_remaining == 0 {
+                stream.header_len = 0;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn der_sequence_len_prefix(input: &[u8]) -> SpdmResult<Option<usize>> {
+    if input.len() < 2 {
+        if input.first().is_some_and(|b| *b != 0x30) {
+            return Err(SPDM_INVALID_REQUEST);
+        }
+        return Ok(None);
+    }
+    if input[0] != 0x30 {
+        return Err(SPDM_INVALID_REQUEST);
+    }
+    let len_byte = input[1];
+    let (header_len, content_len) = if len_byte & 0x80 == 0 {
+        (2usize, len_byte as usize)
+    } else {
+        let len_len = (len_byte & 0x7f) as usize;
+        if len_len == 0 || len_len > 4 {
+            return Err(SPDM_INVALID_REQUEST);
+        }
+        if input.len() < 2 + len_len {
+            return Ok(None);
+        }
+        let mut content_len = 0usize;
+        for &byte in &input[2..2 + len_len] {
+            content_len = content_len.checked_shl(8).ok_or(SPDM_INVALID_REQUEST)?;
+            content_len = content_len
+                .checked_add(byte as usize)
+                .ok_or(SPDM_INVALID_REQUEST)?;
+        }
+        (2 + len_len, content_len)
+    };
+    if content_len == 0 {
+        return Err(SPDM_INVALID_REQUEST);
+    }
+    Ok(Some(
+        header_len
+            .checked_add(content_len)
+            .ok_or(SPDM_INVALID_REQUEST)?,
+    ))
+}
+
 fn unsupported_set_certificate() -> SpdmError {
     SPDM_UNSUPPORTED_REQUEST.with_data(ReqRespCode::SET_CERTIFICATE.0)
 }
@@ -236,30 +495,7 @@ fn validate_der_chain(der: &[u8]) -> SpdmResult<usize> {
 }
 
 fn der_sequence_len(input: &[u8]) -> Option<usize> {
-    if input.len() < 2 || input[0] != 0x30 {
-        return None;
-    }
-
-    let len_byte = input[1];
-    let (header_len, content_len) = if len_byte & 0x80 == 0 {
-        (2usize, len_byte as usize)
-    } else {
-        let len_len = (len_byte & 0x7f) as usize;
-        if len_len == 0 || len_len > 4 || input.len() < 2 + len_len {
-            return None;
-        }
-        let mut content_len = 0usize;
-        for &byte in &input[2..2 + len_len] {
-            content_len = content_len.checked_shl(8)?;
-            content_len = content_len.checked_add(byte as usize)?;
-        }
-        (2 + len_len, content_len)
-    };
-
-    if content_len == 0 {
-        return None;
-    }
-    let total_len = header_len.checked_add(content_len)?;
+    let total_len = der_sequence_len_prefix(input).ok()??;
     (total_len <= input.len()).then_some(total_len)
 }
 

--- a/runtime/userspace/api/spdm-lib/stack/src/set_certificate.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/set_certificate.rs
@@ -278,7 +278,8 @@ pub(crate) async fn finish_set_certificate_stream<Pal: SpdmPal>(
         &stream.root_hash,
         stream.der_len,
     )
-    .await?;
+    .await
+    .map_err(map_set_cert_validation_error)?;
     Ok(stream.slot_id)
 }
 

--- a/runtime/userspace/api/spdm-lib/stack/src/set_certificate.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/set_certificate.rs
@@ -130,7 +130,6 @@ pub(crate) struct SetCertificateStreamState {
     root_hash: [u8; SHA384_DIGEST_SIZE],
     der_len: usize,
     der_received: usize,
-    data_checksum: u32,
     cert_remaining: usize,
     header: [u8; 6],
     header_len: usize,
@@ -218,7 +217,6 @@ pub(crate) async fn start_set_certificate_stream<Pal: SpdmPal>(
         root_hash,
         der_len,
         der_received: 0,
-        data_checksum: 0,
         cert_remaining: 0,
         header: [0; 6],
         header_len: 0,
@@ -254,10 +252,6 @@ pub(crate) async fn continue_set_certificate_stream<Pal: SpdmPal>(
     validate_der_stream_chunk(stream, der)?;
     pal.write_cert_chain_stream_chunk(io, stream.slot_id, algo, stream.der_received, der)
         .await?;
-    stream.data_checksum = stream.data_checksum.wrapping_add(
-        der.iter()
-            .fold(0u32, |acc, &byte| acc.wrapping_add(byte as u32)),
-    );
     stream.der_received = end;
     Ok(())
 }
@@ -283,7 +277,6 @@ pub(crate) async fn finish_set_certificate_stream<Pal: SpdmPal>(
         stream.cert_model,
         &stream.root_hash,
         stream.der_len,
-        stream.data_checksum,
     )
     .await?;
     Ok(stream.slot_id)

--- a/runtime/userspace/api/spdm-lib/stack/src/stack.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/stack.rs
@@ -599,7 +599,7 @@ async fn dispatch<'a, Pal: SpdmPal, Vdm: SpdmVdmBackend, const MAX_SESSIONS: usi
         ReqRespCode::GET_CERTIFICATE => certificate::handle_get_certificate(state, pal, io).await,
         ReqRespCode::CHALLENGE => challenge::handle_challenge(state, pal, io).await,
         ReqRespCode::CHUNK_SEND => {
-            chunk::handle_chunk_send(state, pal, io, vdm, io.request(), false).await
+            chunk::handle_chunk_send(state, pal, io, vdm, io.request(), false, true).await
         }
         ReqRespCode::CHUNK_GET => chunk::handle_chunk_get(state, pal, io, io.request()).await,
         #[cfg(feature = "set-certificate")]
@@ -642,7 +642,7 @@ async fn abort_chunk_reassembly_if_interrupted<Pal: SpdmPal, Vdm: SpdmVdmBackend
     code: ReqRespCode,
 ) {
     if code != ReqRespCode::CHUNK_SEND && state.large_msg_ctx.request_in_progress() {
-        chunk::abort_streaming_request_if_needed(state, pal, io, vdm).await;
+        chunk::abort_active_streaming_request(state, pal, io, vdm).await;
         state.large_msg_ctx.reset();
     }
 }
@@ -921,8 +921,16 @@ async fn handle_secured_inner<'a, Pal: SpdmPal, Vdm: SpdmVdmBackend, const MAX_S
             .await
         }
         ReqRespCode::CHUNK_SEND => {
-            let chunk_send_ack =
-                chunk::handle_chunk_send(state, pal, io, vdm, spdm_msg, true).await?;
+            let chunk_send_ack = chunk::handle_chunk_send(
+                state,
+                pal,
+                io,
+                vdm,
+                spdm_msg,
+                true,
+                session_state == SessionState::Established,
+            )
+            .await?;
             let head = pal.header_size();
             let spdm_rsp = &chunk_send_ack[head..];
             let session = sessions.find_mut(session_id).ok_or(SPDM_UNSPECIFIED)?;

--- a/runtime/userspace/api/spdm-lib/stack/src/stack.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/stack.rs
@@ -599,7 +599,7 @@ async fn dispatch<'a, Pal: SpdmPal, Vdm: SpdmVdmBackend, const MAX_SESSIONS: usi
         ReqRespCode::GET_CERTIFICATE => certificate::handle_get_certificate(state, pal, io).await,
         ReqRespCode::CHALLENGE => challenge::handle_challenge(state, pal, io).await,
         ReqRespCode::CHUNK_SEND => {
-            chunk::handle_chunk_send(state, pal, io, vdm, io.request(), false, true).await
+            chunk::handle_chunk_send(state, pal, io, vdm, io.request(), None, true).await
         }
         ReqRespCode::CHUNK_GET => chunk::handle_chunk_get(state, pal, io, io.request()).await,
         #[cfg(feature = "set-certificate")]
@@ -927,7 +927,7 @@ async fn handle_secured_inner<'a, Pal: SpdmPal, Vdm: SpdmVdmBackend, const MAX_S
                 io,
                 vdm,
                 spdm_msg,
-                true,
+                Some(session_id),
                 session_state == SessionState::Established,
             )
             .await?;

--- a/runtime/userspace/api/spdm-lib/stack/src/stack.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/stack.rs
@@ -247,14 +247,7 @@ impl<S, L: core::ops::DerefMut<Target = [u8]>> ConnectionState<S, L> {
     }
 
     /// Resets the incoming chunk reassembly state, securely wiping any buffered reassembly bytes.
-    #[allow(dead_code)]
     pub(crate) fn reset_chunk_assembly(&mut self) {
-        self.large_msg_ctx.reset();
-    }
-
-    /// Resets the outgoing large response state, securely wiping any buffered response bytes.
-    #[allow(dead_code)]
-    pub(crate) fn reset_large_response(&mut self) {
         self.large_msg_ctx.reset();
     }
 }
@@ -583,7 +576,7 @@ async fn dispatch<'a, Pal: SpdmPal, Vdm: SpdmVdmBackend, const MAX_SESSIONS: usi
     code: ReqRespCode,
     vdm: &Vdm,
 ) -> SpdmResult<PalBytes<'a, Pal>> {
-    abort_chunk_reassembly_if_interrupted(state, code);
+    abort_chunk_reassembly_if_interrupted(state, pal, io, vdm, code).await;
     if code != ReqRespCode::CHUNK_GET
         && code != ReqRespCode::CHUNK_SEND
         && state.large_msg_ctx.response_in_progress()
@@ -641,11 +634,15 @@ async fn dispatch<'a, Pal: SpdmPal, Vdm: SpdmVdmBackend, const MAX_SESSIONS: usi
     }
 }
 
-fn abort_chunk_reassembly_if_interrupted<S, L>(state: &mut ConnectionState<S, L>, code: ReqRespCode)
-where
-    L: core::ops::DerefMut<Target = [u8]>,
-{
+async fn abort_chunk_reassembly_if_interrupted<Pal: SpdmPal, Vdm: SpdmVdmBackend>(
+    state: &mut ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,
+    pal: &Pal,
+    io: &<Pal as SpdmPalIoTransport>::Io<'_>,
+    vdm: &Vdm,
+    code: ReqRespCode,
+) {
     if code != ReqRespCode::CHUNK_SEND && state.large_msg_ctx.request_in_progress() {
+        chunk::abort_streaming_request_if_needed(state, pal, io, vdm).await;
         state.large_msg_ctx.reset();
     }
 }
@@ -790,7 +787,7 @@ async fn handle_secured_inner<'a, Pal: SpdmPal, Vdm: SpdmVdmBackend, const MAX_S
     // ── Dispatch on SPDM code ───────────────────────────────────────
     let (spdm_hdr, _) =
         SpdmMsgHdrPdu::ref_from_prefix(spdm_msg).map_err(|_| SPDM_INVALID_REQUEST)?;
-    abort_chunk_reassembly_if_interrupted(state, spdm_hdr.code);
+    abort_chunk_reassembly_if_interrupted(state, pal, io, vdm, spdm_hdr.code).await;
     let session_state = sessions.find(session_id).ok_or(SPDM_UNSPECIFIED)?.state;
     let response_key_type = validate_message_allowed_phase(spdm_hdr.code, session_state)?;
 

--- a/runtime/userspace/api/spdm-lib/stack/src/tests/stack_set_certificate.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/tests/stack_set_certificate.rs
@@ -104,6 +104,44 @@ fn plaintext_chunked_set_certificate_succeeds() {
 }
 
 #[test]
+fn chunked_set_certificate_rejects_context_switch_without_resetting() {
+    let pal = TestPal::default();
+    let (mut state, mut sessions, session_id) = handshake_session(&pal);
+    let large_req = set_certificate_request(&pal);
+    let (first, second) = split_large_request(&large_req);
+    let first_chunk = chunk_send_request(7, 0, false, Some(large_req.len()), first);
+    let second_chunk = chunk_send_request(7, 1, true, None, second);
+
+    send_plaintext_chunk(&mut state, &mut sessions, &pal, &first_chunk);
+    let rsp = send_secured_chunk(&mut state, &mut sessions, &pal, session_id, &second_chunk);
+    assert_eq!(
+        secured_spdm_response(&rsp),
+        &[
+            SpdmVersion::V12.to_u8(),
+            ReqRespCode::ERROR.0,
+            SPDM_UNEXPECTED_REQUEST.spec_byte(),
+            0,
+        ]
+    );
+    assert!(state.large_msg_ctx.request_in_progress());
+    assert_eq!(pal.stream_aborts.get(), 0);
+    assert_eq!(pal.op.take(), None);
+
+    let rsp = send_plaintext_chunk(&mut state, &mut sessions, &pal, &second_chunk);
+    assert_eq!(
+        &rsp[6..],
+        &[
+            SpdmVersion::V12.to_u8(),
+            ReqRespCode::SET_CERTIFICATE_RSP.0,
+            1,
+            0,
+        ]
+    );
+    assert!(!state.large_msg_ctx.request_in_progress());
+    assert!(pal.op.take().is_some());
+}
+
+#[test]
 fn secured_chunked_set_certificate_succeeds() {
     let pal = TestPal::default();
     let (mut state, mut sessions, session_id) = established_session(&pal);
@@ -223,10 +261,42 @@ fn plaintext_chunked_set_certificate_bad_root_hash_does_not_commit() {
             0,
             SpdmVersion::V12.to_u8(),
             ReqRespCode::ERROR.0,
-            SPDM_UNSPECIFIED.spec_byte(),
+            SPDM_INVALID_REQUEST.spec_byte(),
             0,
         ]
     );
     assert!(!state.large_msg_ctx.request_in_progress());
+    assert_eq!(pal.stream_aborts.get(), 1);
+    assert!(pal.stream_cert.borrow().is_empty());
+    assert_eq!(pal.op.take(), None);
+}
+
+#[test]
+fn plaintext_chunked_set_certificate_truncated_final_der_aborts() {
+    let pal = TestPal::default();
+    let mut state = chunking_state();
+    let mut sessions = crate::session::SessionManager::new();
+    let mut large_req = set_certificate_request(&pal);
+    // The final DER sequence declares two content bytes but supplies one.
+    let final_der_len = large_req.len() - 2;
+    large_req[final_der_len] = 2;
+    let (first, second) = split_large_request(&large_req);
+    let first_chunk = chunk_send_request(9, 0, false, Some(large_req.len()), first);
+    let second_chunk = chunk_send_request(9, 1, true, None, second);
+
+    send_plaintext_chunk(&mut state, &mut sessions, &pal, &first_chunk);
+    let rsp = send_plaintext_chunk(&mut state, &mut sessions, &pal, &second_chunk);
+    assert_eq!(
+        &rsp[6..],
+        &[
+            SpdmVersion::V12.to_u8(),
+            ReqRespCode::ERROR.0,
+            SPDM_INVALID_REQUEST.spec_byte(),
+            0,
+        ]
+    );
+    assert!(!state.large_msg_ctx.request_in_progress());
+    assert_eq!(pal.stream_aborts.get(), 1);
+    assert!(pal.stream_cert.borrow().is_empty());
     assert_eq!(pal.op.take(), None);
 }

--- a/runtime/userspace/api/spdm-lib/stack/src/tests/stack_set_certificate.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/tests/stack_set_certificate.rs
@@ -71,6 +71,7 @@ fn plaintext_chunked_set_certificate_succeeds() {
         ]
     );
     assert!(state.large_msg_ctx.request_in_progress());
+    assert!(state.large_msg_ctx.get_buffer().is_none());
 
     let rsp = send_plaintext_chunk(&mut state, &mut sessions, &pal, &second_chunk);
     assert_eq!(
@@ -123,6 +124,7 @@ fn secured_chunked_set_certificate_is_unsupported() {
         ]
     );
     assert!(state.large_msg_ctx.request_in_progress());
+    assert!(state.large_msg_ctx.get_buffer().is_none());
 
     let rsp = send_secured_chunk(&mut state, &mut sessions, &pal, session_id, &second_chunk);
     assert_eq!(
@@ -137,6 +139,53 @@ fn secured_chunked_set_certificate_is_unsupported() {
             SpdmVersion::V12.to_u8(),
             ReqRespCode::ERROR.0,
             SPDM_UNSUPPORTED_REQUEST.spec_byte(),
+            0,
+        ]
+    );
+    assert!(!state.large_msg_ctx.request_in_progress());
+    assert_eq!(pal.op.take(), None);
+}
+
+#[test]
+fn plaintext_chunked_set_certificate_bad_root_hash_does_not_commit() {
+    let pal = TestPal::default();
+    let mut state = chunking_state();
+    let mut sessions = crate::session::SessionManager::new();
+    let mut large_req = set_certificate_request(&pal);
+    // SPDM header (4) + cert-chain length/reserved (4) = root hash starts at 8.
+    large_req[8] ^= 0x55;
+    let (first, second) = split_large_request(&large_req);
+    let first_chunk = chunk_send_request(8, 0, false, Some(large_req.len()), first);
+    let second_chunk = chunk_send_request(8, 1, true, None, second);
+
+    let rsp = send_plaintext_chunk(&mut state, &mut sessions, &pal, &first_chunk);
+    assert_eq!(
+        &rsp[..],
+        &[
+            SpdmVersion::V12.to_u8(),
+            ReqRespCode::CHUNK_SEND_ACK.0,
+            0,
+            8,
+            0,
+            0
+        ]
+    );
+    assert!(state.large_msg_ctx.request_in_progress());
+    assert!(state.large_msg_ctx.get_buffer().is_none());
+
+    let rsp = send_plaintext_chunk(&mut state, &mut sessions, &pal, &second_chunk);
+    assert_eq!(
+        &rsp[..],
+        &[
+            SpdmVersion::V12.to_u8(),
+            ReqRespCode::CHUNK_SEND_ACK.0,
+            0,
+            8,
+            1,
+            0,
+            SpdmVersion::V12.to_u8(),
+            ReqRespCode::ERROR.0,
+            SPDM_UNSPECIFIED.spec_byte(),
             0,
         ]
     );

--- a/runtime/userspace/api/spdm-lib/stack/src/tests/stack_set_certificate.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/tests/stack_set_certificate.rs
@@ -3,6 +3,7 @@
 extern crate std;
 
 use super::*;
+use caliptra_mcu_spdm_codec::CHUNK_ACK_ATTR_EARLY_ERROR;
 use caliptra_mcu_spdm_traits::NoVdmBackend;
 use futures::executor::block_on;
 use std::vec::Vec;
@@ -103,7 +104,7 @@ fn plaintext_chunked_set_certificate_succeeds() {
 }
 
 #[test]
-fn secured_chunked_set_certificate_is_unsupported() {
+fn secured_chunked_set_certificate_succeeds() {
     let pal = TestPal::default();
     let (mut state, mut sessions, session_id) = established_session(&pal);
     let large_req = set_certificate_request(&pal);
@@ -137,8 +138,45 @@ fn secured_chunked_set_certificate_is_unsupported() {
             1,
             0,
             SpdmVersion::V12.to_u8(),
+            ReqRespCode::SET_CERTIFICATE_RSP.0,
+            1,
+            0,
+        ]
+    );
+    assert!(!state.large_msg_ctx.request_in_progress());
+    assert_eq!(
+        pal.op.take(),
+        Some(StoreOp::Write {
+            slot: 1,
+            key_pair_id: 0,
+            cert_model: 2,
+            root_hash: test_digest(&pal.cert_chain[..5]),
+            cert_chain: pal.cert_chain.to_vec(),
+        })
+    );
+}
+
+#[test]
+fn handshake_session_chunked_set_certificate_is_rejected() {
+    let pal = TestPal::default();
+    let (mut state, mut sessions, session_id) = handshake_session(&pal);
+    let large_req = set_certificate_request(&pal);
+    let (first, _) = split_large_request(&large_req);
+    let first_chunk = chunk_send_request(7, 0, false, Some(large_req.len()), first);
+
+    let rsp = send_secured_chunk(&mut state, &mut sessions, &pal, session_id, &first_chunk);
+    assert_eq!(
+        secured_spdm_response(&rsp),
+        &[
+            SpdmVersion::V12.to_u8(),
+            ReqRespCode::CHUNK_SEND_ACK.0,
+            CHUNK_ACK_ATTR_EARLY_ERROR,
+            7,
+            0,
+            0,
+            SpdmVersion::V12.to_u8(),
             ReqRespCode::ERROR.0,
-            SPDM_UNSUPPORTED_REQUEST.spec_byte(),
+            SPDM_INVALID_REQUEST.spec_byte(),
             0,
         ]
     );

--- a/runtime/userspace/api/spdm-lib/stack/src/tests/support.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/tests/support.rs
@@ -405,7 +405,6 @@ impl SpdmPalCertStore for TestPal {
         cert_model: u8,
         root_hash: &[u8; SHA384_DIGEST_SIZE],
         _data_len: usize,
-        _data_checksum: u32,
     ) -> McuResult<()> {
         if let Some(err) = self.validate_error {
             return Err(err);

--- a/runtime/userspace/api/spdm-lib/stack/src/tests/support.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/tests/support.rs
@@ -18,7 +18,7 @@ use core::ops::{Deref, DerefMut};
 use futures::executor::block_on;
 use mcu_error::{McuErrorCode, McuResult};
 use std::boxed::Box;
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::vec;
 use std::vec::Vec;
 
@@ -107,6 +107,7 @@ pub struct TestPal {
     pub cert_chain: &'static [u8],
     pub op: RefCell<Option<StoreOp>>,
     pub stream_cert: RefCell<Vec<u8>>,
+    pub stream_aborts: Cell<usize>,
 }
 
 impl Default for TestPal {
@@ -121,6 +122,7 @@ impl Default for TestPal {
             cert_chain: TEST_CERT_CHAIN,
             op: RefCell::new(None),
             stream_cert: RefCell::new(Vec::new()),
+            stream_aborts: Cell::new(0),
         }
     }
 }
@@ -430,6 +432,18 @@ impl SpdmPalCertStore for TestPal {
         }));
         Ok(())
     }
+
+    async fn abort_write_cert_chain_stream(
+        &self,
+        _io: &Self::Io<'_>,
+        _slot: u8,
+        _algo: SpdmPalAsymAlgo,
+    ) -> McuResult<()> {
+        self.stream_aborts.set(self.stream_aborts.get() + 1);
+        self.stream_cert.borrow_mut().clear();
+        Ok(())
+    }
+
     #[cfg(feature = "set-certificate")]
     async fn erase_cert_chain(
         &self,

--- a/runtime/userspace/api/spdm-lib/stack/src/tests/support.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/tests/support.rs
@@ -363,7 +363,7 @@ impl SpdmPalCertStore for TestPal {
         Ok(())
     }
 
-async fn begin_write_cert_chain_stream(
+    async fn begin_write_cert_chain_stream(
         &self,
         _io: &Self::Io<'_>,
         slot: u8,

--- a/runtime/userspace/api/spdm-lib/stack/src/tests/support.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/tests/support.rs
@@ -106,6 +106,7 @@ pub struct TestPal {
     pub erase_error: Option<McuErrorCode>,
     pub cert_chain: &'static [u8],
     pub op: RefCell<Option<StoreOp>>,
+    pub stream_cert: RefCell<Vec<u8>>,
 }
 
 impl Default for TestPal {
@@ -119,6 +120,7 @@ impl Default for TestPal {
             erase_error: None,
             cert_chain: TEST_CERT_CHAIN,
             op: RefCell::new(None),
+            stream_cert: RefCell::new(Vec::new()),
         }
     }
 }
@@ -361,7 +363,74 @@ impl SpdmPalCertStore for TestPal {
         Ok(())
     }
 
-    #[cfg(feature = "set-certificate")]
+async fn begin_write_cert_chain_stream(
+        &self,
+        _io: &Self::Io<'_>,
+        slot: u8,
+        _algo: SpdmPalAsymAlgo,
+        key_pair_id: u8,
+        cert_model: u8,
+        root_hash: &[u8; SHA384_DIGEST_SIZE],
+        data_len: usize,
+    ) -> McuResult<()> {
+        if let Some(err) = self.write_error {
+            return Err(err);
+        }
+        let mut data = self.stream_cert.borrow_mut();
+        data.clear();
+        data.resize(data_len, 0);
+        let _ = (slot, key_pair_id, cert_model, root_hash);
+        Ok(())
+    }
+
+    async fn write_cert_chain_stream_chunk(
+        &self,
+        _io: &Self::Io<'_>,
+        _slot: u8,
+        _algo: SpdmPalAsymAlgo,
+        offset: usize,
+        data: &[u8],
+    ) -> McuResult<()> {
+        let mut cert = self.stream_cert.borrow_mut();
+        cert[offset..offset + data.len()].copy_from_slice(data);
+        Ok(())
+    }
+
+    async fn finish_write_cert_chain_stream(
+        &self,
+        _io: &Self::Io<'_>,
+        slot: u8,
+        _algo: SpdmPalAsymAlgo,
+        key_pair_id: u8,
+        cert_model: u8,
+        root_hash: &[u8; SHA384_DIGEST_SIZE],
+        _data_len: usize,
+        _data_checksum: u32,
+    ) -> McuResult<()> {
+        if let Some(err) = self.validate_error {
+            return Err(err);
+        }
+        let cert_chain = self.stream_cert.borrow().clone();
+        let first_len = cert_chain
+            .get(1)
+            .copied()
+            .map(|len| len as usize + 2)
+            .unwrap_or(0);
+        if first_len == 0
+            || first_len > cert_chain.len()
+            || test_digest(&cert_chain[..first_len]) != *root_hash
+        {
+            return Err(mcu_error::codes::INVARIANT);
+        }
+        self.op.replace(Some(StoreOp::Write {
+            slot,
+            key_pair_id,
+            cert_model,
+            root_hash: *root_hash,
+            cert_chain,
+        }));
+        Ok(())
+    }
     async fn erase_cert_chain(
         &self,
         _io: &Self::Io<'_>,

--- a/runtime/userspace/api/spdm-lib/stack/src/tests/support.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/tests/support.rs
@@ -431,6 +431,7 @@ impl SpdmPalCertStore for TestPal {
         }));
         Ok(())
     }
+    #[cfg(feature = "set-certificate")]
     async fn erase_cert_chain(
         &self,
         _io: &Self::Io<'_>,

--- a/runtime/userspace/api/spdm-lib/stack/src/vendor_defined.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/vendor_defined.rs
@@ -223,7 +223,7 @@ pub(crate) async fn handle_large_vendor_defined_request<Pal: SpdmPal, V: SpdmVdm
 /// standard_id + vendor_id + resp_len) directly into `out` (which must be sized
 /// to the envelope). The backend's payload is expected to follow at the same
 /// buffer's offset `out.len()`.
-fn write_vendor_defined_envelope(
+pub(crate) fn write_vendor_defined_envelope(
     version: SpdmVersion,
     standard_id: u16,
     vendor_id: &[u8],

--- a/runtime/userspace/api/spdm-lib/stack/src/vendor_defined.rs
+++ b/runtime/userspace/api/spdm-lib/stack/src/vendor_defined.rs
@@ -165,6 +165,7 @@ pub(crate) async fn handle_vendor_defined_request<'a, Pal: SpdmPal, V: SpdmVdmBa
 /// large-message buffer is still occupied by the reassembled request, so large
 /// VDM responses are intentionally disabled here; handlers get only the inline
 /// response area and must return [`VdmResponse::Inline`].
+#[cfg(any(test, feature = "generic-large-request"))]
 pub(crate) async fn handle_large_vendor_defined_request<Pal: SpdmPal, V: SpdmVdmBackend>(
     vdm: &V,
     state: &ConnectionState<Pal::State, <Pal as SpdmPalAlloc>::LargeBuf>,

--- a/runtime/userspace/api/spdm-lib/traits/src/cert.rs
+++ b/runtime/userspace/api/spdm-lib/traits/src/cert.rs
@@ -165,6 +165,63 @@ pub trait SpdmPalCertStore: crate::SpdmPalIoTransport {
         data: &[u8],
     ) -> McuResult<()>;
 
+    /// Begins a non-atomic streaming SET_CERTIFICATE write transaction.
+    ///
+    /// Implementations may erase/overwrite target storage at begin time. A
+    /// request becomes valid only after [`finish_write_cert_chain_stream`](Self::finish_write_cert_chain_stream)
+    /// commits metadata; interrupted or invalid requests need not preserve the old chain.
+    #[allow(clippy::too_many_arguments)]
+    async fn begin_write_cert_chain_stream(
+        &self,
+        _io: &Self::Io<'_>,
+        _slot: u8,
+        _algo: SpdmPalAsymAlgo,
+        _key_pair_id: u8,
+        _cert_info: u8,
+        _root_hash: &[u8; 48],
+        _data_len: usize,
+    ) -> McuResult<()> {
+        Err(mcu_error::codes::NOT_IMPLEMENTED)
+    }
+
+    /// Writes one DER chunk at `offset` within the streaming cert-chain data.
+    async fn write_cert_chain_stream_chunk(
+        &self,
+        _io: &Self::Io<'_>,
+        _slot: u8,
+        _algo: SpdmPalAsymAlgo,
+        _offset: usize,
+        _data: &[u8],
+    ) -> McuResult<()> {
+        Err(mcu_error::codes::NOT_IMPLEMENTED)
+    }
+
+    /// Commits a streaming SET_CERTIFICATE write transaction.
+    #[allow(clippy::too_many_arguments)]
+    async fn finish_write_cert_chain_stream(
+        &self,
+        _io: &Self::Io<'_>,
+        _slot: u8,
+        _algo: SpdmPalAsymAlgo,
+        _key_pair_id: u8,
+        _cert_info: u8,
+        _root_hash: &[u8; 48],
+        _data_len: usize,
+        _data_checksum: u32,
+    ) -> McuResult<()> {
+        Err(mcu_error::codes::NOT_IMPLEMENTED)
+    }
+
+    /// Aborts a streaming SET_CERTIFICATE write transaction.
+    async fn abort_write_cert_chain_stream(
+        &self,
+        _io: &Self::Io<'_>,
+        _slot: u8,
+        _algo: SpdmPalAsymAlgo,
+    ) -> McuResult<()> {
+        Ok(())
+    }
+
     /// Erase the cert chain in `slot` for the given algorithm.
     #[cfg(feature = "set-certificate")]
     async fn erase_cert_chain(

--- a/runtime/userspace/api/spdm-lib/traits/src/cert.rs
+++ b/runtime/userspace/api/spdm-lib/traits/src/cert.rs
@@ -207,7 +207,6 @@ pub trait SpdmPalCertStore: crate::SpdmPalIoTransport {
         _cert_info: u8,
         _root_hash: &[u8; 48],
         _data_len: usize,
-        _data_checksum: u32,
     ) -> McuResult<()> {
         Err(mcu_error::codes::NOT_IMPLEMENTED)
     }

--- a/runtime/userspace/api/spdm-lib/traits/src/vendor_defined.rs
+++ b/runtime/userspace/api/spdm-lib/traits/src/vendor_defined.rs
@@ -82,6 +82,62 @@ pub trait SpdmVdmBackend {
     /// Returns true when this backend owns the decoded VDM registry ID.
     fn match_id(&self, registry: &VdmRegistry<'_>) -> bool;
 
+    /// Attempts to start streaming a matched large VDM request.
+    ///
+    /// `req_len` is the total VDM payload length (excluding the SPDM
+    /// VENDOR_DEFINED envelope). `first` is the VDM payload bytes carried in the
+    /// first CHUNK_SEND fragment. Backends return `Ok(true)` only when they own
+    /// and have started streaming this request; `Ok(false)` lets the stack fall
+    /// back to buffered large-request handling.
+    async fn start_streaming_request<Alloc, Io>(
+        &self,
+        _req_len: usize,
+        _first: &[u8],
+        _alloc: &Alloc,
+        _io: &Io,
+    ) -> McuResult<bool>
+    where
+        Alloc: SpdmPalAlloc,
+        Io: SpdmPalIo,
+    {
+        Ok(false)
+    }
+
+    /// Streams additional VDM payload bytes for a request accepted by
+    /// [`start_streaming_request`](Self::start_streaming_request).
+    async fn continue_streaming_request<Alloc, Io>(
+        &self,
+        _chunk: &[u8],
+        _alloc: &Alloc,
+        _io: &Io,
+    ) -> McuResult<()>
+    where
+        Alloc: SpdmPalAlloc,
+        Io: SpdmPalIo,
+    {
+        Err(mcu_error::codes::NOT_IMPLEMENTED)
+    }
+
+    /// Finishes a streaming VDM request and writes the VDM response payload.
+    async fn finish_streaming_request<Alloc, Io>(
+        &self,
+        _rsp: VdmResponseBuffer<'_, Alloc, Io>,
+    ) -> McuResult<VdmResponse>
+    where
+        Alloc: SpdmPalAlloc,
+        Io: SpdmPalIo,
+    {
+        Err(mcu_error::codes::NOT_IMPLEMENTED)
+    }
+
+    /// Aborts any in-progress streaming VDM request owned by this backend.
+    async fn abort_streaming_request<Alloc, Io>(&self, _alloc: &Alloc, _io: &Io)
+    where
+        Alloc: SpdmPalAlloc,
+        Io: SpdmPalIo,
+    {
+    }
+
     /// Handles a matched VDM request and writes only the VDM response payload.
     ///
     /// Called only after [`SpdmVdmBackend::match_id`] has selected this backend, so it

--- a/runtime/userspace/api/spdm-lib/traits/src/vendor_defined.rs
+++ b/runtime/userspace/api/spdm-lib/traits/src/vendor_defined.rs
@@ -82,14 +82,14 @@ pub trait SpdmVdmBackend {
     /// Returns true when this backend owns the decoded VDM registry ID.
     fn match_id(&self, registry: &VdmRegistry<'_>) -> bool;
 
-    /// Attempts to start streaming a matched large VDM request.
+    /// Attempts to start streaming an AuthorizeDebugUnlockToken request.
     ///
     /// `req_len` is the total VDM payload length (excluding the SPDM
     /// VENDOR_DEFINED envelope). `first` is the VDM payload bytes carried in the
     /// first CHUNK_SEND fragment. Backends return `Ok(true)` only when they own
     /// and have started streaming this request; `Ok(false)` lets the stack fall
     /// back to buffered large-request handling.
-    async fn start_streaming_request<Alloc, Io>(
+    async fn start_authorize_debug_unlock_token_stream<Alloc, Io>(
         &self,
         _req_len: usize,
         _first: &[u8],
@@ -103,9 +103,8 @@ pub trait SpdmVdmBackend {
         Ok(false)
     }
 
-    /// Streams additional VDM payload bytes for a request accepted by
-    /// [`start_streaming_request`](Self::start_streaming_request).
-    async fn continue_streaming_request<Alloc, Io>(
+    /// Streams additional AuthorizeDebugUnlockToken payload bytes.
+    async fn continue_authorize_debug_unlock_token_stream<Alloc, Io>(
         &self,
         _chunk: &[u8],
         _alloc: &Alloc,
@@ -118,8 +117,8 @@ pub trait SpdmVdmBackend {
         Err(mcu_error::codes::NOT_IMPLEMENTED)
     }
 
-    /// Finishes a streaming VDM request and writes the VDM response payload.
-    async fn finish_streaming_request<Alloc, Io>(
+    /// Finishes a streaming AuthorizeDebugUnlockToken request.
+    async fn finish_authorize_debug_unlock_token_stream<Alloc, Io>(
         &self,
         _rsp: VdmResponseBuffer<'_, Alloc, Io>,
     ) -> McuResult<VdmResponse>
@@ -130,8 +129,8 @@ pub trait SpdmVdmBackend {
         Err(mcu_error::codes::NOT_IMPLEMENTED)
     }
 
-    /// Aborts any in-progress streaming VDM request owned by this backend.
-    async fn abort_streaming_request<Alloc, Io>(&self, _alloc: &Alloc, _io: &Io)
+    /// Aborts an in-progress AuthorizeDebugUnlockToken request.
+    async fn abort_authorize_debug_unlock_token_stream<Alloc, Io>(&self, _alloc: &Alloc, _io: &Io)
     where
         Alloc: SpdmPalAlloc,
         Io: SpdmPalIo,

--- a/runtime/userspace/api/spdm-lib/vdm-handler/src/iana/ocp/caliptra_vdm/mod.rs
+++ b/runtime/userspace/api/spdm-lib/vdm-handler/src/iana/ocp/caliptra_vdm/mod.rs
@@ -158,7 +158,7 @@ impl<H: CaliptraVdmCommands> SpdmVdmBackend for CaliptraVdm<'_, H> {
             && registry.vendor_id == CALIPTRA_VENDOR_ID.to_le_bytes()
     }
 
-    async fn start_streaming_request<Alloc, Io>(
+    async fn start_authorize_debug_unlock_token_stream<Alloc, Io>(
         &self,
         req_len: usize,
         first: &[u8],
@@ -192,7 +192,7 @@ impl<H: CaliptraVdmCommands> SpdmVdmBackend for CaliptraVdm<'_, H> {
         }
     }
 
-    async fn continue_streaming_request<Alloc, Io>(
+    async fn continue_authorize_debug_unlock_token_stream<Alloc, Io>(
         &self,
         chunk: &[u8],
         alloc: &Alloc,
@@ -208,7 +208,7 @@ impl<H: CaliptraVdmCommands> SpdmVdmBackend for CaliptraVdm<'_, H> {
             .map_err(|_| INVARIANT)
     }
 
-    async fn finish_streaming_request<Alloc, Io>(
+    async fn finish_authorize_debug_unlock_token_stream<Alloc, Io>(
         &self,
         rsp: VdmResponseBuffer<'_, Alloc, Io>,
     ) -> McuResult<VdmResponse>
@@ -234,7 +234,7 @@ impl<H: CaliptraVdmCommands> SpdmVdmBackend for CaliptraVdm<'_, H> {
         Ok(VdmResponse::Inline(VDM_HEADER_LEN + 1))
     }
 
-    async fn abort_streaming_request<Alloc, Io>(&self, alloc: &Alloc, _io: &Io)
+    async fn abort_authorize_debug_unlock_token_stream<Alloc, Io>(&self, alloc: &Alloc, _io: &Io)
     where
         Alloc: SpdmPalAlloc,
         Io: SpdmPalIo,

--- a/runtime/userspace/api/spdm-lib/vdm-handler/src/iana/ocp/caliptra_vdm/mod.rs
+++ b/runtime/userspace/api/spdm-lib/vdm-handler/src/iana/ocp/caliptra_vdm/mod.rs
@@ -70,6 +70,36 @@ pub trait CaliptraVdmCommands {
         scratch: &A,
     ) -> CaliptraVdmResult<()>;
 
+    /// Starts streaming a production debug unlock token request.
+    async fn start_authorize_debug_unlock_token_stream<A: SpdmPalAlloc>(
+        &self,
+        _token_len: usize,
+        _first: &[u8],
+        _scratch: &A,
+    ) -> CaliptraVdmResult<()> {
+        Err(CaliptraCompletionCode::UnsupportedOperation)
+    }
+
+    /// Streams additional production debug unlock token bytes.
+    async fn continue_authorize_debug_unlock_token_stream<A: SpdmPalAlloc>(
+        &self,
+        _chunk: &[u8],
+        _scratch: &A,
+    ) -> CaliptraVdmResult<()> {
+        Err(CaliptraCompletionCode::UnsupportedOperation)
+    }
+
+    /// Finishes a streaming production debug unlock token request.
+    async fn finish_authorize_debug_unlock_token_stream<A: SpdmPalAlloc>(
+        &self,
+        _scratch: &A,
+    ) -> CaliptraVdmResult<()> {
+        Err(CaliptraCompletionCode::UnsupportedOperation)
+    }
+
+    /// Aborts a streaming production debug unlock token request.
+    async fn abort_authorize_debug_unlock_token_stream<A: SpdmPalAlloc>(&self, _scratch: &A) {}
+
     /// Exports an attested CSR for `device_key_id` using `algorithm` and `nonce`,
     /// writing the raw CSR bytes into `out` and returning their length.
     async fn export_attested_csr<A: SpdmPalAlloc>(
@@ -126,6 +156,92 @@ impl<H: CaliptraVdmCommands> SpdmVdmBackend for CaliptraVdm<'_, H> {
     fn match_id(&self, registry: &VdmRegistry<'_>) -> bool {
         registry.standard_id == StandardsBodyId::Iana.as_u16()
             && registry.vendor_id == CALIPTRA_VENDOR_ID.to_le_bytes()
+    }
+
+    async fn start_streaming_request<Alloc, Io>(
+        &self,
+        req_len: usize,
+        first: &[u8],
+        alloc: &Alloc,
+        _io: &Io,
+    ) -> McuResult<bool>
+    where
+        Alloc: SpdmPalAlloc,
+        Io: SpdmPalIo,
+    {
+        if first.len() < VDM_HEADER_LEN || req_len < VDM_HEADER_LEN {
+            return Err(INVARIANT);
+        }
+        if first[0] != CALIPTRA_VDM_COMMAND_VERSION
+            || first[1] != CaliptraVdmCommand::AuthorizeDebugUnlockToken as u8
+        {
+            return Ok(false);
+        }
+        match self
+            .cmds
+            .start_authorize_debug_unlock_token_stream(
+                req_len - VDM_HEADER_LEN,
+                &first[VDM_HEADER_LEN..],
+                alloc,
+            )
+            .await
+        {
+            Ok(()) => Ok(true),
+            Err(CaliptraCompletionCode::UnsupportedOperation) => Ok(false),
+            Err(_) => Err(INVARIANT),
+        }
+    }
+
+    async fn continue_streaming_request<Alloc, Io>(
+        &self,
+        chunk: &[u8],
+        alloc: &Alloc,
+        _io: &Io,
+    ) -> McuResult<()>
+    where
+        Alloc: SpdmPalAlloc,
+        Io: SpdmPalIo,
+    {
+        self.cmds
+            .continue_authorize_debug_unlock_token_stream(chunk, alloc)
+            .await
+            .map_err(|_| INVARIANT)
+    }
+
+    async fn finish_streaming_request<Alloc, Io>(
+        &self,
+        rsp: VdmResponseBuffer<'_, Alloc, Io>,
+    ) -> McuResult<VdmResponse>
+    where
+        Alloc: SpdmPalAlloc,
+        Io: SpdmPalIo,
+    {
+        let out = rsp.inline;
+        if out.len() < VDM_HEADER_LEN + 1 {
+            return Err(INVARIANT);
+        }
+        let completion = match self
+            .cmds
+            .finish_authorize_debug_unlock_token_stream(rsp.alloc)
+            .await
+        {
+            Ok(()) => CaliptraCompletionCode::Success,
+            Err(code) => code,
+        };
+        out[0] = CALIPTRA_VDM_COMMAND_VERSION;
+        out[1] = CaliptraVdmCommand::AuthorizeDebugUnlockToken as u8;
+        out[2] = completion as u8;
+        Ok(VdmResponse::Inline(VDM_HEADER_LEN + 1))
+    }
+
+    async fn abort_streaming_request<Alloc, Io>(&self, alloc: &Alloc, _io: &Io)
+    where
+        Alloc: SpdmPalAlloc,
+        Io: SpdmPalIo,
+    {
+        self.cmds
+            .abort_authorize_debug_unlock_token_stream(alloc)
+            .await;
     }
 
     async fn handle_request<Alloc, Io>(

--- a/runtime/userspace/syscall/src/mailbox.rs
+++ b/runtime/userspace/syscall/src/mailbox.rs
@@ -296,10 +296,13 @@ impl<S: Syscalls> Mailbox<S> {
         // Send the payload in chunks
         loop {
             // Read a chunk of data from the payload stream
-            let sz = payload
-                .read(&mut buffer)
-                .await
-                .map_err(MailboxError::ErrorCode)?;
+            let sz = match payload.read(&mut buffer).await {
+                Ok(sz) => sz,
+                Err(err) => {
+                    let _ = self.abort_chunked_request().await;
+                    return Err(MailboxError::ErrorCode(err));
+                }
+            };
             if sz == 0 {
                 break; // No more data to read
             }

--- a/runtime/userspace/syscall/src/mailbox.rs
+++ b/runtime/userspace/syscall/src/mailbox.rs
@@ -9,10 +9,7 @@ use caliptra_api::mailbox::MailboxReqHeader;
 use caliptra_mcu_libtock_platform::{share, DefaultConfig, ErrorCode, Syscalls};
 use caliptra_mcu_libtockasync::TockSubscribe;
 use core::{hint::black_box, marker::PhantomData};
-use embassy_sync::{
-    blocking_mutex::raw::CriticalSectionRawMutex,
-    mutex::{Mutex, MutexGuard},
-};
+use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, mutex::Mutex};
 
 // Global mutex to ensure that multiple tasks do not overwrite each other's upcall pointers.
 static MAILBOX_MUTEX: Mutex<CriticalSectionRawMutex, u32> = Mutex::new(0);
@@ -43,51 +40,6 @@ pub fn populate_checksum(cmd: u32, data: &mut [u8]) -> Result<(), ErrorCode> {
     }
     data[..size_of::<MailboxReqHeader>()].copy_from_slice(&checksum.to_le_bytes());
     Ok(())
-}
-
-/// Guarded chunked mailbox request that holds the process-local mailbox mutex
-/// for the whole start → chunk* → execute/abort sequence.
-pub struct ChunkedMailboxRequest<S: Syscalls = DefaultSyscalls> {
-    mailbox: Mailbox<S>,
-    _mutex: MutexGuard<'static, CriticalSectionRawMutex, u32>,
-    active: bool,
-}
-
-impl<S: Syscalls> ChunkedMailboxRequest<S> {
-    /// Sends a caller-owned chunk into this active mailbox request.
-    pub async fn send_chunk(&self, buffer: &[u8]) -> Result<(u32, u32, u32), MailboxError> {
-        self.mailbox.send_chunk(buffer).await
-    }
-
-    /// Executes this active mailbox request and releases the transaction.
-    pub async fn execute(
-        mut self,
-        command: u32,
-        response_buffer: &mut [u8],
-    ) -> Result<usize, MailboxError> {
-        let result = self
-            .mailbox
-            .execute_chunked_request(command, response_buffer)
-            .await;
-        self.active = false;
-        result
-    }
-
-    /// Aborts this active mailbox request and releases the transaction.
-    pub async fn abort(mut self) -> Result<(), MailboxError> {
-        let result = self.mailbox.abort_chunked_request().await;
-        self.active = false;
-        result
-    }
-}
-
-impl<S: Syscalls> Drop for ChunkedMailboxRequest<S> {
-    fn drop(&mut self) {
-        // Dropping releases the process-local mutex. Callers should use
-        // `abort()` on malformed streams so the kernel/HW mailbox state is also
-        // cleared; Drop cannot perform an async abort syscall.
-        self.active = false;
-    }
 }
 
 impl<S: Syscalls> Mailbox<S> {
@@ -171,27 +123,6 @@ impl<S: Syscalls> Mailbox<S> {
         }
     }
 
-    /// Initiates a guarded chunked mailbox request.
-    ///
-    /// The returned request holds the process-local mailbox mutex until it is
-    /// executed, aborted, or dropped.
-    pub async fn start_guarded_chunked_request(
-        &self,
-        command: u32,
-        request_len: usize,
-    ) -> Result<ChunkedMailboxRequest<S>, MailboxError> {
-        let mutex = MAILBOX_MUTEX.lock().await;
-        self.start_chunked_request(command, request_len).await?;
-        Ok(ChunkedMailboxRequest {
-            mailbox: Mailbox {
-                _syscall: PhantomData,
-                driver_num: self.driver_num,
-            },
-            _mutex: mutex,
-            active: true,
-        })
-    }
-
     /// Initiates a chunked mailbox request.
     ///
     /// Call this first, then send data with [`send_chunk`](Self::send_chunk),
@@ -201,8 +132,8 @@ impl<S: Syscalls> Mailbox<S> {
     /// verifies the calling process ID, so different processes cannot
     /// interleave chunked flows. Within a single process with multiple async
     /// tasks, callers should either use [`execute_with_payload_stream`](Self::execute_with_payload_stream)
-    /// (which holds the global mailbox mutex) or acquire `MAILBOX_MUTEX`
-    /// externally before calling this method.
+    /// (which holds the global mailbox mutex) or serialize their own chunked
+    /// sequence.
     pub async fn start_chunked_request(
         &self,
         command: u32,

--- a/runtime/userspace/syscall/src/mailbox.rs
+++ b/runtime/userspace/syscall/src/mailbox.rs
@@ -9,7 +9,10 @@ use caliptra_api::mailbox::MailboxReqHeader;
 use caliptra_mcu_libtock_platform::{share, DefaultConfig, ErrorCode, Syscalls};
 use caliptra_mcu_libtockasync::TockSubscribe;
 use core::{hint::black_box, marker::PhantomData};
-use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, mutex::Mutex};
+use embassy_sync::{
+    blocking_mutex::raw::CriticalSectionRawMutex,
+    mutex::{Mutex, MutexGuard},
+};
 
 // Global mutex to ensure that multiple tasks do not overwrite each other's upcall pointers.
 static MAILBOX_MUTEX: Mutex<CriticalSectionRawMutex, u32> = Mutex::new(0);
@@ -40,6 +43,51 @@ pub fn populate_checksum(cmd: u32, data: &mut [u8]) -> Result<(), ErrorCode> {
     }
     data[..size_of::<MailboxReqHeader>()].copy_from_slice(&checksum.to_le_bytes());
     Ok(())
+}
+
+/// Guarded chunked mailbox request that holds the process-local mailbox mutex
+/// for the whole start → chunk* → execute/abort sequence.
+pub struct ChunkedMailboxRequest<S: Syscalls = DefaultSyscalls> {
+    mailbox: Mailbox<S>,
+    _mutex: MutexGuard<'static, CriticalSectionRawMutex, u32>,
+    active: bool,
+}
+
+impl<S: Syscalls> ChunkedMailboxRequest<S> {
+    /// Sends a caller-owned chunk into this active mailbox request.
+    pub async fn send_chunk(&self, buffer: &[u8]) -> Result<(u32, u32, u32), MailboxError> {
+        self.mailbox.send_chunk(buffer).await
+    }
+
+    /// Executes this active mailbox request and releases the transaction.
+    pub async fn execute(
+        mut self,
+        command: u32,
+        response_buffer: &mut [u8],
+    ) -> Result<usize, MailboxError> {
+        let result = self
+            .mailbox
+            .execute_chunked_request(command, response_buffer)
+            .await;
+        self.active = false;
+        result
+    }
+
+    /// Aborts this active mailbox request and releases the transaction.
+    pub async fn abort(mut self) -> Result<(), MailboxError> {
+        let result = self.mailbox.abort_chunked_request().await;
+        self.active = false;
+        result
+    }
+}
+
+impl<S: Syscalls> Drop for ChunkedMailboxRequest<S> {
+    fn drop(&mut self) {
+        // Dropping releases the process-local mutex. Callers should use
+        // `abort()` on malformed streams so the kernel/HW mailbox state is also
+        // cleared; Drop cannot perform an async abort syscall.
+        self.active = false;
+    }
 }
 
 impl<S: Syscalls> Mailbox<S> {
@@ -123,6 +171,27 @@ impl<S: Syscalls> Mailbox<S> {
         }
     }
 
+    /// Initiates a guarded chunked mailbox request.
+    ///
+    /// The returned request holds the process-local mailbox mutex until it is
+    /// executed, aborted, or dropped.
+    pub async fn start_guarded_chunked_request(
+        &self,
+        command: u32,
+        request_len: usize,
+    ) -> Result<ChunkedMailboxRequest<S>, MailboxError> {
+        let mutex = MAILBOX_MUTEX.lock().await;
+        self.start_chunked_request(command, request_len).await?;
+        Ok(ChunkedMailboxRequest {
+            mailbox: Mailbox {
+                _syscall: PhantomData,
+                driver_num: self.driver_num,
+            },
+            _mutex: mutex,
+            active: true,
+        })
+    }
+
     /// Initiates a chunked mailbox request.
     ///
     /// Call this first, then send data with [`send_chunk`](Self::send_chunk),
@@ -175,6 +244,13 @@ impl<S: Syscalls> Mailbox<S> {
         .map_err(MailboxError::ErrorCode)
     }
 
+    /// Aborts a previously started chunked mailbox request.
+    pub async fn abort_chunked_request(&self) -> Result<(), MailboxError> {
+        S::command(self.driver_num, mailbox_cmd::ABORT_CHUNKED_REQUEST, 0, 0)
+            .to_result::<(), ErrorCode>()
+            .map_err(MailboxError::ErrorCode)
+    }
+
     /// Executes a previously started chunked mailbox request and returns the response.
     pub async fn execute_chunked_request(
         &self,
@@ -218,6 +294,50 @@ impl<S: Syscalls> Mailbox<S> {
         }
     }
 
+    /// Executes a chunked mailbox command from a caller-owned payload slice.
+    ///
+    /// This helper holds the global mailbox mutex for the full
+    /// `start_chunked_request` → `send_chunk`* → `execute_chunked_request`
+    /// sequence, like [`execute_with_payload_stream`](Self::execute_with_payload_stream),
+    /// but avoids copying the payload through an intermediate local staging buffer.
+    /// The request length is computed internally so callers cannot declare a
+    /// length that diverges from the bytes sent to the mailbox.
+    pub async fn execute_with_payload_slice(
+        &self,
+        command: u32,
+        header: Option<&[u8]>,
+        payload: &[u8],
+        response_buffer: &mut [u8],
+    ) -> Result<usize, MailboxError> {
+        let mutex = MAILBOX_MUTEX.lock().await;
+
+        let request_len = header
+            .map_or(Some(payload.len()), |h| h.len().checked_add(payload.len()))
+            .ok_or(MailboxError::ErrorCode(ErrorCode::Invalid))?;
+
+        self.start_chunked_request(command, request_len).await?;
+
+        if let Some(header) = header {
+            if let Err(err) = self.send_chunk(header).await {
+                let _ = self.abort_chunked_request().await;
+                return Err(err);
+            }
+        }
+
+        for chunk in payload.chunks(PAYLOAD_CHUNK_SIZE) {
+            if !chunk.is_empty() {
+                if let Err(err) = self.send_chunk(chunk).await {
+                    let _ = self.abort_chunked_request().await;
+                    return Err(err);
+                }
+            }
+        }
+
+        let result = self.execute_chunked_request(command, response_buffer).await;
+        black_box(*mutex); // Ensure the mutex is not optimized away
+        result
+    }
+
     pub async fn execute_with_payload_stream(
         &self,
         command: u32,
@@ -236,7 +356,10 @@ impl<S: Syscalls> Mailbox<S> {
         if let Some(header) = header {
             // If a header is provided, write it to the buffer first
             buffer[..header.len()].copy_from_slice(header);
-            self.send_chunk(buffer[..header.len()].as_ref()).await?;
+            if let Err(err) = self.send_chunk(buffer[..header.len()].as_ref()).await {
+                let _ = self.abort_chunked_request().await;
+                return Err(err);
+            }
         }
 
         // Send the payload in chunks
@@ -249,7 +372,10 @@ impl<S: Syscalls> Mailbox<S> {
             if sz == 0 {
                 break; // No more data to read
             }
-            self.send_chunk(buffer[..sz].as_ref()).await?;
+            if let Err(err) = self.send_chunk(buffer[..sz].as_ref()).await {
+                let _ = self.abort_chunked_request().await;
+                return Err(err);
+            }
         }
 
         let result = self.execute_chunked_request(command, response_buffer).await;
@@ -280,6 +406,7 @@ mod mailbox_cmd {
     pub const START_CHUNKED_REQUEST: u32 = 2;
     pub const NEXT_PAYLOAD_CHUNK: u32 = 3;
     pub const EXECUTE_CHUNKED_REQUEST: u32 = 4;
+    pub const ABORT_CHUNKED_REQUEST: u32 = 5;
 }
 
 /// Buffer IDs for mailbox read operations.


### PR DESCRIPTION
Fixes #1356 

## Summary

- Document and preserve the DebugUnlock `AuthorizeDebugUnlockToken` VDM payload as host-prebuilt Caliptra RT mailbox request bytes, including `MailboxReqHeader`/checksum.
- Stream recognized `AuthorizeDebugUnlockToken` CHUNK_SEND payloads directly into a guarded Caliptra mailbox chunked transaction without full large-request reassembly.
- Stream `SET_CERTIFICATE` CHUNK_SEND requests through a minimal non-atomic cert-store transaction and commit metadata only after final validation.
- Add mailbox chunked-request abort support and ensure interrupted streaming requests abort before SPDM state reset.
- Preserve exact DebugUnlock challenge response length validation.

Addresses #1666 

## SPDM validator stats

MCTP:

```text
test suite (spdm_responder_conformance_test) - pass: 655, fail: 0
```

DOE:

```text
test suite (spdm_responder_conformance_test) - pass: 942, fail: 0
```

## Memory stats

```text
Memory report — profile: devel

Kernel (mcu-runtime-emulator)
  Section            Size (B)
  ──────────────── ──────────
  .text               142,232
  .data                    36
  .bss                 24,536

User-app
  Section            Size (B)
  ──────────────── ──────────
  .text               114,978
  .rodata              19,336
  .data                    40
  .bss                 53,644
  FLASH               134,354
  RAM                  53,684

SPDM task (symbol attribution from user-app)
  Section            Size (B)
  ──────────────── ──────────
  .text                99,322
  .rodata                 732
  .data                    28
  .bss                 28,873
  FLASH               100,082
  RAM                  28,901

  Runtime bundle      278,016
```

