### PR TITLE
[doc] Clarify fuse bit-count encoding terminology for 2.0

### DIFF
--- a/docs/src/fuses.md
+++ b/docs/src/fuses.md
@@ -158,6 +158,11 @@ The firmware uses a `FuseLayout` enum to define how fuse values are stored and i
 
 Note that u32s (dwords) are always packed in little-endian byte order and big-endian bit order.
 
+Terminology note: the current `OneHot*` layout names are existing schema/API
+names. They do not mean true one-hot encoding, where exactly one bit is set.
+They implement monotonic bit-count, or thermometer-style, counters: the logical
+value is the number of set bits, and writers encode value `n` as `(1 << n) - 1`.
+
 ### Layout Types
 
 #### Single
@@ -168,14 +173,18 @@ Values stored this way in fuses should be protected with ECC.
 
 **Example:** A 4-bit value `0b1101` is stored as `0b1101`
 
-#### OneHot
+#### Bit-count counter (`OneHot` layout name)
 
-The logical value is the count of bits set to 1 in the fuse field. This is commonly used for version numbers and counters where incrementing requires only burning one additional fuse.
+The logical value is the count of bits set to 1 in the fuse field. This is
+commonly used for version numbers and counters where incrementing requires only
+burning one additional fuse bit.
 
 The values can span multiple u32 words but the result is always a single u32 count value.
 
 **Example:**
 - `0b0000` → 0
+- `0b0001` → 1
+- `0b0011` → 2
 - `0b0111` → 3
 
 Caution: This method of storing fuses is dangerous, since generally ECC cannot be used if the value can be incremented after the initial value is written.
@@ -194,9 +203,11 @@ Generally this method is used for values that do not have ECC protection but are
 
 #### OneHotLinearMajorityVote
 
-Combines `LinearMajorityVote` with `OneHot` encoding. First applies majority voting to each duplicated bit, then counts the number of bits set.
+Combines `LinearMajorityVote` with the `OneHot` bit-count counter layout.
+First applies majority voting to each duplicated bit, then counts the number of
+bits set.
 
-This is the recommended way to
+This combines redundancy with bit-count counter semantics.
 
 **Example:** With 3 logical bits and 3x duplication:
 - Raw fuses: `0b100_110_111` (bit 0 has votes `111`, bit 1 has votes `110`, bit 2 has votes `100`)
@@ -230,7 +241,8 @@ With majority vote the same raw value would yield `0b01` (bit 1 fails the ≥2 t
 
 #### OneHotLinearOr
 
-Combines `LinearOr` with `OneHot` encoding. First applies OR reduction to each duplicated bit, then counts the number of bits set.
+Combines `LinearOr` with the `OneHot` bit-count counter layout. First applies
+OR reduction to each duplicated bit, then counts the number of bits set.
 
 **Example:** With 3 logical bits and 3x duplication:
 - Raw fuses: `0b001_010_111` (bit 0 has copies `111`, bit 1 has copies `010`, bit 2 has copies `001`)
@@ -260,8 +272,8 @@ Entire u32 words are duplicated. Each bit position across the duplicated words i
 
 The default `McuFuseLayoutPolicy` uses:
 - `Single`: For certificate data, identifiers, and validity flags that are assumed to be protected by ECC
-- `OneHotLinearOr` (3x): For SVN fields and counters
-- `LinearOr` (3x): for single revocation fields and flags
-- `WordMajorityVote` (3x): for revocation bitmasks
+- `OneHotLinearOr` (3x): For SVN fields and monotonic bit-count counters
+- `LinearOr` (3x): for single revocation fields, flags, and small bitmasks
+- `WordMajorityVote` (3x): for larger bitmasks
 
 This provides a balance between redundancy for critical security fields and storage efficiency for larger data structures.

--- a/docs/src/integrator-guide.md
+++ b/docs/src/integrator-guide.md
@@ -9,7 +9,9 @@ Caliptra MCU.
 
 The `dot_fuse_array` field in the vendor non-secret OTP partition tracks Device
 Ownership Transfer (DOT) state transitions. Each state change (lock, unlock,
-disable) burns one bit, using a `OneHot` encoding. The total number of bits
+disable) burns one bit, using the current MCU `OneHot` layout name for a
+monotonic bit-count counter. The layout name does not mean true one-hot
+encoding. The total number of bits
 determines the maximum number of ownership state transitions over the lifetime
 of the part.
 
@@ -45,12 +47,12 @@ no redundant encoding is needed.
 | Fuse field | Partition | Size | Encoding | Notes |
 |---|---|:---:|---|---|
 | `dot_initialized` | `VENDOR_NON_SECRET_PROD_PARTITION` | 1 bit (3 bytes with 3× OR duplication) | `LinearOr` | Gates the DOT flow. |
-| `dot_fuse_array` | `VENDOR_NON_SECRET_PROD_PARTITION` | 256 bits (32 bytes) | `OneHot` | State counter. Scales linearly with desired lock/unlock cycles. |
+| `dot_fuse_array` | `VENDOR_NON_SECRET_PROD_PARTITION` | 256 bits (32 bytes) | `OneHot` (bit-count counter) | State counter. Scales linearly with desired lock/unlock cycles. |
 | `vendor_recovery_pk_hash` | `VENDOR_SECRET_PROD_PARTITION` | 384 bits (48 bytes) | `Single` | Optional. For `DOT_OVERRIDE` catastrophic recovery. |
 
 If OTP space is constrained, the `dot_fuse_array` can be made smaller — the
 minimum useful size is 2 bits, but this only allows a single lock/unlock cycle
-with no margin. If redundant encoding (`OneHotLinearOr`) is used,
+with no margin. If redundant bit-count encoding (`OneHotLinearOr`) is used,
 multiply the raw bit count by the duplication factor (e.g., 3×).
 
 A different partition can also be used if there is one specifically allocated in

--- a/docs/src/rom-fuses.md
+++ b/docs/src/rom-fuses.md
@@ -83,7 +83,7 @@ can be reclaimed.
 | Fuse | Logical size | Feature | Notes |
 |---|---|---|---|
 | `dot_initialized` | 1 bit | DOT | Gate flag indicating DOT flow is active for this part |
