### PR TITLE
[doc] Clarify fuse bit-count encoding terminology

### DIFF
--- a/docs/src/fuses.md
+++ b/docs/src/fuses.md
@@ -158,6 +158,16 @@ The firmware uses a `FuseLayout` enum to define how fuse values are stored and i
 
 Note that u32s (dwords) are always packed in little-endian byte order and big-endian bit order.
 
+Terminology note: the current `OneHot` layout names are existing schema/API
+names. In this codebase, `OneHot` does **not** mean true one-hot encoding where
+exactly one bit is set and the bit position is the value. It means a monotonic
+bit-count, or thermometer-style, counter where the logical value is the number
+of set bits.
+For example, logical value 3 is encoded as `0b0111`, not `0b1000`. This style is
+useful for OTP counters because incrementing only requires burning one more bit.
+Revocation fields and validity masks are separate bitmasks, where each bit has
+an independent meaning.
+
 ### Layout Types
 
 #### Single
@@ -168,14 +178,18 @@ Values stored this way in fuses should be protected with ECC.
 
 **Example:** A 4-bit value `0b1101` is stored as `0b1101`
 
-#### OneHot
+#### Bit-count counter (`OneHot` layout name)
 
-The logical value is the count of bits set to 1 in the fuse field. This is commonly used for version numbers and counters where incrementing requires only burning one additional fuse.
+The logical value is the count of bits set to 1 in the fuse field. Writers encode
+logical value `n` as `(1 << n) - 1`. This is commonly used for version numbers
+and counters where incrementing requires only burning one additional fuse.
 
 The values can span multiple u32 words but the result is always a single u32 count value.
 
 **Example:**
 - `0b0000` → 0
+- `0b0001` → 1
+- `0b0011` → 2
 - `0b0111` → 3
 
 Caution: This method of storing fuses is dangerous, since generally ECC cannot be used if the value can be incremented after the initial value is written.
@@ -194,9 +208,11 @@ Generally this method is used for values that do not have ECC protection but are
 
 #### OneHotLinearMajorityVote
 
-Combines `LinearMajorityVote` with `OneHot` encoding. First applies majority voting to each duplicated bit, then counts the number of bits set.
+Combines `LinearMajorityVote` with the `OneHot` bit-count counter layout. First applies majority voting to each duplicated bit, then counts the number of bits set.
 
-This is the recommended way to
+This stores an incrementable counter with majority-vote redundancy, but OR-based
+redundancy is generally preferred for OTP counters because OTP write failures are
+more likely to leave a bit stuck at 0 than to create a spontaneous 1.
 
 **Example:** With 3 logical bits and 3x duplication:
 - Raw fuses: `0b100_110_111` (bit 0 has votes `111`, bit 1 has votes `110`, bit 2 has votes `100`)
@@ -230,7 +246,7 @@ With majority vote the same raw value would yield `0b01` (bit 1 fails the ≥2 t
 
 #### OneHotLinearOr
 
-Combines `LinearOr` with `OneHot` encoding. First applies OR reduction to each duplicated bit, then counts the number of bits set.
+Combines `LinearOr` with the `OneHot` bit-count counter layout. First applies OR reduction to each duplicated bit, then counts the number of bits set.
 
 **Example:** With 3 logical bits and 3x duplication:
 - Raw fuses: `0b001_010_111` (bit 0 has copies `111`, bit 1 has copies `010`, bit 2 has copies `001`)
@@ -260,8 +276,8 @@ Entire u32 words are duplicated. Each bit position across the duplicated words i
 
 The default `McuFuseLayoutPolicy` uses:
 - `Single`: For certificate data, identifiers, and validity flags that are assumed to be protected by ECC
-- `OneHotLinearOr` (3x): For SVN fields and counters
-- `LinearOr` (3x): for single revocation fields and flags
-- `WordMajorityVote` (3x): for revocation bitmasks
+- `OneHotLinearOr` (3x): for monotonic bit-count counters such as SVN fields
+- `LinearOr` (3x): for single flags and small bitmasks
+- `WordMajorityVote` (3x): for large bitmasks
 
 This provides a balance between redundancy for critical security fields and storage efficiency for larger data structures.

--- a/docs/src/integrator-guide.md
+++ b/docs/src/integrator-guide.md
@@ -9,9 +9,9 @@ Caliptra MCU.
 
 The `dot_fuse_array` field in the vendor non-secret OTP partition tracks Device
 Ownership Transfer (DOT) state transitions. Each state change (lock, unlock,
-disable) burns one bit, using a `OneHot` encoding. The total number of bits
-determines the maximum number of ownership state transitions over the lifetime
-of the part.
+disable) burns one bit, using the current MCU `OneHot` layout name for a
+monotonic bit-count counter. The total number of bits determines the maximum
+number of ownership state transitions over the lifetime of the part.
 
 A full ownership transfer cycle (install → lock → unlock) consumes **2 fuse
 bits**: one for the lock transition (EVEN → ODD) and one for the unlock
@@ -45,12 +45,12 @@ no redundant encoding is needed.
 | Fuse field | Partition | Size | Encoding | Notes |
 |---|---|:---:|---|---|
 | `dot_initialized` | `VENDOR_NON_SECRET_PROD_PARTITION` | 1 bit (3 bytes with 3× majority vote) | `LinearMajorityVote` | Gates the DOT flow. |
-| `dot_fuse_array` | `VENDOR_NON_SECRET_PROD_PARTITION` | 256 bits (32 bytes) | `OneHot` | State counter. Scales linearly with desired lock/unlock cycles. |
+| `dot_fuse_array` | `VENDOR_NON_SECRET_PROD_PARTITION` | 256 bits (32 bytes) | `OneHot` (bit-count counter) | State counter. Scales linearly with desired lock/unlock cycles. |
 | `vendor_recovery_pk_hash` | `VENDOR_SECRET_PROD_PARTITION` | 384 bits (48 bytes) | `Single` | Optional. For `DOT_OVERRIDE` catastrophic recovery. |
 
 If OTP space is constrained, the `dot_fuse_array` can be made smaller — the
 minimum useful size is 2 bits, but this only allows a single lock/unlock cycle
-with no margin. If redundant encoding (`OneHotLinearMajorityVote`) is used,
+with no margin. If redundant bit-count encoding (`OneHotLinearMajorityVote`) is used,
 multiply the raw bit count by the duplication factor (e.g., 3×).
 
 A different partition can also be used if there is one specifically allocated in

