### PR TITLE
Enable test_bootfsm_timeout

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -61,6 +61,7 @@ default-filter = """
 (package(caliptra-mcu-tests-integration) and test(jtag::test_uds)) |
 (package(caliptra-mcu-tests-integration) and test(jtag::test_manuf_debug_unlock)) |
 (package(caliptra-mcu-tests-integration) and test(test_sw_digest_lock)) |
+(package(caliptra-mcu-tests-integration) and test(test_bootfsm_timeout)) |
 (package(caliptra-mcu-tests-integration) and test(test_otp_blank_check)) |
 (package(caliptra-mcu-tests-integration) and test(test_otp_scramble_check))
 """


### PR DESCRIPTION
This was fixed in
https://github.com/chipsalliance/caliptra-mcu-sw/pull/1660.