-| `dot_fuse_array` | 256 bits | DOT | One-hot DOT state counter; supports 128 lock/unlock cycles; more or less can be allocated depending on use cases |
+| `dot_fuse_array` | 256 bits | DOT | Monotonic bit-count DOT state counter; supports 128 lock/unlock cycles; more or less can be allocated depending on use cases |
 | `vendor_recovery_pk_hash` | 384 bits | DOT | Vendor master key for `DOT_OVERRIDE` catastrophic recovery (lives in `VENDOR_SECRET_PROD_PARTITION`). One slot today; integrators that need rotation should add `vendor_recovery_pk_hash_{0..N}` + a `vendor_recovery_pk_hash_valid` bitmask and/or revocation bits |
 | `MCU_COMPONENT_SVN_MANIFEST_MIN_SVN` | 32 bits (recommended) | MCU SVN anti-rollback | Min SVN for the MCU Component SVN Manifest itself |
 | `SOC_IMAGE_MIN_SVN[0..M]` | 32 bits each (recommended) | MCU SVN anti-rollback | Per-slot SoC image min SVN; `M` is integrator-defined |
@@ -91,7 +91,7 @@ can be reclaimed.
 | `CPTRA_SS_LOCK_HEK_PROD_{0..7}` | 256 bits each | OCP LOCK (2.1+) | 8 HEK seed slots (`CPTRA_SS_LOCK_HEK_PROD_N_RATCHET_SEED`, 32 B each); one active at a time |
 
 The MCU SVN fuse sizes above are the recommended logical widths from
-[`docs/src/svn.md`](svn.md); integrators choose the actual one-hot width and
+[`docs/src/svn.md`](svn.md); integrators choose the actual bit-count width and
 number of `SOC_IMAGE_MIN_SVN` slots based on their release cadence and
 component count.
 
@@ -190,7 +190,8 @@ transformation from raw OTP bytes to written value. ✓ = Caliptra core fuse reg
   0 or 1, used as the DOT flow gate.
 
 - **`dot_fuse_array`** — MCU internal
-  use only, not written to any register. `OneHot{bits:256}` → count of burned bits, used to track
+  use only, not written to any register. `OneHot{bits:256}` is the current
+  layout name for bit-count encoding: count burned bits to track
   the DOT state counter. Also written (next bit burned) during DOT state transitions.
 
 - **`perma_hek_en`** (2.1+) — MCU internal use only, not written to any register.
@@ -447,14 +448,15 @@ MCU ROM decode, and the final Caliptra `FUSE_PQC_KEY_TYPE` register value.
 
 Unlike the PK hash, this field uses the `OneHotLinearOr` layout for
 fault tolerance. The `OneHotLinearOr { bits: 2, duplication: 3 }`
-layout encodes a logical integer using two stages:
+layout name means bit-count encoding with OR redundancy, not true one-hot
+encoding. It encodes a logical integer using two stages:
 
-1. **OneHot**: the logical value `n` is encoded as `n` consecutive 1-bits: `onehot = (1 << n) - 1`
-2. **LinearOr**: each bit of the OneHot value is replicated `duplication` (3) times in
+1. **Bit-count**: the logical value `n` is encoded as `n` consecutive 1-bits: `bits = (1 << n) - 1`
+2. **LinearOr**: each bit of the bit-count value is replicated `duplication` (3) times in
    consecutive bit positions. The 2 logical bits × 3 replications = 6 physical bits, packed into
    the low 6 bits of the 4-byte field.
 
-| Key type | Logical value | OneHot bits | OTP raw u32 | OTP bytes @ `0x428` |
+| Key type | Logical value | Bit-count pattern | OTP raw u32 | OTP bytes @ `0x428` |
 |---|:---:|:---:|:---:|:---:|
 | MLDSA | 1 | `0b01` | `0x00000007` | `07 00 00 00` |
 | LMS | 2 | `0b11` | `0x0000003F` | `3f 00 00 00` |
@@ -466,7 +468,9 @@ If that is the case, then the duplication and OR reduction in this example can b
 
 ### Example: CPTRA_CORE_PQC_KEY_TYPE_0 (LMS)
 
-We trace `vendor_pqc_key_type_0` provisioned for LMS, i.e., the one-hot encoded value of 0b11 (logical value 2, one-hot encoded as 3), expected by Caliptra core ROM for LMS.
+We trace `vendor_pqc_key_type_0` provisioned for LMS, i.e., the bit-count
+pattern `0b11` (logical value 2, raw encoded value 3), expected by Caliptra
+core ROM for LMS.
 
 #### Layer 1: OTP Raw Bytes
 

--- a/docs/src/svn.md
+++ b/docs/src/svn.md
@@ -92,7 +92,7 @@ Added in a vendor partition (e.g., `VENDOR_NON_SECRET_PROD_PARTITION`):
 | `MCU_COMPONENT_SVN_MANIFEST_MIN_SVN` | 4 B | `OneHotLinearOr{bits:N, dupe:3}` | Min SVN for the MCU Component SVN Manifest itself |
 | `SOC_IMAGE_MIN_SVN[0..M]` | 4 B each | `OneHotLinearOr{bits:N, dupe:3}` | Per-slot SoC image min SVN (optional) |
 
-The number of `SOC_IMAGE_MIN_SVN` slots (`M`) and the number of one-hot bits
+The number of `SOC_IMAGE_MIN_SVN` slots (`M`) and the number of bit-count bits
 per slot are integrator-defined. `MCU_COMPONENT_SVN_MANIFEST_MIN_SVN` exists
 even when the integrator does not provision any `SOC_IMAGE_MIN_SVN` slots,
 because the manifest's own anti-rollback applies regardless of how many
@@ -100,17 +100,20 @@ component slots are mapped.
 
 #### Encoding
 
-SVN fuses **must** use a one-hot encoding so that incrementing requires only
-burning an additional bit (any other encoding would either need 1→0 transitions
-or provide no rollback protection). The recommended layout is `OneHotLinearOr`
-with 3× duplication: OR semantics tolerate single-bit read errors without ECC,
-which is incompatible with fields written more than once. OR is preferred over
-majority vote because OTP bits are far more likely to fail stuck-at-0 than to
-spontaneously flip to 1.
+SVN fuses **must** use monotonic bit-count encoding so that incrementing
+requires only burning an additional bit (any other counter encoding would either
+need 1→0 transitions or provide no rollback protection). The current MCU
+layout names call this `OneHot`, but it is not true one-hot encoding; the
+decoded logical value is the number of set bits. The recommended layout is
+`OneHotLinearOr` with 3× duplication: OR semantics tolerate single-bit read
+errors without ECC, which is incompatible with fields written more than once.
+OR is preferred over majority vote because OTP bits are far more likely to fail
+stuck-at-0 than to spontaneously flip to 1.
 
