### PR TITLE
test: move MCTP and PLDM tests out of emulator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2044,6 +2044,8 @@ dependencies = [
  "crc",
  "hex",
  "rand 0.8.5",
+ "strum",
+ "strum_macros",
  "zerocopy",
 ]
 

--- a/builder/src/features.rs
+++ b/builder/src/features.rs
@@ -36,6 +36,7 @@ pub const EMULATOR_RUNTIME_TEST_FEATURES: &[&str] = &[
     "test-mctp-vdm-cmds",
     "test-pldm-discovery",
     "test-pldm-fw-update",
+    "test-pldm-request-response",
     "test-mci",
     "test-mcu-mbox-driver",
     "test-mcu-mbox-soc-requester-loopback",

--- a/common/testing/Cargo.toml
+++ b/common/testing/Cargo.toml
@@ -14,6 +14,9 @@ caliptra-mcu-mctp-vdm-common.workspace = true
 caliptra-mcu-pldm-common.workspace = true
 caliptra-mcu-pldm-ua.workspace = true
 caliptra-mcu-emulator-state.workspace = true
+rand.workspace = true
+strum_macros.workspace = true
+strum.workspace = true
 zerocopy.workspace = true
 
 [dev-dependencies]

--- a/common/testing/src/lib.rs
+++ b/common/testing/src/lib.rs
@@ -8,8 +8,11 @@ pub mod i3c;
 pub mod i3c_socket;
 pub mod i3c_socket_server;
 pub mod logging_seed;
+pub mod mctp_ctrl_cmds;
 pub mod mctp_transport;
+pub mod mctp_user_loopback;
 pub mod mctp_vdm_transport;
+pub mod pldm_request_response;
 #[macro_use]
 pub mod mctp_util;
 pub mod spdm_responder_validator;

--- a/common/testing/src/mctp_ctrl_cmds.rs
+++ b/common/testing/src/mctp_ctrl_cmds.rs
@@ -1,11 +1,9 @@
 // Licensed under the Apache-2.0 license
 
-use caliptra_mcu_testing_common::i3c_socket::{BufferedStream, MctpTestState, MctpTransportTest};
-use caliptra_mcu_testing_common::mctp_util::base_protocol::{
-    MCTPMsgHdr, MctpMsgType, MCTP_MSG_HDR_SIZE,
-};
-use caliptra_mcu_testing_common::mctp_util::common::MctpUtil;
-use caliptra_mcu_testing_common::mctp_util::ctrl_protocol::*;
+use crate::i3c_socket::{BufferedStream, MctpTestState, MctpTransportTest};
+use crate::mctp_util::base_protocol::{MCTPMsgHdr, MctpMsgType, MCTP_MSG_HDR_SIZE};
+use crate::mctp_util::common::MctpUtil;
+use crate::mctp_util::ctrl_protocol::*;
 use strum::IntoEnumIterator;
 use strum_macros::EnumIter;
 use zerocopy::IntoBytes;
@@ -23,7 +21,7 @@ const MCTP_CTRL_MSG_HDR_OFFSET: usize = MCTP_MSG_HDR_OFFSET + MCTP_MSG_HDR_SIZE;
 const MCTP_CTRL_PAYLOAD_OFFSET: usize = MCTP_CTRL_MSG_HDR_OFFSET + MCTP_CTRL_MSG_HDR_SIZE;
 
 #[derive(EnumIter, Debug)]
-pub(crate) enum MCTPCtrlCmdTests {
+pub enum MCTPCtrlCmdTests {
     SetEID,
     SetEIDForce,
     SetEIDNullFail,
@@ -294,7 +292,7 @@ impl MctpTransportTest for Test {
 
     fn run_test(&mut self, stream: &mut BufferedStream, target_addr: u8) {
         stream.set_nonblocking(true).unwrap();
-        while caliptra_mcu_testing_common::is_emulator_running() {
+        while crate::is_emulator_running() {
             match self.test_state {
                 MctpTestState::Start => {
                     println!("Starting test: {}", self.name);

--- a/common/testing/src/mctp_user_loopback.rs
+++ b/common/testing/src/mctp_user_loopback.rs
@@ -1,12 +1,12 @@
 // Licensed under the Apache-2.0 license
 
-use caliptra_mcu_testing_common::i3c_socket::{BufferedStream, MctpTestState, MctpTransportTest};
-use caliptra_mcu_testing_common::mctp_util::common::MctpUtil;
+use crate::i3c_socket::{BufferedStream, MctpTestState, MctpTransportTest};
+use crate::mctp_util::common::MctpUtil;
 use strum::IntoEnumIterator;
 use strum_macros::EnumIter;
 
 #[derive(EnumIter, Debug)]
-pub(crate) enum MctpUserAppTests {
+pub enum MctpUserAppTests {
     MctpAppResponderReady,
     MctpAppLoopbackTest64,
     MctpAppLoopbackTest63,
@@ -106,7 +106,7 @@ impl Test {
 
     fn run_loopback_test(&mut self, stream: &mut BufferedStream, target_addr: u8) {
         stream.set_nonblocking(true).unwrap();
-        while caliptra_mcu_testing_common::is_emulator_running() {
+        while crate::is_emulator_running() {
             match self.test_state {
                 MctpTestState::Start => {
                     self.test_state = MctpTestState::SendReq;

--- a/common/testing/src/pldm_request_response.rs
+++ b/common/testing/src/pldm_request_response.rs
@@ -2,6 +2,8 @@
 //! This module tests the PLDM request/response interaction between the emulator and the device.
 //! The emulator sends out different PLDM requests and expects a corresponding response for those requests.
 
+use crate::mctp_transport::MctpPldmSocket;
+use crate::wait_for_runtime_start;
 use caliptra_mcu_pldm_common::codec::PldmCodec;
 use caliptra_mcu_pldm_common::message::control::*;
 use caliptra_mcu_pldm_common::message::firmware_update::get_fw_params::{
@@ -13,8 +15,6 @@ use caliptra_mcu_pldm_common::message::firmware_update::query_devid::{
 use caliptra_mcu_pldm_common::protocol::base::*;
 use caliptra_mcu_pldm_common::protocol::firmware_update::*;
 use caliptra_mcu_pldm_ua::transport::PldmSocket;
-use caliptra_mcu_testing_common::mctp_transport::MctpPldmSocket;
-use caliptra_mcu_testing_common::wait_for_runtime_start;
 use std::process::exit;
 
 pub struct PldmRequestResponseTest {
@@ -89,9 +89,9 @@ impl PldmRequestResponseTest {
     }
 
     pub fn run(socket: MctpPldmSocket, test_feature: String) {
-        caliptra_mcu_testing_common::spawn_with_emulator_state(move || {
+        crate::spawn_with_emulator_state(move || {
             wait_for_runtime_start();
-            if !caliptra_mcu_testing_common::is_emulator_running() {
+            if !crate::is_emulator_running() {
                 exit(-1);
             }
             print!("Emulator: Running PLDM Loopback Test: ",);
@@ -102,7 +102,7 @@ impl PldmRequestResponseTest {
             } else {
                 println!("Passed");
             }
-            caliptra_mcu_testing_common::stop_emulator();
+            crate::stop_emulator();
         });
     }
 

--- a/emulator/app/src/emulator.rs
+++ b/emulator/app/src/emulator.rs
@@ -39,7 +39,6 @@ use caliptra_mcu_emulator_registers_generated::root_bus::{AutoRootBus, AutoRootB
 use caliptra_mcu_pldm_fw_pkg::FirmwareManifest;
 use caliptra_mcu_pldm_ua::daemon::PldmDaemon;
 use caliptra_mcu_pldm_ua::transport::{EndpointId, PldmTransport};
-use caliptra_mcu_testing_common::i3c_socket;
 use caliptra_mcu_testing_common::i3c_socket_server::start_i3c_socket;
 use caliptra_mcu_testing_common::mctp_transport::MctpTransport;
 use caliptra_mcu_testing_common::mctp_util::base_protocol::LOCAL_TEST_ENDPOINT_EID;
@@ -59,7 +58,6 @@ use std::rc::Rc;
 use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
-use tests::pldm_request_response_test::PldmRequestResponseTest;
 
 // Type aliases for external shim callbacks
 pub type ExternalReadCallback =
@@ -674,39 +672,6 @@ impl Emulator {
             let tests = tests::doe_user_loopback::generate_tests();
             doe_mbox_fsm::run_doe_transport_tests(test_tx, test_rx, tests);
         }
-        if test_feature == "test-mctp-ctrl-cmds" {
-            i3c_controller_join_handle = Some(i3c_controller.start());
-            println!(
-                "Starting test-mctp-ctrl-cmds test thread for testing target {:?}",
-                i3c.get_dynamic_address().unwrap()
-            );
-
-            let tests = tests::mctp_ctrl_cmd::MCTPCtrlCmdTests::generate_tests();
-            i3c_socket::run_tests(
-                cli.i3c_port.unwrap(),
-                i3c.get_dynamic_address().unwrap(),
-                tests,
-                None,
-            );
-        }
-        if test_feature == "test-mctp-user-loopback" {
-            i3c_controller_join_handle = Some(i3c_controller.start());
-            println!(
-                "Starting loopback test thread for testing target {:?}",
-                i3c.get_dynamic_address().unwrap()
-            );
-
-            let spdm_loopback_tests = tests::mctp_user_loopback::MctpUserAppTests::generate_tests(
-                caliptra_mcu_testing_common::mctp_util::base_protocol::MctpMsgType::Caliptra as u8,
-            );
-
-            i3c_socket::run_tests(
-                cli.i3c_port.unwrap(),
-                i3c.get_dynamic_address().unwrap(),
-                spdm_loopback_tests,
-                None,
-            );
-        }
         if test_feature == "test-doe-spdm-responder-conformance" {
             if std::env::var("SPDM_VALIDATOR_DIR").is_err() {
                 println!("SPDM_VALIDATOR_DIR environment variable is not set. Skipping test");
@@ -732,19 +697,6 @@ impl Emulator {
                 SpdmTestType::SpdmTeeIoValidator,
                 std::time::Duration::from_secs(9000), // timeout in seconds
             );
-        }
-
-        if test_feature == "test-pldm-request-response"
-            || test_feature == "test-pldm-discovery"
-            || test_feature == "test-pldm-fw-update"
-        {
-            i3c_controller_join_handle = Some(i3c_controller.start());
-            let pldm_transport =
-                MctpTransport::new(cli.i3c_port.unwrap(), i3c.get_dynamic_address().unwrap());
-            let pldm_socket = pldm_transport
-                .create_socket(EndpointId(0), EndpointId(1))
-                .unwrap();
-            PldmRequestResponseTest::run(pldm_socket, test_feature.to_string());
         }
 
         let create_flash_controller =

--- a/emulator/app/src/tests/mod.rs
+++ b/emulator/app/src/tests/mod.rs
@@ -5,6 +5,3 @@ pub mod doe_discovery;
 pub mod doe_transport_loopback;
 pub mod doe_user_loopback;
 pub mod emulator_mcu_mailbox_test;
-pub mod mctp_ctrl_cmd;
-pub mod mctp_user_loopback;
-pub mod pldm_request_response_test;

--- a/tests/integration/src/lib.rs
+++ b/tests/integration/src/lib.rs
@@ -25,14 +25,17 @@ mod test_i3c_constant_writes;
 mod test_i3c_simple;
 mod test_log_flash_usermode;
 mod test_mctp_capsule_loopback;
+mod test_mctp_ctrl_cmds;
 mod test_mctp_spdm_attestation;
 mod test_mctp_spdm_attestation_pcr_quote;
 mod test_mctp_spdm_responder_conformance;
+mod test_mctp_user_loopback;
 mod test_mctp_vdm_cmds;
 mod test_mctp_vdm_validator;
 mod test_mcu_mbox;
 mod test_ocp_dev_identity_provision_tool;
 mod test_pldm_fw_update;
+mod test_pldm_request_response;
 mod test_raw_lifecycle_boot;
 mod test_soc_boot;
 mod test_svn_manifest;
@@ -1761,10 +1764,6 @@ mod test {
     run_test!(test_log_flash_linear);
     #[cfg(not(feature = "fpga_realtime"))]
     run_test!(test_log_flash_usermode, example_app);
-    run_test!(test_mctp_ctrl_cmds);
-    run_test!(test_mctp_user_loopback, example_app);
-    run_test!(test_pldm_discovery);
-    run_test!(test_pldm_fw_update);
     run_test!(test_doe_spdm_responder_conformance, nightly);
     run_test!(test_doe_spdm_tdisp_ide_validator, nightly);
     run_test!(test_mci, example_app);

--- a/tests/integration/src/test_mctp_ctrl_cmds.rs
+++ b/tests/integration/src/test_mctp_ctrl_cmds.rs
@@ -1,0 +1,41 @@
+// Licensed under the Apache-2.0 license
+
+//! This module tests MCTP control commands functionality.
+
+#[cfg(test)]
+mod test {
+    use crate::test::{finish_runtime_hw_model, start_runtime_hw_model, TestParams, TEST_LOCK};
+    use caliptra_mcu_hw_model::McuHwModel;
+    use caliptra_mcu_testing_common::i3c::DynamicI3cAddress;
+    use caliptra_mcu_testing_common::i3c_socket;
+    use caliptra_mcu_testing_common::mctp_ctrl_cmds::MCTPCtrlCmdTests;
+    use random_port::PortPicker;
+
+    #[test]
+    fn test_mctp_ctrl_cmds() {
+        let lock = TEST_LOCK.lock().unwrap();
+        lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
+        let mut hw = start_runtime_hw_model(TestParams {
+            i3c_port: Some(PortPicker::new().pick().unwrap()),
+            ..Default::default()
+        });
+
+        hw.start_i3c_controller();
+
+        let tests = MCTPCtrlCmdTests::generate_tests();
+
+        i3c_socket::run_tests(
+            hw.i3c_port().unwrap(),
+            hw.i3c_address().unwrap().into(),
+            tests,
+            None,
+        );
+
+        let test = finish_runtime_hw_model(&mut hw);
+        assert_eq!(0, test);
+
+        // force the compiler to keep the lock
+        lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+}

--- a/tests/integration/src/test_mctp_user_loopback.rs
+++ b/tests/integration/src/test_mctp_user_loopback.rs
@@ -1,0 +1,44 @@
+// Licensed under the Apache-2.0 license
+
+//! This module tests MCTP control commands functionality.
+
+#[cfg(test)]
+mod test {
+    use crate::test::{finish_runtime_hw_model, start_runtime_hw_model, TestParams, TEST_LOCK};
+    use caliptra_mcu_hw_model::McuHwModel;
+    use caliptra_mcu_testing_common::i3c::DynamicI3cAddress;
+    use caliptra_mcu_testing_common::i3c_socket;
+    use caliptra_mcu_testing_common::mctp_user_loopback::MctpUserAppTests;
+    use caliptra_mcu_testing_common::mctp_util::base_protocol::MctpMsgType;
+    use random_port::PortPicker;
+
+    #[test]
+    fn test_mctp_user_loopback() {
+        let lock = TEST_LOCK.lock().unwrap();
+        lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
+        let mut hw = start_runtime_hw_model(TestParams {
+            i3c_port: Some(PortPicker::new().pick().unwrap()),
+            feature: Some("test-mctp-user-loopback"),
+            example_app: true,
+            ..Default::default()
+        });
+
+        hw.start_i3c_controller();
+
+        let tests = MctpUserAppTests::generate_tests(MctpMsgType::Caliptra as u8);
+
+        i3c_socket::run_tests(
+            hw.i3c_port().unwrap(),
+            hw.i3c_address().unwrap().into(),
+            tests,
+            None,
+        );
+
+        let test = finish_runtime_hw_model(&mut hw);
+        assert_eq!(0, test);
+
+        // force the compiler to keep the lock
+        lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+}

--- a/tests/integration/src/test_pldm_request_response.rs
+++ b/tests/integration/src/test_pldm_request_response.rs
@@ -1,0 +1,55 @@
+// Licensed under the Apache-2.0 license
+
+//! This module tests MCTP control commands functionality.
+
+#[cfg(test)]
+mod test {
+    use crate::test::{finish_runtime_hw_model, start_runtime_hw_model, TestParams, TEST_LOCK};
+    use caliptra_mcu_hw_model::McuHwModel;
+    use caliptra_mcu_pldm_ua::transport::{EndpointId, PldmTransport};
+    use caliptra_mcu_testing_common::i3c::DynamicI3cAddress;
+    use caliptra_mcu_testing_common::mctp_transport::MctpTransport;
+    use caliptra_mcu_testing_common::pldm_request_response::PldmRequestResponseTest;
+    use random_port::PortPicker;
+
+    #[test]
+    fn test_pldm_request_response() {
+        let lock = TEST_LOCK.lock().unwrap();
+        lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
+        for (mcu_feature, test_feature, build_example_app) in [
+            (
+                "test-pldm-request-response",
+                "test-pldm-request-response",
+                true,
+            ),
+            ("test-pldm-discovery", "test-pldm-discovery", false),
+            ("test-pldm-discovery", "test-pldm-fw-update", false),
+        ] {
+            let mut hw = start_runtime_hw_model(TestParams {
+                feature: Some(mcu_feature),
+                example_app: build_example_app,
+                i3c_port: Some(PortPicker::new().pick().unwrap()),
+                ..Default::default()
+            });
+
+            hw.start_i3c_controller();
+
+            let pldm_transport = MctpTransport::new(
+                hw.i3c_port().unwrap(),
+                DynamicI3cAddress::from(hw.i3c_address().unwrap()),
+            );
+            let pldm_socket = pldm_transport
+                .create_socket(EndpointId(0), EndpointId(1))
+                .unwrap();
+
+            PldmRequestResponseTest::run(pldm_socket, test_feature.to_string());
+
+            let test = finish_runtime_hw_model(&mut hw);
+            assert_eq!(0, test);
+        }
+
+        // force the compiler to keep the lock
+        lock.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+}


### PR DESCRIPTION
Continued the effort of moving tests out of the emulator crate to their own modules under tests/integartion in order to enable running on FPGA:

- `test_mctp_ctrl_cmds`
- `test_mctp_user_loopback`
- `test_pldm_request_response`

Related to #745. There are still tests remained in the emulator crate. Will take another look at them later.