### PR TITLE
Add MCU HW model C binding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1392,6 +1392,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "caliptra-mcu-hw-model-c-binding"
+version = "0.1.0"
+dependencies = [
+ "caliptra-mcu-hw-model",
+ "caliptra-ureg",
+ "cbindgen",
+]
+
+[[package]]
 name = "caliptra-mcu-i3c-driver"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1395,6 +1395,7 @@ dependencies = [
 name = "caliptra-mcu-hw-model-c-binding"
 version = "0.1.0"
 dependencies = [
+ "caliptra-cfi-lib",
  "caliptra-mcu-hw-model",
  "caliptra-ureg",
  "cbindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1550,6 +1550,7 @@ dependencies = [
 name = "caliptra-mcu-hw-model-c-binding"
 version = "0.1.0"
 dependencies = [
+ "caliptra-cfi-lib 0.1.0 (git+https://github.com/chipsalliance/caliptra-sw?rev=85981e1bc28662a9a9fa5040cbb38ac46e548217)",
  "caliptra-mcu-hw-model",
  "caliptra-ureg",
  "cbindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1547,6 +1547,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "caliptra-mcu-hw-model-c-binding"
+version = "0.1.0"
+dependencies = [
+ "caliptra-mcu-hw-model",
+ "caliptra-ureg",
+ "cbindgen",
+]
+
+[[package]]
 name = "caliptra-mcu-i3c-driver"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -335,6 +335,7 @@ caliptra-emu-derive = { git = "https://github.com/chipsalliance/caliptra-sw", re
 caliptra-emu-periph = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fb13ba3a86a5eca0b26e134e64c5197bdfe7d0c5" }
 caliptra-emu-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fb13ba3a86a5eca0b26e134e64c5197bdfe7d0c5" }
 caliptra-error = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fb13ba3a86a5eca0b26e134e64c5197bdfe7d0c5", default-features = false }
+caliptra-cfi-lib = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fb13ba3a86a5eca0b26e134e64c5197bdfe7d0c5" }
 caliptra-hw-model = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fb13ba3a86a5eca0b26e134e64c5197bdfe7d0c5" }
 caliptra-hw-model-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fb13ba3a86a5eca0b26e134e64c5197bdfe7d0c5" }
 caliptra-image-crypto = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fb13ba3a86a5eca0b26e134e64c5197bdfe7d0c5", default-features = false, features = ["rustcrypto"] }
@@ -367,6 +368,7 @@ size-history = { git = "https://github.com/chipsalliance/caliptra-infra.git", pa
 # caliptra-emu-periph = { path = "../caliptra-sw/sw-emulator/lib/periph" }
 # caliptra-emu-types = { path = "../caliptra-sw/sw-emulator/lib/types" }
 # caliptra-error = { path = "../caliptra-sw/error", default-features = false }
+# caliptra-cfi-lib = { path = "../caliptra-sw/cfi/lib" }
 # caliptra-hw-model = { path = "../caliptra-sw/hw-model" }
 # caliptra-hw-model-types = { path = "../caliptra-sw/hw-model/types" }
 # caliptra-image-crypto = { path = "../caliptra-sw/image/crypto", default-features = false, features = ["rustcrypto"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ members = [
     "hw/model/test-fw/lc-ctrl",
     "hw/model/test-fw/otp-scramble-check",
     "coverage",
+    "hw/model/c-binding",
     "hw/model/test-fw/sw-digest-lock",
     "platforms/common",
     "platforms/emulator/config",
@@ -256,6 +257,7 @@ caliptra-mcu-firmware-bundler = { path = "firmware-bundler" }
 caliptra-mcu-fuses-generator = { path = "registers/fuses" }
 caliptra-mcu-coverage = { path = "coverage" }
 caliptra-mcu-hw-model = { path = "hw/model" }
+caliptra-mcu-hw-model-c-binding = { path = "hw/model/c-binding" }
 caliptra-mcu-test-fw-exception-handler = { path = "hw/model/test-fw/exception-handler" }
 caliptra-mcu-test-fw-hitless-update-flow = { path = "hw/model/test-fw/hitless-update-flow" }
 caliptra-mcu-test-fw-mailbox-responder = { path = "hw/model/test-fw/mailbox-responder" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -306,7 +306,7 @@ caliptra-mcu-pldm-lib = { path = "runtime/userspace/api/pldm-lib" }
 caliptra-mcu-spdm-traits = { path = "runtime/userspace/api/spdm-lib/traits" }
 caliptra-mcu-spdm-stack = { path = "runtime/userspace/api/spdm-lib/stack" }
 caliptra-mcu-spdm-codec = { path = "runtime/userspace/api/spdm-lib/codec" }
-mcu-caliptra-api = { path = "runtime/userspace/api/caliptra-api" }
+mcu-caliptra-api = { path = "runtime/userspace/api/caliptra-api", default-features = false }
 caliptra-mcu-scratch-alloc = { path = "runtime/userspace/scratch-alloc" }
 caliptra-mcu-spdm-transports = { path = "runtime/userspace/api/spdm-lib/transports" }
 caliptra-mcu-spdm-pal = { path = "runtime/userspace/api/spdm-lib/pal" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ members = [
     "hw/model/test-fw/lc-ctrl",
     "hw/model/test-fw/otp-scramble-check",
     "coverage",
+    "hw/model/c-binding",
     "hw/model/test-fw/sw-digest-lock",
     "platforms/common",
     "platforms/emulator/config",
@@ -262,6 +263,7 @@ caliptra-mcu-firmware-bundler = { path = "firmware-bundler" }
 caliptra-mcu-fuses-generator = { path = "registers/fuses" }
 caliptra-mcu-coverage = { path = "coverage" }
 caliptra-mcu-hw-model = { path = "hw/model" }
+caliptra-mcu-hw-model-c-binding = { path = "hw/model/c-binding" }
 caliptra-mcu-test-fw-exception-handler = { path = "hw/model/test-fw/exception-handler" }
 caliptra-mcu-test-fw-hitless-update-flow = { path = "hw/model/test-fw/hitless-update-flow" }
 caliptra-mcu-test-fw-mailbox-responder = { path = "hw/model/test-fw/mailbox-responder" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -306,7 +306,7 @@ caliptra-mcu-pldm-lib = { path = "runtime/userspace/api/pldm-lib" }
 caliptra-mcu-spdm-traits = { path = "runtime/userspace/api/spdm-lib/traits" }
 caliptra-mcu-spdm-stack = { path = "runtime/userspace/api/spdm-lib/stack" }
 caliptra-mcu-spdm-codec = { path = "runtime/userspace/api/spdm-lib/codec" }
-mcu-caliptra-api = { path = "runtime/userspace/api/caliptra-api", default-features = false }
+mcu-caliptra-api = { path = "runtime/userspace/api/caliptra-api" }
 caliptra-mcu-scratch-alloc = { path = "runtime/userspace/scratch-alloc" }
 caliptra-mcu-spdm-transports = { path = "runtime/userspace/api/spdm-lib/transports" }
 caliptra-mcu-spdm-pal = { path = "runtime/userspace/api/spdm-lib/pal" }
@@ -337,6 +337,7 @@ caliptra-api-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev
 caliptra-auth-man-gen = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "e5ceee831f1b6b49a8d139a705133e47deab8711" }
 caliptra-auth-man-types = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "e5ceee831f1b6b49a8d139a705133e47deab8711" }
 caliptra-builder = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "e5ceee831f1b6b49a8d139a705133e47deab8711" }
+caliptra-cfi-lib = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "e5ceee831f1b6b49a8d139a705133e47deab8711" }
 caliptra-drivers = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "e5ceee831f1b6b49a8d139a705133e47deab8711" }
 caliptra-emu-bus = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "e5ceee831f1b6b49a8d139a705133e47deab8711" }
 caliptra-emu-cpu = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "e5ceee831f1b6b49a8d139a705133e47deab8711" }

--- a/hw/model/c-binding/Cargo.toml
+++ b/hw/model/c-binding/Cargo.toml
@@ -6,6 +6,7 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
+caliptra-cfi-lib.workspace = true
 caliptra-mcu-hw-model.workspace = true
 caliptra-ureg.workspace = true
 

--- a/hw/model/c-binding/Cargo.toml
+++ b/hw/model/c-binding/Cargo.toml
@@ -1,0 +1,21 @@
+# Licensed under the Apache-2.0 license
+
+[package]
+name = "caliptra-mcu-hw-model-c-binding"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+caliptra-mcu-hw-model.workspace = true
+caliptra-ureg.workspace = true
+
+[lib]
+crate-type = ["staticlib"]
+
+[features]
+default = []
+fpga_realtime = ["caliptra-mcu-hw-model/fpga_realtime"]
+itrng = ["caliptra-mcu-hw-model/itrng"]
+
+[build-dependencies]
+cbindgen.workspace = true

--- a/hw/model/c-binding/build.rs
+++ b/hw/model/c-binding/build.rs
@@ -1,0 +1,27 @@
+// Licensed under the Apache-2.0 license
+
+use std::env;
+use std::path::PathBuf;
+
+fn main() {
+    let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+
+    let config = cbindgen::Config {
+        header: Some("// Licensed under the Apache-2.0 license".to_string()),
+        language: cbindgen::Language::C,
+        include_guard: Some("CALIPTRA_MCU_HW_MODEL_C_BINDING_CALIPTRA_MCU_MODEL_H".to_string()),
+        cpp_compat: true,
+        documentation: true,
+        ..Default::default()
+    };
+
+    let out_dir = PathBuf::from(&crate_dir).join("out");
+    std::fs::create_dir_all(&out_dir).expect("Unable to create cbindgen output directory");
+
+    cbindgen::Builder::new()
+        .with_crate(crate_dir)
+        .with_config(config)
+        .generate()
+        .expect("Unable to generate bindings")
+        .write_to_file(out_dir.join("caliptra_mcu_model.h"));
+}

--- a/hw/model/c-binding/cbindgen.toml
+++ b/hw/model/c-binding/cbindgen.toml
@@ -1,0 +1,1 @@
+# Licensed under the Apache-2.0 license

--- a/hw/model/c-binding/examples/.gitignore
+++ b/hw/model/c-binding/examples/.gitignore
@@ -1,0 +1,3 @@
+out/
+primary_flash
+secondary_flash

--- a/hw/model/c-binding/examples/Makefile
+++ b/hw/model/c-binding/examples/Makefile
@@ -1,0 +1,22 @@
+# Licensed under the Apache-2.0 license
+
+OUT := out
+TARGET := $(OUT)/smoke_test
+LIB := ../../../../target/debug/libcaliptra_mcu_hw_model_c_binding.a
+CFLAGS += -std=c11 -Wall -Wextra -Werror -I../out
+LDLIBS += -lpthread -ldl -lrt -lm
+
+all: $(TARGET)
+
+$(LIB):
+	cargo build --manifest-path ../Cargo.toml
+
+$(TARGET): smoke_test.c $(LIB)
+	mkdir -p $(OUT)
+	$(CC) $(CFLAGS) $< $(LIB) $(LDLIBS) -o $@
+
+run: $(TARGET)
+	$(TARGET)
+
+clean:
+	$(RM) -r $(OUT)

--- a/hw/model/c-binding/examples/smoke_test.c
+++ b/hw/model/c-binding/examples/smoke_test.c
@@ -1,0 +1,41 @@
+// Licensed under the Apache-2.0 license
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "caliptra_mcu_model.h"
+
+int main(void) {
+    struct caliptra_mcu_model *model = 0;
+    struct caliptra_mcu_model_init_params params = {0};
+    struct caliptra_mcu_buffer response = {0};
+    unsigned int word = 0;
+
+    // This smoke test primarily verifies that C consumers can include the
+    // generated header and link the static library. Empty firmware inputs are
+    // accepted by the C ABI but are not expected to produce a bootable model.
+    (void)caliptra_mcu_model_init_default(params, &model);
+    (void)caliptra_mcu_model_last_error(model);
+    (void)caliptra_mcu_model_ready_for_fw(model);
+    (void)caliptra_mcu_model_cycle_count(model);
+    (void)caliptra_mcu_model_output_peek(model);
+
+    // Keep the rest of the API referenced so link errors are caught, but do not
+    // exercise invalid MMIO/mailbox accesses unless explicitly requested.
+    if (getenv("CALIPTRA_MCU_C_BINDING_EXERCISE_ALL") != 0) {
+        (void)caliptra_mcu_model_mmio_read_u32(model, 0, &word);
+        (void)caliptra_mcu_model_mmio_write_u32(model, 0, word);
+        (void)caliptra_mcu_model_mailbox_execute(model, 0, params.mcu_rom, &response);
+        (void)caliptra_mcu_model_caliptra_mailbox_execute(model, 0, params.mcu_rom, &response);
+        (void)caliptra_mcu_model_mci_flow_status(model);
+        (void)caliptra_mcu_model_mci_boot_checkpoint(model);
+        (void)caliptra_mcu_model_read_dot_flash(model);
+        (void)caliptra_mcu_model_read_otp_memory(model);
+    }
+
+    caliptra_mcu_model_destroy(model);
+
+    puts("Caliptra MCU HW model C binding smoke test linked successfully");
+    return 0;
+}

--- a/hw/model/c-binding/out/caliptra_mcu_model.h
+++ b/hw/model/c-binding/out/caliptra_mcu_model.h
@@ -100,6 +100,8 @@ typedef struct caliptra_mcu_model {
 extern "C" {
 #endif // __cplusplus
 
+void cfi_panic_handler(uint32_t code);
+
 /**
  * Create an unbooted MCU hardware model using default Rust InitParams values for
  * all fields not exposed in caliptra_mcu_model_init_params.
@@ -241,7 +243,8 @@ int caliptra_mcu_model_warm_reset(struct caliptra_mcu_model *model);
 
 /**
  * Return a borrowed copy of DOT flash contents. The data pointer is invalidated
- * by the next caliptra_mcu_model_read_dot_flash() call or destroy.
+ * by the next caliptra_mcu_model_read_dot_flash() or
+ * caliptra_mcu_model_read_otp_memory() call, or by destroy.
  *
  * # Safety
  * `model` must be a pointer returned by caliptra_mcu_model_init_default.
@@ -259,7 +262,8 @@ int caliptra_mcu_model_write_dot_flash(struct caliptra_mcu_model *model,
 
 /**
  * Return a borrowed copy of OTP memory contents. The data pointer is invalidated
- * by the next caliptra_mcu_model_read_otp_memory() call or destroy.
+ * by the next caliptra_mcu_model_read_otp_memory() or
+ * caliptra_mcu_model_read_dot_flash() call, or by destroy.
  *
  * # Safety
  * `model` must be a pointer returned by caliptra_mcu_model_init_default.

--- a/hw/model/c-binding/out/caliptra_mcu_model.h
+++ b/hw/model/c-binding/out/caliptra_mcu_model.h
@@ -1,0 +1,273 @@
+// Licensed under the Apache-2.0 license
+
+#ifndef CALIPTRA_MCU_HW_MODEL_C_BINDING_CALIPTRA_MCU_MODEL_H
+#define CALIPTRA_MCU_HW_MODEL_C_BINDING_CALIPTRA_MCU_MODEL_H
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define CALIPTRA_MCU_MODEL_STATUS_OK 0
+
+#define CALIPTRA_MCU_MODEL_STATUS_INVALID_ARGUMENT -1
+
+#define CALIPTRA_MCU_MODEL_STATUS_INIT_FAILED -2
+
+#define CALIPTRA_MCU_MODEL_STATUS_OPERATION_FAILED -3
+
+#define CALIPTRA_MCU_MODEL_STATUS_INVALID_OBF_KEY_SIZE -4
+
+#define CALIPTRA_MCU_MODEL_STATUS_INVALID_VENDOR_PK_HASH_SIZE -5
+
+#define CALIPTRA_MCU_MODEL_STATUS_PANICKED -6
+
+#define CALIPTRA_MCU_MODEL_OBF_KEY_SIZE 32
+
+#define CALIPTRA_MCU_MODEL_VENDOR_PK_HASH_SIZE 48
+
+typedef struct caliptra_mcu_buffer {
+  const uint8_t *data;
+  uintptr_t len;
+} caliptra_mcu_buffer;
+
+typedef struct caliptra_mcu_model_init_params {
+  /**
+   * The contents of the Caliptra ROM.
+   */
+  struct caliptra_mcu_buffer caliptra_rom;
+  /**
+   * Caliptra firmware bundle.
+   */
+  struct caliptra_mcu_buffer caliptra_firmware;
+  /**
+   * SoC manifest.
+   */
+  struct caliptra_mcu_buffer soc_manifest;
+  /**
+   * The contents of the MCU ROM.
+   */
+  struct caliptra_mcu_buffer mcu_rom;
+  /**
+   * The contents of the MCU firmware.
+   */
+  struct caliptra_mcu_buffer mcu_firmware;
+  /**
+   * Initial contents of Caliptra DCCM SRAM.
+   */
+  struct caliptra_mcu_buffer caliptra_dccm;
+  /**
+   * Initial contents of Caliptra ICCM SRAM.
+   */
+  struct caliptra_mcu_buffer caliptra_iccm;
+  /**
+   * Optional initial contents of OTP memory. Set data to NULL to use defaults.
+   */
+  struct caliptra_mcu_buffer otp_memory;
+  /**
+   * Optional initial contents of DOT flash. Set data to NULL to use defaults.
+   */
+  struct caliptra_mcu_buffer dot_flash_initial_contents;
+  /**
+   * Optional initial contents of primary flash. Set data to NULL to use defaults.
+   */
+  struct caliptra_mcu_buffer primary_flash_initial_contents;
+  /**
+   * Optional 48-byte vendor public key hash. Set data to NULL to use defaults.
+   */
+  struct caliptra_mcu_buffer vendor_pk_hash;
+  /**
+   * Optional 32-byte Caliptra obfuscation key. Set data to NULL to use defaults.
+   */
+  struct caliptra_mcu_buffer optional_obf_key;
+  /**
+   * Optional I3C TCP port. Set to 0 to disable.
+   */
+  unsigned int i3c_port;
+  bool active_mode;
+  bool enable_mcu_uart_log;
+  bool flash_boot;
+  bool force_fuse_owner_pk_hash;
+  bool active_i3c1;
+  bool use_strap_secrets;
+} caliptra_mcu_model_init_params;
+
+typedef struct caliptra_mcu_model {
+  uint8_t _unused[0];
+} caliptra_mcu_model;
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+/**
+ * Create an unbooted MCU hardware model using default Rust InitParams values for
+ * all fields not exposed in caliptra_mcu_model_init_params.
+ *
+ * Buffer pointers may be NULL only when len is 0. Optional buffers are disabled
+ * by setting data to NULL and len to 0. The returned model must be destroyed by
+ * caliptra_mcu_model_destroy().
+ *
+ * # Safety
+ * `model` must be non-NULL. Non-NULL input buffers must point to at least `len`
+ * bytes for the duration of this call.
+ */
+int caliptra_mcu_model_init_default(struct caliptra_mcu_model_init_params params,
+                                    struct caliptra_mcu_model **model);
+
+/**
+ * # Safety
+ * `model` must be either NULL or a pointer returned by caliptra_mcu_model_init_default.
+ */
+void caliptra_mcu_model_destroy(struct caliptra_mcu_model *model);
+
+/**
+ * Return a pointer to a NUL-terminated string describing the last operation
+ * error for this model. The pointer remains valid until the next API call on the
+ * model or until caliptra_mcu_model_destroy().
+ *
+ * # Safety
+ * `model` must be NULL or a pointer returned by caliptra_mcu_model_init_default.
+ */
+const char *caliptra_mcu_model_last_error(struct caliptra_mcu_model *model);
+
+/**
+ * Boot the MCU model to the point where CPU execution can occur.
+ *
+ * # Safety
+ * `model` must be a pointer returned by caliptra_mcu_model_init_default.
+ */
+int caliptra_mcu_model_boot(struct caliptra_mcu_model *model);
+
+/**
+ * # Safety
+ * `model` must be a pointer returned by caliptra_mcu_model_init_default.
+ */
+int caliptra_mcu_model_step(struct caliptra_mcu_model *model);
+
+/**
+ * # Safety
+ * `model` must be a pointer returned by caliptra_mcu_model_init_default.
+ */
+bool caliptra_mcu_model_ready_for_fw(struct caliptra_mcu_model *model);
+
+/**
+ * # Safety
+ * `model` must be a pointer returned by caliptra_mcu_model_init_default.
+ */
+uint64_t caliptra_mcu_model_cycle_count(struct caliptra_mcu_model *model);
+
+/**
+ * # Safety
+ * `model` must be a pointer returned by caliptra_mcu_model_init_default.
+ */
+bool caliptra_mcu_model_exit_requested(struct caliptra_mcu_model *model);
+
+/**
+ * Return a borrowed view of all UART output captured so far. The data pointer is
+ * invalidated by the next API call that mutably accesses the model.
+ *
+ * # Safety
+ * `model` must be a pointer returned by caliptra_mcu_model_init_default.
+ */
+struct caliptra_mcu_buffer caliptra_mcu_model_output_peek(struct caliptra_mcu_model *model);
+
+/**
+ * Read a 32-bit word from the MCU/Caliptra SoC-visible MMIO address space.
+ *
+ * # Safety
+ * `model` and `data` must be non-NULL.
+ */
+int caliptra_mcu_model_mmio_read_u32(struct caliptra_mcu_model *model,
+                                     unsigned int addr,
+                                     unsigned int *data);
+
+/**
+ * Write a 32-bit word to the MCU/Caliptra SoC-visible MMIO address space.
+ *
+ * # Safety
+ * `model` must be a pointer returned by caliptra_mcu_model_init_default.
+ */
+int caliptra_mcu_model_mmio_write_u32(struct caliptra_mcu_model *model,
+                                      unsigned int addr,
+                                      unsigned int data);
+
+/**
+ * Execute an MCU mailbox command and return a borrowed response buffer. If the
+ * command completes without response data, `response` is set to { NULL, 0 }.
+ * The response data pointer is invalidated by the next mailbox call or destroy.
+ *
+ * # Safety
+ * `model` must be valid. `request.data` must be NULL only if `request.len` is 0.
+ * `response` may be NULL if the caller only needs the status code.
+ */
+int caliptra_mcu_model_mailbox_execute(struct caliptra_mcu_model *model,
+                                       unsigned int cmd,
+                                       struct caliptra_mcu_buffer request,
+                                       struct caliptra_mcu_buffer *response);
+
+/**
+ * Execute a Caliptra mailbox command through the SoC mailbox and return a
+ * borrowed response buffer. If the command completes without response data,
+ * `response` is set to { NULL, 0 }. The response data pointer is invalidated by
+ * the next mailbox call or destroy.
+ *
+ * # Safety
+ * `model` must be valid. `request.data` must be NULL only if `request.len` is 0.
+ * `response` may be NULL if the caller only needs the status code.
+ */
+int caliptra_mcu_model_caliptra_mailbox_execute(struct caliptra_mcu_model *model,
+                                                unsigned int cmd,
+                                                struct caliptra_mcu_buffer request,
+                                                struct caliptra_mcu_buffer *response);
+
+/**
+ * # Safety
+ * `model` must be a pointer returned by caliptra_mcu_model_init_default.
+ */
+unsigned int caliptra_mcu_model_mci_flow_status(struct caliptra_mcu_model *model);
+
+/**
+ * # Safety
+ * `model` must be a pointer returned by caliptra_mcu_model_init_default.
+ */
+unsigned int caliptra_mcu_model_mci_boot_checkpoint(struct caliptra_mcu_model *model);
+
+/**
+ * # Safety
+ * `model` must be a pointer returned by caliptra_mcu_model_init_default.
+ */
+int caliptra_mcu_model_warm_reset(struct caliptra_mcu_model *model);
+
+/**
+ * Return a borrowed copy of DOT flash contents. The data pointer is invalidated
+ * by the next caliptra_mcu_model_read_dot_flash() call or destroy.
+ *
+ * # Safety
+ * `model` must be a pointer returned by caliptra_mcu_model_init_default.
+ */
+struct caliptra_mcu_buffer caliptra_mcu_model_read_dot_flash(struct caliptra_mcu_model *model);
+
+/**
+ * Replace DOT flash contents with `data`.
+ *
+ * # Safety
+ * `model` must be valid. `data.data` must be NULL only if `data.len` is 0.
+ */
+int caliptra_mcu_model_write_dot_flash(struct caliptra_mcu_model *model,
+                                       struct caliptra_mcu_buffer data);
+
+/**
+ * Return a borrowed copy of OTP memory contents. The data pointer is invalidated
+ * by the next caliptra_mcu_model_read_otp_memory() call or destroy.
+ *
+ * # Safety
+ * `model` must be a pointer returned by caliptra_mcu_model_init_default.
+ */
+struct caliptra_mcu_buffer caliptra_mcu_model_read_otp_memory(struct caliptra_mcu_model *model);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus
+
+#endif /* CALIPTRA_MCU_HW_MODEL_C_BINDING_CALIPTRA_MCU_MODEL_H */

--- a/hw/model/c-binding/src/lib.rs
+++ b/hw/model/c-binding/src/lib.rs
@@ -1,0 +1,712 @@
+// Licensed under the Apache-2.0 license
+
+use caliptra_mcu_hw_model::{DefaultHwModel, InitParams, McuHwModel, McuManager};
+use caliptra_ureg::{Mmio, MmioMut};
+use std::ffi::CString;
+use std::os::raw::{c_char, c_int, c_uint};
+use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::ptr;
+use std::slice;
+
+const INVALID_MODEL_ERROR: &[u8] = b"invalid model\0";
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct caliptra_mcu_model {
+    _unused: [u8; 0],
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct caliptra_mcu_buffer {
+    pub data: *const u8,
+    pub len: usize,
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct caliptra_mcu_model_init_params {
+    /// The contents of the Caliptra ROM.
+    pub caliptra_rom: caliptra_mcu_buffer,
+    /// Caliptra firmware bundle.
+    pub caliptra_firmware: caliptra_mcu_buffer,
+    /// SoC manifest.
+    pub soc_manifest: caliptra_mcu_buffer,
+    /// The contents of the MCU ROM.
+    pub mcu_rom: caliptra_mcu_buffer,
+    /// The contents of the MCU firmware.
+    pub mcu_firmware: caliptra_mcu_buffer,
+    /// Initial contents of Caliptra DCCM SRAM.
+    pub caliptra_dccm: caliptra_mcu_buffer,
+    /// Initial contents of Caliptra ICCM SRAM.
+    pub caliptra_iccm: caliptra_mcu_buffer,
+    /// Optional initial contents of OTP memory. Set data to NULL to use defaults.
+    pub otp_memory: caliptra_mcu_buffer,
+    /// Optional initial contents of DOT flash. Set data to NULL to use defaults.
+    pub dot_flash_initial_contents: caliptra_mcu_buffer,
+    /// Optional initial contents of primary flash. Set data to NULL to use defaults.
+    pub primary_flash_initial_contents: caliptra_mcu_buffer,
+    /// Optional 48-byte vendor public key hash. Set data to NULL to use defaults.
+    pub vendor_pk_hash: caliptra_mcu_buffer,
+    /// Optional 32-byte Caliptra obfuscation key. Set data to NULL to use defaults.
+    pub optional_obf_key: caliptra_mcu_buffer,
+    /// Optional I3C TCP port. Set to 0 to disable.
+    pub i3c_port: c_uint,
+    pub active_mode: bool,
+    pub enable_mcu_uart_log: bool,
+    pub flash_boot: bool,
+    pub force_fuse_owner_pk_hash: bool,
+    pub active_i3c1: bool,
+    pub use_strap_secrets: bool,
+}
+
+pub const CALIPTRA_MCU_MODEL_STATUS_OK: c_int = 0;
+pub const CALIPTRA_MCU_MODEL_STATUS_INVALID_ARGUMENT: c_int = -1;
+pub const CALIPTRA_MCU_MODEL_STATUS_INIT_FAILED: c_int = -2;
+pub const CALIPTRA_MCU_MODEL_STATUS_OPERATION_FAILED: c_int = -3;
+pub const CALIPTRA_MCU_MODEL_STATUS_INVALID_OBF_KEY_SIZE: c_int = -4;
+pub const CALIPTRA_MCU_MODEL_STATUS_INVALID_VENDOR_PK_HASH_SIZE: c_int = -5;
+pub const CALIPTRA_MCU_MODEL_STATUS_PANICKED: c_int = -6;
+
+pub const CALIPTRA_MCU_MODEL_OBF_KEY_SIZE: usize = 32;
+pub const CALIPTRA_MCU_MODEL_VENDOR_PK_HASH_SIZE: usize = 48;
+
+struct ModelHandle {
+    model: DefaultHwModel,
+    response: Vec<u8>,
+    scratch: Vec<u8>,
+    last_error: CString,
+}
+
+impl ModelHandle {
+    fn new(model: DefaultHwModel) -> Self {
+        Self {
+            model,
+            response: Vec::new(),
+            scratch: Vec::new(),
+            last_error: CString::default(),
+        }
+    }
+
+    fn clear_error(&mut self) {
+        self.last_error = CString::default();
+    }
+
+    fn set_error(&mut self, msg: impl ToString) {
+        self.last_error = string_to_cstring(msg.to_string());
+    }
+}
+
+fn string_to_cstring(msg: String) -> CString {
+    CString::new(msg).unwrap_or_else(|err| {
+        let sanitized: Vec<u8> = err.into_vec().into_iter().filter(|b| *b != 0).collect();
+        CString::new(sanitized).unwrap()
+    })
+}
+
+fn catch_status(f: impl FnOnce() -> c_int) -> c_int {
+    match catch_unwind(AssertUnwindSafe(f)) {
+        Ok(status) => status,
+        Err(_) => CALIPTRA_MCU_MODEL_STATUS_PANICKED,
+    }
+}
+
+unsafe fn handle_from_ptr<'a>(
+    model: *mut caliptra_mcu_model,
+) -> Result<&'a mut ModelHandle, c_int> {
+    if model.is_null() {
+        Err(CALIPTRA_MCU_MODEL_STATUS_INVALID_ARGUMENT)
+    } else {
+        Ok(&mut *(model as *mut ModelHandle))
+    }
+}
+
+unsafe fn slice_from_buffer<'a>(buffer: caliptra_mcu_buffer) -> Result<&'a [u8], c_int> {
+    if buffer.data.is_null() {
+        if buffer.len == 0 {
+            Ok(&[])
+        } else {
+            Err(CALIPTRA_MCU_MODEL_STATUS_INVALID_ARGUMENT)
+        }
+    } else {
+        Ok(slice::from_raw_parts(buffer.data, buffer.len))
+    }
+}
+
+unsafe fn optional_slice_from_buffer<'a>(
+    buffer: caliptra_mcu_buffer,
+) -> Result<Option<&'a [u8]>, c_int> {
+    if buffer.data.is_null() {
+        if buffer.len == 0 {
+            Ok(None)
+        } else {
+            Err(CALIPTRA_MCU_MODEL_STATUS_INVALID_ARGUMENT)
+        }
+    } else {
+        Ok(Some(slice::from_raw_parts(buffer.data, buffer.len)))
+    }
+}
+
+unsafe fn optional_vec_from_buffer(buffer: caliptra_mcu_buffer) -> Result<Option<Vec<u8>>, c_int> {
+    optional_slice_from_buffer(buffer).map(|slice| slice.map(Vec::from))
+}
+
+unsafe fn optional_vendor_pk_hash(
+    buffer: caliptra_mcu_buffer,
+) -> Result<Option<[u8; CALIPTRA_MCU_MODEL_VENDOR_PK_HASH_SIZE]>, c_int> {
+    match optional_slice_from_buffer(buffer)? {
+        None => Ok(None),
+        Some(data) if data.len() == CALIPTRA_MCU_MODEL_VENDOR_PK_HASH_SIZE => {
+            let mut hash = [0u8; CALIPTRA_MCU_MODEL_VENDOR_PK_HASH_SIZE];
+            hash.copy_from_slice(data);
+            Ok(Some(hash))
+        }
+        Some(_) => Err(CALIPTRA_MCU_MODEL_STATUS_INVALID_VENDOR_PK_HASH_SIZE),
+    }
+}
+
+unsafe fn obf_key_from_buffer(buffer: caliptra_mcu_buffer) -> Result<Option<[u32; 8]>, c_int> {
+    match optional_slice_from_buffer(buffer)? {
+        None => Ok(None),
+        Some(data) if data.len() == CALIPTRA_MCU_MODEL_OBF_KEY_SIZE => {
+            let mut key = [0u32; 8];
+            for (word, bytes) in key.iter_mut().zip(data.chunks_exact(4)) {
+                *word = u32::from_le_bytes(bytes.try_into().unwrap());
+            }
+            Ok(Some(key))
+        }
+        Some(_) => Err(CALIPTRA_MCU_MODEL_STATUS_INVALID_OBF_KEY_SIZE),
+    }
+}
+
+fn fill_buffer(buffer: *mut caliptra_mcu_buffer, data: &[u8]) {
+    if !buffer.is_null() {
+        unsafe {
+            *buffer = caliptra_mcu_buffer {
+                data: if data.is_empty() {
+                    ptr::null()
+                } else {
+                    data.as_ptr()
+                },
+                len: data.len(),
+            };
+        }
+    }
+}
+
+unsafe fn init_impl(
+    params: caliptra_mcu_model_init_params,
+    model: *mut *mut caliptra_mcu_model,
+) -> c_int {
+    if model.is_null() {
+        return CALIPTRA_MCU_MODEL_STATUS_INVALID_ARGUMENT;
+    }
+
+    let caliptra_rom = match slice_from_buffer(params.caliptra_rom) {
+        Ok(data) => data,
+        Err(status) => return status,
+    };
+    let caliptra_firmware = match slice_from_buffer(params.caliptra_firmware) {
+        Ok(data) => data,
+        Err(status) => return status,
+    };
+    let soc_manifest = match slice_from_buffer(params.soc_manifest) {
+        Ok(data) => data,
+        Err(status) => return status,
+    };
+    let mcu_rom = match slice_from_buffer(params.mcu_rom) {
+        Ok(data) => data,
+        Err(status) => return status,
+    };
+    let mcu_firmware = match slice_from_buffer(params.mcu_firmware) {
+        Ok(data) => data,
+        Err(status) => return status,
+    };
+    let caliptra_dccm = match slice_from_buffer(params.caliptra_dccm) {
+        Ok(data) => data,
+        Err(status) => return status,
+    };
+    let caliptra_iccm = match slice_from_buffer(params.caliptra_iccm) {
+        Ok(data) => data,
+        Err(status) => return status,
+    };
+    let otp_memory = match optional_slice_from_buffer(params.otp_memory) {
+        Ok(data) => data,
+        Err(status) => return status,
+    };
+    let dot_flash_initial_contents =
+        match optional_vec_from_buffer(params.dot_flash_initial_contents) {
+            Ok(data) => data,
+            Err(status) => return status,
+        };
+    let primary_flash_initial_contents =
+        match optional_vec_from_buffer(params.primary_flash_initial_contents) {
+            Ok(data) => data,
+            Err(status) => return status,
+        };
+    let vendor_pk_hash = match optional_vendor_pk_hash(params.vendor_pk_hash) {
+        Ok(data) => data,
+        Err(status) => return status,
+    };
+    let cptra_obf_key = match obf_key_from_buffer(params.optional_obf_key) {
+        Ok(Some(key)) => key,
+        Ok(None) => InitParams::default().cptra_obf_key,
+        Err(status) => return status,
+    };
+
+    let i3c_port = if params.i3c_port == 0 {
+        None
+    } else {
+        Some(params.i3c_port as u16)
+    };
+
+    let result = caliptra_mcu_hw_model::new_unbooted(InitParams {
+        caliptra_rom,
+        caliptra_firmware,
+        soc_manifest,
+        mcu_rom,
+        mcu_firmware,
+        caliptra_dccm,
+        caliptra_iccm,
+        otp_memory,
+        dot_flash_initial_contents,
+        primary_flash_initial_contents,
+        vendor_pk_hash,
+        cptra_obf_key,
+        i3c_port,
+        active_mode: params.active_mode,
+        enable_mcu_uart_log: params.enable_mcu_uart_log,
+        flash_boot: params.flash_boot,
+        force_fuse_owner_pk_hash: params.force_fuse_owner_pk_hash,
+        active_i3c1: params.active_i3c1,
+        use_strap_secrets: params.use_strap_secrets,
+        ..Default::default()
+    });
+
+    match result {
+        Ok(hw_model) => {
+            *model = Box::into_raw(Box::new(ModelHandle::new(hw_model))) as *mut caliptra_mcu_model;
+            CALIPTRA_MCU_MODEL_STATUS_OK
+        }
+        Err(_) => {
+            *model = ptr::null_mut();
+            CALIPTRA_MCU_MODEL_STATUS_INIT_FAILED
+        }
+    }
+}
+
+/// Create an unbooted MCU hardware model using default Rust InitParams values for
+/// all fields not exposed in caliptra_mcu_model_init_params.
+///
+/// Buffer pointers may be NULL only when len is 0. Optional buffers are disabled
+/// by setting data to NULL and len to 0. The returned model must be destroyed by
+/// caliptra_mcu_model_destroy().
+///
+/// # Safety
+/// `model` must be non-NULL. Non-NULL input buffers must point to at least `len`
+/// bytes for the duration of this call.
+#[no_mangle]
+pub unsafe extern "C" fn caliptra_mcu_model_init_default(
+    params: caliptra_mcu_model_init_params,
+    model: *mut *mut caliptra_mcu_model,
+) -> c_int {
+    catch_status(|| init_impl(params, model))
+}
+
+/// # Safety
+/// `model` must be either NULL or a pointer returned by caliptra_mcu_model_init_default.
+#[no_mangle]
+pub unsafe extern "C" fn caliptra_mcu_model_destroy(model: *mut caliptra_mcu_model) {
+    let _ = catch_unwind(AssertUnwindSafe(|| {
+        if !model.is_null() {
+            drop(Box::from_raw(model as *mut ModelHandle));
+        }
+    }));
+}
+
+/// Return a pointer to a NUL-terminated string describing the last operation
+/// error for this model. The pointer remains valid until the next API call on the
+/// model or until caliptra_mcu_model_destroy().
+///
+/// # Safety
+/// `model` must be NULL or a pointer returned by caliptra_mcu_model_init_default.
+#[no_mangle]
+pub unsafe extern "C" fn caliptra_mcu_model_last_error(
+    model: *mut caliptra_mcu_model,
+) -> *const c_char {
+    match handle_from_ptr(model) {
+        Ok(handle) => handle.last_error.as_ptr(),
+        Err(_) => INVALID_MODEL_ERROR.as_ptr() as *const c_char,
+    }
+}
+
+/// Boot the MCU model to the point where CPU execution can occur.
+///
+/// # Safety
+/// `model` must be a pointer returned by caliptra_mcu_model_init_default.
+#[no_mangle]
+pub unsafe extern "C" fn caliptra_mcu_model_boot(model: *mut caliptra_mcu_model) -> c_int {
+    catch_status(|| match handle_from_ptr(model) {
+        Ok(handle) => match handle.model.boot() {
+            Ok(()) => {
+                handle.clear_error();
+                CALIPTRA_MCU_MODEL_STATUS_OK
+            }
+            Err(err) => {
+                handle.set_error(err);
+                CALIPTRA_MCU_MODEL_STATUS_OPERATION_FAILED
+            }
+        },
+        Err(status) => status,
+    })
+}
+
+/// # Safety
+/// `model` must be a pointer returned by caliptra_mcu_model_init_default.
+#[no_mangle]
+pub unsafe extern "C" fn caliptra_mcu_model_step(model: *mut caliptra_mcu_model) -> c_int {
+    catch_status(|| match handle_from_ptr(model) {
+        Ok(handle) => {
+            handle.model.step();
+            handle.clear_error();
+            CALIPTRA_MCU_MODEL_STATUS_OK
+        }
+        Err(status) => status,
+    })
+}
+
+/// # Safety
+/// `model` must be a pointer returned by caliptra_mcu_model_init_default.
+#[no_mangle]
+pub unsafe extern "C" fn caliptra_mcu_model_ready_for_fw(model: *mut caliptra_mcu_model) -> bool {
+    catch_unwind(AssertUnwindSafe(|| match handle_from_ptr(model) {
+        Ok(handle) => handle.model.ready_for_fw(),
+        Err(_) => false,
+    }))
+    .unwrap_or(false)
+}
+
+/// # Safety
+/// `model` must be a pointer returned by caliptra_mcu_model_init_default.
+#[no_mangle]
+pub unsafe extern "C" fn caliptra_mcu_model_cycle_count(model: *mut caliptra_mcu_model) -> u64 {
+    catch_unwind(AssertUnwindSafe(|| match handle_from_ptr(model) {
+        Ok(handle) => handle.model.cycle_count(),
+        Err(_) => 0,
+    }))
+    .unwrap_or(0)
+}
+
+/// # Safety
+/// `model` must be a pointer returned by caliptra_mcu_model_init_default.
+#[no_mangle]
+pub unsafe extern "C" fn caliptra_mcu_model_exit_requested(model: *mut caliptra_mcu_model) -> bool {
+    catch_unwind(AssertUnwindSafe(|| match handle_from_ptr(model) {
+        Ok(handle) => handle.model.output().exit_requested(),
+        Err(_) => false,
+    }))
+    .unwrap_or(false)
+}
+
+/// Return a borrowed view of all UART output captured so far. The data pointer is
+/// invalidated by the next API call that mutably accesses the model.
+///
+/// # Safety
+/// `model` must be a pointer returned by caliptra_mcu_model_init_default.
+#[no_mangle]
+pub unsafe extern "C" fn caliptra_mcu_model_output_peek(
+    model: *mut caliptra_mcu_model,
+) -> caliptra_mcu_buffer {
+    catch_unwind(AssertUnwindSafe(|| match handle_from_ptr(model) {
+        Ok(handle) => {
+            let output = handle.model.output().peek();
+            caliptra_mcu_buffer {
+                data: output.as_ptr(),
+                len: output.len(),
+            }
+        }
+        Err(_) => caliptra_mcu_buffer {
+            data: ptr::null(),
+            len: 0,
+        },
+    }))
+    .unwrap_or(caliptra_mcu_buffer {
+        data: ptr::null(),
+        len: 0,
+    })
+}
+
+/// Read a 32-bit word from the MCU/Caliptra SoC-visible MMIO address space.
+///
+/// # Safety
+/// `model` and `data` must be non-NULL.
+#[no_mangle]
+pub unsafe extern "C" fn caliptra_mcu_model_mmio_read_u32(
+    model: *mut caliptra_mcu_model,
+    addr: c_uint,
+    data: *mut c_uint,
+) -> c_int {
+    catch_status(|| {
+        if data.is_null() {
+            return CALIPTRA_MCU_MODEL_STATUS_INVALID_ARGUMENT;
+        }
+        match handle_from_ptr(model) {
+            Ok(handle) => {
+                let value = {
+                    let mut manager = handle.model.mcu_manager();
+                    let mmio = manager.mmio_mut();
+                    mmio.read_volatile(addr as *const u32)
+                };
+                *data = value;
+                handle.clear_error();
+                CALIPTRA_MCU_MODEL_STATUS_OK
+            }
+            Err(status) => status,
+        }
+    })
+}
+
+/// Write a 32-bit word to the MCU/Caliptra SoC-visible MMIO address space.
+///
+/// # Safety
+/// `model` must be a pointer returned by caliptra_mcu_model_init_default.
+#[no_mangle]
+pub unsafe extern "C" fn caliptra_mcu_model_mmio_write_u32(
+    model: *mut caliptra_mcu_model,
+    addr: c_uint,
+    data: c_uint,
+) -> c_int {
+    catch_status(|| match handle_from_ptr(model) {
+        Ok(handle) => {
+            {
+                let mut manager = handle.model.mcu_manager();
+                let mmio = manager.mmio_mut();
+                mmio.write_volatile(addr as *mut u32, data);
+            }
+            handle.clear_error();
+            CALIPTRA_MCU_MODEL_STATUS_OK
+        }
+        Err(status) => status,
+    })
+}
+
+/// Execute an MCU mailbox command and return a borrowed response buffer. If the
+/// command completes without response data, `response` is set to { NULL, 0 }.
+/// The response data pointer is invalidated by the next mailbox call or destroy.
+///
+/// # Safety
+/// `model` must be valid. `request.data` must be NULL only if `request.len` is 0.
+/// `response` may be NULL if the caller only needs the status code.
+#[no_mangle]
+pub unsafe extern "C" fn caliptra_mcu_model_mailbox_execute(
+    model: *mut caliptra_mcu_model,
+    cmd: c_uint,
+    request: caliptra_mcu_buffer,
+    response: *mut caliptra_mcu_buffer,
+) -> c_int {
+    catch_status(|| {
+        let request = match slice_from_buffer(request) {
+            Ok(data) => data,
+            Err(status) => return status,
+        };
+        match handle_from_ptr(model) {
+            Ok(handle) => match handle.model.mailbox_execute(cmd, request) {
+                Ok(Some(data)) => {
+                    handle.response = data;
+                    fill_buffer(response, &handle.response);
+                    handle.clear_error();
+                    CALIPTRA_MCU_MODEL_STATUS_OK
+                }
+                Ok(None) => {
+                    handle.response.clear();
+                    fill_buffer(response, &[]);
+                    handle.clear_error();
+                    CALIPTRA_MCU_MODEL_STATUS_OK
+                }
+                Err(err) => {
+                    handle.set_error(err);
+                    CALIPTRA_MCU_MODEL_STATUS_OPERATION_FAILED
+                }
+            },
+            Err(status) => status,
+        }
+    })
+}
+
+/// Execute a Caliptra mailbox command through the SoC mailbox and return a
+/// borrowed response buffer. If the command completes without response data,
+/// `response` is set to { NULL, 0 }. The response data pointer is invalidated by
+/// the next mailbox call or destroy.
+///
+/// # Safety
+/// `model` must be valid. `request.data` must be NULL only if `request.len` is 0.
+/// `response` may be NULL if the caller only needs the status code.
+#[no_mangle]
+pub unsafe extern "C" fn caliptra_mcu_model_caliptra_mailbox_execute(
+    model: *mut caliptra_mcu_model,
+    cmd: c_uint,
+    request: caliptra_mcu_buffer,
+    response: *mut caliptra_mcu_buffer,
+) -> c_int {
+    catch_status(|| {
+        let request = match slice_from_buffer(request) {
+            Ok(data) => data,
+            Err(status) => return status,
+        };
+        match handle_from_ptr(model) {
+            Ok(handle) => match handle.model.caliptra_mailbox_execute(cmd, request) {
+                Ok(Some(data)) => {
+                    handle.response = data;
+                    fill_buffer(response, &handle.response);
+                    handle.clear_error();
+                    CALIPTRA_MCU_MODEL_STATUS_OK
+                }
+                Ok(None) => {
+                    handle.response.clear();
+                    fill_buffer(response, &[]);
+                    handle.clear_error();
+                    CALIPTRA_MCU_MODEL_STATUS_OK
+                }
+                Err(err) => {
+                    handle.set_error(format!("{err:?}"));
+                    CALIPTRA_MCU_MODEL_STATUS_OPERATION_FAILED
+                }
+            },
+            Err(status) => status,
+        }
+    })
+}
+
+/// # Safety
+/// `model` must be a pointer returned by caliptra_mcu_model_init_default.
+#[no_mangle]
+pub unsafe extern "C" fn caliptra_mcu_model_mci_flow_status(
+    model: *mut caliptra_mcu_model,
+) -> c_uint {
+    catch_unwind(AssertUnwindSafe(|| match handle_from_ptr(model) {
+        Ok(handle) => handle.model.mci_flow_status(),
+        Err(_) => 0,
+    }))
+    .unwrap_or(0)
+}
+
+/// # Safety
+/// `model` must be a pointer returned by caliptra_mcu_model_init_default.
+#[no_mangle]
+pub unsafe extern "C" fn caliptra_mcu_model_mci_boot_checkpoint(
+    model: *mut caliptra_mcu_model,
+) -> c_uint {
+    catch_unwind(AssertUnwindSafe(|| match handle_from_ptr(model) {
+        Ok(handle) => handle.model.mci_boot_checkpoint() as c_uint,
+        Err(_) => 0,
+    }))
+    .unwrap_or(0)
+}
+
+/// # Safety
+/// `model` must be a pointer returned by caliptra_mcu_model_init_default.
+#[no_mangle]
+pub unsafe extern "C" fn caliptra_mcu_model_warm_reset(model: *mut caliptra_mcu_model) -> c_int {
+    catch_status(|| match handle_from_ptr(model) {
+        Ok(handle) => {
+            handle.model.warm_reset();
+            handle.clear_error();
+            CALIPTRA_MCU_MODEL_STATUS_OK
+        }
+        Err(status) => status,
+    })
+}
+
+/// Return a borrowed copy of DOT flash contents. The data pointer is invalidated
+/// by the next caliptra_mcu_model_read_dot_flash() call or destroy.
+///
+/// # Safety
+/// `model` must be a pointer returned by caliptra_mcu_model_init_default.
+#[no_mangle]
+pub unsafe extern "C" fn caliptra_mcu_model_read_dot_flash(
+    model: *mut caliptra_mcu_model,
+) -> caliptra_mcu_buffer {
+    catch_unwind(AssertUnwindSafe(|| match handle_from_ptr(model) {
+        Ok(handle) => {
+            handle.scratch = handle.model.read_dot_flash();
+            caliptra_mcu_buffer {
+                data: if handle.scratch.is_empty() {
+                    ptr::null()
+                } else {
+                    handle.scratch.as_ptr()
+                },
+                len: handle.scratch.len(),
+            }
+        }
+        Err(_) => caliptra_mcu_buffer {
+            data: ptr::null(),
+            len: 0,
+        },
+    }))
+    .unwrap_or(caliptra_mcu_buffer {
+        data: ptr::null(),
+        len: 0,
+    })
+}
+
+/// Replace DOT flash contents with `data`.
+///
+/// # Safety
+/// `model` must be valid. `data.data` must be NULL only if `data.len` is 0.
+#[no_mangle]
+pub unsafe extern "C" fn caliptra_mcu_model_write_dot_flash(
+    model: *mut caliptra_mcu_model,
+    data: caliptra_mcu_buffer,
+) -> c_int {
+    catch_status(|| {
+        let data = match slice_from_buffer(data) {
+            Ok(data) => data,
+            Err(status) => return status,
+        };
+        match handle_from_ptr(model) {
+            Ok(handle) => match handle.model.write_dot_flash(data) {
+                Ok(()) => {
+                    handle.clear_error();
+                    CALIPTRA_MCU_MODEL_STATUS_OK
+                }
+                Err(err) => {
+                    handle.set_error(err);
+                    CALIPTRA_MCU_MODEL_STATUS_OPERATION_FAILED
+                }
+            },
+            Err(status) => status,
+        }
+    })
+}
+
+/// Return a borrowed copy of OTP memory contents. The data pointer is invalidated
+/// by the next caliptra_mcu_model_read_otp_memory() call or destroy.
+///
+/// # Safety
+/// `model` must be a pointer returned by caliptra_mcu_model_init_default.
+#[no_mangle]
+pub unsafe extern "C" fn caliptra_mcu_model_read_otp_memory(
+    model: *mut caliptra_mcu_model,
+) -> caliptra_mcu_buffer {
+    catch_unwind(AssertUnwindSafe(|| match handle_from_ptr(model) {
+        Ok(handle) => {
+            handle.scratch = handle.model.read_otp_memory();
+            caliptra_mcu_buffer {
+                data: if handle.scratch.is_empty() {
+                    ptr::null()
+                } else {
+                    handle.scratch.as_ptr()
+                },
+                len: handle.scratch.len(),
+            }
+        }
+        Err(_) => caliptra_mcu_buffer {
+            data: ptr::null(),
+            len: 0,
+        },
+    }))
+    .unwrap_or(caliptra_mcu_buffer {
+        data: ptr::null(),
+        len: 0,
+    })
+}

--- a/hw/model/c-binding/src/lib.rs
+++ b/hw/model/c-binding/src/lib.rs
@@ -1,5 +1,6 @@
 // Licensed under the Apache-2.0 license
 
+use caliptra_cfi_lib::CfiState;
 use caliptra_mcu_hw_model::{DefaultHwModel, InitParams, McuHwModel, McuManager};
 use caliptra_ureg::{Mmio, MmioMut};
 use std::ffi::CString;
@@ -9,6 +10,23 @@ use std::ptr;
 use std::slice;
 
 const INVALID_MODEL_ERROR: &[u8] = b"invalid model\0";
+
+// These symbols are required by Caliptra CFI when this crate is linked as a
+// standalone C static library.
+#[no_mangle]
+pub extern "C" fn cfi_panic_handler(code: u32) -> ! {
+    std::process::exit(code as i32);
+}
+
+#[allow(unused)]
+#[no_mangle]
+static mut CFI_STATE_ORG: [u8; std::mem::size_of::<CfiState>()] =
+    [0; std::mem::size_of::<CfiState>()];
+
+fn ensure_cfi_symbols_linked() {
+    std::hint::black_box(cfi_panic_handler as extern "C" fn(u32) -> !);
+    std::hint::black_box(core::ptr::addr_of_mut!(CFI_STATE_ORG));
+}
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -201,6 +219,8 @@ unsafe fn init_impl(
     if model.is_null() {
         return CALIPTRA_MCU_MODEL_STATUS_INVALID_ARGUMENT;
     }
+    ensure_cfi_symbols_linked();
+    *model = ptr::null_mut();
 
     let caliptra_rom = match slice_from_buffer(params.caliptra_rom) {
         Ok(data) => data,
@@ -256,8 +276,10 @@ unsafe fn init_impl(
 
     let i3c_port = if params.i3c_port == 0 {
         None
-    } else {
+    } else if params.i3c_port <= u16::MAX as c_uint {
         Some(params.i3c_port as u16)
+    } else {
+        return CALIPTRA_MCU_MODEL_STATUS_INVALID_ARGUMENT;
     };
 
     let result = caliptra_mcu_hw_model::new_unbooted(InitParams {
@@ -288,10 +310,7 @@ unsafe fn init_impl(
             *model = Box::into_raw(Box::new(ModelHandle::new(hw_model))) as *mut caliptra_mcu_model;
             CALIPTRA_MCU_MODEL_STATUS_OK
         }
-        Err(_) => {
-            *model = ptr::null_mut();
-            CALIPTRA_MCU_MODEL_STATUS_INIT_FAILED
-        }
+        Err(_) => CALIPTRA_MCU_MODEL_STATUS_INIT_FAILED,
     }
 }
 
@@ -505,6 +524,7 @@ pub unsafe extern "C" fn caliptra_mcu_model_mailbox_execute(
     response: *mut caliptra_mcu_buffer,
 ) -> c_int {
     catch_status(|| {
+        fill_buffer(response, &[]);
         let request = match slice_from_buffer(request) {
             Ok(data) => data,
             Err(status) => return status,
@@ -524,6 +544,8 @@ pub unsafe extern "C" fn caliptra_mcu_model_mailbox_execute(
                     CALIPTRA_MCU_MODEL_STATUS_OK
                 }
                 Err(err) => {
+                    handle.response.clear();
+                    fill_buffer(response, &[]);
                     handle.set_error(err);
                     CALIPTRA_MCU_MODEL_STATUS_OPERATION_FAILED
                 }
@@ -549,6 +571,7 @@ pub unsafe extern "C" fn caliptra_mcu_model_caliptra_mailbox_execute(
     response: *mut caliptra_mcu_buffer,
 ) -> c_int {
     catch_status(|| {
+        fill_buffer(response, &[]);
         let request = match slice_from_buffer(request) {
             Ok(data) => data,
             Err(status) => return status,
@@ -568,6 +591,8 @@ pub unsafe extern "C" fn caliptra_mcu_model_caliptra_mailbox_execute(
                     CALIPTRA_MCU_MODEL_STATUS_OK
                 }
                 Err(err) => {
+                    handle.response.clear();
+                    fill_buffer(response, &[]);
                     handle.set_error(format!("{err:?}"));
                     CALIPTRA_MCU_MODEL_STATUS_OPERATION_FAILED
                 }
@@ -618,7 +643,8 @@ pub unsafe extern "C" fn caliptra_mcu_model_warm_reset(model: *mut caliptra_mcu_
 }
 
 /// Return a borrowed copy of DOT flash contents. The data pointer is invalidated
-/// by the next caliptra_mcu_model_read_dot_flash() call or destroy.
+/// by the next caliptra_mcu_model_read_dot_flash() or
+/// caliptra_mcu_model_read_otp_memory() call, or by destroy.
 ///
 /// # Safety
 /// `model` must be a pointer returned by caliptra_mcu_model_init_default.
@@ -680,7 +706,8 @@ pub unsafe extern "C" fn caliptra_mcu_model_write_dot_flash(
 }
 
 /// Return a borrowed copy of OTP memory contents. The data pointer is invalidated
-/// by the next caliptra_mcu_model_read_otp_memory() call or destroy.
+/// by the next caliptra_mcu_model_read_otp_memory() or
+/// caliptra_mcu_model_read_dot_flash() call, or by destroy.
 ///
 /// # Safety
 /// `model` must be a pointer returned by caliptra_mcu_model_init_default.


### PR DESCRIPTION
## Summary
- Add `caliptra-mcu-hw-model-c-binding` staticlib crate for the MCU hardware model.
- Generate and commit `caliptra_mcu_model.h` via cbindgen.
- Expose C ABI helpers for model init/destroy, boot/step/output, MMIO, MCU and Caliptra mailbox execution, MCI status, reset, DOT flash, and OTP reads.
- Add CFI stubs required for standalone staticlib consumers and a C smoke example/Makefile that verifies header inclusion and normal static linking.

Closes #742

## Validation
- Spawned subagent review against issue #742 and addressed findings.
- `cargo check -p caliptra-mcu-hw-model-c-binding`
- `cargo build -p caliptra-mcu-hw-model-c-binding`
- `make -C hw/model/c-binding/examples clean all run`
