### PR TITLE
Cherry pick to move OneHot encoded fuses to the `VENDOR_TEST` partition

### DIFF
--- a/docs/src/dot.md
+++ b/docs/src/dot.md
@@ -53,7 +53,7 @@ Reference: [OCP Device Ownership Transfer specification](https://opencomputeproj
 
 **DOT_EFFECTIVE_KEY**: A key derived from DOT_ROOT_KEY and the DOT_FUSE_ARRAY value, used to authenticate DOT_BLOBs via HMAC. The derivation varies based on EVEN/ODD state.
 
-**DOT_FUSE_ARRAY**: A minimal fuse array using 1 bit per state change to track DOT state transitions. The fuse value acts as a counter that increments with each state change (one-time programmable).
+**DOT_FUSE_ARRAY**: A minimal fuse array using 1 bit per state change to track DOT state transitions. The fuse value acts as a counter that increments with each state change (one-time programmable). Must reside in a non-ECC protected fuse partition (e.g., `VENDOR_TEST_PARTITION` in the reference map) so that individual bits can be burned sequentially over time without invalidating partition ECC protections.
 
 **DOT_ROOT_KEY**: A hardware-derived secret key unique to the silicon, used as the basis for deriving DOT_EFFECTIVE_KEY. Provides silicon binding.
 
@@ -192,6 +192,7 @@ The DOT_BLOB is authenticated on every boot in ODD state to ensure the CAK and L
 ### DOT_FUSE_ARRAY
 - Hardware fuse array
 - Stores state counter (increments from 0 to maximum)
+- Must be located in a non-ECC protected partition (e.g., `VENDOR_TEST_PARTITION`) to allow multiple sequential 1-bit writes
 - Read during initialization
 - Written during state transitions
 - One-time programmable (OTP) per bit

--- a/docs/src/dot_i3c.md
+++ b/docs/src/dot_i3c.md
@@ -19,7 +19,7 @@ DOT I3C recovery is entered when **any** of the following conditions are met:
 The BMC has two recovery paths available over I3C:
 
 - **DOT_RECOVERY** — Supply a backup DOT blob (HMAC'd with the current DOT effective key). This restores the blob without changing fuse state.
-- **DOT_OVERRIDE** — Challenge/response authentication with the VendorKey. This burns a fuse (ODD→EVEN transition) and writes a new empty DOT blob, effectively factory-resetting device ownership.
+- **DOT_OVERRIDE** — Challenge/response authentication with the VendorKey. This burns a fuse in `DOT_FUSE_ARRAY` (ODD→EVEN transition; requires `DOT_FUSE_ARRAY` to be in a non-ECC protected partition to allow sequential 1-bit writes) and writes a new empty DOT blob, effectively factory-resetting device ownership.
 
 ### `DOT_RECOVERY` Flow
 

--- a/docs/src/integrator-guide.md
+++ b/docs/src/integrator-guide.md
@@ -42,7 +42,10 @@ each burn one bit; key rotation burns two bits to preserve lock/unlock parity.
 The array uses the current MCU `OneHot` layout name for a monotonic bit-count
 counter. The layout name does not mean true one-hot encoding. The total number
 of bits determines the maximum number of ownership state transitions over the
-lifetime of the part.
+lifetime of the part. It must reside in a non-ECC protected partition (such as the
+`VENDOR_TEST_PARTITION` in the reference map) because ECC calculation across a
+partition forbids writing to it more than once, whereas monotonic bit-count
+counters must be incremented sequentially over time.
 
 A full ownership transfer cycle (install → lock → unlock) consumes **2 fuse
 bits**: one for the lock transition (EVEN → ODD) and one for the unlock
@@ -129,7 +132,7 @@ service mode.
 | Fuse field | Partition | Size | Encoding | Notes |
 |---|---|:---:|---|---|
 | `dot_initialized` | `VENDOR_NON_SECRET_PROD_PARTITION` | 1 bit (3 bytes with 3x OR duplication) | `LinearOr` | Gates the DOT flow. |
-| `dot_fuse_array` | `VENDOR_NON_SECRET_PROD_PARTITION` | 256 bits (32 bytes) | `OneHot` (bit-count counter) | State counter. Scales linearly with desired lock/unlock cycles. |
+| `dot_fuse_array` | `VENDOR_TEST_PARTITION` | 256 bits (32 bytes) | `OneHot` (bit-count counter) | State counter. Must be in a non-ECC partition. Scales linearly with desired lock/unlock cycles. |
 | `vendor_recovery_pk_hash` | `VENDOR_NON_SECRET_PROD_PARTITION` | 384 bits (48 bytes) | `Single` | Optional. For `DOT_OVERRIDE` catastrophic recovery. |
 
 If OTP space is constrained, the `dot_fuse_array` can be made smaller — the
@@ -137,8 +140,15 @@ minimum useful size is 2 bits, but this only allows a single lock/unlock cycle
 with no margin. If redundant bit-count encoding (`OneHotLinearOr`) is used,
 multiply the raw bit count by the duplication factor (e.g., 3×).
 
-A different partition can also be used if there is one specifically allocated in
-the integration-specific fuse map.
+### Non-ECC Partition Requirement for Incremental Counters
+
+Monotonic bit-count counters such as `dot_fuse_array`, `mcu_component_svn_manifest_min_svn`, and SoC image SVN counters (`soc_image_min_svn_*`) are written incrementally over multiple boot cycles or state transitions. They **must not** be placed in ECC-protected partitions (like `VENDOR_NON_SECRET_PROD_PARTITION`), because ECC calculation over a partition prevents subsequent write operations once programmed.
+
+In the reference map, these fields are placed in `VENDOR_TEST_PARTITION` (specifically `VENDOR_TEST`). If the test partition is needed for other testing or integration purposes in your deployment, a new vendor fuse partition that is **not ECC-protected** should be added to accommodate these incremental fuse values.
+
+### SoC Image SVN Counters
+
+In the reference schema and map, `soc_image_min_svn_0` and `soc_image_min_svn_1` are provided as baseline examples. More (or fewer) SoC image SVN values should be added or removed depending on the component architecture and anti-rollback requirements for the integration.
 
 ## Owner Public Key Hash Provisioning
 
@@ -339,7 +349,7 @@ available slots):
     Each bit corresponds to a slot. If a bit is set to `1`, the slot is
     considered invalid and skipped.
 2.  **Revocation Check**: For each valid slot, the ROM checks the revocation
-    status of the keys in the `CPTRA_CORE_ECC_REVOCATION_X`,  
+    status of the keys in the `CPTRA_CORE_ECC_REVOCATION_X`,
     `CPTRA_CORE_MLDSA_REVOCATION_X`, and `CPTRA_CORE_LMS_REVOCATION_X` fields:
     -   **ECC Keys**: Checked against the ECC revocation fuses (4 bits per
         slot).
@@ -435,7 +445,7 @@ sequenceDiagram
     participant MCU_ROM as MCU ROM
     participant MCU_RT as MCU RT
     participant Fuses as OTP Fuses
-    
+
     Requester->>MCU_ROM: Push new RT FW (signed with Key N+1)
     MCU_ROM->>Fuses: Read revocation bitmask
     MCU_ROM->>MCU_ROM: Verify signature with Key N+1
@@ -466,7 +476,7 @@ sequenceDiagram
     participant MCU_ROM as MCU ROM
     participant MCU_RT as MCU RT
     participant Fuses as OTP Fuses
-    
+
     Requester->>MCU_RT: MC_PROVISION_VENDOR_PK_HASH(slot M+1)
     MCU_RT->>Fuses: Provision PK hash in slot M+1
     Requester->>MCU_ROM: Push new RT FW (signed with Key in Slot M+1)

--- a/docs/src/provisioning.md
+++ b/docs/src/provisioning.md
@@ -231,7 +231,7 @@ It is the responsibility of the product integrator to ensure the appropriate req
 
 ### Lifecycle State Constraints for Provisioning Fuses
 
-The fuse partition below corresponds to the Caliptra Subsystem 2.1.1 [reference fuse map](https://github.com/chipsalliance/caliptra-ss/blob/css-v2.1.1/src/fuse_ctrl/doc/otp_ctrl_mmap.md).
+The fuse partition below corresponds to the Caliptra Subsystem 2.1.1 [reference fuse map](https://github.com/chipsalliance/caliptra-ss/blob/css-v2.1.1/src/fuse_ctrl/doc/otp_ctrl_mmap.md). Note that for MCU firmware reference mapping, monotonic bit-count counters (such as `dot_fuse_array` and SVN anti-rollback counters) are mapped to `VENDOR_TEST_PARTITION` (`VENDOR_TEST`) rather than `VENDOR_NON_SECRET_PROD_PARTITION`. Because `VENDOR_NON_SECRET_PROD_PARTITION` is ECC-protected, it cannot be written more than once; monotonic counters require a non-ECC protected partition to support sequential incremental bit-burn operations.
 
 |           **Partition**           |                  **Item**                   | **Size [B]** | **Lifecycle State** |
 | :-------------------------------: | :-----------------------------------------: | :----------: | ------------------- |

--- a/docs/src/rom-fuses.md
+++ b/docs/src/rom-fuses.md
@@ -83,17 +83,17 @@ can be reclaimed.
 | Fuse | Logical size | Feature | Notes |
 |---|---|---|---|
 | `dot_initialized` | 1 bit | DOT | Gate flag indicating DOT flow is active for this part |
-| `dot_fuse_array` | 256 bits | DOT | Monotonic bit-count DOT state counter; supports 128 lock/unlock cycles; more or less can be allocated depending on use cases |
+| `dot_fuse_array` | 256 bits | DOT | Monotonic bit-count DOT state counter; must reside in a non-ECC protected partition; supports 128 lock/unlock cycles; more or less can be allocated depending on use cases |
 | `vendor_recovery_pk_hash` | 384 bits | DOT | Vendor master key for `DOT_OVERRIDE` catastrophic recovery (lives in `VENDOR_SECRET_PROD_PARTITION`). One slot today; integrators that need rotation should add `vendor_recovery_pk_hash_{0..N}` + a `vendor_recovery_pk_hash_valid` bitmask and/or revocation bits |
-| `MCU_COMPONENT_SVN_MANIFEST_MIN_SVN` | 32 bits (recommended) | MCU SVN anti-rollback | Min SVN for the MCU Component SVN Manifest itself |
-| `SOC_IMAGE_MIN_SVN[0..M]` | 32 bits each (recommended) | MCU SVN anti-rollback | Per-slot SoC image min SVN; `M` is integrator-defined |
+| `MCU_COMPONENT_SVN_MANIFEST_MIN_SVN` | 32 bits (recommended) | MCU SVN anti-rollback | Min SVN for the MCU Component SVN Manifest itself; must reside in a non-ECC protected partition |
+| `SOC_IMAGE_MIN_SVN[0..M]` | 32 bits each (recommended) | MCU SVN anti-rollback | Per-slot SoC image min SVN; must reside in a non-ECC protected partition; M is integrator-defined (reference map examples like slots 0 and 1 should be scaled per platform needs) |
 | `perma_hek_en` | 1 bit | OCP LOCK (2.1+) | Permanent HEK enable flag |
 | `CPTRA_SS_LOCK_HEK_PROD_{0..7}` | 256 bits each | OCP LOCK (2.1+) | 8 HEK seed slots (`CPTRA_SS_LOCK_HEK_PROD_N_RATCHET_SEED`, 32 B each); one active at a time |
 
 The MCU SVN fuse sizes above are the recommended logical widths from
 [`docs/src/svn.md`](svn.md); integrators choose the actual bit-count width and
 number of `SOC_IMAGE_MIN_SVN` slots based on their release cadence and
-component count.
+component count (reference schema examples like slots 0 and 1 should be added or removed per integration requirements). Monotonic bit-count counters must be placed in non-ECC protected partitions (such as `VENDOR_TEST_PARTITION`) to allow multiple sequential bit-burn operations.
 
 ## Fuse Field Reference
 
@@ -231,14 +231,17 @@ transformation from raw OTP bytes to written value. ✓ = Caliptra core fuse reg
 
 - **`MCU_COMPONENT_SVN_MANIFEST_MIN_SVN`** — MCU internal use only, not written
   to any Caliptra register. Recommended `OneHotLinearOr{bits:N, dupe:3}`
-  (logical width up to 32 bits). MCU ROM compares this against the MCU
-  Component SVN Manifest header to enforce its own anti-rollback floor.
+  (logical width up to 32 bits). Must reside in a non-ECC protected partition.
+  MCU ROM compares this against the MCU Component SVN Manifest header to enforce
+  its own anti-rollback floor.
 
 - **`SOC_IMAGE_MIN_SVN[0..M]`** — MCU internal use only, not written to any
   Caliptra register. Recommended `OneHotLinearOr{bits:N, dupe:3}` per slot
-  (logical width up to 32 bits). Optional per-SoC-component min SVN floor;
-  the number of slots `M` and the `component_id → slot` mapping are
-  integrator-defined.
+  (logical width up to 32 bits). Must reside in a non-ECC protected partition.
+  Optional per-SoC-component min SVN floor; the number of slots `M` and the
+  `component_id → slot` mapping are integrator-defined (reference map examples
+  like `soc_image_min_svn_0` and `soc_image_min_svn_1` should be added or
+  removed depending on integration requirements).
 
 ### OTP Encoding Recommendations
 
@@ -280,6 +283,8 @@ fault tolerance without causing ECC integrity issues.
 | `fw_encryption_key` | ✅ | `Single{bits:256}` (or 128/192 to match the chosen AES key length) |
 | `MCU_COMPONENT_SVN_MANIFEST_MIN_SVN` | ❌ | `OneHotLinearOr{bits:N, dupe:3}` (N up to 32) |
 | `SOC_IMAGE_MIN_SVN_{0..M}` | ❌ | `OneHotLinearOr{bits:N, dupe:3}` (N up to 32) each |
+
+*Note: Fields with `OneHot` or `OneHotLinearOr` monotonic bit-count layouts (`dot_fuse_array`, `MCU_COMPONENT_SVN_MANIFEST_MIN_SVN`, `SOC_IMAGE_MIN_SVN_{0..M}`) must reside in a non-ECC protected partition (e.g., `VENDOR_TEST_PARTITION` in the reference map) because ECC calculation forbids subsequent write operations once a partition has been programmed.*
 
 TODO: there are only 32 LMS revocation bits specificed in the reference fuse map, but with redundant encoding, we would get 16 or fewer bits, unless  they are backed with HW redundancy.
 

--- a/docs/src/svn.md
+++ b/docs/src/svn.md
@@ -85,7 +85,9 @@ manufacturing devices.
 
 ### New MCU SVN Fuses
 
-Added in a vendor partition (e.g., `VENDOR_NON_SECRET_PROD_PARTITION`):
+Added in a non-ECC protected vendor partition (e.g., `VENDOR_TEST_PARTITION` in
+the reference map, or a dedicated non-ECC vendor partition, since ECC protection
+prevents multi-write incremental bit-count advancements):
 
 | Fuse | Size | Recommended Encoding | Purpose |
 |---|---|---|---|
@@ -96,7 +98,10 @@ The number of `SOC_IMAGE_MIN_SVN` slots (`M`) and the number of bit-count bits
 per slot are integrator-defined. `MCU_COMPONENT_SVN_MANIFEST_MIN_SVN` exists
 even when the integrator does not provision any `SOC_IMAGE_MIN_SVN` slots,
 because the manifest's own anti-rollback applies regardless of how many
-component slots are mapped.
+component slots are mapped. In reference schemas and mapping examples,
+`soc_image_min_svn_0` and `soc_image_min_svn_1` are shown as baseline examples.
+Integrators should add or remove SoC image SVN fields depending on the number of
+firmware components and anti-rollback requirements of their integration.
 
 #### Encoding
 
@@ -468,15 +473,15 @@ re-attempted (and complete) on the next boot.
 
 ### Fuse Definition
 
-In `vendor_fuses.hjson`:
+In `vendor_fuses.hjson` (must target a non-ECC protected partition):
 
 ```js
 {
-  non_secret_vendor: [
+  vendor_test: [
     {"mcu_component_svn_manifest_min_svn": 4},
     {"soc_image_min_svn_0": 4},
     {"soc_image_min_svn_1": 4},
-    // ... additional slots as needed
+    // ... additional slots as needed (soc_image_min_svn_0 and _1 are examples)
   ],
   fields: [
     {name: "mcu_component_svn_manifest_min_svn", bits: 8},
@@ -499,6 +504,7 @@ pub struct SvnFuseMapEntry {
     pub fuse_entry: &'static FuseEntryInfo,
 }
 
+// Note: OTP_SOC_IMAGE_MIN_SVN_0 and OTP_SOC_IMAGE_MIN_SVN_1 are examples; add or remove slots depending on your integration.
 pub static SVN_FUSE_MAP: &[SvnFuseMapEntry] = &[
     SvnFuseMapEntry { component_id: 0x0000_1000, fuse_entry: &OTP_SOC_IMAGE_MIN_SVN_0 },
     SvnFuseMapEntry { component_id: 0x0000_1001, fuse_entry: &OTP_SOC_IMAGE_MIN_SVN_0 }, // shares slot 0

--- a/hw/fuses.hjson
+++ b/hw/fuses.hjson
@@ -16,7 +16,6 @@
     {"cptra_itrng_entropy_config_0": 4},
     {"cptra_itrng_entropy_config_1": 4},
     {"stable_owner_key_personalization_seed": 32}, // 256-bit seed for stable owner key derivation
-    {"field_entropy_state": 48},
     {"fpga_test_uds_seed_lo": 32},
     {"fpga_test_uds_seed_hi": 32},
     {"fpga_test_field_entropy": 32},
@@ -41,6 +40,7 @@
     {"mcu_component_svn_manifest_min_svn": 4},
     {"soc_image_min_svn_0": 4},
     {"soc_image_min_svn_1": 4},
+    {"field_entropy_state": 4},
   ],
 
   // Field definitions specify bit-level details within fuse bytes
@@ -662,10 +662,10 @@
     },
     {
         name: "field_entropy_state",
-        bits: 384,
-        description: "Status of field entropy slots. 32 bits per flag (word 3N: started, word 3N+1: finished, word 3N+2: zeroized for slot N).",
-        partition: "VENDOR_NON_SECRET_PROD_PARTITION",
-        otp_item: "CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_7",
+        bits: 12,
+        description: "Status of field entropy slots. 1 bit per flag (bit 3N: started, bit 3N+1: finished, bit 3N+2: zeroized for slot N).",
+        partition: "VENDOR_TEST_PARTITION",
+        otp_item: "VENDOR_TEST",
         layout: {type: "Single"},
     },
     {

--- a/hw/fuses.hjson
+++ b/hw/fuses.hjson
@@ -10,18 +10,29 @@
 
   // Vendor-specific non-secret fuses
   non_secret_vendor: [
-    // DOT state tracking fuses
-    // Each state transition burns one bit in the DOT_FUSE_ARRAY
-    // EVEN state (n % 2 == 0): Uninitialized or Volatile
-    // ODD state (n % 2 == 1): Locked or Disabled
-    // Supporting 128 lock/unlock cycles (256 total state transitions)
     {"dot_initialized": 1}, // 1 bit used to indicate that DOT is enabled and blob is written
-    {"dot_fuse_array": 32},  // 256 bits = 128 complete lock/unlock cycles
     {"perma_hek_en": 1},
     {"trng_health_test_window_size": 2},
     {"cptra_itrng_entropy_config_0": 4},
     {"cptra_itrng_entropy_config_1": 4},
     {"stable_owner_key_personalization_seed": 32}, // 256-bit seed for stable owner key derivation
+    {"field_entropy_state": 48},
+    {"fpga_test_uds_seed_lo": 32},
+    {"fpga_test_uds_seed_hi": 32},
+    {"fpga_test_field_entropy": 32},
+    // Hash of the vendor recovery public keys for DOT_OVERRIDE catastrophic
+    // recovery.
+    {"vendor_recovery_pk_hash": 48},
+  ],
+
+  // Vendor-specific test partition fuses (non-secret, non-ECC protected)
+  vendor_test_partition: [
+    // DOT state tracking fuses
+    // Each state transition burns one bit in the DOT_FUSE_ARRAY
+    // EVEN state (n % 2 == 0): Uninitialized or Volatile
+    // ODD state (n % 2 == 1): Locked or Disabled
+    // Supporting 128 lock/unlock cycles (256 total state transitions)
+    {"dot_fuse_array": 32},  // 256 bits = 128 complete lock/unlock cycles
     // SVN anti-rollback fuses (see docs/src/svn.md).
     // Sizes here are informational and refer to the raw OTP storage actually
     // used by the OneHotLinearOr encoding (bits * duplication / 8). The
@@ -30,13 +41,6 @@
     {"mcu_component_svn_manifest_min_svn": 4},
     {"soc_image_min_svn_0": 4},
     {"soc_image_min_svn_1": 4},
-    {"field_entropy_state": 48},
-    {"fpga_test_uds_seed_lo": 32},
-    {"fpga_test_uds_seed_hi": 32},
-    {"fpga_test_field_entropy": 32},
-    // Hash of the vendor recovery public keys for DOT_OVERRIDE catastrophic
-    // recovery.
-    {"vendor_recovery_pk_hash": 48},
   ],
 
   // Field definitions specify bit-level details within fuse bytes
@@ -54,8 +58,8 @@
       name: "dot_fuse_array",
       bits: 256,
       description: "One-time programmable state counter for DOT transitions. Each bit represents one state change. Increments from 0 to 255.",
-      partition: "VENDOR_NON_SECRET_PROD_PARTITION",
-      otp_item: "CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_1",
+      partition: "VENDOR_TEST_PARTITION",
+      otp_item: "VENDOR_TEST",
       layout: {type: "OneHot"},
     },
     {
@@ -116,24 +120,24 @@
       name: "mcu_component_svn_manifest_min_svn",
       bits: 10,
       description: "MCU Component SVN Manifest min SVN (bit-count counter, used by MCU ROM for manifest-format anti-rollback).",
-      partition: "VENDOR_NON_SECRET_PROD_PARTITION",
-      otp_item: "CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_5",
+      partition: "VENDOR_TEST_PARTITION",
+      otp_item: "VENDOR_TEST",
       layout: {type: "OneHotLinearOr", duplication: 3},
     },
     {
       name: "soc_image_min_svn_0",
       bits: 10,
       description: "SoC component min SVN for fuse slot 0 (bit-count counter, optional per-component rollback floor mapped via SVN_FUSE_MAP).",
-      partition: "VENDOR_NON_SECRET_PROD_PARTITION",
-      otp_item: "CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_6",
+      partition: "VENDOR_TEST_PARTITION",
+      otp_item: "VENDOR_TEST",
       layout: {type: "OneHotLinearOr", duplication: 3},
     },
     {
       name: "soc_image_min_svn_1",
       bits: 10,
       description: "SoC component min SVN for fuse slot 1 (bit-count counter, optional per-component rollback floor mapped via SVN_FUSE_MAP).",
-      partition: "VENDOR_NON_SECRET_PROD_PARTITION",
-      otp_item: "CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_7",
+      partition: "VENDOR_TEST_PARTITION",
+      otp_item: "VENDOR_TEST",
       layout: {type: "OneHotLinearOr", duplication: 3},
     },
     {

--- a/registers/fuses/src/codegen.rs
+++ b/registers/fuses/src/codegen.rs
@@ -185,6 +185,18 @@ pub fn generate_fuses(
     }
     output.push_str("];");
 
+    // Vendor test partition fuses
+    output.push_str("pub const VENDOR_TEST_PARTITION_FUSES: &[Fuse] = &[");
+    for fuse in &spec.vendor_test_partition {
+        for (name, size) in fuse {
+            output.push_str(&format!(
+                "Fuse {{ name: \"{}\", size: Bytes({}) }},",
+                name, size
+            ));
+        }
+    }
+    output.push_str("];");
+
     // Fuse fields
     output.push_str("pub const FUSE_FIELDS: &[FuseField] = &[");
     for field in &spec.fields {
@@ -194,6 +206,28 @@ pub fn generate_fuses(
         ));
     }
     output.push_str("];");
+
+    let mut vendor_test_offsets = HashMap::new();
+    let mut vendor_test_sizes = HashMap::new();
+    let mut vendor_test_offset = 0;
+    for fuse in &spec.vendor_test_partition {
+        for (name, size) in fuse {
+            vendor_test_offsets.insert(name.clone(), vendor_test_offset);
+            vendor_test_sizes.insert(name.clone(), *size as usize);
+            vendor_test_offset += *size as usize;
+        }
+    }
+
+    let mut vendor_test_offsets = HashMap::new();
+    let mut vendor_test_sizes = HashMap::new();
+    let mut vendor_test_offset = 0;
+    for fuse in &spec.vendor_test_partition {
+        for (name, size) in fuse {
+            vendor_test_offsets.insert(name.clone(), vendor_test_offset);
+            vendor_test_sizes.insert(name.clone(), *size as usize);
+            vendor_test_offset += *size as usize;
+        }
+    }
 
     // Fuse entries with partition info — emitted as standalone constants so the
     // compiler can dead-code-eliminate unused entries instead of pulling in one
@@ -209,30 +243,47 @@ pub fn generate_fuses(
             // Look up from OTP mmap info if available
             let mmap_info = partition_mmap.and_then(|m| m.get(partition_name));
 
-            let (part_idx, byte_offset, byte_size, entry_num) = if let Some(mmap) = mmap_info {
-                // Try otp_item first, then fall back to field name
-                let lookup_name = field.otp_item.as_deref().unwrap_or(&field.name);
-                let item = mmap
-                    .items
-                    .iter()
-                    .find(|i| i.name.eq_ignore_ascii_case(lookup_name));
-                if let Some(item) = item {
+            let (part_idx, byte_offset, byte_size, entry_num) =
+                if partition_name == "VENDOR_TEST_PARTITION" {
+                    let part_offset = mmap_info.map(|m| m.byte_offset).unwrap_or(0);
+                    let local_offset = vendor_test_offsets.get(&field.name).cloned().unwrap_or(0);
+                    let byte_size = vendor_test_sizes
+                        .get(&field.name)
+                        .cloned()
+                        .unwrap_or_else(|| field.bits.div_ceil(8) as usize);
+                    let entry_num = mmap_info
+                        .and_then(|m| m.items.first().map(|i| i.entry_num))
+                        .unwrap_or(0);
                     (
-                        mmap.partition_index,
-                        item.byte_offset,
-                        item.byte_size,
-                        item.entry_num,
+                        mmap_info.map(|m| m.partition_index).unwrap_or(0),
+                        part_offset + local_offset,
+                        byte_size,
+                        entry_num,
                     )
+                } else if let Some(mmap) = mmap_info {
+                    // Try otp_item first, then fall back to field name
+                    let lookup_name = field.otp_item.as_deref().unwrap_or(&field.name);
+                    let item = mmap
+                        .items
+                        .iter()
+                        .find(|i| i.name.eq_ignore_ascii_case(lookup_name));
+                    if let Some(item) = item {
+                        (
+                            mmap.partition_index,
+                            item.byte_offset,
+                            item.byte_size,
+                            item.entry_num,
+                        )
+                    } else {
+                        // Field not found in OTP mmap items — use partition-level info
+                        let byte_size = field.bits.div_ceil(8) as usize;
+                        (mmap.partition_index, mmap.byte_offset, byte_size, 0)
+                    }
                 } else {
-                    // Field not found in OTP mmap items — use partition-level info
+                    // No mmap info — use partition_num from fuses.hjson
                     let byte_size = field.bits.div_ceil(8) as usize;
-                    (mmap.partition_index, mmap.byte_offset, byte_size, 0)
-                }
-            } else {
-                // No mmap info — use partition_num from fuses.hjson
-                let byte_size = field.bits.div_ceil(8) as usize;
-                (partition_num.unwrap_or(0), 0, byte_size, 0)
-            };
+                    (partition_num.unwrap_or(0), 0, byte_size, 0)
+                };
 
             let layout_str = layout_to_codegen(&field.layout, field.bits);
             let const_name = field.name.to_uppercase();
@@ -248,10 +299,30 @@ pub fn generate_fuses(
     // the default layout.
     if let Some(mmap) = partition_mmap {
         // Collect fuses.hjson overrides keyed by OTP item name (case-insensitive)
+        let mut otp_item_counts = HashMap::new();
+        for f in &spec.fields {
+            if f.partition.is_some() {
+                let key = f
+                    .otp_item
+                    .as_deref()
+                    .unwrap_or(&f.name)
+                    .to_ascii_uppercase();
+                *otp_item_counts.entry(key).or_insert(0) += 1;
+            }
+        }
+
         let field_overrides: HashMap<String, &crate::schema::FieldDefinition> = spec
             .fields
             .iter()
             .filter(|f| f.partition.is_some())
+            .filter(|f| {
+                let key = f
+                    .otp_item
+                    .as_deref()
+                    .unwrap_or(&f.name)
+                    .to_ascii_uppercase();
+                otp_item_counts.get(&key).copied().unwrap_or(0) == 1
+            })
             .map(|f| {
                 let key = f
                     .otp_item

--- a/registers/fuses/src/schema.rs
+++ b/registers/fuses/src/schema.rs
@@ -11,6 +11,9 @@ pub struct FuseConfig {
     pub secret_vendor: Vec<HashMap<String, u32>>,
     /// Vendor-specific non-secret fuses
     pub non_secret_vendor: Vec<HashMap<String, u32>>,
+    /// Vendor-specific test partition fuses
+    #[serde(default)]
+    pub vendor_test_partition: Vec<HashMap<String, u32>>,
     /// Additional fuses outside of the standard areas
     /// TODO: define this
     pub other_fuses: Option<HashMap<String, String>>,
@@ -93,6 +96,14 @@ impl FuseConfig {
             .sum()
     }
 
+    /// Get the total size of vendor test partition fuses in bytes
+    pub fn vendor_test_partition_total_size(&self) -> u32 {
+        self.vendor_test_partition
+            .iter()
+            .flat_map(|map| map.values())
+            .sum()
+    }
+
     /// Find a field definition by name
     pub fn find_field(&self, name: &str) -> Option<&FieldDefinition> {
         self.fields.iter().find(|field| field.name == name)
@@ -110,6 +121,15 @@ impl FuseConfig {
     /// Get all non-secret vendor fuse names and sizes
     pub fn non_secret_vendor_fuses(&self) -> Vec<(&str, u32)> {
         self.non_secret_vendor
+            .iter()
+            .flat_map(|map| map.iter())
+            .map(|(name, size)| (name.as_str(), *size))
+            .collect()
+    }
+
+    /// Get all vendor test partition fuse names and sizes
+    pub fn vendor_test_partition_fuses(&self) -> Vec<(&str, u32)> {
+        self.vendor_test_partition
             .iter()
             .flat_map(|map| map.iter())
             .map(|(name, size)| (name.as_str(), *size))

--- a/registers/generated-firmware/src/fuse_map.md
+++ b/registers/generated-firmware/src/fuse_map.md
@@ -397,7 +397,7 @@
 | vendor_pqc_key_type_13 | 2 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_13 | OneHotLinearOr(3x) | Bit-count encoded PQC key type for slot 13 (1: MLDSA, 2: LMS). |
 | vendor_pqc_key_type_14 | 2 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_14 | OneHotLinearOr(3x) | Bit-count encoded PQC key type for slot 14 (1: MLDSA, 2: LMS). |
 | vendor_pqc_key_type_15 | 2 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_PQC_KEY_TYPE_15 | OneHotLinearOr(3x) | Bit-count encoded PQC key type for slot 15 (1: MLDSA, 2: LMS). |
-| field_entropy_state | 384 | VENDOR_NON_SECRET_PROD_PARTITION | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_7 | Single | Status of field entropy slots. 32 bits per flag (word 3N: started, word 3N+1: finished, word 3N+2: zeroized for slot N). |
+| field_entropy_state | 12 | VENDOR_TEST_PARTITION | VENDOR_TEST | Single | Status of field entropy slots. 1 bit per flag (bit 3N: started, bit 3N+1: finished, bit 3N+2: zeroized for slot N). |
 | fpga_test_uds_seed_lo | 256 | VENDOR_NON_SECRET_PROD_PARTITION | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_8 | Single | UDS Seed low 256 bits (for FPGA test harness handoff only) |
 | fpga_test_uds_seed_hi | 256 | VENDOR_NON_SECRET_PROD_PARTITION | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_9 | Single | UDS Seed high 256 bits (for FPGA test harness handoff only) |
 | fpga_test_field_entropy | 256 | VENDOR_NON_SECRET_PROD_PARTITION | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_10 | Single | Field Entropy (for FPGA test harness handoff only) |

--- a/registers/generated-firmware/src/fuse_map.md
+++ b/registers/generated-firmware/src/fuse_map.md
@@ -116,7 +116,7 @@
 
 | Entry | Name | Offset | Size (bytes) | Layout |
 |-------|------|--------|-------------|--------|
-| 0 | VENDOR_TEST | 0x03e0 | 32 | Single |
+| 0 | VENDOR_TEST | 0x03e0 | 32 | OneHot |
 
 ### vendor_hashes_manuf_partition (partition 10)
 
@@ -246,13 +246,13 @@
 | Entry | Name | Offset | Size (bytes) | Layout |
 |-------|------|--------|-------------|--------|
 | 0 | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_0 | 0x0aa8 | 32 | LinearOr(3x) |
-| 1 | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_1 | 0x0ac8 | 32 | OneHot |
+| 1 | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_1 | 0x0ac8 | 32 | Single |
 | 2 | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_2 | 0x0ae8 | 32 | LinearMajorityVote(3x) |
 | 3 | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_3 | 0x0b08 | 32 | Single |
 | 4 | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_4 | 0x0b28 | 32 | Single |
 | 5 | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_5 | 0x0b48 | 32 | Single |
 | 6 | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_6 | 0x0b68 | 32 | Single |
-| 7 | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_7 | 0x0b88 | 32 | OneHotLinearOr(3x) |
+| 7 | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_7 | 0x0b88 | 32 | Single |
 | 8 | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_8 | 0x0ba8 | 32 | Single |
 | 9 | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_9 | 0x0bc8 | 32 | Single |
 | 10 | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_10 | 0x0be8 | 32 | Single |
@@ -322,16 +322,16 @@
 | Name | Bits | Partition | OTP Item | Layout | Description |
 |------|------|-----------|----------|--------|-------------|
 | dot_initialized | 1 | VENDOR_NON_SECRET_PROD_PARTITION | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_0 | LinearOr(3x) | DOT is enabled and initialized for this part. |
-| dot_fuse_array | 256 | VENDOR_NON_SECRET_PROD_PARTITION | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_1 | OneHot | One-time programmable state counter for DOT transitions. Each bit represents one state change. Increments from 0 to 255. |
+| dot_fuse_array | 256 | VENDOR_TEST_PARTITION | VENDOR_TEST | OneHot | One-time programmable state counter for DOT transitions. Each bit represents one state change. Increments from 0 to 255. |
 | perma_hek_en | 1 | VENDOR_NON_SECRET_PROD_PARTITION | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_2 | LinearMajorityVote(3x) | Sets the PERMANENT HEK bit. Once set MCU will always provision a sanitized HEK to Caliptra. |
 | cptra_itrng_health_test_window_size | 16 | VENDOR_NON_SECRET_PROD_PARTITION | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_3 | Single | Health test window size for FIPS mode. See [spec](https://chipsalliance.github.io/caliptra-web/docs/2.1/firmware/rom_spec.html#entropy-source-configuration-registers) for details. |
 | cptra_itrng_entropy_config_0 | 32 | VENDOR_NON_SECRET_PROD_PARTITION | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_4 | Single | Entropy config 0: Low threshold (bits 15:0), High threshold (bits 31:16) |
 | cptra_itrng_entropy_config_1 | 32 | VENDOR_NON_SECRET_PROD_PARTITION | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_5 | Single | Entropy config 1: Repetition count (bits 15:0), Alert threshold (bits 31:16). See [spec](https://chipsalliance.github.io/caliptra-web/docs/2.1/firmware/rom_spec.html#entropy-source-configuration-registers) for details. |
 | stable_owner_key_personalization_seed | 256 | VENDOR_NON_SECRET_PROD_PARTITION | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_6 | Single | Personalization seed for stable owner key derivation. |
 | vendor_recovery_pk_hash | 384 | VENDOR_NON_SECRET_PROD_PARTITION | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_8 | Single | Vendor recovery key for DOT_OVERRIDE catastrophic recovery operations |
-| mcu_component_svn_manifest_min_svn | 10 | VENDOR_NON_SECRET_PROD_PARTITION | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_5 | OneHotLinearOr(3x) | MCU Component SVN Manifest min SVN (bit-count counter, used by MCU ROM for manifest-format anti-rollback). |
-| soc_image_min_svn_0 | 10 | VENDOR_NON_SECRET_PROD_PARTITION | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_6 | OneHotLinearOr(3x) | SoC component min SVN for fuse slot 0 (bit-count counter, optional per-component rollback floor mapped via SVN_FUSE_MAP). |
-| soc_image_min_svn_1 | 10 | VENDOR_NON_SECRET_PROD_PARTITION | CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_7 | OneHotLinearOr(3x) | SoC component min SVN for fuse slot 1 (bit-count counter, optional per-component rollback floor mapped via SVN_FUSE_MAP). |
+| mcu_component_svn_manifest_min_svn | 10 | VENDOR_TEST_PARTITION | VENDOR_TEST | OneHotLinearOr(3x) | MCU Component SVN Manifest min SVN (bit-count counter, used by MCU ROM for manifest-format anti-rollback). |
+| soc_image_min_svn_0 | 10 | VENDOR_TEST_PARTITION | VENDOR_TEST | OneHotLinearOr(3x) | SoC component min SVN for fuse slot 0 (bit-count counter, optional per-component rollback floor mapped via SVN_FUSE_MAP). |
+| soc_image_min_svn_1 | 10 | VENDOR_TEST_PARTITION | VENDOR_TEST | OneHotLinearOr(3x) | SoC component min SVN for fuse slot 1 (bit-count counter, optional per-component rollback floor mapped via SVN_FUSE_MAP). |
 | vendor_pk_hash_valid | 16 | VENDOR_HASHES_PROD_PARTITION | CPTRA_CORE_VENDOR_PK_HASH_VALID | LinearOr(3x) | Bitmask indicating vendor PK hash validity. Unburnt bits (0) are valid; burnt bits (1) are revoked/invalid. |
 | vendor_ecc_revocation_0 | 4 | VENDOR_REVOCATIONS_PROD_PARTITION | CPTRA_CORE_ECC_REVOCATION_0 | LinearOr(3x) | Revocation bits for ECC keys in slot 0. |
 | vendor_mldsa_revocation_0 | 4 | VENDOR_REVOCATIONS_PROD_PARTITION | CPTRA_CORE_MLDSA_REVOCATION_0 | LinearOr(3x) | Revocation bits for MLDSA keys in slot 0. |

--- a/registers/generated-firmware/src/fuses.rs
+++ b/registers/generated-firmware/src/fuses.rs
@@ -537,10 +537,6 @@ pub const NON_SECRET_VENDOR_FUSES: &[Fuse] = &[
         size: Bytes(32),
     },
     Fuse {
-        name: "field_entropy_state",
-        size: Bytes(48),
-    },
-    Fuse {
         name: "fpga_test_uds_seed_lo",
         size: Bytes(32),
     },
@@ -572,6 +568,10 @@ pub const VENDOR_TEST_PARTITION_FUSES: &[Fuse] = &[
     },
     Fuse {
         name: "soc_image_min_svn_1",
+        size: Bytes(4),
+    },
+    Fuse {
+        name: "field_entropy_state",
         size: Bytes(4),
     },
 ];
@@ -882,7 +882,7 @@ pub const FUSE_FIELDS: &[FuseField] = &[
     },
     FuseField {
         name: "field_entropy_state",
-        bits: Bits(384),
+        bits: Bits(12),
     },
     FuseField {
         name: "fpga_test_uds_seed_lo",
@@ -1793,12 +1793,12 @@ pub const VENDOR_PQC_KEY_TYPE_15: &FuseEntryInfo = &FuseEntryInfo {
 };
 /// Fuse entry for `field_entropy_state`.
 pub const FIELD_ENTROPY_STATE: &FuseEntryInfo = &FuseEntryInfo {
-    partition_num: 14,
-    entry_num: 7,
-    byte_offset: 0xb88,
-    byte_size: 32,
+    partition_num: 9,
+    entry_num: 0,
+    byte_offset: 0x40c,
+    byte_size: 4,
     name: "field_entropy_state",
-    layout: FuseLayoutType::Single { bits: 384 },
+    layout: FuseLayoutType::Single { bits: 12 },
 };
 /// Fuse entry for `fpga_test_uds_seed_lo`.
 pub const FPGA_TEST_UDS_SEED_LO: &FuseEntryInfo = &FuseEntryInfo {
@@ -3288,14 +3288,14 @@ pub const OTP_CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_6: &FuseEntryInfo = &Fuse
     name: "stable_owner_key_personalization_seed",
     layout: FuseLayoutType::Single { bits: 256 },
 };
-/// OTP item entry for `field_entropy_state`.
+/// OTP item entry for `CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_7`.
 pub const OTP_CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_7: &FuseEntryInfo = &FuseEntryInfo {
     partition_num: 14,
     entry_num: 7,
     byte_offset: 0xb88,
     byte_size: 32,
-    name: "field_entropy_state",
-    layout: FuseLayoutType::Single { bits: 384 },
+    name: "CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_7",
+    layout: FuseLayoutType::Single { bits: 256 },
 };
 /// OTP item entry for `CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_8`.
 pub const OTP_CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_8: &FuseEntryInfo = &FuseEntryInfo {

--- a/registers/generated-firmware/src/fuses.rs
+++ b/registers/generated-firmware/src/fuses.rs
@@ -517,10 +517,6 @@ pub const NON_SECRET_VENDOR_FUSES: &[Fuse] = &[
         size: Bytes(1),
     },
     Fuse {
-        name: "dot_fuse_array",
-        size: Bytes(32),
-    },
-    Fuse {
         name: "perma_hek_en",
         size: Bytes(1),
     },
@@ -541,18 +537,6 @@ pub const NON_SECRET_VENDOR_FUSES: &[Fuse] = &[
         size: Bytes(32),
     },
     Fuse {
-        name: "mcu_component_svn_manifest_min_svn",
-        size: Bytes(4),
-    },
-    Fuse {
-        name: "soc_image_min_svn_0",
-        size: Bytes(4),
-    },
-    Fuse {
-        name: "soc_image_min_svn_1",
-        size: Bytes(4),
-    },
-    Fuse {
         name: "field_entropy_state",
         size: Bytes(48),
     },
@@ -571,6 +555,24 @@ pub const NON_SECRET_VENDOR_FUSES: &[Fuse] = &[
     Fuse {
         name: "vendor_recovery_pk_hash",
         size: Bytes(48),
+    },
+];
+pub const VENDOR_TEST_PARTITION_FUSES: &[Fuse] = &[
+    Fuse {
+        name: "dot_fuse_array",
+        size: Bytes(32),
+    },
+    Fuse {
+        name: "mcu_component_svn_manifest_min_svn",
+        size: Bytes(4),
+    },
+    Fuse {
+        name: "soc_image_min_svn_0",
+        size: Bytes(4),
+    },
+    Fuse {
+        name: "soc_image_min_svn_1",
+        size: Bytes(4),
     },
 ];
 pub const FUSE_FIELDS: &[FuseField] = &[
@@ -909,9 +911,9 @@ pub const DOT_INITIALIZED: &FuseEntryInfo = &FuseEntryInfo {
 };
 /// Fuse entry for `dot_fuse_array`.
 pub const DOT_FUSE_ARRAY: &FuseEntryInfo = &FuseEntryInfo {
-    partition_num: 14,
-    entry_num: 1,
-    byte_offset: 0xac8,
+    partition_num: 9,
+    entry_num: 0,
+    byte_offset: 0x3e0,
     byte_size: 32,
     name: "dot_fuse_array",
     layout: FuseLayoutType::OneHot { bits: 256 },
@@ -975,10 +977,10 @@ pub const VENDOR_RECOVERY_PK_HASH: &FuseEntryInfo = &FuseEntryInfo {
 };
 /// Fuse entry for `mcu_component_svn_manifest_min_svn`.
 pub const MCU_COMPONENT_SVN_MANIFEST_MIN_SVN: &FuseEntryInfo = &FuseEntryInfo {
-    partition_num: 14,
-    entry_num: 5,
-    byte_offset: 0xb48,
-    byte_size: 32,
+    partition_num: 9,
+    entry_num: 0,
+    byte_offset: 0x400,
+    byte_size: 4,
     name: "mcu_component_svn_manifest_min_svn",
     layout: FuseLayoutType::OneHotLinearOr {
         bits: 10,
@@ -987,10 +989,10 @@ pub const MCU_COMPONENT_SVN_MANIFEST_MIN_SVN: &FuseEntryInfo = &FuseEntryInfo {
 };
 /// Fuse entry for `soc_image_min_svn_0`.
 pub const SOC_IMAGE_MIN_SVN_0: &FuseEntryInfo = &FuseEntryInfo {
-    partition_num: 14,
-    entry_num: 6,
-    byte_offset: 0xb68,
-    byte_size: 32,
+    partition_num: 9,
+    entry_num: 0,
+    byte_offset: 0x404,
+    byte_size: 4,
     name: "soc_image_min_svn_0",
     layout: FuseLayoutType::OneHotLinearOr {
         bits: 10,
@@ -999,10 +1001,10 @@ pub const SOC_IMAGE_MIN_SVN_0: &FuseEntryInfo = &FuseEntryInfo {
 };
 /// Fuse entry for `soc_image_min_svn_1`.
 pub const SOC_IMAGE_MIN_SVN_1: &FuseEntryInfo = &FuseEntryInfo {
-    partition_num: 14,
-    entry_num: 7,
-    byte_offset: 0xb88,
-    byte_size: 32,
+    partition_num: 9,
+    entry_num: 0,
+    byte_offset: 0x408,
+    byte_size: 4,
     name: "soc_image_min_svn_1",
     layout: FuseLayoutType::OneHotLinearOr {
         bits: 10,
@@ -3229,14 +3231,14 @@ pub const OTP_CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_0: &FuseEntryInfo = &Fuse
         duplication: 3,
     },
 };
-/// OTP item entry for `dot_fuse_array`.
+/// OTP item entry for `CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_1`.
 pub const OTP_CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_1: &FuseEntryInfo = &FuseEntryInfo {
     partition_num: 14,
     entry_num: 1,
     byte_offset: 0xac8,
     byte_size: 32,
-    name: "dot_fuse_array",
-    layout: FuseLayoutType::OneHot { bits: 256 },
+    name: "CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_1",
+    layout: FuseLayoutType::Single { bits: 256 },
 };
 /// OTP item entry for `perma_hek_en`.
 pub const OTP_CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_2: &FuseEntryInfo = &FuseEntryInfo {
@@ -3268,29 +3270,23 @@ pub const OTP_CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_4: &FuseEntryInfo = &Fuse
     name: "cptra_itrng_entropy_config_0",
     layout: FuseLayoutType::Single { bits: 32 },
 };
-/// OTP item entry for `mcu_component_svn_manifest_min_svn`.
+/// OTP item entry for `cptra_itrng_entropy_config_1`.
 pub const OTP_CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_5: &FuseEntryInfo = &FuseEntryInfo {
     partition_num: 14,
     entry_num: 5,
     byte_offset: 0xb48,
     byte_size: 32,
-    name: "mcu_component_svn_manifest_min_svn",
-    layout: FuseLayoutType::OneHotLinearOr {
-        bits: 10,
-        duplication: 3,
-    },
+    name: "cptra_itrng_entropy_config_1",
+    layout: FuseLayoutType::Single { bits: 32 },
 };
-/// OTP item entry for `soc_image_min_svn_0`.
+/// OTP item entry for `stable_owner_key_personalization_seed`.
 pub const OTP_CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_6: &FuseEntryInfo = &FuseEntryInfo {
     partition_num: 14,
     entry_num: 6,
     byte_offset: 0xb68,
     byte_size: 32,
-    name: "soc_image_min_svn_0",
-    layout: FuseLayoutType::OneHotLinearOr {
-        bits: 10,
-        duplication: 3,
-    },
+    name: "stable_owner_key_personalization_seed",
+    layout: FuseLayoutType::Single { bits: 256 },
 };
 /// OTP item entry for `field_entropy_state`.
 pub const OTP_CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_7: &FuseEntryInfo = &FuseEntryInfo {
@@ -3301,13 +3297,13 @@ pub const OTP_CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_7: &FuseEntryInfo = &Fuse
     name: "field_entropy_state",
     layout: FuseLayoutType::Single { bits: 384 },
 };
-/// OTP item entry for `fpga_test_uds_seed_lo`.
+/// OTP item entry for `CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_8`.
 pub const OTP_CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_8: &FuseEntryInfo = &FuseEntryInfo {
     partition_num: 14,
     entry_num: 8,
     byte_offset: 0xba8,
     byte_size: 32,
-    name: "fpga_test_uds_seed_lo",
+    name: "CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_8",
     layout: FuseLayoutType::Single { bits: 256 },
 };
 /// OTP item entry for `fpga_test_uds_seed_hi`.

--- a/rom/src/cold_boot.rs
+++ b/rom/src/cold_boot.rs
@@ -445,11 +445,11 @@ impl ColdBoot {
 
     /// Measure the field_entropy_state fuses and stash it to DPE.
     fn report_field_entropy_state(soc_manager: &mut CaliptraSoC, otp: &Otp) {
-        let Ok(words) = otp.read_entry_multi::<12>(fuses::FIELD_ENTROPY_STATE) else {
+        let Ok(word) = otp.read_entry(fuses::FIELD_ENTROPY_STATE) else {
             fatal_error(McuError::ROM_COLD_BOOT_READ_FIELD_ENTROPY_STATE_ERROR);
         };
 
-        let measurement = mailbox::cm_sha384(soc_manager, &words);
+        let measurement = mailbox::cm_sha384(soc_manager, &[word]);
 
         Self::stash_measurement(soc_manager, &measurement);
     }

--- a/romtime/src/otp.rs
+++ b/romtime/src/otp.rs
@@ -991,51 +991,27 @@ impl Otp {
         Ok(())
     }
 
-    /// Check if a field entropy slot is started in OTP memory.
-    pub fn is_field_entropy_started(&self, slot: FieldEntropySlot) -> McuResult<bool> {
-        let base_word = fuses::FIELD_ENTROPY_STATE.byte_offset / 4;
-        let word_index = (slot as usize) * 3;
-        let val = self.read_word(base_word + word_index)?;
-        Ok(val == FieldEntropySlot::STARTED_MAGIC)
-    }
-
-    /// Check if a field entropy slot is finished in OTP memory.
-    pub fn is_field_entropy_finished(&self, slot: FieldEntropySlot) -> McuResult<bool> {
-        let base_word = fuses::FIELD_ENTROPY_STATE.byte_offset / 4;
-        let word_index = (slot as usize) * 3 + 1;
-        let val = self.read_word(base_word + word_index)?;
-        Ok(val == FieldEntropySlot::FINISHED_MAGIC)
-    }
-
-    /// Check if a field entropy slot is zeroized in OTP memory.
-    pub fn is_field_entropy_zeroized(&self, slot: FieldEntropySlot) -> McuResult<bool> {
-        let base_word = fuses::FIELD_ENTROPY_STATE.byte_offset / 4;
-        let word_index = (slot as usize) * 3 + 2;
-        let val = self.read_word(base_word + word_index)?;
-        Ok(val == FieldEntropySlot::ZEROIZED_MAGIC)
-    }
-
     /// Mark a field entropy slot as started in OTP memory.
     pub fn mark_field_entropy_started(&self, slot: FieldEntropySlot) -> McuResult<()> {
-        let base_word = fuses::FIELD_ENTROPY_STATE.byte_offset / 4;
-        let word_index = (slot as usize) * 3;
-        self.write_word(base_word + word_index, FieldEntropySlot::STARTED_MAGIC)?;
+        let bit = (slot as usize) * 3 + FieldEntropySlot::STARTED_BIT_OFFSET;
+        let val = self.read_entry(fuses::FIELD_ENTROPY_STATE)?;
+        self.write_entry(fuses::FIELD_ENTROPY_STATE, val | (1 << bit))?;
         Ok(())
     }
 
     /// Mark a field entropy slot as finished in OTP memory.
     pub fn mark_field_entropy_finished(&self, slot: FieldEntropySlot) -> McuResult<()> {
-        let base_word = fuses::FIELD_ENTROPY_STATE.byte_offset / 4;
-        let word_index = (slot as usize) * 3 + 1;
-        self.write_word(base_word + word_index, FieldEntropySlot::FINISHED_MAGIC)?;
+        let bit = (slot as usize) * 3 + FieldEntropySlot::FINISHED_BIT_OFFSET;
+        let val = self.read_entry(fuses::FIELD_ENTROPY_STATE)?;
+        self.write_entry(fuses::FIELD_ENTROPY_STATE, val | (1 << bit))?;
         Ok(())
     }
 
     /// Mark a field entropy slot as zeroized in OTP memory.
     pub fn mark_field_entropy_zeroized(&self, slot: FieldEntropySlot) -> McuResult<()> {
-        let base_word = fuses::FIELD_ENTROPY_STATE.byte_offset / 4;
-        let word_index = (slot as usize) * 3 + 2;
-        self.write_word(base_word + word_index, FieldEntropySlot::ZEROIZED_MAGIC)?;
+        let bit = (slot as usize) * 3 + FieldEntropySlot::ZEROIZED_BIT_OFFSET;
+        let val = self.read_entry(fuses::FIELD_ENTROPY_STATE)?;
+        self.write_entry(fuses::FIELD_ENTROPY_STATE, val | (1 << bit))?;
         Ok(())
     }
 }
@@ -1266,9 +1242,9 @@ impl TryFrom<usize> for FieldEntropySlot {
 }
 
 impl FieldEntropySlot {
-    pub const STARTED_MAGIC: u32 = 0x5354_5254; // "STRT"
-    pub const FINISHED_MAGIC: u32 = 0x4649_4E53; // "FINS"
-    pub const ZEROIZED_MAGIC: u32 = 0x5A45_524F; // "ZERO"
+    pub const STARTED_BIT_OFFSET: usize = 0;
+    pub const FINISHED_BIT_OFFSET: usize = 1;
+    pub const ZEROIZED_BIT_OFFSET: usize = 2;
 }
 
 pub enum FieldEntropyState {
@@ -1280,9 +1256,11 @@ pub enum FieldEntropyState {
 
 impl FieldEntropyState {
     pub fn read(otp: &Otp, slot: FieldEntropySlot) -> McuResult<FieldEntropyState> {
-        let started = otp.is_field_entropy_started(slot)?;
-        let finished = otp.is_field_entropy_finished(slot)?;
-        let zeroized = otp.is_field_entropy_zeroized(slot)?;
+        let val = otp.read_entry(fuses::FIELD_ENTROPY_STATE)?;
+        let base_bit = (slot as usize) * 3;
+        let started = (val & (1 << (base_bit + FieldEntropySlot::STARTED_BIT_OFFSET))) != 0;
+        let finished = (val & (1 << (base_bit + FieldEntropySlot::FINISHED_BIT_OFFSET))) != 0;
+        let zeroized = (val & (1 << (base_bit + FieldEntropySlot::ZEROIZED_BIT_OFFSET))) != 0;
         if zeroized {
             Ok(FieldEntropyState::Zeroized)
         } else if started && !finished {

--- a/tests/integration/src/test_dot.rs
+++ b/tests/integration/src/test_dot.rs
@@ -1200,29 +1200,17 @@ mod test {
     /// Creates OTP memory with DOT in locked state (ODD, 1 fuse bit burned).
     /// Uses the generated fuse entry offsets for correct placement.
     fn create_locked_otp_memory() -> Vec<u8> {
-        use caliptra_mcu_otp_digest::{otp_scramble, OTP_SCRAMBLE_KEYS};
         use caliptra_mcu_registers_generated::fuses;
-        let mut otp =
-            vec![0u8; fuses::DOT_FUSE_ARRAY.byte_offset + fuses::DOT_FUSE_ARRAY.byte_size];
+        let required_size = fuses::VENDOR_RECOVERY_PK_HASH.byte_offset
+            + fuses::VENDOR_RECOVERY_PK_HASH.byte_size
+            + 16;
+        let otp_size =
+            required_size.max(fuses::DOT_FUSE_ARRAY.byte_offset + fuses::DOT_FUSE_ARRAY.byte_size);
+        let mut otp = vec![0u8; otp_size];
         // Set dot_initialized = 1 via LinearOr(1 bit, 3x) encoding: 0b111
         otp[fuses::DOT_INITIALIZED.byte_offset] = 0x07;
         // Set bit 0 of dot_fuse_array to 1 (burned=1, ODD/locked state)
         otp[fuses::DOT_FUSE_ARRAY.byte_offset] = 0x01;
-
-        // VendorSecretProdPartition (partition index 13) is scrambled.
-        // Pre-scramble zero blocks so the DAI read path unscrambles them
-        // back to zeros, ensuring recovery_pk_hash reads as all-zeros (None).
-        let key = OTP_SCRAMBLE_KEYS[5];
-        let part_start = fuses::VENDOR_SECRET_PROD_PARTITION_BYTE_OFFSET;
-        let part_end = part_start + fuses::VENDOR_SECRET_PROD_PARTITION_BYTE_SIZE;
-        let end = part_end.min(otp.len());
-        for off in (part_start..end).step_by(8) {
-            let scrambled = otp_scramble(0, key);
-            let bytes = scrambled.to_le_bytes();
-            let copy_len = bytes.len().min(otp.len() - off);
-            otp[off..off + copy_len].copy_from_slice(&bytes[..copy_len]);
-        }
-
         otp
     }
 

--- a/tests/integration/src/test_fips_zeroization.rs
+++ b/tests/integration/src/test_fips_zeroization.rs
@@ -109,16 +109,16 @@ mod test {
         // Check that FIELD_ENTROPY_STATE has all slots marked as ZEROIZED.
         let otp_mem = hw.read_otp_memory();
         let field_entropy_offset = FIELD_ENTROPY_STATE.byte_offset;
+        let field_entropy_word = u32::from_le_bytes(
+            otp_mem[field_entropy_offset..field_entropy_offset + 4]
+                .try_into()
+                .unwrap(),
+        );
         for slot in 0..4 {
-            let zeroized_word_offset = field_entropy_offset + (slot * 3 + 2) * 4;
-            let zeroized_word = u32::from_le_bytes(
-                otp_mem[zeroized_word_offset..zeroized_word_offset + 4]
-                    .try_into()
-                    .unwrap(),
-            );
-            assert_eq!(
-                zeroized_word,
-                FieldEntropySlot::ZEROIZED_MAGIC,
+            let bit = slot * 3 + FieldEntropySlot::ZEROIZED_BIT_OFFSET;
+            assert_ne!(
+                field_entropy_word & (1 << bit),
+                0,
                 "FIELD_ENTROPY_STATE for slot {slot} should be marked as ZEROIZED"
             );
         }

--- a/tests/integration/src/test_svn_manifest.rs
+++ b/tests/integration/src/test_svn_manifest.rs
@@ -6,8 +6,7 @@ mod test {
     use caliptra_mcu_error::McuError;
     use caliptra_mcu_hw_model::McuHwModel;
     use caliptra_mcu_registers_generated::fuses::{
-        FuseEntryInfo, OTP_CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_5, SOC_IMAGE_MIN_SVN_0,
-        SOC_IMAGE_MIN_SVN_1,
+        FuseEntryInfo, MCU_COMPONENT_SVN_MANIFEST_MIN_SVN, SOC_IMAGE_MIN_SVN_0, SOC_IMAGE_MIN_SVN_1,
     };
     use caliptra_mcu_rom_common::{
         McuComponentSvnEntry, McuComponentSvnManifest, MCU_COMPONENT_SVN_MANIFEST_MAGIC,
@@ -16,7 +15,7 @@ mod test {
     use caliptra_mcu_romtime::{McuBootMilestones, McuRomBootStatus};
     use zerocopy::IntoBytes;
 
-    const MANIFEST_MIN_SVN_FUSE: &FuseEntryInfo = OTP_CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_5;
+    const MANIFEST_MIN_SVN_FUSE: &FuseEntryInfo = MCU_COMPONENT_SVN_MANIFEST_MIN_SVN;
 
     fn manifest_bytes(
         current_svn: u8,


### PR DESCRIPTION
The second commit is not cherry-picked and should be reviewed separately.

It moves `field_entropy_state` to the new non-ECC protected partition. This originally used the `VENDOR_NON_SECRET` partition, but because that partition has ECC protections a full 32-bit word was allocated for each flag. Now that we have started using the `VENDOR_TEST` partition for OTP that needs to be written more than once (anti-rollback fuses) we can move `field_entropy_state` state there.

This makes the move and reduces the number of fuses from 384 to 12 because each state can now be represented with a single bit.