### PR TITLE
Enable main-2.1 SPDM nightly workflows

### DIFF
--- a/.github/workflows/attestation.yml
+++ b/.github/workflows/attestation.yml
@@ -7,16 +7,29 @@ on:
     - cron: "0 0 * * *"
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch to test"
+        required: true
+        default: "main-2.1"
+        type: choice
+        options:
+          - main
+          - main-2.1
 
 jobs:
   attestation_e2e:
     runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: ${{ fromJSON(github.event_name == 'workflow_dispatch' && format('["{0}"]', inputs.branch) || '["main","main-2.1"]') }}
 
     env:
       CARGO_INCREMENTAL: 0
       SCCACHE_VERSION: 0.8.2
-      SCCACHE_GHA_CACHE_TO: sccache-caliptra-mcu-sw
-      SCCACHE_GHA_CACHE_FROM: sccache-caliptra-mcu-sw
+      SCCACHE_GHA_CACHE_TO: sccache-caliptra-mcu-sw-${{ matrix.branch }}
+      SCCACHE_GHA_CACHE_FROM: sccache-caliptra-mcu-sw-${{ matrix.branch }}
 
       # Change this to a new random value if you suspect the cache is corrupted
       SCCACHE_C_CUSTOM_CACHE_BUSTER: 8b42a6e70ec4
@@ -29,6 +42,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
+          ref: ${{ matrix.branch }}
           submodules: recursive
 
       - name: Install required packages
@@ -124,7 +138,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: attestation-artifacts
+          name: attestation-artifacts-${{ matrix.branch }}
           path: |
             attestation-artifacts/
 
@@ -146,7 +160,7 @@ jobs:
         env:
           SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-emu/build/bin
         with:
-          name: spdm-mctp-attestation-test-results
+          name: spdm-mctp-attestation-test-results-${{ matrix.branch }}
           path: |
             ${{ env.SPDM_VALIDATOR_DIR }}/spdm_requester_emu_output.txt
             ${{ env.SPDM_VALIDATOR_DIR }}/caliptra-evidence.pcap

--- a/.github/workflows/caliptra-util-host-validator.yml
+++ b/.github/workflows/caliptra-util-host-validator.yml
@@ -7,11 +7,24 @@ on:
     - cron: "0 0 * * *"
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch to test"
+        required: true
+        default: "main-2.1"
+        type: choice
+        options:
+          - main
+          - main-2.1
 
 jobs:
   precheckin:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: ${{ fromJSON(github.event_name == 'workflow_dispatch' && format('["{0}"]', inputs.branch) || '["main","main-2.1"]') }}
 
     env:
       CARGO_INCREMENTAL: 0
@@ -21,6 +34,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
+          ref: ${{ matrix.branch }}
           submodules: recursive
 
       - name: Test commit name
@@ -76,6 +90,10 @@ jobs:
   caliptra_util_host_validator_tests:
     runs-on: ubuntu-24.04
     needs: [precheckin]
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: ${{ fromJSON(github.event_name == 'workflow_dispatch' && format('["{0}"]', inputs.branch) || '["main","main-2.1"]') }}
 
     env:
       CARGO_INCREMENTAL: 0
@@ -91,6 +109,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
+          ref: ${{ matrix.branch }}
           submodules: recursive
 
       - name: Test commit name
@@ -213,7 +232,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: caliptra-util-host-validator-test-results
+          name: caliptra-util-host-validator-test-results-${{ matrix.branch }}
           path: |
             target/*/debug/*.log
             target/*/debug/*.txt

--- a/.github/workflows/spdm-validator.yml
+++ b/.github/workflows/spdm-validator.yml
@@ -7,16 +7,29 @@ on:
     - cron: "0 0 * * *"
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch to test"
+        required: true
+        default: "main-2.1"
+        type: choice
+        options:
+          - main
+          - main-2.1
 
 jobs:
   spdm_validator_tests:
     runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: ${{ fromJSON(github.event_name == 'workflow_dispatch' && format('["{0}"]', inputs.branch) || '["main","main-2.1"]') }}
 
     env:
       CARGO_INCREMENTAL: 0
       SCCACHE_VERSION: 0.8.2
-      SCCACHE_GHA_CACHE_TO: sccache-caliptra-mcu-sw
-      SCCACHE_GHA_CACHE_FROM: sccache-caliptra-mcu-sw
+      SCCACHE_GHA_CACHE_TO: sccache-caliptra-mcu-sw-${{ matrix.branch }}
+      SCCACHE_GHA_CACHE_FROM: sccache-caliptra-mcu-sw-${{ matrix.branch }}
       # CPTRA_COVERAGE_PATH: /tmp
 
       # Change this to a new random value if you suspect the cache is corrupted
@@ -26,6 +39,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
+          ref: ${{ matrix.branch }}
           submodules: recursive
 
       - name: Test commit name
@@ -115,7 +129,7 @@ jobs:
         env:
           SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-emu/build/bin
         with:
-          name: spdm-mctp-validator-test-results
+          name: spdm-mctp-validator-test-results-${{ matrix.branch }}
           path: |
             ${{ env.SPDM_VALIDATOR_DIR }}/test.log
             ${{ env.SPDM_VALIDATOR_DIR }}/caliptra_spdm_validator.pcap
@@ -157,7 +171,7 @@ jobs:
         env:
           SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-emu/build/bin
         with:
-          name: spdm-doe-validator-test-results
+          name: spdm-doe-validator-test-results-${{ matrix.branch }}
           path: |
             ${{ env.SPDM_VALIDATOR_DIR }}/test.log
             ${{ env.SPDM_VALIDATOR_DIR }}/caliptra_spdm_validator.pcap
@@ -220,6 +234,6 @@ jobs:
         env:
           SPDM_VALIDATOR_DIR: ${{ github.workspace }}/spdm-rs/target/debug
         with:
-          name: spdm-tdisp-ide-validator-test-results
+          name: spdm-tdisp-ide-validator-test-results-${{ matrix.branch }}
           path: |
             ${{ env.SPDM_VALIDATOR_DIR }}/tdisp_ide_validator_output.txt


### PR DESCRIPTION
Enables the nightly SPDM validation, end-to-end attestation, and caliptra-util-host validator workflows to run against both `main` and `main-2.1`.

Changes:
- Add a scheduled matrix for `main` and `main-2.1`.
- Add a manual `branch` input defaulting to `main-2.1`.
- Check out `${{ matrix.branch }}` in each workflow.
- Suffix cache/artifact names by branch to avoid collisions.

Validation:
- `cargo xtask precheckin`
- YAML parsed successfully for the three edited workflows.