--- a/docs/src/rom-fuses.md
+++ b/docs/src/rom-fuses.md
@@ -83,7 +83,7 @@ can be reclaimed.
 | Fuse | Logical size | Feature | Notes |
 |---|---|---|---|
 | `dot_initialized` | 1 bit | DOT | Gate flag indicating DOT flow is active for this part |
-| `dot_fuse_array` | 256 bits | DOT | One-hot DOT state counter; supports 128 lock/unlock cycles; more or less can be allocated depending on use cases |
+| `dot_fuse_array` | 256 bits | DOT | Monotonic bit-count DOT state counter; supports 128 lock/unlock cycles; more or less can be allocated depending on use cases |
 | `vendor_recovery_pk_hash` | 384 bits | DOT | Vendor master key for `DOT_OVERRIDE` catastrophic recovery (lives in `VENDOR_SECRET_PROD_PARTITION`). One slot today; integrators that need rotation should add `vendor_recovery_pk_hash_{0..N}` + a `vendor_recovery_pk_hash_valid` bitmask and/or revocation bits |
 | `MCU_COMPONENT_SVN_MANIFEST_MIN_SVN` | 32 bits (recommended) | MCU SVN anti-rollback | Min SVN for the MCU Component SVN Manifest itself |
 | `SOC_IMAGE_MIN_SVN[0..M]` | 32 bits each (recommended) | MCU SVN anti-rollback | Per-slot SoC image min SVN; `M` is integrator-defined |
@@ -91,7 +91,7 @@ can be reclaimed.
 | `CPTRA_SS_LOCK_HEK_PROD_{0..7}` | 256 bits each | OCP LOCK (2.1+) | 8 HEK seed slots (`CPTRA_SS_LOCK_HEK_PROD_N_RATCHET_SEED`, 32 B each); one active at a time |
 
 The MCU SVN fuse sizes above are the recommended logical widths from
-[`docs/src/svn.md`](svn.md); integrators choose the actual one-hot width and
+[`docs/src/svn.md`](svn.md); integrators choose the actual bit-count width and
 number of `SOC_IMAGE_MIN_SVN` slots based on their release cadence and
 component count.
 
@@ -190,7 +190,7 @@ transformation from raw OTP bytes to written value. ✓ = Caliptra core fuse reg
   0 or 1, used as the DOT flow gate.
 
 - **`dot_fuse_array`** — MCU internal
-  use only, not written to any register. `OneHot{bits:256}` → count of burned bits, used to track
+  use only, not written to any register. `OneHot{bits:256}` (current layout name for bit-count encoding) → count of burned bits, used to track
   the DOT state counter. Also written (next bit burned) during DOT state transitions.
 
 - **`perma_hek_en`** (2.1+) — MCU internal use only, not written to any register.
@@ -268,7 +268,7 @@ fault tolerance without causing ECC integrity issues.
 | `CPTRA_SS_OWNER_PK_HASH` | ✅ | `Single{bits:384}` |
 | `CPTRA_SS_PROD_DEBUG_UNLOCK_PKS_{0..7}` | ✅ | `Single{bits:384}` each |
 | `dot_initialized` | ✅ | `Single{bits:1}` or if no ECC, `LinearMajorityVote{bits:1, dupe:3}` |
-| `dot_fuse_array` | ❌ | `OneHot{bits:256}` or `OneHotLinearMajorityVote{bits:256, dupe: 3}` |
+| `dot_fuse_array` | ❌ | `OneHot{bits:256}` or `OneHotLinearMajorityVote{bits:256, dupe: 3}` (current layout names for bit-count encodings) |
 | `cptra_itrng_health_test_window_size` | ✅ | `Single{bits:16}` |
 | `cptra_itrng_entropy_config_0` | ✅ | `Single{bits:32}` |
 | `cptra_itrng_entropy_config_1` | ✅ | `Single{bits:32}` |
@@ -447,15 +447,16 @@ MCU ROM decode, and the final Caliptra `FUSE_PQC_KEY_TYPE` register value.
 | Layout | `OneHotLinearMajorityVote { bits: 2, duplication: 3 }` |
 
 Unlike the PK hash, this field uses the `OneHotLinearMajorityVote` layout for
-fault tolerance. The `OneHotLinearMajorityVote { bits: 2, duplication: 3 }`
+fault tolerance. Despite the historical name, this is a bit-count encoding, not
+true one-hot encoding. The `OneHotLinearMajorityVote { bits: 2, duplication: 3 }`
 layout encodes a logical integer using two stages:
 
-1. **OneHot**: the logical value `n` is encoded as `n` consecutive 1-bits: `onehot = (1 << n) - 1`
-2. **LinearMajorityVote**: each bit of the OneHot value is replicated `duplication` (3) times in
+1. **Bit-count pattern**: the logical value `n` is encoded as `n` consecutive 1-bits: `bits = (1 << n) - 1`
+2. **LinearMajorityVote**: each bit of that pattern is replicated `duplication` (3) times in
    consecutive bit positions. The 2 logical bits × 3 replications = 6 physical bits, packed into
    the low 6 bits of the 4-byte field.
 
-| Key type | Logical value | OneHot bits | OTP raw u32 | OTP bytes @ `0x428` |
+| Key type | Logical value | Bit-count pattern | OTP raw u32 | OTP bytes @ `0x428` |
 |---|:---:|:---:|:---:|:---:|
 | MLDSA | 1 | `0b01` | `0x00000007` | `07 00 00 00` |
 | LMS | 2 | `0b11` | `0x0000003F` | `3f 00 00 00` |
@@ -467,7 +468,7 @@ If that is the case, then the duplication and majority vote in this example can 
 
 ### Example: CPTRA_CORE_PQC_KEY_TYPE_0 (LMS)
 
-We trace `vendor_pqc_key_type_0` provisioned for LMS, i.e., the one-hot encoded value of 0b11 (logical value 2, one-hot encoded as 3), expected by Caliptra core ROM for LMS.
+We trace `vendor_pqc_key_type_0` provisioned for LMS, i.e., the bit-count encoded value `0b11` (logical value 2), expected by Caliptra core ROM for LMS.
 
 #### Layer 1: OTP Raw Bytes
 