-Integrators with hardware-level fuse redundancy can use a plain `OneHot{bits:N}`
-layout. Other one-hot variants (e.g., `OneHotLinearMajorityVote`) are also
-acceptable. Non-one-hot encodings (e.g., `Single`) cannot be used.
+Integrators with hardware-level fuse redundancy can use a plain
+`OneHot{bits:N}` layout. Other bit-count variants using the current layout
+names (e.g., `OneHotLinearMajorityVote`) are also acceptable. Non-bit-count
+encodings (e.g., `Single`) cannot be used.
 
 See [Fuse Layout Options](fuses.md#fuse-layout-options) for encoding details.
 
@@ -163,14 +166,14 @@ Header constraints (validated; header is rejected on violation):
 
 - `min_svn ≤ current_svn` (manifest-self).
 - Each requested floor (`min_svn`, `caliptra_runtime_min_svn`,
-  `soc_manifest_min_svn`) must fit within its target fuse's one-hot range
+   `soc_manifest_min_svn`) must fit within its target fuse's bit-count range
   (`MCU_COMPONENT_SVN_MANIFEST_MIN_SVN`, `CPTRA_CORE_RUNTIME_SVN`,
   `CPTRA_CORE_SOC_MANIFEST_SVN` respectively).
 
 Per-entry constraints (validated; entry is rejected on violation):
 
 - `min_svn ≤ current_svn`
-- Both values must fit within the corresponding fuse slot's one-hot range.
+- Both values must fit within the corresponding fuse slot's bit-count range.
 
 ### Caliptra runtime and SoC manifest SVN floors
 
@@ -309,7 +312,7 @@ Note: Caliptra fuse registers are latched at cold-boot fuse-write time
 and cannot be re-written during a warm/update reset. Any OTP burn that
 MCU ROM performs after a hitless update therefore only gates Caliptra
 authentication on the *next* cold boot — power-fail safe via the OTP
-one-hot encoding.
+bit-count encoding.
 
 ### Cold Boot and Hitless Update — MCU Component SVN Manifest burn
 
@@ -328,7 +331,7 @@ for those whose `component_id` is in `SVN_FUSE_MAP`, advances the mapped
    with a logged warning (lets new components ship without a dedicated
    fuse slot).
 2. Reject the boot if `entry.current_svn` or `entry.min_svn` exceeds the
-   slot's one-hot range, or if `entry.current_svn < fuse_min_svn`
+   slot's bit-count range, or if `entry.current_svn < fuse_min_svn`
    (rollback).
 3. If `entry.min_svn > fuse_min_svn` and anti-rollback is not disabled,
    burn the slot to `entry.min_svn` and read back to verify.
@@ -368,8 +371,8 @@ For each component in the bundle:
    - Verify the trait-extracted SVN matches the MCU Component SVN Manifest's
      `current_svn` for that component. A mismatch means the manifest and
      image disagree — reject the bundle.
-   - Reject if `current_svn < fuse_min_svn`, or if either `current_svn` or
-     `min_svn` exceeds the slot's one-hot range.
+    - Reject if `current_svn < fuse_min_svn`, or if either `current_svn` or
+       `min_svn` exceeds the slot's bit-count range.
 
 Components without a `SocComponentSvn` implementation skip the
 manifest-vs-image cross-check (a logged warning) but still get the
@@ -449,7 +452,7 @@ committing *any* burn. This guarantees a rejected boot never leaves the
 device with partially-advanced floors; once the burn phase starts, only
 a genuine OTP write/readback hardware error can halt it.
 
-The burn is power-fail safe: one-hot encoding plus OR semantics mean a partial
+The burn is power-fail safe: bit-count encoding plus OR semantics mean a partial
 burn can never decrease the fuse value, and any incomplete burn will be
 re-attempted (and complete) on the next boot.
 
@@ -544,7 +547,7 @@ disable polarity (burning removes a security property) for compatibility with
 the existing Caliptra fuse. Provisioning flows must never set this fuse on
 production devices; ROM should add lifecycle-state checks to enforce this.
 
-**SVN exhaustion.** With one-hot encoding, the maximum `min_svn` equals the
+**SVN exhaustion.** With bit-count encoding, the maximum `min_svn` equals the
 number of allocated bits (e.g., 32 bits → max SVN of 32). Since `current_svn`
 can advance without `min_svn`, exhaustion is rare in practice. At exhaustion,
 no further `min_svn` updates are possible but the device continues to enforce

--- a/emulator/periph/src/otp.rs
+++ b/emulator/periph/src/otp.rs
@@ -190,7 +190,7 @@ impl Otp {
                 otp.partitions.borrow_mut()[offset..offset + size].copy_from_slice(&owner_pk_hash);
             }
         }
