### PR TITLE
Fix VirtualMuxAlarm timer reprogramming bug on VeeR EL2 FPGA

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1040,6 +1040,7 @@ dependencies = [
  "caliptra-mcu-registers-generated",
  "caliptra-mcu-romtime",
  "caliptra-mcu-tock-veer",
+ "caliptra-mcu-virtual-alarm",
  "capsules-core",
  "capsules-extra",
  "capsules-system",
@@ -1142,6 +1143,7 @@ dependencies = [
  "caliptra-mcu-capsules-runtime",
  "caliptra-mcu-registers-generated",
  "caliptra-mcu-romtime",
+ "caliptra-mcu-virtual-alarm",
  "capsules-core",
  "kernel",
  "tock-registers",
@@ -1153,6 +1155,7 @@ version = "0.1.0"
 dependencies = [
  "caliptra-mcu-doe-transport",
  "caliptra-mcu-registers-generated",
+ "caliptra-mcu-virtual-alarm",
  "capsules-core",
  "kernel",
 ]
@@ -1527,6 +1530,7 @@ version = "0.1.0"
 dependencies = [
  "caliptra-mcu-registers-generated",
  "caliptra-mcu-romtime",
+ "caliptra-mcu-virtual-alarm",
  "capsules-core",
  "kernel",
  "rv32i",
@@ -1767,6 +1771,7 @@ dependencies = [
  "caliptra-mcu-mbox-comm",
  "caliptra-mcu-registers-generated",
  "caliptra-mcu-romtime",
+ "caliptra-mcu-virtual-alarm",
  "capsules-core",
  "kernel",
 ]
@@ -2131,6 +2136,7 @@ dependencies = [
  "caliptra-mcu-registers-generated",
  "caliptra-mcu-romtime",
  "caliptra-mcu-tock-veer",
+ "caliptra-mcu-virtual-alarm",
  "capsules-core",
  "capsules-extra",
  "capsules-system",
@@ -2163,6 +2169,7 @@ dependencies = [
  "caliptra-mcu-registers-generated",
  "caliptra-mcu-romtime",
  "caliptra-mcu-tock-veer",
+ "caliptra-mcu-virtual-alarm",
  "capsules-core",
  "capsules-extra",
  "capsules-system",
@@ -2500,6 +2507,7 @@ dependencies = [
  "caliptra-mcu-mbox-driver",
  "caliptra-mcu-registers-generated",
  "caliptra-mcu-romtime",
+ "caliptra-mcu-virtual-alarm",
  "capsules-core",
  "capsules-extra",
  "capsules-system",
@@ -2537,6 +2545,13 @@ dependencies = [
  "embassy-sync",
  "heapless",
  "portable-atomic",
+]
+
+[[package]]
+name = "caliptra-mcu-virtual-alarm"
+version = "0.1.0"
+dependencies = [
+ "kernel",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,7 @@ members = [
     "runtime/kernel/drivers/i3c",
     "runtime/kernel/drivers/mcu_mbox",
     "runtime/kernel/veer",
+    "runtime/kernel/virtual-alarm",
     "runtime/userspace/api/caliptra-api",
     "runtime/userspace/api/caliptra-common-commands",
     "runtime/userspace/api/mcu-mbox-lib",
@@ -305,6 +306,7 @@ caliptra-mcu-network-rom = { path = "network/rom" }
 caliptra-mcu-testing-common = { path = "common/testing" }
 caliptra-mcu-emulator-state = { path = "common/emulator-state" }
 caliptra-mcu-tock-veer = { path = "runtime/kernel/veer" }
+caliptra-mcu-virtual-alarm = { path = "runtime/kernel/virtual-alarm" }
 caliptra-mcu-mctp-vdm-common = { path = "common/mctp-vdm" }
 caliptra-mcu-otp-digest = { path = "common/otp-digest" }
 caliptra-mcu-pldm-common = { path = "common/pldm"}

--- a/firmware-bundler/reference/fpga/user-app.toml
+++ b/firmware-bundler/reference/fpga/user-app.toml
@@ -33,5 +33,5 @@ stack = 0x0_7000
 
 [[app]]
 name = "user-app"
-stack = 0x8000
+stack = 0x10000
 grant_space = 0x4000

--- a/platforms/emulator/runtime/Cargo.toml
+++ b/platforms/emulator/runtime/Cargo.toml
@@ -9,6 +9,7 @@ edition.workspace = true
 [dependencies]
 arrayvec.workspace = true
 capsules-core.workspace = true
+caliptra-mcu-virtual-alarm.workspace = true
 capsules-extra.workspace = true
 caliptra-mcu-capsules-emulator.workspace = true
 caliptra-mcu-capsules-runtime.workspace = true

--- a/platforms/emulator/runtime/kernel/drivers/dma/Cargo.toml
+++ b/platforms/emulator/runtime/kernel/drivers/dma/Cargo.toml
@@ -11,6 +11,7 @@ kernel.workspace = true
 
 # [target.'cfg(target_arch = "riscv32")'.dependencies]
 capsules-core.workspace = true
+caliptra-mcu-virtual-alarm.workspace = true
 caliptra-mcu-capsules-runtime.workspace = true
 caliptra-mcu-registers-generated.workspace = true
 caliptra-mcu-romtime.workspace = true

--- a/platforms/emulator/runtime/kernel/drivers/dma/src/axicdma.rs
+++ b/platforms/emulator/runtime/kernel/drivers/dma/src/axicdma.rs
@@ -8,7 +8,7 @@ use core::cell::RefCell;
 
 use caliptra_mcu_capsules_runtime::dma::hil::{Dma, DmaClient, DmaError, DmaRoute, DmaStatus};
 use caliptra_mcu_registers_generated::axicdma::{bits::*, regs::*, AXICDMA_ADDR};
-use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
+use caliptra_mcu_virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use kernel::hil::time::{Alarm, AlarmClient, Time};
 use kernel::utilities::cells::OptionalCell;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};

--- a/platforms/emulator/runtime/kernel/drivers/dma/src/nodma.rs
+++ b/platforms/emulator/runtime/kernel/drivers/dma/src/nodma.rs
@@ -8,7 +8,7 @@
 use core::cell::RefCell;
 
 use caliptra_mcu_capsules_runtime::dma::hil::{Dma, DmaClient, DmaError, DmaRoute, DmaStatus};
-use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
+use caliptra_mcu_virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use kernel::hil::time::{Alarm, AlarmClient, Time};
 use kernel::utilities::cells::OptionalCell;
 use kernel::ErrorCode;

--- a/platforms/emulator/runtime/kernel/drivers/doe_mbox/Cargo.toml
+++ b/platforms/emulator/runtime/kernel/drivers/doe_mbox/Cargo.toml
@@ -8,6 +8,7 @@ edition.workspace = true
 
 [dependencies]
 capsules-core.workspace = true
+caliptra-mcu-virtual-alarm.workspace = true
 caliptra-mcu-doe-transport.workspace = true
 kernel.workspace = true
 caliptra-mcu-registers-generated.workspace = true

--- a/platforms/emulator/runtime/kernel/drivers/doe_mbox/src/lib.rs
+++ b/platforms/emulator/runtime/kernel/drivers/doe_mbox/src/lib.rs
@@ -7,7 +7,7 @@ use caliptra_mcu_doe_transport::hil::{DoeTransport, DoeTransportRxClient, DoeTra
 use caliptra_mcu_registers_generated::doe_mbox::bits::{DoeMboxEvent, DoeMboxStatus};
 use caliptra_mcu_registers_generated::doe_mbox::regs::DoeMbox;
 use caliptra_mcu_registers_generated::doe_mbox::DOE_MBOX_ADDR;
-use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
+use caliptra_mcu_virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use core::cell::Cell;
 use kernel::hil::time::{Alarm, AlarmClient, Time};
 use kernel::utilities::cells::{OptionalCell, TakeCell};

--- a/platforms/emulator/runtime/kernel/drivers/mcu_mbox/Cargo.toml
+++ b/platforms/emulator/runtime/kernel/drivers/mcu_mbox/Cargo.toml
@@ -8,6 +8,7 @@ edition.workspace = true
 
 [dependencies]
 capsules-core.workspace = true
+caliptra-mcu-virtual-alarm.workspace = true
 caliptra-mcu-mbox-comm.workspace = true
 kernel.workspace = true
 caliptra-mcu-registers-generated.workspace = true

--- a/platforms/emulator/runtime/kernel/drivers/mcu_mbox/src/lib.rs
+++ b/platforms/emulator/runtime/kernel/drivers/mcu_mbox/src/lib.rs
@@ -6,7 +6,7 @@ use caliptra_mcu_mbox_comm::hil::{Mailbox, MailboxClient, MailboxStatus};
 use caliptra_mcu_registers_generated::mci;
 use caliptra_mcu_registers_generated::mci::bits::{MboxCmdStatus, Notif0IntrEnT, Notif0IntrT};
 use caliptra_mcu_romtime::StaticRef;
-use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
+use caliptra_mcu_virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use core::cell::Cell;
 use kernel::hil::time::{Alarm, AlarmClient, Time};
 use kernel::utilities::cells::{OptionalCell, TakeCell};

--- a/platforms/emulator/runtime/src/board.rs
+++ b/platforms/emulator/runtime/src/board.rs
@@ -33,7 +33,7 @@ use caliptra_mcu_tock_veer::chip::{VeeRDefaultPeripherals, TIMERS};
 use caliptra_mcu_tock_veer::pic::Pic;
 use caliptra_mcu_tock_veer::pmp::VeeRProtectionMMLEPMP;
 use caliptra_mcu_tock_veer::timers::InternalTimers;
-use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
+use caliptra_mcu_virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use capsules_core::virtualizers::virtual_flash;
 use core::ptr::{addr_of, addr_of_mut};
 use kernel::capabilities;
@@ -665,18 +665,6 @@ pub unsafe fn main() {
         let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
             .finalize(components::process_printer_text_component_static!());
         PROCESS_PRINTER = Some(process_printer);
-
-        let process_console = components::process_console::ProcessConsoleComponent::new(
-            board_kernel,
-            uart_mux,
-            mux_alarm,
-            process_printer,
-            None,
-        )
-        .finalize(components::process_console_component_static!(
-            InternalTimers
-        ));
-        let _ = process_console.start();
     }
 
     // Select which I3C core to use for MCTP transport based on platform strap.

--- a/platforms/emulator/runtime/src/interrupts.rs
+++ b/platforms/emulator/runtime/src/interrupts.rs
@@ -2,7 +2,7 @@
 
 use crate::io::SemihostUart;
 use caliptra_mcu_tock_veer::timers::InternalTimers;
-use capsules_core::virtualizers::virtual_alarm::MuxAlarm;
+use caliptra_mcu_virtual_alarm::MuxAlarm;
 use kernel::platform::chip::InterruptService;
 
 pub const UART_IRQ: u8 = 0x10;

--- a/platforms/emulator/runtime/src/tests/circular_log_test.rs
+++ b/platforms/emulator/runtime/src/tests/circular_log_test.rs
@@ -8,7 +8,7 @@
 use caliptra_mcu_capsules_runtime::logging::logging_flash as log;
 use caliptra_mcu_capsules_runtime::logging::logging_flash::{ENTRY_HEADER_SIZE, PAGE_HEADER_SIZE};
 use caliptra_mcu_tock_veer::timers::InternalTimers;
-use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
+use caliptra_mcu_virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use core::cell::Cell;
 use core::ptr::addr_of_mut;
 use kernel::hil::flash;

--- a/platforms/emulator/runtime/src/tests/linear_log_test.rs
+++ b/platforms/emulator/runtime/src/tests/linear_log_test.rs
@@ -8,7 +8,7 @@
 use caliptra_mcu_capsules_runtime::logging::logging_flash as log;
 use caliptra_mcu_capsules_runtime::logging::logging_flash::{ENTRY_HEADER_SIZE, PAGE_HEADER_SIZE};
 use caliptra_mcu_tock_veer::timers::InternalTimers;
-use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
+use caliptra_mcu_virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use core::cell::Cell;
 use core::ptr::addr_of_mut;
 use kernel::hil::flash;

--- a/platforms/emulator/runtime/src/tests/mctp_test.rs
+++ b/platforms/emulator/runtime/src/tests/mctp_test.rs
@@ -8,7 +8,7 @@ use caliptra_mcu_components::mock_mctp::MockMctpComponent;
 use caliptra_mcu_components::mock_mctp_component_static;
 use caliptra_mcu_romtime::println;
 use caliptra_mcu_tock_veer::timers::InternalTimers;
-use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
+use caliptra_mcu_virtual_alarm::VirtualMuxAlarm;
 use core::fmt::Write;
 use kernel::component::Component;
 use kernel::hil::time::Alarm;

--- a/platforms/fpga/runtime/Cargo.toml
+++ b/platforms/fpga/runtime/Cargo.toml
@@ -9,6 +9,7 @@ edition.workspace = true
 [dependencies]
 arrayvec.workspace = true
 capsules-core.workspace = true
+caliptra-mcu-virtual-alarm.workspace = true
 capsules-extra.workspace = true
 caliptra-mcu-capsules-emulator.workspace = true
 caliptra-mcu-capsules-runtime.workspace = true

--- a/platforms/fpga/runtime/src/board.rs
+++ b/platforms/fpga/runtime/src/board.rs
@@ -30,7 +30,7 @@ use caliptra_mcu_tock_veer::chip::{VeeRDefaultPeripherals, TIMERS};
 use caliptra_mcu_tock_veer::pic::Pic;
 use caliptra_mcu_tock_veer::pmp::VeeRProtectionMMLEPMP;
 use caliptra_mcu_tock_veer::timers::InternalTimers;
-use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
+use caliptra_mcu_virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use capsules_core::virtualizers::virtual_flash;
 use core::ptr::{addr_of, addr_of_mut};
 use kernel::capabilities;

--- a/platforms/fpga/runtime/src/interrupts.rs
+++ b/platforms/fpga/runtime/src/interrupts.rs
@@ -3,7 +3,7 @@
 use crate::io::SemihostUart;
 use caliptra_mcu_registers_generated::mci;
 use caliptra_mcu_tock_veer::timers::InternalTimers;
-use capsules_core::virtualizers::virtual_alarm::MuxAlarm;
+use caliptra_mcu_virtual_alarm::MuxAlarm;
 use kernel::platform::chip::InterruptService;
 
 pub struct FpgaPeripherals<'a> {

--- a/platforms/fpga/runtime/src/io.rs
+++ b/platforms/fpga/runtime/src/io.rs
@@ -12,7 +12,7 @@ use crate::PROCESSES;
 #[cfg(not(feature = "release"))]
 use crate::PROCESS_PRINTER;
 use caliptra_mcu_tock_veer::timers::InternalTimers;
-use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
+use caliptra_mcu_virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use core::cell::Cell;
 use core::fmt::Write;
 use core::panic::PanicInfo;

--- a/platforms/fpga/runtime/src/tests/mctp_test.rs
+++ b/platforms/fpga/runtime/src/tests/mctp_test.rs
@@ -8,7 +8,7 @@ use caliptra_mcu_components::mock_mctp::MockMctpComponent;
 use caliptra_mcu_components::mock_mctp_component_static;
 use caliptra_mcu_romtime::println;
 use caliptra_mcu_tock_veer::timers::InternalTimers;
-use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
+use caliptra_mcu_virtual_alarm::VirtualMuxAlarm;
 use core::fmt::Write;
 use kernel::component::Component;
 use kernel::static_init;

--- a/runtime/kernel/components/Cargo.toml
+++ b/runtime/kernel/components/Cargo.toml
@@ -8,6 +8,7 @@ edition.workspace = true
 
 [dependencies]
 capsules-core.workspace = true
+caliptra-mcu-virtual-alarm.workspace = true
 capsules-extra.workspace = true
 caliptra-mcu-capsules-emulator.workspace = true
 caliptra-mcu-capsules-runtime.workspace = true

--- a/runtime/kernel/components/src/mailbox.rs
+++ b/runtime/kernel/components/src/mailbox.rs
@@ -5,7 +5,7 @@
 use caliptra_mcu_capsules_runtime::dma::hil::Dma as DmaHal;
 use caliptra_mcu_capsules_runtime::mailbox::Mailbox;
 use caliptra_mcu_romtime::CaliptraSoC;
-use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
+use caliptra_mcu_virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use core::mem::MaybeUninit;
 use kernel::capabilities;
 use kernel::component::Component;
@@ -15,7 +15,7 @@ use kernel::hil::time::Alarm;
 #[macro_export]
 macro_rules! mailbox_component_static {
     ($A:ty, $b:expr, $c:expr, $d:expr, $e:expr) => {{
-        use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
+        use caliptra_mcu_virtual_alarm::VirtualMuxAlarm;
         let alarm = kernel::static_buf!(VirtualMuxAlarm<'static, $A>);
         let caliptra_soc = kernel::static_buf!(CaliptraSoC);
         let mbox = kernel::static_buf!(

--- a/runtime/kernel/components/src/mbox_sram.rs
+++ b/runtime/kernel/components/src/mbox_sram.rs
@@ -4,7 +4,7 @@
 
 use caliptra_mcu_registers_generated::mci;
 use caliptra_mcu_romtime::StaticRef;
-use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
+use caliptra_mcu_virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use core::mem::MaybeUninit;
 use kernel::capabilities;
 use kernel::component::Component;
@@ -14,7 +14,7 @@ use kernel::hil::time::Alarm;
 #[macro_export]
 macro_rules! mbox_sram_component_static {
     ($A:ty) => {{
-        use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
+        use caliptra_mcu_virtual_alarm::VirtualMuxAlarm;
         let alarm = kernel::static_buf!(VirtualMuxAlarm<'static, $A>);
         let mbox_sram = kernel::static_buf!(
             caliptra_mcu_capsules_runtime::mbox_sram::MboxSram<

--- a/runtime/kernel/components/src/mctp_driver.rs
+++ b/runtime/kernel/components/src/mctp_driver.rs
@@ -30,7 +30,7 @@ use caliptra_mcu_capsules_runtime::mctp::recv::MCTPRxState;
 use caliptra_mcu_capsules_runtime::mctp::send::MCTPSender;
 use caliptra_mcu_capsules_runtime::mctp::send::MCTPTxState;
 use caliptra_mcu_capsules_runtime::mctp::transport_binding::MCTPI3CBinding;
-use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
+use caliptra_mcu_virtual_alarm::VirtualMuxAlarm;
 use core::mem::MaybeUninit;
 use kernel::capabilities;
 use kernel::component::Component;
@@ -47,7 +47,7 @@ macro_rules! mctp_driver_component_static {
         use caliptra_mcu_capsules_runtime::mctp::recv::MCTPRxState;
         use caliptra_mcu_capsules_runtime::mctp::send::MCTPTxState;
         use caliptra_mcu_capsules_runtime::mctp::transport_binding::MCTPI3CBinding;
-        use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
+        use caliptra_mcu_virtual_alarm::VirtualMuxAlarm;
 
         let tx_state = kernel::static_buf!(
             MCTPTxState<'static, VirtualMuxAlarm<'static, $A>, MCTPI3CBinding<'static>>

--- a/runtime/kernel/components/src/mock_mctp.rs
+++ b/runtime/kernel/components/src/mock_mctp.rs
@@ -7,7 +7,7 @@ use caliptra_mcu_capsules_runtime::mctp::recv::MCTPRxState;
 use caliptra_mcu_capsules_runtime::mctp::send::{MCTPSender, MCTPTxState};
 use caliptra_mcu_capsules_runtime::mctp::transport_binding::MCTPI3CBinding;
 use caliptra_mcu_capsules_runtime::test::mctp::MockMctp;
-use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
+use caliptra_mcu_virtual_alarm::VirtualMuxAlarm;
 use core::mem::MaybeUninit;
 use kernel::component::Component;
 use kernel::hil::time::Alarm;

--- a/runtime/kernel/components/src/mux_mctp.rs
+++ b/runtime/kernel/components/src/mux_mctp.rs
@@ -22,7 +22,7 @@ use caliptra_mcu_capsules_runtime::mctp::transport_binding::{
     MCTPI3CBinding, MCTPTransportBinding,
 };
 use caliptra_mcu_i3c_driver::core::MAX_READ_WRITE_SIZE;
-use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
+use caliptra_mcu_virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use core::mem::MaybeUninit;
 use kernel::component::Component;
 use kernel::deferred_call::DeferredCallClient;
@@ -35,7 +35,7 @@ macro_rules! mctp_mux_component_static {
         use caliptra_mcu_capsules_runtime::mctp::mux::MuxMCTPDriver;
         use caliptra_mcu_capsules_runtime::mctp::transport_binding::MCTPI3CBinding;
         use caliptra_mcu_i3c_driver::core::MAX_READ_WRITE_SIZE;
-        use capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm;
+        use caliptra_mcu_virtual_alarm::VirtualMuxAlarm;
 
         let alarm = kernel::static_buf!(VirtualMuxAlarm<'static, $A>);
         let tx_buffer = kernel::static_buf!([u8; MAX_READ_WRITE_SIZE]);

--- a/runtime/kernel/drivers/i3c/Cargo.toml
+++ b/runtime/kernel/drivers/i3c/Cargo.toml
@@ -8,6 +8,7 @@ edition.workspace = true
 
 [dependencies]
 capsules-core.workspace = true
+caliptra-mcu-virtual-alarm.workspace = true
 kernel.workspace = true
 caliptra-mcu-registers-generated.workspace = true
 caliptra-mcu-romtime.workspace = true

--- a/runtime/kernel/drivers/i3c/src/core.rs
+++ b/runtime/kernel/drivers/i3c/src/core.rs
@@ -8,7 +8,7 @@ use caliptra_mcu_registers_generated::i3c::bits::{
     InterruptEnable, InterruptStatus, Status, StbyCrDeviceAddr,
 };
 use caliptra_mcu_registers_generated::i3c::regs::I3c;
-use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
+use caliptra_mcu_virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use core::cell::Cell;
 use kernel::deferred_call::{DeferredCall, DeferredCallClient};
 use kernel::hil::time::{Alarm, AlarmClient, Time};

--- a/runtime/kernel/veer/Cargo.toml
+++ b/runtime/kernel/veer/Cargo.toml
@@ -8,6 +8,7 @@ edition.workspace = true
 
 [target.'cfg(target_arch = "riscv32")'.dependencies]
 capsules-core.workspace = true
+caliptra-mcu-virtual-alarm.workspace = true
 capsules-extra.workspace = true
 caliptra-mcu-capsules-runtime.workspace = true
 capsules-system.workspace = true

--- a/runtime/kernel/veer/src/chip.rs
+++ b/runtime/kernel/veer/src/chip.rs
@@ -14,7 +14,7 @@ use caliptra_mcu_config::McuMemoryMap;
 use caliptra_mcu_registers_generated::i3c::regs::I3c;
 use caliptra_mcu_registers_generated::mci;
 use caliptra_mcu_registers_generated::otp_ctrl;
-use capsules_core::virtualizers::virtual_alarm::MuxAlarm;
+use caliptra_mcu_virtual_alarm::MuxAlarm;
 use core::fmt::Write;
 use core::ptr::addr_of;
 use kernel::platform::chip::{Chip, InterruptService};
@@ -173,6 +173,16 @@ impl<'a, I: InterruptService + 'a> kernel::platform::chip::Chip for VeeR<'a, I> 
 
     fn service_pending_interrupts(&self) {
         loop {
+            // Poll hardware timer directly: when mstatus.MIE=0 (kernel mode),
+            // timer interrupts stay pending but the ISR never runs. Detect
+            // expiry here and manually save the interrupt for processing.
+            if self.timers.has_timer0_expired()
+                && self.timers.get_saved_interrupts() == TimerInterrupts::None
+            {
+                CSR.mie.modify(mie::BIT29::CLEAR);
+                self.timers.save_interrupt(0);
+            }
+
             if self.pic.get_saved_interrupts().is_some() {
                 unsafe {
                     self.handle_pic_interrupts();
@@ -196,11 +206,25 @@ impl<'a, I: InterruptService + 'a> kernel::platform::chip::Chip for VeeR<'a, I> 
     fn has_pending_interrupts(&self) -> bool {
         self.pic.get_saved_interrupts().is_some()
             || self.timers.get_saved_interrupts() != TimerInterrupts::None
+            || self.timers.has_timer0_expired()
     }
 
     fn sleep(&self) {
         unsafe {
-            rv32i::support::wfi();
+            if self.timers.is_timer0_enabled() {
+                // Timer is armed. Do NOT use wfi — VeeR's wfi stalls the
+                // core clock which stops the timer counter. Briefly enable
+                // MIE for any pending PIC interrupts, then return to let
+                // the kernel loop poll has_timer0_expired().
+                CSR.mstatus.read_and_set_bits(1 << 3);
+                core::arch::asm!("nop");
+                CSR.mstatus.read_and_clear_bits(1 << 3);
+            } else {
+                // No timer armed. Safe to use wfi for PIC interrupts.
+                CSR.mstatus.read_and_set_bits(1 << 3);
+                rv32i::support::wfi();
+                CSR.mstatus.read_and_clear_bits(1 << 3);
+            }
         }
     }
 

--- a/runtime/kernel/veer/src/timers.rs
+++ b/runtime/kernel/veer/src/timers.rs
@@ -141,6 +141,22 @@ impl<'a> InternalTimers<'a> {
             }
         }
     }
+
+    /// Check if timer0 has expired by polling hardware registers.
+    pub fn has_timer0_expired(&self) -> bool {
+        if self.mitctl0.read(mitctl0::enable) == 1 {
+            let cnt = self.mitcnt0.get();
+            let bound = self.mitb0.read(mitb0::bound);
+            bound > 0 && cnt >= bound
+        } else {
+            false
+        }
+    }
+
+    /// Check if timer0 is currently enabled (armed).
+    pub fn is_timer0_enabled(&self) -> bool {
+        self.mitctl0.read(mitctl0::enable) == 1
+    }
 }
 
 /// Platform-specific frequency for the internal timers.
@@ -158,7 +174,15 @@ impl Time for InternalTimers<'_> {
     type Ticks = Ticks64;
 
     fn now(&self) -> Ticks64 {
-        (((self.mcycleh.get() as u64) << 32) | (self.mcycle.get() as u64)).into()
+        // Race-free 64-bit read: retry if mcycleh changed between reads.
+        loop {
+            let hi = self.mcycleh.get() as u64;
+            let lo = self.mcycle.get() as u64;
+            let hi2 = self.mcycleh.get() as u64;
+            if hi == hi2 {
+                return ((hi << 32) | lo).into();
+            }
+        }
     }
 }
 
@@ -187,8 +211,10 @@ impl<'a> time::Alarm<'a> for InternalTimers<'a> {
 
     fn get_alarm(&self) -> Self::Ticks {
         let bound = self.mitb0.read(mitb0::bound) as u64;
+        let counter = self.mitcnt0.get() as u64;
         let now = self.now().into_u64();
-        (now + bound).into()
+        // fire_time = (now - counter) + bound. When expired, returns past time.
+        now.wrapping_sub(counter).wrapping_add(bound).into()
     }
 
     fn disarm(&self) -> Result<(), ErrorCode> {

--- a/runtime/kernel/virtual-alarm/Cargo.toml
+++ b/runtime/kernel/virtual-alarm/Cargo.toml
@@ -1,0 +1,9 @@
+# Licensed under the Apache-2.0 license
+
+[package]
+name = "caliptra-mcu-virtual-alarm"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+kernel.workspace = true

--- a/runtime/kernel/virtual-alarm/src/lib.rs
+++ b/runtime/kernel/virtual-alarm/src/lib.rs
@@ -1,0 +1,251 @@
+// Licensed under the Apache-2.0 license.
+//
+// Caliptra-specific virtual alarm multiplexer.
+#![no_std]
+//
+// This is a replacement for Tock's `capsules_core::virtualizers::virtual_alarm`
+// that removes the `within_range` + `next_tick_vals` optimization which fails
+// on VeeR EL2 FPGA (stale timer state after disable/re-enable cycles).
+//
+// API-compatible drop-in replacement: same types, same trait implementations.
+
+use core::cell::Cell;
+
+use kernel::collections::list::{List, ListLink, ListNode};
+use kernel::hil::time::{self, Alarm, Ticks, Time};
+use kernel::utilities::cells::OptionalCell;
+use kernel::ErrorCode;
+
+#[derive(Copy, Clone)]
+struct TickDtReference<T: Ticks> {
+    reference: T,
+    dt: T,
+    extended: bool,
+}
+
+impl<T: Ticks> TickDtReference<T> {
+    #[inline]
+    fn reference_plus_dt(&self) -> T {
+        self.reference.wrapping_add(self.dt)
+    }
+}
+
+/// Virtual alarm node — drop-in replacement for `capsules_core::VirtualMuxAlarm`.
+pub struct VirtualMuxAlarm<'a, A: Alarm<'a>> {
+    mux: &'a MuxAlarm<'a, A>,
+    dt_reference: Cell<TickDtReference<A::Ticks>>,
+    armed: Cell<bool>,
+    next: ListLink<'a, VirtualMuxAlarm<'a, A>>,
+    client: OptionalCell<&'a dyn time::AlarmClient>,
+}
+
+impl<'a, A: Alarm<'a>> ListNode<'a, VirtualMuxAlarm<'a, A>> for VirtualMuxAlarm<'a, A> {
+    fn next(&self) -> &'a ListLink<VirtualMuxAlarm<'a, A>> {
+        &self.next
+    }
+}
+
+impl<'a, A: Alarm<'a>> VirtualMuxAlarm<'a, A> {
+    pub fn new(mux_alarm: &'a MuxAlarm<'a, A>) -> VirtualMuxAlarm<'a, A> {
+        let zero = A::Ticks::from(0);
+        VirtualMuxAlarm {
+            mux: mux_alarm,
+            dt_reference: Cell::new(TickDtReference {
+                reference: zero,
+                dt: zero,
+                extended: false,
+            }),
+            armed: Cell::new(false),
+            next: ListLink::empty(),
+            client: OptionalCell::empty(),
+        }
+    }
+
+    pub fn setup(&'a self) {
+        self.mux.virtual_alarms.push_head(self);
+    }
+}
+
+impl<'a, A: Alarm<'a>> Time for VirtualMuxAlarm<'a, A> {
+    type Frequency = A::Frequency;
+    type Ticks = A::Ticks;
+
+    fn now(&self) -> Self::Ticks {
+        self.mux.alarm.now()
+    }
+}
+
+impl<'a, A: Alarm<'a>> Alarm<'a> for VirtualMuxAlarm<'a, A> {
+    fn set_alarm_client(&self, client: &'a dyn time::AlarmClient) {
+        self.client.set(client);
+    }
+
+    fn disarm(&self) -> Result<(), ErrorCode> {
+        if !self.armed.get() {
+            return Ok(());
+        }
+
+        self.armed.set(false);
+
+        let enabled = self.mux.enabled.get() - 1;
+        self.mux.enabled.set(enabled);
+
+        if enabled == 0 {
+            let _ = self.mux.alarm.disarm();
+        }
+        Ok(())
+    }
+
+    fn is_armed(&self) -> bool {
+        self.armed.get()
+    }
+
+    fn set_alarm(&self, reference: Self::Ticks, dt: Self::Ticks) {
+        let enabled = self.mux.enabled.get();
+        let half_max = Self::Ticks::half_max_value();
+
+        // Split large dt into two parts to handle wraparound correctly.
+        let dt_reference = if dt > half_max.wrapping_add(self.minimum_dt()) {
+            TickDtReference {
+                reference,
+                dt: dt.wrapping_sub(half_max),
+                extended: true,
+            }
+        } else {
+            TickDtReference {
+                reference,
+                dt,
+                extended: false,
+            }
+        };
+        self.dt_reference.set(dt_reference);
+        let dt = dt_reference.dt;
+
+        if !self.armed.get() {
+            self.mux.enabled.set(enabled + 1);
+            self.armed.set(true);
+        }
+
+        // First alarm: always program hardware.
+        if enabled == 0 {
+            self.mux.set_alarm(reference, dt);
+        } else if !self.mux.firing.get() {
+            // FIX: Always reprogram the hardware timer.
+            //
+            // Tock's original code has a within_range + next_tick_vals guard
+            // here that skips reprogramming when it believes the current alarm
+            // fires sooner. This optimization fails on VeeR EL2 because:
+            //   - get_alarm() returns stale values after timer disable/re-enable
+            //   - next_tick_vals goes stale after alarm expiry
+            //
+            // By always reprogramming, we ensure our alarm's deadline is met.
+            // Earlier alarms that get "overwritten" are still caught in
+            // MuxAlarm::alarm()'s expired-alarm scan.
+            self.mux.set_alarm(reference, dt);
+        }
+        // If firing is true, MuxAlarm::alarm() will rescan and reprogram
+        // for the soonest alarm after all callbacks complete.
+    }
+
+    fn get_alarm(&self) -> Self::Ticks {
+        let dt_reference = self.dt_reference.get();
+        let extension = if dt_reference.extended {
+            Self::Ticks::half_max_value()
+        } else {
+            Self::Ticks::from(0)
+        };
+        dt_reference.reference_plus_dt().wrapping_add(extension)
+    }
+
+    fn minimum_dt(&self) -> Self::Ticks {
+        self.mux.alarm.minimum_dt()
+    }
+}
+
+impl<'a, A: Alarm<'a>> time::AlarmClient for VirtualMuxAlarm<'a, A> {
+    fn alarm(&self) {
+        self.client.map(|client| client.alarm());
+    }
+}
+
+/// Alarm multiplexer — drop-in replacement for `capsules_core::MuxAlarm`.
+pub struct MuxAlarm<'a, A: Alarm<'a>> {
+    virtual_alarms: List<'a, VirtualMuxAlarm<'a, A>>,
+    enabled: Cell<usize>,
+    alarm: &'a A,
+    firing: Cell<bool>,
+}
+
+impl<'a, A: Alarm<'a>> MuxAlarm<'a, A> {
+    pub const fn new(alarm: &'a A) -> MuxAlarm<'a, A> {
+        MuxAlarm {
+            virtual_alarms: List::new(),
+            enabled: Cell::new(0),
+            alarm,
+            firing: Cell::new(false),
+        }
+    }
+
+    fn set_alarm(&self, reference: A::Ticks, dt: A::Ticks) {
+        self.alarm.set_alarm(reference, dt);
+    }
+
+    fn disarm(&self) {
+        let _ = self.alarm.disarm();
+    }
+}
+
+impl<'a, A: Alarm<'a>> time::AlarmClient for MuxAlarm<'a, A> {
+    fn alarm(&self) {
+        self.firing.set(true);
+
+        // Fire all expired alarms.
+        self.virtual_alarms
+            .iter()
+            .filter(|cur| {
+                let dt_ref = cur.dt_reference.get();
+                let now = self.alarm.now();
+                cur.armed.get() && !now.within_range(dt_ref.reference, dt_ref.reference_plus_dt())
+            })
+            .for_each(|cur| {
+                let dt_ref = cur.dt_reference.get();
+                if dt_ref.extended {
+                    // First half of extended alarm fired; set up second half.
+                    cur.dt_reference.set(TickDtReference {
+                        reference: dt_ref.reference_plus_dt(),
+                        dt: A::Ticks::half_max_value(),
+                        extended: false,
+                    });
+                } else {
+                    // Alarm fully expired.
+                    cur.armed.set(false);
+                    self.enabled.set(self.enabled.get() - 1);
+                    cur.alarm();
+                }
+            });
+
+        self.firing.set(false);
+
+        // Find the soonest remaining alarm and reprogram hardware.
+        let now = self.alarm.now();
+        let next = self
+            .virtual_alarms
+            .iter()
+            .filter(|cur| cur.armed.get())
+            .min_by_key(|cur| {
+                let when = cur.dt_reference.get();
+                if !now.within_range(when.reference, when.reference_plus_dt()) {
+                    A::Ticks::from(0u32)
+                } else {
+                    when.reference_plus_dt().wrapping_sub(now)
+                }
+            });
+
+        if let Some(valrm) = next {
+            let dt_reference = valrm.dt_reference.get();
+            self.set_alarm(dt_reference.reference, dt_reference.dt);
+        } else {
+            self.disarm();
+        }
+    }
+}


### PR DESCRIPTION
Replace Tock's VirtualMuxAlarm with a custom CaliptraVirtualAlarm that removes the within_range + next_tick_vals optimization. This optimization fails on VeeR EL2 because stale timer state after disable/re-enable cycles causes the guard to skip hardware reprogramming.

Changes:
- Add caliptra-mcu-virtual-alarm crate as drop-in replacement for capsules_core::virtualizers::virtual_alarm
- Update all imports across the codebase to use the new crate
- Add hardware timer polling (has_timer0_expired) in chip.rs to detect timer expiry when ISR can't run (mstatus.MIE=0 in kernel mode)
- Skip wfi when timer is armed since VeeR's wfi stalls the core clock and stops the internal timer counter
- Fix get_alarm() wrapping arithmetic so expired timers return past time
- Fix now() with race-free 64-bit read (mcycleh/mcycle retry loop)
- Remove ProcessConsole (incompatible with custom MuxAlarm, debug-only)

Tested on FPGA: test_firmware_update_streaming_fpga passes (534s).
Tested on emulator: test_streaming_soc_boot_successful passes (212s).