### PR TITLE
romtime: use typestate mailbox sessions

### DIFF
--- a/romtime/src/soc_manager.rs
+++ b/romtime/src/soc_manager.rs
@@ -1,6 +1,6 @@
 // Licensed under the Apache-2.0 license
 
-use core::mem;
+use core::{marker::PhantomData, mem};
 
 use caliptra_api::{
     calc_checksum,
@@ -17,6 +17,189 @@ pub struct CaliptraSoC {
     soc_ifc_addr: *mut u32,
     soc_ifc_trng_addr: *mut u32,
     soc_mbox_addr: *mut u32,
+}
+
+/// Mailbox lock acquired, but no command has been programmed yet.
+pub struct MailboxLocked;
+
+/// Mailbox command and payload length have been programmed and data can be sent.
+pub struct MailboxSending;
+
+/// Mailbox command has been executed and is waiting for completion/response.
+pub struct MailboxExecuting;
+
+/// Typestate guard for a Caliptra mailbox transaction.
+///
+/// The guard holds a mutable borrow of [`CaliptraSoC`] for the whole mailbox
+/// transaction, so a second transaction cannot be started while one is alive.
+/// Dropping the guard clears the execute bit, releasing the hardware lock even
+/// on early-return error paths.
+pub struct MailboxSession<'a, State> {
+    soc: Option<&'a mut CaliptraSoC>,
+    _state: PhantomData<State>,
+}
+
+impl<'a, State> MailboxSession<'a, State> {
+    fn new(soc: &'a mut CaliptraSoC) -> Self {
+        Self {
+            soc: Some(soc),
+            _state: PhantomData,
+        }
+    }
+
+    fn soc(&mut self) -> &mut CaliptraSoC {
+        match self.soc.as_deref_mut() {
+            Some(soc) => soc,
+            None => unsafe {
+                // SAFETY: `soc` is only taken when a session is consumed by
+                // `detach`, `abort`, `transition`, or `finish_blocking_with`.
+                // All methods that call this helper require ownership of an
+                // active session value that has not been consumed.
+                core::hint::unreachable_unchecked()
+            },
+        }
+    }
+
+    fn transition<Next>(mut self) -> MailboxSession<'a, Next> {
+        MailboxSession {
+            soc: self.soc.take(),
+            _state: PhantomData,
+        }
+    }
+
+    /// Stop managing the hardware lock with this guard.
+    ///
+    /// This is only used by the legacy split-phase API, where the command is
+    /// started by one method and completed by a later [`CaliptraSoC::finish_mailbox_resp`]
+    /// call. New code should keep the typestate guard alive instead.
+    fn detach(mut self) {
+        let _ = self.soc.take();
+    }
+
+    /// Abort the transaction and return the underlying SoC handle.
+    pub fn abort(mut self) -> &'a mut CaliptraSoC {
+        let soc = match self.soc.take() {
+            Some(soc) => soc,
+            None => unsafe {
+                // SAFETY: `abort` consumes the session, and sessions expose no
+                // API that can call `abort` after their SoC handle was already
+                // taken.
+                core::hint::unreachable_unchecked()
+            },
+        };
+        soc.abort_request();
+        soc
+    }
+}
+
+impl<State> Drop for MailboxSession<'_, State> {
+    fn drop(&mut self) {
+        if let Some(soc) = self.soc.as_deref_mut() {
+            soc.abort_request();
+        }
+    }
+}
+
+impl<'a> MailboxSession<'a, MailboxLocked> {
+    /// Program the command and payload length, transitioning to the sending state.
+    pub fn set_command(
+        mut self,
+        cmd: u32,
+        payload_len_bytes: usize,
+    ) -> core::result::Result<MailboxSession<'a, MailboxSending>, CaliptraApiError> {
+        self.soc().set_command(cmd, payload_len_bytes)?;
+        Ok(self.transition())
+    }
+}
+
+impl<'a> MailboxSession<'a, MailboxSending> {
+    /// Write one 32-bit payload word while the mailbox is in the sending state.
+    pub fn write_data(&mut self, data: u32) -> core::result::Result<(), CaliptraApiError> {
+        self.soc().write_data(data)
+    }
+
+    /// Write all payload words while the mailbox is in the sending state.
+    pub fn write_data_iter(
+        &mut self,
+        buf: impl Iterator<Item = u32>,
+    ) -> core::result::Result<(), CaliptraApiError> {
+        for word in buf {
+            self.write_data(word)?;
+        }
+        Ok(())
+    }
+
+    /// Ask Caliptra to execute the programmed command.
+    pub fn execute(
+        self,
+    ) -> core::result::Result<MailboxSession<'a, MailboxExecuting>, CaliptraApiError> {
+        self.try_execute().map_err(|(err, _session)| err)
+    }
+
+    /// Ask Caliptra to execute the programmed command, returning the sending
+    /// session on failure so async owners can recover the underlying SoC handle.
+    pub fn try_execute(
+        mut self,
+    ) -> core::result::Result<MailboxSession<'a, MailboxExecuting>, (CaliptraApiError, Self)> {
+        match self.soc().execute_command() {
+            Ok(()) => Ok(self.transition()),
+            Err(err) => Err((err, self)),
+        }
+    }
+}
+
+impl<'a> MailboxSession<'a, MailboxExecuting> {
+    /// Return true while Caliptra is still processing this mailbox command.
+    pub fn is_busy(&mut self) -> bool {
+        self.soc().is_mailbox_busy()
+    }
+
+    /// Finish a blocking mailbox request, validating the response shape before returning it.
+    ///
+    /// If a response is returned, the response object owns the lock-release responsibility.
+    /// Otherwise this session releases the lock before returning.
+    pub fn finish_blocking(
+        mut self,
+        resp_min_size: usize,
+        resp_size: usize,
+    ) -> core::result::Result<Option<CaliptraMailboxResponse<'a>>, CaliptraApiError> {
+        let result = finish_mailbox_resp_locked(self.soc(), resp_min_size, resp_size);
+        if matches!(result, Ok(Some(_))) {
+            // The response now owns the mailbox register block and will release
+            // the lock when dropped.
+            self.detach();
+        }
+        result
+    }
+
+    /// Finish a blocking request and process the response before returning the
+    /// SoC handle to the caller.
+    ///
+    /// This supports async owners, such as the runtime mailbox capsule, that
+    /// store the typestate session across callbacks but must eventually recover
+    /// the underlying [`CaliptraSoC`] handle for the next transaction.
+    pub fn finish_blocking_with<R>(
+        mut self,
+        resp_min_size: usize,
+        resp_size: usize,
+        f: impl FnOnce(
+            Option<CaliptraMailboxResponse<'static>>,
+        ) -> core::result::Result<R, CaliptraApiError>,
+    ) -> (
+        &'a mut CaliptraSoC,
+        core::result::Result<R, CaliptraApiError>,
+    ) {
+        let result = finish_mailbox_resp_locked(self.soc(), resp_min_size, resp_size).and_then(f);
+        let soc = match self.soc.take() {
+            Some(soc) => soc,
+            None => unsafe {
+                // SAFETY: this method consumes an active executing session and
+                // takes the SoC handle exactly once before returning it.
+                core::hint::unreachable_unchecked()
+            },
+        };
+        (soc, result)
+    }
 }
 
 impl SocManager for CaliptraSoC {
@@ -93,6 +276,63 @@ impl CaliptraSoC {
         self.soc_mbox().status().read().status().cmd_busy()
     }
 
+    fn soc_mbox_response(
+        &mut self,
+    ) -> caliptra_registers::mbox::RegisterBlock<RealMmioMut<'static>> {
+        unsafe {
+            caliptra_registers::mbox::RegisterBlock::new_with_mmio(
+                self.soc_mbox_addr,
+                RealMmioMut::default(),
+            )
+        }
+    }
+
+    /// Acquire the hardware mailbox lock and return a typestate session guard.
+    ///
+    /// The returned guard releases the mailbox lock on drop unless ownership is
+    /// transferred to a response object.
+    pub fn acquire_mailbox(
+        &mut self,
+    ) -> core::result::Result<MailboxSession<'_, MailboxLocked>, CaliptraApiError> {
+        self.lock_mailbox()?;
+        Ok(MailboxSession::new(self))
+    }
+
+    /// Acquire the mailbox and program a command, returning a sending session.
+    pub fn start_mailbox_session(
+        &mut self,
+        cmd: u32,
+        len_bytes: usize,
+    ) -> core::result::Result<MailboxSession<'_, MailboxSending>, CaliptraApiError> {
+        self.try_start_mailbox_session(cmd, len_bytes)
+            .map_err(|(err, _soc)| err)
+    }
+
+    /// Acquire the mailbox and program a command, returning the SoC handle on
+    /// failure so async owners can put it back into their idle storage.
+    pub fn try_start_mailbox_session(
+        &mut self,
+        cmd: u32,
+        len_bytes: usize,
+    ) -> core::result::Result<MailboxSession<'_, MailboxSending>, (CaliptraApiError, &mut Self)>
+    {
+        if len_bytes > MAILBOX_SIZE {
+            return Err((CaliptraApiError::BufferTooLargeForMailbox, self));
+        }
+
+        // Read a 0 to get the hardware lock. Do this before constructing the
+        // session so the error path can still return the SoC handle.
+        if self.soc_mbox().lock().read().lock() {
+            return Err((CaliptraApiError::UnableToLockMailbox, self));
+        }
+
+        let mut session: MailboxSession<'_, MailboxLocked> = MailboxSession::new(self);
+        match session.soc().set_command(cmd, len_bytes) {
+            Ok(()) => Ok(session.transition()),
+            Err(err) => Err((err, session.abort())),
+        }
+    }
+
     /// Send a command to the mailbox but don't wait for the response
     pub fn start_mailbox_req(
         &mut self,
@@ -100,21 +340,12 @@ impl CaliptraSoC {
         len_bytes: usize,
         buf: impl Iterator<Item = u32>,
     ) -> core::result::Result<(), CaliptraApiError> {
-        if len_bytes > MAILBOX_SIZE {
-            return Err(CaliptraApiError::BufferTooLargeForMailbox);
-        }
-
-        self.lock_mailbox()?;
-
-        self.set_command(cmd, len_bytes)?;
-
-        for word in buf {
-            self.soc_mbox().datain().write(|_| word);
-        }
-
-        // Ask Caliptra to execute this command
-        self.soc_mbox().execute().write(|w| w.execute(true));
-
+        let mut session = self.start_mailbox_session(cmd, len_bytes)?;
+        session.write_data_iter(buf)?;
+        // This split-phase API intentionally returns before the response is
+        // ready. Detach the executing session so the later finish_mailbox_resp()
+        // call owns releasing the hardware lock.
+        session.execute()?.detach();
         Ok(())
     }
 
@@ -123,14 +354,11 @@ impl CaliptraSoC {
         cmd: u32,
         len_bytes: usize,
     ) -> core::result::Result<(), CaliptraApiError> {
-        if len_bytes > MAILBOX_SIZE {
-            return Err(CaliptraApiError::BufferTooLargeForMailbox);
-        }
-
-        self.lock_mailbox()?;
-
-        self.set_command(cmd, len_bytes)?;
-
+        // The runtime capsule's chunked syscall flow writes data and executes
+        // in later syscalls, so this method must keep the legacy split-phase
+        // surface. Still acquire and program the mailbox through the typestate
+        // API so the lock->command transition is checked in one place.
+        self.start_mailbox_session(cmd, len_bytes)?.detach();
         Ok(())
     }
 
@@ -148,8 +376,6 @@ impl CaliptraSoC {
         cmd: u32,
         payload_len_bytes: usize,
     ) -> core::result::Result<(), CaliptraApiError> {
-        // Mailbox lock value should read 1 now
-        // If not, the reads are likely being blocked by the PAUSER check or some other issue
         if !(self.soc_mbox().lock().read().lock()) {
             return Err(CaliptraApiError::UnableToLockMailbox);
         }
@@ -187,53 +413,7 @@ impl CaliptraSoC {
         resp_min_size: usize,
         resp_size: usize,
     ) -> core::result::Result<Option<CaliptraMailboxResponse>, CaliptraApiError> {
-        if resp_size < mem::size_of::<MailboxRespHeader>() {
-            return Err(CaliptraApiError::MailboxRespTypeTooSmall);
-        }
-        if resp_min_size < mem::size_of::<MailboxRespHeader>() {
-            return Err(CaliptraApiError::MailboxRespTypeTooSmall);
-        }
-
-        // Wait for the microcontroller to finish executing
-        let mut timeout_cycles = Self::MAX_WAIT_CYCLES; // 100ms @400MHz
-        while self.soc_mbox().status().read().status().cmd_busy() {
-            self.delay();
-            timeout_cycles -= 1;
-            if timeout_cycles == 0 {
-                return Err(CaliptraApiError::MailboxTimeout);
-            }
-        }
-        let status = self.soc_mbox().status().read().status();
-        if status.cmd_failure() {
-            self.soc_mbox().execute().write(|w| w.execute(false));
-            let soc_ifc = self.soc_ifc();
-            return Err(CaliptraApiError::MailboxCmdFailed(
-                if soc_ifc.cptra_fw_error_fatal().read() != 0 {
-                    soc_ifc.cptra_fw_error_fatal().read()
-                } else {
-                    soc_ifc.cptra_fw_error_non_fatal().read()
-                },
-            ));
-        }
-        if status.cmd_complete() {
-            self.soc_mbox().execute().write(|w| w.execute(false));
-            return Ok(None);
-        }
-        if !status.data_ready() {
-            return Err(CaliptraApiError::UnknownCommandStatus(status as u32));
-        }
-
-        let dlen_bytes = self.soc_mbox().dlen().read();
-
-        let expected_checksum = self.soc_mbox().dataout().read();
-
-        Ok(Some(CaliptraMailboxResponse {
-            soc_mbox: self.soc_mbox(),
-            idx: 0,
-            dlen_bytes: dlen_bytes as usize,
-            checksum: 0,
-            expected_checksum,
-        }))
+        finish_mailbox_resp_locked(self, resp_min_size, resp_size)
     }
 
     /// Executes a mailbox request assembled from a mutable header and
@@ -297,14 +477,18 @@ impl CaliptraSoC {
         // Write checksum into the header (first u32).
         hdr[0] = chksum;
 
-        // Stream header + all data parts to the mailbox.
-        let iter = hdr
-            .iter()
-            .copied()
-            .chain(data_parts.iter().flat_map(|p| p.iter().copied()));
-        self.start_mailbox_req(cmd, total_bytes, iter)?;
+        // Stream header + all data parts to the mailbox through the typestate
+        // session so this blocking helper is typed from lock through response.
+        let mut session = self.start_mailbox_session(cmd, total_bytes)?;
+        session.write_data_iter(
+            hdr.iter()
+                .copied()
+                .chain(data_parts.iter().flat_map(|p| p.iter().copied())),
+        )?;
+        let session = session.execute()?;
+
         let resp_len_bytes = resp.len() * 4;
-        match self.finish_mailbox_resp(resp_len_bytes, resp_len_bytes) {
+        match session.finish_blocking(resp_len_bytes, resp_len_bytes) {
             Ok(Some(mut resp_iter)) => {
                 for (i, r) in resp_iter.by_ref().enumerate() {
                     if i < resp.len() {
@@ -337,12 +521,17 @@ impl CaliptraSoC {
             .as_mut_bytes()
             .split_at_mut(core::mem::size_of::<MailboxReqHeader>());
 
-        let header = MailboxReqHeader::mut_from_bytes(header_bytes as &mut [u8]).unwrap();
+        let Ok(header) = MailboxReqHeader::mut_from_bytes(header_bytes as &mut [u8]) else {
+            return Err(CaliptraApiError::MailboxReqTypeTooSmall);
+        };
         header.chksum = calc_checksum(cmd, payload_bytes);
 
-        self.start_mailbox_req(cmd, req.len() * 4, req.iter().copied())?;
+        let mut session = self.start_mailbox_session(cmd, req.len() * 4)?;
+        session.write_data_iter(req.iter().copied())?;
+        let session = session.execute()?;
+
         let resp_len_bytes = resp.len() * 4;
-        match self.finish_mailbox_resp(resp_len_bytes, resp_len_bytes) {
+        match session.finish_blocking(resp_len_bytes, resp_len_bytes) {
             Ok(Some(mut resp_iter)) => {
                 for (i, r) in resp_iter.by_ref().enumerate() {
                     if i < resp.len() {
@@ -360,6 +549,62 @@ impl CaliptraSoC {
     pub fn read_vendor_pk_hash(&mut self) -> [u32; 12] {
         self.soc_ifc().fuse_vendor_pk_hash().read()
     }
+}
+
+fn finish_mailbox_resp_locked(
+    soc: &mut CaliptraSoC,
+    resp_min_size: usize,
+    resp_size: usize,
+) -> core::result::Result<Option<CaliptraMailboxResponse<'static>>, CaliptraApiError> {
+    if resp_size < mem::size_of::<MailboxRespHeader>() {
+        return Err(CaliptraApiError::MailboxRespTypeTooSmall);
+    }
+    if resp_min_size < mem::size_of::<MailboxRespHeader>() {
+        return Err(CaliptraApiError::MailboxRespTypeTooSmall);
+    }
+
+    // Wait for the microcontroller to finish executing
+    let mut timeout_cycles = CaliptraSoC::MAX_WAIT_CYCLES; // 100ms @400MHz
+    while soc.soc_mbox().status().read().status().cmd_busy() {
+        soc.delay();
+        timeout_cycles -= 1;
+        if timeout_cycles == 0 {
+            soc.abort_request();
+            return Err(CaliptraApiError::MailboxTimeout);
+        }
+    }
+    let status = soc.soc_mbox().status().read().status();
+    if status.cmd_failure() {
+        soc.abort_request();
+        let soc_ifc = soc.soc_ifc();
+        return Err(CaliptraApiError::MailboxCmdFailed(
+            if soc_ifc.cptra_fw_error_fatal().read() != 0 {
+                soc_ifc.cptra_fw_error_fatal().read()
+            } else {
+                soc_ifc.cptra_fw_error_non_fatal().read()
+            },
+        ));
+    }
+    if status.cmd_complete() {
+        soc.abort_request();
+        return Ok(None);
+    }
+    if !status.data_ready() {
+        soc.abort_request();
+        return Err(CaliptraApiError::UnknownCommandStatus(status as u32));
+    }
+
+    let dlen_bytes = soc.soc_mbox().dlen().read();
+
+    let expected_checksum = soc.soc_mbox().dataout().read();
+
+    Ok(Some(CaliptraMailboxResponse {
+        soc_mbox: soc.soc_mbox_response(),
+        idx: 0,
+        dlen_bytes: dlen_bytes as usize,
+        checksum: 0,
+        expected_checksum,
+    }))
 }
 
 pub struct CaliptraMailboxResponse<'a> {

--- a/runtime/kernel/capsules/src/mailbox.rs
+++ b/runtime/kernel/capsules/src/mailbox.rs
@@ -5,7 +5,7 @@
 
 use caliptra_api::CaliptraApiError;
 use caliptra_mcu_romtime::println;
-use caliptra_mcu_romtime::CaliptraSoC;
+use caliptra_mcu_romtime::{CaliptraSoC, MailboxExecuting, MailboxSending, MailboxSession};
 use core::cell::Cell;
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
 use kernel::hil::time::{Alarm, AlarmClient};
@@ -13,7 +13,7 @@ use kernel::processbuffer::{
     ReadableProcessBuffer, ReadableProcessSlice, WriteableProcessBuffer, WriteableProcessSlice,
 };
 use kernel::syscall::{CommandReturn, SyscallDriver};
-use kernel::utilities::cells::{OptionalCell, TakeCell};
+use kernel::utilities::cells::{MapCell, OptionalCell, TakeCell};
 use kernel::{ErrorCode, ProcessId};
 
 fn log_caliptra_error(err: &CaliptraApiError) {
@@ -69,6 +69,9 @@ fn log_caliptra_error(err: &CaliptraApiError) {
 /// The driver number for Caliptra mailbox commands.
 pub const DRIVER_NUM: usize = 0x8000_0009;
 
+type SendingMailboxSession = MailboxSession<'static, MailboxSending>;
+type ExecutingMailboxSession = MailboxSession<'static, MailboxExecuting>;
+
 /// IDs for subscribed upcalls.
 mod upcall {
     /// Command done callback.
@@ -108,8 +111,12 @@ pub struct App {}
 
 pub struct Mailbox<'a, A: Alarm<'a>> {
     pub alarm: &'a A,
-    // The underlying Caliptra API SoC interface
+    // The underlying Caliptra API SoC interface when no transaction is active.
     driver: TakeCell<'static, CaliptraSoC>,
+    // Active chunked transaction after command/length are programmed, before execute.
+    sending_session: MapCell<SendingMailboxSession>,
+    // Active transaction after execute, while polling for completion.
+    executing_session: MapCell<ExecutingMailboxSession>,
     // Per-app state.
     apps: Grant<
         App,
@@ -146,6 +153,8 @@ impl<'a, A: Alarm<'a>> Mailbox<'a, A> {
         Mailbox {
             alarm,
             driver: TakeCell::new(driver),
+            sending_session: MapCell::empty(),
+            executing_session: MapCell::empty(),
             apps: grant,
             current_app: OptionalCell::empty(),
             state: Cell::new(MailboxState::Idle),
@@ -175,13 +184,7 @@ impl<'a, A: Alarm<'a>> Mailbox<'a, A> {
                 })
                 .and_then(|ro_buffer| {
                     ro_buffer
-                        .enter(|app_buffer| {
-                            self.driver
-                                .map(|driver| {
-                                    self.start_request(processid, driver, command, app_buffer)
-                                })
-                                .ok_or(ErrorCode::RESERVE)?
-                        })
+                        .enter(|app_buffer| self.start_request(processid, command, app_buffer))
                         .map_err(|err| {
                             capsule_error!(
                                 "MBOX",
@@ -197,7 +200,6 @@ impl<'a, A: Alarm<'a>> Mailbox<'a, A> {
     fn start_request(
         &self,
         processid: ProcessId,
-        driver: &mut CaliptraSoC,
         command: u32,
         app_buffer: &ReadableProcessSlice,
     ) -> Result<(), ErrorCode> {
@@ -207,24 +209,41 @@ impl<'a, A: Alarm<'a>> Mailbox<'a, A> {
         // payload length is delimited by `dlen` (= `app_buffer.len()`), so the
         // final partial word (if any) must be zero-padded into a u32 rather
         // than rejected or truncated.
-        match driver.start_mailbox_req(
-            command,
-            app_buffer.len(),
-            app_buffer.chunks(4).map(|chunk| {
-                let mut dest = [0u8; 4];
-                let n = chunk.len();
-                chunk.copy_to_slice(&mut dest[..n]);
-                u32::from_le_bytes(dest)
-            }),
-        ) {
-            Ok(_) => {
+        let driver = self.driver.take().ok_or(ErrorCode::RESERVE)?;
+        let mut session = match driver.try_start_mailbox_session(command, app_buffer.len()) {
+            Ok(session) => session,
+            Err((err, driver)) => {
+                log_caliptra_error(&err);
+                self.driver.replace(driver);
+                self.reset_to_idle();
+                return Err(ErrorCode::FAIL);
+            }
+        };
+
+        let write_result = session.write_data_iter(app_buffer.chunks(4).map(|chunk| {
+            let mut dest = [0u8; 4];
+            let n = chunk.len();
+            chunk.copy_to_slice(&mut dest[..n]);
+            u32::from_le_bytes(dest)
+        }));
+        if let Err(err) = write_result {
+            log_caliptra_error(&err);
+            self.driver.replace(session.abort());
+            self.reset_to_idle();
+            return Err(ErrorCode::FAIL);
+        }
+
+        match session.try_execute() {
+            Ok(session) => {
                 self.clear_pending();
                 self.state.set(MailboxState::Executing);
+                self.executing_session.replace(session);
                 self.schedule_alarm();
                 Ok(())
             }
-            Err(err) => {
+            Err((err, session)) => {
                 log_caliptra_error(&err);
+                self.driver.replace(session.abort());
                 self.reset_to_idle();
                 Err(ErrorCode::FAIL)
             }
@@ -241,23 +260,23 @@ impl<'a, A: Alarm<'a>> Mailbox<'a, A> {
         if self.state.get() != MailboxState::Idle {
             return Err(ErrorCode::BUSY);
         }
-        self.driver
-            .map(|driver| {
-                self.current_app.set(processid);
-                self.state.set(MailboxState::Initiated);
-                match driver.initiate_request(command, payload_size) {
-                    Ok(()) => {
-                        self.clear_pending();
-                        self.schedule_initiate_timeout();
-                        Ok(())
-                    }
-                    Err(_) => {
-                        self.reset_to_idle();
-                        Err(ErrorCode::FAIL)
-                    }
-                }
-            })
-            .ok_or(ErrorCode::RESERVE)?
+        let driver = self.driver.take().ok_or(ErrorCode::RESERVE)?;
+        self.current_app.set(processid);
+        self.state.set(MailboxState::Initiated);
+        self.clear_pending();
+        match driver.try_start_mailbox_session(command, payload_size) {
+            Ok(session) => {
+                self.sending_session.replace(session);
+                self.schedule_initiate_timeout();
+                Ok(())
+            }
+            Err((err, driver)) => {
+                log_caliptra_error(&err);
+                self.driver.replace(driver);
+                self.reset_to_idle();
+                Err(ErrorCode::FAIL)
+            }
+        }
     }
 
     fn send_next_chunk(&self, processid: ProcessId) -> Result<(), ErrorCode> {
@@ -280,9 +299,19 @@ impl<'a, A: Alarm<'a>> Mailbox<'a, A> {
                 .and_then(|ro_buffer| {
                     ro_buffer
                         .enter(|app_buffer| {
-                            self.driver
-                                .map(|driver| self.write_chunk(driver, app_buffer))
-                                .ok_or(ErrorCode::RESERVE)?
+                            let mut session =
+                                self.sending_session.take().ok_or(ErrorCode::RESERVE)?;
+                            match self.write_chunk(&mut session, app_buffer) {
+                                Ok(()) => {
+                                    self.sending_session.replace(session);
+                                    Ok(())
+                                }
+                                Err(err) => {
+                                    self.driver.replace(session.abort());
+                                    self.reset_to_idle();
+                                    Err(err)
+                                }
+                            }
                         })
                         .map_err(|err| {
                             capsule_error!(
@@ -306,7 +335,7 @@ impl<'a, A: Alarm<'a>> Mailbox<'a, A> {
 
     fn write_chunk(
         &self,
-        driver: &mut CaliptraSoC,
+        session: &mut SendingMailboxSession,
         app_buffer: &ReadableProcessSlice,
     ) -> Result<(), ErrorCode> {
         let mut pending_bytes = self.pending_bytes.get() as usize;
@@ -316,10 +345,9 @@ impl<'a, A: Alarm<'a>> Mailbox<'a, A> {
             pending_word |= u32::from(app_buffer[i].get()) << (pending_bytes * 8);
             pending_bytes += 1;
             if pending_bytes == 4 {
-                if driver.write_data(pending_word).is_err() {
-                    self.abort_and_reset(driver);
-                    return Err(ErrorCode::FAIL);
-                }
+                session
+                    .write_data(pending_word)
+                    .map_err(|_| ErrorCode::FAIL)?;
                 pending_bytes = 0;
                 pending_word = 0;
             }
@@ -342,11 +370,6 @@ impl<'a, A: Alarm<'a>> Mailbox<'a, A> {
         self.current_app.take();
     }
 
-    fn abort_and_reset(&self, driver: &mut CaliptraSoC) {
-        driver.abort_request();
-        self.reset_to_idle();
-    }
-
     fn abort_initiated_request(&self, processid: ProcessId) -> Result<(), ErrorCode> {
         // Only allowed after initiate_request (command 2).
         if self.state.get() != MailboxState::Initiated {
@@ -356,9 +379,10 @@ impl<'a, A: Alarm<'a>> Mailbox<'a, A> {
         if self.current_app.get() != Some(processid) {
             return Err(ErrorCode::INVAL);
         }
-        self.driver
-            .map(|driver| self.abort_and_reset(driver))
-            .ok_or(ErrorCode::FAIL)
+        let session = self.sending_session.take().ok_or(ErrorCode::FAIL)?;
+        self.driver.replace(session.abort());
+        self.reset_to_idle();
+        Ok(())
     }
 
     fn execute(&self, processid: ProcessId) -> Result<(), ErrorCode> {
@@ -370,34 +394,42 @@ impl<'a, A: Alarm<'a>> Mailbox<'a, A> {
         if self.current_app.get() != Some(processid) {
             return Err(ErrorCode::INVAL);
         }
-        self.driver
-            .map(|driver| {
-                if self.pending_bytes.get() != 0
-                    && driver.write_data(self.pending_word.get()).is_err()
-                {
-                    self.abort_and_reset(driver);
-                    return Err(ErrorCode::FAIL);
-                }
-                if driver.execute_command().is_err() {
-                    self.abort_and_reset(driver);
-                    return Err(ErrorCode::FAIL);
-                }
-                self.clear_pending();
+        let mut session = self.sending_session.take().ok_or(ErrorCode::FAIL)?;
+        if self.pending_bytes.get() != 0 {
+            if let Err(err) = session.write_data(self.pending_word.get()) {
+                log_caliptra_error(&err);
+                self.driver.replace(session.abort());
+                self.reset_to_idle();
+                return Err(ErrorCode::FAIL);
+            }
+        }
+        self.clear_pending();
+        match session.try_execute() {
+            Ok(session) => {
                 self.state.set(MailboxState::Executing);
+                self.executing_session.replace(session);
                 self.schedule_alarm();
                 Ok(())
-            })
-            .unwrap_or(Err(ErrorCode::FAIL))
+            }
+            Err((err, session)) => {
+                log_caliptra_error(&err);
+                self.driver.replace(session.abort());
+                self.reset_to_idle();
+                Err(ErrorCode::FAIL)
+            }
+        }
     }
 
     /// Returns number of bytes in response  if the response was copied to the app.
     fn copy_from_mailbox(
         &self,
-        driver: &mut CaliptraSoC,
+        session: ExecutingMailboxSession,
         output: &WriteableProcessSlice,
     ) -> Result<usize, CaliptraApiError> {
-        match driver.finish_mailbox_resp(self.resp_min_size.get(), self.resp_size.get()) {
-            Ok(resp_option) => {
+        let (driver, result) = session.finish_blocking_with(
+            self.resp_min_size.get(),
+            self.resp_size.get(),
+            |resp_option| {
                 if let Some(mut resp) = resp_option {
                     for (i, word) in (&mut resp).enumerate() {
                         if let Some(out) = output.get(i * 4..((i + 1) * 4)) {
@@ -409,26 +441,35 @@ impl<'a, A: Alarm<'a>> Mailbox<'a, A> {
                     // no response, so we don't need to copy anything
                     Ok(0)
                 }
-            }
-            Err(err) => {
-                log_caliptra_error(&err);
-                Err(err)
-            }
+            },
+        );
+        self.driver.replace(driver);
+        if let Err(err) = &result {
+            log_caliptra_error(err);
         }
+        result
     }
 
     /// Completes the request by copying the response or error from the mailbox.
-    fn try_complete_request(&self, driver: &mut CaliptraSoC) {
+    fn try_complete_request(&self, session: ExecutingMailboxSession) {
         // response is ready, do the dance to pass it to the app
+        let mut session = Some(session);
         if let Some(process_id) = self.current_app.take() {
             let enter_result = self.apps.enter(process_id, |_app, kernel_data| {
                 if let Ok(rw_buffer) = kernel_data.get_readwrite_processbuffer(rw_allow::RESPONSE) {
                     match rw_buffer.mut_enter(|app_buffer| {
                         self.resp_size.set(app_buffer.len());
                         self.resp_min_size.set(app_buffer.len());
-                        self.copy_from_mailbox(driver, app_buffer)
+                        if let Some(session) = session.take() {
+                            self.copy_from_mailbox(session, app_buffer)
+                        } else {
+                            Err(CaliptraApiError::MailboxNoResponseData)
+                        }
                     }) {
                         Err(err) => {
+                            if let Some(session) = session.take() {
+                                self.driver.replace(session.abort());
+                            }
                             capsule_error!(
                                 "MBOX",
                                 "Error accessing writable buffer: 0x{:08x}",
@@ -464,11 +505,18 @@ impl<'a, A: Alarm<'a>> Mailbox<'a, A> {
                             }
                         }
                     }
+                } else if let Some(session) = session.take() {
+                    self.driver.replace(session.abort());
                 }
             });
             if let Err(err) = enter_result {
+                if let Some(session) = session.take() {
+                    self.driver.replace(session.abort());
+                }
                 capsule_error!("MBOX", "Error entering app: 0x{:x}", err as u32);
             }
+        } else if let Some(session) = session.take() {
+            self.driver.replace(session.abort());
         }
     }
 
@@ -494,23 +542,23 @@ impl<'a, A: Alarm<'a>> AlarmClient for Mailbox<'a, A> {
                 // Timeout: user didn't complete the chunked send in time.
                 capsule_debug!("MBOX", "Mailbox initiate timeout: resetting to idle");
                 // Release the HW mailbox lock by clearing the execute bit.
-                self.driver.map(|driver| {
-                    driver.abort_request();
-                });
+                if let Some(session) = self.sending_session.take() {
+                    self.driver.replace(session.abort());
+                }
                 self.reset_to_idle();
             }
             MailboxState::Executing => {
-                let reschedule = self
-                    .driver
-                    .map(|driver| {
-                        if driver.is_mailbox_busy() {
-                            true
-                        } else {
-                            self.try_complete_request(driver);
-                            false
-                        }
-                    })
-                    .unwrap_or_default();
+                let reschedule = if let Some(mut session) = self.executing_session.take() {
+                    if session.is_busy() {
+                        self.executing_session.replace(session);
+                        true
+                    } else {
+                        self.try_complete_request(session);
+                        false
+                    }
+                } else {
+                    false
+                };
 
                 if reschedule {
                     self.schedule_alarm();


### PR DESCRIPTION
## Summary

Refs #1590.

Replaces the CaliptraSoC mailbox transaction flow with an always-available Rust typestate session API. The implementation now uses typed session states in the existing mailbox paths rather than adding a parallel unused API.

The typestate flow models:

- `MailboxSession<'_, MailboxLocked>`: mailbox lock acquired, command not programmed yet
- `MailboxSession<'_, MailboxSending>`: command/length programmed, payload can be written
- `MailboxSession<'_, MailboxExecuting>`: execute bit set, waiting for completion/response

Existing paths now consume that state machine:

- `start_mailbox_req` programs, writes, and executes through `MailboxSession`
- `exec_mailbox_req_u32` and `exec_mailbox_req_u32_parts` use typed lock -> send -> execute -> finish flow
- `finish_mailbox_resp` delegates to the same checked completion helper as typed `finish_blocking`
- the runtime mailbox capsule stores `MailboxSession<Sending>` and `MailboxSession<Executing>` across async syscall phases using `MapCell`, instead of calling raw write/execute/finish methods directly

The compatibility split-phase APIs remain, but their implementation now transitions through the typed state machine.

## CI fixes

- Removed panic-capable `unwrap()` paths from ROM-linked mailbox typestate code so `panic_is_possible` stays absent.
- Fixed runtime capsule completion to avoid re-entering the same `MapCell` while it is borrowed. The alarm callback now takes the executing session before polling, puts it back if still busy, or moves it into response completion.

## Validation

Passed locally:

- `cargo fmt --check`
- `cargo check -p caliptra-mcu-romtime`
- `cargo test -p caliptra-mcu-romtime` (135 tests)
- `cargo check -p caliptra-mcu-capsules-runtime`
- `cargo check -p mcu-runtime-emulator`
- `cargo xtask panic-check --variants emulator:,fpga:`

Full `cargo xtask precheckin` was attempted locally, but it fails in this workspace on an unrelated provisioning fuses build script missing input file:

```text
provisioning/fuses/lib/build.rs:18:89:
called `Result::unwrap()` on an `Err` value: No such file or directory (os error 2)
```

## Size impact

Fresh baseline/current rebuild comparison for the consumed typestate implementation showed zero byte delta for all measured artifacts:

| artifact | text delta | total delta | file delta |
| --- | ---: | ---: | ---: |
| rom-emulator | 0 | 0 | 0 |
| rom-fpga | 0 | 0 | 0 |
| runtime-emulator | 0 | 0 | 0 |
| runtime-fpga | 0 | 0 | 0 |

CI note:
- Extended the FPGA SPDM build job timeout from 60 to 120 minutes after a cache-miss run was cancelled exactly at the one-hour job limit while compiling spdm-emu for aarch64.
- Extended the FPGA Tests build job timeout from 60 to 120 minutes after it also reached the one-hour job limit during FPGA test firmware compilation.