--- a/docs/src/svn.md
+++ b/docs/src/svn.md
@@ -92,7 +92,7 @@ Added in a vendor partition (e.g., `VENDOR_NON_SECRET_PROD_PARTITION`):
 | `MCU_COMPONENT_SVN_MANIFEST_MIN_SVN` | 4 B | `OneHotLinearOr{bits:N, dupe:3}` | Min SVN for the MCU Component SVN Manifest itself |
 | `SOC_IMAGE_MIN_SVN[0..M]` | 4 B each | `OneHotLinearOr{bits:N, dupe:3}` | Per-slot SoC image min SVN (optional) |
 
-The number of `SOC_IMAGE_MIN_SVN` slots (`M`) and the number of one-hot bits
+The number of `SOC_IMAGE_MIN_SVN` slots (`M`) and the number of bit-count bits
 per slot are integrator-defined. `MCU_COMPONENT_SVN_MANIFEST_MIN_SVN` exists
 even when the integrator does not provision any `SOC_IMAGE_MIN_SVN` slots,
 because the manifest's own anti-rollback applies regardless of how many
@@ -100,17 +100,20 @@ component slots are mapped.
 
 #### Encoding
 
-SVN fuses **must** use a one-hot encoding so that incrementing requires only
-burning an additional bit (any other encoding would either need 1→0 transitions
-or provide no rollback protection). The recommended layout is `OneHotLinearOr`
-with 3× duplication: OR semantics tolerate single-bit read errors without ECC,
-which is incompatible with fields written more than once. OR is preferred over
+SVN fuses **must** use a monotonic bit-count encoding so that incrementing
+requires only burning an additional bit (any other encoding would either need
+1→0 transitions or provide no rollback protection). In the current MCU fuse
+layout names this is called `OneHot`, but it is not true one-hot encoding; it is
+decoded by counting set bits. The recommended layout is `OneHotLinearOr` with
+3× duplication: OR semantics tolerate single-bit read errors without ECC, which
+is incompatible with fields written more than once. OR is preferred over
 majority vote because OTP bits are far more likely to fail stuck-at-0 than to
 spontaneously flip to 1.
 
 Integrators with hardware-level fuse redundancy can use a plain `OneHot{bits:N}`
-layout. Other one-hot variants (e.g., `OneHotLinearMajorityVote`) are also
-acceptable. Non-one-hot encodings (e.g., `Single`) cannot be used.
+layout as currently named by MCU software. Other bit-count variants (e.g.,
+`OneHotLinearMajorityVote`) are also acceptable when their fault model is
+appropriate. Literal encodings such as `Single` cannot be used.
 
 See [Fuse Layout Options](fuses.md#fuse-layout-options) for encoding details.
 
@@ -163,14 +166,14 @@ Header constraints (validated; header is rejected on violation):
 
 - `min_svn ≤ current_svn` (manifest-self).
 - Each requested floor (`min_svn`, `caliptra_runtime_min_svn`,
-  `soc_manifest_min_svn`) must fit within its target fuse's one-hot range
+  `soc_manifest_min_svn`) must fit within its target fuse's bit-count range
   (`MCU_COMPONENT_SVN_MANIFEST_MIN_SVN`, `CPTRA_CORE_RUNTIME_SVN`,
   `CPTRA_CORE_SOC_MANIFEST_SVN` respectively).
 
 Per-entry constraints (validated; entry is rejected on violation):
 
 - `min_svn ≤ current_svn`
-- Both values must fit within the corresponding fuse slot's one-hot range.
+- Both values must fit within the corresponding fuse slot's bit-count range.
 
 ### Caliptra runtime and SoC manifest SVN floors
 
@@ -309,7 +312,7 @@ Note: Caliptra fuse registers are latched at cold-boot fuse-write time
 and cannot be re-written during a warm/update reset. Any OTP burn that
 MCU ROM performs after a hitless update therefore only gates Caliptra
 authentication on the *next* cold boot — power-fail safe via the OTP
-one-hot encoding.
+bit-count encoding.
 
 ### Cold Boot and Hitless Update — MCU Component SVN Manifest burn
 
@@ -328,7 +331,7 @@ for those whose `component_id` is in `SVN_FUSE_MAP`, advances the mapped
    with a logged warning (lets new components ship without a dedicated
    fuse slot).
 2. Reject the boot if `entry.current_svn` or `entry.min_svn` exceeds the
-   slot's one-hot range, or if `entry.current_svn < fuse_min_svn`
+   slot's bit-count range, or if `entry.current_svn < fuse_min_svn`
    (rollback).
 3. If `entry.min_svn > fuse_min_svn` and anti-rollback is not disabled,
    burn the slot to `entry.min_svn` and read back to verify.
@@ -368,8 +371,8 @@ For each component in the bundle:
    - Verify the trait-extracted SVN matches the MCU Component SVN Manifest's
      `current_svn` for that component. A mismatch means the manifest and
      image disagree — reject the bundle.
-   - Reject if `current_svn < fuse_min_svn`, or if either `current_svn` or
-     `min_svn` exceeds the slot's one-hot range.
+    - Reject if `current_svn < fuse_min_svn`, or if either `current_svn` or
+       `min_svn` exceeds the slot's bit-count range.
 
 Components without a `SocComponentSvn` implementation skip the
 manifest-vs-image cross-check (a logged warning) but still get the
@@ -449,7 +452,7 @@ committing *any* burn. This guarantees a rejected boot never leaves the
 device with partially-advanced floors; once the burn phase starts, only
 a genuine OTP write/readback hardware error can halt it.
 
-The burn is power-fail safe: one-hot encoding plus OR semantics mean a partial
+The burn is power-fail safe: bit-count encoding plus OR semantics mean a partial
 burn can never decrease the fuse value, and any incomplete burn will be
 re-attempted (and complete) on the next boot.
 
@@ -544,7 +547,7 @@ disable polarity (burning removes a security property) for compatibility with
 the existing Caliptra fuse. Provisioning flows must never set this fuse on
 production devices; ROM should add lifecycle-state checks to enforce this.
 
-**SVN exhaustion.** With one-hot encoding, the maximum `min_svn` equals the
+**SVN exhaustion.** With bit-count encoding, the maximum `min_svn` equals the
 number of allocated bits (e.g., 32 bits → max SVN of 32). Since `current_svn`
 can advance without `min_svn`, exhaustion is rare in practice. At exhaustion,
 no further `min_svn` updates are possible but the device continues to enforce