-        // Encode as one-hot + duplication to match the fuse layout
+        // Encode as bit-count + duplication to match the fuse layout
         // (OneHotLinear{MajorityVote,Or}, bits: 2, duplication: 3):
         // MLDSA = thermometer value 1 (bit 0 set), duplicated 3x = 0b000111 = 0x07.
         // LMS   = thermometer value 2 (bits 0-1 set), duplicated 3x = 0b111111 = 0x3F.

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -260,7 +260,7 @@ impl McuError {
         (
             ROM_FUSE_LAYOUT_ONE_HOT_RESULT_SHOULD_BE_SINGLE_U32,
             0x3_0009,
-            "One-hot encoded output should be single u32"
+            "Bit-count encoded output should be single u32"
         ),
         (
             ROM_FUSE_VALUE_TOO_LARGE,

--- a/hw/fuses.hjson
+++ b/hw/fuses.hjson
@@ -22,7 +22,7 @@
     {"cptra_itrng_entropy_config_1": 4},
     // SVN anti-rollback fuses (see docs/src/svn.md).
     // Sizes here are informational and refer to the raw OTP storage actually
-    // used by the OneHotLinearOr encoding (bits * duplication / 8). The
+    // used by the OneHotLinearOr bit-count encoding (bits * duplication / 8). The
     // underlying OTP slots (VENDOR_SPECIFIC_NON_SECRET_FUSE_5..7) are 32 bytes
     // each; the remaining bits in each slot stay 0.
     {"mcu_component_svn_manifest_min_svn": 4},
@@ -86,14 +86,14 @@
     },
     // SVN anti-rollback fuses (see docs/src/svn.md).
     //
-    // OneHotLinearOr with 3x duplication: each effective bit is stored as
+    // OneHotLinearOr bit-count encoding with 3x duplication: each effective bit is stored as
     // three OR-tied raw bits, so the maximum representable min_svn equals
     // `bits`. The MCU runtime SVN floor lives in CPTRA_CORE_SOC_MANIFEST_SVN
     // (Caliptra-owned) and is not duplicated here.
     {
       name: "mcu_component_svn_manifest_min_svn",
       bits: 10,
-      description: "MCU Component SVN Manifest min SVN (one-hot, used by MCU ROM for manifest-format anti-rollback).",
+    description: "MCU Component SVN Manifest min SVN (bit-count counter, used by MCU ROM for manifest-format anti-rollback).",
       partition: "VENDOR_NON_SECRET_PROD_PARTITION",
       otp_item: "CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_5",
       layout: {type: "OneHotLinearOr", duplication: 3},
@@ -101,7 +101,7 @@
     {
       name: "soc_image_min_svn_0",
       bits: 10,
-      description: "SoC component min SVN for fuse slot 0 (one-hot, optional per-component rollback floor mapped via SVN_FUSE_MAP).",
+    description: "SoC component min SVN for fuse slot 0 (bit-count counter, optional per-component rollback floor mapped via SVN_FUSE_MAP).",
       partition: "VENDOR_NON_SECRET_PROD_PARTITION",
       otp_item: "CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_6",
       layout: {type: "OneHotLinearOr", duplication: 3},
@@ -109,7 +109,7 @@
     {
       name: "soc_image_min_svn_1",
       bits: 10,
-      description: "SoC component min SVN for fuse slot 1 (one-hot, optional per-component rollback floor mapped via SVN_FUSE_MAP).",
+    description: "SoC component min SVN for fuse slot 1 (bit-count counter, optional per-component rollback floor mapped via SVN_FUSE_MAP).",
       partition: "VENDOR_NON_SECRET_PROD_PARTITION",
       otp_item: "CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_7",
       layout: {type: "OneHotLinearOr", duplication: 3},
@@ -509,7 +509,7 @@
     {
         name: "vendor_pqc_key_type_0",
         bits: 2,
-        description: "One-hot encoded PQC key type for slot 0 (1: MLDSA, 2: LMS).",
+        description: "Bit-count encoded PQC key type for slot 0 (1: MLDSA, 2: LMS).",
         partition: "VENDOR_HASHES_MANUF_PARTITION",
         otp_item: "CPTRA_CORE_PQC_KEY_TYPE_0",
         layout: {type: "OneHotLinearOr", duplication: 3},
@@ -517,7 +517,7 @@
     {
         name: "vendor_pqc_key_type_1",
         bits: 2,
-        description: "One-hot encoded PQC key type for slot 1 (1: MLDSA, 2: LMS).",
+        description: "Bit-count encoded PQC key type for slot 1 (1: MLDSA, 2: LMS).",
         partition: "VENDOR_HASHES_PROD_PARTITION",
         otp_item: "CPTRA_CORE_PQC_KEY_TYPE_1",
         layout: {type: "OneHotLinearOr", duplication: 3},
@@ -525,7 +525,7 @@
     {
         name: "vendor_pqc_key_type_2",
         bits: 2,
-        description: "One-hot encoded PQC key type for slot 2 (1: MLDSA, 2: LMS).",
+        description: "Bit-count encoded PQC key type for slot 2 (1: MLDSA, 2: LMS).",
         partition: "VENDOR_HASHES_PROD_PARTITION",
         otp_item: "CPTRA_CORE_PQC_KEY_TYPE_2",
         layout: {type: "OneHotLinearOr", duplication: 3},
@@ -533,7 +533,7 @@
     {
         name: "vendor_pqc_key_type_3",
         bits: 2,
-        description: "One-hot encoded PQC key type for slot 3 (1: MLDSA, 2: LMS).",
+        description: "Bit-count encoded PQC key type for slot 3 (1: MLDSA, 2: LMS).",
         partition: "VENDOR_HASHES_PROD_PARTITION",
         otp_item: "CPTRA_CORE_PQC_KEY_TYPE_3",
         layout: {type: "OneHotLinearOr", duplication: 3},
@@ -541,7 +541,7 @@
     {
         name: "vendor_pqc_key_type_4",
         bits: 2,
-        description: "One-hot encoded PQC key type for slot 4 (1: MLDSA, 2: LMS).",
+        description: "Bit-count encoded PQC key type for slot 4 (1: MLDSA, 2: LMS).",
         partition: "VENDOR_HASHES_PROD_PARTITION",
         otp_item: "CPTRA_CORE_PQC_KEY_TYPE_4",
         layout: {type: "OneHotLinearOr", duplication: 3},
@@ -549,7 +549,7 @@
     {
         name: "vendor_pqc_key_type_5",
         bits: 2,
-        description: "One-hot encoded PQC key type for slot 5 (1: MLDSA, 2: LMS).",
+        description: "Bit-count encoded PQC key type for slot 5 (1: MLDSA, 2: LMS).",
         partition: "VENDOR_HASHES_PROD_PARTITION",
         otp_item: "CPTRA_CORE_PQC_KEY_TYPE_5",
         layout: {type: "OneHotLinearOr", duplication: 3},
@@ -557,7 +557,7 @@
     {
         name: "vendor_pqc_key_type_6",
         bits: 2,
-        description: "One-hot encoded PQC key type for slot 6 (1: MLDSA, 2: LMS).",
+        description: "Bit-count encoded PQC key type for slot 6 (1: MLDSA, 2: LMS).",
         partition: "VENDOR_HASHES_PROD_PARTITION",
         otp_item: "CPTRA_CORE_PQC_KEY_TYPE_6",
         layout: {type: "OneHotLinearOr", duplication: 3},
@@ -565,7 +565,7 @@
     {
         name: "vendor_pqc_key_type_7",
         bits: 2,
-        description: "One-hot encoded PQC key type for slot 7 (1: MLDSA, 2: LMS).",
+        description: "Bit-count encoded PQC key type for slot 7 (1: MLDSA, 2: LMS).",
         partition: "VENDOR_HASHES_PROD_PARTITION",
         otp_item: "CPTRA_CORE_PQC_KEY_TYPE_7",
         layout: {type: "OneHotLinearOr", duplication: 3},
@@ -573,7 +573,7 @@
     {
         name: "vendor_pqc_key_type_8",
         bits: 2,
-        description: "One-hot encoded PQC key type for slot 8 (1: MLDSA, 2: LMS).",
+        description: "Bit-count encoded PQC key type for slot 8 (1: MLDSA, 2: LMS).",
         partition: "VENDOR_HASHES_PROD_PARTITION",
         otp_item: "CPTRA_CORE_PQC_KEY_TYPE_8",
         layout: {type: "OneHotLinearOr", duplication: 3},
@@ -581,7 +581,7 @@
     {
         name: "vendor_pqc_key_type_9",
         bits: 2,
-        description: "One-hot encoded PQC key type for slot 9 (1: MLDSA, 2: LMS).",
+        description: "Bit-count encoded PQC key type for slot 9 (1: MLDSA, 2: LMS).",
         partition: "VENDOR_HASHES_PROD_PARTITION",
         otp_item: "CPTRA_CORE_PQC_KEY_TYPE_9",
         layout: {type: "OneHotLinearOr", duplication: 3},
@@ -589,7 +589,7 @@
     {
         name: "vendor_pqc_key_type_10",
         bits: 2,
-        description: "One-hot encoded PQC key type for slot 10 (1: MLDSA, 2: LMS).",
+        description: "Bit-count encoded PQC key type for slot 10 (1: MLDSA, 2: LMS).",
         partition: "VENDOR_HASHES_PROD_PARTITION",
         otp_item: "CPTRA_CORE_PQC_KEY_TYPE_10",
         layout: {type: "OneHotLinearOr", duplication: 3},
@@ -597,7 +597,7 @@
     {
         name: "vendor_pqc_key_type_11",
         bits: 2,
-        description: "One-hot encoded PQC key type for slot 11 (1: MLDSA, 2: LMS).",
+        description: "Bit-count encoded PQC key type for slot 11 (1: MLDSA, 2: LMS).",
         partition: "VENDOR_HASHES_PROD_PARTITION",
         otp_item: "CPTRA_CORE_PQC_KEY_TYPE_11",
         layout: {type: "OneHotLinearOr", duplication: 3},
@@ -605,7 +605,7 @@
     {
         name: "vendor_pqc_key_type_12",
         bits: 2,
-        description: "One-hot encoded PQC key type for slot 12 (1: MLDSA, 2: LMS).",
+        description: "Bit-count encoded PQC key type for slot 12 (1: MLDSA, 2: LMS).",
         partition: "VENDOR_HASHES_PROD_PARTITION",
         otp_item: "CPTRA_CORE_PQC_KEY_TYPE_12",
         layout: {type: "OneHotLinearOr", duplication: 3},
@@ -613,7 +613,7 @@
     {
         name: "vendor_pqc_key_type_13",
         bits: 2,
-        description: "One-hot encoded PQC key type for slot 13 (1: MLDSA, 2: LMS).",
+        description: "Bit-count encoded PQC key type for slot 13 (1: MLDSA, 2: LMS).",
         partition: "VENDOR_HASHES_PROD_PARTITION",
         otp_item: "CPTRA_CORE_PQC_KEY_TYPE_13",
         layout: {type: "OneHotLinearOr", duplication: 3},
@@ -621,7 +621,7 @@
     {
         name: "vendor_pqc_key_type_14",
         bits: 2,
-        description: "One-hot encoded PQC key type for slot 14 (1: MLDSA, 2: LMS).",
+        description: "Bit-count encoded PQC key type for slot 14 (1: MLDSA, 2: LMS).",
         partition: "VENDOR_HASHES_PROD_PARTITION",
         otp_item: "CPTRA_CORE_PQC_KEY_TYPE_14",
         layout: {type: "OneHotLinearOr", duplication: 3},
@@ -629,7 +629,7 @@
     {
         name: "vendor_pqc_key_type_15",
         bits: 2,
-        description: "One-hot encoded PQC key type for slot 15 (1: MLDSA, 2: LMS).",
+        description: "Bit-count encoded PQC key type for slot 15 (1: MLDSA, 2: LMS).",
         partition: "VENDOR_HASHES_PROD_PARTITION",
         otp_item: "CPTRA_CORE_PQC_KEY_TYPE_15",
         layout: {type: "OneHotLinearOr", duplication: 3},

--- a/hw/model/src/vmem.rs
+++ b/hw/model/src/vmem.rs
@@ -257,8 +257,8 @@ mod tests {
     #[test]
     fn test_pqc_key_type_doc_example() {
         // For OneHotLinearOr { bits: 2, duplication: 3 }:
-        //   MLDSA logical value = 1 → onehot = 0b01 → raw = 0x00000007
-        //   LMS   logical value = 2 → onehot = 0b11 → raw = 0x0000003F
+        //   MLDSA logical value = 1 → bit-count pattern = 0b01 → raw = 0x00000007
+        //   LMS   logical value = 2 → bit-count pattern = 0b11 → raw = 0x0000003F
         let cases: &[(&str, u32, u16)] =
             &[("MLDSA", 0x00000007, 0x0007), ("LMS", 0x0000003F, 0x003f)];
 

--- a/registers/fuses/src/schema.rs
+++ b/registers/fuses/src/schema.rs
@@ -31,17 +31,18 @@ pub struct FusePartitionInfo {
 pub enum FuseLayoutPolicy {
     /// Values stored literally
     Single,
-    /// Value is the count of bits set (one-hot encoding)
+    /// Current layout name for a monotonic bit-count counter; the logical
+    /// value is the count of bits set, not true one-hot encoding.
     OneHot,
     /// Each bit duplicated with majority vote
     LinearMajorityVote { duplication: u32 },
-    /// One-hot with linear majority vote
+    /// Bit-count counter with linear majority vote
     OneHotLinearMajorityVote { duplication: u32 },
     /// Words duplicated with per-bit majority vote
     WordMajorityVote { duplication: u32 },
     /// Each bit duplicated with OR reduction (any copy set → result is 1)
     LinearOr { duplication: u32 },
-    /// One-hot with linear OR reduction
+    /// Bit-count counter with linear OR reduction
     OneHotLinearOr { duplication: u32 },
     /// Words duplicated with per-bit OR reduction
     WordOr { duplication: u32 },

--- a/registers/generated-firmware/src/fuse_map.md
+++ b/registers/generated-firmware/src/fuse_map.md
@@ -271,9 +271,9 @@
 | cptra_itrng_entropy_config_0 | 32 | VENDOR_NON_SECRET_PROD_PARTITION | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_3 | Single | Entropy config 0: Low threshold (bits 15:0), High threshold (bits 31:16) |
 | cptra_itrng_entropy_config_1 | 32 | VENDOR_NON_SECRET_PROD_PARTITION | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_4 | Single | Entropy config 1: Repetition count (bits 15:0), Alert threshold (bits 31:16). See [spec](https://chipsalliance.github.io/caliptra-web/docs/2.1/firmware/rom_spec.html#entropy-source-configuration-registers) for details. |
 | vendor_recovery_pk_hash | 384 | VENDOR_NON_SECRET_PROD_PARTITION | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_8 | Single | Vendor recovery key for DOT_OVERRIDE catastrophic recovery operations |
-| mcu_component_svn_manifest_min_svn | 10 | VENDOR_NON_SECRET_PROD_PARTITION | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_5 | OneHotLinearOr(3x) | MCU Component SVN Manifest min SVN (one-hot, used by MCU ROM for manifest-format anti-rollback). |
-| soc_image_min_svn_0 | 10 | VENDOR_NON_SECRET_PROD_PARTITION | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_6 | OneHotLinearOr(3x) | SoC component min SVN for fuse slot 0 (one-hot, optional per-component rollback floor mapped via SVN_FUSE_MAP). |
-| soc_image_min_svn_1 | 10 | VENDOR_NON_SECRET_PROD_PARTITION | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_7 | OneHotLinearOr(3x) | SoC component min SVN for fuse slot 1 (one-hot, optional per-component rollback floor mapped via SVN_FUSE_MAP). |
+| mcu_component_svn_manifest_min_svn | 10 | VENDOR_NON_SECRET_PROD_PARTITION | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_5 | OneHotLinearOr(3x) | MCU Component SVN Manifest min SVN (bit-count counter, used by MCU ROM for manifest-format anti-rollback). |
+| soc_image_min_svn_0 | 10 | VENDOR_NON_SECRET_PROD_PARTITION | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_6 | OneHotLinearOr(3x) | SoC component min SVN for fuse slot 0 (bit-count counter, optional per-component rollback floor mapped via SVN_FUSE_MAP). |
+| soc_image_min_svn_1 | 10 | VENDOR_NON_SECRET_PROD_PARTITION | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_7 | OneHotLinearOr(3x) | SoC component min SVN for fuse slot 1 (bit-count counter, optional per-component rollback floor mapped via SVN_FUSE_MAP). |
 | vendor_pk_hash_valid | 16 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_VENDOR_PK_HASH_VALID | LinearOr(3x) | Bitmask indicating vendor PK hash validity. Unburnt bits (0) are valid; burnt bits (1) are revoked/invalid. |
 | vendor_ecc_revocation_0 | 4 | VENDOR_REVOCATIONS_PROD_PARTITION | CPTRA_CORE_ECC_REVOCATION_0 | LinearOr(3x) | Revocation bits for ECC keys in slot 0. |
 | vendor_mldsa_revocation_0 | 4 | VENDOR_REVOCATIONS_PROD_PARTITION | CPTRA_CORE_MLDSA_REVOCATION_0 | LinearOr(3x) | Revocation bits for MLDSA keys in slot 0. |
@@ -323,19 +323,19 @@
 | vendor_ecc_revocation_15 | 4 | VENDOR_REVOCATIONS_PROD_PARTITION | CPTRA_CORE_ECC_REVOCATION_15 | LinearOr(3x) | Revocation bits for ECC keys in slot 15. |
 | vendor_mldsa_revocation_15 | 4 | VENDOR_REVOCATIONS_PROD_PARTITION | CPTRA_CORE_MLDSA_REVOCATION_15 | LinearOr(3x) | Revocation bits for MLDSA keys in slot 15. |
 | vendor_lms_revocation_15 | 16 | VENDOR_REVOCATIONS_PROD_PARTITION | CPTRA_CORE_LMS_REVOCATION_15 | LinearOr(2x) | Revocation bits for LMS keys in slot 15. |
-| vendor_pqc_key_type_0 | 2 | VENDOR_HASHES_MANUF_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_0 | OneHotLinearOr(3x) | One-hot encoded PQC key type for slot 0 (1: MLDSA, 2: LMS). |
-| vendor_pqc_key_type_1 | 2 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_1 | OneHotLinearOr(3x) | One-hot encoded PQC key type for slot 1 (1: MLDSA, 2: LMS). |
-| vendor_pqc_key_type_2 | 2 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_2 | OneHotLinearOr(3x) | One-hot encoded PQC key type for slot 2 (1: MLDSA, 2: LMS). |
-| vendor_pqc_key_type_3 | 2 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_3 | OneHotLinearOr(3x) | One-hot encoded PQC key type for slot 3 (1: MLDSA, 2: LMS). |
-| vendor_pqc_key_type_4 | 2 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_4 | OneHotLinearOr(3x) | One-hot encoded PQC key type for slot 4 (1: MLDSA, 2: LMS). |
-| vendor_pqc_key_type_5 | 2 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_5 | OneHotLinearOr(3x) | One-hot encoded PQC key type for slot 5 (1: MLDSA, 2: LMS). |
-| vendor_pqc_key_type_6 | 2 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_6 | OneHotLinearOr(3x) | One-hot encoded PQC key type for slot 6 (1: MLDSA, 2: LMS). |
-| vendor_pqc_key_type_7 | 2 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_7 | OneHotLinearOr(3x) | One-hot encoded PQC key type for slot 7 (1: MLDSA, 2: LMS). |
-| vendor_pqc_key_type_8 | 2 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_8 | OneHotLinearOr(3x) | One-hot encoded PQC key type for slot 8 (1: MLDSA, 2: LMS). |
-| vendor_pqc_key_type_9 | 2 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_9 | OneHotLinearOr(3x) | One-hot encoded PQC key type for slot 9 (1: MLDSA, 2: LMS). |
-| vendor_pqc_key_type_10 | 2 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_10 | OneHotLinearOr(3x) | One-hot encoded PQC key type for slot 10 (1: MLDSA, 2: LMS). |
-| vendor_pqc_key_type_11 | 2 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_11 | OneHotLinearOr(3x) | One-hot encoded PQC key type for slot 11 (1: MLDSA, 2: LMS). |
-| vendor_pqc_key_type_12 | 2 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_12 | OneHotLinearOr(3x) | One-hot encoded PQC key type for slot 12 (1: MLDSA, 2: LMS). |
-| vendor_pqc_key_type_13 | 2 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_13 | OneHotLinearOr(3x) | One-hot encoded PQC key type for slot 13 (1: MLDSA, 2: LMS). |
-| vendor_pqc_key_type_14 | 2 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_14 | OneHotLinearOr(3x) | One-hot encoded PQC key type for slot 14 (1: MLDSA, 2: LMS). |
-| vendor_pqc_key_type_15 | 2 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_15 | OneHotLinearOr(3x) | One-hot encoded PQC key type for slot 15 (1: MLDSA, 2: LMS). |
+| vendor_pqc_key_type_0 | 2 | VENDOR_HASHES_MANUF_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_0 | OneHotLinearOr(3x) | Bit-count encoded PQC key type for slot 0 (1: MLDSA, 2: LMS). |
+| vendor_pqc_key_type_1 | 2 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_1 | OneHotLinearOr(3x) | Bit-count encoded PQC key type for slot 1 (1: MLDSA, 2: LMS). |
+| vendor_pqc_key_type_2 | 2 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_2 | OneHotLinearOr(3x) | Bit-count encoded PQC key type for slot 2 (1: MLDSA, 2: LMS). |
+| vendor_pqc_key_type_3 | 2 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_3 | OneHotLinearOr(3x) | Bit-count encoded PQC key type for slot 3 (1: MLDSA, 2: LMS). |
+| vendor_pqc_key_type_4 | 2 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_4 | OneHotLinearOr(3x) | Bit-count encoded PQC key type for slot 4 (1: MLDSA, 2: LMS). |
+| vendor_pqc_key_type_5 | 2 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_5 | OneHotLinearOr(3x) | Bit-count encoded PQC key type for slot 5 (1: MLDSA, 2: LMS). |
+| vendor_pqc_key_type_6 | 2 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_6 | OneHotLinearOr(3x) | Bit-count encoded PQC key type for slot 6 (1: MLDSA, 2: LMS). |
+| vendor_pqc_key_type_7 | 2 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_7 | OneHotLinearOr(3x) | Bit-count encoded PQC key type for slot 7 (1: MLDSA, 2: LMS). |
+| vendor_pqc_key_type_8 | 2 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_8 | OneHotLinearOr(3x) | Bit-count encoded PQC key type for slot 8 (1: MLDSA, 2: LMS). |
+| vendor_pqc_key_type_9 | 2 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_9 | OneHotLinearOr(3x) | Bit-count encoded PQC key type for slot 9 (1: MLDSA, 2: LMS). |
+| vendor_pqc_key_type_10 | 2 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_10 | OneHotLinearOr(3x) | Bit-count encoded PQC key type for slot 10 (1: MLDSA, 2: LMS). |
+| vendor_pqc_key_type_11 | 2 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_11 | OneHotLinearOr(3x) | Bit-count encoded PQC key type for slot 11 (1: MLDSA, 2: LMS). |
+| vendor_pqc_key_type_12 | 2 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_12 | OneHotLinearOr(3x) | Bit-count encoded PQC key type for slot 12 (1: MLDSA, 2: LMS). |
+| vendor_pqc_key_type_13 | 2 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_13 | OneHotLinearOr(3x) | Bit-count encoded PQC key type for slot 13 (1: MLDSA, 2: LMS). |
+| vendor_pqc_key_type_14 | 2 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_14 | OneHotLinearOr(3x) | Bit-count encoded PQC key type for slot 14 (1: MLDSA, 2: LMS). |
+| vendor_pqc_key_type_15 | 2 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_15 | OneHotLinearOr(3x) | Bit-count encoded PQC key type for slot 15 (1: MLDSA, 2: LMS). |

--- a/rom/src/device_ownership_transfer.rs
+++ b/rom/src/device_ownership_transfer.rs
@@ -97,7 +97,7 @@ impl DotFuses {
         // dot_initialized: LinearOr(1 bit, 3x) → logical 0 or 1
         let enabled = otp.read_entry(fuses::DOT_INITIALIZED)? != 0;
 
-        // dot_fuse_array: OneHot(256 bits) → count of burned bits
+        // dot_fuse_array: OneHot layout name, bit-count counter semantics
         // This is a multi-word field; read raw and count ones
         let mut raw = [0u8; 32];
         otp.read_entry_raw(fuses::DOT_FUSE_ARRAY, &mut raw)?;

--- a/rom/src/firmware_headers.rs
+++ b/rom/src/firmware_headers.rs
@@ -134,7 +134,7 @@ fn process_svn_manifest(env: &mut RomEnv, params: &RomParameters, offset: u32) -
         .set_flow_checkpoint(McuRomBootStatus::ComponentSvnManifestProcessingStarted.into());
 
     let limits = SvnLimits {
-        manifest_min_svn_max: one_hot_bits(MCU_COMPONENT_SVN_MANIFEST_MIN_SVN),
+        manifest_min_svn_max: bit_count_bits(MCU_COMPONENT_SVN_MANIFEST_MIN_SVN),
         caliptra_runtime_min_svn_max: crate::caliptra_svn::CALIPTRA_SVN_BITS,
         soc_manifest_min_svn_max: crate::caliptra_svn::CALIPTRA_SVN_BITS,
     };
@@ -210,7 +210,7 @@ fn burn_manifest_min_svn(
 }
 
 /// Validate each mapped per-component entry against its
-/// `SOC_IMAGE_MIN_SVN[i]` slot (one-hot range and rollback). Entries
+/// `SOC_IMAGE_MIN_SVN[i]` slot (bit-count range and rollback). Entries
 /// with an unmapped `component_id` are skipped with a logged warning
 /// (spec'd behaviour). No OTP writes.
 #[cfg(feature = "svn-manifest")]
@@ -229,7 +229,7 @@ fn check_per_component_min_svn(
             continue;
         };
 
-        let slot_max = one_hot_bits(fuse_entry);
+        let slot_max = bit_count_bits(fuse_entry);
         if u32::from(entry.current_svn) > slot_max || u32::from(entry.min_svn) > slot_max {
             caliptra_mcu_romtime::println!("[mcu-rom] SVN entry {} out of range", idx);
             fatal_error(McuError::ROM_COMPONENT_SVN_MANIFEST_ERROR);
@@ -264,7 +264,7 @@ fn burn_per_component_min_svn(
     }
 }
 
-/// Read a one-hot-encoded SVN fuse via the OTP entry's layout. Halts
+/// Read a bit-count encoded SVN fuse via the OTP entry's layout. Halts
 /// the boot on any OTP error.
 #[cfg(feature = "svn-manifest")]
 fn read_fuse(
@@ -311,10 +311,10 @@ fn anti_rollback_enabled(otp: &caliptra_mcu_romtime::Otp) -> Result<bool, McuErr
     Ok(raw.iter().all(|b| *b == 0))
 }
 
-/// Number of effective (one-hot) bits in `entry`'s layout, i.e. the max
-/// representable logical value. Returns 0 for non-one-hot layouts.
+/// Number of effective bit-count bits in `entry`'s layout, i.e. the max
+/// representable logical value. Returns 0 for layouts without bit-count semantics.
 #[cfg(feature = "svn-manifest")]
-fn one_hot_bits(entry: &caliptra_mcu_registers_generated::fuses::FuseEntryInfo) -> u32 {
+fn bit_count_bits(entry: &caliptra_mcu_registers_generated::fuses::FuseEntryInfo) -> u32 {
     use caliptra_mcu_registers_generated::fuses::FuseLayoutType;
     match entry.layout {
         FuseLayoutType::OneHot { bits }

--- a/romtime/src/component_svn_manifest.rs
+++ b/romtime/src/component_svn_manifest.rs
@@ -96,7 +96,7 @@ pub enum SvnManifestError {
         min_svn: u32,
         current_svn: u32,
     },
-    /// A header SVN does not fit within its target fuse's one-hot range.
+    /// A header SVN does not fit within its target fuse's bit-count range.
     HeaderSvnExceedsFuseRange {
         value: u32,
         max: u32,
@@ -108,7 +108,7 @@ pub enum SvnManifestError {
     },
 }
 
-/// One-hot range limits the caller must supply to [`McuComponentSvnManifest::validate`].
+/// Bit-count range limits the caller must supply to [`McuComponentSvnManifest::validate`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct SvnLimits {
     /// Max representable value for `MCU_COMPONENT_SVN_MANIFEST_MIN_SVN`.
@@ -177,7 +177,7 @@ impl McuComponentSvnManifest {
                     current_svn: entry.current_svn,
                 });
             }
-            // Per-entry one-hot-range checks against SOC_IMAGE_MIN_SVN[i]
+            // Per-entry bit-count range checks against SOC_IMAGE_MIN_SVN[i]
             // are deferred to the fuse-burn step, where SVN_FUSE_MAP
             // supplies the per-slot maximum.
         }

--- a/romtime/src/fuse_layout.rs
+++ b/romtime/src/fuse_layout.rs
@@ -17,15 +17,15 @@ pub struct Duplication(pub NonZero<usize>);
 pub enum FuseLayout {
     /// Values are stored literally
     Single(Bits),
-    /// Value is the number of bits set,
-    /// e.g., 0b110111 -> 5
+    /// Current layout name for a monotonic bit-count counter. The logical
+    /// value is the number of bits set, e.g., 0b110111 -> 5.
     OneHot(Bits),
     /// Each bit is duplicated within a single u32 (or across adjacent u32s) and the majority vote
     /// is used to compute the final value,
     /// e.g., 0b110111 -> 0b11
     LinearMajorityVote(Bits, Duplication),
-    /// Same as LinearMajorityVote, but the end result is to simply the count of the bits,
-    /// e.g., 0b110111 -> 2
+    /// Same as LinearMajorityVote, but with bit-count counter semantics,
+    /// e.g., 0b110111 -> 2.
     OneHotLinearMajorityVote(Bits, Duplication),
     /// u32s are duplicated, with bits are duplicated across multiple u32s. The result takes
     /// the majority vote of each bit,
@@ -34,8 +34,8 @@ pub enum FuseLayout {
     /// Each bit is duplicated and the result is the OR of all copies (any copy set → 1),
     /// e.g., with 3x duplication: 0b001_000_101 -> 0b11 (bit 0 has any set, bit 2 has any set)
     LinearOr(Bits, Duplication),
-    /// Same as LinearOr, but the end result is the count of the bits set,
-    /// e.g., with 3x duplication: 0b001_000_111 -> 2 (bit 0 OR'd to 1, bit 1 OR'd to 0, bit 2... wait)
+    /// Same as LinearOr, but with bit-count counter semantics,
+    /// e.g., with 3x duplication: 0b001_000_111 -> 2.
     OneHotLinearOr(Bits, Duplication),
     /// u32s are duplicated, with bits OR'd across multiple u32s,
     /// e.g., [0b100, 0b010, 0b001] -> [0b111]

--- a/romtime/src/otp.rs
+++ b/romtime/src/otp.rs
@@ -699,7 +699,7 @@ impl Otp {
     ///
     /// Reads `entry.byte_size` bytes from OTP and applies the entry's layout
     /// to produce N decoded u32 words. Use this for entries larger than a
-    /// single u32 (e.g., hash values with WordMajorityVote, large OneHot
+    /// single u32 (e.g., hash values with WordMajorityVote, large bit-count
     /// counters, etc.).
     pub fn read_entry_multi<const N: usize>(&self, entry: &FuseEntryInfo) -> McuResult<[u32; N]> {
         let layout = FuseLayout::from_generated(&entry.layout)


### PR DESCRIPTION
Update 2.0 fuse documentation and source comments to distinguish the existing OneHot* layout names from true one-hot encoding. Describe SVN floors, DOT counters, and PQC key-type fields as monotonic bit-count encodings while preserving the current schema/API names.

Also update HJSON descriptions, helper naming, and the ROM fuse layout error text to use bit-count terminology.