### PR TITLE
Add Measurement API and gated cold-boot/hitless boot init

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1744,6 +1744,13 @@ dependencies = [
 [[package]]
 name = "caliptra-mcu-measurement-api"
 version = "0.1.0"
+dependencies = [
+ "caliptra-mcu-libsyscall-caliptra",
+ "caliptra-mcu-libtock_platform",
+ "caliptra-mcu-runtime-userspace-error",
+ "mcu-caliptra-api-lite",
+ "sha2",
+]
 
 [[package]]
 name = "caliptra-mcu-otp-digest"

--- a/platforms/emulator/runtime/userspace/apps/user/Cargo.toml
+++ b/platforms/emulator/runtime/userspace/apps/user/Cargo.toml
@@ -73,6 +73,11 @@ streaming-boot = []
 flash-boot = []
 firmware-update = []
 mcu-mbox-service = []
+# Measurement boot init (off by default). Runs DPE Handle Storage / Software PCR
+# Storage cold-boot and hitless-update initialization. Cold boot rotates MCU-RT
+# off the default DPE handle, so keep this off until the SPDM evidence path is
+# rewired to track the rotated handle.
+measurement-boot-init = []
 mctp-vdm-service = []
 debug = []
 hw-2-1 = []

--- a/platforms/emulator/runtime/userspace/apps/user/src/main.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/main.rs
@@ -100,6 +100,13 @@ async fn start() {
 }
 
 pub(crate) async fn async_main() {
+    // Initialize measurement state before spawning any task that could consume
+    // it (image loading, firmware update, SPDM/evidence, MCU mailbox). Gated
+    // behind `measurement-boot-init` (off by default) until the SPDM evidence
+    // path is rewired to track the rotated MCU DPE handle; see `measurement::boot`.
+    #[cfg(feature = "measurement-boot-init")]
+    measurement::boot_init().await;
+
     #[cfg(feature = "spdm")]
     spdm::spawn_spdm_tasks(&EXECUTOR.get().spawner());
 

--- a/platforms/emulator/runtime/userspace/apps/user/src/measurement/boot.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/measurement/boot.rs
@@ -1,0 +1,188 @@
+// Licensed under the Apache-2.0 license
+
+//! Measurement boot-initialization wiring.
+//!
+//! Gated behind the `measurement-boot-init` cargo feature (off by default).
+//!
+//! Cold boot rotates the MCU Runtime DPE context off the default handle. The
+//! current SPDM evidence / certificate path still signs with the DPE *default*
+//! context handle (which DPE keeps sticky), so enabling boot init before that
+//! path is rewired to track the rotated handle would break attestation:
+//! `CertifyKey` / `Sign` on a non-default context roll the handle each call.
+//! Enable this feature together with the SPDM handle-lifecycle rewire.
+
+use caliptra_mcu_libsyscall_caliptra::mci::{mci_reg::RESET_REASON, Mci as MciSyscall};
+use caliptra_mcu_libsyscall_caliptra::DefaultSyscalls;
+use caliptra_mcu_libtock_console::Console;
+use caliptra_mcu_libtock_platform::ErrorCode;
+use caliptra_mcu_measurement_api::api::MeasurementApi;
+use caliptra_mcu_measurement_api::BootKind;
+use caliptra_mcu_spdm_pal::{BitmapAllocator, BITMAP_SLOT_SIZE};
+use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+use embassy_sync::mutex::Mutex;
+use mcu_error::McuErrorCode;
+
+#[allow(unused_imports)]
+use core::fmt::Write as _;
+use core::ptr::NonNull;
+
+use super::attestation_manifest_bytes;
+
+/// `FW_HITLESS_UPD_RESET` bit in the MCI `RESET_REASON` register.
+const RESET_REASON_FW_HITLESS_UPD_RESET_MASK: u32 = 0x1;
+/// `FW_BOOT_UPD_RESET` bit in the MCI `RESET_REASON` register.
+const RESET_REASON_FW_BOOT_UPD_RESET_MASK: u32 = 0x2;
+/// `WARM_RESET` bit in the MCI `RESET_REASON` register.
+const RESET_REASON_WARM_RESET_MASK: u32 = 0x4;
+const RESET_REASON_SUPPORTED_MASK: u32 = RESET_REASON_FW_HITLESS_UPD_RESET_MASK
+    | RESET_REASON_FW_BOOT_UPD_RESET_MASK
+    | RESET_REASON_WARM_RESET_MASK;
+
+/// Scratch pool (bytes) backing the boot-init SHA / DPE mailbox request buffers.
+const BOOT_INIT_SCRATCH_SIZE: usize = 4096;
+
+/// Single shared Measurement API instance.
+///
+/// Initialized once by [`boot_init`] and shared by all measurement consumers.
+/// The async mutex serializes concurrent access: each measurement operation is
+/// a multi-step async sequence over shared DPE/PCR capsule state, so a caller
+/// holds the lock for the whole operation. `None` until boot init runs (or if
+/// manifest parsing failed).
+pub(crate) static MEASUREMENT_API: Mutex<
+    CriticalSectionRawMutex,
+    Option<MeasurementApi<'static, DefaultSyscalls>>,
+> = Mutex::new(None);
+
+/// Initialize measurement state before any measurement consumer starts.
+///
+/// Classifies the reset as cold boot or MCU hitless update from `RESET_REASON`,
+/// then runs `measurement_boot_init` through a temporary bitmap allocator that
+/// backs the mailbox request buffers. The allocator is dropped once boot init
+/// completes; the [`MeasurementApi`] instance is published to [`MEASUREMENT_API`]
+/// for later consumers, and the persistent measurement state lives in the DPE
+/// Handle Storage and Software PCR Storage capsules.
+pub(crate) async fn boot_init() {
+    let mut cw = Console::<DefaultSyscalls>::writer();
+
+    let boot_kind = match reset_boot_kind() {
+        Ok(kind) => kind,
+        Err(_) => {
+            crate::log_error!(
+                cw,
+                "[measurement] RESET_REASON read/decode failed; skipping boot init"
+            );
+            return;
+        }
+    };
+
+    #[repr(C, align(64))]
+    struct ScratchBuf([u8; BOOT_INIT_SCRATCH_SIZE]);
+    static mut BOOT_INIT_SCRATCH: ScratchBuf = ScratchBuf([0u8; BOOT_INIT_SCRATCH_SIZE]);
+    // SAFETY: `boot_init` runs once at startup before any task that could use
+    // this buffer is spawned, so it is the sole owner of `BOOT_INIT_SCRATCH`.
+    let scratch_ptr: NonNull<u8> =
+        unsafe { NonNull::new_unchecked(BOOT_INIT_SCRATCH.0.as_mut_ptr()) };
+    debug_assert_eq!(scratch_ptr.as_ptr() as usize % BITMAP_SLOT_SIZE, 0);
+    // SAFETY: `scratch_ptr` points at `'static`, exclusively-owned memory of
+    // `BOOT_INIT_SCRATCH_SIZE` bytes.
+    let allocator = unsafe { BitmapAllocator::new(scratch_ptr, BOOT_INIT_SCRATCH_SIZE) };
+
+    let api = match MeasurementApi::<DefaultSyscalls>::new(attestation_manifest_bytes()) {
+        Ok(api) => api,
+        Err(e) => {
+            crate::log_error!(
+                cw,
+                "[measurement] attestation manifest invalid: 0x{}",
+                crate::Hex32(u32::from(McuErrorCode::from(e)))
+            );
+            return;
+        }
+    };
+
+    // Publish the single shared instance, then drive boot init while holding the
+    // lock. No consumer task is spawned yet, so there is no contention here;
+    // W6+ consumers serialize through this same lock.
+    let mut guard = MEASUREMENT_API.lock().await;
+    let api = guard.insert(api);
+    if let Err(e) = api.measurement_boot_init(boot_kind, &allocator).await {
+        crate::log_error!(
+            cw,
+            "[measurement] boot init failed: 0x{}",
+            crate::Hex32(u32::from(McuErrorCode::from(e)))
+        );
+    }
+}
+
+/// Classify the current reset as cold boot or MCU hitless update.
+fn reset_boot_kind() -> Result<BootKind, ErrorCode> {
+    let mci = MciSyscall::<DefaultSyscalls>::new();
+    let reason = mci.read(RESET_REASON, 0)?;
+    decode_reset_reason(reason).ok_or(ErrorCode::Invalid)
+}
+
+fn decode_reset_reason(reason: u32) -> Option<BootKind> {
+    if reason & !RESET_REASON_SUPPORTED_MASK != 0 {
+        return None;
+    }
+    let hitless = reason & RESET_REASON_FW_HITLESS_UPD_RESET_MASK != 0;
+    let boot_update = reason & RESET_REASON_FW_BOOT_UPD_RESET_MASK != 0;
+    if hitless && boot_update {
+        return None;
+    }
+    if hitless {
+        Some(BootKind::HitlessUpdate)
+    } else {
+        Some(BootKind::ColdBoot)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reset_reason_zero_is_cold_boot() {
+        assert_eq!(decode_reset_reason(0), Some(BootKind::ColdBoot));
+    }
+
+    #[test]
+    fn reset_reason_supported_non_hitless_values_are_cold_boot() {
+        assert_eq!(
+            decode_reset_reason(RESET_REASON_WARM_RESET_MASK),
+            Some(BootKind::ColdBoot)
+        );
+        assert_eq!(
+            decode_reset_reason(RESET_REASON_FW_BOOT_UPD_RESET_MASK),
+            Some(BootKind::ColdBoot)
+        );
+        assert_eq!(
+            decode_reset_reason(RESET_REASON_FW_BOOT_UPD_RESET_MASK | RESET_REASON_WARM_RESET_MASK),
+            Some(BootKind::ColdBoot)
+        );
+    }
+
+    #[test]
+    fn reset_reason_hitless_values_are_hitless_update() {
+        assert_eq!(
+            decode_reset_reason(RESET_REASON_FW_HITLESS_UPD_RESET_MASK),
+            Some(BootKind::HitlessUpdate)
+        );
+        assert_eq!(
+            decode_reset_reason(
+                RESET_REASON_FW_HITLESS_UPD_RESET_MASK | RESET_REASON_WARM_RESET_MASK
+            ),
+            Some(BootKind::HitlessUpdate)
+        );
+    }
+
+    #[test]
+    fn reset_reason_unsupported_or_ambiguous_values_are_rejected() {
+        assert_eq!(decode_reset_reason(0x8), None);
+        assert_eq!(
+            decode_reset_reason(
+                RESET_REASON_FW_HITLESS_UPD_RESET_MASK | RESET_REASON_FW_BOOT_UPD_RESET_MASK
+            ),
+            None
+        );
+    }
+}

--- a/platforms/emulator/runtime/userspace/apps/user/src/measurement/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/measurement/mod.rs
@@ -2,6 +2,15 @@
 
 mod integrator_manifest;
 
+// Boot initialization is gated behind `measurement-boot-init` (off by default)
+// until the SPDM evidence path is rewired to track the rotated MCU DPE handle;
+// see [`boot`] for the rationale.
+#[cfg(feature = "measurement-boot-init")]
+mod boot;
+
+#[cfg(feature = "measurement-boot-init")]
+pub(crate) use boot::boot_init;
+
 #[allow(dead_code)]
 pub(crate) fn attestation_manifest_bytes() -> &'static [u8] {
     integrator_manifest::ATTESTATION_MANIFEST_BYTES

--- a/runtime/userspace/api/caliptra-api-lite/src/dpe.rs
+++ b/runtime/userspace/api/caliptra-api-lite/src/dpe.rs
@@ -1,6 +1,7 @@
 // Licensed under the Apache-2.0 license
 
-//! DPE primitives over Caliptra's `INVOKE_DPE` mailbox command.
+//! DPE primitives over Caliptra's `INVOKE_DPE` mailbox command, plus
+//! the dedicated top-level `DPE_TAG_TCI` tagging command.
 //!
 //! Mirrors the on-wire layouts from
 //! `caliptra-dpe/dpe::commands` (request) and
@@ -15,8 +16,9 @@ use mcu_error::McuResult;
 use zerocopy::{little_endian::U32, FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 use crate::wire::{
-    calc_checksum, CMD_CERTIFY_KEY_CHUNKS, CMD_INVOKE_DPE, DPE_CMD_GET_CERTIFICATE_CHAIN,
-    DPE_CMD_SIGN, DPE_COMMAND_MAGIC, DPE_PROFILE_P384_SHA384, DPE_RESPONSE_MAGIC,
+    calc_checksum, mbox_execute, populate_checksum, CMD_CERTIFY_KEY_CHUNKS, CMD_DPE_TAG_TCI,
+    CMD_INVOKE_DPE, DPE_CMD_GET_CERTIFICATE_CHAIN, DPE_CMD_ROTATE_CONTEXT_HANDLE, DPE_CMD_SIGN,
+    DPE_COMMAND_MAGIC, DPE_PROFILE_P384_SHA384, DPE_RESPONSE_MAGIC, MBOX_RESP_HEADER_SIZE,
 };
 use crate::ApiAlloc;
 
@@ -121,6 +123,36 @@ struct DpeResponseHdr {
     profile: U32,
 }
 
+/// `dpe::commands::RotateCtxCmd`.
+#[repr(C)]
+#[derive(FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+struct RotateCtxCmd {
+    handle: [u8; DPE_CONTEXT_HANDLE_SIZE],
+    flags: U32,
+}
+
+/// `dpe::response::NewHandleResp` — the rotated context handle follows
+/// the response header.
+#[repr(C)]
+#[derive(FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+struct NewHandleRespBody {
+    _resp_hdr: [u8; 12],
+    handle: [u8; DPE_CONTEXT_HANDLE_SIZE],
+}
+
+/// Caliptra `TagTciReq`: `chksum(4) + handle(16) + tag(4)`. The
+/// `DPE_TAG_TCI` response carries no command-specific output.
+#[repr(C)]
+#[derive(FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+struct TagTciReq {
+    chksum: U32,
+    handle: [u8; DPE_CONTEXT_HANDLE_SIZE],
+    tag: U32,
+}
+
+const TAG_TCI_REQ_LEN: usize = size_of::<TagTciReq>();
+const _: () = assert!(TAG_TCI_REQ_LEN == 4 + DPE_CONTEXT_HANDLE_SIZE + 4);
+
 const GET_CERT_CHAIN_REQ_LEN: usize =
     size_of::<InvokeDpeReqPrefix>() + size_of::<DpeCommandHdr>() + size_of::<GetCertChainCmd>();
 const GET_CERT_CHAIN_DPE_PAYLOAD_LEN: u32 =
@@ -147,6 +179,11 @@ const CERTIFY_KEY_CHUNKS_REQ_FORMAT_OFF: usize =
 const CERTIFY_KEY_CHUNKS_REQ_LABEL_OFF: usize = CERTIFY_KEY_CHUNKS_REQ_FORMAT_OFF + 4;
 const CERTIFY_KEY_CHUNKS_RESP_CHUNK_LEN_OFF: usize = 4 + 4 + DPE_CONTEXT_HANDLE_SIZE;
 
+const ROTATE_CTX_REQ_LEN: usize =
+    size_of::<InvokeDpeReqPrefix>() + size_of::<DpeCommandHdr>() + size_of::<RotateCtxCmd>();
+const ROTATE_CTX_DPE_PAYLOAD_LEN: u32 =
+    (size_of::<DpeCommandHdr>() + size_of::<RotateCtxCmd>()) as u32;
+
 const _: () = assert!(size_of::<InvokeDpeReqPrefix>() == 8);
 const _: () = assert!(size_of::<DpeCommandHdr>() == 12);
 const _: () = assert!(size_of::<GetCertChainCmd>() == 8);
@@ -161,6 +198,9 @@ const _: () =
 const _: () = assert!(CERTIFY_KEY_P384_RESP_PREFIX_LEN == 128);
 const _: () = assert!(CERTIFY_KEY_CHUNKS_REQ_LEN == 92);
 const _: () = assert!(CERTIFY_KEY_CHUNKS_RESP_INFO_LEN == 32);
+const _: () = assert!(size_of::<RotateCtxCmd>() == DPE_CONTEXT_HANDLE_SIZE + 4);
+const _: () = assert!(size_of::<NewHandleRespBody>() == 12 + DPE_CONTEXT_HANDLE_SIZE);
+const _: () = assert!(ROTATE_CTX_REQ_LEN == 8 + 12 + 20);
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -217,7 +257,7 @@ pub async fn dpe_get_cert_chain_chunk<A: ApiAlloc>(
     let rsp_max =
         size_of::<InvokeDpeRespPrefix>() + size_of::<DpeResponseHdr>() + 4 + DPE_MAX_CHUNK_SIZE;
     let mut rsp = alloc.alloc(rsp_max)?;
-    let rsp_len = crate::wire::mbox_execute(CMD_INVOKE_DPE, &req, &mut rsp).await?;
+    let rsp_len = mbox_execute(CMD_INVOKE_DPE, &req, &mut rsp).await?;
 
     let outer_prefix_len = size_of::<InvokeDpeRespPrefix>();
     let dpe_hdr_off = outer_prefix_len;
@@ -564,7 +604,7 @@ pub async fn dpe_sign_ecc_p384<A: ApiAlloc>(
 
     let rsp_max = size_of::<InvokeDpeRespPrefix>() + size_of::<SignP384RespBody>();
     let mut rsp = alloc.alloc(rsp_max)?;
-    let rsp_len = crate::wire::mbox_execute(CMD_INVOKE_DPE, &req, &mut rsp).await?;
+    let rsp_len = mbox_execute(CMD_INVOKE_DPE, &req, &mut rsp).await?;
 
     let outer_prefix_len = size_of::<InvokeDpeRespPrefix>();
     let resp_body_off = outer_prefix_len;
@@ -589,4 +629,116 @@ pub async fn dpe_sign_ecc_p384<A: ApiAlloc>(
     let (sig_s, _) = rest.split_first_chunk_mut::<48>().ok_or(INVARIANT)?;
     *sig_s = sign_resp.sig_s;
     Ok(DPE_P384_SIGNATURE_SIZE)
+}
+
+/// Invoke DPE `RotateContextHandle` for the default context handle,
+/// returning the new (rotated) 16-byte context handle.
+///
+/// The request targets the default (all-zero) DPE context handle with
+/// empty flags, which asks DPE to rotate that context to a freshly
+/// generated, non-default handle and return it. MCU Runtime boot
+/// initialization uses this to obtain a stable MCU-held handle for the
+/// MCU Runtime context.
+#[inline(never)]
+pub async fn dpe_rotate_context_default<A: ApiAlloc>(
+    alloc: &A,
+) -> McuResult<[u8; DPE_CONTEXT_HANDLE_SIZE]> {
+    // Build request: prefix + DPE command header + RotateCtx body.
+    let mut req = alloc.alloc(ROTATE_CTX_REQ_LEN)?;
+    req.fill(0);
+    {
+        let prefix =
+            InvokeDpeReqPrefix::mut_from_bytes(&mut req[..size_of::<InvokeDpeReqPrefix>()])
+                .map_err(|_| INVARIANT)?;
+        prefix.data_size = U32::new(ROTATE_CTX_DPE_PAYLOAD_LEN);
+    }
+    let mut cur = size_of::<InvokeDpeReqPrefix>();
+    {
+        let hdr = DpeCommandHdr::mut_from_bytes(&mut req[cur..cur + size_of::<DpeCommandHdr>()])
+            .map_err(|_| INVARIANT)?;
+        hdr.magic = U32::new(DPE_COMMAND_MAGIC);
+        hdr.cmd_id = U32::new(DPE_CMD_ROTATE_CONTEXT_HANDLE);
+        hdr.profile = U32::new(DPE_PROFILE_P384_SHA384);
+    }
+    cur += size_of::<DpeCommandHdr>();
+    {
+        // `handle` stays the default (all-zero) context handle from the zeroed
+        // request buffer; empty `flags` request a freshly generated handle.
+        let cmd = RotateCtxCmd::mut_from_bytes(&mut req[cur..cur + size_of::<RotateCtxCmd>()])
+            .map_err(|_| INVARIANT)?;
+        cmd.flags = U32::new(0);
+    }
+    let checksum = calc_checksum(CMD_INVOKE_DPE, &req);
+    *req.first_chunk_mut::<4>().ok_or(INVARIANT)? = checksum.to_le_bytes();
+
+    let rsp_max = size_of::<InvokeDpeRespPrefix>() + size_of::<NewHandleRespBody>();
+    let mut rsp = alloc.alloc(rsp_max)?;
+    let rsp_len = mbox_execute(CMD_INVOKE_DPE, &req, &mut rsp).await?;
+
+    let resp_body_off = size_of::<InvokeDpeRespPrefix>();
+    if rsp_len < resp_body_off + size_of::<NewHandleRespBody>() {
+        return Err(INTERNAL_BUG);
+    }
+    let dpe_hdr = DpeResponseHdr::ref_from_bytes(
+        &rsp[resp_body_off..resp_body_off + size_of::<DpeResponseHdr>()],
+    )
+    .map_err(|_| INTERNAL_BUG)?;
+    if dpe_hdr.magic.get() != DPE_RESPONSE_MAGIC || dpe_hdr.status.get() != 0 {
+        return Err(INTERNAL_BUG);
+    }
+    let body = NewHandleRespBody::ref_from_bytes(
+        &rsp[resp_body_off..resp_body_off + size_of::<NewHandleRespBody>()],
+    )
+    .map_err(|_| INTERNAL_BUG)?;
+    Ok(body.handle)
+}
+
+/// Tag the DPE context identified by `handle` with `tag` via the
+/// top-level Caliptra `DPE_TAG_TCI` mailbox command.
+///
+/// Unlike the other DPE helpers here, `DPE_TAG_TCI` is a dedicated
+/// Caliptra mailbox command rather than an `INVOKE_DPE` sub-command.
+/// MCU Runtime boot initialization tags the rotated MCU Runtime
+/// context so its TCI can later be read back by tag.
+#[inline(never)]
+pub async fn dpe_tag_tci<A: ApiAlloc>(
+    alloc: &A,
+    handle: &[u8; DPE_CONTEXT_HANDLE_SIZE],
+    tag: u32,
+) -> McuResult<()> {
+    let mut req = alloc.alloc(TAG_TCI_REQ_LEN)?;
+    req.fill(0);
+    {
+        let cmd = TagTciReq::mut_from_bytes(&mut req[..TAG_TCI_REQ_LEN]).map_err(|_| INVARIANT)?;
+        cmd.handle = *handle;
+        cmd.tag = U32::new(tag);
+    }
+    populate_checksum(CMD_DPE_TAG_TCI, &mut req)?;
+
+    let mut rsp = alloc.alloc(MBOX_RESP_HEADER_SIZE)?;
+    let rsp_len = mbox_execute(CMD_DPE_TAG_TCI, &req, &mut rsp).await?;
+    if rsp_len < MBOX_RESP_HEADER_SIZE {
+        return Err(INTERNAL_BUG);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rotate_ctx_wire_layout() {
+        assert_eq!(DPE_CMD_ROTATE_CONTEXT_HANDLE, 0x0e);
+        assert_eq!(size_of::<RotateCtxCmd>(), DPE_CONTEXT_HANDLE_SIZE + 4);
+        assert_eq!(size_of::<NewHandleRespBody>(), 12 + DPE_CONTEXT_HANDLE_SIZE);
+        assert_eq!(ROTATE_CTX_REQ_LEN, 8 + 12 + 20);
+        assert_eq!(ROTATE_CTX_DPE_PAYLOAD_LEN, (12 + 20) as u32);
+    }
+
+    #[test]
+    fn tag_tci_wire_layout() {
+        assert_eq!(CMD_DPE_TAG_TCI, 0x5451_4754);
+        assert_eq!(TAG_TCI_REQ_LEN, 4 + DPE_CONTEXT_HANDLE_SIZE + 4);
+    }
 }

--- a/runtime/userspace/api/caliptra-api-lite/src/lib.rs
+++ b/runtime/userspace/api/caliptra-api-lite/src/lib.rs
@@ -53,9 +53,9 @@ pub use debug_unlock::{
 pub use device_state::{get_pcr_value, pcr_quote_ecc384, PCR_QUOTE_ECC384_LEN};
 pub use dpe::{
     dpe_certify_key, dpe_certify_key_cert_size, dpe_certify_key_cert_slice, dpe_certify_key_pubkey,
-    dpe_get_cert_chain_chunk, dpe_sign_ecc_p384, walk_dpe_chain, DpeChainSink, DpeContextHandle,
-    DPE_CONTEXT_HANDLE_SIZE, DPE_LABEL_LEN, DPE_MAX_CHUNK_SIZE, DPE_MAX_LEAF_CERT_SIZE,
-    DPE_P384_SIGNATURE_SIZE,
+    dpe_get_cert_chain_chunk, dpe_rotate_context_default, dpe_sign_ecc_p384, dpe_tag_tci,
+    walk_dpe_chain, DpeChainSink, DpeContextHandle, DPE_CONTEXT_HANDLE_SIZE, DPE_LABEL_LEN,
+    DPE_MAX_CHUNK_SIZE, DPE_MAX_LEAF_CERT_SIZE, DPE_P384_SIGNATURE_SIZE,
 };
 pub use ecdh::{
     ecdh_finish, ecdh_generate, CMB_ECDH_ENCRYPTED_CONTEXT_SIZE, CMB_ECDH_EXCHANGE_DATA_MAX_SIZE,

--- a/runtime/userspace/api/caliptra-api-lite/src/wire.rs
+++ b/runtime/userspace/api/caliptra-api-lite/src/wire.rs
@@ -45,6 +45,10 @@ pub(crate) const CMD_INVOKE_DPE: u32 = 0x4450_4543; // "DPEC"
 /// Mirrored from `caliptra-api::CommandId::CERTIFY_KEY_CHUNKS`.
 pub(crate) const CMD_CERTIFY_KEY_CHUNKS: u32 = 0x434B_4348; // "CKCH"
 
+/// Caliptra mailbox command ID for the top-level `DPE_TAG_TCI` command.
+/// Mirrored from `caliptra-api::CommandId::DPE_TAG_TCI`.
+pub(crate) const CMD_DPE_TAG_TCI: u32 = 0x5451_4754; // "TGQT"
+
 /// DPE per-command-header magic (`CommandHdr::DPE_COMMAND_MAGIC`).
 pub(crate) const DPE_COMMAND_MAGIC: u32 = 0x4450_4543; // "DPEC"
 
@@ -61,6 +65,10 @@ pub(crate) const DPE_CMD_GET_CERTIFICATE_CHAIN: u32 = 0x10;
 
 /// DPE `Sign` command ID (`dpe::commands::Command::SIGN`).
 pub(crate) const DPE_CMD_SIGN: u32 = 0x0A;
+
+/// DPE `RotateContextHandle` command ID
+/// (`dpe::commands::Command::ROTATE_CONTEXT_HANDLE`).
+pub(crate) const DPE_CMD_ROTATE_CONTEXT_HANDLE: u32 = 0x0e;
 
 /// `QUOTE_PCRS_ECC384` command ID.
 pub(crate) const CMD_QUOTE_PCRS_ECC384: u32 = 0x5043_5251; // "PCRQ"

--- a/runtime/userspace/api/measurement-api/Cargo.toml
+++ b/runtime/userspace/api/measurement-api/Cargo.toml
@@ -7,3 +7,10 @@ authors.workspace = true
 edition.workspace = true
 
 [dependencies]
+mcu-error = { workspace = true }
+caliptra-mcu-libsyscall-caliptra = { workspace = true }
+caliptra-mcu-libtock_platform = { workspace = true }
+mcu-caliptra-api-lite = { workspace = true }
+
+[dev-dependencies]
+sha2 = { workspace = true }

--- a/runtime/userspace/api/measurement-api/src/api.rs
+++ b/runtime/userspace/api/measurement-api/src/api.rs
@@ -1,0 +1,304 @@
+// Licensed under the Apache-2.0 license
+
+//! The `MeasurementApi` instance.
+//!
+//! It owns the parsed attestation manifest view and the attestation boot/error
+//! state. The DPE Handle Storage and Software PCR Storage clients are stateless
+//! syscall handles, so they are instantiated on demand inside each operation
+//! rather than stored. Boot initialization is performed by
+//! `measurement_boot_init`.
+
+use caliptra_mcu_libsyscall_caliptra::dpe_handle_store::{
+    DpeHandleRecord, DpeHandleStore, DPE_HANDLE_STORE_DRIVER_NUM, POLICY_DIGEST_SIZE,
+};
+use caliptra_mcu_libsyscall_caliptra::soft_pcr_store::{
+    SoftwarePcrStore, SOFT_PCR_STORE_DRIVER_NUM,
+};
+use caliptra_mcu_libsyscall_caliptra::DefaultSyscalls;
+use caliptra_mcu_libtock_platform::Syscalls;
+use core::marker::PhantomData;
+use mcu_caliptra_api_lite::{
+    dpe_rotate_context_default, dpe_tag_tci, sha_finish, sha_init, ApiAlloc, HashAlgo,
+    SHA_CONTEXT_SIZE,
+};
+
+use crate::attestation_manifest::{parse_and_validate, AttestationManifest, MCU_RT_FW_ID};
+use crate::errors::{MeasurementApiError, MeasurementApiResult};
+use crate::{AttestationState, BootKind};
+
+/// Owns the attestation configuration and attestation boot/error state.
+///
+/// The user app constructs one instance from the authenticated attestation
+/// manifest bytes and drives boot initialization before any measurement
+/// consumer runs. All later access to the static attestation configuration
+/// goes through this instance. The store clients are cheap syscall handles
+/// created on demand inside each operation.
+pub struct MeasurementApi<'a, S: Syscalls = DefaultSyscalls> {
+    manifest: AttestationManifest<'a>,
+    state: AttestationState,
+    _syscalls: PhantomData<S>,
+}
+
+impl<'a, S: Syscalls> MeasurementApi<'a, S> {
+    /// Parse and validate the integrator attestation manifest and construct the
+    /// Measurement API instance, which owns the parsed manifest view.
+    ///
+    /// A malformed manifest is reported as
+    /// [`MeasurementApiError::InvalidManifest`].
+    pub fn new(manifest_bytes: &'a [u8]) -> MeasurementApiResult<Self> {
+        let manifest = parse_and_validate(manifest_bytes)?;
+        Ok(Self {
+            manifest,
+            state: AttestationState::Uninitialized,
+            _syscalls: PhantomData,
+        })
+    }
+
+    /// Compute `attestation_policy_digest = SHA384(canonical manifest bytes)`
+    /// using the Caliptra SHA mailbox, writing it into `digest_out`.
+    ///
+    /// The digest is taken over the exact canonical manifest bytes, i.e. the
+    /// authenticated integrator static attestation configuration. Any mailbox
+    /// failure is reported as [`MeasurementApiError::DigestFailed`].
+    async fn attestation_policy_digest<A: ApiAlloc>(
+        &self,
+        alloc: &A,
+        digest_out: &mut [u8; POLICY_DIGEST_SIZE],
+    ) -> MeasurementApiResult {
+        let ctx = alloc
+            .alloc(SHA_CONTEXT_SIZE)
+            .map_err(|_| MeasurementApiError::DigestFailed)?;
+        let mut state = sha_init(alloc, ctx, HashAlgo::Sha384, self.manifest.bytes())
+            .await
+            .map_err(|_| MeasurementApiError::DigestFailed)?;
+        sha_finish(alloc, &mut state, digest_out)
+            .await
+            .map_err(|_| MeasurementApiError::DigestFailed)?;
+        Ok(())
+    }
+
+    /// Initialize measurement state after reset.
+    ///
+    /// Cold boot creates fresh measurement state and writes the MCU Runtime
+    /// root DPE record. Hitless update validates the preserved measurement
+    /// state against the authenticated attestation policy without clearing it.
+    /// On any failure the API is left in [`AttestationState::Error`] so later
+    /// measurement flows fail closed; on success it becomes
+    /// [`AttestationState::Active`].
+    pub async fn measurement_boot_init<A: ApiAlloc>(
+        &mut self,
+        boot: BootKind,
+        alloc: &A,
+    ) -> MeasurementApiResult {
+        let result = match boot {
+            BootKind::ColdBoot => self.cold_boot_init(alloc).await,
+            BootKind::HitlessUpdate => self.hitless_update_init(alloc).await,
+        };
+        self.state = if result.is_ok() {
+            AttestationState::Active
+        } else {
+            AttestationState::Error
+        };
+        result
+    }
+
+    /// Cold-boot sequence: compute the policy digest, initialize both stores,
+    /// rotate and tag the MCU Runtime DPE context, write the MCU Runtime root
+    /// record, and mark it as the initial attestation target.
+    async fn cold_boot_init<A: ApiAlloc>(&self, alloc: &A) -> MeasurementApiResult {
+        let dpe_store = DpeHandleStore::<S>::new(DPE_HANDLE_STORE_DRIVER_NUM);
+        let pcr_store = SoftwarePcrStore::<S>::new(SOFT_PCR_STORE_DRIVER_NUM);
+
+        let mut digest = [0u8; POLICY_DIGEST_SIZE];
+        self.attestation_policy_digest(alloc, &mut digest).await?;
+
+        dpe_store
+            .initialize_store(&digest)
+            .map_err(|_| MeasurementApiError::StoreFailed)?;
+        pcr_store
+            .initialize_store()
+            .map_err(|_| MeasurementApiError::StoreFailed)?;
+
+        let handle = dpe_rotate_context_default(alloc)
+            .await
+            .map_err(|_| MeasurementApiError::DpeMailboxFailed)?;
+        dpe_tag_tci(alloc, &handle, MCU_RT_FW_ID)
+            .await
+            .map_err(|_| MeasurementApiError::DpeMailboxFailed)?;
+
+        let record = DpeHandleRecord {
+            fw_id: MCU_RT_FW_ID,
+            parent_fw_id: None,
+            context_handle: handle,
+            tci_tag: MCU_RT_FW_ID,
+            ..Default::default()
+        };
+        dpe_store
+            .write_record(MCU_RT_FW_ID, &record)
+            .map_err(|_| MeasurementApiError::StoreFailed)?;
+        dpe_store
+            .mark_attestation_target(MCU_RT_FW_ID)
+            .map_err(|_| MeasurementApiError::StoreFailed)?;
+        Ok(())
+    }
+
+    /// Hitless-update sequence: recompute the policy digest, validate both
+    /// preserved stores against it, and validate the preserved MCU Runtime
+    /// root record.
+    ///
+    /// The preserved reserved SRAM is never cleared or reinitialized. A digest
+    /// mismatch, a missing required record, or invalid root-record semantics
+    /// fails closed so measurement state is not silently reinitialized under a
+    /// new lineage.
+    async fn hitless_update_init<A: ApiAlloc>(&self, alloc: &A) -> MeasurementApiResult {
+        let dpe_store = DpeHandleStore::<S>::new(DPE_HANDLE_STORE_DRIVER_NUM);
+        let pcr_store = SoftwarePcrStore::<S>::new(SOFT_PCR_STORE_DRIVER_NUM);
+
+        let mut digest = [0u8; POLICY_DIGEST_SIZE];
+        self.attestation_policy_digest(alloc, &mut digest).await?;
+
+        // Validate both preserved stores against the policy digest before use;
+        // a mismatch means the preserved state belongs to a different policy.
+        dpe_store
+            .validate_store(&digest)
+            .map_err(|_| MeasurementApiError::InvalidPreservedState)?;
+        pcr_store
+            .validate_store()
+            .map_err(|_| MeasurementApiError::InvalidPreservedState)?;
+
+        // The preserved MCU Runtime root record must exist and be well-formed.
+        let mut root = DpeHandleRecord::default();
+        dpe_store
+            .read_record(MCU_RT_FW_ID, &mut root)
+            .map_err(|_| MeasurementApiError::InvalidPreservedState)?;
+        if !is_mcu_root_record(&root) {
+            return Err(MeasurementApiError::InvalidPreservedState);
+        }
+
+        // The active DPE leaf must be readable. Its record semantics are not
+        // checked: once downstream SoC TCB components are recorded, the active
+        // leaf is legitimately one of those rather than the MCU Runtime root.
+        let mut leaf = DpeHandleRecord::default();
+        dpe_store
+            .read_leaf_record(&mut leaf)
+            .map_err(|_| MeasurementApiError::InvalidPreservedState)?;
+
+        // The attestation target must be readable and, until downstream target
+        // re-marking exists, still the MCU Runtime root.
+        let mut target = DpeHandleRecord::default();
+        dpe_store
+            .read_attestation_target(&mut target)
+            .map_err(|_| MeasurementApiError::InvalidPreservedState)?;
+        if target.fw_id != MCU_RT_FW_ID {
+            return Err(MeasurementApiError::InvalidPreservedState);
+        }
+
+        Ok(())
+    }
+
+    /// Current attestation availability state.
+    pub fn attestation_state(&self) -> AttestationState {
+        self.state
+    }
+}
+
+/// True if `record` has MCU Runtime root DPE record semantics: the
+/// `MCU_RT_FW_ID` root context (no parent), tagged with `MCU_RT_FW_ID`, and a
+/// non-default (non-zero) context handle.
+fn is_mcu_root_record(record: &DpeHandleRecord) -> bool {
+    record.fw_id == MCU_RT_FW_ID
+        && record.parent_fw_id.is_none()
+        && record.tci_tag == MCU_RT_FW_ID
+        && record.context_handle != [0u8; 16]
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+
+    use std::vec::Vec;
+
+    use super::*;
+    use crate::attestation_manifest::{
+        ATTESTATION_MANIFEST_FIXED_HEADER_SIZE, ATTESTATION_MANIFEST_MARKER,
+        ATTESTATION_MANIFEST_VERSION, MCU_RT_FW_ID,
+    };
+
+    /// Build a minimal valid manifest: no component entries, empty
+    /// vendor/model platform-information strings.
+    fn valid_empty_manifest() -> Vec<u8> {
+        let header_size = ATTESTATION_MANIFEST_FIXED_HEADER_SIZE;
+        let mut out = Vec::new();
+        out.extend_from_slice(&ATTESTATION_MANIFEST_MARKER.to_le_bytes());
+        out.extend_from_slice(&(header_size as u32).to_le_bytes()); // size
+        out.extend_from_slice(&ATTESTATION_MANIFEST_VERSION.to_le_bytes());
+        out.extend_from_slice(&(header_size as u32).to_le_bytes()); // header_size
+        out.extend_from_slice(&0u32.to_le_bytes()); // entry_count
+        out.extend_from_slice(&0u32.to_le_bytes()); // tcb_entry_count
+        out.extend_from_slice(&0u16.to_le_bytes()); // vendor_len
+        out.extend_from_slice(&0u16.to_le_bytes()); // model_len
+        out.resize(header_size, 0); // zero vendor[100] + model[100]
+        out
+    }
+
+    #[test]
+    fn new_accepts_valid_manifest_and_starts_uninitialized() {
+        let bytes = valid_empty_manifest();
+        let api = MeasurementApi::<DefaultSyscalls>::new(&bytes).unwrap();
+        assert_eq!(api.attestation_state(), AttestationState::Uninitialized);
+        assert_eq!(api.manifest.attestation_target_fw_id(), MCU_RT_FW_ID);
+    }
+
+    #[test]
+    fn new_rejects_malformed_manifest() {
+        assert!(matches!(
+            MeasurementApi::<DefaultSyscalls>::new(&[0u8; 4]),
+            Err(MeasurementApiError::InvalidManifest)
+        ));
+    }
+
+    #[test]
+    fn policy_digest_input_is_exact_canonical_manifest_bytes() {
+        use sha2::{Digest, Sha384};
+
+        let bytes = valid_empty_manifest();
+        let api = MeasurementApi::<DefaultSyscalls>::new(&bytes).unwrap();
+
+        // The digest is computed over the exact canonical manifest bytes.
+        assert_eq!(api.manifest.bytes(), &bytes[..]);
+
+        // Reference SHA-384 that the mailbox digest path must reproduce.
+        let reference = Sha384::digest(&bytes);
+        assert_eq!(reference.len(), POLICY_DIGEST_SIZE);
+        assert_eq!(&Sha384::digest(api.manifest.bytes())[..], &reference[..]);
+    }
+
+    #[test]
+    fn mcu_root_record_semantics() {
+        let valid = DpeHandleRecord {
+            fw_id: MCU_RT_FW_ID,
+            parent_fw_id: None,
+            tci_tag: MCU_RT_FW_ID,
+            context_handle: [1u8; 16],
+            ..Default::default()
+        };
+        assert!(is_mcu_root_record(&valid));
+        // Wrong fw_id, a parent, wrong tag, or a default (zero) handle each fail.
+        assert!(!is_mcu_root_record(&DpeHandleRecord {
+            fw_id: MCU_RT_FW_ID + 1,
+            ..valid
+        }));
+        assert!(!is_mcu_root_record(&DpeHandleRecord {
+            parent_fw_id: Some(1),
+            ..valid
+        }));
+        assert!(!is_mcu_root_record(&DpeHandleRecord {
+            tci_tag: 0,
+            ..valid
+        }));
+        assert!(!is_mcu_root_record(&DpeHandleRecord {
+            context_handle: [0u8; 16],
+            ..valid
+        }));
+    }
+}

--- a/runtime/userspace/api/measurement-api/src/errors.rs
+++ b/runtime/userspace/api/measurement-api/src/errors.rs
@@ -1,0 +1,85 @@
+// Licensed under the Apache-2.0 license
+
+//! Measurement API error codes within [`mcu_error::domain::ATTESTATION`].
+//!
+//! Subdomain and code allocations are owned by this crate. The
+//! [`MeasurementApiError`] enum discriminants are the `code` field of the
+//! packed [`McuErrorCode`]; `domain` and `subdomain` are named constants so
+//! the codes stay within the append-only registry.
+
+use mcu_error::{domain, McuErrorCode};
+
+use crate::attestation_manifest::AttestationManifestError;
+
+/// Boot-initialization error subdomain under [`domain::ATTESTATION`].
+pub const SUBDOMAIN_BOOT_INIT: u8 = 0x01;
+
+/// Measurement API boot/initialization error categories.
+///
+/// Each discriminant is the low-16-bit `code` packed into a
+/// [`McuErrorCode`] as `(ATTESTATION, SUBDOMAIN_BOOT_INIT, code)`.
+#[repr(u16)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum MeasurementApiError {
+    /// The attestation manifest failed to parse or validate.
+    InvalidManifest = 0x0001,
+    /// Computing the attestation policy digest failed.
+    DigestFailed = 0x0002,
+    /// A DPE Handle Storage or Software PCR Storage operation failed.
+    StoreFailed = 0x0003,
+    /// A DPE or mailbox command failed.
+    DpeMailboxFailed = 0x0004,
+    /// Preserved measurement state was missing or semantically invalid.
+    InvalidPreservedState = 0x0005,
+    /// Attestation is disabled because measurement state is in an error state.
+    AttestationDisabled = 0x0006,
+}
+
+/// Convenience alias for a Measurement API operation result. `T` defaults to
+/// `()` so `MeasurementApiResult` reads as "succeeds or fails with a
+/// [`MeasurementApiError`]".
+pub type MeasurementApiResult<T = ()> = Result<T, MeasurementApiError>;
+
+impl From<MeasurementApiError> for McuErrorCode {
+    fn from(e: MeasurementApiError) -> Self {
+        McuErrorCode::new(domain::ATTESTATION, SUBDOMAIN_BOOT_INIT, e as u16)
+    }
+}
+
+impl From<AttestationManifestError> for MeasurementApiError {
+    fn from(_: AttestationManifestError) -> Self {
+        MeasurementApiError::InvalidManifest
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+
+    use super::*;
+
+    #[test]
+    fn error_codes_pack_expected_fields() {
+        for (err, code) in [
+            (MeasurementApiError::InvalidManifest, 0x0001u16),
+            (MeasurementApiError::DigestFailed, 0x0002),
+            (MeasurementApiError::StoreFailed, 0x0003),
+            (MeasurementApiError::DpeMailboxFailed, 0x0004),
+            (MeasurementApiError::InvalidPreservedState, 0x0005),
+            (MeasurementApiError::AttestationDisabled, 0x0006),
+        ] {
+            let mcu: McuErrorCode = err.into();
+            assert_eq!(mcu.domain(), domain::ATTESTATION);
+            assert_eq!(mcu.subdomain(), SUBDOMAIN_BOOT_INIT);
+            assert_eq!(mcu.code(), code);
+        }
+    }
+
+    #[test]
+    fn manifest_error_folds_to_invalid_manifest() {
+        assert_eq!(
+            MeasurementApiError::from(AttestationManifestError::InvalidMarker),
+            MeasurementApiError::InvalidManifest
+        );
+    }
+}

--- a/runtime/userspace/api/measurement-api/src/lib.rs
+++ b/runtime/userspace/api/measurement-api/src/lib.rs
@@ -2,4 +2,32 @@
 
 #![no_std]
 
+pub mod api;
 pub mod attestation_manifest;
+pub mod errors;
+
+/// Reset classification passed to `measurement_boot_init`.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum BootKind {
+    /// Cold boot: persistent measurement state is stale and must be
+    /// reinitialized.
+    ColdBoot,
+    /// MCU hitless update: preserved measurement state must be validated
+    /// against the authenticated attestation policy.
+    HitlessUpdate,
+}
+
+/// Attestation availability state owned by the Measurement API.
+///
+/// Later Measurement API entry points (W6-W9) gate evidence generation and
+/// component measurement-state mutation on this state.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum AttestationState {
+    /// Boot initialization has not completed yet.
+    Uninitialized,
+    /// Measurement state is valid; attestation flows may run.
+    Active,
+    /// Measurement state is invalid; normal attestation flows are blocked
+    /// until cold boot reinitializes measurement state.
+    Error,
+}

--- a/runtime/userspace/error/src/lib.rs
+++ b/runtime/userspace/error/src/lib.rs
@@ -140,6 +140,9 @@ pub mod domain {
     /// MCU↔Caliptra mailbox protocol (`mcu-mbox-lib`).
     pub const MAILBOX: u8 = 0x06;
 
+    /// Attestation / measurement API (`caliptra-mcu-measurement-api`).
+    pub const ATTESTATION: u8 = 0x07;
+
     /// Memory / allocator failures (singleton — any allocator may
     /// produce these, but the meaning never varies).
     pub const MEMORY: u8 = 0x10;


### PR DESCRIPTION
Fixes #1674 
Implements measurement_boot_init on caliptra-mcu-measurement-api: cold boot initializes DPE/PCR stores and writes the MCU-RT root record; hitless update validates preserved state and fails closed. Adds dpe_rotate_context_default and dpe_tag_tci to caliptra-api-lite, and an ATTESTATION error domain.

App boot wiring is gated behind the off-by-default `measurement-boot-init` feature: cold boot rotates MCU-RT off the DPE default handle, which the current SPDM path still signs with, so it stays disabled until that path is rewired to track the rotated handle.