--- a/emulator/periph/src/otp.rs
+++ b/emulator/periph/src/otp.rs
@@ -151,7 +151,7 @@ impl Otp {
             let size = fuses::OTP_CPTRA_SS_OWNER_PK_HASH.byte_size;
             otp.partitions.borrow_mut()[offset..offset + size].copy_from_slice(&owner_pk_hash);
         }
-        // Encode as one-hot + duplication to match the fuse layout
+        // Encode as bit-count + duplication to match the fuse layout
         // (OneHotLinear{MajorityVote,Or}, bits: 2, duplication: 3):
         // MLDSA = thermometer value 1 (bit 0 set), duplicated 3x = 0b000111 = 0x07.
         // LMS   = thermometer value 2 (bits 0-1 set), duplicated 3x = 0b111111 = 0x3F.

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -285,7 +285,7 @@ impl McuError {
         (
             ROM_FUSE_LAYOUT_ONE_HOT_RESULT_SHOULD_BE_SINGLE_U32,
             0x3_0009,
-            "One-hot encoded output should be single u32"
+            "Bit-count encoded output should be single u32"
         ),
         (
             ROM_FUSE_VALUE_TOO_LARGE,

--- a/hw/fuses.hjson
+++ b/hw/fuses.hjson
@@ -115,7 +115,7 @@
     {
       name: "mcu_component_svn_manifest_min_svn",
       bits: 10,
-      description: "MCU Component SVN Manifest min SVN (one-hot, used by MCU ROM for manifest-format anti-rollback).",
+      description: "MCU Component SVN Manifest min SVN (bit-count counter, used by MCU ROM for manifest-format anti-rollback).",
       partition: "VENDOR_NON_SECRET_PROD_PARTITION",
       otp_item: "CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_5",
       layout: {type: "OneHotLinearOr", duplication: 3},
@@ -123,7 +123,7 @@
     {
       name: "soc_image_min_svn_0",
       bits: 10,
-      description: "SoC component min SVN for fuse slot 0 (one-hot, optional per-component rollback floor mapped via SVN_FUSE_MAP).",
+      description: "SoC component min SVN for fuse slot 0 (bit-count counter, optional per-component rollback floor mapped via SVN_FUSE_MAP).",
       partition: "VENDOR_NON_SECRET_PROD_PARTITION",
       otp_item: "CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_6",
       layout: {type: "OneHotLinearOr", duplication: 3},
@@ -131,7 +131,7 @@
     {
       name: "soc_image_min_svn_1",
       bits: 10,
-      description: "SoC component min SVN for fuse slot 1 (one-hot, optional per-component rollback floor mapped via SVN_FUSE_MAP).",
+      description: "SoC component min SVN for fuse slot 1 (bit-count counter, optional per-component rollback floor mapped via SVN_FUSE_MAP).",
       partition: "VENDOR_NON_SECRET_PROD_PARTITION",
       otp_item: "CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_7",
       layout: {type: "OneHotLinearOr", duplication: 3},
@@ -531,7 +531,7 @@
     {
         name: "vendor_pqc_key_type_0",
         bits: 2,
-        description: "One-hot encoded PQC key type for slot 0 (1: MLDSA, 2: LMS).",
+        description: "Bit-count encoded PQC key type for slot 0 (1: MLDSA, 2: LMS).",
         partition: "VENDOR_HASHES_MANUF_PARTITION",
         otp_item: "CPTRA_CORE_PQC_KEY_TYPE_0",
         layout: {type: "OneHotLinearOr", duplication: 3},
@@ -539,7 +539,7 @@
     {
         name: "vendor_pqc_key_type_1",
         bits: 2,
-        description: "One-hot encoded PQC key type for slot 1 (1: MLDSA, 2: LMS).",
+        description: "Bit-count encoded PQC key type for slot 1 (1: MLDSA, 2: LMS).",
         partition: "VENDOR_HASHES_PROD_PARTITION",
         otp_item: "CPTRA_CORE_PQC_KEY_TYPE_1",
         layout: {type: "OneHotLinearOr", duplication: 3},
@@ -547,7 +547,7 @@
     {
         name: "vendor_pqc_key_type_2",
         bits: 2,
-        description: "One-hot encoded PQC key type for slot 2 (1: MLDSA, 2: LMS).",
+        description: "Bit-count encoded PQC key type for slot 2 (1: MLDSA, 2: LMS).",
         partition: "VENDOR_HASHES_PROD_PARTITION",
         otp_item: "CPTRA_CORE_PQC_KEY_TYPE_2",
         layout: {type: "OneHotLinearOr", duplication: 3},
@@ -555,7 +555,7 @@
     {
         name: "vendor_pqc_key_type_3",
         bits: 2,
-        description: "One-hot encoded PQC key type for slot 3 (1: MLDSA, 2: LMS).",
+        description: "Bit-count encoded PQC key type for slot 3 (1: MLDSA, 2: LMS).",
         partition: "VENDOR_HASHES_PROD_PARTITION",
         otp_item: "CPTRA_CORE_PQC_KEY_TYPE_3",
         layout: {type: "OneHotLinearOr", duplication: 3},
@@ -563,7 +563,7 @@
     {
         name: "vendor_pqc_key_type_4",
         bits: 2,
-        description: "One-hot encoded PQC key type for slot 4 (1: MLDSA, 2: LMS).",
+        description: "Bit-count encoded PQC key type for slot 4 (1: MLDSA, 2: LMS).",
         partition: "VENDOR_HASHES_PROD_PARTITION",
         otp_item: "CPTRA_CORE_PQC_KEY_TYPE_4",
         layout: {type: "OneHotLinearOr", duplication: 3},
@@ -571,7 +571,7 @@
     {
         name: "vendor_pqc_key_type_5",
         bits: 2,
-        description: "One-hot encoded PQC key type for slot 5 (1: MLDSA, 2: LMS).",
+        description: "Bit-count encoded PQC key type for slot 5 (1: MLDSA, 2: LMS).",
         partition: "VENDOR_HASHES_PROD_PARTITION",
         otp_item: "CPTRA_CORE_PQC_KEY_TYPE_5",
         layout: {type: "OneHotLinearOr", duplication: 3},
@@ -579,7 +579,7 @@
     {
         name: "vendor_pqc_key_type_6",
         bits: 2,
-        description: "One-hot encoded PQC key type for slot 6 (1: MLDSA, 2: LMS).",
+        description: "Bit-count encoded PQC key type for slot 6 (1: MLDSA, 2: LMS).",
         partition: "VENDOR_HASHES_PROD_PARTITION",
         otp_item: "CPTRA_CORE_PQC_KEY_TYPE_6",
         layout: {type: "OneHotLinearOr", duplication: 3},
@@ -587,7 +587,7 @@
     {
         name: "vendor_pqc_key_type_7",
         bits: 2,
-        description: "One-hot encoded PQC key type for slot 7 (1: MLDSA, 2: LMS).",
+        description: "Bit-count encoded PQC key type for slot 7 (1: MLDSA, 2: LMS).",
         partition: "VENDOR_HASHES_PROD_PARTITION",
         otp_item: "CPTRA_CORE_PQC_KEY_TYPE_7",
         layout: {type: "OneHotLinearOr", duplication: 3},
@@ -595,7 +595,7 @@
     {
         name: "vendor_pqc_key_type_8",
         bits: 2,
-        description: "One-hot encoded PQC key type for slot 8 (1: MLDSA, 2: LMS).",
+        description: "Bit-count encoded PQC key type for slot 8 (1: MLDSA, 2: LMS).",
         partition: "VENDOR_HASHES_PROD_PARTITION",
         otp_item: "CPTRA_CORE_PQC_KEY_TYPE_8",
         layout: {type: "OneHotLinearOr", duplication: 3},
@@ -603,7 +603,7 @@
     {
         name: "vendor_pqc_key_type_9",
         bits: 2,
-        description: "One-hot encoded PQC key type for slot 9 (1: MLDSA, 2: LMS).",
+        description: "Bit-count encoded PQC key type for slot 9 (1: MLDSA, 2: LMS).",
         partition: "VENDOR_HASHES_PROD_PARTITION",
         otp_item: "CPTRA_CORE_PQC_KEY_TYPE_9",
         layout: {type: "OneHotLinearOr", duplication: 3},
@@ -611,7 +611,7 @@
     {
         name: "vendor_pqc_key_type_10",
         bits: 2,
-        description: "One-hot encoded PQC key type for slot 10 (1: MLDSA, 2: LMS).",
+        description: "Bit-count encoded PQC key type for slot 10 (1: MLDSA, 2: LMS).",
         partition: "VENDOR_HASHES_PROD_PARTITION",
         otp_item: "CPTRA_CORE_PQC_KEY_TYPE_10",
         layout: {type: "OneHotLinearOr", duplication: 3},
@@ -619,7 +619,7 @@
     {
         name: "vendor_pqc_key_type_11",
         bits: 2,
-        description: "One-hot encoded PQC key type for slot 11 (1: MLDSA, 2: LMS).",
+        description: "Bit-count encoded PQC key type for slot 11 (1: MLDSA, 2: LMS).",
         partition: "VENDOR_HASHES_PROD_PARTITION",
         otp_item: "CPTRA_CORE_PQC_KEY_TYPE_11",
         layout: {type: "OneHotLinearOr", duplication: 3},
@@ -627,7 +627,7 @@
     {
         name: "vendor_pqc_key_type_12",
         bits: 2,
-        description: "One-hot encoded PQC key type for slot 12 (1: MLDSA, 2: LMS).",
+        description: "Bit-count encoded PQC key type for slot 12 (1: MLDSA, 2: LMS).",
         partition: "VENDOR_HASHES_PROD_PARTITION",
         otp_item: "CPTRA_CORE_PQC_KEY_TYPE_12",
         layout: {type: "OneHotLinearOr", duplication: 3},
@@ -635,7 +635,7 @@
     {
         name: "vendor_pqc_key_type_13",
         bits: 2,
-        description: "One-hot encoded PQC key type for slot 13 (1: MLDSA, 2: LMS).",
+        description: "Bit-count encoded PQC key type for slot 13 (1: MLDSA, 2: LMS).",
         partition: "VENDOR_HASHES_PROD_PARTITION",
         otp_item: "CPTRA_CORE_PQC_KEY_TYPE_13",
         layout: {type: "OneHotLinearOr", duplication: 3},
@@ -643,7 +643,7 @@
     {
         name: "vendor_pqc_key_type_14",
         bits: 2,
-        description: "One-hot encoded PQC key type for slot 14 (1: MLDSA, 2: LMS).",
+        description: "Bit-count encoded PQC key type for slot 14 (1: MLDSA, 2: LMS).",
         partition: "VENDOR_HASHES_PROD_PARTITION",
         otp_item: "CPTRA_CORE_PQC_KEY_TYPE_14",
         layout: {type: "OneHotLinearOr", duplication: 3},
@@ -651,7 +651,7 @@
     {
         name: "vendor_pqc_key_type_15",
         bits: 2,
-        description: "One-hot encoded PQC key type for slot 15 (1: MLDSA, 2: LMS).",
+        description: "Bit-count encoded PQC key type for slot 15 (1: MLDSA, 2: LMS).",
         partition: "VENDOR_HASHES_PROD_PARTITION",
         otp_item: "CPTRA_CORE_PQC_KEY_TYPE_15",
         layout: {type: "OneHotLinearOr", duplication: 3},

--- a/hw/model/src/vmem.rs
+++ b/hw/model/src/vmem.rs
@@ -257,8 +257,8 @@ mod tests {
     #[test]
     fn test_pqc_key_type_doc_example() {
         // For OneHotLinearMajorityVote { bits: 2, duplication: 3 }:
-        //   MLDSA logical value = 1 → onehot = 0b01 → raw = 0x00000007
-        //   LMS   logical value = 2 → onehot = 0b11 → raw = 0x0000003F
+        //   MLDSA logical value = 1 → bit-count pattern = 0b01 → raw = 0x00000007
+        //   LMS   logical value = 2 → bit-count pattern = 0b11 → raw = 0x0000003F
         let cases: &[(&str, u32, u16)] =
             &[("MLDSA", 0x00000007, 0x0007), ("LMS", 0x0000003F, 0x003f)];
 

--- a/registers/fuses/src/schema.rs
+++ b/registers/fuses/src/schema.rs
@@ -31,17 +31,18 @@ pub struct FusePartitionInfo {
 pub enum FuseLayoutPolicy {
     /// Values stored literally
     Single,
-    /// Value is the count of bits set (one-hot encoding)
+    /// Current layout name for a monotonic bit-count / thermometer-style counter.
+    /// The logical value is the count of bits set, not true one-hot.
     OneHot,
     /// Each bit duplicated with majority vote
     LinearMajorityVote { duplication: u32 },
-    /// One-hot with linear majority vote
+    /// `OneHot` bit-count counter with linear majority vote
     OneHotLinearMajorityVote { duplication: u32 },
     /// Words duplicated with per-bit majority vote
     WordMajorityVote { duplication: u32 },
     /// Each bit duplicated with OR reduction (any copy set → result is 1)
     LinearOr { duplication: u32 },
-    /// One-hot with linear OR reduction
+    /// `OneHot` bit-count counter with linear OR reduction
     OneHotLinearOr { duplication: u32 },
     /// Words duplicated with per-bit OR reduction
     WordOr { duplication: u32 },

--- a/registers/generated-firmware/src/fuse_map.md
+++ b/registers/generated-firmware/src/fuse_map.md
@@ -329,9 +329,9 @@
 | cptra_itrng_entropy_config_1 | 32 | VENDOR_NON_SECRET_PROD_PARTITION | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_5 | Single | Entropy config 1: Repetition count (bits 15:0), Alert threshold (bits 31:16). See [spec](https://chipsalliance.github.io/caliptra-web/docs/2.1/firmware/rom_spec.html#entropy-source-configuration-registers) for details. |
 | stable_owner_key_personalization_seed | 256 | VENDOR_NON_SECRET_PROD_PARTITION | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_6 | Single | Personalization seed for stable owner key derivation. |
 | vendor_recovery_pk_hash | 384 | VENDOR_NON_SECRET_PROD_PARTITION | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_8 | Single | Vendor recovery key for DOT_OVERRIDE catastrophic recovery operations |
-| mcu_component_svn_manifest_min_svn | 10 | VENDOR_NON_SECRET_PROD_PARTITION | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_5 | OneHotLinearOr(3x) | MCU Component SVN Manifest min SVN (one-hot, used by MCU ROM for manifest-format anti-rollback). |
-| soc_image_min_svn_0 | 10 | VENDOR_NON_SECRET_PROD_PARTITION | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_6 | OneHotLinearOr(3x) | SoC component min SVN for fuse slot 0 (one-hot, optional per-component rollback floor mapped via SVN_FUSE_MAP). |
-| soc_image_min_svn_1 | 10 | VENDOR_NON_SECRET_PROD_PARTITION | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_7 | OneHotLinearOr(3x) | SoC component min SVN for fuse slot 1 (one-hot, optional per-component rollback floor mapped via SVN_FUSE_MAP). |
+| mcu_component_svn_manifest_min_svn | 10 | VENDOR_NON_SECRET_PROD_PARTITION | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_5 | OneHotLinearOr(3x) | MCU Component SVN Manifest min SVN (bit-count counter, used by MCU ROM for manifest-format anti-rollback). |
+| soc_image_min_svn_0 | 10 | VENDOR_NON_SECRET_PROD_PARTITION | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_6 | OneHotLinearOr(3x) | SoC component min SVN for fuse slot 0 (bit-count counter, optional per-component rollback floor mapped via SVN_FUSE_MAP). |
+| soc_image_min_svn_1 | 10 | VENDOR_NON_SECRET_PROD_PARTITION | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_7 | OneHotLinearOr(3x) | SoC component min SVN for fuse slot 1 (bit-count counter, optional per-component rollback floor mapped via SVN_FUSE_MAP). |
 | vendor_pk_hash_valid | 16 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_VENDOR_PK_HASH_VALID | LinearOr(3x) | Bitmask indicating vendor PK hash validity. Unburnt bits (0) are valid; burnt bits (1) are revoked/invalid. |
 | vendor_ecc_revocation_0 | 4 | VENDOR_REVOCATIONS_PROD_PARTITION | CPTRA_CORE_ECC_REVOCATION_0 | LinearOr(3x) | Revocation bits for ECC keys in slot 0. |
 | vendor_mldsa_revocation_0 | 4 | VENDOR_REVOCATIONS_PROD_PARTITION | CPTRA_CORE_MLDSA_REVOCATION_0 | LinearOr(3x) | Revocation bits for MLDSA keys in slot 0. |
@@ -381,22 +381,22 @@
 | vendor_ecc_revocation_15 | 4 | VENDOR_REVOCATIONS_PROD_PARTITION | CPTRA_CORE_ECC_REVOCATION_15 | LinearOr(3x) | Revocation bits for ECC keys in slot 15. |
 | vendor_mldsa_revocation_15 | 4 | VENDOR_REVOCATIONS_PROD_PARTITION | CPTRA_CORE_MLDSA_REVOCATION_15 | LinearOr(3x) | Revocation bits for MLDSA keys in slot 15. |
 | vendor_lms_revocation_15 | 16 | VENDOR_REVOCATIONS_PROD_PARTITION | CPTRA_CORE_LMS_REVOCATION_15 | LinearOr(2x) | Revocation bits for LMS keys in slot 15. |
-| vendor_pqc_key_type_0 | 2 | VENDOR_HASHES_MANUF_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_0 | OneHotLinearOr(3x) | One-hot encoded PQC key type for slot 0 (1: MLDSA, 2: LMS). |
-| vendor_pqc_key_type_1 | 2 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_1 | OneHotLinearOr(3x) | One-hot encoded PQC key type for slot 1 (1: MLDSA, 2: LMS). |
-| vendor_pqc_key_type_2 | 2 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_2 | OneHotLinearOr(3x) | One-hot encoded PQC key type for slot 2 (1: MLDSA, 2: LMS). |
-| vendor_pqc_key_type_3 | 2 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_3 | OneHotLinearOr(3x) | One-hot encoded PQC key type for slot 3 (1: MLDSA, 2: LMS). |
-| vendor_pqc_key_type_4 | 2 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_4 | OneHotLinearOr(3x) | One-hot encoded PQC key type for slot 4 (1: MLDSA, 2: LMS). |
-| vendor_pqc_key_type_5 | 2 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_5 | OneHotLinearOr(3x) | One-hot encoded PQC key type for slot 5 (1: MLDSA, 2: LMS). |
-| vendor_pqc_key_type_6 | 2 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_6 | OneHotLinearOr(3x) | One-hot encoded PQC key type for slot 6 (1: MLDSA, 2: LMS). |
-| vendor_pqc_key_type_7 | 2 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_7 | OneHotLinearOr(3x) | One-hot encoded PQC key type for slot 7 (1: MLDSA, 2: LMS). |
-| vendor_pqc_key_type_8 | 2 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_8 | OneHotLinearOr(3x) | One-hot encoded PQC key type for slot 8 (1: MLDSA, 2: LMS). |
-| vendor_pqc_key_type_9 | 2 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_9 | OneHotLinearOr(3x) | One-hot encoded PQC key type for slot 9 (1: MLDSA, 2: LMS). |
-| vendor_pqc_key_type_10 | 2 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_10 | OneHotLinearOr(3x) | One-hot encoded PQC key type for slot 10 (1: MLDSA, 2: LMS). |
-| vendor_pqc_key_type_11 | 2 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_11 | OneHotLinearOr(3x) | One-hot encoded PQC key type for slot 11 (1: MLDSA, 2: LMS). |
-| vendor_pqc_key_type_12 | 2 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_12 | OneHotLinearOr(3x) | One-hot encoded PQC key type for slot 12 (1: MLDSA, 2: LMS). |
-| vendor_pqc_key_type_13 | 2 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_13 | OneHotLinearOr(3x) | One-hot encoded PQC key type for slot 13 (1: MLDSA, 2: LMS). |
-| vendor_pqc_key_type_14 | 2 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_14 | OneHotLinearOr(3x) | One-hot encoded PQC key type for slot 14 (1: MLDSA, 2: LMS). |
-| vendor_pqc_key_type_15 | 2 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_15 | OneHotLinearOr(3x) | One-hot encoded PQC key type for slot 15 (1: MLDSA, 2: LMS). |
+| vendor_pqc_key_type_0 | 2 | VENDOR_HASHES_MANUF_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_0 | OneHotLinearOr(3x) | Bit-count encoded PQC key type for slot 0 (1: MLDSA, 2: LMS). |
+| vendor_pqc_key_type_1 | 2 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_1 | OneHotLinearOr(3x) | Bit-count encoded PQC key type for slot 1 (1: MLDSA, 2: LMS). |
+| vendor_pqc_key_type_2 | 2 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_2 | OneHotLinearOr(3x) | Bit-count encoded PQC key type for slot 2 (1: MLDSA, 2: LMS). |
+| vendor_pqc_key_type_3 | 2 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_3 | OneHotLinearOr(3x) | Bit-count encoded PQC key type for slot 3 (1: MLDSA, 2: LMS). |
+| vendor_pqc_key_type_4 | 2 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_4 | OneHotLinearOr(3x) | Bit-count encoded PQC key type for slot 4 (1: MLDSA, 2: LMS). |
+| vendor_pqc_key_type_5 | 2 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_5 | OneHotLinearOr(3x) | Bit-count encoded PQC key type for slot 5 (1: MLDSA, 2: LMS). |
+| vendor_pqc_key_type_6 | 2 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_6 | OneHotLinearOr(3x) | Bit-count encoded PQC key type for slot 6 (1: MLDSA, 2: LMS). |
+| vendor_pqc_key_type_7 | 2 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_7 | OneHotLinearOr(3x) | Bit-count encoded PQC key type for slot 7 (1: MLDSA, 2: LMS). |
+| vendor_pqc_key_type_8 | 2 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_8 | OneHotLinearOr(3x) | Bit-count encoded PQC key type for slot 8 (1: MLDSA, 2: LMS). |
+| vendor_pqc_key_type_9 | 2 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_9 | OneHotLinearOr(3x) | Bit-count encoded PQC key type for slot 9 (1: MLDSA, 2: LMS). |
+| vendor_pqc_key_type_10 | 2 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_10 | OneHotLinearOr(3x) | Bit-count encoded PQC key type for slot 10 (1: MLDSA, 2: LMS). |
+| vendor_pqc_key_type_11 | 2 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_11 | OneHotLinearOr(3x) | Bit-count encoded PQC key type for slot 11 (1: MLDSA, 2: LMS). |
+| vendor_pqc_key_type_12 | 2 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_12 | OneHotLinearOr(3x) | Bit-count encoded PQC key type for slot 12 (1: MLDSA, 2: LMS). |
+| vendor_pqc_key_type_13 | 2 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_13 | OneHotLinearOr(3x) | Bit-count encoded PQC key type for slot 13 (1: MLDSA, 2: LMS). |
+| vendor_pqc_key_type_14 | 2 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_14 | OneHotLinearOr(3x) | Bit-count encoded PQC key type for slot 14 (1: MLDSA, 2: LMS). |
+| vendor_pqc_key_type_15 | 2 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_15 | OneHotLinearOr(3x) | Bit-count encoded PQC key type for slot 15 (1: MLDSA, 2: LMS). |
 | field_entropy_state | 384 | VENDOR_NON_SECRET_PROD_PARTITION | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_7 | Single | Status of field entropy slots. 32 bits per flag (word 3N: started, word 3N+1: finished, word 3N+2: zeroized for slot N). |
 | fpga_test_uds_seed_lo | 256 | VENDOR_NON_SECRET_PROD_PARTITION | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_8 | Single | UDS Seed low 256 bits (for FPGA test harness handoff only) |
 | fpga_test_uds_seed_hi | 256 | VENDOR_NON_SECRET_PROD_PARTITION | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_9 | Single | UDS Seed high 256 bits (for FPGA test harness handoff only) |

--- a/rom/src/firmware_headers.rs
+++ b/rom/src/firmware_headers.rs
@@ -134,7 +134,7 @@ fn process_svn_manifest(env: &mut RomEnv, params: &RomParameters, offset: u32) -
         .set_flow_checkpoint(McuRomBootStatus::ComponentSvnManifestProcessingStarted.into());
 
     let limits = SvnLimits {
-        manifest_min_svn_max: one_hot_bits(MCU_COMPONENT_SVN_MANIFEST_MIN_SVN),
+        manifest_min_svn_max: bit_count_bits(MCU_COMPONENT_SVN_MANIFEST_MIN_SVN),
         caliptra_runtime_min_svn_max: crate::caliptra_svn::CALIPTRA_SVN_BITS,
         soc_manifest_min_svn_max: crate::caliptra_svn::CALIPTRA_SVN_BITS,
     };
@@ -210,7 +210,7 @@ fn burn_manifest_min_svn(
 }
 
 /// Validate each mapped per-component entry against its
-/// `SOC_IMAGE_MIN_SVN[i]` slot (one-hot range and rollback). Entries
+/// `SOC_IMAGE_MIN_SVN[i]` slot (bit-count range and rollback). Entries
 /// with an unmapped `component_id` are skipped with a logged warning
 /// (spec'd behaviour). No OTP writes.
 #[cfg(feature = "svn-manifest")]
@@ -229,7 +229,7 @@ fn check_per_component_min_svn(
             continue;
         };
 
-        let slot_max = one_hot_bits(fuse_entry);
+        let slot_max = bit_count_bits(fuse_entry);
         if u32::from(entry.current_svn) > slot_max || u32::from(entry.min_svn) > slot_max {
             caliptra_mcu_romtime::println!("[mcu-rom] SVN entry {} out of range", idx);
             fatal_error(McuError::ROM_COMPONENT_SVN_MANIFEST_ERROR);
@@ -264,7 +264,7 @@ fn burn_per_component_min_svn(
     }
 }
 
-/// Read a one-hot-encoded SVN fuse via the OTP entry's layout. Halts
+/// Read a bit-count encoded SVN fuse via the OTP entry's layout. Halts
 /// the boot on any OTP error.
 #[cfg(feature = "svn-manifest")]
 fn read_fuse(
@@ -311,10 +311,10 @@ fn anti_rollback_enabled(otp: &caliptra_mcu_romtime::Otp) -> Result<bool, McuErr
     Ok(raw.iter().all(|b| *b == 0))
 }
 
-/// Number of effective (one-hot) bits in `entry`'s layout, i.e. the max
-/// representable logical value. Returns 0 for non-one-hot layouts.
+/// Number of effective bit-count bits in `entry`'s layout, i.e. the max
+/// representable logical value. Returns 0 for non-bit-count layouts.
 #[cfg(feature = "svn-manifest")]
-fn one_hot_bits(entry: &caliptra_mcu_registers_generated::fuses::FuseEntryInfo) -> u32 {
+fn bit_count_bits(entry: &caliptra_mcu_registers_generated::fuses::FuseEntryInfo) -> u32 {
     use caliptra_mcu_registers_generated::fuses::FuseLayoutType;
     match entry.layout {
         FuseLayoutType::OneHot { bits }

--- a/romtime/src/component_svn_manifest.rs
+++ b/romtime/src/component_svn_manifest.rs
@@ -96,7 +96,7 @@ pub enum SvnManifestError {
         min_svn: u32,
         current_svn: u32,
     },
-    /// A header SVN does not fit within its target fuse's one-hot range.
+    /// A header SVN does not fit within its target fuse's bit-count range.
     HeaderSvnExceedsFuseRange {
         value: u32,
         max: u32,
@@ -108,7 +108,7 @@ pub enum SvnManifestError {
     },
 }
 
-/// One-hot range limits the caller must supply to [`McuComponentSvnManifest::validate`].
+/// Bit-count range limits the caller must supply to [`McuComponentSvnManifest::validate`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct SvnLimits {
     /// Max representable value for `MCU_COMPONENT_SVN_MANIFEST_MIN_SVN`.
@@ -177,7 +177,7 @@ impl McuComponentSvnManifest {
                     current_svn: entry.current_svn,
                 });
             }
-            // Per-entry one-hot-range checks against SOC_IMAGE_MIN_SVN[i]
+            // Per-entry bit-count range checks against SOC_IMAGE_MIN_SVN[i]
             // are deferred to the fuse-burn step, where SVN_FUSE_MAP
             // supplies the per-slot maximum.
         }

--- a/romtime/src/fuse_layout.rs
+++ b/romtime/src/fuse_layout.rs
@@ -17,14 +17,16 @@ pub struct Duplication(pub NonZero<usize>);
 pub enum FuseLayout {
     /// Values are stored literally
     Single(Bits),
-    /// Value is the number of bits set,
-    /// e.g., 0b110111 -> 5
+    /// Current layout name for a monotonic bit-count / thermometer-style counter,
+    /// not true one-hot. The logical value is the number of bits set,
+    /// e.g., 0b110111 -> 5. Writers produce `(1 << value) - 1`.
     OneHot(Bits),
     /// Each bit is duplicated within a single u32 (or across adjacent u32s) and the majority vote
     /// is used to compute the final value,
     /// e.g., 0b110111 -> 0b11
     LinearMajorityVote(Bits, Duplication),
-    /// Same as LinearMajorityVote, but the end result is to simply the count of the bits,
+    /// Same as LinearMajorityVote, but the end result is the count of the bits,
+    /// matching the `OneHot` bit-count counter semantics,
     /// e.g., 0b110111 -> 2
     OneHotLinearMajorityVote(Bits, Duplication),
     /// u32s are duplicated, with bits are duplicated across multiple u32s. The result takes
@@ -35,6 +37,7 @@ pub enum FuseLayout {
     /// e.g., with 3x duplication: 0b001_000_101 -> 0b11 (bit 0 has any set, bit 2 has any set)
     LinearOr(Bits, Duplication),
     /// Same as LinearOr, but the end result is the count of the bits set,
+    /// matching the `OneHot` bit-count counter semantics,
     /// e.g., with 3x duplication: 0b001_000_111 -> 2 (bit 0 OR'd to 1, bit 1 OR'd to 0, bit 2... wait)
     OneHotLinearOr(Bits, Duplication),
     /// u32s are duplicated, with bits OR'd across multiple u32s,

--- a/romtime/src/otp.rs
+++ b/romtime/src/otp.rs
@@ -946,7 +946,7 @@ impl Otp {
     ///
     /// Reads `entry.byte_size` bytes from OTP and applies the entry's layout
     /// to produce N decoded u32 words. Use this for entries larger than a
-    /// single u32 (e.g., hash values with WordMajorityVote, large OneHot
+    /// single u32 (e.g., hash values with WordMajorityVote, large bit-count
     /// counters, etc.).
     pub fn read_entry_multi<const N: usize>(&self, entry: &FuseEntryInfo) -> McuResult<[u32; N]> {
         let layout = FuseLayout::from_generated(&entry.layout)


### PR DESCRIPTION
Update fuse documentation and comments to distinguish the existing OneHot* layout names from true one-hot encoding. Describe SVN floors, DOT counters, and related redundant layouts as monotonic bit-count counters while preserving the current schema/API names.

Also update HJSON descriptions, source comments, and the ROM fuse layout error text to use bit-count terminology.