### PR TITLE
[main-2.1] Fix MCTP control version discovery

### DIFF
--- a/caliptra-util-host/transport/src/transports/mctp_vdm/encode.rs
+++ b/caliptra-util-host/transport/src/transports/mctp_vdm/encode.rs
@@ -327,6 +327,7 @@ pub fn handle_get_debug_log(
 mod tests {
     use super::*;
     use caliptra_mcu_mctp_vdm_common::codec::VdmCodec;
+    use caliptra_mcu_mctp_vdm_common::protocol::CALIPTRA_IANA_ENTERPRISE_ID_BYTES;
 
     // Verify that request encoding produces valid VDM wire bytes
     #[test]
@@ -335,9 +336,7 @@ mod tests {
         let mut buf = [0u8; 64];
         let len = req.encode(&mut buf).unwrap();
         assert_eq!(len, VDM_MSG_HEADER_LEN + 4);
-        // First two bytes = vendor ID 0x1414 LE
-        assert_eq!(buf[0], 0x14);
-        assert_eq!(buf[1], 0x14);
+        assert_eq!(&buf[..4], &CALIPTRA_IANA_ENTERPRISE_ID_BYTES);
     }
 
     #[test]

--- a/common/mctp-vdm/src/protocol/header.rs
+++ b/common/mctp-vdm/src/protocol/header.rs
@@ -5,15 +5,16 @@ use bitfield::bitfield;
 use core::convert::TryFrom;
 use zerocopy::{FromBytes, Immutable, IntoBytes};
 
-/// MCTP message type for Vendor Defined Messages.
-pub const MCTP_VDM_MSG_TYPE: u8 = 0x7E;
+/// MCTP message type for IANA Vendor Defined Messages.
+pub const MCTP_VDM_MSG_TYPE: u8 = 0x7F;
 
-/// PCI Vendor ID for Caliptra (Microsoft).
-pub const CALIPTRA_PCI_VENDOR_ID: u16 = 0x1414;
+/// OCP IANA enterprise number used for Caliptra VDM commands.
+pub const CALIPTRA_IANA_ENTERPRISE_ID: u32 = 42623;
+pub const CALIPTRA_IANA_ENTERPRISE_ID_BYTES: [u8; 4] = [0x00, 0x00, 0xA6, 0x7F];
 
 /// Length of the VDM message header in bytes.
-/// Header consists of: Vendor ID (2 bytes) + Request/Crypt byte (1 byte) + Command Code (1 byte)
-pub const VDM_MSG_HEADER_LEN: usize = 4;
+/// Header consists of: IANA enterprise ID (4 bytes) + Request/Crypt byte (1 byte) + Command Code (1 byte)
+pub const VDM_MSG_HEADER_LEN: usize = 6;
 
 /// VDM completion codes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -94,17 +95,17 @@ impl VdmControlByte {
 }
 
 /// VDM Message Header structure.
-/// This is the header that follows the MCTP common header (msg type 0x7E).
+/// This is the header that follows the MCTP common header (msg type 0x7F).
 ///
 /// Layout:
-/// - Bytes 0:1 - PCI Vendor ID (little-endian, 0x1414 for Caliptra)
-/// - Byte 2    - Control byte (Request/Crypt/Reserved)
-/// - Byte 3    - Command Code
+/// - Bytes 0:3 - IANA enterprise ID (MSB first, OCP 42623 for Caliptra VDM commands)
+/// - Byte 4    - Control byte (Request/Crypt/Reserved)
+/// - Byte 5    - Command Code
 #[derive(Debug, Clone, Copy, PartialEq, FromBytes, IntoBytes, Immutable, Default)]
 #[repr(C, packed)]
 pub struct VdmMsgHeader {
-    /// PCI Vendor ID (little-endian).
-    pub vendor_id: u16,
+    /// IANA enterprise ID (MSB first).
+    pub enterprise_id: [u8; 4],
     /// Control byte containing request type and crypt flags.
     pub control: VdmControlByte,
     /// Command code.
@@ -115,7 +116,7 @@ impl VdmMsgHeader {
     /// Create a new VDM message header for a request.
     pub fn new_request(command_code: u8) -> Self {
         VdmMsgHeader {
-            vendor_id: CALIPTRA_PCI_VENDOR_ID,
+            enterprise_id: CALIPTRA_IANA_ENTERPRISE_ID_BYTES,
             control: VdmControlByte::new_request(),
             command_code,
         }
@@ -124,7 +125,7 @@ impl VdmMsgHeader {
     /// Create a new VDM message header for a response.
     pub fn new_response(command_code: u8) -> Self {
         VdmMsgHeader {
-            vendor_id: CALIPTRA_PCI_VENDOR_ID,
+            enterprise_id: CALIPTRA_IANA_ENTERPRISE_ID_BYTES,
             control: VdmControlByte::new_response(),
             command_code,
         }
@@ -133,15 +134,20 @@ impl VdmMsgHeader {
     /// Convert this header to a response header (keeping same command code).
     pub fn into_response(&self) -> Self {
         VdmMsgHeader {
-            vendor_id: self.vendor_id,
+            enterprise_id: self.enterprise_id,
             control: VdmControlByte::new_response(),
             command_code: self.command_code,
         }
     }
 
-    /// Check if the vendor ID is valid (Caliptra/Microsoft).
+    /// Return the IANA enterprise ID as an integer.
+    pub fn enterprise_id(&self) -> u32 {
+        u32::from_be_bytes(self.enterprise_id)
+    }
+
+    /// Check if the vendor ID is valid (OCP for Caliptra VDM commands).
     pub fn is_vendor_id_valid(&self) -> bool {
-        self.vendor_id == CALIPTRA_PCI_VENDOR_ID
+        self.enterprise_id == CALIPTRA_IANA_ENTERPRISE_ID_BYTES
     }
 
     /// Check if this is a request message.
@@ -196,9 +202,8 @@ mod tests {
     #[test]
     fn test_vdm_msg_header_request() {
         let hdr = VdmMsgHeader::new_request(0x01);
-        let vendor_id = hdr.vendor_id;
         let command_code = hdr.command_code;
-        assert_eq!(vendor_id, CALIPTRA_PCI_VENDOR_ID);
+        assert_eq!(hdr.enterprise_id(), CALIPTRA_IANA_ENTERPRISE_ID);
         assert!(hdr.is_request());
         assert!(hdr.is_vendor_id_valid());
         assert_eq!(command_code, 0x01);
@@ -207,9 +212,8 @@ mod tests {
     #[test]
     fn test_vdm_msg_header_response() {
         let hdr = VdmMsgHeader::new_response(0x02);
-        let vendor_id = hdr.vendor_id;
         let command_code = hdr.command_code;
-        assert_eq!(vendor_id, CALIPTRA_PCI_VENDOR_ID);
+        assert_eq!(hdr.enterprise_id(), CALIPTRA_IANA_ENTERPRISE_ID);
         assert!(hdr.is_response());
         assert!(hdr.is_vendor_id_valid());
         assert_eq!(command_code, 0x02);
@@ -220,10 +224,9 @@ mod tests {
         let req = VdmMsgHeader::new_request(0x03);
         let resp = req.into_response();
         let command_code = resp.command_code;
-        let vendor_id = resp.vendor_id;
         assert!(resp.is_response());
         assert_eq!(command_code, 0x03);
-        assert_eq!(vendor_id, CALIPTRA_PCI_VENDOR_ID);
+        assert_eq!(resp.enterprise_id(), CALIPTRA_IANA_ENTERPRISE_ID);
     }
 
     #[test]
@@ -247,9 +250,9 @@ mod tests {
             VdmCompletionCode::UnsupportedCommand as u32
         );
 
-        let mut buffer = [0u8; 8];
+        let mut buffer = [0u8; VDM_MSG_HEADER_LEN + 4];
         let size = resp.encode(&mut buffer).unwrap();
-        assert_eq!(size, 8);
+        assert_eq!(size, VDM_MSG_HEADER_LEN + 4);
 
         let decoded = VdmFailureResponse::decode(&buffer).unwrap();
         assert_eq!(resp, decoded);

--- a/common/mctp-vdm/src/util/mctp_transport.rs
+++ b/common/mctp-vdm/src/util/mctp_transport.rs
@@ -3,11 +3,9 @@
 //! MCTP transport utilities for VDM messages.
 
 use crate::error::UtilError;
+pub use crate::protocol::MCTP_VDM_MSG_TYPE;
 use crate::protocol::VDM_MSG_HEADER_LEN;
 use bitfield::bitfield;
-
-/// MCTP message type for Vendor Defined Messages.
-pub const MCTP_VDM_MSG_TYPE: u8 = 0x7E;
 
 /// Offset of the MCTP common header in the payload.
 pub const MCTP_COMMON_HEADER_OFFSET: usize = 0;
@@ -18,7 +16,7 @@ pub const VDM_MSG_OFFSET: usize = 1;
 bitfield! {
     /// MCTP Common Header (first byte of MCTP message body).
     /// - Bit 7: IC (Integrity Check bit)
-    /// - Bits 6:0: Message Type (0x7E for VDM)
+    /// - Bits 6:0: Message Type (0x7F for IANA VDM)
     #[derive(Copy, Clone, PartialEq)]
     pub struct MctpCommonHeader(u8);
     impl Debug;
@@ -108,7 +106,7 @@ mod tests {
         assert_eq!(header.ic(), 0);
         assert_eq!(header.msg_type(), MCTP_VDM_MSG_TYPE);
         assert!(header.is_vdm());
-        assert_eq!(header.0, 0x7E);
+        assert_eq!(header.0, 0x7F);
     }
 
     #[test]
@@ -121,12 +119,12 @@ mod tests {
         );
 
         // Valid VDM message
-        mctp_payload[0] = 0x7E;
+        mctp_payload[0] = 0x7F;
         let vdm_msg = extract_vdm_msg(&mut mctp_payload).unwrap();
         assert_eq!(vdm_msg.len(), 15); // 16 - 1 (MCTP common header)
 
         // Buffer too short
-        let mut short_payload = [0x7E; 3];
+        let mut short_payload = [0x7F; 3];
         assert_eq!(
             extract_vdm_msg(&mut short_payload),
             Err(UtilError::InvalidMctpPayloadLength)
@@ -140,7 +138,7 @@ mod tests {
             let vdm_msg = construct_mctp_vdm_msg(&mut mctp_payload).unwrap();
             assert_eq!(vdm_msg.len(), 15);
         }
-        assert_eq!(mctp_payload[0], 0x7E);
+        assert_eq!(mctp_payload[0], 0x7F);
 
         // Buffer too short
         let mut short_payload = [0u8; 3];

--- a/common/testing/src/mctp_util/base_protocol.rs
+++ b/common/testing/src/mctp_util/base_protocol.rs
@@ -14,7 +14,7 @@ pub enum MctpMsgType {
     Pldm = 0x1,
     Spdm = 0x5,
     SecureSpdm = 0x6,
-    Caliptra = 0x7E,
+    Caliptra = 0x7F,
 }
 
 bitfield! {

--- a/common/testing/src/mctp_util/ctrl_protocol.rs
+++ b/common/testing/src/mctp_util/ctrl_protocol.rs
@@ -5,7 +5,6 @@ use bitfield::bitfield;
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 pub const MCTP_CTRL_MSG_HDR_SIZE: usize = 2;
-
 pub fn set_eid_req_bytes(op: SetEIDOp, eid: u8) -> Vec<u8> {
     let mut req_bytes: [u8; 2] = [0; 2];
     let cmd: &mut SetEIDReq<[u8; 2]> = SetEIDReq::mut_from_bytes(&mut req_bytes).unwrap();
@@ -38,12 +37,19 @@ pub fn get_eid_resp_bytes(cc: CmdCompletionCode, eid: u8) -> Vec<u8> {
 }
 
 pub fn get_version_support_resp_bytes(cc: u8, entries: Option<&[VersionEntry]>) -> Vec<u8> {
-    let mut resp_bytes = Vec::new();
-    resp_bytes.push(cc); // completion code
+    let entry_count = entries.map_or(0, |entries| entries.len());
+    let mut resp_bytes = vec![0; 2 + entry_count * 4];
+    resp_bytes[0] = cc; // completion code
+    resp_bytes[1] = entry_count as u8; // Number of version entries
     if let Some(entries) = entries {
-        resp_bytes.push(entries.len() as u8); // Number of version entries
-        for entry in entries {
-            resp_bytes.extend_from_slice(&entry.to_u32().to_le_bytes());
+        for (i, entry) in entries.iter().enumerate() {
+            let offset = 2 + i * 4;
+            resp_bytes[offset..offset + 4].copy_from_slice(&[
+                entry.major,
+                entry.minor,
+                entry.update,
+                entry.alpha,
+            ]);
         }
     }
     resp_bytes
@@ -250,8 +256,8 @@ impl From<u8> for EIDType {
 pub enum VersionSupportMessageType {
     MctpBase = 0xFF,
     MctpControlProtocol = 0x00,
-    VendorDefined = 0x7E,
-    Unspecified = 0x7F,
+    VendorDefinedPci = 0x7E,
+    VendorDefinedIana = 0x7F,
 }
 
 // For MCTP version entries, typically represented as:

--- a/docs/src/external_mctp_vdm_cmds.md
+++ b/docs/src/external_mctp_vdm_cmds.md
@@ -2,31 +2,31 @@
 
 ## Overview
 
-This document specifies the external command protocol used by the Baseboard Management Controller (BMC) to communicate with the device integrating the Caliptra RoT subsystem. The protocol is based on the MCTP (Management Component Transport Protocol) over the I3C interface and uses a vendor-defined message type (`0x7E`).
+This document specifies the external command protocol used by the Baseboard Management Controller (BMC) to communicate with the device integrating the Caliptra RoT subsystem. The protocol is based on the MCTP (Management Component Transport Protocol) over the I3C interface and uses a vendor-defined IANA message type (`0x7F`).
 
 ### Protocol
 
 - **Transport Layer**: MCTP
-- **Message Type**: The message type is `0x7E` as per the MCTP Base Specification. This message type supports Vendor Defined Messages, where the vendor is identified by the PCI-based Vendor ID. The initial message header is specified in the MCTP Base Specification and detailed below for completeness:
+- **Message Type**: The message type is `0x7F` as per the MCTP Base Specification. This message type supports Vendor Defined Messages, where the vendor is identified by an IANA enterprise number. The initial message header is specified in the MCTP Base Specification and detailed below for completeness:
 
 | Field Name                  | Byte(s) | Description                                                             |
 |-----------------------------|---------|-------------------------------------------------------------------------|
 | **Request Data**            |         |                                                                         |
-| PCI/PCIe Vendor ID          | 1:2     | The MCTP Vendor ID formatted per `00h` Vendor ID format offset.         |
-| Vendor-Defined Message Body | 3:N     | Vendor-defined message body, 0 to N bytes.                              |
+| IANA Enterprise ID          | 1:4     | The MCTP Vendor ID formatted per `01h` Vendor ID format offset.         |
+| Vendor-Defined Message Body | 5:N     | Vendor-defined message body, 0 to N bytes.                              |
 | **Response Data**           |         |                                                                         |
-| PCI/PCIe Vendor ID          | 1:2     | The value is formatted per `00h` Vendor ID offset.                      |
-| Vendor-Defined Message Body | 3:M     | Vendor-defined message body, 0 to M bytes.                              |
+| IANA Enterprise ID          | 1:4     | The value is formatted per `01h` Vendor ID offset.                      |
+| Vendor-Defined Message Body | 5:M     | Vendor-defined message body, 0 to M bytes.                              |
 
-The Vendor ID is a 16-bit unsigned integer, described in the PCI 2.3 specification. The value identifies the device manufacturer. The message body and content are described in the sections below.
+The IANA Enterprise ID is a 32-bit unsigned integer assigned by IANA. The message body and content are described in the sections below.
 
 ### Message Format
 
 This section describes the MCTP message format used to support Caliptra subsystem external command protocol. The request/response message body encapsulates the Vendor Defined MCTP message within the MCTP transport. Details of MCTP message encapsulation can be found in the MCTP Base Specification. The MCTP Get Vendor Defined Message Support command allows discovery of the vendor-defined messages supported by an endpoint. This discovery process identifies the vendor organization and the supported message types. The format of this request is specified in the MCTP Base Specification.
 
 For the Caliptra external command protocol, the following information is returned in response to the MCTP Get Vendor Defined Message Support request:
-- **Vendor ID Format**: `0`
-- **PCI Vendor ID**: `0x1414`
+- **Vendor ID Format**: `1`
+- **OCP Vendor ID**: `42623`
 - **Command Set Version**: `4`
 
 The following table provides detailed descriptions of the fields used in the Caliptra external command protocol:
@@ -35,7 +35,7 @@ The following table provides detailed descriptions of the fields used in the Cal
 |----------------------|---------------------------------------------------------------------------------------------------------------|
 | **IC**               | (MCTP Integrity Check bit) Indicates whether the MCTP message is covered by an overall MCTP message payload integrity check. |
 | **Message Type**     | Indicates an MCTP Vendor Defined Message.                                                                     |
-| **MCTP PCI Vendor**  | ID for PCI Vendor. Caliptra messages use the Microsoft PCI ID of `0x1414`.                                    |
+| **MCTP IANA Enterprise ID** | IANA enterprise ID for the vendor. Caliptra messages use the OCP Vendor ID `42623`.                    |
 | **Request Type**     | Distinguishes between request and response messages: set to `1` for requests, and `0` for responses. |
 | **Crypt**            | Indicates whether the Message Payload and Command are encrypted.                                              |
 | **Command Code**     | The command ID for the operation to execute.                                                                  |

--- a/emulator/app/src/tests/mctp_ctrl_cmd.rs
+++ b/emulator/app/src/tests/mctp_ctrl_cmd.rs
@@ -32,7 +32,10 @@ pub(crate) enum MCTPCtrlCmdTests {
     GetEID,
     GetMctpVersionSupportMctpBase,
     GetMctpVersionSupportMctpControlProtocol,
-    GetMctpVersionSupportUnspecified,
+    GetMctpVersionSupportPldm,
+    GetMctpVersionSupportSpdm,
+    GetMctpVersionSupportSecuredSpdmUnsupported,
+    GetMctpVersionSupportCaliptra,
     GetMctpVersionSupportUnsupported,
     GetMsgTypeSupport,
     UnsupportedCmd,
@@ -78,11 +81,20 @@ impl MCTPCtrlCmdTests {
             MCTPCtrlCmdTests::GetMctpVersionSupportMctpControlProtocol => {
                 vec![0x00]
             }
-            MCTPCtrlCmdTests::GetMctpVersionSupportUnspecified => {
-                vec![0x7E]
+            MCTPCtrlCmdTests::GetMctpVersionSupportPldm => {
+                vec![MctpMsgType::Pldm as u8]
+            }
+            MCTPCtrlCmdTests::GetMctpVersionSupportSpdm => {
+                vec![MctpMsgType::Spdm as u8]
+            }
+            MCTPCtrlCmdTests::GetMctpVersionSupportSecuredSpdmUnsupported => {
+                vec![MctpMsgType::SecureSpdm as u8]
+            }
+            MCTPCtrlCmdTests::GetMctpVersionSupportCaliptra => {
+                vec![MctpMsgType::Caliptra as u8]
             }
             MCTPCtrlCmdTests::GetMctpVersionSupportUnsupported => {
-                vec![0x01]
+                vec![0x04]
             }
             MCTPCtrlCmdTests::GetMsgTypeSupport => {
                 vec![]
@@ -140,20 +152,30 @@ impl MCTPCtrlCmdTests {
             }
             MCTPCtrlCmdTests::GetMctpVersionSupportMctpBase
             | MCTPCtrlCmdTests::GetMctpVersionSupportMctpControlProtocol => {
-                // 1.0.0 (major version 1, minor version 0, update 0 alpha 0)
-                let version1 = VersionEntry::from_u32(0xF1F0F000);
-                // 1.1.0 (major version 1, minor version 1, update 0 alpha 0)
-                let version2 = VersionEntry::from_u32(0xF1F1F000);
-                // 1.2.0 (major version 1, minor version 2, update 0 alpha 0)
-                let version3 = VersionEntry::from_u32(0xF1F2F000);
-                // 1.3.3 (major version 1, minor version 3, update 3 alpha 0)
+                // Backward compatibility with MCTP base/control protocol 1.0, 1.1, and 1.2.
+                let version1 = VersionEntry::from_u32(0xF1F0FF00);
+                let version2 = VersionEntry::from_u32(0xF1F1FF00);
+                let version3 = VersionEntry::from_u32(0xF1F2FF00);
+                // Current MCTP base/control protocol version 1.3.3.
                 let version4 = VersionEntry::from_u32(0xF1F3F300);
                 get_version_support_resp_bytes(
                     CmdCompletionCode::Success as u8,
                     Some(&[version1, version2, version3, version4]),
                 )
             }
-            MCTPCtrlCmdTests::GetMctpVersionSupportUnspecified
+            MCTPCtrlCmdTests::GetMctpVersionSupportPldm => get_version_support_resp_bytes(
+                CmdCompletionCode::Success as u8,
+                Some(&[VersionEntry::from_u32(0xF1F0F000)]),
+            ),
+            MCTPCtrlCmdTests::GetMctpVersionSupportSpdm => get_version_support_resp_bytes(
+                CmdCompletionCode::Success as u8,
+                Some(&[VersionEntry::from_u32(0xF1F0F200)]),
+            ),
+            MCTPCtrlCmdTests::GetMctpVersionSupportCaliptra => get_version_support_resp_bytes(
+                CmdCompletionCode::Success as u8,
+                Some(&[VersionEntry::from_u32(0xF1F0F000)]),
+            ),
+            MCTPCtrlCmdTests::GetMctpVersionSupportSecuredSpdmUnsupported
             | MCTPCtrlCmdTests::GetMctpVersionSupportUnsupported => {
                 get_version_support_resp_bytes(0x80, None)
             }
@@ -162,7 +184,6 @@ impl MCTPCtrlCmdTests {
                     MctpMsgType::Ctrl,
                     MctpMsgType::Pldm,
                     MctpMsgType::Spdm,
-                    MctpMsgType::SecureSpdm,
                     MctpMsgType::Caliptra,
                 ];
                 generate_msg_type_support_resp_bytes(CmdCompletionCode::Success as u8, &msg_types)
@@ -213,7 +234,10 @@ impl MCTPCtrlCmdTests {
             MCTPCtrlCmdTests::GetEID => MCTPCtrlCmd::GetEID as u8,
             MCTPCtrlCmdTests::GetMctpVersionSupportMctpBase
             | MCTPCtrlCmdTests::GetMctpVersionSupportMctpControlProtocol
-            | MCTPCtrlCmdTests::GetMctpVersionSupportUnspecified
+            | MCTPCtrlCmdTests::GetMctpVersionSupportPldm
+            | MCTPCtrlCmdTests::GetMctpVersionSupportSpdm
+            | MCTPCtrlCmdTests::GetMctpVersionSupportSecuredSpdmUnsupported
+            | MCTPCtrlCmdTests::GetMctpVersionSupportCaliptra
             | MCTPCtrlCmdTests::GetMctpVersionSupportUnsupported => {
                 MCTPCtrlCmd::GetMctpVersionSupport as u8
             }

--- a/runtime/kernel/capsules/src/mctp/base_protocol.rs
+++ b/runtime/kernel/capsules/src/mctp/base_protocol.rs
@@ -20,7 +20,15 @@ pub const MCTP_BROADCAST_EID: u8 = 0xFF;
 
 pub const MCTP_BASELINE_TRANSMISSION_UNIT: usize = 64;
 
+// Maximum number of message types this stack can advertise. The MCTP mux
+// filters this list based on the board's registered MCTP driver capsules.
 pub const MCTP_NUM_MSG_TYPES_SUPPORTED: usize = 5;
+pub const MCTP_DISCOVERABLE_MSG_TYPES: [MessageType; 4] = [
+    MessageType::Pldm,
+    MessageType::Spdm,
+    MessageType::SecureSpdm,
+    MessageType::Caliptra,
+];
 
 bitfield! {
     #[derive(Clone, Copy, Default)]
@@ -75,7 +83,7 @@ pub enum MessageType {
     Pldm = 1,
     Spdm = 5,
     SecureSpdm = 6,
-    Caliptra = 0x7E, // Vendor defined PCI message type
+    Caliptra = 0x7F, // Vendor defined IANA message type
     TestMsgType = MCTP_TEST_MSG_TYPE as isize,
     Invalid,
 }
@@ -87,23 +95,30 @@ impl From<u8> for MessageType {
             1 => MessageType::Pldm,
             5 => MessageType::Spdm,
             6 => MessageType::SecureSpdm,
-            0x7E => MessageType::Caliptra,
+            0x7F => MessageType::Caliptra,
             MCTP_TEST_MSG_TYPE => MessageType::TestMsgType,
             _ => MessageType::Invalid,
         }
     }
 }
 
-impl MessageType {
-    pub fn supported() -> [MessageType; MCTP_NUM_MSG_TYPES_SUPPORTED] {
-        [
-            MessageType::MctpControl,
-            MessageType::Pldm,
-            MessageType::Spdm,
-            MessageType::SecureSpdm,
-            MessageType::Caliptra,
-        ]
+pub fn supported_msg_types(
+    mut is_registered: impl FnMut(MessageType) -> bool,
+) -> ([MessageType; MCTP_NUM_MSG_TYPES_SUPPORTED], usize) {
+    let mut supported = [MessageType::Invalid; MCTP_NUM_MSG_TYPES_SUPPORTED];
+    let mut count = 0;
+
+    supported[count] = MessageType::MctpControl;
+    count += 1;
+
+    for msg_type in MCTP_DISCOVERABLE_MSG_TYPES {
+        if is_registered(msg_type) {
+            supported[count] = msg_type;
+            count += 1;
+        }
     }
+
+    (supported, count)
 }
 
 pub fn valid_eid(eid: u8) -> bool {

--- a/runtime/kernel/capsules/src/mctp/control_msg.rs
+++ b/runtime/kernel/capsules/src/mctp/control_msg.rs
@@ -7,6 +7,30 @@ use zerocopy::{FromBytes, Immutable, IntoBytes};
 
 pub const MCTP_CTRL_MSG_HEADER_LEN: usize = 3;
 
+const MCTP_BASE_CONTROL_VERSIONS: [[u8; 4]; 4] = [
+    [0xF1, 0xF0, 0xFF, 0x00], // 1.0
+    [0xF1, 0xF1, 0xFF, 0x00], // 1.1
+    [0xF1, 0xF2, 0xFF, 0x00], // 1.2
+    [0xF1, 0xF3, 0xF3, 0x00], // 1.3.3
+];
+
+const PLDM_OVER_MCTP_VERSIONS: [[u8; 4]; 1] = [
+    [0xF1, 0xF0, 0xF0, 0x00], // DSP0241 1.0.0
+];
+
+const SPDM_OVER_MCTP_VERSIONS: [[u8; 4]; 1] = [
+    [0xF1, 0xF0, 0xF2, 0x00], // DSP0275 1.0.2
+];
+
+// Current Caliptra Secure SPDM support reports only DSP0276 2.0.0.
+const SECURED_SPDM_OVER_MCTP_VERSIONS: [[u8; 4]; 1] = [
+    [0xF2, 0xF0, 0xF0, 0x00], // DSP0276 2.0.0
+];
+
+const CALIPTRA_IANA_VDM_VERSIONS: [[u8; 4]; 1] = [
+    [0xF1, 0xF0, 0xF0, 0x00], // Caliptra/OCP VDM 1.0.0
+];
+
 bitfield! {
     #[derive(Default)]
     pub struct MCTPCtrlMsgHdr(u32);
@@ -31,6 +55,88 @@ impl MCTPCtrlMsgHdr {
         self.set_instance_id(instance_id);
         self.set_cmd(cmd);
     }
+
+    fn write_to_buf(&self, resp_buf: &mut [u8]) -> Result<(), ErrorCode> {
+        if resp_buf.len() < MCTP_CTRL_MSG_HEADER_LEN {
+            return Err(ErrorCode::INVAL);
+        }
+
+        resp_buf[..MCTP_CTRL_MSG_HEADER_LEN]
+            .copy_from_slice(&self.0.to_le_bytes()[..MCTP_CTRL_MSG_HEADER_LEN]);
+        Ok(())
+    }
+}
+
+pub struct MCTPCtrlMsgResp {
+    pub assigned_eid: Option<u8>,
+    pub resp_len: usize,
+}
+
+pub fn process_mctp_control_msg(
+    msg_buf: &[u8],
+    local_eid: u8,
+    supported_msg_types: &[MessageType],
+    resp_buf: &mut [u8],
+) -> Result<MCTPCtrlMsgResp, ErrorCode> {
+    if msg_buf.len() < MCTP_CTRL_MSG_HEADER_LEN {
+        return Err(ErrorCode::INVAL);
+    }
+
+    let mut hdr = [0; 4];
+    hdr[..MCTP_CTRL_MSG_HEADER_LEN].copy_from_slice(&msg_buf[..MCTP_CTRL_MSG_HEADER_LEN]);
+    let mctp_ctrl_msg_hdr = MCTPCtrlMsgHdr(u32::from_le_bytes(hdr));
+
+    if mctp_ctrl_msg_hdr.rq() != 1 || mctp_ctrl_msg_hdr.datagram() != 0 {
+        return Err(ErrorCode::INVAL);
+    }
+
+    let mut mctp_ctrl_msg_hdr_resp = MCTPCtrlMsgHdr::new();
+    mctp_ctrl_msg_hdr_resp.prepare_header(
+        0,
+        mctp_ctrl_msg_hdr.datagram(),
+        mctp_ctrl_msg_hdr.instance_id(),
+        mctp_ctrl_msg_hdr.cmd(),
+    );
+
+    let req_buf = &msg_buf[MCTP_CTRL_MSG_HEADER_LEN..];
+    let mctp_ctrl_cmd: MCTPCtrlCmd = mctp_ctrl_msg_hdr.cmd().into();
+    if req_buf.len() < mctp_ctrl_cmd.req_data_len() {
+        return Err(ErrorCode::INVAL);
+    }
+
+    if resp_buf.len() < MCTP_CTRL_MSG_HEADER_LEN + mctp_ctrl_cmd.resp_data_len() {
+        return Err(ErrorCode::NOMEM);
+    }
+
+    let rsp_payload = &mut resp_buf[MCTP_CTRL_MSG_HEADER_LEN..];
+    let mut assigned_eid = None;
+    let resp_data_len = match mctp_ctrl_cmd {
+        MCTPCtrlCmd::SetEID => mctp_ctrl_cmd
+            .process_set_endpoint_id(req_buf, rsp_payload)
+            .map(|eid| {
+                assigned_eid = eid;
+                mctp_ctrl_cmd.resp_data_len()
+            }),
+        MCTPCtrlCmd::GetEID => mctp_ctrl_cmd
+            .process_get_endpoint_id(local_eid, rsp_payload)
+            .map(|_| mctp_ctrl_cmd.resp_data_len()),
+        MCTPCtrlCmd::GetVersionSupport => {
+            mctp_ctrl_cmd.process_get_version_support(req_buf, rsp_payload, supported_msg_types)
+        }
+        MCTPCtrlCmd::GetMsgTypeSupport => {
+            mctp_ctrl_cmd.process_get_msg_type_support(req_buf, rsp_payload, supported_msg_types)
+        }
+        MCTPCtrlCmd::Unsupported => {
+            rsp_payload[0] = CmdCompletionCode::ErrorNotSupportedCmd as u8;
+            Ok(mctp_ctrl_cmd.resp_data_len())
+        }
+    }?;
+
+    mctp_ctrl_msg_hdr_resp.write_to_buf(resp_buf)?;
+    Ok(MCTPCtrlMsgResp {
+        assigned_eid,
+        resp_len: MCTP_CTRL_MSG_HEADER_LEN + resp_data_len,
+    })
 }
 
 pub enum MCTPCtrlCmd {
@@ -143,61 +249,89 @@ impl MCTPCtrlCmd {
         &self,
         req: &[u8],
         rsp_buf: &mut [u8],
-    ) -> Result<(), ErrorCode> {
+        supported_msg_types: &[MessageType],
+    ) -> Result<usize, ErrorCode> {
+        if req.len() < self.req_data_len() {
+            return Err(ErrorCode::INVAL);
+        }
+        if rsp_buf.len() < self.resp_data_len() {
+            return Err(ErrorCode::NOMEM);
+        }
+
+        rsp_buf[..self.resp_data_len()].fill(0);
         let version_type = VersionSupportType::from(req[0]);
 
         match version_type {
             VersionSupportType::BaseSpec | VersionSupportType::ControlProtocolMessage => {
-                // MCTP Base and Control specs: versions 1.0, 1.1, 1.2, 1.3.3
-                const VERSIONS: [[u8; 4]; 4] = [
-                    [0xF1, 0xF0, 0xFF, 0x00], // 1.0
-                    [0xF1, 0xF1, 0xFF, 0x00], // 1.1
-                    [0xF1, 0xF2, 0xFF, 0x00], // 1.2
-                    [0xF1, 0xF3, 0xF3, 0x00], // 1.3.3
-                ];
-
-                let header = GetVersionSupportHeaderResp {
-                    completion_code: 0x00,
-                    entry_counter: VERSIONS.len() as u8,
-                };
-                header
-                    .write_to(&mut rsp_buf[..2])
-                    .map_err(|_| ErrorCode::FAIL)?;
-
-                for (i, ver) in VERSIONS.iter().enumerate() {
-                    let offset = 2 + i * 4;
-                    rsp_buf[offset..offset + 4].copy_from_slice(ver);
-                }
+                Self::write_get_version_support_success(rsp_buf, &MCTP_BASE_CONTROL_VERSIONS)
             }
-            _ => {
-                let header = GetVersionSupportHeaderResp {
-                    completion_code: 0x80, // Unsupported
-                    entry_counter: 0,
-                };
-                header
-                    .write_to(&mut rsp_buf[..2])
-                    .map_err(|_| ErrorCode::FAIL)?;
+            VersionSupportType::DSP0241 if supported_msg_types.contains(&MessageType::Pldm) => {
+                Self::write_get_version_support_success(rsp_buf, &PLDM_OVER_MCTP_VERSIONS)
             }
+            VersionSupportType::DSP0275 if supported_msg_types.contains(&MessageType::Spdm) => {
+                Self::write_get_version_support_success(rsp_buf, &SPDM_OVER_MCTP_VERSIONS)
+            }
+            VersionSupportType::DSP0276
+                if supported_msg_types.contains(&MessageType::SecureSpdm) =>
+            {
+                Self::write_get_version_support_success(rsp_buf, &SECURED_SPDM_OVER_MCTP_VERSIONS)
+            }
+            VersionSupportType::VendorControlled7F
+                if supported_msg_types.contains(&MessageType::Caliptra) =>
+            {
+                Self::write_get_version_support_success(rsp_buf, &CALIPTRA_IANA_VDM_VERSIONS)
+            }
+            _ => Self::write_get_version_support_unsupported(rsp_buf),
         }
-        Ok(())
+    }
+
+    fn write_get_version_support_success(
+        rsp_buf: &mut [u8],
+        versions: &[[u8; 4]],
+    ) -> Result<usize, ErrorCode> {
+        let header = GetVersionSupportHeaderResp {
+            completion_code: 0x00,
+            entry_counter: versions.len() as u8,
+        };
+        header
+            .write_to(&mut rsp_buf[..2])
+            .map_err(|_| ErrorCode::FAIL)?;
+
+        for (i, ver) in versions.iter().enumerate() {
+            let offset = 2 + i * 4;
+            rsp_buf[offset..offset + 4].copy_from_slice(ver);
+        }
+
+        Ok(2 + versions.len() * 4)
+    }
+
+    fn write_get_version_support_unsupported(rsp_buf: &mut [u8]) -> Result<usize, ErrorCode> {
+        let header = GetVersionSupportHeaderResp {
+            completion_code: 0x80,
+            entry_counter: 0,
+        };
+        header
+            .write_to(&mut rsp_buf[..2])
+            .map_err(|_| ErrorCode::FAIL)?;
+        Ok(2)
     }
 
     pub fn process_get_msg_type_support(
         &self,
         _req: &[u8],
         rsp_buf: &mut [u8],
-    ) -> Result<(), ErrorCode> {
-        if rsp_buf.len() < self.resp_data_len() {
+        supported_msg_types: &[MessageType],
+    ) -> Result<usize, ErrorCode> {
+        if rsp_buf.len() < 2 + supported_msg_types.len() {
             return Err(ErrorCode::NOMEM);
         }
         rsp_buf[0] = 0x00; // Completion code: Success
-        let supported_msg_types = MessageType::supported();
         rsp_buf[1] = supported_msg_types.len() as u8;
         for (i, msg_type) in supported_msg_types.iter().enumerate() {
             rsp_buf[2 + i] = *msg_type as u8;
         }
 
-        Ok(())
+        Ok(2 + supported_msg_types.len())
     }
 }
 
@@ -363,6 +497,8 @@ enum VersionSupportType {
     ControlProtocolMessage,
     DSP0241,
     DSP0261,
+    DSP0275,
+    DSP0276,
     #[allow(dead_code)]
     Other(u8),
 }
@@ -379,6 +515,8 @@ impl From<u8> for VersionSupportType {
             0x00 => VersionSupportType::ControlProtocolMessage,
             0x01 => VersionSupportType::DSP0241,
             0x02 => VersionSupportType::DSP0261,
+            0x05 => VersionSupportType::DSP0275,
+            0x06 => VersionSupportType::DSP0276,
             _ => VersionSupportType::Other(val),
         }
     }
@@ -470,6 +608,23 @@ mod tests {
     }
 
     #[test]
+    fn test_process_mctp_control_msg_returns_assigned_eid() {
+        let mut msg_req = [0; MCTP_CTRL_MSG_HEADER_LEN + 2];
+        let mut msg_hdr = MCTPCtrlMsgHdr::new();
+        msg_hdr.prepare_header(1, 0, 0, MCTPCtrlCmd::SetEID as u8);
+        msg_hdr
+            .write_to_buf(&mut msg_req[..MCTP_CTRL_MSG_HEADER_LEN])
+            .unwrap();
+        msg_req[MCTP_CTRL_MSG_HEADER_LEN..].copy_from_slice(&[0x00, 0x0A]);
+
+        let rsp_buf = &mut [0; MCTP_CTRL_MSG_HEADER_LEN + 4];
+        let resp = process_mctp_control_msg(&msg_req, 0, &[], rsp_buf).unwrap();
+
+        assert_eq!(resp.assigned_eid, Some(0x0A));
+        assert_eq!(resp.resp_len, MCTP_CTRL_MSG_HEADER_LEN + 4);
+    }
+
+    #[test]
     fn test_set_null_endpoint_id() {
         let msg_req = [0x00, 0x00];
 
@@ -522,7 +677,7 @@ mod tests {
         let rsp_buf = &mut [0; 18];
 
         MCTPCtrlCmd::GetVersionSupport
-            .process_get_version_support(&req, rsp_buf)
+            .process_get_version_support(&req, rsp_buf, &[])
             .unwrap();
 
         // Check header (first 2 bytes)
@@ -566,32 +721,157 @@ mod tests {
 
     #[test]
     fn test_get_version_support_unsupported() {
-        let req = [0x01]; // DSP0241 version type (unsupported)
+        for type_num in [0x04, 0x09, 0x10] {
+            let req = [type_num];
+            let rsp_buf = &mut [0; 18];
+
+            MCTPCtrlCmd::GetVersionSupport
+                .process_get_version_support(&req, rsp_buf, &[])
+                .unwrap();
+
+            // Check header (first 2 bytes)
+            let header: GetVersionSupportHeaderResp =
+                GetVersionSupportHeaderResp::read_from_bytes(&rsp_buf[..2]).unwrap();
+            assert_eq!(header.completion_code, 0x80); // Unsupported
+            assert_eq!(header.entry_counter, 0);
+        }
+    }
+
+    #[test]
+    fn test_get_version_support_short_request_returns_invalid() {
+        let req = [];
+        let rsp_buf = &mut [0; 18];
+
+        let err = MCTPCtrlCmd::GetVersionSupport
+            .process_get_version_support(&req, rsp_buf, &[])
+            .unwrap_err();
+
+        assert_eq!(err, ErrorCode::INVAL);
+    }
+
+    #[test]
+    fn test_get_version_support_supported_message_types() {
+        assert_get_version_support(
+            &[MessageType::Pldm],
+            MessageType::Pldm as u8,
+            &[
+                [0xF1, 0xF0, 0xF0, 0x00], // DSP0241 1.0.0
+            ],
+        );
+        assert_get_version_support(
+            &[MessageType::Spdm],
+            MessageType::Spdm as u8,
+            &[
+                [0xF1, 0xF0, 0xF2, 0x00], // DSP0275 1.0.2
+            ],
+        );
+        assert_get_version_support(
+            &[MessageType::SecureSpdm],
+            MessageType::SecureSpdm as u8,
+            &[
+                [0xF2, 0xF0, 0xF0, 0x00], // DSP0276 2.0.0
+            ],
+        );
+        assert_get_version_support(
+            &[MessageType::Caliptra],
+            MessageType::Caliptra as u8,
+            &[
+                [0xF1, 0xF0, 0xF0, 0x00], // Caliptra/OCP VDM 1.0.0
+            ],
+        );
+    }
+
+    #[test]
+    fn test_get_version_support_unadvertised_message_type() {
+        let req = [MessageType::SecureSpdm as u8];
         let rsp_buf = &mut [0; 18];
 
         MCTPCtrlCmd::GetVersionSupport
-            .process_get_version_support(&req, rsp_buf)
+            .process_get_version_support(&req, rsp_buf, &[MessageType::Pldm, MessageType::Spdm])
             .unwrap();
 
-        // Check header (first 2 bytes)
         let header: GetVersionSupportHeaderResp =
             GetVersionSupportHeaderResp::read_from_bytes(&rsp_buf[..2]).unwrap();
-        assert_eq!(header.completion_code, 0x80); // Unsupported
+        assert_eq!(header.completion_code, 0x80);
         assert_eq!(header.entry_counter, 0);
+    }
+
+    #[test]
+    fn test_version_support_consistent_with_msg_type_support() {
+        let supported_msg_types = [
+            MessageType::MctpControl,
+            MessageType::Pldm,
+            MessageType::Spdm,
+            MessageType::SecureSpdm,
+            MessageType::Caliptra,
+        ];
+
+        for msg_type in supported_msg_types {
+            let type_num = msg_type as u8;
+            let req = [type_num];
+            let rsp_buf = &mut [0; 18];
+            MCTPCtrlCmd::GetVersionSupport
+                .process_get_version_support(&req, rsp_buf, &supported_msg_types)
+                .unwrap();
+
+            let header: GetVersionSupportHeaderResp =
+                GetVersionSupportHeaderResp::read_from_bytes(&rsp_buf[..2]).unwrap();
+            assert_ne!(
+                header.completion_code, 0x80,
+                "msg type 0x{:02X} advertised but Get Version Support returned 0x80",
+                type_num
+            );
+            assert!(
+                header.entry_counter > 0,
+                "msg type 0x{:02X} returned zero entries",
+                type_num
+            );
+        }
     }
 
     #[test]
     fn test_get_msg_type_support() {
         let rsp_buf = &mut [0; 2 + MCTP_NUM_MSG_TYPES_SUPPORTED];
+        let supported_msg_types = [
+            MessageType::MctpControl,
+            MessageType::Pldm,
+            MessageType::Spdm,
+            MessageType::Caliptra,
+        ];
         MCTPCtrlCmd::GetMsgTypeSupport
-            .process_get_msg_type_support(&[], rsp_buf)
+            .process_get_msg_type_support(&[], rsp_buf, &supported_msg_types)
             .unwrap();
 
         assert_eq!(rsp_buf[0], 0x00); // Completion code: Success
         let supported_msg_types_count = rsp_buf[1] as usize;
-        assert_eq!(supported_msg_types_count, MessageType::supported().len());
+        assert_eq!(supported_msg_types_count, supported_msg_types.len());
         for i in 0..supported_msg_types_count {
-            assert_eq!(rsp_buf[2 + i], MessageType::supported()[i] as u8);
+            assert_eq!(rsp_buf[2 + i], supported_msg_types[i] as u8);
         }
+    }
+
+    fn assert_get_version_support(
+        supported_msg_types: &[MessageType],
+        type_num: u8,
+        expected_versions: &[[u8; 4]],
+    ) {
+        let req = [type_num];
+        let rsp_buf = &mut [0xA5; 18];
+        MCTPCtrlCmd::GetVersionSupport
+            .process_get_version_support(&req, rsp_buf, supported_msg_types)
+            .unwrap();
+
+        let header: GetVersionSupportHeaderResp =
+            GetVersionSupportHeaderResp::read_from_bytes(&rsp_buf[..2]).unwrap();
+        assert_eq!(header.completion_code, 0x00);
+        assert_eq!(header.entry_counter, expected_versions.len() as u8);
+
+        for (i, expected_version) in expected_versions.iter().enumerate() {
+            let offset = 2 + i * 4;
+            assert_eq!(&rsp_buf[offset..offset + 4], expected_version);
+        }
+
+        let used_len = 2 + expected_versions.len() * 4;
+        assert!(rsp_buf[used_len..].iter().all(|byte| *byte == 0));
     }
 }

--- a/runtime/kernel/capsules/src/mctp/mux.rs
+++ b/runtime/kernel/capsules/src/mctp/mux.rs
@@ -1,11 +1,9 @@
 // Licensed under the Apache-2.0 license
 
 use crate::mctp::base_protocol::{
-    MCTPHeader, MessageType, MCTP_BASELINE_TRANSMISSION_UNIT, MCTP_HDR_SIZE,
+    supported_msg_types, MCTPHeader, MessageType, MCTP_BASELINE_TRANSMISSION_UNIT, MCTP_HDR_SIZE,
 };
-use crate::mctp::control_msg::{
-    CmdCompletionCode, MCTPCtrlCmd, MCTPCtrlMsgHdr, MCTP_CTRL_MSG_HEADER_LEN,
-};
+use crate::mctp::control_msg::process_mctp_control_msg;
 use crate::mctp::recv::MCTPRxState;
 use crate::mctp::send::MCTPTxState;
 use crate::mctp::transport_binding::{MCTPTransportBinding, TransportRxClient, TransportTxClient};
@@ -134,19 +132,6 @@ impl<'a, A: Alarm<'a>, M: MCTPTransportBinding<'a>> MuxMCTPDriver<'a, A, M> {
         (mctp_header, msg_type, MCTP_HDR_SIZE)
     }
 
-    fn fill_mctp_ctrl_hdr_resp(
-        &self,
-        mctp_ctrl_msg_hdr_resp: MCTPCtrlMsgHdr,
-        resp_buf: &mut [u8],
-    ) -> Result<(), ErrorCode> {
-        if resp_buf.len() < MCTP_CTRL_MSG_HEADER_LEN {
-            return Err(ErrorCode::INVAL);
-        }
-        resp_buf[0..MCTP_CTRL_MSG_HEADER_LEN]
-            .copy_from_slice(&mctp_ctrl_msg_hdr_resp.0.to_le_bytes()[..MCTP_CTRL_MSG_HEADER_LEN]);
-        Ok(())
-    }
-
     fn fill_mctp_hdr_resp(
         &self,
         mctp_hdr_resp: MCTPHeader,
@@ -164,19 +149,6 @@ impl<'a, A: Alarm<'a>, M: MCTPTransportBinding<'a>> MuxMCTPDriver<'a, A, M> {
         mctp_hdr: MCTPHeader,
         msg_buf: &[u8],
     ) -> Result<(), ErrorCode> {
-        if msg_buf.len() < MCTP_CTRL_MSG_HEADER_LEN {
-            return Err(ErrorCode::INVAL);
-        }
-
-        let mut hdr = [0; 4];
-        hdr[0..MCTP_CTRL_MSG_HEADER_LEN].copy_from_slice(&msg_buf[0..MCTP_CTRL_MSG_HEADER_LEN]);
-        let mctp_ctrl_msg_hdr = MCTPCtrlMsgHdr(u32::from_le_bytes(hdr));
-
-        if mctp_ctrl_msg_hdr.rq() != 1 || mctp_ctrl_msg_hdr.datagram() != 0 {
-            // Only Command/Request messages are handled
-            return Err(ErrorCode::INVAL);
-        }
-
         let mctp_hdr_resp = MCTPHeader::new(
             mctp_hdr.src_eid(),
             mctp_hdr.dest_eid(),
@@ -187,83 +159,44 @@ impl<'a, A: Alarm<'a>, M: MCTPTransportBinding<'a>> MuxMCTPDriver<'a, A, M> {
             mctp_hdr.msg_tag(),
         );
 
-        let mut mctp_ctrl_msg_hdr_resp = MCTPCtrlMsgHdr::new();
-        mctp_ctrl_msg_hdr_resp.prepare_header(
-            0,
-            mctp_ctrl_msg_hdr.datagram(),
-            mctp_ctrl_msg_hdr.instance_id(),
-            mctp_ctrl_msg_hdr.cmd(),
-        );
-
         let mctp_hdr_start = self.mctp_hdr_offset();
         let mctp_ctrl_hdr_start = mctp_hdr_start + MCTP_HDR_SIZE;
-        let msg_payload_start = mctp_ctrl_hdr_start + MCTP_CTRL_MSG_HEADER_LEN;
-
-        let req_buf = &msg_buf[MCTP_CTRL_MSG_HEADER_LEN..];
-        let mctp_ctrl_cmd: MCTPCtrlCmd = mctp_ctrl_msg_hdr.cmd().into();
-        let resp_len = MCTP_CTRL_MSG_HEADER_LEN + MCTP_HDR_SIZE + mctp_ctrl_cmd.resp_data_len();
-
-        if req_buf.len() < mctp_ctrl_cmd.req_data_len() {
-            capsule_debug!(
-                "MCTP",
-                "Invalid buffer len Dropping packet. {} ctrl_cmd_len {}",
-                req_buf.len(),
-                mctp_ctrl_cmd.req_data_len()
-            );
-            Err(ErrorCode::INVAL)?;
-        }
+        let (advertised_msg_types, advertised_msg_types_count) =
+            supported_msg_types(|msg_type| self.is_msg_type_registered(msg_type));
+        let advertised_msg_types = &advertised_msg_types[..advertised_msg_types_count];
 
         self.tx_pkt_buffer
             .take()
             .map_or(Err(ErrorCode::NOMEM), |resp_buf| {
-                let result = match mctp_ctrl_cmd {
-                    MCTPCtrlCmd::SetEID => mctp_ctrl_cmd
-                        .process_set_endpoint_id(req_buf, &mut resp_buf[msg_payload_start..])
-                        .map(|eid| {
-                            if let Some(eid) = eid {
-                                self.set_local_eid(eid);
-                            }
-                        }),
-
-                    MCTPCtrlCmd::GetEID => mctp_ctrl_cmd.process_get_endpoint_id(
-                        self.get_local_eid(),
-                        &mut resp_buf[msg_payload_start..],
-                    ),
-
-                    MCTPCtrlCmd::GetVersionSupport => mctp_ctrl_cmd
-                        .process_get_version_support(req_buf, &mut resp_buf[msg_payload_start..]),
-
-                    MCTPCtrlCmd::GetMsgTypeSupport => mctp_ctrl_cmd
-                        .process_get_msg_type_support(req_buf, &mut resp_buf[msg_payload_start..]),
-                    MCTPCtrlCmd::Unsupported => {
-                        resp_buf[msg_payload_start] = CmdCompletionCode::ErrorNotSupportedCmd as u8;
-                        Ok(())
-                    }
-                };
+                let result = process_mctp_control_msg(
+                    msg_buf,
+                    self.get_local_eid(),
+                    advertised_msg_types,
+                    &mut resp_buf[mctp_ctrl_hdr_start..],
+                );
 
                 match result {
-                    Ok(_) => {
-                        let res = self
-                            .fill_mctp_ctrl_hdr_resp(
-                                mctp_ctrl_msg_hdr_resp,
-                                &mut resp_buf[mctp_ctrl_hdr_start
-                                    ..mctp_ctrl_hdr_start + MCTP_CTRL_MSG_HEADER_LEN],
-                            )
-                            .and_then(|_| {
-                                self.fill_mctp_hdr_resp(
-                                    mctp_hdr_resp,
-                                    &mut resp_buf[mctp_hdr_start..mctp_hdr_start + MCTP_HDR_SIZE],
-                                )
-                            });
+                    Ok(control_resp) => {
+                        if let Some(eid) = control_resp.assigned_eid {
+                            self.set_local_eid(eid);
+                        }
+
+                        let res = self.fill_mctp_hdr_resp(
+                            mctp_hdr_resp,
+                            &mut resp_buf[mctp_hdr_start..mctp_hdr_start + MCTP_HDR_SIZE],
+                        );
 
                         match res {
-                            Ok(_) => match self.mctp_device.transmit(resp_buf, resp_len) {
-                                Ok(_) => Ok(()),
-                                Err((err, tx_buf)) => {
-                                    self.tx_pkt_buffer.replace(tx_buf);
-                                    Err(err)
+                            Ok(_) => {
+                                let resp_len = MCTP_HDR_SIZE + control_resp.resp_len;
+                                match self.mctp_device.transmit(resp_buf, resp_len) {
+                                    Ok(_) => Ok(()),
+                                    Err((err, tx_buf)) => {
+                                        self.tx_pkt_buffer.replace(tx_buf);
+                                        Err(err)
+                                    }
                                 }
-                            },
+                            }
                             Err(e) => {
                                 self.tx_pkt_buffer.replace(resp_buf);
                                 Err(e)
@@ -372,6 +305,12 @@ impl<'a, A: Alarm<'a>, M: MCTPTransportBinding<'a>> MuxMCTPDriver<'a, A, M> {
 
     fn mctp_hdr_offset(&self) -> usize {
         self.mctp_device.get_hdr_size()
+    }
+
+    fn is_msg_type_registered(&self, msg_type: MessageType) -> bool {
+        self.receiver_list
+            .iter()
+            .any(|rx_state| rx_state.msg_type() == msg_type)
     }
 }
 

--- a/runtime/kernel/capsules/src/mctp/recv.rs
+++ b/runtime/kernel/capsules/src/mctp/recv.rs
@@ -63,6 +63,10 @@ impl<'a> MCTPRxState<'a> {
         self.client.set(client);
     }
 
+    pub fn msg_type(&self) -> MessageType {
+        self.msg_type
+    }
+
     /// Checks if a message of the given type is expected to be received.
     ///
     /// # Arguments

--- a/runtime/userspace/syscall/src/mctp.rs
+++ b/runtime/userspace/syscall/src/mctp.rs
@@ -238,7 +238,7 @@ impl<S: Syscalls> Mctp<S> {
             driver_num::MCTP_SPDM => Ok(5),
             driver_num::MCTP_SECURE => Ok(6),
             driver_num::MCTP_PLDM => Ok(1),
-            driver_num::MCTP_CALIPTRA => Ok(0x7E),
+            driver_num::MCTP_CALIPTRA => Ok(0x7F),
             _ => Err(ErrorCode::Invalid)?,
         }
     }


### PR DESCRIPTION
Cherry-pick of #1702 to main-2.1.

This fixes MCTP control discovery consistency, reports version support for advertised message types, and uses IANA VDM 0x7F with the OCP Vendor ID for Caliptra VDM.