### PR TITLE
Unify Caliptra SPDM VDM command handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2021,6 +2021,7 @@ dependencies = [
 name = "caliptra-mcu-spdm-vdm-handler"
 version = "0.1.0"
 dependencies = [
+ "caliptra-mcu-common-commands",
  "caliptra-mcu-mbox-common",
  "caliptra-mcu-runtime-userspace-error",
  "caliptra-mcu-spdm-codec",

--- a/caliptra-util-host/transport/src/transports/spdm_vdm/commands.rs
+++ b/caliptra-util-host/transport/src/transports/spdm_vdm/commands.rs
@@ -240,36 +240,34 @@ pub fn handle_prod_debug_unlock_req(
     let req = ProdDebugUnlockReqRequest::from_bytes(payload)
         .map_err(|_| TransportError::InvalidMessage)?;
 
+    // VDM payload: [unlock_level(1)]
+    let vdm_payload = [req.unlock_level];
     let mut resp_buf = [0u8; MAX_VDM_RESPONSE_SIZE];
     let resp_len = send_vdm_request(
         CaliptraVdmCommand::RequestDebugUnlock,
-        req.as_bytes(),
+        &vdm_payload,
         driver,
         &mut resp_buf,
     )?;
 
     let data = &resp_buf[VDM_RESPONSE_HEADER_SIZE..resp_len];
 
-    // Response data: [length(4), unique_device_identifier(32), challenge(48)]
-    if data.len()
-        != core::mem::size_of::<u32>() + UNIQUE_DEVICE_ID_SIZE + DEBUG_UNLOCK_CHALLENGE_SIZE
-    {
+    // Response data: [unique_device_identifier(32), challenge(48)]
+    if data.len() != UNIQUE_DEVICE_ID_SIZE + DEBUG_UNLOCK_CHALLENGE_SIZE {
         return Err(TransportError::InvalidMessage);
     }
-    let length = u32::from_le_bytes([data[0], data[1], data[2], data[3]]);
-    let challenge_data = &data[core::mem::size_of::<u32>()..];
 
     let mut unique_device_identifier = [0u8; UNIQUE_DEVICE_ID_SIZE];
-    unique_device_identifier.copy_from_slice(&challenge_data[..UNIQUE_DEVICE_ID_SIZE]);
+    unique_device_identifier.copy_from_slice(&data[..UNIQUE_DEVICE_ID_SIZE]);
 
     let mut challenge = [0u8; DEBUG_UNLOCK_CHALLENGE_SIZE];
     challenge.copy_from_slice(
-        &challenge_data[UNIQUE_DEVICE_ID_SIZE..UNIQUE_DEVICE_ID_SIZE + DEBUG_UNLOCK_CHALLENGE_SIZE],
+        &data[UNIQUE_DEVICE_ID_SIZE..UNIQUE_DEVICE_ID_SIZE + DEBUG_UNLOCK_CHALLENGE_SIZE],
     );
 
     let internal_resp = ProdDebugUnlockReqResponse {
         common: CommonResponse { fips_status: 0 },
-        length,
+        length: 0,
         unique_device_identifier,
         challenge,
     };
@@ -292,6 +290,8 @@ pub fn handle_prod_debug_unlock_token(
     let req = ProdDebugUnlockTokenRequest::from_bytes(payload)
         .map_err(|_| TransportError::InvalidMessage)?;
 
+    // The request already carries the Caliptra mailbox checksum as its first
+    // word, allowing the MCU to stream it without buffering the whole token.
     let mut resp_buf = [0u8; MAX_VDM_RESPONSE_SIZE];
     let _resp_len = send_vdm_request(
         CaliptraVdmCommand::AuthorizeDebugUnlockToken,
@@ -357,6 +357,33 @@ mod tests {
     }
 
     #[test]
+    fn debug_unlock_token_preserves_caliptra_mailbox_request() {
+        let mut req = ProdDebugUnlockTokenRequest {
+            length: 1,
+            unlock_level: 2,
+            ..Default::default()
+        };
+        req.populate_checksum();
+        let mut driver = FakeDriver {
+            response: success_response(CaliptraVdmCommand::AuthorizeDebugUnlockToken, &[]),
+            last_request: Vec::new(),
+        };
+        let mut response_buffer = [0u8; core::mem::size_of::<ProdDebugUnlockTokenResponse>()];
+
+        handle_prod_debug_unlock_token(req.as_bytes(), &mut driver, &mut response_buffer)
+            .expect("DebugUnlock token should be accepted");
+
+        assert_eq!(
+            &driver.last_request[..2],
+            &[
+                CALIPTRA_VDM_COMMAND_VERSION,
+                CaliptraVdmCommand::AuthorizeDebugUnlockToken as u8,
+            ]
+        );
+        assert_eq!(&driver.last_request[2..], req.as_bytes());
+    }
+
+    #[test]
     fn export_attested_csr_rejects_oversized_csr_len() {
         let req = certificate::ExportAttestedCsrRequest {
             device_key_id: 1,
@@ -386,13 +413,7 @@ mod tests {
     #[test]
     fn debug_unlock_req_rejects_trailing_response_bytes() {
         let req = ProdDebugUnlockReqRequest::new(1);
-        let mut data = vec![
-            0xA5;
-            core::mem::size_of::<u32>()
-                + UNIQUE_DEVICE_ID_SIZE
-                + DEBUG_UNLOCK_CHALLENGE_SIZE
-                + 1
-        ];
+        let mut data = vec![0xA5; UNIQUE_DEVICE_ID_SIZE + DEBUG_UNLOCK_CHALLENGE_SIZE + 1];
         let mut driver = FakeDriver {
             response: success_response(CaliptraVdmCommand::RequestDebugUnlock, &data),
             last_request: Vec::new(),
@@ -403,13 +424,17 @@ mod tests {
             .expect_err("DebugUnlock response with trailing bytes must be rejected");
 
         assert!(matches!(err, TransportError::InvalidMessage));
-        data.truncate(
-            core::mem::size_of::<u32>() + UNIQUE_DEVICE_ID_SIZE + DEBUG_UNLOCK_CHALLENGE_SIZE,
-        );
-        data[..core::mem::size_of::<u32>()].copy_from_slice(&21u32.to_le_bytes());
+        data.truncate(UNIQUE_DEVICE_ID_SIZE + DEBUG_UNLOCK_CHALLENGE_SIZE);
         driver.response = success_response(CaliptraVdmCommand::RequestDebugUnlock, &data);
         handle_prod_debug_unlock_req(req.as_bytes(), &mut driver, &mut response_buffer)
             .expect("exact-length DebugUnlock response should be accepted");
-        assert_eq!(&driver.last_request[2..], req.as_bytes());
+        assert_eq!(
+            driver.last_request,
+            [
+                CALIPTRA_VDM_COMMAND_VERSION,
+                CaliptraVdmCommand::RequestDebugUnlock as u8,
+                req.unlock_level,
+            ]
+        );
     }
 }

--- a/caliptra-util-host/transport/src/transports/spdm_vdm/dispatch.rs
+++ b/caliptra-util-host/transport/src/transports/spdm_vdm/dispatch.rs
@@ -36,3 +36,35 @@ pub fn get_command_handler(command_id: u32) -> Option<VdmCommandHandlerFn> {
         _ => None,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::transports::spdm_vdm::protocol::command_id_to_vdm;
+    use caliptra_mcu_core_util_host_command_types::CaliptraCommandId;
+
+    #[test]
+    fn dispatch_and_protocol_mappings_stay_aligned() {
+        let ids = [
+            CaliptraCommandId::ExportAttestedCsr,
+            CaliptraCommandId::ProdDebugUnlockReq,
+            CaliptraCommandId::ProdDebugUnlockToken,
+            CaliptraCommandId::FeProg,
+            CaliptraCommandId::GetAuthCmdChallenge,
+        ];
+
+        for id in ids {
+            assert!(
+                get_command_handler(id as u32).is_some(),
+                "missing dispatch for {id:?}"
+            );
+            assert!(
+                command_id_to_vdm(id as u32).is_some(),
+                "missing VDM code for {id:?}"
+            );
+        }
+
+        assert!(get_command_handler(CaliptraCommandId::HashInit as u32).is_none());
+        assert!(command_id_to_vdm(CaliptraCommandId::HashInit as u32).is_none());
+    }
+}

--- a/platforms/emulator/runtime/userspace/apps/user/src/caliptra_cmd_handler/device_ops.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/caliptra_cmd_handler/device_ops.rs
@@ -13,9 +13,9 @@ use caliptra_mcu_libsyscall_caliptra::DefaultSyscalls;
 use caliptra_mcu_libtock_platform::ErrorCode;
 use caliptra_mcu_mbox_common::messages::HybridSignature;
 use mcu_caliptra_api_lite::{
-    fe_prog, get_attested_csr_ecc384, get_attested_csr_mldsa87, request_debug_unlock_challenge,
-    rng_generate, ApiAlloc, McuErrorCode, PRODUCTION_AUTH_DEBUG_UNLOCK_TOKEN_CMD,
-    PRODUCTION_AUTH_DEBUG_UNLOCK_TOKEN_RSP_LEN,
+    fe_prog, get_attested_csr_ecc384, get_attested_csr_mldsa87, get_idev_csr_ecc384,
+    request_debug_unlock_challenge, rng_generate, ApiAlloc, McuErrorCode,
+    PRODUCTION_AUTH_DEBUG_UNLOCK_TOKEN_CMD, PRODUCTION_AUTH_DEBUG_UNLOCK_TOKEN_RSP_LEN,
 };
 use zerocopy::IntoBytes;
 
@@ -78,6 +78,17 @@ pub async fn export_attested_csr(
         _ => return Err(CaliptraCompletionCode::InvalidParameter),
     };
     result.map_err(map_mcu_err)
+}
+
+pub async fn export_idevid_csr(algorithm: u32, out: &mut [u8]) -> CaliptraCmdResult<usize> {
+    match algorithm {
+        ALGO_ECC_P384 => get_idev_csr_ecc384(out)
+            .await
+            .map_err(map_mcu_err)?
+            .ok_or(CaliptraCompletionCode::InvalidState),
+        ALGO_MLDSA87 => Err(CaliptraCompletionCode::UnsupportedOperation),
+        _ => Err(CaliptraCompletionCode::InvalidParameter),
+    }
 }
 
 pub async fn generate_auth_challenge<A: ApiAlloc>(alloc: &A) -> CaliptraCmdResult<[u8; 32]> {

--- a/platforms/emulator/runtime/userspace/apps/user/src/caliptra_cmd_handler/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/caliptra_cmd_handler/mod.rs
@@ -5,8 +5,9 @@ pub(crate) mod device_ops;
 
 use caliptra_mcu_common_commands::{
     CaliptraCmdHandler, CaliptraCmdResult, CaliptraCompletionCode, DebugUnlockChallenge,
-    DeviceCapabilities, FirmwareVersion, GetLogResult, LogType,
+    DeviceCapabilities, FirmwareVersion, GetLogResult, LogType, MAX_FW_VERSION_LEN,
 };
+use caliptra_mcu_mbox_common::config;
 use mcu_caliptra_api_lite::ApiAlloc;
 
 pub struct CaliptraCmdBackend;
@@ -14,17 +15,33 @@ pub struct CaliptraCmdBackend;
 impl CaliptraCmdHandler for CaliptraCmdBackend {
     async fn get_firmware_version(
         &self,
-        _index: u32,
-        _version: &mut FirmwareVersion,
+        index: u32,
+        version: &mut FirmwareVersion,
     ) -> CaliptraCmdResult<()> {
-        Err(CaliptraCompletionCode::UnsupportedOperation)
+        let bytes = config::TEST_FIRMWARE_VERSIONS
+            .get(index as usize)
+            .ok_or(CaliptraCompletionCode::InvalidParameter)?
+            .as_bytes();
+        if bytes.len() > MAX_FW_VERSION_LEN {
+            return Err(CaliptraCompletionCode::InvalidPayloadSize);
+        }
+        version.ver_str[..bytes.len()].copy_from_slice(bytes);
+        version.len = bytes.len();
+        Ok(())
     }
 
     async fn get_device_capabilities(
         &self,
-        _capabilities: &mut DeviceCapabilities,
+        capabilities: &mut DeviceCapabilities,
     ) -> CaliptraCmdResult<()> {
-        Err(CaliptraCompletionCode::UnsupportedOperation)
+        let caps = &config::TEST_DEVICE_CAPABILITIES;
+        capabilities.caliptra_rt = caps.caliptra_rt;
+        capabilities.caliptra_fmc = caps.caliptra_fmc;
+        capabilities.caliptra_rom = caps.caliptra_rom;
+        capabilities.mcu_rt = caps.mcu_rt;
+        capabilities.mcu_rom = caps.mcu_rom;
+        capabilities.reserved = caps.reserved;
+        Ok(())
     }
 
     async fn export_attested_csr<Alloc: ApiAlloc>(
@@ -36,6 +53,15 @@ impl CaliptraCmdHandler for CaliptraCmdBackend {
         csr_buf: &mut [u8],
     ) -> CaliptraCmdResult<usize> {
         device_ops::export_attested_csr(device_key_id, algorithm, nonce, csr_buf).await
+    }
+
+    async fn export_idevid_csr<Alloc: ApiAlloc>(
+        &self,
+        _alloc: &Alloc,
+        algorithm: u32,
+        csr_buf: &mut [u8],
+    ) -> CaliptraCmdResult<usize> {
+        device_ops::export_idevid_csr(algorithm, csr_buf).await
     }
 
     /// Drain entries of `log_type` from the backing store.

--- a/platforms/emulator/runtime/userspace/apps/user/src/mcu_mbox/cmd_auth_mock.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/mcu_mbox/cmd_auth_mock.rs
@@ -1,19 +1,27 @@
 // Licensed under the Apache-2.0 license
+
 use crate::auth_keys::{TEST_AUTH_ECC_PUB_KEY_X, TEST_AUTH_ECC_PUB_KEY_Y, TEST_AUTH_MLDSA_PUB_KEY};
 use caliptra_mcu_common_commands::{AuthorizationError, CommandAuthorizer};
 use caliptra_mcu_mbox_common::messages::{
     CommandId, FuseIncreaseCaliptraMinSvnReq, FuseRevokeVendorPkHashReq, FuseRevokeVendorPubKeyReq,
     HybridSignature, MailboxReqHeader, McuFeProgReq, ProvisionVendorPkHashReq,
 };
+use core::cell::RefCell;
 use core::mem::size_of;
+use embassy_sync::blocking_mutex::{raw::CriticalSectionRawMutex, Mutex};
 use mcu_caliptra_api_lite::ApiAlloc;
 use zerocopy::FromBytes;
 
 extern crate alloc;
 
+static CHALLENGE: Mutex<CriticalSectionRawMutex, RefCell<Option<[u8; 32]>>> =
+    Mutex::new(RefCell::new(None));
+
 #[derive(Default)]
-pub struct MockCommandAuthorizer {
-    challenge: Option<[u8; 32]>,
+pub struct MockCommandAuthorizer;
+
+fn set_challenge(challenge: [u8; 32]) {
+    CHALLENGE.lock(|state| *state.borrow_mut() = Some(challenge));
 }
 
 impl CommandAuthorizer for MockCommandAuthorizer {
@@ -31,21 +39,19 @@ impl CommandAuthorizer for MockCommandAuthorizer {
             CommandId::MC_FE_PROG => size_of::<McuFeProgReq>(),
             CommandId::MC_FUSE_REVOKE_VENDOR_PUB_KEY => size_of::<FuseRevokeVendorPubKeyReq>(),
             CommandId::MC_FUSE_REVOKE_VENDOR_PK_HASH => size_of::<FuseRevokeVendorPkHashReq>(),
-            _ => Err(AuthorizationError)?,
+            _ => return Err(AuthorizationError),
         };
 
         let sigs_bytes = req
             .get(cmd_len..cmd_len + size_of::<HybridSignature>())
             .ok_or(AuthorizationError)?;
         let sig = HybridSignature::ref_from_bytes(sigs_bytes).map_err(|_| AuthorizationError)?;
-
         let cmd_body = req
             .get(size_of::<MailboxReqHeader>()..cmd_len)
             .ok_or(AuthorizationError)?;
 
         self.verify_signatures(u32::from(cmd_id), cmd_body, sig)
             .await?;
-
         Ok(&req[..cmd_len])
     }
 
@@ -55,7 +61,9 @@ impl CommandAuthorizer for MockCommandAuthorizer {
         payload: &[u8],
         sig: &HybridSignature,
     ) -> Result<(), AuthorizationError> {
-        let challenge = self.challenge.take().ok_or(AuthorizationError)?;
+        let challenge = CHALLENGE
+            .lock(|state| state.borrow_mut().take())
+            .ok_or(AuthorizationError)?;
 
         crate::caliptra_cmd_handler::device_ops::verify_authorized_signatures(
             cmd_id,
@@ -71,10 +79,10 @@ impl CommandAuthorizer for MockCommandAuthorizer {
     }
 
     fn take_challenge(&mut self) -> Option<[u8; 32]> {
-        self.challenge.take()
+        CHALLENGE.lock(|state| state.borrow_mut().take())
     }
 
     fn set_challenge(&mut self, challenge: [u8; 32]) {
-        self.challenge = Some(challenge)
+        set_challenge(challenge);
     }
 }

--- a/platforms/emulator/runtime/userspace/apps/user/src/mcu_mbox/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/mcu_mbox/mod.rs
@@ -80,10 +80,8 @@ async fn start_mcu_mbox_service() -> Result<(), ErrorCode> {
             unsafe { MCU_MBOX_ALLOC_CELL.init_once(scratch_ptr, MCU_MBOX_SCRATCH_SIZE) };
         let scratch = McuMboxScratchAlloc(scratch_allocator);
 
-        // Command handler: production wires the real `CaliptraCmdBackend`
-        // (unimplemented device-identity queries return `UnsupportedOperation`).
-        // Test builds (`mcu-mbox-test-handlers`) wire the mock that returns
-        // `config::TEST_*` identity for integration tests.
+        // Command handler shared with the Caliptra SPDM VDM backend.
+        // Test builds can still replace it with the dedicated integration mock.
         #[cfg(feature = "mcu-mbox-test-handlers")]
         let handler = cmd_handler_mock::NonCryptoCmdHandlerMock;
         #[cfg(not(feature = "mcu-mbox-test-handlers"))]
@@ -91,7 +89,7 @@ async fn start_mcu_mbox_service() -> Result<(), ErrorCode> {
         // Authorizer: HMAC-based command authorization stays wired in production
         // (uses a placeholder test key for now; to be replaced with real
         // provisioned key material later).
-        let mut cmd_authorizer = cmd_auth_mock::MockCommandAuthorizer::default();
+        let mut cmd_authorizer = cmd_auth_mock::MockCommandAuthorizer;
         let mut transport = caliptra_mcu_mbox_lib::transport::McuMboxTransport::new(
             caliptra_mcu_libsyscall_caliptra::mcu_mbox::MCU_MBOX0_DRIVER_NUM,
         );

--- a/platforms/emulator/runtime/userspace/apps/user/src/spdm/caliptra_vdm.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/spdm/caliptra_vdm.rs
@@ -1,23 +1,16 @@
 // Licensed under the Apache-2.0 license
 
-//! Platform implementation of the Caliptra VDM device-operations hook.
-//!
-//! [`CaliptraVdmHook`] is the emulator's [`CaliptraVdmCommands`] backend: it
-//! performs the actual device work (Caliptra mailbox calls) for the Caliptra
-//! VDM commands. The protocol/dispatch/framing all live in the
-//! `caliptra-mcu-spdm-vdm-handler` lib; this hook only supplies the device ops.
+//! Platform hooks for Caliptra SPDM VDM streaming and authorization.
 
-use crate::auth_keys::{TEST_AUTH_ECC_PUB_KEY_X, TEST_AUTH_ECC_PUB_KEY_Y, TEST_AUTH_MLDSA_PUB_KEY};
 use caliptra_mcu_common_commands::{
-    CaliptraCompletionCode as CommonCompletionCode, DEBUG_UNLOCK_CHALLENGE_SIZE,
-    DEBUG_UNLOCK_UNIQUE_DEVICE_ID_SIZE,
+    CaliptraCmdHandler, CaliptraCompletionCode as CommonCode, CommandAuthorizer,
 };
 use caliptra_mcu_libsyscall_caliptra::mailbox::{Mailbox, MailboxError};
 use caliptra_mcu_libsyscall_caliptra::DefaultSyscalls;
 use caliptra_mcu_mbox_common::messages::HybridSignature;
 use caliptra_mcu_spdm_traits::SpdmPalAlloc;
 use caliptra_mcu_spdm_vdm_handler::iana::ocp::caliptra_vdm::{
-    CaliptraCompletionCode, CaliptraVdmCommands, CaliptraVdmResult,
+    CaliptraCompletionCode, CaliptraVdmAuthorization, CaliptraVdmResult, CaliptraVdmStreamOps,
 };
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_sync::mutex::Mutex;
@@ -25,47 +18,20 @@ use mcu_caliptra_api_lite::{
     PRODUCTION_AUTH_DEBUG_UNLOCK_TOKEN_CMD, PRODUCTION_AUTH_DEBUG_UNLOCK_TOKEN_RSP_LEN,
 };
 
-/// HMAC command ID used by the host for the FE_PROG authorized sub-command.
+use crate::caliptra_cmd_handler::CaliptraCmdBackend;
+use crate::mcu_mbox::cmd_auth_mock;
+
+/// MC_FE_PROG sub-command (`MCFP`).
 const FE_PROG_CMD_ID: u32 = 0x4D43_4650;
 
-static AUTH_CHALLENGE: Mutex<CriticalSectionRawMutex, Option<[u8; 32]>> = Mutex::new(None);
 // Kernel chunked-mailbox state rejects other processes; this flag serializes this
 // app's DebugUnlock stream and lets abort clean up the in-flight mailbox request.
 static DEBUG_UNLOCK_TOKEN_STREAM: Mutex<CriticalSectionRawMutex, bool> = Mutex::new(false);
 
-/// Emulator Caliptra VDM device-operations backend.
-pub struct CaliptraVdmHook;
+pub struct CaliptraVdmStreamHook;
+pub struct CaliptraVdmAuthorizationHook;
 
-impl CaliptraVdmCommands for CaliptraVdmHook {
-    async fn request_debug_unlock<A: SpdmPalAlloc>(
-        &self,
-        unlock_level: u8,
-        scratch: &A,
-        out: &mut [u8],
-    ) -> CaliptraVdmResult<usize> {
-        let needed = DEBUG_UNLOCK_UNIQUE_DEVICE_ID_SIZE + DEBUG_UNLOCK_CHALLENGE_SIZE;
-        if out.len() < needed {
-            return Err(CaliptraCompletionCode::InsufficientResources);
-        }
-
-        crate::caliptra_cmd_handler::device_ops::request_debug_unlock(scratch, unlock_level, out)
-            .await
-            .map_err(map_common_completion)
-    }
-
-    async fn authorize_debug_unlock_token<A: SpdmPalAlloc>(
-        &self,
-        token_data: &[u8],
-        scratch: &A,
-    ) -> CaliptraVdmResult<()> {
-        // The host sends AuthorizeDebugUnlockToken as a complete Caliptra RT
-        // mailbox request, including MailboxReqHeader.checksum. Preserve those
-        // payload bytes exactly; do not synthesize another mailbox header here.
-        crate::caliptra_cmd_handler::device_ops::authorize_debug_unlock_token(scratch, token_data)
-            .await
-            .map_err(map_common_completion)
-    }
-
+impl CaliptraVdmStreamOps for CaliptraVdmStreamHook {
     async fn start_authorize_debug_unlock_token_stream<A: SpdmPalAlloc>(
         &self,
         token_len: usize,
@@ -124,20 +90,13 @@ impl CaliptraVdmCommands for CaliptraVdmHook {
             return Err(CaliptraCompletionCode::InvalidState);
         }
         let mailbox = Mailbox::<DefaultSyscalls>::new();
-        // 8-byte response header is a write-only throwaway; a stack buffer avoids
-        // the scratch alloc and its failure/cleanup path for a fixed tiny size.
-        let mut resp_buf = [0u8; PRODUCTION_AUTH_DEBUG_UNLOCK_TOKEN_RSP_LEN];
+        let mut resp = [0u8; PRODUCTION_AUTH_DEBUG_UNLOCK_TOKEN_RSP_LEN];
         let result = mailbox
-            .execute_chunked_request(PRODUCTION_AUTH_DEBUG_UNLOCK_TOKEN_CMD, &mut resp_buf)
+            .execute_chunked_request(PRODUCTION_AUTH_DEBUG_UNLOCK_TOKEN_CMD, &mut resp)
             .await
-            .map_err(|e| {
-                map_common_completion(crate::caliptra_cmd_handler::device_ops::map_mailbox_error(
-                    e,
-                ))
-            });
+            .map_err(map_mailbox_error);
         *active = false;
-        result?;
-        Ok(())
+        result.map(|_| ())
     }
 
     async fn abort_authorize_debug_unlock_token_stream<A: SpdmPalAlloc>(&self, _scratch: &A) {
@@ -149,25 +108,9 @@ impl CaliptraVdmCommands for CaliptraVdmHook {
             *active = false;
         }
     }
+}
 
-    async fn export_attested_csr<A: SpdmPalAlloc>(
-        &self,
-        device_key_id: u32,
-        algorithm: u32,
-        nonce: &[u8; 32],
-        _scratch: &A,
-        out: &mut [u8],
-    ) -> CaliptraVdmResult<usize> {
-        crate::caliptra_cmd_handler::device_ops::export_attested_csr(
-            device_key_id,
-            algorithm,
-            nonce,
-            out,
-        )
-        .await
-        .map_err(map_common_completion)
-    }
-
+impl CaliptraVdmAuthorization for CaliptraVdmAuthorizationHook {
     async fn get_auth_challenge<A: SpdmPalAlloc>(
         &self,
         scratch: &A,
@@ -176,8 +119,12 @@ impl CaliptraVdmCommands for CaliptraVdmHook {
         let challenge = crate::caliptra_cmd_handler::device_ops::generate_auth_challenge(scratch)
             .await
             .map_err(map_common_completion)?;
-        *AUTH_CHALLENGE.lock().await = Some(challenge);
-        copy_bytes(&challenge, out)
+        let mut authorizer = cmd_auth_mock::MockCommandAuthorizer;
+        authorizer.set_challenge(challenge);
+        out.get_mut(..challenge.len())
+            .ok_or(CaliptraCompletionCode::InsufficientResources)?
+            .copy_from_slice(&challenge);
+        Ok(challenge.len())
     }
 
     async fn program_field_entropy<A: SpdmPalAlloc>(
@@ -186,75 +133,43 @@ impl CaliptraVdmCommands for CaliptraVdmHook {
         sig: &HybridSignature,
         scratch: &A,
     ) -> CaliptraVdmResult<()> {
-        verify_fe_prog_signatures(partition, sig).await?;
-        crate::caliptra_cmd_handler::device_ops::program_field_entropy(scratch, partition)
+        let mut authorizer = cmd_auth_mock::MockCommandAuthorizer;
+        authorizer
+            .verify_signatures(FE_PROG_CMD_ID, &partition.to_le_bytes(), sig)
+            .await
+            .map_err(|_| CaliptraCompletionCode::AccessDenied)?;
+        CaliptraCmdBackend
+            .program_field_entropy(scratch, partition)
             .await
             .map_err(map_common_completion)
     }
 }
 
-fn map_mailbox_error(e: MailboxError) -> CaliptraCompletionCode {
+fn map_mailbox_error(error: MailboxError) -> CaliptraCompletionCode {
     map_common_completion(crate::caliptra_cmd_handler::device_ops::map_mailbox_error(
-        e,
+        error,
     ))
 }
 
-fn copy_bytes(src: &[u8], out: &mut [u8]) -> CaliptraVdmResult<usize> {
-    if src.len() > out.len() {
-        return Err(CaliptraCompletionCode::InsufficientResources);
-    }
-    for (d, s) in out.iter_mut().zip(src) {
-        *d = *s;
-    }
-    Ok(src.len())
-}
-
-async fn verify_fe_prog_signatures(partition: u32, sig: &HybridSignature) -> CaliptraVdmResult<()> {
-    let challenge = AUTH_CHALLENGE
-        .lock()
-        .await
-        .take()
-        .ok_or(CaliptraCompletionCode::AccessDenied)?;
-    let partition_bytes = partition.to_le_bytes();
-
-    crate::caliptra_cmd_handler::device_ops::verify_authorized_signatures(
-        FE_PROG_CMD_ID,
-        &partition_bytes,
-        &challenge,
-        TEST_AUTH_ECC_PUB_KEY_X,
-        TEST_AUTH_ECC_PUB_KEY_Y,
-        TEST_AUTH_MLDSA_PUB_KEY,
-        sig,
-    )
-    .await
-    .map_err(map_common_completion)
-}
-
-fn map_common_completion(code: CommonCompletionCode) -> CaliptraCompletionCode {
+fn map_common_completion(code: CommonCode) -> CaliptraCompletionCode {
     match code {
-        CommonCompletionCode::Success => CaliptraCompletionCode::Success,
-        CommonCompletionCode::GeneralError => CaliptraCompletionCode::GeneralError,
-        CommonCompletionCode::InvalidParameter => CaliptraCompletionCode::InvalidParameter,
-        CommonCompletionCode::InvalidLength => CaliptraCompletionCode::InvalidLength,
-        CommonCompletionCode::InvalidIdentifier => CaliptraCompletionCode::InvalidIdentifier,
-        CommonCompletionCode::OperationFailed => CaliptraCompletionCode::OperationFailed,
-        CommonCompletionCode::InsufficientResources => {
-            CaliptraCompletionCode::InsufficientResources
-        }
-        CommonCompletionCode::UnsupportedOperation => CaliptraCompletionCode::UnsupportedOperation,
-        CommonCompletionCode::DeviceNotReady => CaliptraCompletionCode::DeviceNotReady,
-        CommonCompletionCode::InvalidCommandVersion => {
-            CaliptraCompletionCode::InvalidCommandVersion
-        }
-        CommonCompletionCode::InvalidPayloadSize => CaliptraCompletionCode::InvalidPayloadSize,
-        CommonCompletionCode::Timeout => CaliptraCompletionCode::Timeout,
-        CommonCompletionCode::AccessDenied => CaliptraCompletionCode::AccessDenied,
-        CommonCompletionCode::ResourceUnavailable => CaliptraCompletionCode::ResourceUnavailable,
-        CommonCompletionCode::PolicyViolation => CaliptraCompletionCode::PolicyViolation,
-        CommonCompletionCode::InvalidState => CaliptraCompletionCode::InvalidState,
-        CommonCompletionCode::CaliptraMailboxBusy => CaliptraCompletionCode::CaliptraMailboxBusy,
-        CommonCompletionCode::CaliptraBufferTooSmall => {
-            CaliptraCompletionCode::CaliptraBufferTooSmall
-        }
+        CommonCode::Success => CaliptraCompletionCode::Success,
+        CommonCode::GeneralError => CaliptraCompletionCode::GeneralError,
+        CommonCode::InvalidParameter => CaliptraCompletionCode::InvalidParameter,
+        CommonCode::InvalidLength => CaliptraCompletionCode::InvalidLength,
+        CommonCode::InvalidIdentifier => CaliptraCompletionCode::InvalidIdentifier,
+        CommonCode::OperationFailed => CaliptraCompletionCode::OperationFailed,
+        CommonCode::InsufficientResources => CaliptraCompletionCode::InsufficientResources,
+        CommonCode::UnsupportedOperation => CaliptraCompletionCode::UnsupportedOperation,
+        CommonCode::DeviceNotReady => CaliptraCompletionCode::DeviceNotReady,
+        CommonCode::InvalidCommandVersion => CaliptraCompletionCode::InvalidCommandVersion,
+        CommonCode::InvalidPayloadSize => CaliptraCompletionCode::InvalidPayloadSize,
+        CommonCode::Timeout => CaliptraCompletionCode::Timeout,
+        CommonCode::AccessDenied => CaliptraCompletionCode::AccessDenied,
+        CommonCode::ResourceUnavailable => CaliptraCompletionCode::ResourceUnavailable,
+        CommonCode::PolicyViolation => CaliptraCompletionCode::PolicyViolation,
+        CommonCode::InvalidState => CaliptraCompletionCode::InvalidState,
+        CommonCode::CaliptraMailboxBusy => CaliptraCompletionCode::CaliptraMailboxBusy,
+        CommonCode::CaliptraBufferTooSmall => CaliptraCompletionCode::CaliptraBufferTooSmall,
     }
 }

--- a/platforms/emulator/runtime/userspace/apps/user/src/spdm/mod.rs
+++ b/platforms/emulator/runtime/userspace/apps/user/src/spdm/mod.rs
@@ -160,8 +160,12 @@ async fn spdm_mctp_responder() {
     let pal = unsafe { McuSpdmPal::new(transport, allocator, &CERT_STORE, measurement_provider()) };
     // MCTP hosts the IANA / Caliptra VDM backend (plaintext today). DOE uses
     // the default NoVdmBackend unless the TDISP/IDE validator feature wires PCI-SIG.
-    static MCTP_VDM_HOOK: caliptra_vdm::CaliptraVdmHook = caliptra_vdm::CaliptraVdmHook;
-    let vdm = CaliptraVdm::new(&MCTP_VDM_HOOK);
+    static COMMANDS: crate::caliptra_cmd_handler::CaliptraCmdBackend =
+        crate::caliptra_cmd_handler::CaliptraCmdBackend;
+    static STREAM: caliptra_vdm::CaliptraVdmStreamHook = caliptra_vdm::CaliptraVdmStreamHook;
+    static AUTHORIZATION: caliptra_vdm::CaliptraVdmAuthorizationHook =
+        caliptra_vdm::CaliptraVdmAuthorizationHook;
+    let vdm = CaliptraVdm::new(&COMMANDS, &STREAM, &AUTHORIZATION);
     let mut stack = SpdmStack::<_, 1, _>::with_vdm_backend(pal, vdm);
 
     crate::log_info!(cw, "SPDM_MCTP: starting spdm-lib MCTP run loop");

--- a/runtime/userspace/api/caliptra-api-lite/src/cert.rs
+++ b/runtime/userspace/api/caliptra-api-lite/src/cert.rs
@@ -7,7 +7,8 @@ use mcu_error::McuResult;
 use zerocopy::{little_endian::U32, FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 use crate::wire::{
-    calc_checksum, CMD_GET_ATTESTED_ECC384_CSR, CMD_GET_ATTESTED_MLDSA87_CSR, MBOX_RESP_HEADER_SIZE,
+    calc_checksum, CMD_GET_ATTESTED_ECC384_CSR, CMD_GET_ATTESTED_MLDSA87_CSR,
+    CMD_GET_IDEV_ECC384_CSR, MBOX_RESP_HEADER_SIZE,
 };
 use crate::ApiAlloc;
 
@@ -56,23 +57,53 @@ pub async fn populate_idev_ecc384_cert<A: ApiAlloc>(alloc: &A, cert: &[u8]) -> M
 }
 
 // ---------------------------------------------------------------------------
-// GET_ATTESTED_*_CSR — alloc-backed, in-place response handling
+// GET_*_CSR — in-place response handling
 // ---------------------------------------------------------------------------
+
+/// Bytes preceding variable CSR data in a mailbox response:
+/// `MailboxRespHeader(8) | data_size(4)`.
+const CSR_RSP_PREFIX_LEN: usize = MBOX_RESP_HEADER_SIZE + 4;
+
+/// Issue `GET_IDEV_ECC384_CSR` and write the returned CSR DER bytes into
+/// `csr_out`. Returns `Ok(None)` when the CSR is not provisioned.
+#[inline(never)]
+pub async fn get_idev_csr_ecc384(csr_out: &mut [u8]) -> McuResult<Option<usize>> {
+    if csr_out.len() <= CSR_RSP_PREFIX_LEN {
+        return Err(INVARIANT);
+    }
+
+    let mut req = [0u8; 4];
+    req.copy_from_slice(&calc_checksum(CMD_GET_IDEV_ECC384_CSR, &[]).to_le_bytes());
+
+    let actual = crate::wire::mbox_execute(CMD_GET_IDEV_ECC384_CSR, &req, csr_out).await?;
+    if actual < CSR_RSP_PREFIX_LEN {
+        return Err(INVARIANT);
+    }
+    let data_size = u32::from_le_bytes([csr_out[8], csr_out[9], csr_out[10], csr_out[11]]);
+    if data_size == u32::MAX {
+        return Ok(None);
+    }
+    let data_size = data_size as usize;
+    if data_size == 0
+        || data_size > csr_out.len() - CSR_RSP_PREFIX_LEN
+        || CSR_RSP_PREFIX_LEN + data_size > actual
+    {
+        return Err(INVARIANT);
+    }
+    csr_out.copy_within(CSR_RSP_PREFIX_LEN..CSR_RSP_PREFIX_LEN + data_size, 0);
+    Ok(Some(data_size))
+}
 
 /// `GET_ATTESTED_*_CSR` request size on the wire:
 /// `chksum(4) | key_id(4) | nonce(32)` = 40 B.
 const ATTESTED_CSR_REQ_LEN: usize = 40;
-
-/// Bytes preceding the CSR data in the mailbox response:
-/// `MailboxRespHeader(8) | data_size(4)` = 12 B.
-const ATTESTED_CSR_RSP_PREFIX_LEN: usize = MBOX_RESP_HEADER_SIZE + 4;
 
 /// Issue `GET_ATTESTED_ECC384_CSR` and write the returned CSR DER bytes into
 /// `csr_out`, returning the number of bytes written.
 ///
 /// `csr_out` is also used as the mailbox response buffer for the duration of
 /// the call; on return, only the CSR data occupies its prefix. The caller must
-/// provide a `csr_out` of at least [`ATTESTED_CSR_RSP_PREFIX_LEN`] bytes plus
+/// provide a `csr_out` of at least [`CSR_RSP_PREFIX_LEN`] bytes plus
 /// the expected CSR size.
 #[inline(never)]
 pub async fn get_attested_csr_ecc384(
@@ -100,7 +131,7 @@ async fn get_attested_csr_inner(
     nonce: &[u8; 32],
     csr_out: &mut [u8],
 ) -> McuResult<usize> {
-    if csr_out.len() <= ATTESTED_CSR_RSP_PREFIX_LEN {
+    if csr_out.len() <= CSR_RSP_PREFIX_LEN {
         return Err(INVARIANT);
     }
 
@@ -116,19 +147,16 @@ async fn get_attested_csr_inner(
     // Use the caller's buffer as the mailbox response buffer; afterwards
     // memmove the CSR data over the response prefix.
     let actual = crate::wire::mbox_execute(cmd, &req, csr_out).await?;
-    if actual < ATTESTED_CSR_RSP_PREFIX_LEN {
+    if actual < CSR_RSP_PREFIX_LEN {
         return Err(INVARIANT);
     }
     let data_size = u32::from_le_bytes([csr_out[8], csr_out[9], csr_out[10], csr_out[11]]) as usize;
     if data_size == 0
-        || data_size > csr_out.len() - ATTESTED_CSR_RSP_PREFIX_LEN
-        || ATTESTED_CSR_RSP_PREFIX_LEN + data_size > actual
+        || data_size > csr_out.len() - CSR_RSP_PREFIX_LEN
+        || CSR_RSP_PREFIX_LEN + data_size > actual
     {
         return Err(INVARIANT);
     }
-    csr_out.copy_within(
-        ATTESTED_CSR_RSP_PREFIX_LEN..ATTESTED_CSR_RSP_PREFIX_LEN + data_size,
-        0,
-    );
+    csr_out.copy_within(CSR_RSP_PREFIX_LEN..CSR_RSP_PREFIX_LEN + data_size, 0);
     Ok(data_size)
 }

--- a/runtime/userspace/api/caliptra-api-lite/src/lib.rs
+++ b/runtime/userspace/api/caliptra-api-lite/src/lib.rs
@@ -78,7 +78,10 @@ pub use auth_stash::{
     AUTHORIZE_AND_STASH_CONTEXT_SIZE, AUTHORIZE_AND_STASH_MEASUREMENT_SIZE,
 };
 #[cfg(feature = "mailbox-io")]
-pub use cert::{get_attested_csr_ecc384, get_attested_csr_mldsa87, populate_idev_ecc384_cert};
+pub use cert::{
+    get_attested_csr_ecc384, get_attested_csr_mldsa87, get_idev_csr_ecc384,
+    populate_idev_ecc384_cert,
+};
 #[cfg(feature = "mailbox-io")]
 pub use debug_unlock::{
     request_debug_unlock_challenge, DEBUG_UNLOCK_CHALLENGE_LEN,

--- a/runtime/userspace/api/caliptra-api-lite/src/wire.rs
+++ b/runtime/userspace/api/caliptra-api-lite/src/wire.rs
@@ -88,6 +88,9 @@ pub(crate) const CMD_QUOTE_PCRS_ECC384: u32 = 0x5043_5251; // "PCRQ"
 /// `EXTEND_PCR` command ID.
 pub(crate) const CMD_EXTEND_PCR: u32 = 0x5043_5245; // "PCRE"
 
+/// `GET_IDEV_ECC384_CSR` command ID.
+pub(crate) const CMD_GET_IDEV_ECC384_CSR: u32 = 0x4944_4352; // "IDCR"
+
 /// `GET_ATTESTED_ECC384_CSR` command ID.
 pub(crate) const CMD_GET_ATTESTED_ECC384_CSR: u32 = 0x4145_4352; // "AECR"
 

--- a/runtime/userspace/api/caliptra-common-commands/src/lib.rs
+++ b/runtime/userspace/api/caliptra-common-commands/src/lib.rs
@@ -183,6 +183,17 @@ pub trait CaliptraCmdHandler {
         csr_buf: &mut [u8],
     ) -> CaliptraCmdResult<usize>;
 
+    /// Exports an IDevID CSR (manufacturing mode only).
+    async fn export_idevid_csr<Alloc: ApiAlloc>(
+        &self,
+        alloc: &Alloc,
+        algorithm: u32,
+        csr_buf: &mut [u8],
+    ) -> CaliptraCmdResult<usize> {
+        let _ = (alloc, algorithm, csr_buf);
+        Err(CaliptraCompletionCode::UnsupportedOperation)
+    }
+
     /// Requests a production debug unlock challenge.
     ///
     /// # Arguments

--- a/runtime/userspace/api/spdm-lib/vdm-handler/Cargo.toml
+++ b/runtime/userspace/api/spdm-lib/vdm-handler/Cargo.toml
@@ -10,6 +10,7 @@ edition.workspace = true
 default = []
 
 [dependencies]
+caliptra-mcu-common-commands = { workspace = true }
 caliptra-mcu-spdm-traits = { workspace = true }
 caliptra-mcu-spdm-codec = { workspace = true }
 caliptra-mcu-spdm-errors = { workspace = true }

--- a/runtime/userspace/api/spdm-lib/vdm-handler/src/iana/ocp/caliptra_vdm/commands/authorized_command.rs
+++ b/runtime/userspace/api/spdm-lib/vdm-handler/src/iana/ocp/caliptra_vdm/commands/authorized_command.rs
@@ -4,7 +4,7 @@
 
 use caliptra_mcu_spdm_traits::SpdmPalAlloc;
 
-use crate::iana::ocp::caliptra_vdm::CaliptraVdmCommands;
+use crate::iana::ocp::caliptra_vdm::CaliptraVdmAuthorization;
 use caliptra_mcu_mbox_common::messages::HybridSignature;
 use caliptra_mcu_spdm_codec::vendor_defined::iana::ocp::caliptra::{
     CaliptraCompletionCode, CaliptraVdmCmdResult,
@@ -30,7 +30,7 @@ pub(crate) async fn handle<H, A>(
     out: &mut [u8],
 ) -> CaliptraVdmCmdResult
 where
-    H: CaliptraVdmCommands,
+    H: CaliptraVdmAuthorization,
     A: SpdmPalAlloc,
 {
     let Some(sub_cmd_bytes) = req.get(..4) else {
@@ -57,7 +57,7 @@ async fn handle_get_auth_challenge<H, A>(
     out: &mut [u8],
 ) -> CaliptraVdmCmdResult
 where
-    H: CaliptraVdmCommands,
+    H: CaliptraVdmAuthorization,
     A: SpdmPalAlloc,
 {
     if let Err(code) = super::require_empty(req) {
@@ -80,7 +80,7 @@ async fn handle_fe_prog<H, A>(
     out: &mut [u8],
 ) -> CaliptraVdmCmdResult
 where
-    H: CaliptraVdmCommands,
+    H: CaliptraVdmAuthorization,
     A: SpdmPalAlloc,
 {
     let Ok(fe_req) = FeProgVdmReq::ref_from_bytes(req) else {

--- a/runtime/userspace/api/spdm-lib/vdm-handler/src/iana/ocp/caliptra_vdm/commands/debug_unlock.rs
+++ b/runtime/userspace/api/spdm-lib/vdm-handler/src/iana/ocp/caliptra_vdm/commands/debug_unlock.rs
@@ -2,11 +2,13 @@
 
 //! Production debug unlock VDM commands.
 
+use caliptra_mcu_common_commands::{
+    CaliptraCmdHandler, DebugUnlockChallenge, DEBUG_UNLOCK_CHALLENGE_SIZE,
+    DEBUG_UNLOCK_UNIQUE_DEVICE_ID_SIZE,
+};
 use caliptra_mcu_spdm_traits::SpdmPalAlloc;
 
-use crate::iana::ocp::caliptra_vdm::{
-    CaliptraCompletionCode, CaliptraVdmCmdResult, CaliptraVdmCommands,
-};
+use crate::iana::ocp::caliptra_vdm::{CaliptraCompletionCode, CaliptraVdmCmdResult};
 
 pub(crate) async fn handle_request_debug_unlock<H, A>(
     cmds: &H,
@@ -15,38 +17,34 @@ pub(crate) async fn handle_request_debug_unlock<H, A>(
     out: &mut [u8],
 ) -> CaliptraVdmCmdResult
 where
-    H: CaliptraVdmCommands,
+    H: CaliptraCmdHandler,
     A: SpdmPalAlloc,
 {
-    const REQUEST_LENGTH_DWORDS: u32 = 2;
-    const RESPONSE_LENGTH_DWORDS: u32 = 21;
-
-    let &[length_0, length_1, length_2, length_3, unlock_level, _, _, _] = req else {
+    let &[unlock_level] = req else {
         return CaliptraVdmCmdResult::Error(CaliptraCompletionCode::InvalidPayloadSize);
     };
-    let length = u32::from_le_bytes([length_0, length_1, length_2, length_3]);
-    if length != REQUEST_LENGTH_DWORDS {
-        return CaliptraVdmCmdResult::Error(CaliptraCompletionCode::InvalidPayloadSize);
-    }
 
     let data = match super::write_success(out) {
         Ok(data) => data,
         Err(code) => return CaliptraVdmCmdResult::Error(code),
     };
-    let Some((length_out, challenge_out)) = data.split_at_mut_checked(core::mem::size_of::<u32>())
-    else {
+    let needed = DEBUG_UNLOCK_UNIQUE_DEVICE_ID_SIZE + DEBUG_UNLOCK_CHALLENGE_SIZE;
+    if data.len() < needed {
         return CaliptraVdmCmdResult::Error(CaliptraCompletionCode::InsufficientResources);
-    };
+    }
 
+    let mut challenge = DebugUnlockChallenge::default();
     match cmds
-        .request_debug_unlock(unlock_level, scratch, challenge_out)
+        .request_debug_unlock(scratch, unlock_level, &mut challenge)
         .await
     {
-        Ok(n) => {
-            length_out.copy_from_slice(&RESPONSE_LENGTH_DWORDS.to_le_bytes());
-            CaliptraVdmCmdResult::Response(1 + length_out.len() + n)
+        Ok(()) => {
+            data[..DEBUG_UNLOCK_UNIQUE_DEVICE_ID_SIZE]
+                .copy_from_slice(&challenge.unique_device_identifier);
+            data[DEBUG_UNLOCK_UNIQUE_DEVICE_ID_SIZE..needed].copy_from_slice(&challenge.challenge);
+            CaliptraVdmCmdResult::Response(1 + needed)
         }
-        Err(code) => CaliptraVdmCmdResult::Error(code),
+        Err(code) => CaliptraVdmCmdResult::Error(super::map_common_completion(code)),
     }
 }
 
@@ -57,14 +55,14 @@ pub(crate) async fn handle_authorize_debug_unlock_token<H, A>(
     out: &mut [u8],
 ) -> CaliptraVdmCmdResult
 where
-    H: CaliptraVdmCommands,
+    H: CaliptraCmdHandler,
     A: SpdmPalAlloc,
 {
-    match cmds.authorize_debug_unlock_token(req, scratch).await {
+    match cmds.authorize_debug_unlock_token(scratch, req).await {
         Ok(()) => match super::write_success(out) {
             Ok(_) => CaliptraVdmCmdResult::Response(1),
             Err(code) => CaliptraVdmCmdResult::Error(code),
         },
-        Err(code) => CaliptraVdmCmdResult::Error(code),
+        Err(code) => CaliptraVdmCmdResult::Error(super::map_common_completion(code)),
     }
 }

--- a/runtime/userspace/api/spdm-lib/vdm-handler/src/iana/ocp/caliptra_vdm/commands/export_attested_csr.rs
+++ b/runtime/userspace/api/spdm-lib/vdm-handler/src/iana/ocp/caliptra_vdm/commands/export_attested_csr.rs
@@ -3,38 +3,56 @@
 //! EXPORT_ATTESTED_CSR (0x08): exports an attested CSR.
 //!
 //! This is the largest Caliptra VDM response and exercises the inline-or-large
-//! response path. The CSR bytes are fetched (via the device-ops hook) into the
-//! `large` staging buffer's tail, then framed inline when the whole response
-//! fits one transport frame, otherwise as a chunked large response.
+//! response path. The CSR bytes are fetched through the shared command handler
+//! into the `large` staging buffer's tail, then framed inline when the whole
+//! response fits one transport frame, otherwise as a chunked large response.
 
+use caliptra_mcu_common_commands::CaliptraCmdHandler;
 use caliptra_mcu_spdm_traits::SpdmPalAlloc;
 
-use crate::iana::ocp::caliptra_vdm::CaliptraVdmCommands;
 use caliptra_mcu_spdm_codec::vendor_defined::iana::ocp::caliptra::{
     CaliptraCompletionCode, CaliptraVdmCmdResult, CALIPTRA_VDM_COMMAND_VERSION,
 };
 
-/// Request payload: `device_key_id` (u32 LE) | `algorithm` (u32 LE) | `nonce` (32 bytes).
-const REQ_LEN: usize = 4 + 4 + 32;
-
-/// Length of the `csr_len` (u32 LE) field in the response payload.
+const ATTESTED_REQ_LEN: usize = 4 + 4 + 32;
 const CSR_LEN_FIELD: usize = 4;
-
-/// Complete VDM payload header preceding the CSR bytes in the large buffer:
-/// `[command_version, command_code, completion_code, csr_len (u32 LE)]`.
 const CSR_PAYLOAD_HEADER_LEN: usize = 2 + 1 + CSR_LEN_FIELD;
-
-/// Inline payload prefix (after the 2-byte VDM header the dispatcher already
-/// wrote): `[completion_code, csr_len (u32 LE)]`.
 const INLINE_PREFIX_LEN: usize = 1 + CSR_LEN_FIELD;
 
-/// Handles an EXPORT_ATTESTED_CSR command.
-///
-/// `inline_payload` is the inline buffer region after the 2-byte VDM header
-/// (receives `[completion, csr_len, csr_data]`). `large` is the worst-case
-/// staging buffer; when present, the CSR is fetched into its tail and either
-/// copied back inline (if it fits one frame) or framed in place as a large
-/// response.
+fn finish_staged_csr_response(
+    command_code: u8,
+    inline_payload: &mut [u8],
+    large: &mut [u8],
+    data_len: usize,
+) -> CaliptraVdmCmdResult {
+    if data_len > large.len().saturating_sub(CSR_PAYLOAD_HEADER_LEN) {
+        return CaliptraVdmCmdResult::Error(CaliptraCompletionCode::InsufficientResources);
+    }
+
+    if INLINE_PREFIX_LEN + data_len <= inline_payload.len() {
+        inline_payload[0] = CaliptraCompletionCode::Success as u8;
+        inline_payload[1..INLINE_PREFIX_LEN].copy_from_slice(&(data_len as u32).to_le_bytes());
+        inline_payload[INLINE_PREFIX_LEN..INLINE_PREFIX_LEN + data_len]
+            .copy_from_slice(&large[CSR_PAYLOAD_HEADER_LEN..CSR_PAYLOAD_HEADER_LEN + data_len]);
+        CaliptraVdmCmdResult::Response(INLINE_PREFIX_LEN + data_len)
+    } else {
+        large[0] = CALIPTRA_VDM_COMMAND_VERSION;
+        large[1] = command_code;
+        large[2] = CaliptraCompletionCode::Success as u8;
+        large[3..CSR_PAYLOAD_HEADER_LEN].copy_from_slice(&(data_len as u32).to_le_bytes());
+        CaliptraVdmCmdResult::Large(CSR_PAYLOAD_HEADER_LEN + data_len)
+    }
+}
+
+fn finish_inline_csr_response(inline_payload: &mut [u8], data_len: usize) -> CaliptraVdmCmdResult {
+    if INLINE_PREFIX_LEN + data_len > inline_payload.len() {
+        return CaliptraVdmCmdResult::Error(CaliptraCompletionCode::InsufficientResources);
+    }
+    inline_payload[0] = CaliptraCompletionCode::Success as u8;
+    inline_payload[1..INLINE_PREFIX_LEN].copy_from_slice(&(data_len as u32).to_le_bytes());
+    CaliptraVdmCmdResult::Response(INLINE_PREFIX_LEN + data_len)
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn handle<H, A>(
     cmds: &H,
@@ -45,70 +63,55 @@ pub(crate) async fn handle<H, A>(
     scratch: &A,
 ) -> CaliptraVdmCmdResult
 where
-    H: CaliptraVdmCommands,
+    H: CaliptraCmdHandler,
     A: SpdmPalAlloc,
 {
-    if req.len() != REQ_LEN {
+    if req.len() != ATTESTED_REQ_LEN {
         return CaliptraVdmCmdResult::Error(CaliptraCompletionCode::InvalidPayloadSize);
     }
     let device_key_id = u32::from_le_bytes([req[0], req[1], req[2], req[3]]);
     let algorithm = u32::from_le_bytes([req[4], req[5], req[6], req[7]]);
-    let mut nonce = [0u8; 32];
-    nonce.copy_from_slice(&req[8..REQ_LEN]);
+    let nonce: &[u8; 32] = match req[8..].try_into() {
+        Ok(nonce) => nonce,
+        Err(_) => return CaliptraVdmCmdResult::Error(CaliptraCompletionCode::InvalidPayloadSize),
+    };
 
-    // Prefer the worst-case `large` staging buffer when the stack provisioned
-    // one; otherwise only a single-frame inline response is possible.
     if large.len() > CSR_PAYLOAD_HEADER_LEN {
         let data_len = match cmds
             .export_attested_csr(
+                scratch,
                 device_key_id,
                 algorithm,
-                &nonce,
-                scratch,
+                nonce,
                 &mut large[CSR_PAYLOAD_HEADER_LEN..],
             )
             .await
         {
             Ok(n) => n,
-            Err(code) => return CaliptraVdmCmdResult::Error(code),
+            Err(code) => {
+                return CaliptraVdmCmdResult::Error(super::map_common_completion(code));
+            }
         };
-
-        if INLINE_PREFIX_LEN + data_len <= inline_payload.len() {
-            // Fits one frame: emit inline `[completion, csr_len, csr_data]`.
-            inline_payload[0] = CaliptraCompletionCode::Success as u8;
-            inline_payload[1..INLINE_PREFIX_LEN].copy_from_slice(&(data_len as u32).to_le_bytes());
-            inline_payload[INLINE_PREFIX_LEN..INLINE_PREFIX_LEN + data_len]
-                .copy_from_slice(&large[CSR_PAYLOAD_HEADER_LEN..CSR_PAYLOAD_HEADER_LEN + data_len]);
-            CaliptraVdmCmdResult::Response(INLINE_PREFIX_LEN + data_len)
-        } else {
-            // Too large for one frame: frame the complete VDM payload header in
-            // `large`; the CSR data is already at large[CSR_PAYLOAD_HEADER_LEN..].
-            large[0] = CALIPTRA_VDM_COMMAND_VERSION;
-            large[1] = command_code;
-            large[2] = CaliptraCompletionCode::Success as u8;
-            large[3..CSR_PAYLOAD_HEADER_LEN].copy_from_slice(&(data_len as u32).to_le_bytes());
-            CaliptraVdmCmdResult::Large(CSR_PAYLOAD_HEADER_LEN + data_len)
-        }
+        finish_staged_csr_response(command_code, inline_payload, large, data_len)
     } else {
-        // No large staging buffer (chunking unavailable): inline only.
-        if inline_payload.len() <= INLINE_PREFIX_LEN {
+        if inline_payload.len() < INLINE_PREFIX_LEN {
             return CaliptraVdmCmdResult::Error(CaliptraCompletionCode::InsufficientResources);
         }
         let data_len = match cmds
             .export_attested_csr(
+                scratch,
                 device_key_id,
                 algorithm,
-                &nonce,
-                scratch,
+                nonce,
                 &mut inline_payload[INLINE_PREFIX_LEN..],
             )
             .await
         {
             Ok(n) => n,
-            Err(code) => return CaliptraVdmCmdResult::Error(code),
+            Err(code) => {
+                return CaliptraVdmCmdResult::Error(super::map_common_completion(code));
+            }
         };
-        inline_payload[0] = CaliptraCompletionCode::Success as u8;
-        inline_payload[1..INLINE_PREFIX_LEN].copy_from_slice(&(data_len as u32).to_le_bytes());
-        CaliptraVdmCmdResult::Response(INLINE_PREFIX_LEN + data_len)
+        finish_inline_csr_response(inline_payload, data_len)
     }
 }

--- a/runtime/userspace/api/spdm-lib/vdm-handler/src/iana/ocp/caliptra_vdm/commands/mod.rs
+++ b/runtime/userspace/api/spdm-lib/vdm-handler/src/iana/ocp/caliptra_vdm/commands/mod.rs
@@ -1,11 +1,8 @@
 // Licensed under the Apache-2.0 license
 
 //! Per-command handlers for the Caliptra VDM protocol.
-//!
-//! Each handler decodes its command-specific request, invokes the platform
-//! [`CaliptraVdmCommands`](super::CaliptraVdmCommands) PAL hook, and writes the
-//! VDM response payload `[completion_code, command_data..]`.
 
+use caliptra_mcu_common_commands::CaliptraCompletionCode as CommonCompletionCode;
 use caliptra_mcu_spdm_codec::vendor_defined::iana::ocp::caliptra::CaliptraCompletionCode;
 
 pub(crate) mod authorized_command;
@@ -26,4 +23,33 @@ pub(crate) fn write_success(out: &mut [u8]) -> Result<&mut [u8], CaliptraComplet
     };
     *completion = CaliptraCompletionCode::Success as u8;
     Ok(rest)
+}
+
+pub(crate) fn map_common_completion(code: CommonCompletionCode) -> CaliptraCompletionCode {
+    match code {
+        CommonCompletionCode::Success => CaliptraCompletionCode::Success,
+        CommonCompletionCode::GeneralError => CaliptraCompletionCode::GeneralError,
+        CommonCompletionCode::InvalidParameter => CaliptraCompletionCode::InvalidParameter,
+        CommonCompletionCode::InvalidLength => CaliptraCompletionCode::InvalidLength,
+        CommonCompletionCode::InvalidIdentifier => CaliptraCompletionCode::InvalidIdentifier,
+        CommonCompletionCode::OperationFailed => CaliptraCompletionCode::OperationFailed,
+        CommonCompletionCode::InsufficientResources => {
+            CaliptraCompletionCode::InsufficientResources
+        }
+        CommonCompletionCode::UnsupportedOperation => CaliptraCompletionCode::UnsupportedOperation,
+        CommonCompletionCode::DeviceNotReady => CaliptraCompletionCode::DeviceNotReady,
+        CommonCompletionCode::InvalidCommandVersion => {
+            CaliptraCompletionCode::InvalidCommandVersion
+        }
+        CommonCompletionCode::InvalidPayloadSize => CaliptraCompletionCode::InvalidPayloadSize,
+        CommonCompletionCode::Timeout => CaliptraCompletionCode::Timeout,
+        CommonCompletionCode::AccessDenied => CaliptraCompletionCode::AccessDenied,
+        CommonCompletionCode::ResourceUnavailable => CaliptraCompletionCode::ResourceUnavailable,
+        CommonCompletionCode::PolicyViolation => CaliptraCompletionCode::PolicyViolation,
+        CommonCompletionCode::InvalidState => CaliptraCompletionCode::InvalidState,
+        CommonCompletionCode::CaliptraMailboxBusy => CaliptraCompletionCode::CaliptraMailboxBusy,
+        CommonCompletionCode::CaliptraBufferTooSmall => {
+            CaliptraCompletionCode::CaliptraBufferTooSmall
+        }
+    }
 }

--- a/runtime/userspace/api/spdm-lib/vdm-handler/src/iana/ocp/caliptra_vdm/mod.rs
+++ b/runtime/userspace/api/spdm-lib/vdm-handler/src/iana/ocp/caliptra_vdm/mod.rs
@@ -5,12 +5,12 @@
 //! Implements [`SpdmVdmBackend`] for the Caliptra VDM protocol (IANA standards
 //! body, vendor id [`CALIPTRA_VENDOR_ID`]). The backend decodes the
 //! Caliptra VDM message header, dispatches the command, and frames the response.
-//! Per-command device operations are provided by the platform through the
-//! [`CaliptraVdmCommands`] PAL hook — the protocol/dispatch stays in this lib,
-//! only the device work crosses to the platform.
+//! Transport-neutral operations use [`caliptra_mcu_common_commands::CaliptraCmdHandler`].
+//! SPDM-specific stream state and shared command authorization use separate hooks.
 
 mod commands;
 
+use caliptra_mcu_common_commands::CaliptraCmdHandler;
 use caliptra_mcu_mbox_common::messages::HybridSignature;
 use caliptra_mcu_spdm_codec::StandardsBodyId;
 use caliptra_mcu_spdm_traits::{
@@ -31,34 +31,8 @@ const MAX_LARGE_COMMAND_DATA_LEN: usize = 4 * 1024;
 /// `[command_version, command_code, completion, data_len, data...]`.
 const MAX_LARGE_VDM_PAYLOAD_LEN: usize = VDM_HEADER_LEN + 1 + 4 + MAX_LARGE_COMMAND_DATA_LEN;
 
-/// Platform hook for executing Caliptra VDM commands ("device operations").
-///
-/// The protocol and dispatch layers live in this crate; the platform implements
-/// this trait to perform the actual device work (e.g. Caliptra mailbox calls).
-/// Each method writes its command-specific response data into `out` and returns
-/// the number of bytes written, or a [`CaliptraCompletionCode`] on failure
-/// (surfaced as a VDM error completion, not an SPDM error).
-///
-/// `scratch` gives each device op the request-scoped scratch allocator so it can
-/// stage device interactions without owning persistent buffers.
-pub trait CaliptraVdmCommands {
-    /// Requests a production debug unlock challenge for `unlock_level`, writing
-    /// `[unique_device_identifier, challenge]` into `out`.
-    async fn request_debug_unlock<A: SpdmPalAlloc>(
-        &self,
-        unlock_level: u8,
-        scratch: &A,
-        out: &mut [u8],
-    ) -> CaliptraVdmResult<usize>;
-
-    /// Submits a production debug unlock token. `token_data` is the remaining
-    /// command payload exactly as sent by the requester.
-    async fn authorize_debug_unlock_token<A: SpdmPalAlloc>(
-        &self,
-        token_data: &[u8],
-        scratch: &A,
-    ) -> CaliptraVdmResult<()>;
-
+/// Platform hook for SPDM-specific Caliptra VDM stream state.
+pub trait CaliptraVdmStreamOps {
     /// Starts streaming a production debug unlock token request.
     async fn start_authorize_debug_unlock_token_stream<A: SpdmPalAlloc>(
         &self,
@@ -88,19 +62,10 @@ pub trait CaliptraVdmCommands {
 
     /// Aborts a streaming production debug unlock token request.
     async fn abort_authorize_debug_unlock_token_stream<A: SpdmPalAlloc>(&self, _scratch: &A) {}
+}
 
-    /// Exports an attested CSR for `device_key_id` using `algorithm` and `nonce`,
-    /// writing the raw CSR bytes into `out` and returning their length.
-    async fn export_attested_csr<A: SpdmPalAlloc>(
-        &self,
-        device_key_id: u32,
-        algorithm: u32,
-        nonce: &[u8; 32],
-        scratch: &A,
-        out: &mut [u8],
-    ) -> CaliptraVdmResult<usize>;
-
-    /// Generates an authorization challenge nonce into `out`.
+/// Platform hook for the shared command-authorization service.
+pub trait CaliptraVdmAuthorization {
     async fn get_auth_challenge<A: SpdmPalAlloc>(
         &self,
         scratch: &A,
@@ -116,19 +81,29 @@ pub trait CaliptraVdmCommands {
     ) -> CaliptraVdmResult<()>;
 }
 
-/// Caliptra VDM backend, parameterized over a platform [`CaliptraVdmCommands`] hook.
-pub struct CaliptraVdm<'a, H: CaliptraVdmCommands> {
-    cmds: &'a H,
+/// Caliptra VDM backend with separate shared-command, stream, and authorization hooks.
+pub struct CaliptraVdm<'a, H, S, A> {
+    commands: &'a H,
+    stream: &'a S,
+    authorization: &'a A,
 }
 
-impl<'a, H: CaliptraVdmCommands> CaliptraVdm<'a, H> {
-    /// Creates a backend that dispatches commands to `cmds`.
-    pub fn new(cmds: &'a H) -> Self {
-        Self { cmds }
+impl<'a, H, S, A> CaliptraVdm<'a, H, S, A> {
+    pub fn new(commands: &'a H, stream: &'a S, authorization: &'a A) -> Self {
+        Self {
+            commands,
+            stream,
+            authorization,
+        }
     }
 }
 
-impl<H: CaliptraVdmCommands> SpdmVdmBackend for CaliptraVdm<'_, H> {
+impl<H, S, A> SpdmVdmBackend for CaliptraVdm<'_, H, S, A>
+where
+    H: CaliptraCmdHandler,
+    S: CaliptraVdmStreamOps,
+    A: CaliptraVdmAuthorization,
+{
     // Caliptra VDM can emit responses (CSRs, logs) larger than one transport
     // frame, so the stack provisions the buffered large-response path.
     const USES_LARGE_RESPONSE: bool = true;
@@ -159,7 +134,7 @@ impl<H: CaliptraVdmCommands> SpdmVdmBackend for CaliptraVdm<'_, H> {
             return Ok(false);
         }
         match self
-            .cmds
+            .stream
             .start_authorize_debug_unlock_token_stream(
                 req_len - VDM_HEADER_LEN,
                 &first[VDM_HEADER_LEN..],
@@ -183,7 +158,7 @@ impl<H: CaliptraVdmCommands> SpdmVdmBackend for CaliptraVdm<'_, H> {
         Alloc: SpdmPalAlloc,
         Io: SpdmPalIo,
     {
-        self.cmds
+        self.stream
             .continue_authorize_debug_unlock_token_stream(chunk, alloc)
             .await
             .map_err(|_| INVARIANT)
@@ -202,7 +177,7 @@ impl<H: CaliptraVdmCommands> SpdmVdmBackend for CaliptraVdm<'_, H> {
             return Err(INVARIANT);
         }
         let completion = match self
-            .cmds
+            .stream
             .finish_authorize_debug_unlock_token_stream(rsp.alloc)
             .await
         {
@@ -220,7 +195,7 @@ impl<H: CaliptraVdmCommands> SpdmVdmBackend for CaliptraVdm<'_, H> {
         Alloc: SpdmPalAlloc,
         Io: SpdmPalIo,
     {
-        self.cmds
+        self.stream
             .abort_authorize_debug_unlock_token_stream(alloc)
             .await;
     }
@@ -273,19 +248,25 @@ impl<H: CaliptraVdmCommands> SpdmVdmBackend for CaliptraVdm<'_, H> {
         let result = match CaliptraVdmCommand::try_from(command_code) {
             Ok(CaliptraVdmCommand::RequestDebugUnlock) => {
                 commands::debug_unlock::handle_request_debug_unlock(
-                    self.cmds, cmd_req, scratch, payload,
+                    self.commands,
+                    cmd_req,
+                    scratch,
+                    payload,
                 )
                 .await
             }
             Ok(CaliptraVdmCommand::AuthorizeDebugUnlockToken) => {
                 commands::debug_unlock::handle_authorize_debug_unlock_token(
-                    self.cmds, cmd_req, scratch, payload,
+                    self.commands,
+                    cmd_req,
+                    scratch,
+                    payload,
                 )
                 .await
             }
             Ok(CaliptraVdmCommand::ExportAttestedCsr) => {
                 commands::export_attested_csr::handle(
-                    self.cmds,
+                    self.commands,
                     cmd_req,
                     command_code,
                     payload,
@@ -295,7 +276,8 @@ impl<H: CaliptraVdmCommands> SpdmVdmBackend for CaliptraVdm<'_, H> {
                 .await
             }
             Ok(CaliptraVdmCommand::AuthorizedCommand) => {
-                commands::authorized_command::handle(self.cmds, cmd_req, scratch, payload).await
+                commands::authorized_command::handle(self.authorization, cmd_req, scratch, payload)
+                    .await
             }
             // Recognized-but-unimplemented and unknown command codes both map to
             // an UnsupportedOperation completion.
@@ -318,18 +300,19 @@ impl<H: CaliptraVdmCommands> SpdmVdmBackend for CaliptraVdm<'_, H> {
 mod tests {
     extern crate std;
 
-    use core::cell::RefCell;
     use core::future::Future;
     use core::marker::PhantomData;
     use core::ops::{Deref, DerefMut};
     use core::pin::Pin;
     use core::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
 
+    use caliptra_mcu_common_commands::{DeviceCapabilities, FirmwareVersion};
     use caliptra_mcu_spdm_traits::{
         SpdmPalAlloc, SpdmPalIo, SpdmPalIoKind, SpdmVdmBackend, VdmResponse, VdmResponseBuffer,
     };
     use mcu_error::McuResult;
     use std::boxed::Box;
+    use std::sync::Mutex;
     use std::vec;
     use std::vec::Vec;
 
@@ -425,20 +408,25 @@ mod tests {
 
     struct TestCommands {
         csr_len: usize,
-        authorized_token: RefCell<Option<Vec<u8>>>,
+        authorized_token: Mutex<Option<Vec<u8>>>,
     }
 
     impl TestCommands {
         fn new(csr_len: usize) -> Self {
             Self {
                 csr_len,
-                authorized_token: RefCell::new(None),
+                authorized_token: Mutex::new(None),
             }
         }
 
-        fn write_csr(&self, out: &mut [u8]) -> CaliptraVdmResult<usize> {
+        fn write_csr(
+            &self,
+            out: &mut [u8],
+        ) -> caliptra_mcu_common_commands::CaliptraCmdResult<usize> {
             if out.len() < self.csr_len {
-                return Err(CaliptraCompletionCode::InsufficientResources);
+                return Err(
+                    caliptra_mcu_common_commands::CaliptraCompletionCode::InsufficientResources,
+                );
             }
             for (i, byte) in out[..self.csr_len].iter_mut().enumerate() {
                 *byte = i as u8;
@@ -447,45 +435,70 @@ mod tests {
         }
     }
 
-    impl CaliptraVdmCommands for TestCommands {
-        async fn request_debug_unlock<A: SpdmPalAlloc>(
+    impl CaliptraCmdHandler for TestCommands {
+        async fn get_firmware_version(
             &self,
-            unlock_level: u8,
-            _scratch: &A,
-            out: &mut [u8],
-        ) -> CaliptraVdmResult<usize> {
-            if unlock_level != 7 {
-                return Err(CaliptraCompletionCode::InvalidParameter);
+            area_index: u32,
+            out: &mut FirmwareVersion,
+        ) -> caliptra_mcu_common_commands::CaliptraCmdResult<()> {
+            if area_index != 1 {
+                return Err(caliptra_mcu_common_commands::CaliptraCompletionCode::InvalidParameter);
             }
-            let needed = DEBUG_UNLOCK_UNIQUE_DEVICE_ID_SIZE + DEBUG_UNLOCK_CHALLENGE_SIZE;
-            if out.len() < needed {
-                return Err(CaliptraCompletionCode::InsufficientResources);
-            }
-            out[..DEBUG_UNLOCK_UNIQUE_DEVICE_ID_SIZE].fill(0x11);
-            out[DEBUG_UNLOCK_UNIQUE_DEVICE_ID_SIZE..needed].fill(0x22);
-            Ok(needed)
-        }
-
-        async fn authorize_debug_unlock_token<A: SpdmPalAlloc>(
-            &self,
-            token_data: &[u8],
-            _scratch: &A,
-        ) -> CaliptraVdmResult<()> {
-            self.authorized_token.replace(Some(token_data.to_vec()));
+            out.ver_str[..5].copy_from_slice(b"1.2.3");
+            out.len = 5;
             Ok(())
         }
 
-        async fn export_attested_csr<A: SpdmPalAlloc>(
+        async fn get_device_capabilities(
             &self,
+            out: &mut DeviceCapabilities,
+        ) -> caliptra_mcu_common_commands::CaliptraCmdResult<()> {
+            out.caliptra_rt = [0x11; 8];
+            out.mcu_rt = [0x22; 8];
+            Ok(())
+        }
+
+        async fn export_attested_csr<Alloc: mcu_caliptra_api_lite::ApiAlloc>(
+            &self,
+            _alloc: &Alloc,
             _device_key_id: u32,
             _algorithm: u32,
             _nonce: &[u8; 32],
-            _scratch: &A,
             out: &mut [u8],
-        ) -> CaliptraVdmResult<usize> {
+        ) -> caliptra_mcu_common_commands::CaliptraCmdResult<usize> {
             self.write_csr(out)
         }
 
+        async fn request_debug_unlock<Alloc: mcu_caliptra_api_lite::ApiAlloc>(
+            &self,
+            _alloc: &Alloc,
+            unlock_level: u8,
+            challenge: &mut caliptra_mcu_common_commands::DebugUnlockChallenge,
+        ) -> caliptra_mcu_common_commands::CaliptraCmdResult<()> {
+            if unlock_level != 7 {
+                return Err(caliptra_mcu_common_commands::CaliptraCompletionCode::InvalidParameter);
+            }
+            challenge.unique_device_identifier.fill(0x11);
+            challenge.challenge.fill(0x22);
+            Ok(())
+        }
+
+        async fn authorize_debug_unlock_token<Alloc: mcu_caliptra_api_lite::ApiAlloc>(
+            &self,
+            _alloc: &Alloc,
+            token_data: &[u8],
+        ) -> caliptra_mcu_common_commands::CaliptraCmdResult<()> {
+            self.authorized_token
+                .lock()
+                .unwrap()
+                .replace(token_data.to_vec());
+            Ok(())
+        }
+    }
+
+    impl CaliptraVdmStreamOps for TestCommands {}
+
+    impl CaliptraVdmAuthorization for TestCommands {
         async fn get_auth_challenge<A: SpdmPalAlloc>(
             &self,
             _scratch: &A,
@@ -543,7 +556,7 @@ mod tests {
     ) -> (VdmResponse, Vec<u8>, Vec<u8>) {
         let alloc = TestAlloc;
         let io = TestIo;
-        let backend = CaliptraVdm::new(cmds);
+        let backend = CaliptraVdm::new(cmds, cmds, cmds);
         let mut inline = vec![0; inline_len];
         let mut large = vec![0; large_len];
         let response = block_on(backend.handle_request(
@@ -662,6 +675,17 @@ mod tests {
     }
 
     #[test]
+    fn export_attested_csr_allows_empty_inline_csr() {
+        let cmds = TestCommands::new(0);
+        let req = export_attested_csr_req();
+        let (response, inline, _) = dispatch(&cmds, &req, 2 + 1 + 4, 0);
+
+        assert_inline(response, 2 + 1 + 4);
+        assert_eq!(inline[2], CaliptraCompletionCode::Success as u8);
+        assert_eq!(u32::from_le_bytes(inline[3..7].try_into().unwrap()), 0);
+    }
+
+    #[test]
     fn export_attested_csr_uses_large_response_when_inline_is_too_small() {
         let cmds = TestCommands::new(12);
         let req = export_attested_csr_req();
@@ -681,32 +705,24 @@ mod tests {
         let req = [
             CALIPTRA_VDM_COMMAND_VERSION,
             CaliptraVdmCommand::RequestDebugUnlock as u8,
-            2,
-            0,
-            0,
-            0,
             7,
-            0,
-            0,
-            0,
         ];
         let (response, inline, _) = dispatch(&cmds, &req, 128, 0);
 
         assert_inline(
             response,
-            2 + 1 + 4 + DEBUG_UNLOCK_UNIQUE_DEVICE_ID_SIZE + DEBUG_UNLOCK_CHALLENGE_SIZE,
+            2 + 1 + DEBUG_UNLOCK_UNIQUE_DEVICE_ID_SIZE + DEBUG_UNLOCK_CHALLENGE_SIZE,
         );
         assert_eq!(inline[0], CALIPTRA_VDM_COMMAND_VERSION);
         assert_eq!(inline[1], CaliptraVdmCommand::RequestDebugUnlock as u8);
         assert_eq!(inline[2], CaliptraCompletionCode::Success as u8);
-        assert_eq!(u32::from_le_bytes(inline[3..7].try_into().unwrap()), 21);
         assert_eq!(
-            &inline[7..7 + DEBUG_UNLOCK_UNIQUE_DEVICE_ID_SIZE],
+            &inline[3..3 + DEBUG_UNLOCK_UNIQUE_DEVICE_ID_SIZE],
             &[0x11; DEBUG_UNLOCK_UNIQUE_DEVICE_ID_SIZE]
         );
         assert_eq!(
-            &inline[7 + DEBUG_UNLOCK_UNIQUE_DEVICE_ID_SIZE
-                ..7 + DEBUG_UNLOCK_UNIQUE_DEVICE_ID_SIZE + DEBUG_UNLOCK_CHALLENGE_SIZE],
+            &inline[3 + DEBUG_UNLOCK_UNIQUE_DEVICE_ID_SIZE
+                ..3 + DEBUG_UNLOCK_UNIQUE_DEVICE_ID_SIZE + DEBUG_UNLOCK_CHALLENGE_SIZE],
             &[0x22; DEBUG_UNLOCK_CHALLENGE_SIZE]
         );
     }
@@ -717,14 +733,7 @@ mod tests {
         let req = [
             CALIPTRA_VDM_COMMAND_VERSION,
             CaliptraVdmCommand::RequestDebugUnlock as u8,
-            2,
-            0,
-            0,
-            0,
             7,
-            0,
-            0,
-            0,
             0xaa,
         ];
         let (response, inline, _) = dispatch(&cmds, &req, 128, 0);
@@ -746,6 +755,6 @@ mod tests {
 
         assert_inline(response, 3);
         assert_eq!(inline[2], CaliptraCompletionCode::Success as u8);
-        assert_eq!(cmds.authorized_token.take(), Some(token));
+        assert_eq!(cmds.authorized_token.lock().unwrap().take(), Some(token));
     }
 }

--- a/runtime/userspace/api/spdm-lib/vdm-handler/src/lib.rs
+++ b/runtime/userspace/api/spdm-lib/vdm-handler/src/lib.rs
@@ -6,7 +6,8 @@
 //! command codes, and request/response framing for each supported standards
 //! body — and implements the VDM backend used to route
 //! `VENDOR_DEFINED_REQUEST`s. The actual device operations are delegated to
-//! platform-supplied PAL hooks (e.g. [`iana::ocp::caliptra_vdm::CaliptraVdmCommands`]).
+//! platform-supplied PAL hooks (for example,
+//! [`iana::ocp::caliptra_vdm::CaliptraVdmStreamOps`]).
 //!
 //! Handling is organized by SPDM Standards Body ID:
 //!
@@ -20,7 +21,7 @@ pub mod pci_sig;
 
 /// Integrator-facing platform hook traits for supported VDM protocols.
 pub mod drivers {
-    pub use crate::iana::ocp::caliptra_vdm::CaliptraVdmCommands;
+    pub use crate::iana::ocp::caliptra_vdm::{CaliptraVdmAuthorization, CaliptraVdmStreamOps};
     pub use crate::pci_sig::ide_km::{IdeDriver, IdeDriverError, IdeDriverResult};
     pub use crate::pci_sig::tdisp::{TdispDriver, TdispDriverError, TdispDriverResult};
 }


### PR DESCRIPTION
- Route transport-neutral Caliptra commands through `CaliptraCmdHandler` while keeping SPDM-specific streaming and authorization operations in the SPDM VDM hook.
- Add SPDM VDM support for firmware version, device capabilities, device ID, device info, debug log mapping, attestation log routing, and IDevID CSR export.
- Allocate fixed command responses from the SPDM task scratch pool and use caller-owned buffers for CSR mailbox responses.
- Fix `GET_DEBUG_LOG` response length accounting and add byte-exact coverage.
- Keep the standalone MCTP VDM transport unchanged; it shares the common command-service contract rather than SPDM framing code.

Tests:
- `cargo fmt --all -- --check`
- `cargo test -p caliptra-mcu-spdm-vdm-handler`
- `cargo test -p caliptra-mcu-core-util-host-transport`
- `cargo check -p mcu-caliptra-api-lite`
- `cargo check -p user-app --features spdm`
