### PR TITLE
Fixing the current failures in the size-history workflow

### DIFF
--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -100,6 +100,7 @@ fn build_runtime(target_dir: &Path) -> Result<PathBuf> {
         platform: Some("fpga"),
         features: Some("release"),
         profile: Some("release"),
+        no_default_features: true,
         target_dir: Some(target_dir.to_path_buf()),
         ..Default::default()
     })


### PR DESCRIPTION
The Enable all features (#1691) PR added a new option in CaliptraBuildArgs, no_default_features. This flag was added to most of the uses of this structure for executing build commands, but the code for size-history was not updated. Without this flag the resulting roms are too big to be properly linked. 
