### PR TITLE
Fix FE_PROG core response handling

### DIFF
--- a/platforms/emulator/runtime/userspace/apps/user/src/caliptra_cmd_handler/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/caliptra_cmd_handler/mod.rs
@@ -137,10 +137,14 @@ impl CaliptraCmdHandler for CaliptraCmdBackend {
     }
 
     async fn program_field_entropy(&self, partition: u32) -> CaliptraCmdResult<()> {
-        use caliptra_api::mailbox::{CommandId, FeProgReq};
+        use caliptra_api::mailbox::{CommandId, FeProgReq, MailboxRespHeader};
         use caliptra_mcu_libapi_caliptra::mailbox_api::execute_mailbox_cmd;
         use caliptra_mcu_libsyscall_caliptra::mailbox::Mailbox;
         use zerocopy::IntoBytes;
+
+        const CORE_FE_PROG_RESP_LEN: usize =
+            core::mem::size_of::<MailboxRespHeader>() + core::mem::size_of::<u32>();
+        const CORE_FE_PROG_RESP_MIN_LEN: usize = core::mem::size_of::<MailboxRespHeader>();
 
         let mailbox = Mailbox::new();
         let mut req = FeProgReq {
@@ -148,8 +152,8 @@ impl CaliptraCmdHandler for CaliptraCmdBackend {
             ..Default::default()
         };
 
-        let mut resp_buf = [0u8; 8];
-        execute_mailbox_cmd(
+        let mut resp_buf = [0u8; CORE_FE_PROG_RESP_LEN];
+        let resp_len = execute_mailbox_cmd(
             &mailbox,
             CommandId::FE_PROG.0,
             req.as_mut_bytes(),
@@ -157,6 +161,17 @@ impl CaliptraCmdHandler for CaliptraCmdBackend {
         )
         .await
         .map_err(|_| CaliptraCompletionCode::OperationFailed)?;
+
+        if resp_len > CORE_FE_PROG_RESP_MIN_LEN && resp_len < CORE_FE_PROG_RESP_LEN {
+            return Err(CaliptraCompletionCode::OperationFailed);
+        }
+        if resp_len >= CORE_FE_PROG_RESP_LEN {
+            let dpe_result =
+                u32::from_le_bytes([resp_buf[8], resp_buf[9], resp_buf[10], resp_buf[11]]);
+            if dpe_result != 0 {
+                return Err(CaliptraCompletionCode::OperationFailed);
+            }
+        }
 
         Ok(())
     }

--- a/rom/src/cold_boot.rs
+++ b/rom/src/cold_boot.rs
@@ -22,8 +22,8 @@ use crate::{
     I3cMailboxHandler, I3cServicesModes, RomEnv, RomParameters, MCU_MEMORY_MAP,
 };
 use caliptra_api::mailbox::{
-    CmStableKeyType, CommandId, FeProgReq, MailboxReqHeader, StashMeasurementReq,
-    StashMeasurementResp,
+    CmStableKeyType, CommandId, FeProgReq, MailboxReqHeader, MailboxRespHeader,
+    StashMeasurementReq, StashMeasurementResp,
 };
 use caliptra_api::CaliptraApiError;
 use caliptra_api::SocManager;
@@ -80,6 +80,12 @@ fn maybe_enter_dot_recovery_reset_failure_flow(
     fatal_error(err);
 }
 
+const FE_PROG_CORE_RESP_WORDS: usize = (core::mem::size_of::<MailboxRespHeader>()
+    + core::mem::size_of::<u32>())
+    / core::mem::size_of::<u32>();
+const FE_PROG_CORE_RESP_MIN_BYTES: usize = core::mem::size_of::<MailboxRespHeader>();
+const FE_PROG_CORE_RESP_BYTES: usize = FE_PROG_CORE_RESP_WORDS * core::mem::size_of::<u32>();
+
 impl ColdBoot {
     fn program_field_entropy(
         program_field_entropy: &[bool; 4],
@@ -126,20 +132,71 @@ impl ColdBoot {
                 }
                 fatal_error(McuError::ROM_COLD_BOOT_FIELD_ENTROPY_PROG_START);
             }
-            if let Err(err) = soc_manager.finish_mailbox_resp(8, 8) {
-                match err {
-                    CaliptraApiError::MailboxCmdFailed(code) => {
-                        caliptra_mcu_romtime::println!(
-                            "[mcu-rom] Error finishing mailbox command: {}",
-                            HexWord(code)
-                        );
+            match soc_manager
+                .finish_mailbox_resp(FE_PROG_CORE_RESP_MIN_BYTES, FE_PROG_CORE_RESP_BYTES)
+            {
+                Ok(Some(mut resp_iter)) => {
+                    let mut resp = [0u32; FE_PROG_CORE_RESP_WORDS];
+                    for (i, word) in resp_iter.by_ref().enumerate() {
+                        if i < resp.len() {
+                            resp[i] = word;
+                        }
                     }
-                    _ => {
-                        caliptra_mcu_romtime::println!("[mcu-rom] Error finishing mailbox command");
+                    if let Err(err) = resp_iter.verify_checksum() {
+                        match err {
+                            CaliptraApiError::MailboxCmdFailed(code) => {
+                                caliptra_mcu_romtime::println!(
+                                    "[mcu-rom] Error finishing mailbox command: {}",
+                                    HexWord(code)
+                                );
+                            }
+                            _ => {
+                                caliptra_mcu_romtime::println!(
+                                    "[mcu-rom] Error finishing mailbox command"
+                                );
+                            }
+                        }
+                        fatal_error(McuError::ROM_COLD_BOOT_FIELD_ENTROPY_PROG_FINISH);
+                    }
+
+                    // Core FE_PROG / ZEROIZE_UDS_FE response is MailboxRespHeader + dpe_result.
+                    // Older Core revisions may return only the header; treat exactly that legacy
+                    // shape as success, but reject malformed partial dpe_result responses.
+                    if resp_iter.len() > FE_PROG_CORE_RESP_MIN_BYTES
+                        && resp_iter.len() < FE_PROG_CORE_RESP_BYTES
+                    {
+                        caliptra_mcu_romtime::println!(
+                            "[mcu-rom] FE_PROG returned malformed response length={}",
+                            resp_iter.len()
+                        );
+                        fatal_error(McuError::ROM_COLD_BOOT_FIELD_ENTROPY_PROG_FINISH);
+                    }
+                    if resp_iter.len() >= FE_PROG_CORE_RESP_BYTES && resp[2] != 0 {
+                        caliptra_mcu_romtime::println!(
+                            "[mcu-rom] FE_PROG failed: dpe_result={}",
+                            resp[2]
+                        );
+                        fatal_error(McuError::ROM_COLD_BOOT_FIELD_ENTROPY_PROG_FINISH);
                     }
                 }
-                fatal_error(McuError::ROM_COLD_BOOT_FIELD_ENTROPY_PROG_FINISH);
-            };
+                Ok(None) => {}
+                Err(err) => {
+                    match err {
+                        CaliptraApiError::MailboxCmdFailed(code) => {
+                            caliptra_mcu_romtime::println!(
+                                "[mcu-rom] Error finishing mailbox command: {}",
+                                HexWord(code)
+                            );
+                        }
+                        _ => {
+                            caliptra_mcu_romtime::println!(
+                                "[mcu-rom] Error finishing mailbox command"
+                            );
+                        }
+                    }
+                    fatal_error(McuError::ROM_COLD_BOOT_FIELD_ENTROPY_PROG_FINISH);
+                }
+            }
 
             // Set status for each partition completion
             let partition_status = match partition {

--- a/runtime/userspace/api/caliptra-api-lite/src/fe_prog.rs
+++ b/runtime/userspace/api/caliptra-api-lite/src/fe_prog.rs
@@ -9,6 +9,8 @@ use crate::ApiAlloc;
 
 /// Request layout: `chksum(4) | partition(4)` = 8 B.
 const FE_PROG_REQ_LEN: usize = 8;
+/// Core response layout: `MailboxRespHeader(8) | dpe_result(4)` = 12 B.
+const FE_PROG_RESP_LEN: usize = MBOX_RESP_HEADER_SIZE + 4;
 
 /// Program field entropy for `partition`. Returns once Caliptra has
 /// completed the operation.
@@ -20,7 +22,16 @@ pub async fn fe_prog<A: ApiAlloc>(alloc: &A, partition: u32) -> McuResult<()> {
     let checksum = calc_checksum(CMD_FE_PROG, &req[4..]);
     req[..4].copy_from_slice(&checksum.to_le_bytes());
 
-    let mut rsp = alloc.alloc(MBOX_RESP_HEADER_SIZE)?;
-    let _rsp_len = crate::wire::mbox_execute(CMD_FE_PROG, &req, &mut rsp).await?;
+    let mut rsp = alloc.alloc(FE_PROG_RESP_LEN)?;
+    let rsp_len = crate::wire::mbox_execute(CMD_FE_PROG, &req, &mut rsp).await?;
+    if rsp_len > MBOX_RESP_HEADER_SIZE && rsp_len < FE_PROG_RESP_LEN {
+        return Err(mcu_error::codes::INTERNAL_BUG);
+    }
+    if rsp_len >= FE_PROG_RESP_LEN {
+        let dpe_result = u32::from_le_bytes([rsp[8], rsp[9], rsp[10], rsp[11]]);
+        if dpe_result != 0 {
+            return Err(mcu_error::codes::INTERNAL_BUG);
+        }
+    }
     Ok(())
 }

--- a/runtime/userspace/api/mcu-mbox-lib/src/cmd_interface.rs
+++ b/runtime/userspace/api/mcu-mbox-lib/src/cmd_interface.rs
@@ -35,6 +35,10 @@ use core::sync::atomic::{AtomicBool, Ordering};
 use mcu_error::McuResult;
 use zerocopy::{FromBytes, IntoBytes};
 
+const CORE_FE_PROG_RESP_LEN: usize =
+    core::mem::size_of::<MailboxRespHeader>() + core::mem::size_of::<u32>();
+const CORE_FE_PROG_RESP_MIN_LEN: usize = core::mem::size_of::<MailboxRespHeader>();
+
 /// Command interface for handling MCU mailbox commands.
 pub struct CmdInterface<'a> {
     transport: &'a mut McuMboxTransport,
@@ -722,14 +726,32 @@ impl<'a> CmdInterface<'a> {
         };
 
         // Invoke Caliptra mailbox API (checksum is computed by execute_mailbox_cmd)
-        let _caliptra_resp_len = execute_mailbox_cmd(
+        let mut caliptra_resp = [0u8; CORE_FE_PROG_RESP_LEN];
+        let caliptra_resp_len = execute_mailbox_cmd(
             &self.caliptra_mbox,
             CaliptraCommandId::FE_PROG.into(),
             caliptra_req.as_mut_bytes(),
-            resp.as_mut_bytes(),
+            &mut caliptra_resp,
         )
         .await
         .map_err(|_| errors::MCU_MBOX_COMMON)?;
+
+        if caliptra_resp_len > CORE_FE_PROG_RESP_MIN_LEN
+            && caliptra_resp_len < CORE_FE_PROG_RESP_LEN
+        {
+            return Err(errors::MCU_MBOX_COMMON);
+        }
+        if caliptra_resp_len >= CORE_FE_PROG_RESP_LEN {
+            let dpe_result = u32::from_le_bytes([
+                caliptra_resp[8],
+                caliptra_resp[9],
+                caliptra_resp[10],
+                caliptra_resp[11],
+            ]);
+            if dpe_result != 0 {
+                return Err(errors::MCU_MBOX_COMMON);
+            }
+        }
 
         *resp = FuseWriteResp::default();
         let resp_len = resp.as_bytes().len();


### PR DESCRIPTION
## Summary
- Size Core `FE_PROG` / `ZEROIZE_UDS_FE` response buffers for `MailboxRespHeader + dpe_result` instead of header-only responses.
- Consume and checksum the full Core response, and fail when `dpe_result != 0`.
- Preserve legacy 8-byte header-only response compatibility while rejecting malformed partial `dpe_result` responses.

Fixes #1513.
